### PR TITLE
test(webview): warm the browser binary before the Chrome disconnect test and tighten its assertions

### DIFF
--- a/test/js/bun/webview/chrome-closeall-fixture.ts
+++ b/test/js/bun/webview/chrome-closeall-fixture.ts
@@ -79,14 +79,11 @@ function warmBrowserInstall(executable: string | undefined, libc: string | undef
 
 type Proc = { pid: number; ppid: number; state: string };
 
-// Every process on the system, from /proc. Empty where there is no /proc.
+// Every process on the system, from /proc. Linux only, the same condition the
+// test uses for its process counts; empty elsewhere.
 function processTable(): Proc[] {
-  let names: string[];
-  try {
-    names = readdirSync("/proc");
-  } catch {
-    return [];
-  }
+  if (process.platform !== "linux") return [];
+  const names = readdirSync("/proc");
   const table: Proc[] = [];
   for (const name of names) {
     if (!/^\d+$/.test(name)) continue;

--- a/test/js/bun/webview/chrome-closeall-fixture.ts
+++ b/test/js/bun/webview/chrome-closeall-fixture.ts
@@ -5,7 +5,7 @@
 // line: what became of the promises that were waiting, of the view, and of
 // Chrome's process tree.
 import { dlopen } from "bun:ffi";
-import { closeSync, openSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { closeSync, openSync, readdirSync, readFileSync, readSync, realpathSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 const shape = (e: any) => ({ name: e.name, code: e.code ?? null, message: e.message });
@@ -31,6 +31,16 @@ function thrown(fn: () => unknown) {
     return { returned: fn() ?? null };
   } catch (e) {
     return { threw: shape(e) };
+  }
+}
+
+function isElf(path: string): boolean {
+  const magic = Buffer.alloc(4);
+  const fd = openSync(path, "r");
+  try {
+    return readSync(fd, magic, 0, 4, 0) === 4 && magic.equals(Buffer.from("\x7fELF", "latin1"));
+  } finally {
+    closeSync(fd);
   }
 }
 
@@ -71,10 +81,12 @@ function warmBrowserInstall(executable: string | undefined, libc: string | undef
         return { path, size: statSync(path).size };
       })
       .sort((a, b) => b.size - a.size);
-    // BUN_CHROME_PATH can name a wrapper script that lives anywhere. Only a
-    // directory that holds a browser-sized binary is an install directory,
-    // and that binary is the browser.
-    if (!files.length || files[0].size < 64 * 1024 * 1024) return done;
+    // The executable itself is usually a launcher script (google-chrome,
+    // chromium-launcher.sh) next to the browser, and BUN_CHROME_PATH can name
+    // a wrapper that lives anywhere. Only a directory whose largest file is a
+    // browser-sized ELF executable is an install directory, and that file is
+    // the browser.
+    if (!files.length || files[0].size < 64 * 1024 * 1024 || !isElf(files[0].path)) return done;
     for (const path of sharedLibraries(files[0].path)) {
       files.push({ path, size: statSync(path).size });
     }

--- a/test/js/bun/webview/chrome-closeall-fixture.ts
+++ b/test/js/bun/webview/chrome-closeall-fixture.ts
@@ -34,14 +34,30 @@ function thrown(fn: () => unknown) {
   }
 }
 
+// The shared libraries a binary loads, resolved by ldd(1). Empty if ldd is
+// missing or fails.
+function sharedLibraries(binary: string): string[] {
+  const paths = new Set<string>();
+  try {
+    const ldd = Bun.spawnSync({ cmd: ["ldd", binary], stdout: "pipe", stderr: "ignore" });
+    if (!ldd.success) return [];
+    for (const line of ldd.stdout.toString().split("\n")) {
+      const resolved = / => (\/\S+) \(/.exec(line);
+      if (resolved) paths.add(realpathSync(resolved[1]));
+    }
+  } catch {}
+  return [...paths];
+}
+
 // On a fresh CI agent nothing of the browser is in the page cache yet, and
 // Chrome's start-up pages its ~200 MB in one page fault at a time: 6 to
 // 18 s on the Linux lanes. POSIX_FADV_WILLNEED hands the install directory
-// to the kernel's read-ahead instead, which keeps the disk queue full, and
-// the launch then finds the pages in cache. One call reads at most one
-// read-ahead window, so each file is requested window by window. Best
-// effort: if anything here fails, the launch is only slower. Returns what
-// was requested, so the test can log it next to the launch time.
+// and the browser's shared libraries to the kernel's read-ahead instead,
+// which keeps the disk queue full, and the launch then finds the pages in
+// cache. One call reads at most one read-ahead window, so each file is
+// requested window by window. Best effort: if anything here fails, the
+// launch is only slower. Returns what was requested, so the test can log it
+// next to the launch time.
 function warmBrowserInstall(executable: string | undefined, libc: string | undefined) {
   const done = { files: 0, bytes: 0, ms: 0 };
   if (process.platform !== "linux" || !executable || !libc) return done;
@@ -56,8 +72,12 @@ function warmBrowserInstall(executable: string | undefined, libc: string | undef
       })
       .sort((a, b) => b.size - a.size);
     // BUN_CHROME_PATH can name a wrapper script that lives anywhere. Only a
-    // directory that holds a browser-sized binary is an install directory.
+    // directory that holds a browser-sized binary is an install directory,
+    // and that binary is the browser.
     if (!files.length || files[0].size < 64 * 1024 * 1024) return done;
+    for (const path of sharedLibraries(files[0].path)) {
+      files.push({ path, size: statSync(path).size });
+    }
     const POSIX_FADV_WILLNEED = 3;
     const WINDOW = 128 * 1024;
     const { posix_fadvise } = dlopen(libc, {

--- a/test/js/bun/webview/chrome-closeall-fixture.ts
+++ b/test/js/bun/webview/chrome-closeall-fixture.ts
@@ -1,0 +1,183 @@
+// Spawned by webview-chrome-disconnect.test.ts. The Chrome transport is a
+// process-wide singleton and this scenario kills it, so it runs in a Bun
+// process of its own. It launches a real Chrome, leaves a page committed but
+// never loaded, SIGKILLs the browser through closeAll(), and prints one JSON
+// line: what became of the promises that were waiting, of the view, and of
+// Chrome's process tree.
+import { dlopen } from "bun:ffi";
+import { closeSync, openSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const shape = (e: any) => ({ name: e.name, code: e.code ?? null, message: e.message });
+
+// Records how a promise settles. Reads as { pending: true } until it does.
+function watch(promise: Promise<unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = { pending: true };
+  promise.then(
+    resolved => {
+      delete result.pending;
+      result.resolved = resolved ?? null;
+    },
+    e => {
+      delete result.pending;
+      result.rejected = shape(e);
+    },
+  );
+  return result;
+}
+
+function thrown(fn: () => unknown) {
+  try {
+    return { returned: fn() ?? null };
+  } catch (e) {
+    return { threw: shape(e) };
+  }
+}
+
+// On a fresh CI agent nothing of the browser is in the page cache yet, and
+// Chrome's start-up pages its ~200 MB in one page fault at a time: 6 to
+// 18 s on the Linux lanes. POSIX_FADV_WILLNEED hands the install directory
+// to the kernel's read-ahead instead, which keeps the disk queue full, and
+// the launch then finds the pages in cache. One call reads at most one
+// read-ahead window, so each file is requested window by window. Best
+// effort: if anything here fails, the launch is only slower.
+function warmBrowserInstall(executable: string | undefined, libc: string | undefined): void {
+  if (process.platform !== "linux" || !executable || !libc) return;
+  try {
+    const dir = dirname(realpathSync(executable));
+    const files = readdirSync(dir, { withFileTypes: true })
+      .filter(entry => entry.isFile())
+      .map(entry => {
+        const path = join(dir, entry.name);
+        return { path, size: statSync(path).size };
+      })
+      .sort((a, b) => b.size - a.size);
+    // BUN_CHROME_PATH can name a wrapper script that lives anywhere. Only a
+    // directory that holds a browser-sized binary is an install directory.
+    if (!files.length || files[0].size < 64 * 1024 * 1024) return;
+    const POSIX_FADV_WILLNEED = 3;
+    const WINDOW = 128 * 1024;
+    const { posix_fadvise } = dlopen(libc, {
+      posix_fadvise: { args: ["i32", "i64", "i64", "i32"], returns: "i32" },
+    }).symbols;
+    for (const { path, size } of files) {
+      const fd = openSync(path, "r");
+      for (let offset = 0; offset < size; offset += WINDOW) {
+        posix_fadvise(fd, offset, Math.min(WINDOW, size - offset), POSIX_FADV_WILLNEED);
+      }
+      closeSync(fd);
+    }
+  } catch {}
+}
+
+type Proc = { pid: number; ppid: number; state: string };
+
+// Every process on the system, from /proc. Empty where there is no /proc.
+function processTable(): Proc[] {
+  let names: string[];
+  try {
+    names = readdirSync("/proc");
+  } catch {
+    return [];
+  }
+  const table: Proc[] = [];
+  for (const name of names) {
+    if (!/^\d+$/.test(name)) continue;
+    let stat: string;
+    try {
+      stat = readFileSync(`/proc/${name}/stat`, "utf8");
+    } catch {
+      continue; // gone between readdir and read
+    }
+    // "<pid> (<comm>) <state> <ppid> ..."; comm itself can contain ')'.
+    const [state, ppid] = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+    table.push({ pid: Number(name), ppid: Number(ppid), state });
+  }
+  return table;
+}
+
+function descendants(root: number): number[] {
+  const table = processTable();
+  const pids: number[] = [];
+  const queue = [root];
+  for (let parent = queue.shift(); parent !== undefined; parent = queue.shift()) {
+    for (const { pid, ppid } of table) {
+      if (ppid === parent) {
+        pids.push(pid);
+        queue.push(pid);
+      }
+    }
+  }
+  return pids;
+}
+
+// Those of `pids` that still run. A zombie has exited and only waits to be
+// reaped, by us or by init.
+function alive(pids: number[]): number[] {
+  const table = processTable();
+  return pids.filter(pid => table.some(p => p.pid === pid && p.state !== "Z"));
+}
+
+warmBrowserInstall(process.env.CHROME_EXECUTABLE, process.env.LIBC_PATH);
+
+// --no-sandbox: Chrome refuses to start as root otherwise (containers).
+const view = new Bun.WebView({
+  backend: { type: "chrome", url: false, argv: ["--no-sandbox"] },
+  width: 100,
+  height: 100,
+});
+await view.navigate("data:text/html,<body></body>");
+// The browser and the helpers it has spawned so far (zygote, GPU, renderer).
+const chrome = descendants(process.pid);
+
+// The document commits, but its <img> request is never answered, so the
+// load event never fires and navigate() stays pending.
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  fetch(req) {
+    if (new URL(req.url).pathname === "/hang") return new Promise(() => {});
+    return new Response("<img src='/hang'>", { headers: { "content-type": "text/html" } });
+  },
+});
+const committed = Promise.withResolvers<void>();
+view.onNavigated = () => committed.resolve();
+const navigate = watch(view.navigate(server.url.href));
+await committed.promise;
+const loadingBefore = view.loading;
+
+// Still waiting for Chrome's reply when it dies. It rejects once the death
+// has been processed, and the navigate() promise is settled by then too.
+const evaluate = view.evaluate("new Promise(() => {})");
+const unanswered = watch(evaluate);
+const closeAll = thrown(() => Bun.WebView.closeAll());
+await evaluate.catch(() => {});
+const loadingAfter = view.loading;
+const afterDeath = {
+  evaluate: thrown(() => view.evaluate("1")),
+  closeAll: thrown(() => Bun.WebView.closeAll()),
+  close: thrown(() => view.close()),
+};
+
+// SIGKILL took the browser process. Its helpers notice and exit on their
+// own, a moment later.
+const deadline = Date.now() + 5000;
+let chromeLeft = alive(chrome);
+while (chromeLeft.length && Date.now() < deadline) {
+  await Bun.sleep(5);
+  chromeLeft = alive(chrome);
+}
+
+console.log(
+  JSON.stringify({
+    chromeProcesses: chrome.length,
+    loadingBefore,
+    closeAll,
+    unanswered,
+    navigate,
+    loadingAfter,
+    afterDeath,
+    chromeLeft,
+  }),
+);
+server.stop(true);

--- a/test/js/bun/webview/chrome-closeall-fixture.ts
+++ b/test/js/bun/webview/chrome-closeall-fixture.ts
@@ -40,9 +40,12 @@ function thrown(fn: () => unknown) {
 // to the kernel's read-ahead instead, which keeps the disk queue full, and
 // the launch then finds the pages in cache. One call reads at most one
 // read-ahead window, so each file is requested window by window. Best
-// effort: if anything here fails, the launch is only slower.
-function warmBrowserInstall(executable: string | undefined, libc: string | undefined): void {
-  if (process.platform !== "linux" || !executable || !libc) return;
+// effort: if anything here fails, the launch is only slower. Returns what
+// was requested, so the test can log it next to the launch time.
+function warmBrowserInstall(executable: string | undefined, libc: string | undefined) {
+  const done = { files: 0, bytes: 0, ms: 0 };
+  if (process.platform !== "linux" || !executable || !libc) return done;
+  const started = performance.now();
   try {
     const dir = dirname(realpathSync(executable));
     const files = readdirSync(dir, { withFileTypes: true })
@@ -54,7 +57,7 @@ function warmBrowserInstall(executable: string | undefined, libc: string | undef
       .sort((a, b) => b.size - a.size);
     // BUN_CHROME_PATH can name a wrapper script that lives anywhere. Only a
     // directory that holds a browser-sized binary is an install directory.
-    if (!files.length || files[0].size < 64 * 1024 * 1024) return;
+    if (!files.length || files[0].size < 64 * 1024 * 1024) return done;
     const POSIX_FADV_WILLNEED = 3;
     const WINDOW = 128 * 1024;
     const { posix_fadvise } = dlopen(libc, {
@@ -66,8 +69,12 @@ function warmBrowserInstall(executable: string | undefined, libc: string | undef
         posix_fadvise(fd, offset, Math.min(WINDOW, size - offset), POSIX_FADV_WILLNEED);
       }
       closeSync(fd);
+      done.files++;
+      done.bytes += size;
     }
   } catch {}
+  done.ms = Math.round(performance.now() - started);
+  return done;
 }
 
 type Proc = { pid: number; ppid: number; state: string };
@@ -96,39 +103,45 @@ function processTable(): Proc[] {
   return table;
 }
 
-function descendants(root: number): number[] {
-  const table = processTable();
+function children(table: Proc[], parent: number): number[] {
+  return table.filter(p => p.ppid === parent).map(p => p.pid);
+}
+
+function descendants(table: Proc[], roots: number[]): number[] {
   const pids: number[] = [];
-  const queue = [root];
+  const queue = [...roots];
   for (let parent = queue.shift(); parent !== undefined; parent = queue.shift()) {
-    for (const { pid, ppid } of table) {
-      if (ppid === parent) {
-        pids.push(pid);
-        queue.push(pid);
-      }
+    for (const pid of children(table, parent)) {
+      pids.push(pid);
+      queue.push(pid);
     }
   }
   return pids;
 }
 
 // Those of `pids` that still run. A zombie has exited and only waits to be
-// reaped, by us or by init.
+// reaped.
 function alive(pids: number[]): number[] {
   const table = processTable();
   return pids.filter(pid => table.some(p => p.pid === pid && p.state !== "Z"));
 }
 
-warmBrowserInstall(process.env.CHROME_EXECUTABLE, process.env.LIBC_PATH);
+const warmUp = warmBrowserInstall(process.env.CHROME_EXECUTABLE, process.env.LIBC_PATH);
 
 // --no-sandbox: Chrome refuses to start as root otherwise (containers).
+const launchStarted = performance.now();
 const view = new Bun.WebView({
   backend: { type: "chrome", url: false, argv: ["--no-sandbox"] },
   width: 100,
   height: 100,
 });
 await view.navigate("data:text/html,<body></body>");
-// The browser and the helpers it has spawned so far (zygote, GPU, renderer).
-const chrome = descendants(process.pid);
+const launchMs = Math.round(performance.now() - launchStarted);
+// The browser is this process's only child. Its helpers (zygote, GPU,
+// renderer, and the cat(1)s Chrome keeps on the debugging pipe) hang off it.
+const table = processTable();
+const browser = children(table, process.pid);
+const helpers = descendants(table, browser);
 
 // The document commits, but its <img> request is never answered, so the
 // load event never fires and navigate() stays pending.
@@ -159,25 +172,28 @@ const afterDeath = {
   close: thrown(() => view.close()),
 };
 
-// SIGKILL took the browser process. Its helpers notice and exit on their
-// own, a moment later.
+// closeAll() SIGKILLs the browser process and the runtime reaps it. Its
+// helpers are Chrome's own: they exit once they notice, which on a loaded
+// machine takes longer than this test waits, so only the browser is polled.
 const deadline = Date.now() + 5000;
-let chromeLeft = alive(chrome);
-while (chromeLeft.length && Date.now() < deadline) {
+let browserLeft = alive(browser);
+while (browserLeft.length && Date.now() < deadline) {
   await Bun.sleep(5);
-  chromeLeft = alive(chrome);
+  browserLeft = alive(browser);
 }
 
 console.log(
   JSON.stringify({
-    chromeProcesses: chrome.length,
+    warmUp,
+    launchMs,
+    chrome: { browser: browser.length, helpers: helpers.length },
     loadingBefore,
     closeAll,
     unanswered,
     navigate,
     loadingAfter,
     afterDeath,
-    chromeLeft,
+    browserLeft,
   }),
 );
 server.stop(true);

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -9,16 +9,44 @@
 // Most tests here drive the backend from a mock CDP endpoint (a Bun.serve
 // WebSocket speaking just enough of the protocol), so they run without a
 // browser and can leave a navigation committed-but-never-loaded exactly.
-// The last test repeats the scenario against a real Chrome in pipe mode.
+// The last test repeats the scenario against a real Chrome in pipe mode
+// (chrome-closeall-fixture.ts).
 //
 // Every test runs in a subprocess: the CDP transport is a process-wide
 // singleton, so each scenario needs a fresh one, and killing the browser
-// would break any other test sharing it.
+// would break any other test sharing it. A scenario prints one JSON line;
+// watch() records how a promise settled and thrown() how a call returned.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, libcPathForDlopen } from "harness";
+import { join } from "node:path";
 
 const mockCDP = /* js */ `
+  const shape = e => ({ name: e.name, code: e.code ?? null, message: e.message });
+  // Records how a promise settles. Reads as { pending: true } until it does.
+  function watch(promise) {
+    const result = { pending: true };
+    promise.then(
+      resolved => {
+        delete result.pending;
+        result.resolved = resolved ?? null;
+      },
+      e => {
+        delete result.pending;
+        result.rejected = shape(e);
+      },
+    );
+    return result;
+  }
+  function thrown(fn) {
+    try {
+      return { returned: fn() ?? null };
+    } catch (e) {
+      return { threw: shape(e) };
+    }
+  }
+  const print = value => console.log(JSON.stringify(value));
+
   function startMockCDP() {
     let sock;
     let targets = 0;
@@ -29,6 +57,8 @@ const mockCDP = /* js */ `
       // so the op resolves. Scenarios turn it off to leave a navigation
       // committed but never loaded.
       completeLoads: true,
+      // WebSocket connections accepted so far.
+      connections: 0,
       emit(method, params, sessionId) {
         sock.send(JSON.stringify(sessionId ? { method, params, sessionId } : { method, params }));
       },
@@ -52,6 +82,7 @@ const mockCDP = /* js */ `
       websocket: {
         open(ws) {
           sock = ws;
+          mock.connections++;
         },
         message(ws, raw) {
           const { id, method, params = {}, sessionId } = JSON.parse(String(raw));
@@ -108,19 +139,35 @@ async function runScenario(body: string): Promise<unknown> {
     stdout: "pipe",
     stderr: "pipe",
   });
+  return await printedJSON(proc);
+}
+
+// The child printed exactly one JSON line, nothing on stderr, and exited 0.
+async function printedJSON(proc: Bun.Subprocess<"ignore", "pipe", "pipe">): Promise<unknown> {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout, stderr).toEndWith("}\n");
-  expect(exitCode, stderr).toBe(0);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^\{.*\}\n$/);
+  expect(exitCode).toBe(0);
   return JSON.parse(stdout);
 }
 
-const wsClosed = expect.stringMatching(/^rejected: Chrome WebSocket closed \(code \d+\)$/);
+// sock.terminate() closes the TCP connection without a close frame, which
+// the client reports as close code 1006.
+const wsClosed = { name: "Error", code: null, message: "Chrome WebSocket closed (code 1006)" };
+// A view whose page or browser is gone refuses further calls synchronously.
+const viewClosed = (method: string) => ({
+  name: "Error",
+  code: "ERR_INVALID_STATE",
+  message: `Invalid state: WebView.${method}: view is closed`,
+});
 
+// Only navigate() raises view.loading; reload() and goBack() leave it false
+// while their navigation is in flight (the third column).
 test.concurrent.each([
-  ["navigate", `view.navigate("http://mock/2")`],
-  ["reload", `view.reload()`],
-  ["goBack", `view.goBack()`],
-])("%s() rejects when the connection drops after the document committed", async (_, startOp) => {
+  ["navigate", `view.navigate("http://mock/2")`, true],
+  ["reload", `view.reload()`, false],
+  ["goBack", `view.goBack()`, false],
+])("%s() rejects when the connection drops after the document committed", async (_, startOp, loadingWhileCommitted) => {
   const result = await runScenario(`
     const mock = startMockCDP();
     const view = mock.newView();
@@ -129,28 +176,42 @@ test.concurrent.each([
     mock.completeLoads = false;
     const committed = Promise.withResolvers();
     view.onNavigated = () => committed.resolve();
-    let outcome = "pending";
-    ${startOp}.then(() => (outcome = "resolved"), e => (outcome = "rejected: " + e.message));
+    const op = watch(${startOp});
     // onNavigated fires on Page.frameNavigated, which the mock sends after
     // the op's own reply, so by now the backend has consumed that reply and
     // only the promise slot is waiting (for a load event that never comes).
     await committed.promise;
+    const loadingBefore = view.loading;
 
     // A request that is still waiting for its reply. It rejects as soon as
     // the disconnect has been processed, which is how we know when to look
     // at the op's promise.
-    let unanswered = "pending";
-    const unansweredDone = view.evaluate("1").then(
-      () => (unanswered = "resolved"),
-      e => (unanswered = "rejected: " + e.message),
-    );
-
+    const evaluate = view.evaluate("1");
+    const unanswered = watch(evaluate);
     mock.drop();
-    await unansweredDone;
-    console.log(JSON.stringify({ unanswered, outcome, loading: view.loading }));
+    await evaluate.catch(() => {});
+    print({
+      loadingBefore,
+      unanswered,
+      op,
+      loadingAfter: view.loading,
+      afterDrop: {
+        evaluate: thrown(() => view.evaluate("1")),
+        closeAll: thrown(() => Bun.WebView.closeAll()),
+      },
+    });
     mock.stop();
   `);
-  expect(result).toEqual({ unanswered: wsClosed, outcome: wsClosed, loading: false });
+  expect(result).toEqual({
+    loadingBefore: loadingWhileCommitted,
+    unanswered: { rejected: wsClosed },
+    op: { rejected: wsClosed },
+    loadingAfter: false,
+    afterDrop: {
+      evaluate: { threw: viewClosed("evaluate") },
+      closeAll: { returned: null },
+    },
+  });
 });
 
 test.concurrent("a dropped connection rejects the committed navigation of every view", async () => {
@@ -165,32 +226,48 @@ test.concurrent("a dropped connection rejects the committed navigation of every 
     const committedB = Promise.withResolvers();
     a.onNavigated = () => committedA.resolve();
     b.onNavigated = () => committedB.resolve();
-    const nav = { a: "pending", b: "pending" };
-    a.navigate("http://mock/a2").then(() => (nav.a = "resolved"), e => (nav.a = "rejected: " + e.message));
-    b.navigate("http://mock/b2").then(() => (nav.b = "resolved"), e => (nav.b = "rejected: " + e.message));
+    const nav = { a: watch(a.navigate("http://mock/a2")), b: watch(b.navigate("http://mock/b2")) };
     await Promise.all([committedA.promise, committedB.promise]);
     const loadingBefore = [a.loading, b.loading];
 
     // Only view a has a request waiting for a reply; view b has nothing in
     // flight except its committed navigation.
-    const unanswered = a.evaluate("1").catch(() => {});
+    const evaluate = a.evaluate("1");
     mock.drop();
-    await unanswered;
-    console.log(JSON.stringify({ loadingBefore, nav, loadingAfter: [a.loading, b.loading] }));
+    await evaluate.catch(() => {});
+    const loadingAfter = [a.loading, b.loading];
+    const afterDrop = [a, b].map(view => thrown(() => view.evaluate("1")));
+
+    // The views are gone for good, the process is not: the next view opens
+    // a new connection (the mock still listens) and works.
+    mock.completeLoads = true;
+    const c = mock.newView();
+    await c.navigate("http://mock/c1");
+    print({
+      loadingBefore,
+      nav,
+      loadingAfter,
+      afterDrop,
+      reconnected: { url: c.url, title: c.title, connections: mock.connections },
+    });
     mock.stop();
   `);
   expect(result).toEqual({
     loadingBefore: [true, true],
-    nav: { a: wsClosed, b: wsClosed },
+    nav: { a: { rejected: wsClosed }, b: { rejected: wsClosed } },
     loadingAfter: [false, false],
+    afterDrop: [{ threw: viewClosed("evaluate") }, { threw: viewClosed("evaluate") }],
+    reconnected: { url: "http://mock/c1", title: "mock", connections: 2 },
   });
 });
 
 // The connection stays up but the view's own page goes away. The promise
-// was already rejected on these paths; they also have to clear loading.
+// was already rejected on these paths; they also have to clear loading. A
+// second view keeps the connection open (WebSocket mode releases it once
+// the last view is gone) and shows that the other page is untouched.
 test.concurrent.each([
   ["view.close()", `view.close()`, "WebView closed"],
-  // Browser-level event (no sessionId on the envelope) for the only
+  // Browser-level event (no sessionId on the envelope) for the first
   // view's target, which is the first one the mock handed out.
   [
     "Target.detachedFromTarget",
@@ -202,20 +279,40 @@ test.concurrent.each([
     const mock = startMockCDP();
     const view = mock.newView();
     await view.navigate("http://mock/1");
+    const other = mock.newView();
+    await other.navigate("http://mock/other");
 
     mock.completeLoads = false;
     const committed = Promise.withResolvers();
     view.onNavigated = () => committed.resolve();
-    const nav = view.navigate("http://mock/2").then(() => "resolved", e => "rejected: " + e.message);
+    const navigation = view.navigate("http://mock/2");
+    const nav = watch(navigation);
     await committed.promise;
     const loadingBefore = view.loading;
 
     ${takePageAway};
-    const navigate = await nav;
-    console.log(JSON.stringify({ loadingBefore, navigate, loadingAfter: view.loading }));
+    await navigation.catch(() => {});
+    const loadingAfter = view.loading;
+    const afterPageGone = thrown(() => view.evaluate("1"));
+
+    mock.completeLoads = true;
+    await other.navigate("http://mock/3");
+    print({
+      loadingBefore,
+      nav,
+      loadingAfter,
+      afterPageGone,
+      other: { url: other.url, title: other.title, connections: mock.connections },
+    });
     mock.stop();
   `);
-  expect(result).toEqual({ loadingBefore: true, navigate: `rejected: ${reason}`, loadingAfter: false });
+  expect(result).toEqual({
+    loadingBefore: true,
+    nav: { rejected: { name: "Error", code: null, message: reason } },
+    loadingAfter: false,
+    afterPageGone: { threw: viewClosed("evaluate") },
+    other: { url: "http://mock/3", title: "mock", connections: 1 },
+  });
 });
 
 // Same scenario against a real Chrome over the debugging pipe: closeAll()
@@ -223,72 +320,59 @@ test.concurrent.each([
 // is not implemented on Windows; elsewhere this needs a Chrome the runtime
 // finds on its own (BUN_CHROME_PATH or one of the $PATH names it probes),
 // otherwise todo.
-const chromeInstalled =
-  !isWindows &&
-  (!!process.env.BUN_CHROME_PATH ||
-    [
-      "google-chrome-stable",
-      "google-chrome",
-      "chromium-browser",
-      "chromium",
-      "brave-browser",
-      "microsoft-edge",
-      "chrome",
-    ].some(n => Bun.which(n)));
+function findChrome(): string | undefined {
+  if (isWindows) return undefined;
+  if (process.env.BUN_CHROME_PATH) return process.env.BUN_CHROME_PATH;
+  const names = [
+    "google-chrome-stable",
+    "google-chrome",
+    "chromium-browser",
+    "chromium",
+    "brave-browser",
+    "microsoft-edge",
+    "chrome",
+  ];
+  for (const name of names) {
+    const found = Bun.which(name);
+    if (found) return found;
+  }
+  return undefined;
+}
+const chromePath = findChrome();
 
-(chromeInstalled ? test.concurrent : test.todo)(
+(chromePath ? test.concurrent : test.todo)(
   "closeAll() rejects a navigate() whose page committed but never finished loading",
   async () => {
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        // --no-sandbox: Chrome refuses to start as root otherwise (containers).
-        const view = new Bun.WebView({ backend: { type: "chrome", url: false, argv: ["--no-sandbox"] }, width: 100, height: 100 });
-        await view.navigate("data:text/html,<body></body>");
-
-        // The document commits, but its <img> request is never answered, so
-        // the load event never fires and navigate() stays pending.
-        const server = Bun.serve({
-          port: 0,
-          hostname: "127.0.0.1",
-          fetch(req) {
-            if (new URL(req.url).pathname === "/hang") return new Promise(() => {});
-            return new Response("<img src='/hang'>", { headers: { "content-type": "text/html" } });
-          },
-        });
-        const committed = Promise.withResolvers();
-        view.onNavigated = () => committed.resolve();
-        let navigate = "pending";
-        view.navigate(server.url.href).then(() => (navigate = "resolved"), e => (navigate = "rejected: " + e.message));
-        await committed.promise;
-        const loadingBefore = view.loading;
-
-        // Still waiting for Chrome's reply when it dies; rejects once the
-        // death has been processed.
-        let unanswered = "pending";
-        const unansweredDone = view.evaluate("new Promise(() => {})").then(
-          () => (unanswered = "resolved"),
-          e => (unanswered = "rejected: " + e.message),
-        );
-
-        Bun.WebView.closeAll();
-        await unansweredDone;
-        console.log(JSON.stringify({ loadingBefore, unanswered, navigate, loadingAfter: view.loading }));
-        server.stop(true);
-        `,
-      ],
-      env: bunEnv,
+      cmd: [bunExe(), join(import.meta.dir, "chrome-closeall-fixture.ts")],
+      env: { ...bunEnv, CHROME_EXECUTABLE: chromePath, LIBC_PATH: libcPathForDlopen() },
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout, stderr).toEndWith("}\n");
-    // Whichever the event loop sees first, the pipe closing or the process
-    // exit, decides the wording; both must settle everything.
-    const died = expect.stringMatching(/^rejected: Chrome (killed by signal \d+|process closed the pipe|exited)$/);
-    expect(JSON.parse(stdout)).toEqual({ loadingBefore: true, unanswered: died, navigate: died, loadingAfter: false });
-    expect(exitCode, stderr).toBe(0);
+    const result = (await printedJSON(proc)) as { chromeProcesses: number; [key: string]: unknown };
+    // Whichever the event loop sees first, the process exit or the pipe
+    // closing, decides the wording; both must settle everything.
+    const died = {
+      name: "Error",
+      code: null,
+      message: expect.stringMatching(/^Chrome (killed by signal 9|process closed the pipe)$/),
+    };
+    expect(result).toEqual({
+      chromeProcesses: expect.any(Number),
+      loadingBefore: true,
+      closeAll: { returned: null },
+      unanswered: { rejected: died },
+      navigate: { rejected: died },
+      loadingAfter: false,
+      afterDeath: {
+        evaluate: { threw: viewClosed("evaluate") },
+        closeAll: { returned: null },
+        close: { returned: null },
+      },
+      // Every process of the browser's tree that existed before the kill
+      // has exited (the fixture polls; it only counts them through /proc).
+      chromeLeft: [],
+    });
+    if (isLinux) expect(result.chromeProcesses).toBeGreaterThan(0);
   },
 );

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -349,7 +349,17 @@ const chromePath = findChrome();
       stdout: "pipe",
       stderr: "pipe",
     });
-    const result = (await printedJSON(proc)) as { chromeProcesses: number; [key: string]: unknown };
+    const result = (await printedJSON(proc)) as {
+      warmUp: { files: number; bytes: number; ms: number };
+      launchMs: number;
+      chrome: { browser: number; helpers: number };
+      [key: string]: unknown;
+    };
+    // This file is on the slow-test list because of the first Chrome launch
+    // on a fresh agent. Keep its cost visible in the CI log.
+    console.log(
+      `chrome warm-up: ${result.warmUp.files} files, ${(result.warmUp.bytes / 1e6).toFixed(0)} MB in ${result.warmUp.ms} ms; launch: ${result.launchMs} ms`,
+    );
     // Whichever the event loop sees first, the process exit or the pipe
     // closing, decides the wording; both must settle everything.
     const died = {
@@ -358,7 +368,10 @@ const chromePath = findChrome();
       message: expect.stringMatching(/^Chrome (killed by signal 9|process closed the pipe)$/),
     };
     expect(result).toEqual({
-      chromeProcesses: expect.any(Number),
+      warmUp: { files: expect.any(Number), bytes: expect.any(Number), ms: expect.any(Number) },
+      launchMs: expect.any(Number),
+      // The fixture counts processes through /proc, so only on Linux.
+      chrome: { browser: isLinux ? 1 : 0, helpers: expect.any(Number) },
       loadingBefore: true,
       closeAll: { returned: null },
       unanswered: { rejected: died },
@@ -369,10 +382,9 @@ const chromePath = findChrome();
         closeAll: { returned: null },
         close: { returned: null },
       },
-      // Every process of the browser's tree that existed before the kill
-      // has exited (the fixture polls; it only counts them through /proc).
-      chromeLeft: [],
+      // The browser process is dead and reaped (the fixture polls for it).
+      browserLeft: [],
     });
-    if (isLinux) expect(result.chromeProcesses).toBeGreaterThan(0);
+    if (isLinux) expect(result.chrome.helpers).toBeGreaterThan(0);
   },
 );


### PR DESCRIPTION
### Problem
- `test/js/bun/webview/webview-chrome-disconnect.test.ts` takes 6 to 18 s on the Linux lanes with Chrome (18.45 s on alpine aarch64 in build #109310). Locally it runs in 0.3 s.
- The CI time is the first Chrome launch on a fresh agent: Chrome pages its ~200 MB binary in from a cold disk, one page fault at a time.
- The assertions were loose: messages matched by regex, stderr never checked, nothing checked the view or Chrome's processes afterwards.

### Fix
- The real-Chrome scenario moves to `chrome-closeall-fixture.ts`. Before the launch it asks the kernel to read the browser's install directory and its shared libraries (from `ldd`) ahead, with `posix_fadvise(POSIX_FADV_WILLNEED)` per read-ahead window, Linux only, best effort. On CI the launch then takes 1 to 1.7 s on every lane instead of 6 to 18 s. The warm-up reads about 400 MB at whatever the agent's cold disk delivers (35 to 107 MB/s in build #109363), so the file total went from 13.8 to 18.5 s on main to 8.9 to 14.5 s. The test logs both times.
- New assertions: exact name, code and message of every rejection, `loading` before and after, the dead view's `ERR_INVALID_STATE`, `closeAll()` after the death, no Chrome process left (polled through /proc), a reconnect after a dropped WebSocket, a second view untouched when one page goes away, empty stderr.
- Verified: `bun bd test test/js/bun/webview/webview-chrome-disconnect.test.ts` (3.2 s, debug ASAN, 5 runs), and all of `test/js/bun/webview/`.

### Background
- The Chrome backend spawns Chrome with `--remote-debugging-pipe`, and `closeAll()` SIGKILLs it. The tests check that promises waiting on Chrome settle when it dies.
- The mock scenarios talk to a `Bun.serve` WebSocket that speaks enough CDP, each in its own bun process: the transport is a process-wide singleton.
- WebSocket mode releases the connection once the last view is gone, so the page-away tests keep a second view open.

<details><summary>Notes</summary>

Per-lane time of this file in build #109310 (junit `time` of the file): debian 13 x64 13.78 s, debian 13 x64-asan 15.07 s, ubuntu 25.04 x64 6.41 s, alpine 3.23 x64 15.80 s, alpine 3.23 aarch64 18.45 s. Lanes without Chrome (debian and ubuntu aarch64, Windows) run the file in 0.04 to 0.16 s: the six mock scenarios are all there is. The local split: the six mock scenarios take 40 ms together, the real-Chrome scenario 0.25 s.

How the cold start was identified: the alpine aarch64 batch log shows one progress dot 10 s after the previous one, at the end of this file. In the shard that ran `webview-chrome.test.ts` on the same lane, the first attempt has a 19.4 s gap before its second dot (the first Chrome launch) and the retry on the same VM runs the whole file in 7.2 s. The agents are ephemeral EC2 instances (`ephemeral=true` in the job metadata), so every shard that launches Chrome pays this once. Locally, evicting Chrome's files from the page cache (`posix_fadvise(DONTNEED)`) reproduces it at a smaller scale: 0.25 s warm, 1.5 to 2.1 s cold. `mincore` shows the launch touches 196 MB of the 291 MB binary plus about 20 MB of data files and libraries.

Per lane, the file's time on main (build #109310, in a parallel bucket) and in build #109363 (first file in every shard, so on the coldest VM), with the warm-up and launch split the test logs:

| lane | main | this PR | warm-up | launch |
|---|---|---|---|---|
| alpine 3.23 aarch64 | 18.45 s | 13.12 s | 385 MB in 10.9 s | 1.5 s |
| alpine 3.23 x64 | 15.80 s | 14.53 s | 430 MB in 12.4 s | 1.7 s |
| debian 13 x64 | 13.78 s | 8.85 s | 394 MB in 7.8 s | 0.95 s |
| debian 13 x64-asan | 15.07 s | 10.46 s | 394 MB in 3.7 s | 1.35 s |
| ubuntu 25.04 x64 | 6.41 s | 7.66 s | 396 MB in 6.0 s | 1.1 s |

Before the shared libraries were included (build #109354) the launch still took 2.3 s on debian x64 and 7.8 to 9.3 s on alpine, whose chromium links against about a hundred system libraries. The warm-up's rate is the agent's lazy EBS load and varies by agent (the same 394 MB took 3.7 s on one and 7.8 s on another). One sample per lane.

Why `POSIX_FADV_WILLNEED` per window: one call reads at most `max(io_pages, ra_pages)` (256 KB here), measured with `mincore` after a single call over the whole file (0.3 MB resident). 128 KB windows cover every default. A sequential read gives the kernel one request at a time. Reading slices through `Bun.file().slice().arrayBuffer()` is as wide as the thread pool (4 on the CI agents). `WILLNEED` keeps the device queue full. Pinned to 4 CPUs with the cache evicted, the launch alone drops from 2.1 s to 0.4 s after the warm-up.

Finding, not changed here: `view.loading` is raised by `navigate()` only. `reload()` and `goBack()` leave it false while their navigation is in flight (`JSWebView::navigate` sets `m_loading`, the other ops do not). The op table records that.

`webview-chrome.test.ts` fails in this container without a `--no-sandbox` wrapper in `BUN_CHROME_PATH` (the container is root). That is the state on main, and #39490 addresses it. With the wrapper, the directory run is 82 pass, 62 skip (WebKit), 6 todo.

The first CI run also showed that Chrome's helpers (zygote, renderers, and two `cat` processes that hold the debugging pipe) can outlive the SIGKILLed browser by more than 5 s on a loaded agent. `closeAll()` does not kill them, so the fixture now polls only for the browser process, which the runtime kills and reaps.

Warm timings, release build: 0.30 to 0.32 s before, 0.32 to 0.33 s after. Debug build warm: 2.8 to 3.0 s before, 3.2 to 3.3 s after (the new scenarios do more: a second view, a reconnect, the /proc scans).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-disconnect.test.ts

<!-- robobun:evidence:end -->