### PR TITLE
bundler: make --min-chunk-size effective on React apps and cheap; fix the static import cycle it could create

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -604,20 +604,22 @@ With `splitting`, also fold small side-effect-free chunks into a chunk that more
       entrypoints: ['./index.tsx'],
       outdir: './out',
       splitting: true,
-      minChunkSize: 16 * 1024, // default 0 (disabled)
+      minChunkSize: 64 * 1024, // default: 16 KiB with target "browser", else 0 (off)
     })
     ```
   </Tab>
   <Tab title="CLI">
     ```bash terminal icon="terminal"
-    bun build ./index.tsx --outdir ./out --splitting --min-chunk-size=16384
+    bun build ./index.tsx --outdir ./out --splitting --min-chunk-size=65536
     ```
   </Tab>
 </Tabs>
 
 Code splitting gives each distinct set of importers its own chunk, then folds chunks that are always loaded together: a module that `index.tsx` imports and that a lazily `import()`ed module also imports lives in `index.js`, and the lazy chunk imports it from there, because the lazy module can only load after `index.tsx` has run. That fold never makes an entrypoint load more code, so it is always on.
 
-`minChunkSize` goes further for chunks whose source files add up to fewer than this many bytes and whose modules run nothing at the top level: only declarations, `"sideEffects": false` in their `package.json`, or a lazily initialized CommonJS/ESM wrapper. Such a chunk folds into a chunk loaded by a superset of its importers. Everything it imports must already be loaded whenever that target is, or be side-effect free as well. The extra entrypoints then carry some unused definitions, capped at about 1.5% of what each entrypoint loaded to begin with. No side effect runs earlier than before and nothing lazy becomes eager. Because these rules bound what an entrypoint can end up loading, a large `minChunkSize` is reasonable.
+`minChunkSize` goes further for chunks whose source files add up to fewer than this many bytes and whose modules run nothing at the top level: only declarations, `"sideEffects": false` in their `package.json`, a lazily initialized CommonJS/ESM wrapper, or an import of a CommonJS module (such as `react`) that is already initialized wherever the chunk's code ends up. Such a chunk folds into a chunk loaded by a superset of its importers. Everything it imports must already be loaded whenever that target is, or be side-effect free as well. The extra entrypoints then carry some unused definitions, capped at about 1.5% of what each entrypoint loaded to begin with. No side effect runs earlier than before and nothing lazy becomes eager. Because these rules bound what an entrypoint can end up loading, a large `minChunkSize` is reasonable.
+
+With `target: "browser"`, where every chunk is a request, `minChunkSize` defaults to 16 KiB; pass `0` to keep every chunk. Other targets default to `0`.
 
 A chunk that absorbs other chunks exports the symbols those chunks' importers need. An entrypoint that has exports of its own never absorbs one, so its module namespace stays as written; an entrypoint without exports can. With `--compile`, nothing folds into the entrypoint's own chunk.
 
@@ -1807,7 +1809,7 @@ interface BuildConfig {
   root?: string; // project root
   splitting?: boolean; // default false, enable code splitting
   splitRequire?: boolean; // default true, with splitting and target "bun": require() of an ES module is a chunk too
-  minChunkSize?: number; // default 0, also fold side-effect-free chunks smaller than this many source bytes
+  minChunkSize?: number; // default 16 KiB for target "browser", else 0: also fold side-effect-free chunks smaller than this many source bytes
   modulePreload?: boolean; // default true, with splitting and target "browser": <link rel=modulepreload> the chunks an entrypoint or import() depends on
   plugins?: BunPlugin[];
   external?: string[];

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -604,13 +604,13 @@ With `splitting`, also fold small side-effect-free chunks into a chunk that more
       entrypoints: ['./index.tsx'],
       outdir: './out',
       splitting: true,
-      minChunkSize: 64 * 1024, // default: 16 KiB with target "browser", else 0 (off)
+      minChunkSize: 16 * 1024, // default 0 (off)
     })
     ```
   </Tab>
   <Tab title="CLI">
     ```bash terminal icon="terminal"
-    bun build ./index.tsx --outdir ./out --splitting --min-chunk-size=65536
+    bun build ./index.tsx --outdir ./out --splitting --min-chunk-size=16384
     ```
   </Tab>
 </Tabs>
@@ -619,7 +619,7 @@ Code splitting gives each distinct set of importers its own chunk, then folds ch
 
 `minChunkSize` goes further for chunks whose source files add up to fewer than this many bytes and whose modules run nothing at the top level: only declarations, `"sideEffects": false` in their `package.json`, a lazily initialized CommonJS/ESM wrapper, or an import of a CommonJS module (such as `react`) that is already initialized wherever the chunk's code ends up. Such a chunk folds into a chunk loaded by a superset of its importers. Everything it imports must already be loaded whenever that target is, or be side-effect free as well. The extra entrypoints then carry some unused definitions, capped at about 1.5% of what each entrypoint loaded to begin with. No side effect runs earlier than before and nothing lazy becomes eager. Because these rules bound what an entrypoint can end up loading, a large `minChunkSize` is reasonable.
 
-With `target: "browser"`, where every chunk is a request, `minChunkSize` defaults to 16 KiB; pass `0` to keep every chunk. Other targets default to `0`.
+For `target: "browser"`, where every chunk is a request, 16 KiB is a good starting point.
 
 A chunk that absorbs other chunks exports the symbols those chunks' importers need. An entrypoint that has exports of its own never absorbs one, so its module namespace stays as written; an entrypoint without exports can. With `--compile`, nothing folds into the entrypoint's own chunk.
 
@@ -1809,7 +1809,7 @@ interface BuildConfig {
   root?: string; // project root
   splitting?: boolean; // default false, enable code splitting
   splitRequire?: boolean; // default true, with splitting and target "bun": require() of an ES module is a chunk too
-  minChunkSize?: number; // default 16 KiB for target "browser", else 0: also fold side-effect-free chunks smaller than this many source bytes
+  minChunkSize?: number; // default 0, also fold side-effect-free chunks smaller than this many source bytes
   modulePreload?: boolean; // default true, with splitting and target "browser": <link rel=modulepreload> the chunks an entrypoint or import() depends on
   plugins?: BunPlugin[];
   external?: string[];

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3195,9 +3195,10 @@ declare module "bun" {
      * superset of their importers, so fewer modules are loaded at runtime.
      * Nothing lazy becomes eager and no side effect runs earlier; the chunk
      * that absorbs a folded chunk exports the symbols other chunks import
-     * from it. Requires `splitting: true`; `0` disables it. CLI: `--min-chunk-size`.
+     * from it. Requires `splitting: true`. CLI: `--min-chunk-size`. For browser
+     * builds, where every chunk is a request, 16384 is a good value.
      *
-     * @default 16384 with `target: "browser"`, otherwise 0
+     * @default 0 (disabled)
      */
     minChunkSize?: number;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3195,9 +3195,9 @@ declare module "bun" {
      * superset of their importers, so fewer modules are loaded at runtime.
      * Nothing lazy becomes eager and no side effect runs earlier; the chunk
      * that absorbs a folded chunk exports the symbols other chunks import
-     * from it. Requires `splitting: true`. CLI: `--min-chunk-size`.
+     * from it. Requires `splitting: true`; `0` disables it. CLI: `--min-chunk-size`.
      *
-     * @default 0 (disabled)
+     * @default 16384 with `target: "browser"`, otherwise 0
      */
     minChunkSize?: number;
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -133,6 +133,10 @@ pub struct LinkerContext<'a> {
 
     /// User entry points (by source index) that reach a split browser `import()`: their chunk registers the chunk graph.
     pub(crate) preload_entries: AutoBitSet,
+    /// Files whose only top-level effect, `init_x()` / `require_x()` calls,
+    /// `merge_small_chunks` proved to be no-ops where it moved them: a chunk
+    /// their chunk imports makes the same calls first.
+    pub(crate) inits_already_done: Option<AutoBitSet>,
     /// The part `scan_imports_and_exports` adds to each entry point file (`u32::MAX` elsewhere).
     pub(crate) entry_point_part_indices: Vec<u32>,
 }
@@ -172,6 +176,7 @@ impl<'a> Default for LinkerContext<'a> {
             mangled_props: Default::default(),
             cross_chunk_names: Default::default(),
             preload_entries: AutoBitSet::init_empty(0).expect("static AutoBitSet"),
+            inits_already_done: None,
             entry_point_part_indices: Vec::new(),
         }
     }
@@ -374,6 +379,28 @@ impl<'a> LinkerContext<'a> {
                 .is_entry_point()
     }
 
+    /// The bundled file a live part's import record makes the importer's
+    /// chunk load, if any: not a split `import()` / `require()`, which loads
+    /// on demand, and not an `import` or `export ... from` of a side-effect-free
+    /// file, which prints nothing (the bindings used from it are part
+    /// dependencies). Chunk assignment follows these edges, so everything that
+    /// reasons about which chunks load together must too.
+    pub(crate) fn file_loaded_by_import(
+        &self,
+        record: &ImportRecord,
+        source_index: u32,
+    ) -> Option<u32> {
+        if !record.source_index.is_valid() || self.is_external_dynamic_import(record, source_index)
+        {
+            return None;
+        }
+        let other = record.source_index.get();
+        if record.kind == ImportKind::Stmt && self.file_has_no_side_effects(other) {
+            return None;
+        }
+        Some(other)
+    }
+
     /// `"sideEffects": false` (or the resolver's equivalent), unless
     /// `--ignore-dce-annotations` says not to trust it.
     pub(crate) fn file_has_no_side_effects(&self, source_index: u32) -> bool {
@@ -495,6 +522,7 @@ impl<'a> LinkerContext<'a> {
             bun_ptr::ParentRef::from_raw(core::ptr::from_ref(&transpiler.resolver).cast())
         });
         self.cycle_detector = Vec::new();
+        self.inits_already_done = None;
 
         // Note: `reachable_files` is `Vec<Index>`; clone the
         // caller-owned slice into the linker arena.
@@ -2791,19 +2819,11 @@ impl<'a> LinkerContext<'a> {
                 }
 
                 for &import_index in part.import_record_indices.iter() {
-                    let record = &records[import_index as usize];
-                    if !record.source_index.is_valid()
-                        || self.is_external_dynamic_import(record, source_index)
-                    {
+                    let Some(other) =
+                        self.file_loaded_by_import(&records[import_index as usize], source_index)
+                    else {
                         continue;
-                    }
-                    let other = record.source_index.get();
-
-                    // Prints nothing; its bindings are the part dependencies below.
-                    if record.kind == ImportKind::Stmt && self.file_has_no_side_effects(other) {
-                        continue;
-                    }
-
+                    };
                     if !ctx.file_entry_bits[other as usize].is_set(entry_points_count) {
                         ctx.queue.push_back((other, out_dist));
                     }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3041,7 +3041,10 @@ pub mod bv2_impl {
             // SAFETY: same `'a`-owned `Transpiler` field as `banner` above.
             this.linker.options.footer = unsafe { interned_slice(&this.transpiler.options.footer) };
             this.linker.options.css_chunking = this.transpiler.options.css_chunking;
-            this.linker.options.min_chunk_size = this.transpiler.options.min_chunk_size;
+            this.linker.options.min_chunk_size =
+                this.transpiler.options.min_chunk_size.unwrap_or_else(|| {
+                    crate::options::default_min_chunk_size(this.transpiler.options.target)
+                });
             this.linker.options.module_preload = this.transpiler.options.module_preload;
             this.linker.options.source_maps = this.transpiler.options.source_map;
             this.linker.options.tree_shaking = this.transpiler.options.tree_shaking;

--- a/src/bundler/linker_context/README.md
+++ b/src/bundler/linker_context/README.md
@@ -741,7 +741,7 @@ The renamed symbols are then used during final code generation to produce output
 - Computes, per `import()` entry point, which other entry points are guaranteed to be loaded already whenever it loads
 - Reduces each chunk key (`File.entry_bits`) to its load-condition class by dropping such redundant dynamic entries
 - Rewrites the entry bits of files to those of the class's parent chunk (the chunk keyed by the reduced set, else the largest member) before `computeChunks()` groups files
-- With `--min-chunk-size`, additionally folds small chunks with no top-level side effects into a chunk loaded by a superset of their entries when every dependency is already loaded wherever the target is
+- With `--min-chunk-size` (16 KiB by default for `--target=browser`), additionally folds small chunks with no top-level side effects into a chunk loaded by a superset of their entries when every dependency is already loaded wherever the target is, no static import cycle between chunks results, and every CommonJS/ESM wrapper the moved code initializes at the top level is already initialized by a chunk the target imports
 
 #### `computeCrossChunkDependencies.rs`
 

--- a/src/bundler/linker_context/README.md
+++ b/src/bundler/linker_context/README.md
@@ -741,7 +741,7 @@ The renamed symbols are then used during final code generation to produce output
 - Computes, per `import()` entry point, which other entry points are guaranteed to be loaded already whenever it loads
 - Reduces each chunk key (`File.entry_bits`) to its load-condition class by dropping such redundant dynamic entries
 - Rewrites the entry bits of files to those of the class's parent chunk (the chunk keyed by the reduced set, else the largest member) before `computeChunks()` groups files
-- With `--min-chunk-size` (16 KiB by default for `--target=browser`), additionally folds small chunks with no top-level side effects into a chunk loaded by a superset of their entries when every dependency is already loaded wherever the target is, no static import cycle between chunks results, and every CommonJS/ESM wrapper the moved code initializes at the top level is already initialized by a chunk the target imports
+- With `--min-chunk-size`, additionally folds small chunks with no top-level side effects into a chunk loaded by a superset of their entries when every dependency is already loaded wherever the target is, no static import cycle between chunks results, and every CommonJS/ESM wrapper the moved code initializes at the top level is already initialized by a chunk the target imports
 
 #### `computeCrossChunkDependencies.rs`
 

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -384,11 +384,9 @@ fn inert_chunks(c: &LinkerContext, chunks: &[Chunk]) -> Result<AutoBitSet, bun_a
                     continue;
                 }
                 for &i in part.import_record_indices.iter() {
-                    let record = &records[i as usize];
-                    if record.source_index.is_valid()
-                        && !c.is_external_dynamic_import(record, source_index)
+                    if let Some(other) = c.file_loaded_by_import(&records[i as usize], source_index)
                     {
-                        add(record.source_index.get());
+                        add(other);
                     }
                 }
                 for dep in part.dependencies.iter() {

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -33,12 +33,28 @@ impl LinkerContext<'_> {
     /// None of the file's live parts run anything at the top level:
     /// declarations only, `"sideEffects": false`, or a lazily initialized
     /// `__esm` / `__commonJS` wrapper. An entry point never qualifies (its
-    /// tail runs it), nor does top-level await. A static import of a wrapped module is printed as a
-    /// top-level `init_x()` / `require_x()` call in the importer, and one of
-    /// an external module loads it (hoisted out of a wrapper, too); either
-    /// counts as running something. An import of an unwrapped bundled file
-    /// does not: that file is judged on its own.
+    /// tail runs it), nor does top-level await. A static import of a wrapped
+    /// module is printed as a top-level `init_x()` / `require_x()` call in the
+    /// importer, and one of an external module loads it (hoisted out of a
+    /// wrapper, too); either counts as running something. An import of an
+    /// unwrapped bundled file does not: that file is judged on its own.
     pub(crate) fn loading_file_has_no_side_effects(&self, source_index: u32) -> bool {
+        self.inits_already_done
+            .as_ref()
+            .is_some_and(|files| files.is_set(source_index as usize))
+            || self.loading_file_side_effects(source_index, None)
+    }
+
+    /// `loading_file_has_no_side_effects`, except that a top-level
+    /// `init_x()` / `require_x()` of a bundled wrapped module is collected into
+    /// `inits` (by source index) instead of counting as a side effect: the
+    /// call does nothing where that module is already initialized. A bare
+    /// `import "x"` still counts; it is there for the effect.
+    pub(crate) fn loading_file_side_effects(
+        &self,
+        source_index: u32,
+        mut inits: Option<&mut Vec<u32>>,
+    ) -> bool {
         let flags = self.graph.meta.items_flags();
         if self.graph.files.items_entry_point_kind()[source_index as usize].is_entry_point()
             || flags[source_index as usize].is_async_or_has_async_dependency
@@ -50,13 +66,24 @@ impl LinkerContext<'_> {
         let declared_pure = self.file_has_no_side_effects(source_index);
         let wrapped = flags[source_index as usize].wrap != WrapKind::None;
         let records = &self.graph.ast.items_import_records()[source_index as usize];
-        let import_has_no_side_effects = |record: &bun_ast::ImportRecord| {
+        let mut import_has_no_side_effects = |record: &bun_ast::ImportRecord| {
             record.flags.contains(ImportRecordFlags::IS_UNUSED)
                 || match record.kind {
                     ImportKind::Stmt => {
                         if record.source_index.is_valid() {
                             wrapped
                                 || flags[record.source_index.get() as usize].wrap == WrapKind::None
+                                || match inits.as_deref_mut() {
+                                    Some(inits)
+                                        if !record.flags.contains(
+                                            ImportRecordFlags::WAS_ORIGINALLY_BARE_IMPORT,
+                                        ) =>
+                                    {
+                                        inits.push(record.source_index.get());
+                                        true
+                                    }
+                                    _ => false,
+                                }
                         } else {
                             record
                                 .flags
@@ -83,6 +110,37 @@ impl LinkerContext<'_> {
                             .all(|&i| import_has_no_side_effects(&records[i as usize])))
             })
     }
+
+    /// The bundled wrapped modules an unwrapped file initializes at its top
+    /// level (`init_x()` / `require_x()` printed for a live static import).
+    pub(crate) fn top_level_inits(&self, source_index: u32, inits: &mut Vec<u32>) {
+        let flags = self.graph.meta.items_flags();
+        if flags[source_index as usize].wrap != WrapKind::None {
+            return;
+        }
+        let records = &self.graph.ast.items_import_records()[source_index as usize];
+        let parts_live = &self.graph.parts_live[source_index as usize];
+        for (part_index, part) in self.graph.ast.items_parts()[source_index as usize]
+            .as_slice()
+            .iter()
+            .enumerate()
+        {
+            if !parts_live.is_set(part_index) {
+                continue;
+            }
+            for &i in part.import_record_indices.iter() {
+                let record = &records[i as usize];
+                if record.kind == ImportKind::Stmt
+                    && !record.flags.contains(ImportRecordFlags::IS_UNUSED)
+                    && record.source_index.is_valid()
+                    && record.source_index.get() != source_index
+                    && flags[record.source_index.get() as usize].wrap != WrapKind::None
+                {
+                    inits.push(record.source_index.get());
+                }
+            }
+        }
+    }
 }
 
 /// The files sharing one chunk key (`File.entry_bits`).
@@ -100,38 +158,101 @@ struct Group {
     /// of its importer's.
     loaded: AutoBitSet,
     loaded_count: usize,
+    /// Rule 2 last considered folding this group in the pass that started at
+    /// this tick; nothing that could give it a target has happened since
+    /// unless `recheck` is set, an entry of `loaded` has a newer `entry_tick`,
+    /// or (`wants_inits`) something was folded at all.
+    checked_at: u32,
+    recheck: bool,
+    wants_inits: bool,
     /// Neither merged nor merged into.
     pinned: bool,
     /// Every live part of every file is side-effect free.
     pure: bool,
     /// Groups holding files that this group's live parts statically import
-    /// or depend on.
+    /// or depend on, and (rule 2 only) the groups importing this one.
     deps: Vec<usize>,
+    importers: Vec<usize>,
+    /// Wrapped modules (source indices) the group's side-effect-free files
+    /// `init_x()` / `require_x()` at the top level, and the ones any of its
+    /// unwrapped files do. Sorted.
+    needs_init: Vec<u32>,
+    provides_init: Vec<u32>,
+    /// Position in a topological order of the live groups' static imports
+    /// (importer before imported).
+    topo: u32,
     /// `Some(target)` once folded into another group.
     merged_into: Option<usize>,
+    /// ... by rule 2, which checked `needs_init` against the target.
+    hoisted: bool,
+    /// A file of the group, for logs.
+    first_source: u32,
+}
+
+impl Group {
+    fn new(
+        target: Target,
+        bits: &AutoBitSet,
+        pinned: bool,
+        first_source: u32,
+    ) -> Result<Group, bun_alloc::AllocError> {
+        Ok(Group {
+            first_source,
+            size: 0,
+            target: Some(target),
+            bits: bits.clone()?,
+            loaded: bits.clone()?,
+            loaded_count: 0,
+            checked_at: 0,
+            recheck: false,
+            wants_inits: false,
+            pinned,
+            pure: true,
+            deps: Vec::new(),
+            importers: Vec::new(),
+            needs_init: Vec::new(),
+            provides_init: Vec::new(),
+            topo: 0,
+            merged_into: None,
+            hoisted: false,
+        })
+    }
+}
+
+fn merge_sorted<T: Ord + Copy>(into: &mut Vec<T>, from: &[T]) {
+    if from.is_empty() {
+        return;
+    }
+    into.extend_from_slice(from);
+    into.sort_unstable();
+    into.dedup();
 }
 
 /// Fold `from` into `into`: `into` inherits the size, dependencies, load
 /// conditions and impurity; the files are re-keyed through `resolve` at the
 /// end.
 fn fold(groups: &mut [Group], from: usize, into: usize) {
-    let deps = core::mem::take(&mut groups[from].deps);
-    let (size, pure) = (groups[from].size, groups[from].pure);
     groups[from].merged_into = Some(into);
-    let (from, target) = if from < into {
+    let (source, target) = if from < into {
         let (a, b) = groups.split_at_mut(into);
-        (&a[from], &mut b[0])
+        (&mut a[from], &mut b[0])
     } else {
         let (a, b) = groups.split_at_mut(from);
-        (&b[0], &mut a[into])
+        (&mut b[0], &mut a[into])
     };
-    target.size += size;
-    target.pure &= pure;
-    target.loaded.set_union(&from.loaded);
-    target.deps.extend(deps);
-    target.deps.sort_unstable();
-    target.deps.dedup();
-    target.deps.retain(|&d| d != into);
+    target.size += source.size;
+    target.pure &= source.pure;
+    target.loaded.set_union(&source.loaded);
+    for (t, s) in [
+        (&mut target.deps, &mut source.deps),
+        (&mut target.importers, &mut source.importers),
+    ] {
+        merge_sorted(t, s);
+        t.retain(|&g| g != into && g != from);
+        s.clear();
+    }
+    merge_sorted(&mut target.needs_init, &source.needs_init);
+    merge_sorted(&mut target.provides_init, &source.provides_init);
 }
 
 /// Follow `merged_into` links to the group that now owns the files.
@@ -145,12 +266,113 @@ fn resolve(groups: &[Group], mut index: usize) -> usize {
 /// Per-attempt scratch for `collect_newly_loaded`; `visited` is epoch-stamped
 /// so each attempt resets it in O(1).
 struct Scratch {
-    visited: Vec<u32>,
-    epoch: u32,
+    visited: Vec<u64>,
+    epoch: u64,
     stack: Vec<usize>,
     /// `candidate` plus the side-effect-free groups the target's extra entries
     /// would start loading.
     newly_loaded: Vec<usize>,
+}
+
+impl Scratch {
+    fn next_epoch(&mut self) -> u64 {
+        self.epoch += 1;
+        self.epoch
+    }
+}
+
+/// `from` statically imports `to`, directly or through other groups. Every
+/// edge goes up in `topo`, so nothing past `to` there needs visiting.
+fn reaches(groups: &[Group], from: usize, to: usize, scratch: &mut Scratch) -> bool {
+    let bound = groups[to].topo;
+    if groups[from].topo >= bound {
+        return from == to;
+    }
+    let epoch = scratch.next_epoch();
+    scratch.stack.clear();
+    scratch.stack.push(from);
+    scratch.visited[from] = epoch;
+    while let Some(g) = scratch.stack.pop() {
+        for &d in &groups[g].deps {
+            let d = resolve(groups, d);
+            if d == to {
+                return true;
+            }
+            if groups[d].topo < bound && core::mem::replace(&mut scratch.visited[d], epoch) != epoch
+            {
+                scratch.stack.push(d);
+            }
+        }
+    }
+    false
+}
+
+/// Every `x` in `needs` (top-level `init_x()` / `require_x()` calls) lives in
+/// a chunk other than `merged` whose own top level makes the same call. Code
+/// making the call imports `init_x` / `require_x` from that chunk, so the
+/// chunk has run to completion first and the call finds `x` initialized.
+fn inits_provided(
+    groups: &[Group],
+    group_of_file: &[usize],
+    needs: &[u32],
+    merged: [usize; 2],
+) -> bool {
+    needs.iter().all(|&x| {
+        let home = resolve(groups, group_of_file[x as usize]);
+        !merged.contains(&home) && groups[home].provides_init.binary_search(&x).is_ok()
+    })
+}
+
+/// `topo` for every live group: Kahn's algorithm, releasing ties in order of
+/// how many entries load the group so a fold target (loaded by a superset)
+/// tends to sort after the groups that would start importing it.
+fn number_topologically(groups: &mut [Group], indegree: &mut Vec<u32>) {
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+    indegree.clear();
+    indegree.resize(groups.len(), 0);
+    for g in 0..groups.len() {
+        if groups[g].merged_into.is_some() {
+            continue;
+        }
+        for i in 0..groups[g].deps.len() {
+            let d = resolve(groups, groups[g].deps[i]);
+            if d != g {
+                indegree[d] += 1;
+            }
+        }
+    }
+    let mut ready: BinaryHeap<Reverse<(usize, usize)>> = BinaryHeap::new();
+    for g in 0..groups.len() {
+        if groups[g].merged_into.is_none() && indegree[g] == 0 {
+            ready.push(Reverse((groups[g].loaded_count, g)));
+        }
+    }
+    let mut next = 0u32;
+    while let Some(Reverse((_, g))) = ready.pop() {
+        groups[g].topo = next;
+        next += 1;
+        for i in 0..groups[g].deps.len() {
+            let d = resolve(groups, groups[g].deps[i]);
+            if d == g {
+                continue;
+            }
+            indegree[d] -= 1;
+            if indegree[d] == 0 {
+                ready.push(Reverse((groups[d].loaded_count, d)));
+            }
+        }
+    }
+    for g in 0..groups.len() {
+        // A static import cycle between chunks cannot come out of
+        // `entry_bits` (an importer's key is a subset of the imported file's);
+        // number any stragglers last rather than loop.
+        if groups[g].merged_into.is_none() && indegree[g] != 0 {
+            debug_assert!(false, "static import cycle between chunks");
+            groups[g].topo = next;
+            next += 1;
+        }
+    }
 }
 
 /// Walks `candidate`'s dependencies: each must already be loaded wherever
@@ -164,8 +386,7 @@ fn collect_newly_loaded(
     target: usize,
     scratch: &mut Scratch,
 ) -> bool {
-    scratch.epoch += 1;
-    let epoch = scratch.epoch;
+    let epoch = scratch.next_epoch();
     scratch.visited[candidate] = epoch;
     scratch.visited[target] = epoch;
     scratch.stack.clear();
@@ -192,6 +413,120 @@ fn collect_newly_loaded(
             .extend(dep.deps.iter().map(|&e| resolve(groups, e)));
     }
     true
+}
+
+/// Calls `each` with the index of every set bit.
+fn for_each_bit(words: &[usize], mut each: impl FnMut(usize)) {
+    for (w, &word) in words.iter().enumerate() {
+        let mut word = word;
+        while word != 0 {
+            each(w * usize::BITS as usize + word.trailing_zeros() as usize);
+            word &= word - 1;
+        }
+    }
+}
+
+/// What `entry_id` starts loading out of `newly_loaded` (rule 2).
+fn bytes_started(groups: &[Group], newly_loaded: &[usize], entry_id: usize) -> u64 {
+    newly_loaded
+        .iter()
+        .map(|&g| &groups[g])
+        .filter(|g| !g.loaded.is_set(entry_id))
+        .map(|g| g.size)
+        .sum()
+}
+
+/// Rule 2's byte budgets. `headroom[e]` is what entry `e` may still gain;
+/// `levels[k]` holds the entries with at least `2^k` of it left, so "can
+/// every entry in this mask afford `n` bytes" is a mask test per word except
+/// for the entries whose headroom is within a factor of two of `n`.
+struct Budget {
+    headroom: Vec<u64>,
+    levels: Vec<AutoBitSet>,
+}
+
+impl Budget {
+    const LEVELS: usize = 48;
+
+    fn new(
+        entries: usize,
+        initial: impl Fn(usize) -> u64,
+    ) -> Result<Budget, bun_alloc::AllocError> {
+        let mut levels = Vec::with_capacity(Self::LEVELS);
+        for _ in 0..Self::LEVELS {
+            levels.push(AutoBitSet::init_empty(entries)?);
+        }
+        let mut budget = Budget {
+            headroom: vec![0; entries],
+            levels,
+        };
+        for entry_id in 0..entries {
+            budget.set(entry_id, initial(entry_id));
+        }
+        Ok(budget)
+    }
+
+    fn set(&mut self, entry_id: usize, headroom: u64) {
+        self.headroom[entry_id] = headroom;
+        for (k, level) in self.levels.iter_mut().enumerate() {
+            if headroom >> k != 0 {
+                level.set(entry_id);
+            } else {
+                level.unset(entry_id);
+            }
+        }
+    }
+
+    fn charge(&mut self, entry_id: usize, bytes: u64) {
+        self.set(entry_id, self.headroom[entry_id].saturating_sub(bytes));
+    }
+
+    /// A superset of the entries with at least `bytes` left (exactly those
+    /// with at least `2^floor(log2(bytes))`).
+    fn can_afford(&self, bytes: u64) -> &AutoBitSet {
+        &self.levels[(bytes.max(1).ilog2() as usize).min(Self::LEVELS - 1)]
+    }
+
+    /// Every entry in `mask` has at least `bytes` left.
+    fn all_afford(&self, mask: &[usize], bytes: u64) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+        // 2^k <= bytes < 2^(k+1): outside level k nobody can pay, inside
+        // level k + 1 everybody can; ask the ones in between.
+        let k = bytes.ilog2() as usize;
+        let (Some(maybe), Some(surely)) = (self.levels.get(k), self.levels.get(k + 1)) else {
+            return self.all_afford_each(mask, bytes, |_| bytes);
+        };
+        let mut between = false;
+        for ((&m, &lo), &hi) in mask.iter().zip(maybe.words()).zip(surely.words()) {
+            if m & !lo != 0 {
+                return false;
+            }
+            between |= m & !hi != 0;
+        }
+        !between || self.all_afford_each(mask, bytes, |_| bytes)
+    }
+
+    /// Every entry `e` in `mask` has at least `price(e) <= most` left.
+    fn all_afford_each(&self, mask: &[usize], most: u64, price: impl Fn(usize) -> u64) -> bool {
+        // Everybody inside level floor(log2(most)) + 1 can pay; ask the rest.
+        let surely = self
+            .levels
+            .get(most.max(1).ilog2() as usize + 1)
+            .map(|level| level.words());
+        mask.iter().enumerate().all(|(w, &m)| {
+            let mut word = m & !surely.map_or(0, |s| s[w]);
+            while word != 0 {
+                let entry_id = w * usize::BITS as usize + word.trailing_zeros() as usize;
+                if self.headroom[entry_id] < price(entry_id) {
+                    return false;
+                }
+                word &= word - 1;
+            }
+            true
+        })
+    }
 }
 
 const UNREACHED: u32 = u32::MAX;
@@ -281,7 +616,11 @@ fn immediate_dominators<'a>(
 ///    already loaded wherever that target is (or is side-effect free too); the
 ///    extra entries then carry some unused definitions, but no side effect
 ///    runs earlier than before. What an entry gains this way is capped
-///    relative to what it already loaded.
+///    relative to what it already loaded. A top-level `require_x()` /
+///    `init_x()` (a static import of a wrapped module, e.g. `react`) does not
+///    count as a side effect when a chunk the target statically imports makes
+///    the same call first, and no fold may close a static import cycle
+///    between chunks.
 ///
 /// Runs before `compute_chunks` groups files by `entry_bits`; it rewrites
 /// `File.entry_bits` in place so everything downstream (chunk membership,
@@ -536,6 +875,8 @@ pub(crate) fn merge_small_chunks(
             || !export_aliases[source_index].is_empty()
     };
     let group_of_file: &mut [usize] = temp.alloc_slice_fill_copy(files_len, usize::MAX);
+    let mut inits: Vec<u32> = Vec::new();
+    let mut files_with_inits = AutoBitSet::init_empty(files_len)?;
     let mut groups: ArrayHashMap<&[u8], Group> = ArrayHashMap::new();
     let mut classes: ArrayHashMap<&[u8], (AutoBitSet, Vec<usize>)> = ArrayHashMap::new();
     for source_index in this.graph.reachable_files.iter() {
@@ -555,8 +896,11 @@ pub(crate) fn merge_small_chunks(
         // Loading a file earlier than before is only unobservable when none
         // of its live parts run anything at the top level.
         let wrapped = flags[source_index as usize].wrap != WrapKind::None;
-        let pure = fold_pure && this.loading_file_has_no_side_effects(source_index);
+        inits.clear();
+        let pure = fold_pure && this.loading_file_side_effects(source_index, Some(&mut inits));
         if fold_pure && !pure {
+            inits.clear();
+            this.top_level_inits(source_index, &mut inits);
             debug_merge!(
                 "not side-effect free: {}{}",
                 bstr::BStr::new(sources[source_index as usize].path.text),
@@ -567,21 +911,16 @@ pub(crate) fn merge_small_chunks(
                 },
             );
         }
+        inits.sort_unstable();
+        inits.dedup();
         let entry = groups.entry(temp.alloc_slice_copy(bits.bytes(entry_points_len)));
         let group_index = match &entry {
             MapEntry::Occupied(entry) => entry.index(),
             MapEntry::Vacant(entry) => entry.index(),
         };
         group_of_file[source_index as usize] = group_index;
-        match entry {
-            MapEntry::Occupied(entry) => {
-                let group = entry.into_mut();
-                group.size += size;
-                group.pure &= pure;
-                if group.target != Some(target) {
-                    group.target = None;
-                }
-            }
+        let group = match entry {
+            MapEntry::Occupied(entry) => entry.into_mut(),
             MapEntry::Vacant(entry) => {
                 let class = load_class(bits)?;
                 match classes.entry(temp.alloc_slice_copy(class.bytes(entry_points_len))) {
@@ -592,18 +931,20 @@ pub(crate) fn merge_small_chunks(
                 }
                 let pinned = bits.count() == 1
                     && pin_entry_chunk(bits.find_first_set().expect("one bit set"));
-                entry.insert(Group {
-                    size,
-                    target: Some(target),
-                    bits: bits.clone()?,
-                    loaded: bits.clone()?,
-                    loaded_count: 0,
-                    pinned,
-                    pure,
-                    deps: Vec::new(),
-                    merged_into: None,
-                });
+                entry.insert(Group::new(target, bits, pinned, source_index)?)
             }
+        };
+        group.size += size;
+        group.pure &= pure;
+        if group.target != Some(target) {
+            group.target = None;
+        }
+        if pure && !inits.is_empty() {
+            merge_sorted(&mut group.needs_init, &inits);
+            files_with_inits.set(source_index as usize);
+        }
+        if !wrapped {
+            merge_sorted(&mut group.provides_init, &inits);
         }
     }
 
@@ -621,23 +962,20 @@ pub(crate) fn merge_small_chunks(
         if !is_live_js(source_index) {
             continue;
         }
-        let group = Group {
-            size: 0,
-            target: Some(ast_targets[source_index as usize]),
-            bits: class.clone()?,
-            loaded: class.clone()?,
-            loaded_count: 0,
-            pinned: pin_entry_chunk(entry_id),
-            pure: false,
-            deps: Vec::new(),
-            merged_into: None,
-        };
+        let mut group = Group::new(
+            ast_targets[source_index as usize],
+            class,
+            pin_entry_chunk(entry_id),
+            source_index,
+        )?;
+        group.pure = false;
         classes.values_mut()[class_index].1.push(groups.count());
         groups.put(key, group)?;
     }
 
-    // Static dependencies between groups, from the live parts' import records
-    // and symbol dependencies. Only rule 2 consults them.
+    // Static dependencies between groups, along the edges that assigned
+    // `File.entry_bits` (so a dependency's key is a superset of its
+    // importer's) and symbol dependencies. Only rule 2 consults them.
     for (source_index, &group_index) in group_of_file.iter().enumerate() {
         if !fold_pure {
             break;
@@ -653,14 +991,31 @@ pub(crate) fn merge_small_chunks(
             }
             for &record_index in part.import_record_indices.iter() {
                 let record = &import_records[source_index][record_index as usize];
-                if record.source_index.is_valid()
-                    && !this.is_external_dynamic_import(record, source_index as u32)
-                {
-                    deps.push(group_of_file[record.source_index.get() as usize]);
+                if let Some(other) = this.file_loaded_by_import(record, source_index as u32) {
+                    deps.push(group_of_file[other as usize]);
                 }
             }
             for dependency in part.dependencies.iter() {
                 deps.push(group_of_file[dependency.source_index.get() as usize]);
+            }
+        }
+    }
+    // An entry point's chunk also imports every binding the entry re-exports
+    // (`compute_cross_chunk_dependencies`).
+    if fold_pure {
+        let resolved_exports = this.graph.meta.items_resolved_exports();
+        for &source_index in entry_source_indices.iter() {
+            let group_index = group_of_file[source_index as usize];
+            if group_index == usize::MAX || flags[source_index as usize].wrap == WrapKind::Cjs {
+                continue;
+            }
+            let deps = &mut groups.values_mut()[group_index].deps;
+            for alias in export_aliases[source_index as usize].iter() {
+                if let Some(export) = resolved_exports[source_index as usize].get(alias)
+                    && export.data.source_index.is_valid()
+                {
+                    deps.push(group_of_file[export.data.source_index.get() as usize]);
+                }
             }
         }
     }
@@ -714,10 +1069,35 @@ pub(crate) fn merge_small_chunks(
         return Ok(());
     }
 
+    // An `import()` entry every load path of which passes through entry `e`
+    // (its dominators) is loaded only once `e`'s chunks are.
+    let group_count = groups.count();
+    {
+        let mut dominated: Vec<AutoBitSet> = Vec::with_capacity(entry_points_len);
+        for _ in 0..entry_points_len {
+            dominated.push(AutoBitSet::init_empty(entry_points_len)?);
+        }
+        for entry_id in 0..entry_points_len {
+            let mut up = idom[entry_id];
+            while up != UNREACHED && up as usize != vroot {
+                dominated[up as usize].set(entry_id);
+                up = idom[up as usize];
+            }
+        }
+        for group in groups.values_mut() {
+            if group.merged_into.is_some() {
+                continue;
+            }
+            let mut iter = group.bits.iterator::<true, true>();
+            while let Some(entry_id) = iter.next() {
+                group.loaded.set_union(&dominated[entry_id]);
+            }
+        }
+    }
+
     // A parent's extra entries now reach everything the folded members
     // imported; propagate so every dependency's `loaded` covers its
     // importer's.
-    let group_count = groups.count();
     loop {
         let mut changed = false;
         for group_index in 0..group_count {
@@ -754,8 +1134,24 @@ pub(crate) fn merge_small_chunks(
     // for noticeably more code to parse.
     const EXTRA_LOAD_DIVISOR: u64 = 64;
     let mut folded_pure = 0usize;
+    let groups = groups.values_mut();
+    for g in 0..group_count {
+        if groups[g].merged_into.is_some() {
+            continue;
+        }
+        for i in 0..groups[g].deps.len() {
+            let d = resolve(groups, groups[g].deps[i]);
+            if d != g {
+                groups[d].importers.push(g);
+            }
+        }
+    }
+    for group in groups.iter_mut() {
+        group.importers.sort_unstable();
+        group.importers.dedup();
+    }
     let mut load_size: Vec<u64> = vec![0; entry_points_len];
-    for group in groups.values().iter() {
+    for group in groups.iter() {
         if group.merged_into.is_some() {
             continue;
         }
@@ -764,8 +1160,16 @@ pub(crate) fn merge_small_chunks(
             load_size[entry_id] += group.size;
         }
     }
-    let mut extra_loaded: Vec<u64> = vec![0; entry_points_len];
-    let mut gained: Vec<(usize, u64)> = Vec::new();
+    // What each entry may still gain, and, per power of two, the entries with
+    // at least that much left: a fold charges every entry in
+    // `target.loaded & !candidate.loaded`, so most verdicts are word-wide
+    // mask tests, with exact arithmetic only for entries within a factor of
+    // two of the price.
+    let mut budget = Budget::new(entry_points_len, |entry_id| {
+        load_size[entry_id] / EXTRA_LOAD_DIVISOR
+    })?;
+    let words = budget.levels[0].words().len();
+    let mut payers: Vec<usize> = vec![0; words];
     // Groups loaded by each entry: a target must be loaded by every entry of
     // the candidate, so scanning the candidate's rarest entry's list suffices.
     let mut groups_by_entry: Vec<Vec<usize>> = vec![Vec::new(); entry_points_len];
@@ -775,43 +1179,71 @@ pub(crate) fn merge_small_chunks(
         stack: Vec::new(),
         newly_loaded: Vec::new(),
     };
+    let mut indegree: Vec<u32> = Vec::new();
+    let mut by_preference: Vec<(u32, core::cmp::Reverse<u64>, usize)> =
+        Vec::with_capacity(group_count);
+    // See `Group::checked_at`.
+    let mut tick = 1u32;
+    let mut entry_tick: Vec<u32> = vec![0; entry_points_len];
+    let mut fold_tick = 0u32;
+    let mut passes = 0usize;
     loop {
+        passes += 1;
+        let pass_tick = tick;
         // Sizes and load conditions change as groups absorb others; rebuild
         // the lists in preference order once per pass so the first target
         // that passes every check wins.
         for list in groups_by_entry.iter_mut() {
             list.clear();
         }
-        for (group_index, group) in groups.values_mut().iter_mut().enumerate() {
-            if group.merged_into.is_some() {
-                continue;
-            }
-            group.loaded_count = group.loaded.count();
-            let mut iter = group.loaded.iterator::<true, true>();
-            while let Some(entry_id) = iter.next() {
-                groups_by_entry[entry_id].push(group_index);
+        by_preference.clear();
+        for (group_index, group) in groups.iter_mut().enumerate() {
+            if group.merged_into.is_none() {
+                group.loaded_count = group.loaded.count();
+                by_preference.push((
+                    group.loaded_count as u32,
+                    core::cmp::Reverse(group.size),
+                    group_index,
+                ));
             }
         }
-        for list in groups_by_entry.iter_mut() {
-            list.sort_unstable_by(|&a, &b| {
-                let (ga, gb) = (&groups.values()[a], &groups.values()[b]);
-                ga.loaded_count
-                    .cmp(&gb.loaded_count)
-                    .then_with(|| gb.size.cmp(&ga.size))
-                    .then_with(|| a.cmp(&b))
+        by_preference.sort_unstable();
+        for &(_, _, group_index) in &by_preference {
+            for_each_bit(groups[group_index].loaded.words(), |entry_id| {
+                groups_by_entry[entry_id].push(group_index)
             });
         }
+        number_topologically(groups, &mut indegree);
+        let max_headroom = budget.headroom.iter().copied().max().unwrap_or(0);
         let mut progressed = false;
         for candidate in 0..group_count {
-            let c = &groups.values()[candidate];
+            let c = &groups[candidate];
             if c.merged_into.is_some()
                 || c.pinned
                 || !c.pure
                 || c.size >= min_chunk_size
+                || c.size > max_headroom
                 || c.target.is_none()
             {
                 continue;
             }
+            // A target appears only when a superset of `loaded` starts being
+            // loaded by an entry of it, an importer's dependency moved, or new
+            // initializers landed somewhere; budgets and cycles only get worse.
+            if c.checked_at != 0 && !c.recheck && !(c.wants_inits && fold_tick >= c.checked_at) {
+                let mut newest = 0;
+                for_each_bit(c.loaded.words(), |entry_id| {
+                    newest = newest.max(entry_tick[entry_id])
+                });
+                if newest < c.checked_at {
+                    continue;
+                }
+            }
+            let c = &mut groups[candidate];
+            c.checked_at = pass_tick;
+            c.recheck = false;
+            c.wants_inits = false;
+            let c = &groups[candidate];
             let mut rarest: Option<usize> = None;
             let mut iter = c.loaded.iterator::<true, true>();
             while let Some(entry_id) = iter.next() {
@@ -823,68 +1255,206 @@ pub(crate) fn merge_small_chunks(
             let Some(rarest) = rarest else {
                 continue;
             };
-            let chosen = groups_by_entry[rarest].iter().copied().find(|&target| {
-                let t = &groups.values()[target];
+            // A target's `loaded` holds all of the candidate's entries and
+            // otherwise only ones that can afford the candidate, which bounds
+            // its size on both sides; the list is sorted by that size.
+            let list = &groups_by_entry[rarest];
+            let first = list.partition_point(|&g| groups[g].loaded_count < c.loaded_count);
+            let mut most = if c.size == 0 { entry_points_len } else { 0 };
+            for (&can, &l) in budget
+                .can_afford(c.size)
+                .words()
+                .iter()
+                .zip(c.loaded.words())
+            {
+                most += (can | l).count_ones() as usize;
+            }
+            let last = first + list[first..].partition_point(|&g| groups[g].loaded_count <= most);
+            let mut chosen = None;
+            for ti in first..last {
+                let target = groups_by_entry[rarest][ti];
+                let (c, t) = (&groups[candidate], &groups[target]);
                 if target == candidate
                     || t.merged_into.is_some()
                     || t.pinned
                     || t.target != c.target
                     || !c.loaded.subset_of(&t.loaded)
-                    || !collect_newly_loaded(groups.values(), candidate, target, &mut scratch)
                 {
-                    return false;
+                    continue;
                 }
-                gained.clear();
-                let mut iter = t.loaded.iterator::<true, true>();
-                while let Some(entry_id) = iter.next() {
-                    let bytes: u64 = scratch
-                        .newly_loaded
-                        .iter()
-                        .map(|&g| &groups.values()[g])
-                        .filter(|g| !g.loaded.is_set(entry_id))
-                        .map(|g| g.size)
-                        .sum();
-                    if bytes == 0 {
+                for ((p, &t), &c) in payers
+                    .iter_mut()
+                    .zip(t.loaded.words())
+                    .zip(c.loaded.words())
+                {
+                    *p = t & !c;
+                }
+                if !budget.all_afford(&payers, c.size) {
+                    continue;
+                }
+                // The candidate's importers will import the target and the
+                // target will import what the candidate did; neither may close
+                // a static import cycle (cross-chunk bindings are plain `var`s,
+                // read before assignment in a cycle).
+                if reaches(groups, target, candidate, &mut scratch)
+                    || (0..groups[candidate].deps.len()).any(|i| {
+                        let d = resolve(groups, groups[candidate].deps[i]);
+                        d != target && d != candidate && reaches(groups, d, target, &mut scratch)
+                    })
+                {
+                    debug_merge!(
+                        "would cycle: {} -> {}",
+                        bstr::BStr::new(
+                            sources[groups[candidate].first_source as usize].path.pretty
+                        ),
+                        bstr::BStr::new(sources[groups[target].first_source as usize].path.pretty),
+                    );
+                    continue;
+                }
+                if !collect_newly_loaded(groups, candidate, target, &mut scratch) {
+                    continue;
+                }
+                if scratch.newly_loaded.len() > 1 {
+                    let most: u64 = scratch.newly_loaded.iter().map(|&g| groups[g].size).sum();
+                    if !budget.all_afford_each(&payers, most, |entry_id| {
+                        bytes_started(groups, &scratch.newly_loaded, entry_id)
+                    }) {
                         continue;
                     }
-                    if extra_loaded[entry_id] + bytes > load_size[entry_id] / EXTRA_LOAD_DIVISOR {
-                        return false;
-                    }
-                    gained.push((entry_id, bytes));
                 }
-                true
-            });
-            if let Some(target) = chosen {
-                for &(entry_id, bytes) in &gained {
-                    extra_loaded[entry_id] += bytes;
+                // A wrapped module the moved code initializes at the top level
+                // must already be initialized by then (`inits_provided`); the
+                // order of files inside one chunk guarantees nothing, so that
+                // module may not end up in the merged chunk, whichever side
+                // brings it. The same goes for a side-effect-free dependency more
+                // entries start loading.
+                let inits_covered = inits_provided(
+                    groups,
+                    group_of_file,
+                    &groups[candidate].needs_init,
+                    [target, candidate],
+                ) && inits_provided(
+                    groups,
+                    group_of_file,
+                    &groups[target].needs_init,
+                    [candidate; 2],
+                ) && scratch.newly_loaded[1..]
+                    .iter()
+                    .all(|&g| inits_provided(groups, group_of_file, &groups[g].needs_init, [g; 2]));
+                if !inits_covered {
+                    groups[candidate].wants_inits = true;
+                    debug_merge!(
+                        "would initialize a wrapped module early: {} -> {}",
+                        bstr::BStr::new(
+                            sources[groups[candidate].first_source as usize].path.pretty
+                        ),
+                        bstr::BStr::new(sources[groups[target].first_source as usize].path.pretty),
+                    );
+                    continue;
                 }
-                let target_loaded = groups.values()[target].loaded.clone()?;
-                for &g in &scratch.newly_loaded {
-                    groups.values_mut()[g].loaded.set_union(&target_loaded);
-                }
-                // Keep a shared chunk's `bits` covering every entry that
-                // statically reaches its files (route manifests read
-                // `File.entry_bits` directly). A single bit is an entry
-                // point's own chunk, which must stay keyed by that bit; only
-                // `import()` entries it precedes can be missing there.
-                if groups.values()[target].bits.count() > 1 {
-                    let candidate_bits = groups.values()[candidate].bits.clone()?;
-                    groups.values_mut()[target].bits.set_union(&candidate_bits);
-                }
-                fold(groups.values_mut(), candidate, target);
-                folded_pure += 1;
-                progressed = true;
+                for_each_bit(&payers, |entry_id| {
+                    budget.charge(
+                        entry_id,
+                        bytes_started(groups, &scratch.newly_loaded, entry_id),
+                    )
+                });
+                chosen = Some(target);
+                break;
             }
+            let Some(target) = chosen else {
+                continue;
+            };
+            tick += 1;
+            fold_tick = tick;
+            let target_loaded = groups[target].loaded.clone()?;
+            // Whatever imports a group that changed here, directly or not, may
+            // price differently now.
+            let epoch = scratch.next_epoch();
+            scratch.stack.clear();
+            scratch.stack.push(candidate);
+            scratch.visited[candidate] = epoch;
+            for &g in &scratch.newly_loaded[1..] {
+                for ((&t, &had), ticks) in target_loaded
+                    .words()
+                    .iter()
+                    .zip(groups[g].loaded.words())
+                    .zip(entry_tick.chunks_mut(usize::BITS as usize))
+                {
+                    let mut gained = t & !had;
+                    while gained != 0 {
+                        ticks[gained.trailing_zeros() as usize] = tick;
+                        gained &= gained - 1;
+                    }
+                }
+                groups[g].loaded.set_union(&target_loaded);
+                scratch.stack.push(g);
+                scratch.visited[g] = epoch;
+            }
+            while let Some(g) = scratch.stack.pop() {
+                for i in 0..groups[g].importers.len() {
+                    let importer = resolve(groups, groups[g].importers[i]);
+                    if core::mem::replace(&mut scratch.visited[importer], epoch) != epoch {
+                        groups[importer].recheck = true;
+                        scratch.stack.push(importer);
+                    }
+                }
+            }
+            // Keep a shared chunk's `bits` covering every entry that
+            // statically reaches its files (route manifests read
+            // `File.entry_bits` directly). A single bit is an entry
+            // point's own chunk, which must stay keyed by that bit; only
+            // `import()` entries it precedes can be missing there.
+            if groups[target].bits.count() > 1 {
+                let candidate_bits = groups[candidate].bits.clone()?;
+                groups[target].bits.set_union(&candidate_bits);
+            }
+            // Keep `topo` an order of the import graph: the target takes over
+            // the candidate's edges, which is only certainly fine where it
+            // sat between the candidate's importers and dependencies already.
+            let topo = groups[target].topo;
+            let out_of_order = |list: &[usize], before: bool| {
+                list.iter()
+                    .map(|&g| resolve(groups, g))
+                    .any(|g| g != target && g != candidate && (groups[g].topo < topo) != before)
+            };
+            let renumber = out_of_order(&groups[candidate].importers, true)
+                || out_of_order(&groups[candidate].deps, false);
+            fold(groups, candidate, target);
+            groups[candidate].hoisted = true;
+            if renumber {
+                number_topologically(groups, &mut indegree);
+            }
+            folded_pure += 1;
+            progressed = true;
         }
         if !progressed {
             break;
         }
     }
+    // The `init_x()` / `require_x()` calls of a file rule 2 moved were shown
+    // to repeat ones the destination chunk's imports make first, so they no
+    // longer say anything about where that chunk must be imported
+    // (`find_imported_parts_in_js_order`, `inert_chunks`).
+    if folded_pure > 0 {
+        let mut done = AutoBitSet::init_empty(files_len)?;
+        let mut iter = files_with_inits.iterator::<true, true>();
+        while let Some(source_index) = iter.next() {
+            let mut group = group_of_file[source_index];
+            while let Some(into) = groups[group].merged_into {
+                if groups[group].hoisted {
+                    done.set(source_index);
+                    break;
+                }
+                group = into;
+            }
+        }
+        this.inits_already_done = Some(done);
+    }
 
-    rekey_files(this, group_of_file, groups.values())?;
+    rekey_files(this, group_of_file, groups)?;
     debug!(
-        "mergeSmallChunks: {} chunks folded into chunks with the same load conditions, {} side-effect-free chunks folded into a superset (min size {} bytes)",
-        folded_same, folded_pure, min_chunk_size
+        "mergeSmallChunks: {} chunks folded into chunks with the same load conditions, {} side-effect-free chunks folded into a superset in {} passes (min size {} bytes)",
+        folded_same, folded_pure, passes, min_chunk_size
     );
     Ok(())
 }

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -325,8 +325,11 @@ fn inits_provided(
 
 /// `topo` for every live group: Kahn's algorithm, releasing ties in order of
 /// how many entries load the group so a fold target (loaded by a superset)
-/// tends to sort after the groups that would start importing it.
-fn number_topologically(groups: &mut [Group], indegree: &mut Vec<u32>) {
+/// tends to sort after the groups that would start importing it. False if the
+/// groups' imports already form a cycle, which `entry_bits` cannot produce (an
+/// importer's key is a subset of the imported file's); `reaches` would then
+/// prune wrongly, so rule 2 stops.
+fn number_topologically(groups: &mut [Group], indegree: &mut Vec<u32>) -> bool {
     use std::cmp::Reverse;
     use std::collections::BinaryHeap;
     indegree.clear();
@@ -363,16 +366,9 @@ fn number_topologically(groups: &mut [Group], indegree: &mut Vec<u32>) {
             }
         }
     }
-    for g in 0..groups.len() {
-        // A static import cycle between chunks cannot come out of
-        // `entry_bits` (an importer's key is a subset of the imported file's);
-        // number any stragglers last rather than loop.
-        if groups[g].merged_into.is_none() && indegree[g] != 0 {
-            debug_assert!(false, "static import cycle between chunks");
-            groups[g].topo = next;
-            next += 1;
-        }
-    }
+    let acyclic = (0..groups.len()).all(|g| groups[g].merged_into.is_some() || indegree[g] == 0);
+    debug_assert!(acyclic, "static import cycle between chunks");
+    acyclic
 }
 
 /// Walks `candidate`'s dependencies: each must already be loaded wherever
@@ -1213,7 +1209,9 @@ pub(crate) fn merge_small_chunks(
                 groups_by_entry[entry_id].push(group_index)
             });
         }
-        number_topologically(groups, &mut indegree);
+        if !number_topologically(groups, &mut indegree) {
+            break;
+        }
         let max_headroom = budget.headroom.iter().copied().max().unwrap_or(0);
         let mut progressed = false;
         for candidate in 0..group_count {
@@ -1421,11 +1419,12 @@ pub(crate) fn merge_small_chunks(
                 || out_of_order(&groups[candidate].deps, false);
             fold(groups, candidate, target);
             groups[candidate].hoisted = true;
-            if renumber {
-                number_topologically(groups, &mut indegree);
-            }
             folded_pure += 1;
             progressed = true;
+            if renumber && !number_topologically(groups, &mut indegree) {
+                progressed = false;
+                break;
+            }
         }
         if !progressed {
             break;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2505,12 +2505,11 @@ impl From<PathTemplateConst> for PathTemplate {
     }
 }
 
-/// `--min-chunk-size` when none was given. In a browser every chunk is a
-/// request, so small side-effect-free chunks fold by default there; what an
-/// entry point can gain from that is bounded (see `merge_small_chunks`).
+/// `--min-chunk-size` when none was given: off for now. In a browser every
+/// chunk is a request and what an entry point can gain is bounded (see
+/// `merge_small_chunks`), so `Target::Browser` is meant to default to 16 KiB
+/// once the pass has shipped opt-in for a release or two.
 pub fn default_min_chunk_size(target: Target) -> u64 {
-    match target {
-        Target::Browser => 16 * 1024,
-        _ => 0,
-    }
+    let _ = target;
+    0
 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1319,7 +1319,8 @@ pub struct BundleOptions<'a> {
     /// Code splitting: also fold side-effect-free chunks whose source is
     /// smaller than this many bytes into a chunk more entry points load.
     /// 0 disables that; chunks with identical load conditions always fold.
-    pub min_chunk_size: u64,
+    /// `None` picks `default_min_chunk_size(target)`.
+    pub min_chunk_size: Option<u64>,
     /// `<link rel=modulepreload>` for split browser chunks (HTML + `import()`).
     pub module_preload: bool,
 
@@ -1702,7 +1703,7 @@ impl<'a> BundleOptions<'a> {
             env: Env::default(),
             transform_options: std::sync::Arc::clone(&transform),
             css_chunking: false,
-            min_chunk_size: 0,
+            min_chunk_size: None,
             module_preload: true,
             drop: transform.drop.clone().into_boxed_slice(),
             bundler_feature_flags,
@@ -2501,5 +2502,15 @@ impl From<PathTemplateConst> for PathTemplate {
                 target: Box::from(c.placeholder.target),
             },
         }
+    }
+}
+
+/// `--min-chunk-size` when none was given. In a browser every chunk is a
+/// request, so small side-effect-free chunks fold by default there; what an
+/// entry point can gain from that is bounded (see `merge_small_chunks`).
+pub fn default_min_chunk_size(target: Target) -> u64 {
+    match target {
+        Target::Browser => 16 * 1024,
+        _ => 0,
     }
 }

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -1132,6 +1132,15 @@ impl AutoBitSet {
         self.raw_bytes()
     }
 
+    /// The backing words (bit `i` is `words()[i / usize::BITS] >> (i % usize::BITS) & 1`);
+    /// bits past the length are zero.
+    pub fn words(&self) -> &[usize] {
+        match self {
+            AutoBitSet::Static(s) => &s.masks,
+            AutoBitSet::Dynamic(d) => d.masks_slice(),
+        }
+    }
+
     pub fn eql(&self, b: &AutoBitSet) -> bool {
         self.raw_bytes() == b.raw_bytes()
     }

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -213,7 +213,8 @@ pub struct BundlerOptions {
     pub banner: Box<[u8]>,
     pub footer: Box<[u8]>,
     pub css_chunking: bool,
-    pub min_chunk_size: u64,
+    /// `None`: the target's default (`bun_bundler::options::default_min_chunk_size`).
+    pub min_chunk_size: Option<u64>,
     pub module_preload: bool,
     pub bake: bool,
     pub bake_debug_dump_server: bool,
@@ -272,7 +273,7 @@ impl Default for BundlerOptions {
             banner: Box::default(),
             footer: Box::default(),
             css_chunking: false,
-            min_chunk_size: 0,
+            min_chunk_size: None,
             module_preload: true,
             bake: false,
             bake_debug_dump_server: false,

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -145,7 +145,7 @@ pub mod js_bundler {
         pub(crate) metafile_markdown_path: OwnedString,
         pub(crate) css_chunking: bool,
         /// `minChunkSize`: see `BundleOptions::min_chunk_size`.
-        pub(crate) min_chunk_size: u64,
+        pub(crate) min_chunk_size: Option<u64>,
         pub(crate) module_preload: bool,
         pub(crate) drop: StringSet,
         pub(crate) features: StringSet,
@@ -210,7 +210,7 @@ pub mod js_bundler {
                 metafile_json_path: OwnedString::default(),
                 metafile_markdown_path: OwnedString::default(),
                 css_chunking: false,
-                min_chunk_size: 0,
+                min_chunk_size: None,
                 module_preload: true,
                 drop: StringSet::default(),
                 features: StringSet::default(),
@@ -819,7 +819,7 @@ pub mod js_bundler {
                         "minChunkSize requires splitting to be true."
                     )));
                 }
-                this.min_chunk_size = min_chunk_size;
+                this.min_chunk_size = Some(min_chunk_size);
             }
 
             if let Some(minify) = config.get_truthy(global_this, "minify")? {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -473,7 +473,7 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
             "--no-module-preload              With --splitting and --target browser: don't emit <link rel=modulepreload> for the chunks an entry or import() loads"
         ),
         parse_param!(
-            "--min-chunk-size <INT>           With --splitting, also fold side-effect-free chunks smaller than this many source bytes into a chunk more entry points load"
+            "--min-chunk-size <INT>           With --splitting, also fold side-effect-free chunks smaller than this many source bytes into a chunk more entry points load. Default: 16384 for --target=browser, else 0"
         ),
         parse_param!(
             "--public-path <STR>              A prefix to be appended to any import paths in bundled code"
@@ -2572,7 +2572,7 @@ fn parse_build_command_options(
             Output::err_generic("--min-chunk-size requires --splitting", ());
             Global::crash();
         }
-        ctx.bundler_options.min_chunk_size = min_chunk_size;
+        ctx.bundler_options.min_chunk_size = Some(min_chunk_size);
     }
 
     for (flag, slot) in [

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -473,7 +473,7 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
             "--no-module-preload              With --splitting and --target browser: don't emit <link rel=modulepreload> for the chunks an entry or import() loads"
         ),
         parse_param!(
-            "--min-chunk-size <INT>           With --splitting, also fold side-effect-free chunks smaller than this many source bytes into a chunk more entry points load. Default: 16384 for --target=browser, else 0"
+            "--min-chunk-size <INT>           With --splitting, also fold side-effect-free chunks smaller than this many source bytes into a chunk more entry points load. Default: 0 (off); 16384 is a good value for browser builds"
         ),
         parse_param!(
             "--public-path <STR>              A prefix to be appended to any import paths in bundled code"

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1892,8 +1892,268 @@ describe("bundler", () => {
     run: { file: "/out/c.js", stdout: "c 20000" },
   });
 
-  // A static import of a CommonJS module is a top-level require_x() call in
-  // the importer, so the importer is not side-effect free.
+  // A static import of a CommonJS module is a top-level require_lib() call
+  // in the importer. f.js may still move into g.js's chunk: that chunk
+  // imports main.js, which has already made the call by then, so repeating it
+  // does nothing.
+  itBundled("splitting/MinChunkSizeFoldsImporterOfInitializedWrappedModule", {
+    files: {
+      "/main.js": /* js */ `
+        import lib from './lib.cjs'
+        import { shared } from './shared.js'
+        console.log('main', shared.length + lib.v)
+        const routes = { a: () => import('./a.js'), b: () => import('./b.js'), c: () => import('./c.js') }
+        if (process.argv[2]) routes[process.argv[2]]().then(m => console.log(m.default()))
+      `,
+      "/a.js": /* js */ `
+        import { f } from './f.js'
+        import { g } from './g.js'
+        export default () => 'a ' + (f() + g())
+      `,
+      "/b.js": /* js */ `
+        import { f } from './f.js'
+        import { g } from './g.js'
+        export default () => 'b ' + (f() + g())
+      `,
+      "/c.js": /* js */ `
+        import { g } from './g.js'
+        export default () => 'c ' + g()
+      `,
+      "/f.js": /* js */ `
+        import lib from './lib.cjs'
+        export const f = () => lib.v
+      `,
+      "/g.js": /* js */ `
+        import { shared } from './shared.js'
+        console.log('g evaluated')
+        export const g = () => shared.length
+      `,
+      "/lib.cjs": /* js */ `
+        console.log('lib evaluated')
+        module.exports = { v: 1 }
+      `,
+      "/shared.js": /* js */ `
+        export const shared = "${Buffer.alloc(20000, "x").toString()}"
+      `,
+    },
+    entryPoints: ["/main.js"],
+    splitting: true,
+    minChunkSize: 1024,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      // main, a, b, c and g.js's chunk, now holding f.js.
+      expect(jsFilesIn(api)).toHaveLength(5);
+      api.expectFile("/out/" + chunkContaining(api, "g evaluated")).toContain("var f = ");
+    },
+    run: [
+      { file: "/out/main.js", stdout: "lib evaluated\nmain 20001" },
+      { file: "/out/main.js", args: ["a"], stdout: "lib evaluated\nmain 20001\ng evaluated\na 20001" },
+    ],
+  });
+
+  // c.js moves into t.js's chunk as above. r1 imports c.js, then x.js, then
+  // t.js: c.js's require_lib() call (a no-op there) must not pull the whole
+  // t.js chunk, and its side effect, ahead of x.js's chunk.
+  itBundled("splitting/MinChunkSizeHoistedRequireKeepsChunkOrder", {
+    files: {
+      "/main.js": /* js */ `
+        import lib from './lib.cjs'
+        import { shared } from './shared.js'
+        console.log('main', shared.length + lib.v)
+        const routes = { r1: () => import('./r1.js'), r2: () => import('./r2.js'), r3: () => import('./r3.js') }
+        if (process.argv[2]) routes[process.argv[2]]()
+      `,
+      "/r1.js": /* js */ `
+        import { c } from './c.js'
+        import './x.js'
+        import { t } from './t.js'
+        console.log('r1', c() + t)
+      `,
+      "/r2.js": /* js */ `
+        import { c } from './c.js'
+        import { t } from './t.js'
+        console.log('r2', c() + t)
+      `,
+      "/r3.js": /* js */ `
+        import './x.js'
+        import { t } from './t.js'
+        console.log('r3', t)
+      `,
+      "/c.js": /* js */ `
+        import lib from './lib.cjs'
+        export const c = () => lib.v
+      `,
+      "/x.js": `console.log('x')`,
+      "/t.js": /* js */ `
+        import { shared } from './shared.js'
+        console.log('t evaluated')
+        export const t = shared.length
+      `,
+      "/lib.cjs": /* js */ `
+        console.log('lib evaluated')
+        module.exports = { v: 1 }
+      `,
+      "/shared.js": /* js */ `
+        export const shared = "${Buffer.alloc(20000, "x").toString()}"
+      `,
+    },
+    entryPoints: ["/main.js"],
+    splitting: true,
+    minChunkSize: 1024,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      // main, r1, r2, r3, x.js's chunk and t.js's chunk, now holding c.js.
+      expect(jsFilesIn(api)).toHaveLength(6);
+      api.expectFile("/out/" + chunkContaining(api, "t evaluated")).toContain("var c = ");
+    },
+    run: { file: "/out/main.js", args: ["r1"], stdout: "lib evaluated\nmain 20001\nx\nt evaluated\nr1 20001" },
+  });
+
+  // Here nothing main.js loads initializes lib.cjs, so moving f.js (and its
+  // require_lib() call) into main.js would run lib.cjs at startup.
+  itBundled("splitting/MinChunkSizeKeepsFirstInitializerOfWrappedModule", {
+    files: {
+      "/main.js": /* js */ `
+        import { shared } from './shared.js'
+        console.log('main', shared.length)
+        const routes = { a: () => import('./a.js'), b: () => import('./b.js') }
+        if (process.argv[2]) routes[process.argv[2]]().then(m => console.log(m.default()))
+      `,
+      "/a.js": /* js */ `
+        import { f } from './f.js'
+        export default () => 'a ' + f()
+      `,
+      "/b.js": /* js */ `
+        import { f } from './f.js'
+        export default () => 'b ' + f()
+      `,
+      "/f.js": /* js */ `
+        import lib from './lib.cjs'
+        export const f = () => lib.v
+      `,
+      "/lib.cjs": /* js */ `
+        console.log('lib evaluated')
+        module.exports = { v: 1 }
+      `,
+      "/shared.js": /* js */ `
+        export const shared = "${Buffer.alloc(20000, "x").toString()}"
+      `,
+    },
+    entryPoints: ["/main.js"],
+    splitting: true,
+    minChunkSize: 1024 * 1024,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(jsFilesIn(api)).toHaveLength(4);
+      api.expectFile("/out/main.js").not.toContain("lib evaluated");
+    },
+    run: [
+      { file: "/out/main.js", stdout: "main 20000" },
+      { file: "/out/main.js", args: ["b"], stdout: "main 20000\nlib evaluated\nb 1" },
+    ],
+  });
+
+  // Browser builds fold small side-effect-free chunks by default (every chunk
+  // is a request there); `minChunkSize: 0` opts out, other targets opt in.
+  for (const [name, options, outputs] of [
+    ["Browser", {}, 3],
+    ["BrowserZero", { minChunkSize: 0 }, 4],
+    ["Bun", { target: "bun" }, 4],
+  ] as const) {
+    itBundled("splitting/MinChunkSizeDefault" + name, {
+      files: {
+        "/main.js": /* js */ `
+          import { shared } from './shared.js'
+          console.log('main', shared.length)
+          const routes = { a: () => import('./a.js'), b: () => import('./b.js') }
+          if (process.argv[2]) routes[process.argv[2]]().then(m => console.log(m.default()))
+        `,
+        "/a.js": /* js */ `
+          import { f } from './f.js'
+          export default () => 'a ' + f()
+        `,
+        "/b.js": /* js */ `
+          import { f } from './f.js'
+          export default () => 'b ' + f()
+        `,
+        "/f.js": /* js */ `
+          export const f = () => 1
+        `,
+        "/shared.js": /* js */ `
+          export const shared = "${Buffer.alloc(20000, "x").toString()}"
+        `,
+      },
+      entryPoints: ["/main.js"],
+      splitting: true,
+      outdir: "/out",
+      format: "esm",
+      ...options,
+      onAfterBundle(api) {
+        expect(jsFilesIn(api)).toHaveLength(outputs);
+      },
+      run: { file: "/out/main.js", args: ["a"], stdout: "main 20000\na 1" },
+    });
+  }
+
+  // pkg's barrel stays live (`export *`) inside entry.js and has import
+  // records for b.js and b2.js, which only lazy routes use. Those records print
+  // nothing and must not count as entry.js importing the b.js chunks: if they
+  // did, c.js (which does import them) could move into entry.js, entry.js
+  // would import the b.js chunk, and that chunk imports require_lib from
+  // entry.js — a static cycle that reads require_lib before it is assigned.
+  itBundled("splitting/MinChunkSizeBarrelRecordIsNotAnImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from "lib"
+        import { A } from "pkg"
+        import { big } from "./big.js"
+        console.log("entry", A, lib.v, big.length)
+        if (process.argv[2] === "r1") import("./r1.js")
+        if (process.argv[2] === "all") [import("./r2.js"), import("./r3.js"), import("./r4.js")]
+      `,
+      "/big.js": `export const big = "${Buffer.alloc(40000, "x").toString()}"`,
+      "/c.js": /* js */ `
+        import { B, B2 } from "pkg"
+        export const c = () => B + B2
+      `,
+      "/r1.js": `import { c } from "./c.js"; console.log("r1", c())`,
+      "/r2.js": `import { c } from "./c.js"; console.log("r2", c())`,
+      "/r3.js": `import { B } from "pkg"; console.log("r3", B)`,
+      "/r4.js": `import { B2 } from "pkg"; console.log("r4", B2)`,
+      "/node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js", sideEffects: false }),
+      "/node_modules/pkg/index.js": /* js */ `
+        export * from "./star.js"
+        export { A } from "./a.js"
+        export { B } from "./b.js"
+        export { B2 } from "./b2.js"
+      `,
+      "/node_modules/pkg/star.js": `export const S = 1`,
+      "/node_modules/pkg/a.js": `export const A = "A"`,
+      // A top-level require() runs lib, so these chunks have a side effect and
+      // may only be imported where they already were.
+      "/node_modules/pkg/b.js": `const lib = require("lib"); export const B = lib.v`,
+      "/node_modules/pkg/b2.js": `const lib = require("lib"); export const B2 = lib.w`,
+      "/node_modules/lib/package.json": JSON.stringify({ name: "lib", main: "index.js" }),
+      "/node_modules/lib/index.js": `module.exports = { v: 1, w: 2 }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    minChunkSize: 1024,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      // entry, r1..r4, and the c.js, b.js and b2.js chunks.
+      expect(jsFilesIn(api)).toHaveLength(8);
+      expect(api.readFile("/out/entry.js")).not.toMatch(/^import /m);
+    },
+    run: { file: "/out/entry.js", args: ["r1"], stdout: "entry A 1 40000\nr1 3" },
+  });
+
+  // An entry point runs its own code when loaded, so its chunk never moves,
+  // whatever it imports.
   itBundled("splitting/MinChunkSizeKeepsImporterOfWrappedModule", {
     files: {
       "/main.js": /* js */ `
@@ -1922,9 +2182,10 @@ describe("bundler", () => {
     run: { file: "/out/main.js", stdout: "main 20000\nlib evaluated\nlazy 20001" },
   });
 
-  // Once the {x, y} chunk folds into the {main, x, y} chunk, that chunk
-  // imports d.js, so d.js is loaded whenever main is; d.js may then no longer
-  // fold into q's chunk, whose side effect would run at startup.
+  // The {x, y} chunk (c0.js, c.js) folds into q.js's {x, y, z, w} chunk and
+  // takes d.js's {x, y, z} chunk along as a new import of it, so d.js is then
+  // loaded wherever q.js is and folds there too; nothing may land in main.js,
+  // which must not run q.js's side effect at startup.
   itBundled("splitting/MinChunkSizeTracksLoadConditionsAcrossFolds", {
     files: {
       "/main.js": /* js */ `
@@ -1987,10 +2248,11 @@ describe("bundler", () => {
     outdir: "/out",
     format: "esm",
     onAfterBundle(api) {
-      // main, x, y, z, w, the q.js chunk and the d.js chunk; mxy.js (with
-      // c.js and c0.js) lives in main.js rather than an 8th {main, x, y} chunk.
-      expect(jsFilesIn(api)).toHaveLength(7);
-      expect(api.readFile("/out/main.js").length).toBeGreaterThan(12000);
+      // main (with mxy.js), x, y, z, w and the q.js chunk holding c0, c and d.
+      expect(jsFilesIn(api)).toHaveLength(6);
+      const q = chunkContaining(api, "q evaluated");
+      for (const f of ["c0", "c", "d"]) api.expectFile("/out/" + q).toContain(`function ${f}()`);
+      api.expectFile("/out/main.js").not.toContain("q evaluated");
     },
     run: { file: "/out/main.js", stdout: "main 12000" },
   });

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -2056,12 +2056,14 @@ describe("bundler", () => {
     ],
   });
 
-  // Browser builds fold small side-effect-free chunks by default (every chunk
-  // is a request there); `minChunkSize: 0` opts out, other targets opt in.
+  // Off unless asked for, on every target; `minChunkSize: 0` is the same as
+  // leaving it out.
   for (const [name, options, outputs] of [
-    ["Browser", {}, 3],
+    ["Browser", {}, 4],
     ["BrowserZero", { minChunkSize: 0 }, 4],
+    ["BrowserOn", { minChunkSize: 16 * 1024 }, 3],
     ["Bun", { target: "bun" }, 4],
+    ["BunOn", { target: "bun", minChunkSize: 16 * 1024 }, 3],
   ] as const) {
     itBundled("splitting/MinChunkSizeDefault" + name, {
       files: {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -2064,6 +2064,7 @@ describe("bundler", () => {
     ["BrowserOn", { minChunkSize: 16 * 1024 }, 3],
     ["Bun", { target: "bun" }, 4],
     ["BunOn", { target: "bun", minChunkSize: 16 * 1024 }, 3],
+    ["Node", { target: "node" }, 4],
   ] as const) {
     itBundled("splitting/MinChunkSizeDefault" + name, {
       files: {


### PR DESCRIPTION
### What does this PR do?

`--min-chunk-size` (#40430, #40506) folds small side-effect-free code-splitting chunks into a chunk that a superset of their entry points already loads, within a per-entry byte budget. This makes it actually fire on React apps, fixes the crash it caused on the Medusa admin dashboard after #41145, and makes the pass cheap enough to run by default later. The default stays 0 (off) in this PR; the option is now `Option`-plumbed with a per-target default hook so a later release can turn it on for `--target=browser` (16 KiB is the value the numbers below use).

**Component files were never candidates.** `import React from "react"` prints a top-level `require_react()` in the importer, which counted as a side effect. Such a call is now permitted when the wrapped module lives in another chunk whose own top level makes the same call: the moved code imports `require_x` from that chunk, so that chunk has run to completion first and the call is a no-op. A bare `import "x"` still counts as a side effect (it exists for the effect), a dependency that starts being loaded by more entries has to pass the same test, and a file moved this way no longer anchors where its new chunk sits in the importer's evaluation order (test: `MinChunkSizeHoistedRequireKeepsChunkOrder`).

**The Medusa cycle.** The pass built its dependency graph from every live import record; since #41145 chunk assignment skips `import … from` records into `sideEffects: false` files. A live barrel in the entry chunk (`react-query/index.js`) re-exporting a route-only module therefore looked like "the entry loads that module", a small chunk importing it was allowed into the entry chunk, and the entry chunk imported a chunk that imports `require_react` back from it: `TypeError: i is not a function`, blank page. `file_loaded_by_import` is now the one predicate used by the entry-bit walk, this pass and `inert_chunks`; the entry chunk's re-export edges are added too; and a reachability check over topologically numbered groups rejects any fold that would close a static import cycle. Supersedes #41164 (same root cause; this keeps those chunks foldable instead of leaving them per-route, and the cycle check is pruned rather than a full walk per attempt).

**`loaded` and dominators.** An `import()` entry that can only load after entry `e` (its dominator in the `import()` graph rule 1 already builds) now counts `e`'s chunks as loaded, so a lazy route's budget and "already loaded wherever the target is" reflect the page's entry chunk.

**Cost.** Byte budgets are mirrored into per-power-of-two bitsets so "can every entry in `target.loaded & ~candidate.loaded` afford this" is a word-wide mask test with exact arithmetic only near the boundary; a target's `loaded` size is bounded by how many entries can afford the candidate, and the per-entry lists are sorted by it; groups are sorted once per pass; a candidate is re-examined only when something that could give it a target happened (a superset started loading under one of its entries, an importer's dependency moved, or it failed on `require_*` coverage and something folded).

### Numbers (release builds, same commit as baseline, `--min-chunk-size=16384`)

| | main | this PR |
|---|---|---|
| Medusa admin v2.8.4, `bun build ./index.html --production --splitting`: JS files | 349 (no flag) / blank page (flag) | 245 |
| route navigation, requests median / max | 13 / 75 | 8 / 30 |
| startup requests / bytes | 1 / 4.37 MB | 1 / 4.37 MB |
| static import cycles with the flag | 5 | 0 |
| build time | 272 ms (no flag) | 265 ms (flag) |
| 50-route synthetic React SPA: JS files | 242 (no flag) / 209 (flag) | 123 |
| requests per route navigation | 54 / 25 | 15 |
| route navigation, headless Chrome, LTE / 4G emulation | 535 / 676 ms (no flag) | 412 / 616 ms |
| adversarial 1000-route / 8000-module synthetic where nothing can fold: build | 293 ms (no flag), 380 ms (flag) | 306 ms (flag) |

The 50-route app's self-test output is byte-identical to the unfolded build; Medusa `/login`, `/orders`, `/products` render in headless Chrome.

### How did you verify your code works?

`test/bundler/bundler_splitting.test.ts`:
- `MinChunkSizeBarrelRecordIsNotAnImport` — the Medusa shape (live `sideEffects:false` barrel in the entry chunk re-exporting route-only modules that `require()` a CommonJS module from the entry chunk); on main the output throws `require_lib is not a function`.
- `MinChunkSizeFoldsImporterOfInitializedWrappedModule` / `MinChunkSizeKeepsFirstInitializerOfWrappedModule` — a `require_lib()` importer moves only when `lib`'s own chunk already initializes it.
- `MinChunkSizeHoistedRequireKeepsChunkOrder` — a moved `require_lib()` does not pull its new chunk's side effects ahead of a sibling import.
- `MinChunkSizeDefault{Browser,BrowserZero,BrowserOn,Bun,BunOn}` — off unless asked for on every target.
- Two existing expectations updated for folds the dominator change enables (commented in place).

Also ran `esbuild/splitting`, `bundler_compile_splitting`, `bundler_html`, `bundler_edgecase`, `bundler_barrel`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_dynamic_import_dce`, `esbuild/default`, `esbuild/importstar`, `esbuild/css`, `css-modules`, `metafile`, `bundler_regressions` on the debug build.