### PR TITLE
test(sql): prestart mariadb for sql-empty-column-name, one mock child per adapter, assert whole rows

### DIFF
--- a/test/docker/prestart-map.mjs
+++ b/test/docker/prestart-map.mjs
@@ -12,6 +12,7 @@
 export const prestartMap = {
   "js/sql/sql-mysql": ["mysql_plain", "mysql_native_password", "mysql_tls"],
   "js/sql/sql-mariadb": ["mariadb_plain"],
+  "js/sql/sql-empty-column-name": ["mariadb_plain"],
   "js/sql/tls-sql": ["postgres_tls"],
   "js/sql/local-sql": ["postgres_tls"],
   "js/sql/sql.test": ["postgres_plain"],

--- a/test/js/sql/sql-empty-column-name.fixture.ts
+++ b/test/js/sql/sql-empty-column-name.fixture.ts
@@ -1,11 +1,16 @@
-// Spawned by sql-empty-column-name.test.ts. Serves one result set whose
-// column names are given on the command line from an in-process mock server,
-// queries it with Bun.SQL and prints the decoded rows as JSON. It runs in its
-// own process because the bug under test takes the whole process down.
+// Spawned by sql-empty-column-name.test.ts. Takes a JSON array of jobs on the
+// command line and, for each one in order, serves one result set from an
+// in-process mock server, queries it with Bun.SQL and prints one line of JSON:
+// the job without its `names`, plus the decoded `rows`. One process runs many
+// jobs because a debug build pays most of a second to start up and
+// milliseconds per job. It is still a separate process because the bug under
+// test takes the whole process down: a crash shows up as a truncated list of
+// lines plus a signal, not as a dead test runner.
 //
-// Usage: <adapter: postgres | mysql> <protocol: simple | prepared> <JSON array of column names>
-// Every column holds the text value "v<index>". The mock servers ignore the
-// statement text; the result set they return is defined entirely by the names.
+// A job is `{ adapter: "postgres" | "mysql", protocol: "simple" | "prepared",
+// names: string[], ...rest }`; `rest` is echoed back untouched. Every column
+// holds the text value "v<index>". The mock servers ignore the statement text;
+// the result set they return is defined entirely by the names.
 //
 // All wire bytes come from ./wire-frames.ts.
 
@@ -33,9 +38,7 @@ import {
   pgRowDescription,
 } from "./wire-frames";
 
-const [adapter, protocol, namesJson] = process.argv.slice(2);
-const names: string[] = JSON.parse(namesJson);
-const values = names.map((_, i) => `v${i}`);
+type Job = { adapter: "postgres" | "mysql"; protocol: "simple" | "prepared"; names: string[] };
 
 const PG_TEXT_OID = 25;
 const COM_QUERY = 0x03;
@@ -44,7 +47,11 @@ const COM_STMT_EXECUTE = 0x17;
 const COM_STMT_CLOSE = 0x19;
 const MYSQL_TYPE_VAR_STRING = 0xfd;
 
-async function postgresServer() {
+const valuesFor = (names: string[]) => names.map((_, i) => `v${i}`);
+
+async function postgresServer(names: string[]) {
+  const values = valuesFor(names);
+  const rowDescription = pgRowDescription(names.map(name => ({ name, typeOid: PG_TEXT_OID })));
   const resultRows = Buffer.concat([pgDataRow(values.map(v => Buffer.from(v))), pgCommandComplete("SELECT 1")]);
   return listeningServer(socket => {
     socket.on("error", () => {});
@@ -60,17 +67,13 @@ async function postgresServer() {
       buffered = pgReadFrontendMessages(Buffer.concat([buffered, data]), type => {
         switch (String.fromCharCode(type)) {
           case "Q": // simple query
-            out.push(
-              pgRowDescription(names.map(name => ({ name, typeOid: PG_TEXT_OID }))),
-              resultRows,
-              pgReadyForQuery(),
-            );
+            out.push(rowDescription, resultRows, pgReadyForQuery());
             break;
           case "P": // Parse
             out.push(pgParseComplete());
             break;
           case "D": // Describe (statement)
-            out.push(pgParameterDescription([]), pgRowDescription(names.map(name => ({ name, typeOid: PG_TEXT_OID }))));
+            out.push(pgParameterDescription([]), rowDescription);
             break;
           case "B": // Bind
             out.push(pgBindComplete());
@@ -88,7 +91,8 @@ async function postgresServer() {
   });
 }
 
-async function mysqlServer() {
+async function mysqlServer(names: string[]) {
+  const values = valuesFor(names);
   const columns = names.map(name => ({ name, type: MYSQL_TYPE_VAR_STRING }));
   const columnDefinitions = (firstSeq: number) =>
     Buffer.concat(columns.map((column, i) => mysqlColumnDefinition(firstSeq + i, column)));
@@ -139,12 +143,15 @@ async function mysqlServer() {
   });
 }
 
-const { server, port } = adapter === "postgres" ? await postgresServer() : await mysqlServer();
-try {
-  await using sql = new SQL({ url: `${adapter}://u@127.0.0.1:${port}/db`, max: 1 });
-  const query = sql`select 1`;
-  const rows = await (protocol === "simple" ? query.simple() : query);
-  console.log(JSON.stringify(rows));
-} finally {
-  server.close();
+const jobs: Job[] = JSON.parse(process.argv[2]);
+for (const { names, ...job } of jobs) {
+  const { server, port } = job.adapter === "postgres" ? await postgresServer(names) : await mysqlServer(names);
+  try {
+    await using sql = new SQL({ url: `${job.adapter}://u@127.0.0.1:${port}/db`, max: 1 });
+    const query = sql`select 1`;
+    const rows = await (job.protocol === "simple" ? query.simple() : query);
+    console.log(JSON.stringify({ ...job, rows }));
+  } finally {
+    server.close();
+  }
 }

--- a/test/js/sql/sql-empty-column-name.test.ts
+++ b/test/js/sql/sql-empty-column-name.test.ts
@@ -10,8 +10,9 @@
 // the bottom). Postgres itself rejects `as ""` (zero-length delimited
 // identifier), so for that adapter an empty name only comes from a proxy or a
 // misbehaving server; the mock servers in sql-empty-column-name.fixture.ts
-// cover it for both adapters. The fixture runs in a child process because the
-// failure mode is the process dying. All wire bytes come from ./wire-frames.ts.
+// cover it for both adapters. The fixture runs all of an adapter's scenarios
+// in one child process because the failure mode is the process dying. All wire
+// bytes come from ./wire-frames.ts.
 
 import { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
@@ -37,81 +38,115 @@ const scenarios: Record<string, string[]> = {
   "an unnamed column in a wide result set with an indexed column": wide([40, ""], [41, "7"]),
 };
 
-async function decodeThroughMockServer(
-  adapter: "postgres" | "mysql",
-  protocol: "simple" | "prepared",
-  names: string[],
-) {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), fixture, adapter, protocol, JSON.stringify(names)],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-    timeout: 20_000,
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  let rows: unknown = null;
-  try {
-    rows = JSON.parse(stdout);
-  } catch {}
-  // stderr is not asserted (debug/ASan builds print benign notes); it is part
-  // of the compared object so the crash report shows up when the fixture dies.
-  return { rows, exitCode, signalCode: proc.signalCode, stderr };
-}
+// Column i of every result set, mock or real, holds "v<i>", so a row that maps
+// each name to its own column's value proves the names landed in the right
+// slots.
+const expectedRow = (names: string[]) => Object.fromEntries(names.map((name, i) => [name, `v${i}`]));
 
-function expectedRow(names: string[]) {
-  return Object.fromEntries(names.map((name, i) => [name, `v${i}`]));
-}
+const protocols = ["simple", "prepared"] as const;
 
-describe.each(["postgres", "mysql"] as const)("%s: a result set with an empty column name", adapter => {
-  // The text protocol of each adapter carries every scenario; the row object is
-  // built the same way on both protocols, so the prepared (binary) protocol
-  // only needs to prove it reaches the same place.
-  test.concurrent.each(Object.entries(scenarios))(
-    '%s decodes to a row with a "" key',
-    async (_, names) => {
-      expect(await decodeThroughMockServer(adapter, "simple", names)).toEqual({
-        rows: [expectedRow(names)],
-        exitCode: 0,
-        signalCode: null,
-        stderr: expect.any(String),
-      });
-    },
-    30_000,
-  );
+// One child per adapter: a debug build pays most of a second to start a child
+// and milliseconds per scenario, and the two children run side by side. Under
+// ASan with exception-check validation a child takes about 4s on a slow box,
+// hence the explicit timeout.
+test.concurrent.each(["postgres", "mysql"] as const)(
+  '%s: every mock-server scenario decodes to a row with a "" key, over both protocols',
+  async adapter => {
+    const jobs = protocols.flatMap(protocol =>
+      Object.entries(scenarios).map(([scenario, names]) => ({ scenario, adapter, protocol, names })),
+    );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture, JSON.stringify(jobs)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  test.concurrent(
-    "a single unnamed column decodes over the prepared-statement protocol",
-    async () => {
-      expect(await decodeThroughMockServer(adapter, "prepared", [""])).toEqual({
-        rows: [{ "": "v0" }],
-        exitCode: 0,
-        signalCode: null,
-        stderr: expect.any(String),
-      });
-    },
-    30_000,
-  );
-});
+    // One line per job, in job order. A crash mid-matrix shows up as a list
+    // that stops at the job that died, next to the signal and the stderr trace.
+    const results = stdout
+      .split("\n")
+      .filter(Boolean)
+      .map(line => JSON.parse(line));
+    expect({ results, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      results: jobs.map(({ names, ...job }) => ({ ...job, rows: [expectedRow(names)] })),
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+    // toEqual ignores property order; the row must also list its keys in column
+    // order (array indices first, as for any object), so `Object.values(row)`
+    // walks the columns in order.
+    expect(results.map(({ rows }) => Object.keys(rows[0]))).toEqual(
+      jobs.map(({ names }) => Object.keys(expectedRow(names))),
+    );
+  },
+  15_000,
+);
 
 // Real-server coverage: `select ''` is enough to get an unnamed column out of
-// MySQL and MariaDB; the client decodes both servers' result sets identically.
+// MariaDB, and `as ''` puts a chosen value under the empty name; the client
+// decodes MySQL's and MariaDB's result sets identically.
 // Same gating as sql-mariadb-json.test.ts: only attempt the container when
 // something can provide it, since a half-working local docker would fail the
 // suite instead of skipping it.
 const mariadbProvided =
   !!process.env.BUN_TEST_SERVICE_mariadb_plain || !!process.env.BUN_DOCKER_COORDINATOR || (isCI && isDockerEnabled());
 if (!mariadbProvided) {
-  describe.todo("mariadb: select '' returns a row with a \"\" key");
+  describe.todo("mariadb: a result set with an empty column name");
 } else {
-  describeWithContainer("mariadb", { image: "mariadb_plain" }, container => {
-    test("select '' returns a row with a \"\" key", async () => {
-      await container.ready;
-      await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
+  describeWithContainer(
+    "mariadb: a result set with an empty column name",
+    { image: "mariadb_plain", concurrent: true },
+    container => {
+      const connect = () => new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
 
-      expect(await sql`select ''`).toEqual([{ "": "" }]);
-      expect(await sql`select ''`.simple()).toEqual([{ "": "" }]);
-      expect(await sql`select '', 'abc', 1 as n`).toEqual([{ "": "", abc: "abc", n: 1 }]);
-    });
-  });
+      test("select '' returns a row with a \"\" key over both protocols", async () => {
+        await container.ready;
+        await using sql = connect();
+
+        expect(await sql`select ''`).toEqual([{ "": "" }]);
+        expect(await sql`select ''`.simple()).toEqual([{ "": "" }]);
+        expect(await sql`select 'v0' as ''`).toEqual([{ "": "v0" }]);
+        expect(await sql`select 'v0' as ''`.simple()).toEqual([{ "": "v0" }]);
+
+        const [row] = await sql`select '', 'abc', 1 as n`;
+        expect(row).toEqual({ "": "", abc: "abc", n: 1 });
+        expect(Object.keys(row)).toEqual(["", "abc", "n"]);
+      });
+
+      test("an unnamed column between a named and an indexed column", async () => {
+        await container.ready;
+        await using sql = connect();
+
+        const expected = { "7": "v2", x: "v0", "": "v1" };
+        const prepared = await sql`select 'v0' as x, 'v1' as '', 'v2' as \`7\``;
+        expect(prepared).toEqual([expected]);
+        expect(Object.keys(prepared[0])).toEqual(["7", "x", ""]);
+        const simple = await sql`select 'v0' as x, 'v1' as '', 'v2' as \`7\``.simple();
+        expect(simple).toEqual([expected]);
+        expect(Object.keys(simple[0])).toEqual(["7", "x", ""]);
+      });
+
+      test("an unnamed column in a wide result set with an indexed column", async () => {
+        await container.ready;
+        await using sql = connect();
+
+        const names = wide([40, ""], [41, "7"]);
+        const expected = expectedRow(names);
+        const columns = names.map((name, i) => `'v${i}' as \`${name}\``);
+        // unsafe() without parameters takes the text protocol; binding the
+        // unnamed column's value is what makes the first query a prepared one.
+        columns[40] = "? as ``";
+        const prepared = await sql.unsafe(`select ${columns.join(", ")}`, ["v40"]);
+        expect(prepared).toEqual([expected]);
+        expect(Object.keys(prepared[0])).toEqual(Object.keys(expected));
+        columns[40] = "'v40' as ``";
+        const simple = await sql.unsafe(`select ${columns.join(", ")}`);
+        expect(simple).toEqual([expected]);
+        expect(Object.keys(simple[0])).toEqual(Object.keys(expected));
+      });
+    },
+  );
 }


### PR DESCRIPTION
### Problem
- `test/js/sql/sql-empty-column-name.test.ts` took 20.9s on alpine x64 in build 109310. The job log shows `coordinator: ensuring mariadb_plain` 21.1s before `coordinator: mariadb_plain ready`, and the file's output right after. The file waited for a cold container. Its own tests finish in about 2s.
- The file is not in `test/docker/prestart-map.mjs`, so the coordinator starts `mariadb_plain` on the file's first request instead of at shard launch.
- The mock-server part spawned ten debug-build children (one per adapter and scenario), each about 1.6s of startup for a few milliseconds of work, and asserted `stderr: expect.any(String)`.

### Fix
- Add `js/sql/sql-empty-column-name` to the prestart map, the same pattern as #41104 and #40537. The container now starts with the shard and the runner schedules the file after the non-docker tests.
- One child per adapter runs every scenario over both the text and the prepared protocol (16 jobs, up from 10) and prints one JSON line per job. The test compares the whole list: rows, `stderr: ""`, exit code and signal in one `toEqual`, then the key order of every row. A crash shows up as a list that stops at the job that died.
- The real-server block is `concurrent: true`. It asserts whole rows and `Object.keys` order for `select ''`, a chosen value under `as ''`, a named plus an indexed (`7`) column, and an 80-column row over both protocols.
- Verified: `bun bd test test/js/sql/sql-empty-column-name.test.ts` with the local MariaDB, two runs each. Local wall time with a warm container: 6.3s and 6.5s before, 5.1s and 5.3s after. CPU time: 20.4s and 21.1s before, 8.5s after. The CI win is the prestart: the 21s wait goes away.

### Background
- `describeWithContainer` asks the docker coordinator for a service. Without a prestart entry the coordinator runs `compose up` at that moment, and the test waits for the health check.
- The fixture's mock servers reply with a result set built from a list of column names. The SQL client decodes it, and the empty name used to crash the process, which is why the decode runs in a child.

<details><summary>Notes</summary>

Timings on this box (debug ASan build, warm local MariaDB):

- old file: 6.29s and 6.53s wall, 20.4s and 21.1s user CPU
- new file: 5.27s and 5.12s wall, 8.5s user CPU
- with the ASan lane env (`BUN_JSC_validateExceptionChecks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1`): old 7.5s wall and 25s CPU, new 7.1s wall and 11.6s CPU. One child takes up to 3.9s here, which is why the two child tests carry a 15s timeout. This box is 5 to 6 times slower than the CI ASan lane (`sqlite-sql.test.ts`: 32s here, 6.1s there).
- release bun 1.4.1: old 125ms, new 122ms for the whole file.

One child for all 16 jobs was measured too: 2.9s on the plain env and 4.7s on the ASan lane env, slower in wall time than two children side by side, because the work is CPU bound in one event loop.

Assertion changes:

- the child's `stderr` must be empty (was `expect.any(String)`)
- rows, stderr, exit code and signal are one `toEqual`, so a crash diff shows the truncated list next to the signal
- `Object.keys(row)` is asserted for every mock scenario and every real-server query
- the prepared protocol now runs all four scenarios on both adapters (was one scenario)
- the real server also covers `as ''` with a non-empty value, the named plus indexed column layout, and the wide (80 column) layout, each over both protocols
- the spawn `timeout` is gone, the test timeout and the runner's auto-killer cover a hung child

No test was removed or skipped. The docker gate is unchanged.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/sql-empty-column-name.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/sql-empty-column-name.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/sql/sql-empty-column-name.test.ts:
(pass) postgres: every mock-server scenario decodes to a row with a "" key, over both protocols [2171.47ms]
(pass) mysql: every mock-server scenario decodes to a row with a "" key, over both protocols [2497.50ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [4.76s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/docker/prestart-map.mjs                 |   1 +
 test/js/sql/sql-empty-column-name.fixture.ts |  59 +++++-----
 test/js/sql/sql-empty-column-name.test.ts    | 167 ++++++++++++++++-----------
 3 files changed, 135 insertions(+), 92 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
test/docker/prestart-map.mjs                      1      1     20
test/js/sql/sql-empty-column-name.fixture.ts      2      5     22
test/js/sql/sql-empty-column-name.test.ts         7     11     18
```

</details>

<!-- robobun:evidence:end -->