### PR TITLE
fuzzilli: let ASAN report fatal signals in the REPRL child

### DIFF
--- a/src/jsc/bindings/FuzzilliREPRL.cpp
+++ b/src/jsc/bindings/FuzzilliREPRL.cpp
@@ -256,8 +256,7 @@ void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject* globalObject)
     JSC::VM& vm = globalObject->vm();
 
 #if ASAN_ENABLED
-    // ASAN reports the fatal signals (see __asan_default_options). A signal()
-    // call here would replace its handler and lose that report.
+    // ASAN reports the fatal signals; a signal() here would replace its handler.
     __sanitizer_set_death_callback(fuzzilliFlushOutputBeforeDeath);
 #endif
 

--- a/src/jsc/bindings/FuzzilliREPRL.cpp
+++ b/src/jsc/bindings/FuzzilliREPRL.cpp
@@ -256,10 +256,8 @@ void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject* globalObject)
     JSC::VM& vm = globalObject->vm();
 
 #if ASAN_ENABLED
-    // ASAN owns the handlers for SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGTRAP and
-    // SIGABRT (the last three are enabled in __asan_default_options), so every
-    // crash gets a report with a stack trace. Installing a handler here with
-    // signal() would replace ASAN's and discard that report.
+    // ASAN reports the fatal signals (see __asan_default_options). A signal()
+    // call here would replace its handler and lose that report.
     __sanitizer_set_death_callback(fuzzilliFlushOutputBeforeDeath);
 #endif
 

--- a/src/jsc/bindings/FuzzilliREPRL.cpp
+++ b/src/jsc/bindings/FuzzilliREPRL.cpp
@@ -6,7 +6,6 @@
 #include "root.h"
 #include "wtf/text/WTFString.h"
 #include <cerrno>
-#include <csignal>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
@@ -19,19 +18,16 @@
 
 extern "C" {
 
-// Signal handler to ensure output is flushed before crash
-static void fuzzilliSignalHandler(int sig)
+#if ASAN_ENABLED
+// Runs right before ASAN terminates the process, after it printed its report.
+static void fuzzilliFlushOutputBeforeDeath()
 {
-    // Flush all output
     fflush(stdout);
     fflush(stderr);
     fsync(STDOUT_FILENO);
     fsync(STDERR_FILENO);
-
-    // Re-raise the signal with default handler
-    signal(sig, SIG_DFL);
-    raise(sig);
 }
+#endif
 
 // Implementation of the global fuzzilli() function for Bun
 // This function is used by Fuzzilli to:
@@ -259,12 +255,13 @@ void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject* globalObject)
 {
     JSC::VM& vm = globalObject->vm();
 
-    // Install signal handlers to ensure output is flushed before crashes
-    // This is important for ASAN output to be captured
-    signal(SIGABRT, fuzzilliSignalHandler);
-    signal(SIGSEGV, fuzzilliSignalHandler);
-    signal(SIGILL, fuzzilliSignalHandler);
-    signal(SIGFPE, fuzzilliSignalHandler);
+#if ASAN_ENABLED
+    // ASAN owns the handlers for SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGTRAP and
+    // SIGABRT (the last three are enabled in __asan_default_options), so every
+    // crash gets a report with a stack trace. Installing a handler here with
+    // signal() would replace ASAN's and discard that report.
+    __sanitizer_set_death_callback(fuzzilliFlushOutputBeforeDeath);
+#endif
 
     globalObject->putDirectNativeFunction(
         vm,

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -79,9 +79,7 @@ pub(crate) extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     // suppressed allocations as leaks. If local debug crashes feel slow to
     // print, set `ASAN_OPTIONS=symbolize=0` in your shell instead.
     //
-    // Fuzzilli: a bare CRASH(), abort() or __builtin_trap() prints nothing, so
-    // ASAN reports those signals too. abort_on_error keeps the death a signal,
-    // which is what Fuzzilli counts as a crash (an _exit(1) is a failed run).
+    // Fuzzilli counts a signal death as a crash; a bare abort() prints nothing.
     if bun_core::Environment::ENABLE_FUZZILLI {
         return c"detect_stack_use_after_return=0:detect_leaks=0:abort_on_error=1:handle_abort=1:handle_sigill=1:handle_sigtrap=1".as_ptr();
     }

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -79,12 +79,9 @@ pub(crate) extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     // suppressed allocations as leaks. If local debug crashes feel slow to
     // print, set `ASAN_OPTIONS=symbolize=0` in your shell instead.
     //
-    // Fuzzilli builds: the REPRL child installs no signal handler of its own
-    // (FuzzilliREPRL.cpp), so ASAN must report every fatal signal, including
-    // SIGABRT from a bare CRASH() or abort() and SIGILL/SIGTRAP from
-    // __builtin_trap() and int3, which print nothing by themselves.
-    // abort_on_error=1 keeps the death a signal, which is what Fuzzilli
-    // counts as a crash; the default _exit(1) would count as a failed run.
+    // Fuzzilli: a bare CRASH(), abort() or __builtin_trap() prints nothing, so
+    // ASAN reports those signals too. abort_on_error keeps the death a signal,
+    // which is what Fuzzilli counts as a crash (an _exit(1) is a failed run).
     if bun_core::Environment::ENABLE_FUZZILLI {
         return c"detect_stack_use_after_return=0:detect_leaks=0:abort_on_error=1:handle_abort=1:handle_sigill=1:handle_sigtrap=1".as_ptr();
     }

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -78,8 +78,6 @@ pub(crate) extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     // `leak:uws_create_app` silently stops matching and CI reports the
     // suppressed allocations as leaks. If local debug crashes feel slow to
     // print, set `ASAN_OPTIONS=symbolize=0` in your shell instead.
-    //
-    // Fuzzilli counts a signal death as a crash; a bare abort() prints nothing.
     if bun_core::Environment::ENABLE_FUZZILLI {
         return c"detect_stack_use_after_return=0:detect_leaks=0:abort_on_error=1:handle_abort=1:handle_sigill=1:handle_sigtrap=1".as_ptr();
     }

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -78,6 +78,16 @@ pub(crate) extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     // `leak:uws_create_app` silently stops matching and CI reports the
     // suppressed allocations as leaks. If local debug crashes feel slow to
     // print, set `ASAN_OPTIONS=symbolize=0` in your shell instead.
+    //
+    // Fuzzilli builds: the REPRL child installs no signal handler of its own
+    // (FuzzilliREPRL.cpp), so ASAN must report every fatal signal, including
+    // SIGABRT from a bare CRASH() or abort() and SIGILL/SIGTRAP from
+    // __builtin_trap() and int3, which print nothing by themselves.
+    // abort_on_error=1 keeps the death a signal, which is what Fuzzilli
+    // counts as a crash; the default _exit(1) would count as a failed run.
+    if bun_core::Environment::ENABLE_FUZZILLI {
+        return c"detect_stack_use_after_return=0:detect_leaks=0:abort_on_error=1:handle_abort=1:handle_sigill=1:handle_sigtrap=1".as_ptr();
+    }
     c"detect_stack_use_after_return=0:detect_leaks=0".as_ptr()
 }
 

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -41,24 +41,26 @@ const crashEnv = {
 describe.skipIf(!isFuzzilliBuild)("fuzzilli crash reporting", () => {
   // FUZZILLI_CRASH types: 0 is std::abort(), 1 is __builtin_trap() (SIGILL on
   // x64, SIGTRAP on arm64), 5 writes through a null pointer.
-  test.concurrent.each([
+  describe.each([
     [0, /AddressSanitizer: ABRT/],
     [1, /AddressSanitizer: (ILL|TRAP)/],
     [5, /AddressSanitizer: SEGV/],
-  ])("FUZZILLI_CRASH %d dies with an ASAN report", async (type, report) => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `fuzzilli("FUZZILLI_CRASH", ${type})`],
-      env: crashEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+  ])("FUZZILLI_CRASH %d", (type, report) => {
+    test.concurrent("dies with an ASAN report", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", `fuzzilli("FUZZILLI_CRASH", ${type})`],
+        env: crashEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain(`FUZZILLI_CRASH: ${type}`);
+      expect(stderr).toMatch(report);
+      // ASAN aborts after the report, so the death is still a signal, which is
+      // what Fuzzilli counts as a crash.
+      expect(proc.signalCode).toBe("SIGABRT");
     });
-
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stdout).toContain(`FUZZILLI_CRASH: ${type}`);
-    expect(stderr).toMatch(report);
-    // ASAN aborts after the report, so the death is still a signal, which is
-    // what Fuzzilli counts as a crash.
-    expect(proc.signalCode).toBe("SIGABRT");
   });
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -29,9 +29,10 @@ const isFuzzilliBuild = typeof fuzzilli === "function";
 
 // symbolize=0: ASAN would otherwise run llvm-symbolizer over every frame of
 // the fuzz binary, which takes seconds. The report header is enough here.
+// Nothing else is set, so the signal handling comes from __asan_default_options.
 const crashEnv = {
   ...bunEnv,
-  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "abort_on_error=1"].filter(Boolean).join(":"),
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
 };
 
 // A crash in the REPRL child must leave an ASAN report on stderr. The REPRL

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "node:path";
 
@@ -20,4 +20,45 @@ test("REPRL loop survives a payload that calls process.execve", async () => {
 
   expect(stdout).toContain("STATUS_WRITES=2 LIVE=true");
   expect(exitCode).toBe(0);
+});
+
+declare const fuzzilli: unknown;
+// The native side (src/jsc/bindings/FuzzilliREPRL.cpp) only exists in the
+// fuzzilli build, which is the only build with a fuzzilli() global.
+const isFuzzilliBuild = typeof fuzzilli === "function";
+
+// symbolize=0: ASAN would otherwise run llvm-symbolizer over every frame of
+// the fuzz binary, which takes seconds. The report header is enough here.
+const crashEnv = {
+  ...bunEnv,
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "abort_on_error=1"].filter(Boolean).join(":"),
+};
+
+// A crash in the REPRL child must leave an ASAN report on stderr. The REPRL
+// code used to install its own signal handler, which replaced ASAN's and
+// re-raised the signal, so a SIGSEGV died with no report, and a bare abort()
+// died with no output at all.
+describe.skipIf(!isFuzzilliBuild)("fuzzilli crash reporting", () => {
+  // FUZZILLI_CRASH types: 0 is std::abort(), 1 is __builtin_trap() (SIGILL on
+  // x64, SIGTRAP on arm64), 5 writes through a null pointer.
+  test.concurrent.each([
+    [0, /AddressSanitizer: ABRT/],
+    [1, /AddressSanitizer: (ILL|TRAP)/],
+    [5, /AddressSanitizer: SEGV/],
+  ])("FUZZILLI_CRASH %d dies with an ASAN report", async (type, report) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `fuzzilli("FUZZILLI_CRASH", ${type})`],
+      env: crashEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(`FUZZILLI_CRASH: ${type}`);
+    expect(stderr).toMatch(report);
+    // ASAN aborts after the report, so the death is still a signal, which is
+    // what Fuzzilli counts as a crash.
+    expect(proc.signalCode).toBe("SIGABRT");
+  });
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -29,10 +29,11 @@ const isFuzzilliBuild = typeof fuzzilli === "function";
 
 // symbolize=0: ASAN would otherwise run llvm-symbolizer over every frame of
 // the fuzz binary, which takes seconds. The report header is enough here.
-// Nothing else is set, so the signal handling comes from __asan_default_options.
+// The inherited ASAN_OPTIONS is dropped so that the signal handling under test
+// comes from __asan_default_options only.
 const crashEnv = {
   ...bunEnv,
-  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+  ASAN_OPTIONS: "symbolize=0",
 };
 
 // A crash in the REPRL child must leave an ASAN report on stderr. The REPRL


### PR DESCRIPTION
### What does this PR do?

The REPRL child (`bun fuzzilli`) installed its own handler for SIGABRT, SIGSEGV, SIGILL and SIGFPE in `FuzzilliREPRL.cpp`. The handler flushed stdio and re-raised the signal with the default disposition. Three things followed from that:

- The handler replaced the ASAN handler. A SIGSEGV died with no report. Checked with `fuzzilli('FUZZILLI_CRASH', 5)` under libreprl: status 11, empty stderr.
- A bare `CRASH()` or `abort()` prints nothing on Linux (`CRASH()` is `std::abort()` there, and `CRASH_WITH_INFO` is `CRASH()`). So a SIGABRT died with no output at all. Checked with `fuzzilli('FUZZILLI_CRASH', 0)`: status 6, empty stderr.
- The handler also replaced JSC's `jscSignalHandler`, which sits in front of ASAN's handler. JSC relies on it for signal based VMTraps and Wasm fault handling (see the analysis in #30092).

Fuzzilli stored such crashes with an empty stderr, which leaves nothing to work from.

This PR lets ASAN own the fatal signals:

- `__asan_default_options` adds `abort_on_error=1:handle_abort=1:handle_sigill=1:handle_sigtrap=1` in fuzzilli builds (`Environment::ENABLE_FUZZILLI` is a build-time constant). ASAN already handles SIGSEGV, SIGBUS and SIGFPE by default. With these it also reports SIGABRT, SIGILL (`__builtin_trap()` on x64) and SIGTRAP, with the faulting pc, the registers, and a stack trace unwound from the signal context. `abort_on_error=1` keeps the death a signal. Without it ASAN calls `_exit(1)` after the report and Fuzzilli counts the run as failed, not crashed.
- `FuzzilliREPRL.cpp` no longer calls `signal()`. It registers the stdio flush as the ASAN death callback, so the flush still runs right before the process dies.

### Prior attempts

#29775 and #30092 fixed the SIGSEGV half of this. Both kept a REPRL signal handler and chained it to the previous handler. Both were closed by the test gate, with no maintainer comment, because `FuzzilliREPRL.cpp` only compiles in the fuzzilli build and CI does not build it.

This PR removes the REPRL handler instead of chaining it. There is no saved action to forward to and no re-entry hazard from a second global object. It also covers the SIGABRT class, which the chained shape could not: nothing in the chain reports a bare `abort()`.

### Background

Fuzzilli reported a flaky crash with `TERMSIG: 6`, empty stderr and empty stdout. The program was the profile prefix and suffix around a constructor that calls `Bun.concatArrayBuffers([])`. It did not reproduce:

- 60 standalone runs and 30 in-process evaluations of the script.
- 1000 executions of the exact script through libreprl in one child process.
- A local Fuzzilli run with the bun profile, 8 jobs, 200,332 executions, with an `LD_PRELOAD` hook on `abort()` that logged a stack for every abort. The only aborts were the three startup crash tests.

The program has an empty `CONTRIBUTORS` field, which is what a program imported from another instance looks like. Such programs run once in a long-lived child. With no stderr, nothing in the crash file says where the child died. After this change the next crash of this kind comes with a stack.

### Tests

`test/js/bun/util/fuzzilli-reprl.test.ts` gets three cases. They run only when `fuzzilli` is a global, which is the case only in a fuzzilli build. `bun bd test` skips them.

With `bun run build:debug:fuzzilli` and `build/debug-fuzz/bun-debug test test/js/bun/util/fuzzilli-reprl.test.ts`:

- Before this change: the three cases fail. stderr holds only the `[COV]` banner.
- After this change: the three cases pass. `FUZZILLI_CRASH 0` gives `AddressSanitizer: ABRT`, `FUZZILLI_CRASH 1` gives `AddressSanitizer: ILL`, `FUZZILLI_CRASH 5` gives `AddressSanitizer: SEGV`, and each process dies with SIGABRT.

The previous two PRs were closed because their test could not run in CI. This one has the same limitation, for the same reason: the code under test is not in the CI binary. Maintainers, please say whether a fuzzilli-gated test is acceptable here.

### Verification of the reports

Patched fuzzilli binary under libreprl, with the profile's `ASAN_OPTIONS` (`symbolize=false`):

- `FUZZILLI_CRASH 0`: status 6 in 147ms. Frames: `pthread_kill`, `raise`, `abort`, then `functionFuzzilli` at the `std::abort()` call. The slow unwinder stops at the JIT boundary above it. `fast_unwind_on_fatal=1` was tried and rejected: the frame pointer walk skips `abort` and the function that called it.
- `FUZZILLI_CRASH 5`: status 6 in 153ms. `SEGV on unknown address 0x0`, frame #0 is `functionFuzzilli` at the null write, frame #6 is `jscSignalHandler`.
- `FUZZILLI_CRASH 3`: the heap-buffer-overflow report is unchanged.
- Fuzzilli's startup tests pass with the patched binary, a short fuzz round ran with no crash, and the reported crash script still exits with status 0.
