### PR TITLE
resolver: compare browser map keys with forward slashes on every platform

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -610,8 +610,6 @@ impl PackageJSON {
                         // import of "foo", but that's actually not a bug. Or arguably it's a
                         // bug in Browserify but we have to replicate this bug because packages
                         // do this in the wild.
-                        //
-                        // Keys keep forward slashes on every platform, like the lookup path.
                         let key: &[u8] = resolve_path::resolve_path::normalize_string_spill::<
                             true,
                             resolve_path::platform::Posix,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -610,9 +610,13 @@ impl PackageJSON {
                         // import of "foo", but that's actually not a bug. Or arguably it's a
                         // bug in Browserify but we have to replicate this bug because packages
                         // do this in the wild.
+                        //
+                        // The keys keep forward slashes on every platform. A key like
+                        // "pkg/sub" is looked up with the import path as written, which
+                        // has forward slashes on Windows too.
                         let key: &[u8] = resolve_path::resolve_path::normalize_string_spill::<
                             true,
-                            resolve_path::platform::Auto,
+                            resolve_path::platform::Posix,
                         >(&mut key_spill, prop.key.slice());
 
                         match &prop.value {

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -611,9 +611,7 @@ impl PackageJSON {
                         // bug in Browserify but we have to replicate this bug because packages
                         // do this in the wild.
                         //
-                        // The keys keep forward slashes on every platform. A key like
-                        // "pkg/sub" is looked up with the import path as written, which
-                        // has forward slashes on Windows too.
+                        // Keys keep forward slashes on every platform, like the lookup path.
                         let key: &[u8] = resolve_path::resolve_path::normalize_string_spill::<
                             true,
                             resolve_path::platform::Posix,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5070,9 +5070,8 @@ impl<'a> Resolver<'a> {
             return None;
         }
 
-        // Normalize the path so we can compare against it without getting confused by "./".
-        // The map keys use forward slashes on every platform (see `parse_package_json`),
-        // so the normalized path does too.
+        // Normalize the path (forward slashes, like the map keys) so we can compare
+        // against it without getting confused by "./"
         let cleaned: &[u8] = bun_paths::resolve_path::normalize_string_buf::<
             false,
             bun_paths::platform::Posix,
@@ -5084,8 +5083,7 @@ impl<'a> Resolver<'a> {
             return None;
         }
 
-        // A path inside the package is compared in its normalized form. A package
-        // path is compared as written.
+        // A path inside the package is compared normalized, a package path as written.
         let input_path: &[u8] = match KIND {
             BrowserMapPathKind::AbsolutePath => cleaned,
             BrowserMapPathKind::PackagePath => input_path,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5070,15 +5070,26 @@ impl<'a> Resolver<'a> {
             return None;
         }
 
-        // Normalize the path so we can compare against it without getting confused by "./"
-        let cleaned = self
-            .fs_ref()
-            .normalize_buf(bufs!(check_browser_map), input_path);
+        // Normalize the path so we can compare against it without getting confused by "./".
+        // The map keys use forward slashes on every platform (see `parse_package_json`),
+        // so the normalized path does too.
+        let cleaned: &[u8] = bun_paths::resolve_path::normalize_string_buf::<
+            false,
+            bun_paths::platform::Posix,
+            false,
+        >(input_path, bufs!(check_browser_map));
 
         if cleaned.len() == 1 && cleaned[0] == b'.' {
             // No bundler supports remapping ".", so we don't either
             return None;
         }
+
+        // A path inside the package is compared in its normalized form. A package
+        // path is compared as written.
+        let input_path: &[u8] = match KIND {
+            BrowserMapPathKind::AbsolutePath => cleaned,
+            BrowserMapPathKind::PackagePath => input_path,
+        };
 
         let mut checker = BrowserMapPath {
             remapped: b"",
@@ -6650,15 +6661,12 @@ impl<'b> BrowserMapPath<'b> {
         // If that failed, try assuming this is a directory and looking for an "index" file
 
         let index_path: &[u8] = {
-            let trimmed = strings::trim_right(path_to_check, &[SEP]);
-            let parts = [
-                trimmed,
-                const_format::concatcp!(SEP_STR, "index").as_bytes(),
-            ];
+            let trimmed = strings::trim_right(path_to_check, b"/");
+            let parts = [trimmed, b"/index".as_slice()];
             ResolvePath::join_string_buf(
                 bufs!(tsconfig_base_url),
                 &parts,
-                bun_paths::Platform::AUTO,
+                bun_paths::Platform::Posix,
             )
         };
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5070,8 +5070,7 @@ impl<'a> Resolver<'a> {
             return None;
         }
 
-        // Normalize the path (forward slashes, like the map keys) so we can compare
-        // against it without getting confused by "./"
+        // Normalize the path so we can compare against it without getting confused by "./"
         let cleaned: &[u8] = bun_paths::resolve_path::normalize_string_buf::<
             false,
             bun_paths::platform::Posix,

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -503,6 +503,76 @@ describe("bundler", () => {
     },
   });
 
+  // A "browser" map key with a slash ("pkg/sub", "@scope/pkg") must match the
+  // import specifier on Windows too. The keys used to be stored with native
+  // separators there, so "pkg/sub" became "pkg\sub" and never matched.
+  itBundled("browser/BrowserFieldDisablesPackageSubpath", {
+    files: {
+      "/entry.js": /* js */ `
+        const sub = require("pkg/sub");
+        const scoped = require("@scope/pkg");
+        console.log(typeof sub.value, typeof scoped.value);
+      `,
+      "/package.json": /* json */ `
+        { "name": "app", "browser": { "pkg/sub": false, "@scope/pkg": false } }
+      `,
+      "/node_modules/pkg/package.json": /* json */ `
+        { "name": "pkg" }
+      `,
+      "/node_modules/pkg/sub.js": /* js */ `
+        module.exports = { value: "node-only-sub" };
+      `,
+      "/node_modules/@scope/pkg/package.json": /* json */ `
+        { "name": "@scope/pkg" }
+      `,
+      "/node_modules/@scope/pkg/index.js": /* js */ `
+        module.exports = { value: "node-only-scoped" };
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "undefined undefined",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      assert(!out.includes("node-only-sub"), 'browser:{"pkg/sub":false} should keep pkg/sub.js out of the bundle');
+      assert(
+        !out.includes("node-only-scoped"),
+        'browser:{"@scope/pkg":false} should keep @scope/pkg out of the bundle',
+      );
+    },
+  });
+  itBundled("browser/BrowserFieldRemapsPackageSubpath", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("pkg/sub").value);
+      `,
+      "/package.json": /* json */ `
+        { "name": "app", "browser": { "pkg/sub": "./sub-shim.js" } }
+      `,
+      "/sub-shim.js": /* js */ `
+        module.exports = { value: "shim" };
+      `,
+      "/node_modules/pkg/package.json": /* json */ `
+        { "name": "pkg" }
+      `,
+      "/node_modules/pkg/sub.js": /* js */ `
+        module.exports = { value: "node-only-sub" };
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "shim",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      assert(
+        !out.includes("node-only-sub"),
+        'browser:{"pkg/sub":"./sub-shim.js"} should keep pkg/sub.js out of the bundle',
+      );
+    },
+  });
+
   // unsure: do we want polyfills or no-op stuff like node:* has
   // right now all error except bun:wrap which errors at resolve time, but is included if external
   const bunModules: Record<string, "no-op" | "polyfill" | "error"> = {


### PR DESCRIPTION
### Problem
- On Windows, a `browser` map key with a slash never matches a bare import under `--target=browser`. `{"pkg/sub": false}` and `{"@scope/pkg": false}` bundle the Node file, and `{"pkg/sub": "./shim.js"}` is ignored. Linux and macOS apply the same entries.
- `parse_package_json` normalized each key with the native separator (`src/resolver/package_json.rs:617`), so `pkg/sub` was stored as `pkg\sub`. `check_browser_map` (`src/resolver/resolver.rs:5042`) compares a package path as written, with forward slashes.

### Fix
- Store the keys with forward slashes on every platform. Normalize the lookup path the same way, and build the `<path>/index` probe with forward slashes.
- A path inside the package (`AbsolutePath` mode) is compared in its normalized form, so `foo\bar.js` matches `./foo/bar.js` on Windows. A package path is compared as written. esbuild does the same: keys go through `path.Clean` and the relative path gets forward slashes.
- POSIX behavior does not change, because the normalization already used forward slashes there. The new tests pass on Linux with and without the fix. On Windows they fail on bun 1.4.1 and on a debug build of main, and pass with this change.
- Verified: `test/bundler/bundler_browser.test.ts` (2 new cases) on Linux and Windows. Also `esbuild/packagejson`, `bundler_edgecase` and `bun/resolve` on both, plus `bundler_npm` and the bake `browser field is used` test.

### Background
- The `browser` field maps a specifier, or a file in the package, to another file or to `false` (an empty module). Bundlers apply it for `--target=browser`.
- `check_browser_map` has two modes. `PackagePath` takes the import specifier as written. `AbsolutePath` takes a resolved file path and strips the package directory.
- #40832 reworks the browser field to match esbuild and stores the keys as written. It is not mergeable right now. This is the small fix for the released behavior.

<details><summary>Notes</summary>

Repro on Windows with bun 1.4.1, `bun build --target=browser entry.js`:

```
package.json:                  {"name":"app","browser":{"pkg/sub":false}}
node_modules/pkg/package.json: {"name":"pkg"}
node_modules/pkg/sub.js:       module.exports = 1
entry.js:                      import x from "pkg/sub"; console.log(x)
```

Linux prints `var { default: x} = (() => ({}));`. Windows bundles `node_modules/pkg/sub.js`. Every scoped package key (`@scope/pkg`) has a slash, so those are affected too. A slash-free key such as `"pkg": false` works on both.

Why only the `PackagePath` mode broke: `DirInfo.abs_path` ends with a separator, so the `AbsolutePath` input is the path below the package directory, with native separators on both sides of the lookup. The bare exact match for a package path was the only probe that compared a raw specifier against a normalized key.

The first version of this change added `map.get(cleaned)` as a fallback, which is the input cleaning esbuild removed in 0.11.16 (#1209, over-matching). The self-review pointed that out, so the change now mirrors esbuild's current shape instead. A specifier with redundant segments (`pkg/./sub`) still does not match the key `pkg/sub`, on any platform, as before.

The fail-before can only be observed on Windows. The gate runs the proof on Linux, where the two tests pass with and without the fix. Windows proof: with `src/resolver/` checked out from `origin/main` and the rest of the branch in place, `bun bd test test/bundler/bundler_browser.test.ts -t "BrowserField.*PackageSubpath"` fails both tests (`string string` and `node-only-sub` instead of `undefined undefined` and `shim`). With the branch's `src/`, both pass.

Suites run: `test/bundler/bundler_browser.test.ts` (27 tests, Linux and Windows), `test/bundler/esbuild/packagejson.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/js/bun/resolve/resolve.test.ts` (Linux and Windows), `test/bundler/bundler_npm.test.ts` (Linux), `test/bake/dev/esm.test.ts -t "browser field is used"` (Linux and Windows).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1420.93ms]
(pass) bundler > browser/NodeBuffer#12272 [704.92ms]
(pass) bundler > browser/NodeFS [368.65ms]
(pass) bundler > browser/NodeTTY [352.24ms]
(pass) bundler > browser/NodeEventsOnce [504.62ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [520.80ms]
(pass) bundler > browser/NodePolyfills [7310.56ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [466.13ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [459.18ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [372.88ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [457.85ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [246.66ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [221.06ms]
(pass) bundler > browser/EntryPointDisab
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.1-canary.1 (a6c4cc276)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [29.91ms]
(pass) bundler > browser/NodeBuffer#12272 [14.96ms]
(pass) bundler > browser/NodeFS [8.03ms]
(pass) bundler > browser/NodeTTY [7.70ms]
(pass) bundler > browser/NodeEventsOnce [10.88ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [10.49ms]
(pass) bundler > browser/NodePolyfills [141.68ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [11.09ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [10.18ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [10.17ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [10.77ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [4.64ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [4.10ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldOnlyAppliesToBrowserTarget [11.70ms]
(pass) bundler > browser/EntryPointDisabledByPackageMainBrowserField [4.66ms]
1114 |                 errorsLeft.splice(i, 1)
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1435.64ms]
(pass) bundler > browser/NodeBuffer#12272 [691.74ms]
(pass) bundler > browser/NodeFS [355.71ms]
(pass) bundler > browser/NodeTTY [429.81ms]
(pass) bundler > browser/NodeEventsOnce [500.24ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [456.51ms]
(pass) bundler > browser/NodePolyfills [7429.11ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [399.60ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [466.64ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [380.59ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [465.07ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [252.26ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [222.80ms]
(pass) bundler > browser/EntryPointDisab
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c6a02b74e8
  features     baseline

23 deps, 131 codegen, 1172 objects in 646ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 26 installs across 63 packages (no changes) [5.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] gen .bind.ts → GeneratedBindings.cpp
[7/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Proce
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/package_json.rs         |  6 +++-
 src/resolver/resolver.rs             | 28 +++++++++------
 test/bundler/bundler_browser.test.ts | 70 ++++++++++++++++++++++++++++++++++++
 3 files changed, 93 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/resolver/package_json.rs              1      1     22
src/resolver/resolver.rs                 20      4     22
test/bundler/bundler_browser.test.ts      3      4     22
```

</details>

<!-- robobun:evidence:end -->