### PR TITLE
minify: never give a slot the name of a pinned symbol

### DIFF
--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -41,9 +41,7 @@ pub struct Scope {
     // evaluated code might reference anything that it has access to.
     pub contains_direct_eval: bool,
 
-    // Set on a "with" statement's scope and every scope that encloses it. A
-    // symbol read through the "with" body keeps its original name, so the
-    // renamer walks these scopes to keep those names away from other symbols.
+    // Set on a "with" scope and every scope that encloses it, for compute_reserved_names_for_scope.
     pub contains_with: bool,
 
     // This is to help forbid "arguments" inside class body scopes

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -41,6 +41,11 @@ pub struct Scope {
     // evaluated code might reference anything that it has access to.
     pub contains_direct_eval: bool,
 
+    // Set on a "with" statement's scope and every scope that encloses it. A
+    // symbol read through the "with" body keeps its original name, so the
+    // renamer walks these scopes to keep those names away from other symbols.
+    pub contains_with: bool,
+
     // This is to help forbid "arguments" inside class body scopes
     pub forbid_arguments: bool,
 
@@ -73,6 +78,7 @@ impl Scope {
         label_ref: Ref::NONE,
         label_stmt_is_loop: false,
         contains_direct_eval: false,
+        contains_with: false,
         forbid_arguments: false,
         strict_mode: StrictModeKind::SloppyMode,
         is_after_const_local_prefix: false,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3275,6 +3275,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Check for collisions that would prevent to hoisting "var" symbols up to the enclosing function scope
             if let Some(scope_parent) = scope_ref.parent {
                 let scope_strict_mode = scope_ref.strict_mode;
+                let scope_is_with = scope_ref.kind == js_ast::scope::Kind::With;
                 // The loop below never inserts into `scope.members` itself (only ancestors), so
                 // snapshotting `(name_ptr, Member)` pairs up front preserves iteration semantics
                 // and lets us re-borrow `*scope` mutably inside the body.
@@ -3317,6 +3318,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     if !self.symbols[symbol_idx].is_hoisted() {
                         continue;
+                    }
+
+                    // `with (obj) var t = 2` declares `t` in the "with" scope
+                    // itself. The walk below starts at the parent, so it does
+                    // not see that scope.
+                    if scope_is_with {
+                        self.set_must_not_be_renamed_through_links(value.ref_);
                     }
 
                     let mut __scope: Option<js_ast::StoreRef<Scope>> = Some(scope_parent);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1856,9 +1856,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Pins `ref_` and every symbol on its link chain. The renamer follows
-    /// the chain before it reads the flag, so a pin on a linked ref alone is
-    /// lost.
+    /// The renamer follows links before it reads the flag, so pin the whole chain.
     pub(crate) fn set_must_not_be_renamed_through_links(&mut self, ref_: Ref) {
         let mut ref_ = ref_;
         loop {
@@ -3320,9 +3318,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         continue;
                     }
 
-                    // `with (obj) var t = 2` declares `t` in the "with" scope
-                    // itself. The walk below starts at the parent, so it does
-                    // not see that scope.
+                    // `with (obj) var t = 2` declares `t` in the "with" scope, which the walk below starts above.
                     if scope_is_with {
                         self.set_must_not_be_renamed_through_links(value.ref_);
                     }
@@ -3610,10 +3606,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.has_with_scope = true;
             }
 
-            // The renamer reserves the names of the symbols this body can read
-            // (`compute_reserved_names_for_scope`). Those symbols live in the
-            // enclosing scopes, so mark the whole chain. An ancestor that is
-            // already marked has its own ancestors marked too.
+            // Marked up the chain like contains_direct_eval, for compute_reserved_names_for_scope.
             let mut scope_iter: Option<js_ast::StoreRef<Scope>> = Some(scope);
             while let Some(mut s) = scope_iter {
                 if s.contains_with {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1856,6 +1856,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Pins `ref_` and every symbol on its link chain. The renamer follows
+    /// the chain before it reads the flag, so a pin on a linked ref alone is
+    /// lost.
+    pub(crate) fn set_must_not_be_renamed_through_links(&mut self, ref_: Ref) {
+        let mut ref_ = ref_;
+        loop {
+            let symbol = &mut self.symbols[ref_.inner_index() as usize];
+            symbol.set_must_not_be_renamed(true);
+            if !symbol.has_link() {
+                return;
+            }
+            ref_ = symbol.link.get();
+        }
+    }
+
     pub(crate) fn log_arrow_arg_errors(&mut self, errors: &mut DeferredArrowArgErrors) {
         if errors.invalid_expr_await.len > 0 {
             let r = errors.invalid_expr_await;
@@ -3372,7 +3387,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         //   assert(obj.foo === 2)
                         //
                         if scope_kind == js_ast::scope::Kind::With {
-                            self.symbols[symbol_idx].set_must_not_be_renamed(true);
+                            self.set_must_not_be_renamed_through_links(value.ref_);
                         }
 
                         if let Some(member_in_scope) =
@@ -3397,6 +3412,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             {
                                 // Silently merge this symbol into the existing symbol
                                 self.symbols[symbol_idx].link.set(member_in_scope.ref_);
+                                if self.symbols[symbol_idx].must_not_be_renamed() {
+                                    self.set_must_not_be_renamed_through_links(
+                                        member_in_scope.ref_,
+                                    );
+                                }
                                 // `StringHashMap` get_or_put already stores the key on insert and
                                 // cannot hand out `&mut K` (see StringHashMapGetOrPut docs), so
                                 // no key write is needed here.
@@ -3580,6 +3600,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // "with" statements are not allowed in strict mode.
             if self.options.features.commonjs_at_runtime {
                 self.has_with_scope = true;
+            }
+
+            // The renamer reserves the names of the symbols this body can read
+            // (`compute_reserved_names_for_scope`). Those symbols live in the
+            // enclosing scopes, so mark the whole chain. An ancestor that is
+            // already marked has its own ancestors marked too.
+            let mut scope_iter: Option<js_ast::StoreRef<Scope>> = Some(scope);
+            while let Some(mut s) = scope_iter {
+                if s.contains_with {
+                    break;
+                }
+                s.contains_with = true;
+                scope_iter = s.parent;
             }
         }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3318,11 +3318,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         continue;
                     }
 
-                    // `with (obj) var t = 2` declares `t` in the "with" scope, which the walk below starts above.
-                    if scope_is_with {
-                        self.set_must_not_be_renamed_through_links(value.ref_);
-                    }
-
                     let mut __scope: Option<js_ast::StoreRef<Scope>> = Some(scope_parent);
                     debug_assert!(__scope.is_some());
 
@@ -3368,6 +3363,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             symbol_idx = hoisted_ref.inner_index() as usize;
                             is_sloppy_mode_block_level_fn_stmt = true;
                         }
+                    }
+
+                    // `with (obj) var t = 2` declares `t` in the "with" scope, which the walk below starts above.
+                    if scope_is_with {
+                        self.set_must_not_be_renamed_through_links(value.ref_);
                     }
 
                     if hash.is_none() {

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -136,7 +136,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // property on the target object of the "with" statement. We must not rename
         // it or we risk changing the behavior of the code.
         if is_inside_with_scope {
-            self.symbols[ref_.inner_index() as usize].set_must_not_be_renamed(true);
+            self.set_must_not_be_renamed_through_links(ref_);
         }
 
         // Track how many times we've referenced this symbol

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7633,8 +7633,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     let module_scope = &tree.module_scope;
     let stable_source_indices = [source.index.0];
     let renamer: rename::Renamer<'_, '_> = if opts.minify_identifiers {
-        // Pinned before the reserved names are computed, so no slot is given
-        // one of these names.
+        // Pinned before the reserved names are computed so no slot takes one of these names.
         let dont_break_the_code = [tree.module_ref, tree.exports_ref, tree.require_ref];
         for ref_ in dont_break_the_code {
             if let Some(symbol) = symbols.get_mut(ref_) {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7611,7 +7611,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     _writer: W,
     bump: &'a bun_alloc::Arena,
     tree: &'a Ast,
-    symbols: js_ast::symbol::Map,
+    mut symbols: js_ast::symbol::Map,
     source: &'a bun_ast::Source,
     opts: Options<'a>,
 ) -> crate::Result<usize> {
@@ -7633,6 +7633,21 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     let module_scope = &tree.module_scope;
     let stable_source_indices = [source.index.0];
     let renamer: rename::Renamer<'_, '_> = if opts.minify_identifiers {
+        // Pinned before the reserved names are computed, so no slot is given
+        // one of these names.
+        let dont_break_the_code = [tree.module_ref, tree.exports_ref, tree.require_ref];
+        for ref_ in dont_break_the_code {
+            if let Some(symbol) = symbols.get_mut(ref_) {
+                symbol.set_must_not_be_renamed(true);
+            }
+        }
+
+        for named_export in tree.named_exports.values() {
+            if let Some(symbol) = symbols.get_mut(named_export.ref_) {
+                symbol.set_must_not_be_renamed(true);
+            }
+        }
+
         let mut reserved_names = rename::compute_initial_reserved_names(opts.module_type)?;
         for child in module_scope.children.slice() {
             // `StoreRef<Scope>` has safe `DerefMut`; copy the handle to a mut
@@ -7655,21 +7670,6 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         let exports_ref = tree.exports_ref;
         let module_ref = tree.module_ref;
         let parts = &tree.parts;
-
-        // `symbols` was moved into `minify_renamer`; reach it through
-        // the renamer for the post-init `must_not_be_renamed` pass.
-        let dont_break_the_code = [tree.module_ref, tree.exports_ref, tree.require_ref];
-        for ref_ in dont_break_the_code {
-            if let Some(symbol) = minify_renamer.symbols.get_mut(ref_) {
-                symbol.set_must_not_be_renamed(true);
-            }
-        }
-
-        for named_export in tree.named_exports.values() {
-            if let Some(symbol) = minify_renamer.symbols.get_mut(named_export.ref_) {
-                symbol.set_must_not_be_renamed(true);
-            }
-        }
 
         if uses_exports_ref {
             minify_renamer.accumulate_symbol_use_count(

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1218,12 +1218,16 @@ pub fn compute_reserved_names_for_scope(
         }
     }
 
-    // If there's a direct "eval" somewhere inside the current scope, continue
-    // traversing down the scope tree until we find it to get all reserved names
-    if scope.contains_direct_eval {
+    // If there's a direct "eval" or a "with" statement somewhere inside the
+    // current scope, continue traversing down the scope tree until we find it
+    // to get all reserved names. Symbols pinned by either have no slot, so
+    // reserving their names is what keeps the minifier from giving one to a
+    // symbol in an enclosing scope, like a parameter of the function that
+    // declares a `var` read through the "with" body.
+    if scope.contains_direct_eval || scope.contains_with {
         for child in scope.children.slice() {
             // `StoreRef<Scope>: Deref<Target = Scope>` — safe arena-backed deref.
-            if child.contains_direct_eval {
+            if child.contains_direct_eval || child.contains_with {
                 compute_reserved_names_for_scope(child, symbols, names);
             }
         }

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1218,8 +1218,7 @@ pub fn compute_reserved_names_for_scope(
         }
     }
 
-    // If there's a direct "eval" or a "with" somewhere inside the current scope,
-    // continue traversing down the scope tree until we find it to get all reserved names
+    // Keep traversing down the scope tree toward a direct "eval" or a "with" to get all reserved names
     if scope.contains_direct_eval || scope.contains_with {
         for child in scope.children.slice() {
             // `StoreRef<Scope>: Deref<Target = Scope>` — safe arena-backed deref.

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1218,12 +1218,8 @@ pub fn compute_reserved_names_for_scope(
         }
     }
 
-    // If there's a direct "eval" or a "with" statement somewhere inside the
-    // current scope, continue traversing down the scope tree until we find it
-    // to get all reserved names. Symbols pinned by either have no slot, so
-    // reserving their names is what keeps the minifier from giving one to a
-    // symbol in an enclosing scope, like a parameter of the function that
-    // declares a `var` read through the "with" body.
+    // If there's a direct "eval" or a "with" somewhere inside the current scope,
+    // continue traversing down the scope tree until we find it to get all reserved names
     if scope.contains_direct_eval || scope.contains_with {
         for child in scope.children.slice() {
             // `StoreRef<Scope>: Deref<Target = Scope>` — safe arena-backed deref.

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -19,6 +19,66 @@ describe("bundler", () => {
     },
     run: { stdout: "top fn" },
   });
+
+  // A symbol read through a `with` body keeps its original name. The renamer
+  // must not give that name to another symbol the body can see, such as the
+  // parameter of the enclosing function: `function f(obj) { var t = 1; with
+  // (obj) { return t } }` printed as `function f(t) { var t = 1; with (t)
+  // return t }` reads the local instead of `obj.t`. Each `f_` function pins
+  // one of the 54 single-character names the minifier can produce, so
+  // whichever name the (most used) parameter slot gets, one `with` body breaks
+  // without the fix. `hoisted` and `merged` declare the pinned `var` twice, so
+  // the reference that the `with` pins is a link to the function-level symbol,
+  // which has to keep its name too.
+  const singleCharNames = [..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$"];
+  const withPinnedNamesSource = [
+    ...singleCharNames.map(n => `function f_${n}(obj) { var ${n} = 1; obj.p; obj.p; with (obj) { return ${n}; } }`),
+    "function hoisted(obj) { var t = 1; obj.p; obj.p; with (obj) { var t = 2; } return [t, obj.t]; }",
+    "function merged(obj) { var t = 1; obj.p; obj.p; { var t = 2; with (obj) { return t; } } }",
+    "const bad = [];",
+    ...singleCharNames.map(n => `if (f_${n}({}) !== 1 || f_${n}({ ${n}: 9 }) !== 9) bad.push("${n}");`),
+    `if (JSON.stringify([hoisted({}), hoisted({ t: 9 })]) !== "[[2,null],[1,2]]") bad.push("hoisted");`,
+    `if (merged({}) !== 2 || merged({ t: 9 }) !== 9) bad.push("merged");`,
+    "console.log(JSON.stringify(bad));",
+  ].join("\n");
+  itBundled("minify/WithStatementPinnedNameNotReusedByEnclosingScope", {
+    files: {
+      "/entry.js": withPinnedNamesSource,
+    },
+    format: "cjs",
+    minifyIdentifiers: true,
+    run: { stdout: "[]" },
+  });
+  // `bun build --no-bundle` names symbols through the same reserved set.
+  itBundled("minify/WithStatementPinnedNameNotReusedByEnclosingScopeNoBundle", {
+    files: {
+      "/entry.js": withPinnedNamesSource,
+    },
+    bundling: false,
+    format: "cjs",
+    minifyIdentifiers: true,
+    run: { stdout: "[]" },
+  });
+  // `bun build --no-bundle` keeps the export names. They were pinned after the
+  // reserved names were computed, so a local in a nested function could take
+  // one of them and shadow the export it reads.
+  itBundled("minify/NoBundleExportNameNotReusedByLocal", {
+    files: {
+      "/entry.js": [
+        ...singleCharNames.map(n => `export const ${n} = "${n}";`),
+        "export function check() {",
+        "  let local = 0; local; local;",
+        "  const bad = [];",
+        ...singleCharNames.map(n => `  if (${n} !== "${n}") bad.push("${n}");`),
+        "  return bad;",
+        "}",
+        "console.log(JSON.stringify(check()));",
+      ].join("\n"),
+    },
+    bundling: false,
+    minifyIdentifiers: true,
+    run: { stdout: "[]" },
+  });
   itBundled("minify/TemplateStringFolding", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -29,16 +29,19 @@ describe("bundler", () => {
   // whichever name the (most used) parameter slot gets, one `with` body breaks
   // without the fix. `hoisted` and `merged` declare the pinned `var` twice, so
   // the reference that the `with` pins is a link to the function-level symbol,
-  // which has to keep its name too.
+  // which has to keep its name too. `braceless` declares the `var` in the
+  // `with` scope itself, which the hoisting walk starts above.
   const singleCharNames = [..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$"];
   const withPinnedNamesSource = [
     ...singleCharNames.map(n => `function f_${n}(obj) { var ${n} = 1; obj.p; obj.p; with (obj) { return ${n}; } }`),
     "function hoisted(obj) { var t = 1; obj.p; obj.p; with (obj) { var t = 2; } return [t, obj.t]; }",
     "function merged(obj) { var t = 1; obj.p; obj.p; { var t = 2; with (obj) { return t; } } }",
+    "function braceless(obj) { obj.p; obj.p; with (obj) var t = 2; return [t, obj.t]; }",
     "const bad = [];",
     ...singleCharNames.map(n => `if (f_${n}({}) !== 1 || f_${n}({ ${n}: 9 }) !== 9) bad.push("${n}");`),
     `if (JSON.stringify([hoisted({}), hoisted({ t: 9 })]) !== "[[2,null],[1,2]]") bad.push("hoisted");`,
     `if (merged({}) !== 2 || merged({ t: 9 }) !== 9) bad.push("merged");`,
+    `if (JSON.stringify([braceless({}), braceless({ t: 9 })]) !== "[[2,null],[null,2]]") bad.push("braceless");`,
     "console.log(JSON.stringify(bad));",
   ].join("\n");
   itBundled("minify/WithStatementPinnedNameNotReusedByEnclosingScope", {


### PR DESCRIPTION
### Problem
- `bun build --minify` can give a parameter the name of a `var` that a nested `with` body reads. `function f(o) { var t = 1; with (o) { return t } }` prints as `function f(t){var t=1;with(t)return t}`, so `f({ t: 9 })` returns 1 instead of 9. esbuild 0.25.1 does the same.
- A pinned symbol keeps its name and gets no slot, but `compute_reserved_names_for_scope` (`src/js_printer/renamer.rs:1196`) only reserves the pinned names of the module scope and of direct eval scopes.
- Three sibling holes: with a `var` declared twice, the `with` pin lands on a linked ref and the renamer follows the link (`src/js_parser/p.rs:3389`, `scan_symbols.rs:138`). `with (obj) var t = 2` declares `t` in the `with` scope, which the hoisting walk starts above, so it is never pinned. `bun build --no-bundle` pins its exports after the reserved set is computed (`src/js_printer/lib.rs:7635`).

### Fix
- Add `Scope.contains_with`, set on a `with` scope and on every scope that encloses it like `contains_direct_eval`. `compute_reserved_names_for_scope` walks into children with either flag. Slot names are chunk-wide, so the reservation is too.
- Pin through the link chain at both `with` pin sites and when hoisting links a pinned symbol to an existing one. Pin the members of a `with` scope before the walk. In `print_ast`, pin the exports first.
- Correct because a `with` body only pins symbols declared in its scope or in an ancestor, and the pin now reaches the symbol the renamer names. Unflagged scopes are not walked, as before.
- Verified: `test/bundler/bundler_minify.test.ts`, three new cases that fail on 1.4.1 (`["t","hoisted","merged","braceless"]` and `["o","t"]`). Also ran `bundler_splitting`, `bundler_edgecase`, `esbuild/default` and the transpiler suites.

### Background
- The parser gives each nested symbol a slot. The linker picks one name per slot for the whole chunk, skipping `reserved_names` (keywords, unbound globals, pinned names). Pinned (`must_not_be_renamed`) symbols keep their name and get no slot.
- A `var` declared twice in one function is two symbols. Hoisting links the inner one to the function-level one, and every consumer follows the link.

<details><summary>Notes</summary>

- Pinned symbols are unbound globals, the members of scopes with a direct eval, symbols read or hoisted through a `with` body, and the exports of a `--no-bundle` build. Cross-chunk naming unions the reserved set of every chunk.
- The implicit `arguments` symbol of each function on the marked path is pinned too and lands in the reserved set. The minifier never produces a nine character name, and a direct eval already reserves it the same way.
- The link cases on 1.4.1: `var t = 1; with (obj) { var t = 2 } return [t, obj.t]` gives `[2, 9]` for `{ t: 9 }` instead of `[1, 2]`, and `var t = 1; { var t = 2; with (obj) { return t } }` gives 2 instead of 9. Both print `var n` for the pinned `t`.
- The brace-less case on 1.4.1: `with (obj) var t = 2; return [t, obj.t]` gives `[2, 9]` for `{ t: 9 }` instead of `[undefined, 2]`. esbuild 0.25.1 renames it too.
- The export case on 1.4.1: `bun build --no-bundle --minify-identifiers` on a file with `export const t = ...` and a function whose local is the most used nested slot prints `let t = 0` inside that function.
- The `f_` functions in the test pin all 54 single-character names through `with` bodies, one function each, so the test does not depend on which name the character frequency puts first. The two `with` cases use `format: "cjs"` so the output stays sloppy mode whatever the ESM defaults become.
- Not changed here: `const u = 1; with (obj) { return u }` is folded to `return 1` by the parser's constant substitution, under `--minify` and under `bun run`. That is a separate mechanism (`must_keep_due_to_with_stmt` is not checked there) and needs its own change.
- Clippy is clean on `bun_ast`, `bun_js_parser` and `bun_js_printer`.
</details>
