### PR TITLE
Fix crash when SharedArrayBuffer-backed TypedArray is passed to IDLArrayBufferRef converter

### DIFF
--- a/src/jsc/bindings/BunIDLConvert.h
+++ b/src/jsc/bindings/BunIDLConvert.h
@@ -189,10 +189,18 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
             return jsBuffer;
         }
         if (auto* jsView = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
-            return jsView->unsharedBuffer();
+            if (jsView->isShared())
+                return std::nullopt;
+            if (auto* buf = jsView->unsharedBuffer())
+                return buf;
+            return std::nullopt;
         }
         if (auto* jsDataView = dynamicDowncast<JSC::JSDataView>(value)) {
-            return jsDataView->unsharedBuffer();
+            if (jsDataView->isShared())
+                return std::nullopt;
+            if (auto* buf = jsDataView->unsharedBuffer())
+                return buf;
+            return std::nullopt;
         }
         return std::nullopt;
     }

--- a/src/jsc/bindings/BunIDLConvert.h
+++ b/src/jsc/bindings/BunIDLConvert.h
@@ -188,8 +188,7 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
         if (auto* jsBuffer = JSC::toUnsharedArrayBuffer(vm, value)) {
             return jsBuffer;
         }
-        // This branch also matches DataView: dynamicDowncast<JSArrayBufferView>
-        // covers the whole typed-array JSType range, which ends at DataViewType.
+        // Also matches DataView: the JSArrayBufferView JSType range ends at DataViewType.
         if (auto* jsView = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
             if (jsView->isShared())
                 return std::nullopt;

--- a/src/jsc/bindings/BunIDLConvert.h
+++ b/src/jsc/bindings/BunIDLConvert.h
@@ -188,17 +188,12 @@ template<> struct WebCore::Converter<Bun::IDLArrayBufferRef>
         if (auto* jsBuffer = JSC::toUnsharedArrayBuffer(vm, value)) {
             return jsBuffer;
         }
+        // This branch also matches DataView: dynamicDowncast<JSArrayBufferView>
+        // covers the whole typed-array JSType range, which ends at DataViewType.
         if (auto* jsView = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
             if (jsView->isShared())
                 return std::nullopt;
             if (auto* buf = jsView->unsharedBuffer())
-                return buf;
-            return std::nullopt;
-        }
-        if (auto* jsDataView = dynamicDowncast<JSC::JSDataView>(value)) {
-            if (jsDataView->isShared())
-                return std::nullopt;
-            if (auto* buf = jsDataView->unsharedBuffer())
                 return buf;
             return std::nullopt;
         }

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -152,19 +152,20 @@ describe("Bun.serve SSL validations", () => {
     }
   }
 
-  test("SharedArrayBuffer-backed TypedArray as ALPNProtocols does not crash", () => {
-    const shared = new SharedArrayBuffer(16);
-    for (const view of [new Int16Array(shared), new DataView(shared)]) {
-      expect(() => {
-        using server = Bun.serve({
-          port: 0,
-          fetch() {
-            return new Response("ok");
-          },
-          ALPNProtocols: view,
-        });
-      }).toThrow(TypeError);
-    }
+  test.each([
+    ["Int16Array", (buffer: SharedArrayBuffer) => new Int16Array(buffer)],
+    ["DataView", (buffer: SharedArrayBuffer) => new DataView(buffer)],
+  ] as const)("SharedArrayBuffer-backed %s as ALPNProtocols does not crash", (_name, makeView) => {
+    const view = makeView(new SharedArrayBuffer(16));
+    expect(() => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("ok");
+        },
+        ALPNProtocols: view,
+      });
+    }).toThrow(TypeError);
   });
 });
 

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -151,6 +151,20 @@ describe("Bun.serve SSL validations", () => {
       });
     }
   }
+
+  test("SharedArrayBuffer-backed TypedArray as ALPNProtocols does not crash", () => {
+    const shared = new SharedArrayBuffer(16);
+    const view = new Int16Array(shared);
+    expect(() => {
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response("ok");
+        },
+        ALPNProtocols: view,
+      });
+    }).toThrow(TypeError);
+  });
 });
 
 describe("Bun.serve per-serverName client certificate policy", () => {

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
+import { bunEnv, bunExe } from "harness";
 import tls from "node:tls";
 import { join } from "path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
@@ -152,21 +153,24 @@ describe("Bun.serve SSL validations", () => {
     }
   }
 
-  test.each([
-    ["Int16Array", (buffer: SharedArrayBuffer) => new Int16Array(buffer)],
-    ["DataView", (buffer: SharedArrayBuffer) => new DataView(buffer)],
-  ] as const)("SharedArrayBuffer-backed %s as ALPNProtocols does not crash", (_name, makeView) => {
-    const view = makeView(new SharedArrayBuffer(16));
-    expect(() => {
-      using server = Bun.serve({
-        port: 0,
-        fetch() {
-          return new Response("ok");
-        },
-        ALPNProtocols: view,
+  // Spawned so a regressed RELEASE_ASSERT aborts the child, not this test file.
+  test.concurrent.each(["Int16Array", "DataView"])(
+    "SharedArrayBuffer-backed %s as ALPNProtocols does not crash",
+    async viewType => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `Bun.serve({ port: 0, fetch() { return new Response("ok"); }, ALPNProtocols: new ${viewType}(new SharedArrayBuffer(16)) });`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
       });
-    }).toThrow(TypeError);
-  });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("TypeError");
+      expect(exitCode).toBe(1);
+    },
+  );
 });
 
 describe("Bun.serve per-serverName client certificate policy", () => {

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -154,16 +154,17 @@ describe("Bun.serve SSL validations", () => {
 
   test("SharedArrayBuffer-backed TypedArray as ALPNProtocols does not crash", () => {
     const shared = new SharedArrayBuffer(16);
-    const view = new Int16Array(shared);
-    expect(() => {
-      using server = Bun.serve({
-        port: 0,
-        fetch() {
-          return new Response("ok");
-        },
-        ALPNProtocols: view,
-      });
-    }).toThrow(TypeError);
+    for (const view of [new Int16Array(shared), new DataView(shared)]) {
+      expect(() => {
+        using server = Bun.serve({
+          port: 0,
+          fetch() {
+            return new Response("ok");
+          },
+          ALPNProtocols: view,
+        });
+      }).toThrow(TypeError);
+    }
   });
 });
 

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -161,7 +161,7 @@ describe("Bun.serve SSL validations", () => {
         cmd: [
           bunExe(),
           "-e",
-          `Bun.serve({ port: 0, fetch() { return new Response("ok"); }, ALPNProtocols: new ${viewType}(new SharedArrayBuffer(16)) });`,
+          `const server = Bun.serve({ port: 0, fetch() { return new Response("ok"); }, ALPNProtocols: new ${viewType}(new SharedArrayBuffer(16)) }); server.stop(true); process.exit(2);`,
         ],
         env: bunEnv,
         stderr: "pipe",


### PR DESCRIPTION
Supersedes #28428 (same commits, moved to a correctly-prefixed branch).

## What does this PR do?

When a TypedArray backed by a `SharedArrayBuffer` was passed where an unshared `ArrayBuffer` was expected (for example `ALPNProtocols`, `ca`, `key`, or `cert` in `Bun.serve()`), `JSArrayBufferView::unsharedBuffer()` hit a `RELEASE_ASSERT` and aborted the process.

**Crash**: `ASSERTION FAILED: !result || !result->isShared()` at `JSArrayBufferView.cpp(224)`

**Repro**:
```js
const v = new Int16Array(new SharedArrayBuffer(16));
Bun.serve({ fetch() { return new Response(); }, ALPNProtocols: v });
```

The fix checks `isShared()` in the `IDLArrayBufferRef` converter before calling `unsharedBuffer()`, returning `std::nullopt` so the union converter throws a proper `TypeError`. A null return from `unsharedBuffer()` is handled the same way. The unreachable `JSDataView` branch is removed (DataView is matched by the `JSArrayBufferView` cast) and the regression test covers DataView too.

## How did you verify your code works?

- `bun bd test test/js/bun/http/bun-serve-ssl.test.ts`: all tests pass, including the new SharedArrayBuffer regression test.
- `USE_SYSTEM_BUN=1` on the same test crashes the process, confirming the test catches the bug.
- The fuzzer reproduces this fingerprint repeatedly on main; the fix covers every field routed through the converter.

Review history: #28428 carries the full review discussion and repeated LGTMs.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 51 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [9.26ms]
(pass) Bun.serve SSL validations > invalid key #2 development [1.93ms]
(pass) Bun.serve SSL validations > invalid cert development [2.19ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [29.00ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.41ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [2.02ms]
(pass) Bun.serve SSL validations > invalid key production [1.93ms]
(pass) Bun.serve SSL validations > invalid key #2 production [2.02ms]
(pass) Bun.serve SSL validations > invalid cert production [1.71ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.52ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.66ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [2.39ms]
(pass) Bun.se
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [0.28ms]
(pass) Bun.serve SSL validations > invalid key #2 development [0.06ms]
(pass) Bun.serve SSL validations > invalid cert development [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [2.87ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [0.03ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [0.01ms]
(pass) Bun.serve SSL validations > invalid key production [0.04ms]
(pass) Bun.serve SSL validations > invalid key #2 production [0.03ms]
(pass) Bun.serve SSL validations > invalid cert production [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [0.27ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [0.01ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [0.01ms]
(pass) Bun.serve SSL validations > valid development [4.45ms]
(pass) Bun.serve SSL validations > valid 2 development [2.44ms]
(pass) Bun.serve SSL validations > valid productio
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [9.36ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.19ms]
(pass) Bun.serve SSL validations > invalid cert development [1.61ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [29.11ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.57ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [1.69ms]
(pass) Bun.serve SSL validations > invalid key production [2.44ms]
(pass) Bun.serve SSL validations > invalid key #2 production [1.74ms]
(pass) Bun.serve SSL validations > invalid cert production [2.13ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.46ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.65ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [1.91ms]
(pass) Bun.se
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 598ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/11] cxx obj/codegen/GeneratedSocketConfig.cpp.o
[2/11] cxx obj/codegen/GeneratedSocketConfigHandlers.cpp.o
[3/11] cxx obj/codegen/GeneratedSSLConfig.cpp.o
[4/11] cxx obj/codegen/GeneratedFakeTimersConfig.cpp.o
[5/11] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[6/11] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[6/11] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunIDLConvert.h       | 10 ++++++----
 test/js/bun/http/bun-serve-ssl.test.ts | 20 ++++++++++++++++++++
 2 files changed, 26 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 51

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/bindings/BunIDLConvert.h            0      0     36
test/js/bun/http/bun-serve-ssl.test.ts     11      9     36
```

</details>

**root cause** · written by the author bot

When Bun.serve received a TypedArray or DataView backed by a SharedArrayBuffer for an option converted via IDLArrayBufferRef, the converter called unsharedBuffer() on a shared view, tripping a debug assertion in JavaScriptCore and aborting the process. The fix adds an isShared() guard and a null check on the unsharedBuffer() result in the converter, so shared views are rejected with a TypeError instead of reaching the assertion. Regression tests spawn a child process per view type to confirm the TypeError is thrown and the process no longer crashes.

<!-- robobun:evidence:end -->