### PR TITLE
bake: check for exceptions in the production build's module loader hooks and helpers

### DIFF
--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -22,37 +22,30 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     bool deferred)
 {
     UNUSED_PARAM(deferred);
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Returning nullptr with an exception pending is what JSModuleLoader::importModule
+    // itself does. globalFuncImportModule rejects the import() promise with it.
     WTF::String keyString = moduleNameValue->getString(global);
+    RETURN_IF_EXCEPTION(scope, nullptr);
     if (keyString.startsWith("bake:/"_s)) {
-        auto& vm = JSC::getVM(global);
-        return JSC::importModule(global, JSC::Identifier::fromString(vm, keyString),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, keyString), JSC::Identifier(), WTF::move(parameters), nullptr));
     }
 
     if (!sourceOrigin.isNull() && sourceOrigin.string().startsWith("bake:/"_s)) {
-        auto& vm = JSC::getVM(global);
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
         WTF::String refererString = sourceOrigin.string();
-        WTF::String keyString = moduleNameValue->getString(global);
-
-        if (!keyString) {
-            auto promise = JSC::JSPromise::create(vm, global->promiseStructure());
-            promise->reject(vm, JSC::createError(global, "import() requires a string"_s));
-            return promise;
-        }
 
         BunString refererBunString = Bun::toString(refererString);
         BunString keyBunString = Bun::toString(keyString);
         BunString result = BakeProdResolve(global, &refererBunString, &keyBunString);
         RETURN_IF_EXCEPTION(scope, nullptr);
 
-        return JSC::importModule(global, JSC::Identifier::fromString(vm, result.transferToWTFString()),
-            JSC::Identifier(), WTF::move(parameters), nullptr);
+        RELEASE_AND_RETURN(scope, JSC::importModule(global, JSC::Identifier::fromString(vm, result.transferToWTFString()), JSC::Identifier(), WTF::move(parameters), nullptr));
     }
 
     // TODO: make static cast instead of jscast
-    return uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin, false);
+    RELEASE_AND_RETURN(scope, uncheckedDowncast<Zig::GlobalObject>(global)->moduleLoaderImportModule(global, moduleLoader, moduleNameValue, WTF::move(parameters), sourceOrigin, false));
 }
 
 JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,
@@ -95,7 +88,7 @@ JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,
         }
     }
 
-    return Zig::GlobalObject::moduleLoaderResolve(jsGlobal, loader, key, referrer, WTF::move(origin), useImportMap);
+    RELEASE_AND_RETURN(scope, Zig::GlobalObject::moduleLoaderResolve(jsGlobal, loader, key, referrer, WTF::move(origin), useImportMap));
 }
 
 static JSC::JSPromise* rejectedInternalPromise(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
@@ -172,14 +165,12 @@ JSC::JSPromise* bakeModuleLoaderFetch(JSC::JSGlobalObject* globalObject,
 #endif
             JSString* bakePrefixRemovedString = jsNontrivialString(vm, bakePrefixRemoved);
             JSValue bakePrefixRemovedJsvalue = bakePrefixRemovedString;
-            return Zig::GlobalObject::moduleLoaderFetch(globalObject, loader, bakePrefixRemovedJsvalue, referrer, WTF::move(parameters), WTF::move(script));
+            RELEASE_AND_RETURN(scope, Zig::GlobalObject::moduleLoaderFetch(globalObject, loader, bakePrefixRemovedJsvalue, referrer, WTF::move(parameters), WTF::move(script)));
         }
         return rejectedInternalPromise(globalObject, createTypeError(globalObject, "BakeGlobalObject does not have per-thread data configured"_s));
     }
 
-    auto result = Zig::GlobalObject::moduleLoaderFetch(globalObject, loader, key, referrer, WTF::move(parameters), WTF::move(script));
-    RETURN_IF_EXCEPTION(scope, rejectedInternalPromise(globalObject, scope.exception()->value()));
-    return result;
+    RELEASE_AND_RETURN(scope, Zig::GlobalObject::moduleLoaderFetch(globalObject, loader, key, referrer, WTF::move(parameters), WTF::move(script)));
 }
 
 GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure,

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -25,8 +25,6 @@ bakeModuleLoaderImportModule(JSC::JSGlobalObject* global,
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Returning nullptr with an exception pending is what JSModuleLoader::importModule
-    // itself does. globalFuncImportModule rejects the import() promise with it.
     WTF::String keyString = moduleNameValue->getString(global);
     RETURN_IF_EXCEPTION(scope, nullptr);
     if (keyString.startsWith("bake:/"_s)) {

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -185,7 +185,8 @@ extern "C" JSC::EncodedJSValue BakeGetOnModuleNamespace(
   auto scope = DECLARE_THROW_SCOPE(vm);
 
   auto* moduleNamespace = uncheckedDowncast<JSC::JSModuleNamespaceObject>(JSC::JSValue::decode(moduleNamespaceValue));
-  const auto propertyString = String(StringImpl::createWithoutCopying({ key.ptr, key.len }));
+  // Copy: Identifier::fromString atomizes the impl in place, and the key is only borrowed for this call.
+  const auto propertyString = String::fromUTF8(std::span { key.ptr, key.len });
   const auto identifier = JSC::Identifier::fromString(vm, propertyString);
   const auto property = JSC::PropertyName(identifier);
   JSC::JSValue value = moduleNamespace->get(global, property);

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -4,6 +4,7 @@
 #include "BakeGlobalObject.h"
 #include "JavaScriptCore/CallData.h"
 #include "JavaScriptCore/Completion.h"
+#include "JavaScriptCore/Error.h"
 #include "JavaScriptCore/Identifier.h"
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/JSCast.h"
@@ -15,6 +16,7 @@
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/JSModuleNamespaceObject.h"
 #include "ImportMetaObject.h"
+#include <wtf/text/MakeString.h>
 
 namespace Bake {
 
@@ -131,14 +133,17 @@ static JSC::JSModuleNamespaceObject* getModuleNamespace(JSC::JSGlobalObject* glo
   auto scope = DECLARE_THROW_SCOPE(vm);
 
   JSC::JSString* key = uncheckedDowncast<JSC::JSString>(keyValue);
-  String keyString = key->value(global);
+  String keyString = key->getString(global);
   RETURN_IF_EXCEPTION(scope, nullptr);
 
   auto keyIdent = JSC::Identifier::fromString(vm, keyString);
   auto* entry = global->moduleLoader()->registryEntry(keyIdent);
-  ASSERT(entry); // should have called BakeLoadModuleByKey and waited for that promise
   auto* module = entry ? entry->record() : nullptr;
-  ASSERT(module);
+  // The caller waited for BakeLoadModuleByKey's promise, so both exist unless the loader registered the module under another key.
+  if (!module) [[unlikely]] {
+    throwTypeError(global, scope, makeString("Module \""_s, keyString, "\" is not in the module registry"_s));
+    return nullptr;
+  }
   JSC::JSModuleNamespaceObject* namespaceObject = global->moduleLoader()->getModuleNamespaceObject(global, module);
   RETURN_IF_EXCEPTION(scope, nullptr);
   ASSERT(namespaceObject);

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -24,6 +24,9 @@ extern "C" BunString BakeSourceProvider__getSourceSlice(SourceProvider* provider
     return Bun::toStringView(provider->source());
 }
 
+// The EncodedJSValue-returning entry points below return empty if and only if
+// an exception is pending (Rust calls them through `jsc::from_js_host_call`).
+
 extern "C" JSC::EncodedJSValue BakeLoadInitialServerCode(JSC::JSGlobalObject* global, BunString source, bool separateSSRGraph) {
   auto& vm = JSC::getVM(global);
   auto scope = DECLARE_THROW_SCOPE(vm);
@@ -51,11 +54,24 @@ extern "C" JSC::EncodedJSValue BakeLoadInitialServerCode(JSC::JSGlobalObject* gl
   args.append(JSC::jsBoolean(separateSSRGraph)); // separateSSRGraph
   args.append(Zig::ImportMetaObject::create(global, "bake://server-runtime.js"_s)); // importMeta
 
-  RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::profiledCall(global, JSC::ProfilingReason::API, fn, callData, JSC::jsUndefined(), args)));
+  // `JSC::call` returns undefined (not empty) when the callee throws.
+  JSC::JSValue result = JSC::profiledCall(global, JSC::ProfilingReason::API, fn, callData, JSC::jsUndefined(), args);
+  RETURN_IF_EXCEPTION(scope, {});
+  return JSC::JSValue::encode(result);
 }
 
-extern "C" JSC::JSPromise* BakeLoadModuleByKey(GlobalObject* global, JSC::JSString* key) {
-  return JSC::loadAndEvaluateModule(global, key->getString(global), nullptr, nullptr);
+extern "C" JSC::EncodedJSValue BakeLoadModuleByKey(JSC::JSGlobalObject* global, JSC::EncodedJSValue keyValue) {
+  auto& vm = JSC::getVM(global);
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  JSC::JSString* key = uncheckedDowncast<JSC::JSString>(JSC::JSValue::decode(keyValue));
+  String keyString = key->getString(global);
+  RETURN_IF_EXCEPTION(scope, {});
+
+  JSC::JSPromise* promise = JSC::loadAndEvaluateModule(global, keyString, nullptr, nullptr);
+  RETURN_IF_EXCEPTION(scope, {});
+  ASSERT(promise);
+  return JSC::JSValue::encode(promise);
 }
 
 extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatch(GlobalObject* global, BunString source) {
@@ -108,42 +124,71 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(GlobalObject*
   return JSC::JSValue::encode(result);
 }
 
-extern "C" JSC::EncodedJSValue BakeGetModuleNamespace(
-  JSC::JSGlobalObject* global,
-  JSC::JSValue keyValue
-) {
-  JSC::JSString* key = uncheckedDowncast<JSC::JSString>(keyValue);
+// `keyValue` must name a module whose evaluation promise has already settled.
+// Returns nullptr if and only if an exception is pending.
+static JSC::JSModuleNamespaceObject* getModuleNamespace(JSC::JSGlobalObject* global, JSC::JSValue keyValue) {
   auto& vm = JSC::getVM(global);
-  auto keyIdent = JSC::Identifier::fromString(vm, key->value(global));
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  JSC::JSString* key = uncheckedDowncast<JSC::JSString>(keyValue);
+  String keyString = key->value(global);
+  RETURN_IF_EXCEPTION(scope, nullptr);
+
+  auto keyIdent = JSC::Identifier::fromString(vm, keyString);
   auto* entry = global->moduleLoader()->registryEntry(keyIdent);
-  ASSERT(entry); // should have called BakeLoadServerCode and wait for that promise
+  ASSERT(entry); // should have called BakeLoadModuleByKey and waited for that promise
   auto* module = entry ? entry->record() : nullptr;
   ASSERT(module);
   JSC::JSModuleNamespaceObject* namespaceObject = global->moduleLoader()->getModuleNamespaceObject(global, module);
+  RETURN_IF_EXCEPTION(scope, nullptr);
   ASSERT(namespaceObject);
-  return JSC::JSValue::encode(namespaceObject);
+  return namespaceObject;
+}
+
+extern "C" JSC::EncodedJSValue BakeGetModuleNamespace(
+  JSC::JSGlobalObject* global,
+  JSC::EncodedJSValue keyValue
+) {
+  return JSC::JSValue::encode(getModuleNamespace(global, JSC::JSValue::decode(keyValue)));
 }
 
 extern "C" JSC::EncodedJSValue BakeGetDefaultExportFromModule(
   JSC::JSGlobalObject* global,
-  JSC::JSValue keyValue
+  JSC::EncodedJSValue keyValue
 ) {
   auto& vm = JSC::getVM(global);
-  return JSC::JSValue::encode(uncheckedDowncast<JSC::JSModuleNamespaceObject>(JSC::JSValue::decode(BakeGetModuleNamespace(global, keyValue)))->get(global, vm.propertyNames->defaultKeyword));
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  JSC::JSModuleNamespaceObject* namespaceObject = getModuleNamespace(global, JSC::JSValue::decode(keyValue));
+  RETURN_IF_EXCEPTION(scope, {});
+
+  JSC::JSValue defaultExport = namespaceObject->get(global, vm.propertyNames->defaultKeyword);
+  RETURN_IF_EXCEPTION(scope, {});
+  return JSC::JSValue::encode(defaultExport);
 }
 
-// There were issues when trying to use JSValue.get from zig
+// `bun_core::ffi::FfiSlice<u8>`: a borrowed `&[u8]` passed by value.
+struct BakeModuleNamespaceKey {
+  const unsigned char* ptr;
+  size_t len;
+};
+
+// `moduleNamespaceValue` must be a namespace object from BakeGetModuleNamespace.
 extern "C" JSC::EncodedJSValue BakeGetOnModuleNamespace(
   JSC::JSGlobalObject* global,
-  JSC::JSModuleNamespaceObject* moduleNamespace,
-  const unsigned char* key,
-  size_t keyLength
+  JSC::EncodedJSValue moduleNamespaceValue,
+  BakeModuleNamespaceKey key
 ) {
   auto& vm = JSC::getVM(global);
-  const auto propertyString = String(StringImpl::createWithoutCopying({ key, keyLength }));
+  auto scope = DECLARE_THROW_SCOPE(vm);
+
+  auto* moduleNamespace = uncheckedDowncast<JSC::JSModuleNamespaceObject>(JSC::JSValue::decode(moduleNamespaceValue));
+  const auto propertyString = String(StringImpl::createWithoutCopying({ key.ptr, key.len }));
   const auto identifier = JSC::Identifier::fromString(vm, propertyString);
   const auto property = JSC::PropertyName(identifier);
-  return JSC::JSValue::encode(moduleNamespace->get(global, property));
+  JSC::JSValue value = moduleNamespace->get(global, property);
+  RETURN_IF_EXCEPTION(scope, {});
+  return JSC::JSValue::encode(value);
 }
 
 } // namespace Bake

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -26,8 +26,7 @@ extern "C" BunString BakeSourceProvider__getSourceSlice(SourceProvider* provider
     return Bun::toStringView(provider->source());
 }
 
-// The EncodedJSValue-returning entry points below return empty if and only if
-// an exception is pending (Rust calls them through `jsc::from_js_host_call`).
+// Rust calls the EncodedJSValue entry points below through `from_js_host_call`: empty return <=> exception pending.
 
 extern "C" JSC::EncodedJSValue BakeLoadInitialServerCode(JSC::JSGlobalObject* global, BunString source, bool separateSSRGraph) {
   auto& vm = JSC::getVM(global);
@@ -126,8 +125,7 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(GlobalObject*
   return JSC::JSValue::encode(result);
 }
 
-// `keyValue` must name a module whose evaluation promise has already settled.
-// Returns nullptr if and only if an exception is pending.
+// nullptr <=> exception pending.
 static JSC::JSModuleNamespaceObject* getModuleNamespace(JSC::JSGlobalObject* global, JSC::JSValue keyValue) {
   auto& vm = JSC::getVM(global);
   auto scope = DECLARE_THROW_SCOPE(vm);
@@ -139,7 +137,6 @@ static JSC::JSModuleNamespaceObject* getModuleNamespace(JSC::JSGlobalObject* glo
   auto keyIdent = JSC::Identifier::fromString(vm, keyString);
   auto* entry = global->moduleLoader()->registryEntry(keyIdent);
   auto* module = entry ? entry->record() : nullptr;
-  // The caller waited for BakeLoadModuleByKey's promise, so both exist unless the loader registered the module under another key.
   if (!module) [[unlikely]] {
     throwTypeError(global, scope, makeString("Module \""_s, keyString, "\" is not in the module registry"_s));
     return nullptr;

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -355,10 +355,11 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     {
         Unwrapped::Pending => unreachable!(),
         Unwrapped::Fulfilled(_) => {
-            let default = BakeGetDefaultExportFromModule(
+            let default = c::bake_get_default_export_from_module(
                 global,
                 config_entry_point_string.to_js(global).map_err(js_err)?,
-            );
+            )
+            .map_err(js_err)?;
 
             if !default.is_object() {
                 return Err(js_err(global.throw_invalid_arguments(format_args!(
@@ -846,17 +847,10 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
 
         let server_file = router_type.server_file;
         let server_entry_point = pt.load_bundled_module(server_file)?;
-        let server_render_func = 'brk: {
-            let Some(raw) = bake_get_on_module_namespace(global, server_entry_point, b"prerender")
-            else {
-                break 'brk None;
-            };
-            if !raw.is_callable() {
-                break 'brk None;
-            }
-            break 'brk Some(raw);
-        };
-        let Some(server_render_func) = server_render_func else {
+        let server_render_func =
+            c::bake_get_on_module_namespace(global, server_entry_point, b"prerender")
+                .map_err(js_err)?;
+        if !server_render_func.is_callable() {
             bun_core::err_generic!("Framework does not support static site generation");
             bun_core::note!(
                 "The file {} is missing the \"prerender\" export, which defines how to generate static files.",
@@ -866,34 +860,23 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 ))
             );
             Global::crash();
-        };
+        }
 
         let server_param_func = if router.dynamic_routes.count() > 0 {
-            let f = 'brk: {
-                let Some(raw) =
-                    bake_get_on_module_namespace(global, server_entry_point, b"getParams")
-                else {
-                    break 'brk None;
-                };
-                if !raw.is_callable() {
-                    break 'brk None;
-                }
-                break 'brk Some(raw);
-            };
-            match f {
-                Some(f) => f,
-                None => {
-                    bun_core::err_generic!("Framework does not support static site generation");
-                    bun_core::note!(
-                        "The file {} is missing the \"getParams\" export, which defines how to generate static files.",
-                        bun_core::fmt::quote(resolve_path::relative(
-                            cwd,
-                            pt.input_file(server_file).abs_path()
-                        ))
-                    );
-                    Global::crash();
-                }
+            let f = c::bake_get_on_module_namespace(global, server_entry_point, b"getParams")
+                .map_err(js_err)?;
+            if !f.is_callable() {
+                bun_core::err_generic!("Framework does not support static site generation");
+                bun_core::note!(
+                    "The file {} is missing the \"getParams\" export, which defines how to generate static files.",
+                    bun_core::fmt::quote(resolve_path::relative(
+                        cwd,
+                        pt.input_file(server_file).abs_path()
+                    ))
+                );
+                Global::crash();
             }
+            f
         } else {
             JSValue::NULL
         };
@@ -1200,13 +1183,13 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
 }
 
 /// unsafe function, must be run outside of the event loop
-/// quits the process on exception
+/// fails with `JSError` on exception
 fn load_module(
     vm: *mut VirtualMachine,
     global: &JSGlobalObject,
     key: JSValue,
 ) -> crate::Result<JSValue> {
-    let promise_value = BakeLoadModuleByKey(global, key);
+    let promise_value = c::bake_load_module_by_key(global, key).map_err(js_err)?;
     let promise: *mut jsc::JSInternalPromise = match promise_value.as_any_promise().unwrap() {
         AnyPromise::Internal(p) => p,
         AnyPromise::Normal(_) => unreachable!(),
@@ -1233,38 +1216,64 @@ fn load_module(
     let jsc_vm = vm_ref.as_mut().jsc_vm_mut();
     match jsc::JSInternalPromise::opaque_mut(promise).unwrap(jsc_vm, UnwrapMode::MarkHandled) {
         Unwrapped::Pending => unreachable!(),
-        Unwrapped::Fulfilled(_) => Ok(BakeGetModuleNamespace(global, key)),
+        Unwrapped::Fulfilled(_) => c::bake_get_module_namespace(global, key).map_err(js_err),
         Unwrapped::Rejected(err) => Err(js_err(vm_ref.global().throw_value(err))),
     }
 }
 
-// extern apis:
+/// BakeSourceProvider.cpp entry points. Each returns empty if and only if it
+/// threw, so every call goes through `from_js_host_call`.
+mod c {
+    use super::*;
 
-unsafe extern "C" {
-    safe fn BakeGetDefaultExportFromModule(global: &JSGlobalObject, key: JSValue) -> JSValue;
-    safe fn BakeGetModuleNamespace(global: &JSGlobalObject, key: JSValue) -> JSValue;
-    safe fn BakeLoadModuleByKey(global: &JSGlobalObject, key: JSValue) -> JSValue;
-}
-
-fn bake_get_on_module_namespace(
-    global: &JSGlobalObject,
-    module: JSValue,
-    property: &[u8],
-) -> Option<JSValue> {
     unsafe extern "C" {
-        // PRECONDITION: `ptr` must be readable for `len` bytes (C++ builds an
-        // `Identifier` from the slice). Cannot be `safe fn` — raw ptr+len pair
-        // carries a caller-side validity precondition.
-        #[link_name = "BakeGetOnModuleNamespace"]
-        fn f(global: *const JSGlobalObject, module: JSValue, ptr: *const u8, len: usize)
-        -> JSValue;
+        safe fn BakeLoadModuleByKey(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        safe fn BakeGetModuleNamespace(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        safe fn BakeGetDefaultExportFromModule(global: &JSGlobalObject, key: JSValue) -> JSValue;
+        // `key` is borrowed for the call (C++ builds an `Identifier` from it).
+        safe fn BakeGetOnModuleNamespace(
+            global: &JSGlobalObject,
+            module_namespace: JSValue,
+            key: bun_core::ffi::FfiSlice<'_, u8>,
+        ) -> JSValue;
     }
-    // SAFETY: `global` is a live `&JSGlobalObject`, `module` is a stack-held
-    // `JSValue`, and `property.as_ptr()`/`len()` describe a valid borrowed
-    // `&[u8]` for the call duration — discharges the ptr+len precondition above.
-    let result: JSValue = unsafe { f(global, module, property.as_ptr(), property.len()) };
-    debug_assert!(!result.is_empty());
-    Some(result)
+
+    /// Starts loading and evaluating the module that `key` (a JSString) names
+    /// and returns its `JSInternalPromise`.
+    pub(super) fn bake_load_module_by_key(
+        global: &JSGlobalObject,
+        key: JSValue,
+    ) -> JsResult<JSValue> {
+        jsc::from_js_host_call(global, || BakeLoadModuleByKey(global, key))
+    }
+
+    /// The promise from [`bake_load_module_by_key`] for `key` must have settled.
+    pub(super) fn bake_get_module_namespace(
+        global: &JSGlobalObject,
+        key: JSValue,
+    ) -> JsResult<JSValue> {
+        jsc::from_js_host_call(global, || BakeGetModuleNamespace(global, key))
+    }
+
+    /// The module `key` names must already be evaluated.
+    pub(super) fn bake_get_default_export_from_module(
+        global: &JSGlobalObject,
+        key: JSValue,
+    ) -> JsResult<JSValue> {
+        jsc::from_js_host_call(global, || BakeGetDefaultExportFromModule(global, key))
+    }
+
+    /// Reads `property` off a module namespace object returned by
+    /// [`bake_get_module_namespace`].
+    pub(super) fn bake_get_on_module_namespace(
+        global: &JSGlobalObject,
+        module_namespace: JSValue,
+        property: &[u8],
+    ) -> JsResult<JSValue> {
+        jsc::from_js_host_call(global, || {
+            BakeGetOnModuleNamespace(global, module_namespace, property.into())
+        })
+    }
 }
 
 // Renders all routes for static site generation by calling the JavaScript implementation.

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1221,8 +1221,7 @@ fn load_module(
     }
 }
 
-/// BakeSourceProvider.cpp entry points. Each returns empty if and only if it
-/// threw, so every call goes through `from_js_host_call`.
+/// BakeSourceProvider.cpp entry points: each returns empty iff it threw (`from_js_host_call`).
 mod c {
     use super::*;
 
@@ -1230,7 +1229,6 @@ mod c {
         safe fn BakeLoadModuleByKey(global: &JSGlobalObject, key: JSValue) -> JSValue;
         safe fn BakeGetModuleNamespace(global: &JSGlobalObject, key: JSValue) -> JSValue;
         safe fn BakeGetDefaultExportFromModule(global: &JSGlobalObject, key: JSValue) -> JSValue;
-        // `key` is borrowed for the call (C++ builds an `Identifier` from it).
         safe fn BakeGetOnModuleNamespace(
             global: &JSGlobalObject,
             module_namespace: JSValue,
@@ -1238,8 +1236,7 @@ mod c {
         ) -> JSValue;
     }
 
-    /// Starts loading and evaluating the module that `key` (a JSString) names
-    /// and returns its `JSInternalPromise`.
+    /// Returns the `JSInternalPromise` that evaluates the module `key` (a JSString) names.
     pub(super) fn bake_load_module_by_key(
         global: &JSGlobalObject,
         key: JSValue,
@@ -1263,8 +1260,7 @@ mod c {
         jsc::from_js_host_call(global, || BakeGetDefaultExportFromModule(global, key))
     }
 
-    /// Reads `property` off a module namespace object returned by
-    /// [`bake_get_module_namespace`].
+    /// Reads `property` off a namespace object from [`bake_get_module_namespace`].
     pub(super) fn bake_get_on_module_namespace(
         global: &JSGlobalObject,
         module_namespace: JSValue,

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -667,7 +667,8 @@ export default function IndexPage() {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "build", "--app", ...args],
         cwd,
-        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+        // BUN_DEV_SERVER_TEST_RUNNER silences the "highly experimental" banner, so stderr is only the build's progress and errors.
+        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1", BUN_DEV_SERVER_TEST_RUNNER: "1" },
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -677,8 +678,22 @@ export default function IndexPage() {
         .split("\n")
         .map(line => line.trim())
         .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
-      return { stdout, stderr, exitCode, signalCode: proc.signalCode, uncheckedScopes };
+      return {
+        stdout: normalizeBunSnapshot(stdout, cwd),
+        stderr: normalizeBunSnapshot(stderr, cwd),
+        exitCode,
+        signalCode: proc.signalCode,
+        uncheckedScopes,
+      };
     }
+
+    const rendered = {
+      stdout: "done",
+      stderr: "Loading configuration\nBundling routes\nRendering routes",
+      exitCode: 0,
+      signalCode: null,
+      uncheckedScopes: [],
+    };
 
     test("a config import that fails to resolve", async () => {
       // The bake resolve hook hands a specifier it does not own to the regular resolver, which throws.
@@ -687,13 +702,13 @@ export default function IndexPage() {
           export default { app: { framework: "react" } };`,
       });
 
-      const { stderr, exitCode, signalCode, uncheckedScopes } = await buildApp(String(dir));
-      expect({ exitCode, signalCode, uncheckedScopes }).toStrictEqual({
+      expect(await buildApp(String(dir))).toStrictEqual({
+        stdout: "",
+        stderr: "Loading configuration\nerror: Cannot find module './does-not-exist' from '<dir>/bun.app.ts'",
         exitCode: 1,
         signalCode: null,
         uncheckedScopes: [],
       });
-      expect(stderr).toContain("Cannot find module './does-not-exist'");
     });
 
     test("loading the server entry point and prerendering routes", async () => {
@@ -725,22 +740,17 @@ export function getStaticPaths() {
 }`,
       });
 
-      const { exitCode, signalCode, uncheckedScopes } = await buildApp(dir, "./src/index.tsx");
-      expect({ exitCode, signalCode, uncheckedScopes }).toStrictEqual({
-        exitCode: 0,
-        signalCode: null,
-        uncheckedScopes: [],
-      });
+      expect(await buildApp(dir, "./src/index.tsx")).toStrictEqual(rendered);
 
-      const rendered = await Promise.all(
+      const pages = await Promise.all(
         ["index.html", "posts/first/index.html", "posts/second/index.html"].map(file =>
           Bun.file(path.join(dir, "dist", file)).text(),
         ),
       );
-      expect(rendered[0]).toContain("<h1>Static Home</h1>");
-      expect(rendered[0]).toContain("<p>Hello from the client</p>");
-      expect(rendered[1]).toContain("<h1>Post first</h1>");
-      expect(rendered[2]).toContain("<h1>Post second</h1>");
+      expect(pages[0]).toContain("<h1>Static Home</h1>");
+      expect(pages[0]).toContain("<p>Hello from the client</p>");
+      expect(pages[1]).toContain("<h1>Post first</h1>");
+      expect(pages[2]).toContain("<h1>Post second</h1>");
     });
 
     // todo on Windows: BakeProdResolve joins the absolute drive path as if it were relative,
@@ -759,12 +769,7 @@ export default async function IndexPage() {
 }`,
       });
 
-      const { exitCode, signalCode, uncheckedScopes } = await buildApp(dir, "./src/index.tsx");
-      expect({ exitCode, signalCode, uncheckedScopes }).toStrictEqual({
-        exitCode: 0,
-        signalCode: null,
-        uncheckedScopes: [],
-      });
+      expect(await buildApp(dir, "./src/index.tsx")).toStrictEqual(rendered);
       expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain(
         "<p>read from disk while rendering</p>",
       );

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -658,5 +658,116 @@ export default function IndexPage() {
 
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
+  });
+
+  // BUN_JSC_validateExceptionChecks=1 makes a debug build abort on the first
+  // JSC call whose exception nobody checked. Release builds ignore the option.
+  describe.concurrent("exception checks", () => {
+    async function buildApp(cwd: string, ...args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--app", ...args],
+        cwd,
+        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The two report lines that name the throwing scope and the scope that failed to check it.
+      const uncheckedScopes = stderr
+        .split("\n")
+        .map(line => line.trim())
+        .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+      return { stdout, stderr, exitCode, signalCode: proc.signalCode, uncheckedScopes };
+    }
+
+    test("a config import that fails to resolve", async () => {
+      // The bake resolve hook hands a specifier it does not own to the regular resolver, which throws.
+      using dir = tempDir("bake-production-validate-unresolved", {
+        "bun.app.ts": `import "./does-not-exist";
+          export default { app: { framework: "react" } };`,
+      });
+
+      const { stderr, exitCode, signalCode, uncheckedScopes } = await buildApp(String(dir));
+      expect({ exitCode, signalCode, uncheckedScopes }).toStrictEqual({
+        exitCode: 1,
+        signalCode: null,
+        uncheckedScopes: [],
+      });
+      expect(stderr).toContain("Cannot find module './does-not-exist'");
+    });
+
+    test("loading the server entry point and prerendering routes", async () => {
+      // Loads the framework's server entry point, reads its prerender and getParams exports,
+      // and (through the client component) has a "bake:/" module call import().
+      const dir = await tempDirWithBakeDeps("bake-production-validate-prerender", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/index.tsx": `import Greeting from "../components/Greeting";
+
+export default function IndexPage() {
+  return (
+    <main>
+      <h1>Static Home</h1>
+      <Greeting />
+    </main>
+  );
+}`,
+        "components/Greeting.tsx": `"use client";
+
+export default function Greeting() {
+  return <p>Hello from the client</p>;
+}`,
+        "pages/posts/[slug].tsx": `export default function Post({ params }) {
+  return <h1>{"Post " + params.slug}</h1>;
+}
+
+export function getStaticPaths() {
+  return { paths: [{ params: { slug: "first" } }, { params: { slug: "second" } }], fallback: false };
+}`,
+      });
+
+      const { exitCode, signalCode, uncheckedScopes } = await buildApp(dir, "./src/index.tsx");
+      expect({ exitCode, signalCode, uncheckedScopes }).toStrictEqual({
+        exitCode: 0,
+        signalCode: null,
+        uncheckedScopes: [],
+      });
+
+      const rendered = await Promise.all(
+        ["index.html", "posts/first/index.html", "posts/second/index.html"].map(file =>
+          Bun.file(path.join(dir, "dist", file)).text(),
+        ),
+      );
+      expect(rendered[0]).toContain("<h1>Static Home</h1>");
+      expect(rendered[0]).toContain("<p>Hello from the client</p>");
+      expect(rendered[1]).toContain("<h1>Post first</h1>");
+      expect(rendered[2]).toContain("<h1>Post second</h1>");
+    });
+
+    // todo on Windows: BakeProdResolve joins the absolute drive path as if it were relative,
+    // so this import fails with EINVAL before it reaches the fetch hook (see #39092).
+    test.todoIf(isWindows)("a route importing a file outside the bundle while rendering", async () => {
+      // A "bake:/" key that is not in the output map is handed to the regular loader, which reads it from disk.
+      const dir = await tempDirWithBakeDeps("bake-production-validate-disk-import", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "extra/banner.mjs": `export const banner = "read from disk while rendering";`,
+        "pages/index.tsx": `import { join } from "node:path";
+
+export default async function IndexPage() {
+  // A computed specifier, so the bundler leaves this import() for the runtime.
+  const { banner } = await import(join(import.meta.dir, "../extra/banner.mjs"));
+  return <p>{banner}</p>;
+}`,
+      });
+
+      const { exitCode, signalCode, uncheckedScopes } = await buildApp(dir, "./src/index.tsx");
+      expect({ exitCode, signalCode, uncheckedScopes }).toStrictEqual({
+        exitCode: 0,
+        signalCode: null,
+        uncheckedScopes: [],
+      });
+      expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain(
+        "<p>read from disk while rendering</p>",
+      );
+    });
   });
 });

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -1,7 +1,6 @@
 # List of tests for which we do NOT set validateExceptionChecks=1 when running in ASAN CI
 
 # List of tests that potentially throw inside of reifyStaticProperties
-test/bake/dev/production.test.ts
 test/integration/vite-build/vite-build.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
 test/js/bun/util/BunObject.test.ts


### PR DESCRIPTION
Extracted from #39488 (commit 647d6bb8e5, the rework of #38949) and rebased onto main. #39488 is conflicting and has not moved since Aug 20. If it ships as one unit instead, close this one.

### Problem
- `BUN_JSC_validateExceptionChecks=1 bun build --app` aborts on a debug build right after "Loading configuration":
  ```
  This scope can throw a JS exception: moduleLoaderResolve @ src/jsc/bindings/ZigGlobalObject.cpp:3422
  But the exception was unchecked as of this scope: bakeModuleLoaderResolve @ src/runtime/bake/BakeGlobalObject.cpp:64
  ```
- Cause: the loader hooks in src/runtime/bake/BakeGlobalObject.cpp hand off to the parent hooks with a plain `return` inside a live throw scope. The helpers in src/runtime/bake/BakeSourceProvider.cpp have no scope at all.

### Fix
- Every hand-off in the three hooks goes through `RELEASE_AND_RETURN`.
- Each helper in BakeSourceProvider.cpp declares a throw scope, checks after every throwing call, and returns empty if and only if an exception is pending. `BakeLoadInitialServerCode` checks its call result too: `JSC::call` returns `undefined` on a throw.
- src/runtime/bake/production.rs calls the externs through `jsc::from_js_host_call`, as DevServer.rs does. A real exception is printed, not carried into unrelated code.
- Verified: test/bake/dev/production.test.ts gains an "exception checks" group and leaves test/no-validate-exceptions.txt. 15 of 15 pass under validation on a debug ASAN build. scripts/jsc-exception-lint: 12 findings to 1 on the two files.

### Background
- A native function that calls anything that can throw declares a `ThrowScope`. After each call it checks (`RETURN_IF_EXCEPTION`) or hands the check to its caller on a tail call (`RELEASE_AND_RETURN`). `BUN_JSC_validateExceptionChecks=1` makes a debug build simulate a throw at every scope exit and abort if a scope ends with it unchecked.
- `jsc::from_js_host_call` is the Rust side of that rule. In debug builds it asserts that the callee returned empty exactly when an exception is pending.
- `bun build --app` runs the config and the framework's server entry point in a VM with a `Bake::GlobalObject`. Its hooks serve the `bake:/...` output chunks and defer to the regular hooks for other keys.

<details><summary>Notes</summary>

Landing order with the open PRs that touch the same lines:
- #41163 adds test/bake/build-app-options.test.ts to test/no-validate-exceptions.txt for exactly these scopes. Once this lands, that entry can go.
- #40261 changes `BakeGetOnModuleNamespace` to take the key as a by-value `FfiSlice<u8>`. This PR uses that signature already, so only the function body and the `mod c` block in production.rs need a rebase on whichever lands second. One difference: #40261 returns empty for a non-namespace value without an exception. Here the value always comes from `BakeGetModuleNamespace`, so the helper keeps the empty-iff-exception contract that `from_js_host_call` asserts.
- #39855 fixes a bundler teardown race that a zero-chunk `bun build --app` (no routes directory, source maps on by default) can hit on the ASAN lane. The hermetic no-routes test from #38949 is left out here for that reason. It aborts on the unfixed tree naming the same `bakeModuleLoaderResolve` scope as the tests below, so coverage does not change.
- The Windows-only failure of the out-of-bundle import test is the `BakeProdResolve` drive-path bug from #39092 (closed into #39488). The test is `todoIf(isWindows)` until that fix lands.

Repro on an unfixed debug build: a `bun.app.ts` with a custom framework (`fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" }]`), no routes directory, `BUN_JSC_validateExceptionChecks=1 bun build --app ./bun.app.ts`. It aborts naming `moduleLoaderResolve` / `bakeModuleLoaderResolve`. With only the resolve hook fixed, it aborts naming `getModuleNamespaceObject` / `get @ JSObjectInlines.h:133`.

The helpers with missing checks: `BakeGetModuleNamespace`, `BakeGetDefaultExportFromModule`, `BakeGetOnModuleNamespace` and `BakeLoadModuleByKey`. Their Rust callers in production.rs used the result without checking for a pending exception either.

Coverage check, done by reverting one hunk at a time on the fixed tree and rebuilding:
- BakeSourceProvider.cpp reverted: "loading the server entry point and prerendering routes" fails naming `getModuleNamespaceObject` / `get`.
- `bakeModuleLoaderImportModule` reverted: the same test fails naming `requestImportModule` / `bakeModuleLoaderImportModule`.
- `bakeModuleLoaderFetch` hand-offs reverted: "a route importing a file outside the bundle while rendering" fails naming `moduleLoaderFetch` / `bakeModuleLoaderFetch`.
- On the fully unfixed tree all three builds fail first at `bakeModuleLoaderResolve`. "a config import that fails to resolve" covers the case where the parent resolver really throws: it exits 1 with "Cannot find module" instead of aborting.

Other details:
- The dead `!keyString` branch in `bakeModuleLoaderImportModule` is removed: a `JSString` value is null only when reading it threw, which now returns at the top of the function.
- The final hand-off in `bakeModuleLoaderFetch` used to wrap the parent's result in a second rejected promise while leaving the exception pending. `Zig::GlobalObject::moduleLoaderFetch` already returns a rejected promise for that case, so `RELEASE_AND_RETURN` is equivalent.
- `BakeLoadInitialServerCode` is the dev server's runtime init. Without the check, a throw there returned `undefined`, and `DevServer::init_server_runtime` panicked on "expected interface ... to be an object" with the real error left unprinted. Now the error is printed first.
- The tests set `BUN_JSC_validateExceptionChecks=1` in the child env themselves, so any debug or ASAN run enforces them, not only the CI runner. Release builds ignore the option, so the group also checks the rendered output.
- Static checker numbers are from `bun scripts/jsc-exception-lint/run.ts --no-summaries` on the two files. The one remaining finding is `profiledCall` after `ImportMetaObject::create` in `BakeLoadInitialServerCode`. `create` only allocates and cannot throw, so the signature convention flags it without summaries.
- Other suites run under validation: test/bake/dev/{vfile,server-sourcemap,request-cookies,ssg-pages-router}.test.ts and test/bake/app-options.test.ts. `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.
- Not changed here, same as in #39488: the nine `Global::crash()` exits in production.rs, and the "Runtime file not found" panic for a custom framework with a routes directory, which is why the tests that need routes use the react fixture.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->