### PR TITLE
bundler: read import() / require() exports without a namespace object

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -164,8 +164,26 @@ pub struct CommonJSNamedExport {
 pub type CommonJSNamedExports = StringArrayHashMap<CommonJSNamedExport, StringContext, AstAlloc>;
 
 pub type NamedImports = ArrayHashMap<Ref, NamedImport, AutoContext, AstAlloc>;
-pub type DynamicImportAliases =
-    ArrayHashMap<u32, crate::StoreSlice<crate::StoreStr>, AutoContext, AstAlloc>;
+/// One `import()` / `require()` whose every use the parser accounted for.
+#[derive(Clone, Copy, Default)]
+pub struct DynamicImportUse {
+    /// The export names read off the result, sorted and deduplicated.
+    pub aliases: crate::StoreSlice<crate::StoreStr>,
+    /// The import items those names are read through: a local a pattern
+    /// binds (`const { z } = …`) or a read off a namespace local (`ns.z`).
+    pub items: crate::StoreSlice<DynamicImportItem>,
+    /// Some use needs the namespace object whatever the linker binds: a read
+    /// that is not an item, or a local that may hold several namespaces.
+    pub needs_namespace_object: bool,
+}
+
+#[derive(Clone, Copy)]
+pub struct DynamicImportItem {
+    pub local: Ref,
+    pub alias: crate::StoreStr,
+    pub namespace_ref: Ref,
+}
+pub type DynamicImportAliases = ArrayHashMap<u32, DynamicImportUse, AutoContext, AstAlloc>;
 pub type NamedExports = StringArrayHashMap<NamedExport, StringContext, AstAlloc>;
 pub type ConstValuesMap = ArrayHashMap<Ref, Expr, AutoContext, AstAlloc>;
 pub type TsEnumsMap =

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -97,6 +97,10 @@ bitflags::bitflags! {
         /// The linker pointed `path` at another output chunk (a split
         /// `import()` / `require()`): `text` is its path, `pretty` its id; `source_index` is cleared.
         const IMPORTS_CHUNK = 1 << 16;
+
+        /// `import()` / `require()` whose value nothing reads: the linker bound
+        /// every name read off it to an export, so it evaluates to `{}`.
+        const NAMESPACE_UNUSED = 1 << 17;
     }
 }
 

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -227,6 +227,13 @@ impl Symbol {
     pub fn has_link(&self) -> bool {
         self.link.get().is_valid()
     }
+
+    /// An import item the linker merged into the export it names. A local
+    /// that a hoisting merge links has no import item status.
+    #[inline]
+    pub fn is_bound_import_item(&self) -> bool {
+        self.import_item_status != ImportItemStatus::None && self.has_link()
+    }
 }
 
 #[repr(u8)]

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4234,29 +4234,25 @@ impl<'a> LinkerContext<'a> {
     /// An item read off an `import()` / `require()` result is bound only to an
     /// export the importer may read directly. Otherwise it reads as written:
     /// `ns.a` off the namespace object, or the local a pattern binds.
-    fn binds_call_item(
-        &self,
-        source_index: crate::IndexInt,
-        import_ref: Ref,
-        named_import: &NamedImport,
-        result: &MatchImport,
-    ) -> bool {
-        if !matches!(result.kind, MatchImportKind::Normal) {
-            return false;
-        }
+    fn call_record_binds(&self, source_index: crate::IndexInt, record_index: u32) -> bool {
         let record = &self.graph.ast.items_import_records()[source_index as usize].as_slice()
-            [named_import.import_record_index as usize];
-        let target = result.source_index as usize;
+            [record_index as usize];
         // Its own chunk: the name is a binding of the loaded module.
-        if !record.source_index.is_valid()
-            || self.is_external_dynamic_import(record, source_index)
+        record.source_index.is_valid()
+            && !self.is_external_dynamic_import(record, source_index)
             // `require()` returns this export, not the namespace.
-            || (record.kind == ImportKind::Require
+            && !(record.kind == ImportKind::Require
                 && self.graph.meta.items_resolved_exports()[record.source_index.get() as usize]
                     .contains(b"module.exports"))
-            // A lifted CommonJS export changes through `exports.x = …`, which the
-            // parser does not record as an assignment.
-            || self.graph.ast.items_flags()[target].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+    }
+
+    /// Whether the export an item of such a record matched can stand in for it.
+    fn binds_call_item(&self, import_ref: Ref, result: &MatchImport) -> bool {
+        // A lifted CommonJS export changes through `exports.x = …`, which the
+        // parser does not record as an assignment.
+        if !matches!(result.kind, MatchImportKind::Normal)
+            || self.graph.ast.items_flags()[result.source_index as usize]
+                .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
         {
             return false;
         }
@@ -4346,6 +4342,15 @@ impl<'a> LinkerContext<'a> {
             // SAFETY: `keys`/`values` point into stable SoA storage (see above); read-only deref.
             let (import_ref, named_import) = unsafe { ((*keys)[i], &(*values)[i]) };
 
+            // Not matched at all: matching marks a name it can't find `Missing`,
+            // which prints `undefined` where the read should stay `ns.a`.
+            let is_call_item = self.is_call_record(source_index, named_import.import_record_index);
+            if is_call_item
+                && !self.call_record_binds(source_index, named_import.import_record_index)
+            {
+                continue;
+            }
+
             // Re-use memory for the cycle detector
             self.cycle_detector.clear();
 
@@ -4359,9 +4364,7 @@ impl<'a> LinkerContext<'a> {
                 &mut re_exports,
             );
 
-            if self.is_call_record(source_index, named_import.import_record_index)
-                && !self.binds_call_item(source_index, import_ref, named_import, &result)
-            {
+            if is_call_item && !self.binds_call_item(import_ref, &result) {
                 continue;
             }
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2350,6 +2350,11 @@ impl<'a> LinkerContext<'a> {
             // .const_values = c.graph.const_values,
             ts_enums: Some(ts_enums),
             import_member_bindings: Some(import_member_bindings),
+            has_dynamic_import_items: ast
+                .dynamic_import_aliases
+                .values()
+                .iter()
+                .any(|dynamic_use| !dynamic_use.items.is_empty()),
 
             minify_whitespace: self.options.minify_whitespace,
             minify_syntax: self.options.minify_syntax,
@@ -3925,7 +3930,9 @@ impl<'a> LinkerContext<'a> {
                     }
 
                     // Warn about importing from a file that is known to not have any exports
-                    if status == ImportTrackerStatus::CjsWithoutExports {
+                    if status == ImportTrackerStatus::CjsWithoutExports
+                        && !self.is_call_record(prev_source_index, named_import.import_record_index)
+                    {
                         let source = self.get_source(tracker.source_index.get());
                         // SAFETY: `alias` is an arena `*const [u8]` valid for the link pass.
                         let alias = named_import
@@ -4019,7 +4026,11 @@ impl<'a> LinkerContext<'a> {
                         // "undefined" instead of emitting an error.
                         symbol.import_item_status = ImportItemStatus::Missing;
 
-                        if self.resolver().opts.target == Target::Browser
+                        // A name read off `import()` / `require()` is `undefined`
+                        // at run time too, so there is nothing to say.
+                        if self.is_call_record(prev_source_index, named_import.import_record_index)
+                        {
+                        } else if self.resolver().opts.target == Target::Browser
                             && bun_resolve_builtins::Alias::has(
                                 next_source.path.pretty,
                                 Target::Bun,
@@ -4211,6 +4222,62 @@ impl<'a> LinkerContext<'a> {
 
     /// Is `ref_` the `exports` object of ES module `source_index` (i.e. an
     /// import that resolved here is that module's namespace)?
+    /// The record of a named import in `source_index` is an `import()` or a
+    /// `require()`, so the name is read off the call's result.
+    fn is_call_record(&self, source_index: crate::IndexInt, record_index: u32) -> bool {
+        self.graph.ast.items_import_records()[source_index as usize]
+            .as_slice()
+            .get(record_index as usize)
+            .is_some_and(|record| matches!(record.kind, ImportKind::Dynamic | ImportKind::Require))
+    }
+
+    /// An item read off an `import()` / `require()` result is bound only to an
+    /// export the importer may read directly. Otherwise it reads as written:
+    /// `ns.a` off the namespace object, or the local a pattern binds.
+    fn binds_call_item(
+        &self,
+        source_index: crate::IndexInt,
+        import_ref: Ref,
+        named_import: &NamedImport,
+        result: &MatchImport,
+    ) -> bool {
+        if !matches!(result.kind, MatchImportKind::Normal) {
+            return false;
+        }
+        let record = &self.graph.ast.items_import_records()[source_index as usize].as_slice()
+            [named_import.import_record_index as usize];
+        let target = result.source_index as usize;
+        // Its own chunk: the name is a binding of the loaded module.
+        if !record.source_index.is_valid()
+            || self.is_external_dynamic_import(record, source_index)
+            // `require()` returns this export, not the namespace.
+            || (record.kind == ImportKind::Require
+                && self.graph.meta.items_resolved_exports()[record.source_index.get() as usize]
+                    .contains(b"module.exports"))
+            // A lifted CommonJS export changes through `exports.x = …`, which the
+            // parser does not record as an assignment.
+            || self.graph.ast.items_flags()[target].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+        {
+            return false;
+        }
+        // `ns.a` is a live read, but a pattern copies the value: a local it
+        // binds stays a copy of an export that can change.
+        let is_pattern_local = self
+            .graph
+            .symbols
+            .get_const(import_ref)
+            .is_some_and(|symbol| symbol.namespace_alias.is_none());
+        !is_pattern_local
+            || !self
+                .graph
+                .symbols
+                .get_const(result.r#ref)
+                .is_some_and(|symbol| {
+                    // A direct `eval` in the exporting file can assign it too.
+                    symbol.has_been_assigned_to() || symbol.must_not_be_renamed()
+                })
+    }
+
     fn is_esm_namespace_ref(&self, source_index: crate::IndexInt, ref_: Ref) -> bool {
         let id = source_index as usize;
         id < self.graph.ast.len()
@@ -4291,6 +4358,12 @@ impl<'a> LinkerContext<'a> {
                 },
                 &mut re_exports,
             );
+
+            if self.is_call_record(source_index, named_import.import_record_index)
+                && !self.binds_call_item(source_index, import_ref, named_import, &result)
+            {
+                continue;
+            }
 
             match result.kind {
                 MatchImportKind::Normal | MatchImportKind::NormalAndNamespace => {

--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -320,6 +320,35 @@ fn record_target(
     map?.get_path(&rec.path)
 }
 
+/// The export names the result of `import()` / `require()` record `idx` can
+/// be read by, when the parser accounted for every use of it: the names read
+/// off it, and the one the call itself reads (`await` reads `then`; `require()`
+/// of an ES module returns its `module.exports` export). `None`: every export.
+fn call_reads(
+    uses: &bun_ast::ast_result::DynamicImportAliases,
+    dev_server: bool,
+    idx: usize,
+    kind: ImportKind,
+) -> Option<impl Iterator<Item = &'static [u8]>> {
+    if dev_server {
+        return None;
+    }
+    let dynamic_use = uses.get(&(idx as u32))?;
+    let implicit: &'static [u8] = if kind == ImportKind::Require {
+        b"module.exports"
+    } else {
+        b"then"
+    };
+    Some(
+        dynamic_use
+            .aliases
+            .slice()
+            .iter()
+            .map(|alias| alias.slice())
+            .chain(core::iter::once(implicit)),
+    )
+}
+
 /// BFS work queue item: un-defer an export from a barrel.
 // `'a` borrows arena-backed AST alias strings.
 struct BarrelWorkItem<'a> {
@@ -401,6 +430,10 @@ pub(crate) fn schedule_barrel_deferred_imports(
         bun_ptr::BackRef::new(&this.graph.ast.items_import_records()[result_source_index as usize]);
     let file_named_imports: bun_ptr::BackRef<JSAst::NamedImports> =
         bun_ptr::BackRef::new(&this.graph.ast.items_named_imports()[result_source_index as usize]);
+    let file_dynamic_uses: bun_ptr::BackRef<bun_ast::ast_result::DynamicImportAliases> =
+        bun_ptr::BackRef::new(
+            &this.graph.ast.items_dynamic_import_aliases()[result_source_index as usize],
+        );
 
     // `DevServerHandle` copied out so `&mut this.*` field borrows
     // don't conflict with the `&self` accessor.
@@ -472,8 +505,13 @@ pub(crate) fn schedule_barrel_deferred_imports(
         if ni.import_record_index as usize >= file_import_records.len() {
             continue;
         }
-        named_ir_indices.set(ni.import_record_index as usize);
         let ir = &file_import_records.as_slice()[ni.import_record_index as usize];
+        // A name destructured from `import()` / `require()` is a named import
+        // too, but the call needs every export (see below).
+        if matches!(ir.kind, ImportKind::Require | ImportKind::Dynamic) {
+            continue;
+        }
+        named_ir_indices.set(ni.import_record_index as usize);
         // In dev server mode, source_index may not be patched — resolve via
         // path map as a read-only fallback. Do NOT write back to the import
         // record — the dev server intentionally leaves source_indices unset
@@ -542,9 +580,19 @@ pub(crate) fn schedule_barrel_deferred_imports(
             continue;
         }
         if matches!(ir.kind, ImportKind::Require | ImportKind::Dynamic) {
-            // require() and import() expose the full module namespace — preserve all exports.
+            // require() and import() expose the full module namespace: preserve
+            // every export, unless the parser saw each name the result is read by.
             let (_, value) = RequestedExports::entry(&mut this.requested_exports, target);
-            *value = RequestedExports::All;
+            match call_reads(&file_dynamic_uses, dev_handle.is_some(), idx, ir.kind) {
+                Some(names) => {
+                    if let RequestedExports::Partial(p) = value {
+                        for name in names {
+                            p.put(name, ())?;
+                        }
+                    }
+                }
+                None => *value = RequestedExports::All,
+            }
         }
     }
 
@@ -561,6 +609,9 @@ pub(crate) fn schedule_barrel_deferred_imports(
             continue;
         }
         let ir = &file_import_records.as_slice()[ni.import_record_index as usize];
+        if matches!(ir.kind, ImportKind::Require | ImportKind::Dynamic) {
+            continue;
+        }
         let resolved_path_text = if ir.flags.contains(import_record::Flags::IS_UNUSED) {
             dedup_fallback
                 .get(ir.path.text)
@@ -615,11 +666,22 @@ pub(crate) fn schedule_barrel_deferred_imports(
         }
         let should_add = ir.kind == ImportKind::Require || ir.kind == ImportKind::Dynamic;
         if should_add {
-            queue.push(BarrelWorkItem {
-                barrel_source_index: target,
-                alias: b"",
-                is_star: true,
-            });
+            match call_reads(&file_dynamic_uses, dev_handle.is_some(), idx, ir.kind) {
+                Some(names) => {
+                    for alias in names {
+                        queue.push(BarrelWorkItem {
+                            barrel_source_index: target,
+                            alias,
+                            is_star: false,
+                        });
+                    }
+                }
+                None => queue.push(BarrelWorkItem {
+                    barrel_source_index: target,
+                    alias: b"",
+                    is_star: true,
+                }),
+            }
         }
     }
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -647,6 +647,8 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     // BackRef: the arena is the caller's `temp_arena: &Bump`,
                     // which strictly outlives this local helper struct.
                     arena: bun_ptr::BackRef<Bump>,
+                    // BackRef: `c.graph.symbols`, not resized while printing.
+                    symbols: bun_ptr::BackRef<bun_ast::symbol::Map>,
                 }
 
                 impl ExportHoist {
@@ -666,6 +668,47 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                         Expr::init_identifier(ref_, loc)
                     }
 
+                    /// The pattern without the locals the linker bound to exports
+                    /// (`const { a } = await import(…)`): assigning one would
+                    /// overwrite the export.
+                    fn without_bound_items(&self, binding: Binding) -> Binding {
+                        let bun_ast::binding::Data::BObject(object) = binding.data else {
+                            return binding;
+                        };
+                        let symbols = self.symbols.get();
+                        let is_bound = |property: &&B::Property| {
+                            matches!(property.value.data, bun_ast::binding::Data::BIdentifier(id)
+                                if symbols.get_const(id.get().r#ref)
+                                    .is_some_and(|symbol| symbol.is_bound_import_item()))
+                        };
+                        let properties = object.get().properties.slice();
+                        if !properties.iter().any(|property| is_bound(&property)) {
+                            return binding;
+                        }
+                        let mut kept = bun_alloc::ArenaVec::with_capacity_in(
+                            properties.len(),
+                            self.arena.get(),
+                        );
+                        for property in properties.iter().filter(|property| !is_bound(property)) {
+                            kept.push(B::Property {
+                                flags: property.flags,
+                                key: property.key,
+                                value: property.value,
+                                default_value: property.default_value,
+                            });
+                        }
+                        Binding::alloc(
+                            self.arena.get(),
+                            B::Object {
+                                properties: bun_ast::StoreSlice::new_mut(
+                                    kept.into_bump_slice_mut(),
+                                ),
+                                is_single_line: object.get().is_single_line,
+                            },
+                            binding.loc,
+                        )
+                    }
+
                     /// Trampoline matching `ToExprWrapper`'s erased fn-pointer signature.
                     fn wrap_trampoline(
                         ctx: *mut core::ffi::c_void,
@@ -681,6 +724,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 let mut hoist = ExportHoist {
                     decls: Vec::new(),
                     arena: bun_ptr::BackRef::new(temp_arena),
+                    symbols: bun_ptr::BackRef::new(&c.graph.symbols),
                 };
                 let hoist_wrapper = ToExprWrapper::new(temp_arena, ExportHoist::wrap_trampoline);
 
@@ -720,7 +764,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                                             // A pattern runs getters or the iterator, so it stays inside the wrapper
                                             // ie `var { append } = { append() {} }` => `var append; __esm(() => ({ append } = { append() {} }))`
                                             let binding = Binding::to_expr(
-                                                &decl.binding,
+                                                &hoist.without_bound_items(decl.binding),
                                                 (&raw mut hoist).cast::<core::ffi::c_void>(),
                                                 hoist_wrapper,
                                             );
@@ -731,7 +775,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                                         }
                                     } else {
                                         let _ = Binding::to_expr(
-                                            &decl.binding,
+                                            &hoist.without_bound_items(decl.binding),
                                             (&raw mut hoist).cast::<core::ffi::c_void>(),
                                             hoist_wrapper,
                                         );

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -248,20 +248,21 @@ pub(crate) fn scan_imports_and_exports(
                             {
                                 None => col!(dyn_ref_aliases)[other_file].merge_all(),
                                 // `default` of a lifted CommonJS module is its namespace.
-                                Some(aliases)
+                                Some(dynamic_use)
                                     if record.kind == ImportKind::Dynamic
                                         && other_flags
                                             .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
-                                        && aliases
+                                        && dynamic_use
+                                            .aliases
                                             .slice()
                                             .iter()
                                             .any(|alias| alias.slice() == b"default") =>
                                 {
                                     col!(dyn_ref_aliases)[other_file].merge_all()
                                 }
-                                Some(aliases) => {
+                                Some(dynamic_use) => {
                                     col!(dyn_ref_aliases)[other_file]
-                                        .merge_partial(aliases.slice());
+                                        .merge_partial(dynamic_use.aliases.slice());
                                     // Observed without being named: `await import()`
                                     // resolves through a `then` export, and `require()`
                                     // of an ES module returns its `module.exports`
@@ -646,6 +647,43 @@ pub(crate) fn scan_imports_and_exports(
 
     if FeatureFlags::HELP_CATCH_MEMORY_ISSUES {
         this.check_for_memory_corruption();
+    }
+
+    // An `import()` / `require()` of a wrapped ES module whose every read step
+    // 4 bound to an export needs no value: nothing depends on the namespace
+    // object through it, so tree shaking can drop that object.
+    for source_index_ in &reachable {
+        let id = source_index_.get() as usize;
+        let uses = &col_ref!(dynamic_import_aliases)[id];
+        for (&record_index, dynamic_use) in uses.keys().iter().zip(uses.values()) {
+            let record = &col_ref!(import_records_list)[id].as_slice()[record_index as usize];
+            if dynamic_use.needs_namespace_object
+                || !record.source_index.is_valid()
+                || col_ref!(flags)[record.source_index.get() as usize].wrap != WrapKind::Esm
+                || col_ref!(exports_kind)[record.source_index.get() as usize] != ExportsKind::Esm
+            {
+                continue;
+            }
+            let bound = &col_ref!(imports_to_bind_list)[id];
+            // `ns.a` of a name the importee does not export prints `undefined`.
+            // A pattern would read it off `{}`, which has a prototype.
+            let satisfied = |item: &bun_ast::ast_result::DynamicImportItem| {
+                bound.contains(&item.local)
+                    || this
+                        .graph
+                        .symbols
+                        .get_const(item.local)
+                        .is_some_and(|symbol| {
+                            symbol.import_item_status == bun_ast::ImportItemStatus::Missing
+                                && symbol.namespace_alias.is_some()
+                        })
+            };
+            if dynamic_use.items.slice().iter().all(satisfied) {
+                col!(import_records_list)[id].as_mut_slice()[record_index as usize]
+                    .flags
+                    .insert(ImportRecordFlags::NAMESPACE_UNUSED);
+            }
+        }
     }
 
     // Step 6: Bind imports to exports. This adds non-local dependencies on the
@@ -1167,7 +1205,10 @@ pub(crate) fn scan_imports_and_exports(
                         // This must be done for "require()" and "import()" expressions
                         // but does not need to be done for "import" statements since
                         // those just cause us to reference the exports directly.
-                        if other_flags.wrap == WrapKind::Esm && kind != ImportKind::Stmt {
+                        if other_flags.wrap == WrapKind::Esm
+                            && kind != ImportKind::Stmt
+                            && !rec_flags.contains(ImportRecordFlags::NAMESPACE_UNUSED)
+                        {
                             this.graph.generate_symbol_import_and_use(
                                 source_index,
                                 part_index as u32,

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -173,25 +173,34 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
                 js_ast::ExprData::EIdentifier(id) => {
-                    // Dynamic-import / require namespace local: record the alias so
-                    // the importee can drop unreferenced exports and leave the
-                    // access intact. An assign/delete target leaves the use
-                    // counted (namespace escapes).
+                    // A local holding one module's namespace (`const ns = await
+                    // import(…)`) reads its exports as `import * as ns` does:
+                    // `ns.a` becomes an import item of that record, below.
+                    let mut dynamic_record = None;
                     if p.dynamic_import_namespace_locals.contains_key(&id.ref_) {
                         if can_track_dynamic_import_member {
-                            if let Some(map) = p.import_items_for_namespace.get_mut(&id.ref_) {
-                                map.put(
-                                    name,
-                                    LocRef {
-                                        loc: name_loc,
-                                        ref_: bun_ast::Ref::NONE,
-                                    },
-                                )
-                                .expect("oom");
-                                p.note_tracked_namespace_use(id.ref_);
-                            }
+                            dynamic_record = p.dynamic_import_item_record(id.ref_, name);
                         }
-                        break 'sw;
+                        // Otherwise record the alias so the importee can drop
+                        // unreferenced exports, and leave the access intact. An
+                        // assign/delete target leaves the use counted (namespace
+                        // escapes).
+                        if dynamic_record.is_none() {
+                            if can_track_dynamic_import_member {
+                                if let Some(map) = p.import_items_for_namespace.get_mut(&id.ref_) {
+                                    map.put(
+                                        name,
+                                        LocRef {
+                                            loc: name_loc,
+                                            ref_: bun_ast::Ref::NONE,
+                                        },
+                                    )
+                                    .expect("oom");
+                                    p.note_tracked_namespace_use(id.ref_);
+                                }
+                            }
+                            break 'sw;
+                        }
                     }
                     // Rewrite property accesses on explicit namespace imports as an identifier.
                     // This lets us replace them easily in the printer to rebind them to
@@ -232,6 +241,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     // generated.
                                     symbol.import_item_status =
                                         bun_ast::ImportItemStatus::Generated;
+                                    // Not bound to an export, it reads `ns.a`.
+                                    if let Some(import_record_index) = dynamic_record {
+                                        symbol.namespace_alias =
+                                            Some(bun_alloc::ast_box(G::NamespaceAlias {
+                                                namespace_ref: id.ref_,
+                                                alias: js_ast::StoreStr::new(name),
+                                                import_record_index,
+                                                was_originally_property_access: true,
+                                            }));
+                                    }
 
                                     new_ref
                                 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -325,6 +325,16 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Import records whose namespace is known to escape regardless of use
     /// counts (one local bound to two records).
     pub(crate) dynamic_import_escaped_records: HashMap<u32, ()>,
+    /// Import records with a use the printer can't rewrite to a direct read
+    /// of an export, so the linker must keep the namespace object.
+    pub(crate) dynamic_import_needs_object: HashMap<u32, ()>,
+    /// Namespace locals that hold a copy, not the namespace (`{...rest}`), or
+    /// that no source reads by name (`require_namespace_ref`).
+    pub(crate) dynamic_import_copied_locals: HashMap<Ref, ()>,
+    /// Locals a tracked destructure binds (`const { z } = await import(...)`).
+    /// `z.name` off one is recorded as an import property use so the linker
+    /// can bind it, once `parse_entry` has made the local an import item.
+    pub(crate) dynamic_import_destructured_locals: HashMap<Ref, ()>,
     /// Per namespace ref, how many of its `use_count_estimate` uses were an
     /// accounted-for read (`ns.a`, a destructure, a truthiness test). Kept
     /// beside the real count rather than decremented from it so the minifier's
@@ -1055,6 +1065,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .unwrap();
         let rest_ref = record_destructured_aliases(self.arena, map, properties, keep_all)?;
         if let Some((rest, loc)) = rest_ref {
+            self.dynamic_import_copied_locals.insert(rest, ());
             self.register_dynamic_import_namespace_local_multi(rest, loc, records);
         }
         // The destructured locals live in this scope: a direct `eval` here can
@@ -1071,6 +1082,98 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 });
         }
         Some(())
+    }
+
+    /// Registers the items of each tracked call as named imports of its record,
+    /// as `import { alias as local }` would: the linker matches each against
+    /// the export and merges the symbol. One it does not bind reads as written
+    /// (`LinkerContext::match_imports_with_exports_for_file`). An exported local
+    /// stays a local, or an importer of this file would bind through it and
+    /// load the module eagerly. Runs after `ImportScanner` records exports.
+    fn register_dynamic_import_items(&mut self) {
+        if self.dynamic_import_aliases.count() == 0 {
+            return;
+        }
+        let mut exported: HashMap<Ref, ()> = HashMap::default();
+        for export in self.named_exports.values() {
+            exported.insert(export.ref_, ());
+        }
+        for i in 0..self.dynamic_import_aliases.count() {
+            let record = self.dynamic_import_aliases.keys()[i];
+            let items = self.dynamic_import_aliases.values()[i].items;
+            for item in items.slice() {
+                if exported.contains_key(&item.local) {
+                    continue;
+                }
+                self.is_import_item.insert(item.local, ());
+                // A name the importee does not export reads `undefined`, as it
+                // does off a namespace object, rather than failing the build.
+                self.symbols[item.local.inner_index() as usize].import_item_status =
+                    bun_ast::ImportItemStatus::Generated;
+                bun_core::handle_oom(self.named_imports.put(
+                    item.local,
+                    js_ast::NamedImport {
+                        alias: Some(item.alias),
+                        alias_loc: bun_ast::Loc::EMPTY,
+                        namespace_ref: item.namespace_ref,
+                        import_record_index: record,
+                        local_parts_with_uses: bun_alloc::AstAlloc::vec(),
+                        alias_is_star: false,
+                        is_exported: false,
+                    },
+                ));
+            }
+        }
+    }
+
+    /// The import record `ns.name` reads an export of, when `ns` holds that one
+    /// module's namespace, so the read can become an import item.
+    pub(crate) fn dynamic_import_item_record(&self, ns: Ref, name: &[u8]) -> Option<u32> {
+        if !self.options.bundle
+            || self.options.output_format == options::Format::InternalBakeDev
+            || self.dynamic_import_copied_locals.contains_key(&ns)
+        {
+            return None;
+        }
+        let &[record] = self.dynamic_import_namespace_locals.get(&ns)?.as_slice() else {
+            return None;
+        };
+        if self.dynamic_import_needs_object.contains_key(&record)
+            || is_require_marker(&self.import_records.items()[record as usize], name)
+        {
+            return None;
+        }
+        // A destructure of `ns` already holds the name with its own local.
+        match self.import_items_for_namespace.get(&ns)?.get(name) {
+            Some(existing) if !self.is_import_item.contains_key(&existing.ref_) => None,
+            _ => Some(record),
+        }
+    }
+
+    /// `const { a, b: c } = …` or `.then(({ a }) => …)`: the locals may become
+    /// import items. One already read (before its declaration, or from a
+    /// function above it) stays a local, since that read must not see the
+    /// export.
+    pub(crate) fn note_destructured_locals(&mut self, properties: &[bun_ast::B::Property]) {
+        // The dev server does not link, so nothing would bind them. A bound
+        // name leaves the pattern, and `...rest` would then collect it.
+        if !self.options.bundle
+            || self.options.output_format == options::Format::InternalBakeDev
+            || properties
+                .iter()
+                .any(|p| p.flags.contains(bun_ast::flags::Property::IsSpread))
+        {
+            return;
+        }
+        for prop in properties {
+            if let bun_ast::binding::Data::BIdentifier(id) = prop.value.data
+                && prop.default_value.is_none()
+                && !prop.flags.contains(bun_ast::flags::Property::IsSpread)
+                && self.symbols[id.r#ref.inner_index() as usize].use_count_estimate == 0
+            {
+                self.dynamic_import_destructured_locals.insert(id.r#ref, ());
+            }
+        }
     }
 
     /// Register a user-declared local (`const|let|var ns`, `.then(ns => …)`,
@@ -1109,6 +1212,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         if records.is_empty() {
             return;
+        }
+        // `ns.a` can only be rewritten to `a` when `ns` is one namespace.
+        if records.len() > 1 {
+            for &r in records {
+                self.dynamic_import_needs_object.insert(r, ());
+            }
         }
         self.import_items_for_namespace
             .insert(local, ImportItemForNamespaceMap::default());
@@ -1296,6 +1405,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .insert(ns, ImportItemForNamespaceMap::default());
         self.dynamic_import_namespace_locals
             .insert(ns, vec![req.import_record_index]);
+        self.dynamic_import_copied_locals.insert(ns, ());
         self.imports_to_convert_from_dynamic_import
             .push(DeferredImportNamespace {
                 namespace: LocRef {
@@ -6245,8 +6355,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name: &[u8],
         opts: IdentifierOpts,
     ) -> bool {
-        let js_ast::ExprData::EImportIdentifier(id) = target.data else {
-            return false;
+        let base = match target.data {
+            js_ast::ExprData::EImportIdentifier(id) => id.ref_,
+            // Not an import item until `parse_entry` decides it is one, but
+            // its reads are recorded the same way so that it can be.
+            // Every `x.y` reaches this: skip the lookup call in a file with none.
+            js_ast::ExprData::EIdentifier(id)
+                if !self.dynamic_import_destructured_locals.is_empty()
+                    && self
+                        .dynamic_import_destructured_locals
+                        .contains_key(&id.ref_) =>
+            {
+                id.ref_
+            }
+            _ => return false,
         };
         if !self.options.bundle
             || self.is_control_flow_dead
@@ -6259,13 +6381,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if self.is_revisit_for_substitution {
             return true;
         }
-        let use_ = self.symbol_uses.get_mut(&id.ref_).unwrap();
+        let Some(use_) = self.symbol_uses.get_mut(&base) else {
+            return false;
+        };
         use_.count_estimate = use_.count_estimate.saturating_sub(1);
         // note: this use is not removed as we assume it exists later
 
         let gop = self
             .import_symbol_property_uses
-            .get_or_put_value(id.ref_, Default::default())
+            .get_or_put_value(base, Default::default())
             .expect("unreachable");
         let inner_use = gop
             .value_ptr
@@ -8649,6 +8773,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        self.register_dynamic_import_items();
+
         // A direct eval at module scope can assign every top-level variable and
         // reach every top-level name. Nested scopes are pinned in `pop_scope`;
         // the module scope never pops. When the bundler wraps this file in a
@@ -9334,6 +9460,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             dynamic_import_aliases: Default::default(),
             dynamic_import_namespace_locals: Default::default(),
             dynamic_import_escaped_records: Default::default(),
+            dynamic_import_needs_object: Default::default(),
+            dynamic_import_copied_locals: Default::default(),
+            dynamic_import_destructured_locals: Default::default(),
             namespace_tracked_uses: Default::default(),
             unwrap_all_requires,
             commonjs_named_exports: Default::default(),
@@ -9840,6 +9969,13 @@ pub(crate) fn null_stmt_data() -> js_ast::StmtData {
 #[inline]
 pub(crate) fn null_value_expr() -> js_ast::ExprData {
     js_ast::ExprData::ENull(E::Null {})
+}
+
+/// `require()` of an ES module returns a copy of the namespace with
+/// `__esModule` set, and reads `default` off `module.exports`: neither name is
+/// the export the linker would bind.
+pub(crate) fn is_require_marker(record: &ImportRecord, name: &[u8]) -> bool {
+    record.kind == bun_ast::ImportKind::Require && (name == b"default" || name == b"__esModule")
 }
 
 /// The property walk of `try_track_dynamic_import_destructure`, which does not

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1236,6 +1236,10 @@ impl<'a> Parser<'a> {
             struct PerRecord {
                 escaped: bool,
                 aliases: Vec<bun_ast::StoreStr>,
+                items: Vec<bun_ast::ast_result::DynamicImportItem>,
+                /// A name is read some other way (a `{...rest}` copy, a local
+                /// that stays one), so the call's value must hold it.
+                needs_value: bool,
             }
             let mut by_record: bun_collections::ArrayHashMap<u32, PerRecord> = Default::default();
             // A namespace ref is listed once per registration and once per
@@ -1300,8 +1304,41 @@ impl<'a> Parser<'a> {
                             continue;
                         }
                     }
-                    rec.aliases
-                        .push(bun_ast::StoreStr::new(arena.alloc_slice_copy(key)));
+                    let alias = bun_ast::StoreStr::new(arena.alloc_slice_copy(key));
+                    rec.aliases.push(alias);
+                    let is_require_marker = p
+                        .import_records
+                        .items()
+                        .get(import_record_id as usize)
+                        .is_some_and(|record| crate::p::is_require_marker(record, key));
+                    // A read off `ns` (an item already), or a local a pattern
+                    // binds. Assigning to either, or reaching the local through
+                    // a hoisting merge or a direct `eval`, keeps the read as
+                    // written.
+                    let is_item = local.is_valid()
+                        && !is_require_marker
+                        && (p.is_import_item.contains_key(&local)
+                            || p.dynamic_import_destructured_locals.contains_key(&local))
+                        && !p.symbols[ns_ref.inner_index() as usize].has_been_assigned_to()
+                        && p.dynamic_import_namespace_locals
+                            .get(&ns_ref)
+                            .is_none_or(|records| records.len() == 1)
+                        && {
+                            let symbol = &p.symbols[local.inner_index() as usize];
+                            !symbol.has_been_assigned_to()
+                                && !symbol.has_link()
+                                && !symbol.must_not_be_renamed()
+                                && !p.named_imports.contains(&local)
+                        };
+                    if is_item {
+                        rec.items.push(bun_ast::ast_result::DynamicImportItem {
+                            local,
+                            alias,
+                            namespace_ref: ns_ref,
+                        });
+                    } else {
+                        rec.needs_value = true;
+                    }
                 }
             }
 
@@ -1313,12 +1350,19 @@ impl<'a> Parser<'a> {
                 }
                 rec.aliases.sort_by(|a, b| a.slice().cmp(b.slice()));
                 rec.aliases.dedup_by(|a, b| a.slice() == b.slice());
-                let aliases = &rec.aliases;
-                let alias_slice = arena
-                    .alloc_slice_fill_with::<bun_ast::StoreStr, _>(aliases.len(), |j| aliases[j]);
+                let aliases = arena.alloc_slice_copy(&rec.aliases);
+                let items = arena.alloc_slice_copy(&rec.items);
                 bun_core::handle_oom(
-                    p.dynamic_import_aliases
-                        .put(import_record_id, bun_ast::StoreSlice::new(alias_slice)),
+                    p.dynamic_import_aliases.put(
+                        import_record_id,
+                        bun_ast::ast_result::DynamicImportUse {
+                            aliases: bun_ast::StoreSlice::new(aliases),
+                            items: bun_ast::StoreSlice::new(items),
+                            needs_namespace_object: rec.needs_value
+                                || p.dynamic_import_needs_object
+                                    .contains_key(&import_record_id),
+                        },
+                    ),
                 );
             }
         }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -427,6 +427,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 .is_some()
                             {
                                 self.note_tracked_namespace_use(namespace_ref);
+                                // Another `var` declaration is the same variable.
+                                if kind != LocalKind::KVar && !is_export {
+                                    self.note_destructured_locals(obj.properties());
+                                }
                             }
                         }
                         // `var ns` redeclaration resolves to the same ref;
@@ -468,6 +472,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             self.dynamic_import_escaped_records.insert(r, ());
                         }
                         break 'conditional;
+                    }
+                    // `ns.a` can't become `a`: `ns` may be null.
+                    for &r in &records {
+                        self.dynamic_import_needs_object.insert(r, ());
                     }
                     if !records.is_empty()
                         && !self.import_items_for_namespace.contains_key(&id.r#ref)
@@ -521,6 +529,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             {
                                 self.dynamic_import_escaped_records
                                     .insert(req.import_record_index, ());
+                            } else if kind != LocalKind::KVar && !is_export {
+                                self.note_destructured_locals(obj.properties());
                             }
                         }
                         BData::BIdentifier(id) if kind != LocalKind::KVar && !is_export => {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2061,6 +2061,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             .is_some()
                             {
                                 p.note_tracked_namespace_use(im.namespace_ref);
+                                p.note_destructured_locals(obj.properties());
                             }
                         }
                         js_ast::binding::Data::BIdentifier(id) => {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -5793,10 +5793,33 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 StmtData::SLocal(s) => {
-                    self.print_indent();
-                    self.print_space_before_identifier();
-                    self.add_source_mapping(stmt.loc);
-                    self.print_decl_stmt(s.is_export, s.kind, s.decls.slice());
+                    // `const { a } = await import(…)` whose names are all bound
+                    // to exports declares nothing: only the load is left. The
+                    // other declarators keep their order around it.
+                    let decls = s.decls.slice();
+                    let mut run_start = 0;
+                    if self.options.has_dynamic_import_items && !s.is_export {
+                        for (i, decl) in decls.iter().enumerate() {
+                            if !self.binds_only_bound_imports(decl) {
+                                continue;
+                            }
+                            if run_start < i {
+                                self.print_local_stmt(
+                                    stmt.loc,
+                                    false,
+                                    s.kind,
+                                    &decls[run_start..i],
+                                );
+                            }
+                            run_start = i + 1;
+                            if let Some(value) = decl.value {
+                                self.print_unused_load(stmt.loc, value);
+                            }
+                        }
+                    }
+                    if run_start == 0 || run_start < decls.len() {
+                        self.print_local_stmt(stmt.loc, s.is_export, s.kind, &decls[run_start..]);
+                    }
                 }
                 StmtData::SIf(s) => {
                     self.print_indent();
@@ -6614,6 +6637,62 @@ pub(crate) mod __gated_printer {
                     _ => return false,
                 }
             }
+        }
+
+        /// A declarator whose pattern binds only names the linker bound to
+        /// exports, so it declares nothing.
+        fn binds_only_bound_imports(&self, decl: &G::Decl) -> bool {
+            let BindingData::BObject(object) = &decl.binding.data else {
+                return false;
+            };
+            let properties = slice_of(object.get().properties);
+            !properties.is_empty()
+                && properties.iter().all(|property| {
+                    matches!(&property.value.data, BindingData::BIdentifier(id)
+                        if self.symbols().get_const(id.get().r#ref)
+                            .is_some_and(|symbol| symbol.is_bound_import_item()))
+                })
+        }
+
+        fn print_local_stmt(
+            &mut self,
+            loc: bun_ast::Loc,
+            is_export: bool,
+            kind: S::Kind,
+            decls: &[G::Decl],
+        ) {
+            self.print_semicolon_if_needed();
+            self.print_indent();
+            self.print_space_before_identifier();
+            self.add_source_mapping(loc);
+            self.print_decl_stmt(is_export, kind, decls);
+        }
+
+        /// The initializer of such a declarator, as a statement. Its value is
+        /// `{}`, so an `await` of it is unused too.
+        fn print_unused_load(&mut self, loc: bun_ast::Loc, value: Expr) {
+            if matches!(value.data, ExprData::EIdentifier(_)) {
+                return;
+            }
+            self.print_semicolon_if_needed();
+            if !self.options.minify_whitespace && self.options.indent.count > 0 {
+                self.print_indent();
+            }
+            self.stmt_start = self.writer.written();
+            self.add_source_mapping(loc);
+            if let ExprData::EAwait(e) = value.data {
+                self.print_space_before_identifier();
+                self.print(b"await");
+                self.print_space();
+                self.print_expr(
+                    e.value,
+                    Level::Prefix.sub(1),
+                    ExprFlag::expr_result_is_unused(),
+                );
+            } else {
+                self.print_expr(value, Level::Lowest, ExprFlag::expr_result_is_unused());
+            }
+            self.print_semicolon_after_statement();
         }
 
         /// The import `target` names: an import identifier, or a local a

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1366,6 +1366,9 @@ pub struct Options<'a> {
     /// Borrowed from `LinkerGraph.import_member_bindings`: `X.name` property
     /// reads the linker bound straight to an export (see `E::Dot::is_import_property_use`).
     pub import_member_bindings: Option<&'a js_ast::ast_result::ImportMemberBindings>,
+    /// Some `import()` / `require()` in this file reads through import items,
+    /// so a pattern may bind one (see `Symbol::is_bound_import_item`).
+    pub has_dynamic_import_items: bool,
 
     // If we're writing out a source map, this table of line start indices lets
     // us do binary search on to figure out what line a given AST node came from
@@ -1428,6 +1431,7 @@ impl<'a> Default for Options<'a> {
             module_type: bundle_opts::Format::Esm,
             ts_enums: None,
             import_member_bindings: None,
+            has_dynamic_import_items: false,
             line_offset_tables: None,
             mangled_props: None,
         }
@@ -2275,7 +2279,10 @@ pub(crate) mod __gated_printer {
                         let symbols = self.renamer.symbols();
                         let target_ref = symbols.follow(target_id.ref_);
 
-                        if !self.is_stable_destructuring_target(*target_id, target_ref) {
+                        if !self.is_stable_destructuring_target(*target_id, target_ref)
+                            // A local bound like an import: its reads print as exports.
+                            || self.import_ref(target_e_dot.target).is_some()
+                        {
                             break 'brk;
                         }
 
@@ -2757,6 +2764,9 @@ pub(crate) mod __gated_printer {
 
                 // Wrap this with a call to "__toESM()" if this is a CommonJS file
                 let wrap_with_to_esm = record.flags.contains(ImportRecordFlags::WRAP_WITH_TO_ESM);
+                // The linker bound every name read off the result, so the
+                // namespace object may not exist: the result is `{}`.
+                let namespace_unused = record.flags.contains(ImportRecordFlags::NAMESPACE_UNUSED);
 
                 // Internal "import()" of async ESM
                 if record.kind == ImportKind::Dynamic && meta.is_wrapper_async {
@@ -2766,13 +2776,17 @@ pub(crate) mod __gated_printer {
                     if meta.exports_ref.is_valid() {
                         let _ = self.print_dot_then_prefix();
                         self.print_space_before_identifier();
-                        if wrap_with_to_esm {
-                            self.print_symbol(self.options.to_esm_ref);
-                            self.print(b"(");
-                        }
-                        self.print_symbol(meta.exports_ref);
-                        if wrap_with_to_esm {
-                            self.print_to_esm_suffix();
+                        if namespace_unused {
+                            self.print(b"({})");
+                        } else {
+                            if wrap_with_to_esm {
+                                self.print_symbol(self.options.to_esm_ref);
+                                self.print(b"(");
+                            }
+                            self.print_symbol(meta.exports_ref);
+                            if wrap_with_to_esm {
+                                self.print_to_esm_suffix();
+                            }
                         }
                         self.print_dot_then_suffix();
                     }
@@ -2832,7 +2846,15 @@ pub(crate) mod __gated_printer {
                     }
 
                     // Return the namespace object if this is an ESM file
-                    if meta.exports_ref.is_valid() {
+                    if meta.exports_ref.is_valid() && namespace_unused {
+                        // Without `init_x(), ` before it, `{}` could start an
+                        // arrow body or a statement.
+                        self.print(if meta.wrapper_ref.is_valid() {
+                            b"{}".as_slice()
+                        } else {
+                            b"({})".as_slice()
+                        });
+                    } else if meta.exports_ref.is_valid() {
                         // Wrap this with a call to "__toCommonJS()" if this is an ESM file
                         let wrap_with_to_cjs = record
                             .flags
@@ -5159,16 +5181,32 @@ pub(crate) mod __gated_printer {
                 BindingData::BObject(b) => {
                     let b = b.get();
                     let properties = slice_of(b.properties);
+                    // A local the linker bound to an export (`const { a } =
+                    // await import(…)`) is that export, so it is not declared.
+                    let is_bound = |printer: &Self, property: &B::Property| {
+                        printer.options.has_dynamic_import_items
+                            && matches!(&property.value.data, BindingData::BIdentifier(id)
+                                if printer.symbols().get_const(id.get().r#ref)
+                                    .is_some_and(|symbol| symbol.is_bound_import_item()))
+                    };
                     self.print(b"{");
-                    if !properties.is_empty() {
+                    if !properties.is_empty()
+                        && (!self.options.has_dynamic_import_items
+                            || properties.iter().any(|property| !is_bound(self, property)))
+                    {
                         if !b.is_single_line {
                             self.indent();
                         }
 
-                        for (i, property) in properties.iter().enumerate() {
-                            if i != 0 {
+                        let mut printed = 0usize;
+                        for property in properties.iter() {
+                            if is_bound(self, property) {
+                                continue;
+                            }
+                            if printed != 0 {
                                 self.print(b",");
                             }
+                            printed += 1;
 
                             if b.is_single_line {
                                 self.print_space();
@@ -6578,17 +6616,35 @@ pub(crate) mod __gated_printer {
             }
         }
 
+        /// The import `target` names: an import identifier, or a local a
+        /// pattern binds that the linker bound like one (`const { X } = await
+        /// import(…)`).
+        #[inline]
+        fn import_ref(&self, target: Expr) -> Option<Ref> {
+            match &target.data {
+                ExprData::EImportIdentifier(id) => Some(id.ref_),
+                ExprData::EIdentifier(id)
+                    if self.options.has_dynamic_import_items
+                        && self
+                            .symbols()
+                            .get_const(id.ref_)
+                            .is_some_and(|symbol| symbol.is_bound_import_item()) =>
+                {
+                    Some(id.ref_)
+                }
+                _ => None,
+            }
+        }
+
         /// `X.name` where the linker bound the access straight to an export
         /// (`LinkerGraph::import_member_bindings`): the import identifier to
         /// print in its place.
         fn import_member_binding(&self, target: Expr, name: &[u8]) -> Option<Expr> {
-            let ExprData::EImportIdentifier(id) = &target.data else {
-                return None;
-            };
+            let import_ref = self.import_ref(target)?;
             let binding = *self
                 .options
                 .import_member_bindings?
-                .get(&id.ref_)?
+                .get(&import_ref)?
                 .get(name)?;
             Some(Expr::init(
                 E::ImportIdentifier::new(binding, false),
@@ -6601,8 +6657,9 @@ pub(crate) mod __gated_printer {
             target: Expr,
             name: &[u8],
         ) -> Option<js_ast::InlinedEnumValueDecoded> {
-            if let ExprData::EImportIdentifier(id) = &target.data {
-                let ref_ = self.symbols().follow(id.ref_);
+            let base = self.import_ref(target)?;
+            {
+                let ref_ = self.symbols().follow(base);
                 if let Some(symbol) = self.symbols().get_const(ref_) {
                     if symbol.kind == js_ast::symbol::Kind::TsEnum {
                         if let Some(enum_value) = self.options.ts_enums.and_then(|m| m.get(&ref_)) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -325,7 +325,17 @@ export var __decorateElement = (array, flags, name, decorators, target, extra) =
   );
 };
 
-export var __esm = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
+// A module whose evaluation threw throws the same error on every later import.
+export var __esm = (fn, res, err) => () => {
+  if (fn)
+    try {
+      res = fn((fn = 0));
+    } catch (e) {
+      err = [e];
+    }
+  if (err) throw err[0];
+  return res;
+};
 
 // This is used for JSX inlining with React.
 export var $$typeof = /* @__PURE__ */ Symbol.for("react.element");

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -4,7 +4,6 @@ import { existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import vm from "node:vm";
 import { basename, join } from "path";
-import { gzipSync } from "zlib";
 
 // `bun build --compile --bytecode --target=<other platform>` embeds bytecode produced by this machine's JSC into an
 // executable that another OS/CPU will decode. JSC's cache format is the in-memory image of C++ objects, so it is only
@@ -377,21 +376,13 @@ function build({ name, entry, args }: { name: string; entry: string; args: reado
 // The payload starts with GenericCacheEntry { uint32 cacheVersion; uint32 headerSize; uint32 headerChecksum; ... }.
 // cacheVersion is a hash of the WebKit version string and headerChecksum covers it, so both change on every WebKit
 // upgrade whether or not the format did; mask them so the snapshot only moves when the serialized bytes do.
-const payloads: Record<string, Uint8Array> = {};
-function fingerprint(name: string, bytecode: Uint8Array, isPayload = true) {
+function fingerprint(bytecode: Uint8Array, isPayload = true) {
   const copy = new Uint8Array(bytecode);
   if (isPayload) {
     copy.fill(0, 0, 4);
     copy.fill(0, 8, 12);
   }
-  payloads[name] = copy;
   return { sha256: Bun.CryptoHasher.hash("sha256", copy, "hex"), bytes: copy.byteLength };
-}
-
-// A mismatch found on a platform nobody has a shell on is only actionable with the bytes in hand.
-function dumpPayloads() {
-  for (const [name, payload] of Object.entries(payloads))
-    console.log(`payload ${JSON.stringify(name)} (gzip, base64): ${gzipSync(payload).toString("base64")}`);
 }
 
 describe("bytecode cache portability", () => {
@@ -401,62 +392,48 @@ describe("bytecode cache portability", () => {
     const outputs: Record<string, unknown> = {};
     // Program and module code blocks straight from the encoder, without the bundler in between.
     outputs["vm.Script features.js"] = fingerprint(
-      "vm.Script features.js",
       new vm.Script(featuresSource, { filename: "features.js", produceCachedData: true }).cachedData!,
     );
     outputs["vm.Script shapes.js"] = fingerprint(
-      "vm.Script shapes.js",
       new vm.Script(shapesSource(), { filename: "shapes.js", produceCachedData: true }).cachedData!,
     );
     outputs["vm.Script records.js"] = fingerprint(
-      "vm.Script records.js",
       new vm.Script(recordsSource, { filename: "records.js", produceCachedData: true }).cachedData!,
     );
     // A builtin (what `bun build --compile --bytecode` embeds for node:* / bun:* modules): @-intrinsics and the
     // builtin-executable entry, which user source never produces. Bun's own internal modules are not hashed here because
     // their source is per-OS (process.platform is inlined); the next test covers them.
     const builtin = internalModuleBytecode(builtinSource, "corpus:builtin");
-    outputs["builtin corpus"] = fingerprint("builtin corpus", builtin.bytecode);
-    outputs["builtin corpus strings"] = fingerprint("builtin corpus strings", builtin.strings, false); // the external string table --compile embeds beside it
+    outputs["builtin corpus"] = fingerprint(builtin.bytecode);
+    outputs["builtin corpus strings"] = fingerprint(builtin.strings, false); // the external string table --compile embeds beside it
     outputs["vm.SourceTextModule module.js"] = fingerprint(
-      "vm.SourceTextModule module.js",
       new vm.SourceTextModule(moduleSource, { identifier: "module.js" }).createCachedData(),
     );
     outputs["vm.Script big.js"] = fingerprint(
-      "vm.Script big.js",
       new vm.Script(bigSource(), { filename: "big.js", produceCachedData: true }).cachedData!,
     );
     outputs["vm.Script source-forms.js"] = fingerprint(
-      "vm.Script source-forms.js",
       new vm.Script(sourceFormsSource(), { filename: "source-forms.js", produceCachedData: true }).cachedData!,
     );
     const librarySource = (lib: string) => readFileSync(join(corpusDir, "../../node_modules", lib), "utf8");
     outputs["vm.Script lodash.js"] = fingerprint(
-      "vm.Script lodash.js",
       new vm.Script(librarySource("lodash/lodash.js"), { filename: "lodash.js", produceCachedData: true }).cachedData!,
     );
     outputs["vm.Script typescript.js"] = fingerprint(
-      "vm.Script typescript.js",
       new vm.Script(librarySource("typescript/lib/typescript.js"), {
         filename: "typescript.js",
         produceCachedData: true,
       }).cachedData!,
     );
     outputs["vm.SourceTextModule acorn.mjs"] = fingerprint(
-      "vm.SourceTextModule acorn.mjs",
       new vm.SourceTextModule(librarySource("acorn/dist/acorn.mjs"), { identifier: "acorn.mjs" }).createCachedData(),
     );
     for (const [i, { name }] of bundlerBuilds.entries()) {
       const { js, jsc } = (await bundled)[i];
       // If `js` differs between platforms the bundler is at fault, not the bytecode format.
-      outputs[name] = { js: Bun.CryptoHasher.hash("sha256", js, "hex"), jsc: fingerprint(name, jsc) };
+      outputs[name] = { js: Bun.CryptoHasher.hash("sha256", js, "hex"), jsc: fingerprint(jsc) };
     }
-    try {
-      expectOutputs(outputs);
-    } catch (e) {
-      dumpPayloads();
-      throw e;
-    }
+    expectOutputs(outputs);
   });
 
   function expectOutputs(outputs: Record<string, unknown>) {
@@ -653,7 +630,7 @@ describe("bytecode cache portability", () => {
       `,
     });
     const { entry, args } = bundlerBuilds[0];
-    const hash = (bytes: Uint8Array) => fingerprint("", bytes).sha256;
+    const hash = (bytes: Uint8Array) => fingerprint(bytes).sha256;
     const conditions: Record<string, Record<string, string>> = {
       "collectContinuously": { BUN_JSC_collectContinuously: "1" },
       "useSourceProviderCache=0": { BUN_JSC_useSourceProviderCache: "0" },
@@ -679,7 +656,7 @@ describe("bytecode cache portability", () => {
     // Every one of Bun's internal modules as builtin bytecode, in this process and in the busy one: same bytes.
     const internalModules: Record<string, string> = {};
     for (let i = 0, m; (m = internalModuleBytecode(i)); i++)
-      internalModules[m.name] = hash(m.bytecode) + " " + fingerprint("", m.strings, false).sha256;
+      internalModules[m.name] = hash(m.bytecode) + " " + fingerprint(m.strings, false).sha256;
     const vmExpected = hash(
       new vm.Script(featuresSource, { filename: "features.js", produceCachedData: true }).cachedData!,
     );

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -537,10 +537,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "7f20b9f07e1d09afd9427c3cfece4390aa60b2647ca42d6fbec1b68e986c8592",
+          "js": "1f68e441cd2fca858d1d4d4591dadaa2e79e181fe54252cdc4cc3fb148ff6960",
           "jsc": {
             "bytes": 23789856,
-            "sha256": "88041c9d5a9c51c293b131596aaf49be5f5930dd202ed9b603d0de8fa0e113cb",
+            "sha256": "70afd133ad4b7006f51bd42fa9eb858dd4a7de3cbb781519f606c14fa3bb4e0c",
           },
         },
         "bun build --bytecode lodash/lodash.js": {

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -474,10 +474,10 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "721d67b0c2135aad554c9962b4e4505a4d6856b50da537fee7566d43f6cfdbda",
+          "js": "5d2ce9ace50d60d07530d33bea5f58669ae9c3b8c8ded447c09dda11364bc73f",
           "jsc": {
-            "bytes": 1998992,
-            "sha256": "f2631b3ba2b532e52183d5e6a44a7dbf5c0515b368d95fc692bf0e5ad15eb8f6",
+            "bytes": 1997464,
+            "sha256": "1fc3a766354fb508a3e45d9dcd0459869d9577fc8cf7b557837df128b31fdb1f",
           },
         },
         "bun build --bytecode --minify features.js": {
@@ -502,10 +502,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode all.js": {
-          "js": "c0f212b766071d77e9691261160635b50ccaf7f1c56e08ba87ccbb6d5e01fcd4",
+          "js": "b694a11873c7b3755c194d8ed04030e40c95afc33f0f1cc4ab834bc8f0df7bf2",
           "jsc": {
-            "bytes": 2178656,
-            "sha256": "41d4c0ba8cce1abdd369a4ce729e1615bce65a4c1b854db5ceda6d4c6568b3e0",
+            "bytes": 2176816,
+            "sha256": "0ed7dd7caefbbdc3f7fdc9ed616d0d1bf3b712cbd8882f4c67d058b76f725ccd",
           },
         },
         "bun build --bytecode big.js": {
@@ -537,10 +537,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "046e3e45447b4dedd103218f7a9d96ef7a8192e03b51b997776c9d9a2c2e6dee",
+          "js": "7f20b9f07e1d09afd9427c3cfece4390aa60b2647ca42d6fbec1b68e986c8592",
           "jsc": {
-            "bytes": 23789264,
-            "sha256": "27f1a233c4d2ef984ff6ac2ce67e49328841d371b58027178b0a3d7665d21c03",
+            "bytes": 23789856,
+            "sha256": "88041c9d5a9c51c293b131596aaf49be5f5930dd202ed9b603d0de8fa0e113cb",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -579,10 +579,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode undici/index.js": {
-          "js": "d0bd3791e7c8f77a06814429d5d95cb26a06baaa3c135502bcd3e984310f1d2c",
+          "js": "69bf9c543e66889d9ed35bcc99ffd8f4bc3315437f0f0aaf7c264fadd660eb03",
           "jsc": {
             "bytes": 937000,
-            "sha256": "d7cff4df84668b14987703bcd950a6753a574cf48e4372e4fe8779f747c0ed89",
+            "sha256": "a7df79cea1f01223e4160c68c2a9faf75f159e8e549aa273ac2f85c545dc1106",
           },
         },
         "vm.Script big.js": {

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -3592,7 +3592,7 @@ describe("bundler", () => {
     run: { stdout: "true" },
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
-      expect(out).toContain("await Promise.resolve().then(() => ({}))");
+      expect(out).toContain("await Promise.resolve();");
       expect(out).toContain("console.log(isOdd(3))");
       expect(out).not.toContain("isEven");
       expect(out).not.toContain("__export");
@@ -3620,7 +3620,7 @@ describe("bundler", () => {
     },
     stdout: "before\nx init\nafter 1\nsync after import()\ny init\nthen 2",
     output(out) {
-      expect(out).toContain("init_x(), {}");
+      expect(out).toContain("await Promise.resolve().then(() => init_x());");
       expect(out).toContain("init_y(), {}");
     },
   });
@@ -4007,6 +4007,27 @@ describe("bundler", () => {
       "/y.js": `export const a = "y"; export const d = "DROPPED";`,
     },
     stdout: "x y",
+  });
+
+  // A read off a split chunk's namespace is not matched: a name it can't see
+  // (from `export *` of an external) must not print `undefined`.
+  itBundled("dynamic_import_dce/SplitChunkExternalStarRead", {
+    files: {
+      "/entry.js": /* js */ `
+        const mod = await import("./reexports.js");
+        const { rfs } = await import("./reexports.js");
+        console.log(typeof mod.join, typeof mod.rfs, typeof rfs);
+      `,
+      "/reexports.js": /* js */ `
+        export * from "node:path";
+        export { readFileSync as rfs } from "node:fs";
+      `,
+    },
+    target: "bun",
+    format: "esm",
+    splitting: true,
+    outdir: "/out",
+    run: { file: "/out/entry.js", stdout: "function function function" },
   });
 
   // A `var` with another declaration is one variable, so it stays a local.

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "bun:test";
 import { readdirSync, readFileSync } from "fs";
 import path from "path";
-import { itBundled } from "./expectBundled";
+import { itBundled, type BundlerTestInput } from "./expectBundled";
 
 function readAllOutputs(outdir: string) {
   return readdirSync(outdir)
@@ -40,8 +40,9 @@ describe("bundler", () => {
     dce: true,
     run: { stdout: "43" },
     onAfterBundle(api) {
-      // Still lazy (namespace served from `exports_b`), `d` tree-shaken.
-      api.expectFile("/out.js").toContain("exports_b");
+      // `d` tree-shaken, and no namespace object: `c` is bound to the export.
+      api.expectFile("/out.js").toContain("return c(42)");
+      api.expectFile("/out.js").not.toContain("exports_b");
       api.expectFile("/out.js").not.toContain("99");
     },
   });
@@ -2673,7 +2674,7 @@ describe("bundler", () => {
     format: "esm",
     run: { stdout: "after" },
     onAfterBundle(api) {
-      api.expectFile("/out.js").toContain("exports_b");
+      api.expectFile("/out.js").not.toContain("exports_b");
       api.expectFile("/out.js").not.toContain("DROPPED");
     },
   });
@@ -3236,9 +3237,9 @@ describe("bundler", () => {
     },
   });
 
-  // Importee exports `then`: `await import()` resolves through it. `then` is
-  // observed by the `await` itself, so it must be kept even though no
-  // importer names it.
+  // Importee exports `then`. Unbundled, `await import()` resolves through it.
+  // That is intentionally not special-cased without splitting: `v` is bound to
+  // the export.
   itBundled("dynamic_import_dce/NoSplitThenableImportee", {
     files: {
       "/entry.js": /* js */ `
@@ -3248,9 +3249,10 @@ describe("bundler", () => {
       "/b.js": `export const v = "direct"; export function then(r) { r({ v: "unwrapped" }); }`,
     },
     format: "esm",
-    run: { stdout: "unwrapped" },
+    run: { stdout: "direct" },
   });
 
+  // With splitting the importee is a real ES module, so `then` is called.
   itBundled("dynamic_import_dce/SplittingThenableImportee", {
     files: {
       "/entry.js": /* js */ `
@@ -3522,5 +3524,829 @@ describe("bundler", () => {
     },
     format: "esm",
     bundleErrors: { "/entry.js": ['Cannot assign to import "foo"'] },
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // No namespace object. When every use of a narrowed importee names its
+  // exports, the `import()` / `require()` evaluates to an object literal of
+  // the exports a destructuring pattern reads, or to `{}` for a namespace
+  // local whose reads print the exports themselves. `__export`, `exports_x`
+  // and the helpers go away. Each case runs as ESM and CJS, minified and not.
+  // ──────────────────────────────────────────────────────────────────────
+
+  const minify = { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true };
+  const elisionVariants = {
+    esm: { format: "esm" },
+    cjs: { format: "cjs" },
+    esmMinify: { format: "esm", ...minify },
+    cjsMinify: { format: "cjs", ...minify },
+  } as const;
+
+  function itElides(
+    name: string,
+    opts: {
+      files: Record<string, string>;
+      stdout: string;
+      variants?: (keyof typeof elisionVariants)[];
+      /** Some call still needs the namespace object. */
+      keepsNamespace?: boolean;
+      /** Checks on the unminified `/out.js`. */
+      output?: (out: string) => void;
+    },
+  ) {
+    for (const variant of opts.variants ?? (Object.keys(elisionVariants) as (keyof typeof elisionVariants)[])) {
+      const options = elisionVariants[variant];
+      itBundled(`dynamic_import_dce/Elide${name}_${variant}`, {
+        files: opts.files,
+        ...options,
+        run: { stdout: opts.stdout },
+        onAfterBundle(api) {
+          const out = api.readFile("/out.js");
+          expect(out).not.toContain("DROPPED");
+          if (!("minifyIdentifiers" in options)) {
+            if (opts.keepsNamespace) {
+              expect(out).toContain("__export");
+            } else {
+              expect(out).not.toContain("__export");
+              expect(out).not.toMatch(/exports_\w/);
+            }
+            opts.output?.(out);
+          }
+        },
+      });
+    }
+  }
+
+  itBundled("dynamic_import_dce/ElideIsExample", {
+    files: {
+      "/entry.ts": /* ts */ `
+        const { isOdd } = await import("./is");
+        console.log(isOdd(3));
+      `,
+      "/is.ts": /* ts */ `
+        export function isNumber(n) { return typeof n === "number"; }
+        export function isOdd(n) { return isNumber(n) && n % 2 === 1; }
+        export function isEven(n) { return !isOdd(n); }
+      `,
+    },
+    run: { stdout: "true" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("await Promise.resolve().then(() => ({}))");
+      expect(out).toContain("console.log(isOdd(3))");
+      expect(out).not.toContain("isEven");
+      expect(out).not.toContain("__export");
+      expect(out).not.toContain("__defProp");
+      expect(out).not.toContain("exports_is");
+    },
+  });
+
+  // The importee's top-level code runs when the `import()` resolves.
+  itElides("Order", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          console.log("before");
+          const { x } = await import("./x.js");
+          console.log("after", x);
+          const loaded = import("./y.js").then(({ y }) => console.log("then", y));
+          console.log("sync after import()");
+          await loaded;
+        }
+        main();
+      `,
+      "/x.js": `console.log("x init"); export const x = 1; export const d = "DROPPED";`,
+      "/y.js": `console.log("y init"); export const y = 2; export const d = "DROPPED";`,
+    },
+    stdout: "before\nx init\nafter 1\nsync after import()\ny init\nthen 2",
+    output(out) {
+      expect(out).toContain("init_x(), {}");
+      expect(out).toContain("init_y(), {}");
+    },
+  });
+
+  // A throwing importee rejects the `import()` (caught by the surrounding
+  // `try`), and every later `import()` / `require()` throws the same error.
+  itElides("InitThrows", {
+    files: {
+      "/entry.js": /* js */ `
+        async function load() {
+          try {
+            const { z } = await import("./bad.js");
+            return z;
+          } catch (e) {
+            return e;
+          }
+        }
+        function loadSync() {
+          try {
+            const { z } = require("./bad.js");
+            return z;
+          } catch (e) {
+            return e;
+          }
+        }
+        async function main() {
+          const first = await load();
+          const second = await load();
+          console.log(first instanceof Error, first.message, first === second, loadSync() === first);
+          await import("./bad.js").then(
+            ns => console.log("resolved", ns.z),
+            e => console.log("rejected", e === first),
+          );
+        }
+        main();
+      `,
+      "/bad.js": /* js */ `
+        console.log("bad init");
+        throw new Error("boom");
+        export const z = 1;
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "bad init\ntrue boom true true\nrejected true",
+  });
+
+  // A read through the namespace is live: it prints the binding.
+  itElides("LiveRead", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const ns = await import("./x.js");
+          console.log(ns.b);
+          ns.bump();
+          console.log(ns.b, ns["b"]);
+          const r = require("./x.js");
+          r.bump();
+          console.log(r.b);
+          await import("./x.js").then(m => {
+            m.bump();
+            console.log(m.b);
+          });
+        }
+        main();
+      `,
+      "/x.js": /* js */ `
+        export let b = 1;
+        export function bump() { b++; }
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "1\n2 2\n3\n4",
+    output(out) {
+      expect(out).toContain("console.log(b, b)");
+    },
+  });
+
+  // A destructured binding is a snapshot taken when the pattern runs. An
+  // export that can change stays a copy, so its call keeps the object.
+  itElides("Snapshot", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { b } = await import("./x.js");
+          const ns = await import("./x.js");
+          ns.bump();
+          const { b: b2 } = ns;
+          ns.bump();
+          const { b: b3 } = require("./x.js");
+          ns.bump();
+          console.log(b, b2, b3, ns.b);
+        }
+        main();
+      `,
+      "/x.js": /* js */ `
+        console.log("x init");
+        export let b = 1;
+        export function bump() { b++; }
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "x init\n1 2 3 4",
+    output(out) {
+      expect(out).toContain("const { b: b3 } = (init_x(), __toCommonJS(exports_x));");
+    },
+  });
+
+  // `init_x()` of an importee with top-level await is a promise: the object
+  // is built after it settles. (CJS output has no top-level await.)
+  itElides("TopLevelAwaitInImportee", {
+    variants: ["esm", "esmMinify"],
+    files: {
+      "/entry.js": /* js */ `
+        console.log("before");
+        const { u } = await import("./t.js");
+        const ns = await import("./t.js");
+        console.log("got", u, ns.t);
+        await import("./t.js").then(ns => console.log("then", ns.t));
+      `,
+      "/t.js": /* js */ `
+        console.log("t start");
+        export let t = "early";
+        export const u = "u";
+        await 0;
+        t = "late";
+        console.log("t end");
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "before\nt start\nt end\ngot u late\nthen late",
+    output(out) {
+      expect(out).toContain("await init_t().then(() => ({}))");
+    },
+  });
+
+  // The importee statically imports the module that dynamically imports it.
+  itElides("Cycle", {
+    files: {
+      "/entry.js": /* js */ `
+        import { run } from "./a.js";
+        run();
+      `,
+      "/a.js": /* js */ `
+        export const fromA = "a";
+        export async function run() {
+          const { fromX, readA } = await import("./x.js");
+          const x = await import("./x.js");
+          console.log(fromX, readA(), x.readA());
+        }
+      `,
+      "/x.js": /* js */ `
+        import { fromA } from "./a.js";
+        console.log("x init", fromA);
+        export const fromX = "x";
+        export function readA() { return fromA; }
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "x init a\nx a a",
+  });
+
+  // A default value reads the name off the real object.
+  itElides("ThenAndPromiseAll", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          await import("./x.js").then(({ a, b: renamed = "default" }) => console.log("then", a, renamed));
+          await import("./x.js").then(ns => console.log("ns", ns.a));
+          await import("./x.js").then(() => console.log("bare"));
+          const [{ a }, ns, , { missing = "fallback" }] = await Promise.all([
+            import("./x.js"),
+            import("./x.js"),
+            import("./x.js"),
+            import("./x.js"),
+          ]);
+          console.log(a, ns.a, missing);
+        }
+        main();
+      `,
+      "/x.js": `console.log("x init"); export const a = "a"; export const d = "DROPPED";`,
+    },
+    stdout: "x init\nthen a default\nns a\nbare\na a fallback",
+  });
+
+  // `...rest` is a copy of the real object.
+  itElides("Rest", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { a, ...rest } = await import("./x.js");
+          console.log(a, rest.b, rest.c, rest.a);
+        }
+        main();
+      `,
+      "/x.js": `export const a = "a", b = "b"; export let c = "c"; export const d = "DROPPED";`,
+    },
+    stdout: "a b c undefined",
+  });
+
+  // `ns.name` of a name that is not an export reads `undefined`, as it does on
+  // a namespace object (which has no prototype). `__proto__` is an export like
+  // any other.
+  itElides("OddKeys", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const ns = await import("./x.js");
+          const { a, "with-dash": w, "__proto__": pp } = await import("./x.js");
+          console.log(a, w, pp);
+          console.log(ns.missing, ns.constructor, ns["with-dash"], ns["__proto__"], typeof ns);
+        }
+        main();
+      `,
+      "/x.js": /* js */ `
+        const p = "P";
+        export { p as "__proto__", p as "with-dash" };
+        export const a = "a";
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "a P P\nundefined undefined P P object",
+  });
+
+  // A pattern reads a name the importee does not export off the real object.
+  itElides("PatternReadsMissingName", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { b, missing } = await import("./x.js");
+          console.log(b, missing);
+        }
+        main();
+      `,
+      "/x.js": `export const b = 2; export const d = "DROPPED";`,
+    },
+    stdout: "2 undefined",
+  });
+
+  // A wrapped importer turns its top-level declarations into assignments;
+  // the pattern's source is still the object literal.
+  itElides("WrappedImporter", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { show } = await import("./inner.js");
+          show();
+        }
+        main();
+      `,
+      "/inner.js": /* js */ `
+        const { b } = require("./x.js");
+        const ns = require("./x.js");
+        const one = ns.a, two = ns.b;
+        export function show() { console.log(b, one, two, ns.a); }
+      `,
+      "/x.js": `console.log("x init"); export const a = "a", b = "b"; export const d = "DROPPED";`,
+    },
+    stdout: "x init\nb a b a",
+  });
+
+  // The minifier's `a = ns.x, b = ns.y` => `{x: a, y: b} = ns` would read `{}`.
+  itElides("SameTargetDestructuring", {
+    files: {
+      "/entry.js": /* js */ `
+        const ns = require("./x.js");
+        const one = ns.a, two = ns.b;
+        console.log(one, two);
+      `,
+      "/x.js": `console.log("x init"); export const a = "a", b = "b"; export const d = "DROPPED";`,
+    },
+    stdout: "x init\na b",
+  });
+
+  itElides("ReExport", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { a, renamed } = await import("./barrel.js");
+          const ns = await import("./barrel.js");
+          console.log(a, renamed, ns.star);
+        }
+        main();
+      `,
+      "/barrel.js": /* js */ `
+        export { a, b as renamed } from "./x.js";
+        export * from "./y.js";
+        export const d = "DROPPED";
+      `,
+      "/x.js": `export const a = "a", b = "b"; export const d2 = "DROPPED";`,
+      "/y.js": `export const star = "star"; export const d3 = "DROPPED";`,
+    },
+    stdout: "a b star",
+  });
+
+  // `export *` of the importee, from a file imported statically, does not need
+  // its namespace object either.
+  itElides("ExportStarOfImportee", {
+    variants: ["esm", "esmMinify"],
+    files: {
+      "/entry.js": `import { a as viaBarrel } from "./barrel.js"; const { a } = await import("./x.js"); console.log(a, viaBarrel);`,
+      "/barrel.js": `export * from "./x.js";`,
+      "/x.js": `export const a = "a"; export const d = "DROPPED";`,
+    },
+    stdout: "a a",
+  });
+
+  // Intentionally not special-cased: unbundled, `await import()` would call a
+  // `then` export. Bundled, the import resolves to `{}`.
+  itElides("ThenExport", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { a } = await import("./x.js");
+          console.log(a);
+        }
+        main();
+      `,
+      "/x.js": `export function then(resolve) { resolve({ a: "DROPPED" }); } export const a = "a";`,
+    },
+    stdout: "a",
+  });
+
+  // `import * as z; export { z }` (zod, Effect): a `const` destructured from
+  // the call is bound like `import { z }`, so `z.a` reads the export and the
+  // rest of the namespace tree-shakes.
+  itElides("NamespaceExport", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { z } = await import("./lib.js");
+          const { z: fromRequire } = require("./lib.js");
+          console.log(z.a(), fromRequire.b, z.b === fromRequire.b);
+        }
+        main();
+      `,
+      "/lib.js": `import * as z from "./external.js"; export { z }; export const d = "DROPPED";`,
+      "/external.js": /* js */ `
+        export function a() { return "a"; }
+        export const b = "b";
+        export const unused = "DROPPED";
+      `,
+    },
+    stdout: "a b true",
+  });
+
+  itElides("NamespaceExportReadsOnly", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { z } = await import("./lib.js");
+          console.log(z.a(), z.b);
+        }
+        main();
+      `,
+      "/lib.js": `import * as z from "./external.js"; export { z };`,
+      "/external.js": `export function a() { return "a"; } export const b = "b"; export const unused = "DROPPED";`,
+    },
+    stdout: "a b",
+    output(out) {
+      expect(out).toContain("console.log(a(), b)");
+    },
+  });
+
+  // A `var` redeclared in another branch is one variable, so it stays a local.
+  itElides("VarRedeclaredInBranches", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        async function pick(first) {
+          if (first) {
+            var { a } = await import("./x.js");
+          } else {
+            var { a } = await import("./y.js");
+          }
+          return a;
+        }
+        pick(true).then(a => pick(false).then(b => console.log(a, b)));
+      `,
+      "/x.js": `export const a = "x"; export const d = "DROPPED";`,
+      "/y.js": `export const a = "y"; export const d = "DROPPED";`,
+    },
+    stdout: "x y",
+  });
+
+  // A `var` with another declaration is one variable, so it stays a local.
+  itElides("VarDeclaredTwice", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        var a = 1;
+        var { a } = await import("./x.js");
+        for (var b of [3]) {}
+        var { b } = await import("./x.js");
+        console.log(a, b, (await import("./other.js")).a);
+      `,
+      "/x.js": `export const a = 2, b = 4;`,
+      "/other.js": `import { a } from "./x.js"; export { a };`,
+    },
+    variants: ["esm", "esmMinify"],
+    stdout: "2 4 2",
+  });
+
+  // A `{...rest}` copy of the same namespace still needs `a` in the object.
+  itElides("RestBesideBoundName", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const ns = await import("./x.js");
+          const { ...rest } = ns;
+          const { a } = ns;
+          console.log(rest.a, a);
+        }
+        main();
+      `,
+      "/x.js": `export const a = 1; export const d = "DROPPED";`,
+    },
+    stdout: "1 1",
+  });
+
+  itElides("EnumBoundName", {
+    files: {
+      "/entry.ts": /* ts */ `
+        async function main() {
+          const { E } = await import("./x.ts");
+          console.log(E.A, E.B);
+        }
+        main();
+      `,
+      "/x.ts": `export enum E { A = 1, B = 2 } export const d = "DROPPED";`,
+    },
+    stdout: "1 2",
+  });
+
+  // An importer of the file that destructured the name must not bind
+  // through it: that would load the split chunk eagerly.
+  itBundled("dynamic_import_dce/ReexportedDestructuredNameStaysLazy", {
+    files: {
+      "/entry.js": `import { a } from "./mid.js"; console.log("entry", a);`,
+      "/mid.js": /* js */ `
+        console.log("mid start");
+        const { a } = await import("./x.js");
+        export { a };
+      `,
+      "/x.js": `console.log("x init"); export const a = 1;`,
+    },
+    splitting: true,
+    outdir: "/out",
+    run: { file: "/out/entry.js", stdout: "mid start\nx init\nentry 1" },
+  });
+
+  // `require()` reads `default` off `module.exports`.
+  itBundled("dynamic_import_dce/RequireDefaultOfLiftedCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        const { default: d, a } = require("./lib.cjs");
+        console.log(d, a);
+      `,
+      "/lib.cjs": `exports.a = 1;`,
+    },
+    run: { stdout: "undefined 1" },
+  });
+
+  // A wrapped importer hoists its top-level names out of the closure. A bound
+  // name is the export's own binding (here a class), so it is not redeclared.
+  itElides("WrappedImporterBoundClass", {
+    files: {
+      "/entry.js": `const { y } = require("./b.js"); console.log(y);`,
+      "/b.js": `const { z } = require("./a.js"); export const y = z.v;`,
+      "/a.js": `export class z { static v = "zv" } export const d = "DROPPED";`,
+    },
+    stdout: "zv",
+  });
+
+  // No single export to bind to: the name reads `undefined`, with no warning.
+  itBundled("dynamic_import_dce/AmbiguousStarExportIsQuiet", {
+    files: {
+      "/entry.js": `const { q } = await import("./amb.js"); console.log(q);`,
+      "/amb.js": `export * from "./x.js"; export * from "./y.js";`,
+      "/x.js": `export const q = 1;`,
+      "/y.js": `export const q = 2;`,
+    },
+    run: { stdout: "undefined" },
+    bundleWarnings: {},
+  });
+
+  // `const p = ns.foo, q = ns.bar` must not become `{foo: p, bar: q} = ns`
+  // when `ns` is a bound name: there is no namespace object to read.
+  itElides("BoundNamespaceSameTargetReads", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { ns } = await import("./a.js");
+          const p = ns.foo, q = ns.bar;
+          console.log(p, q);
+        }
+        main();
+      `,
+      "/a.js": `import * as ns from "./c.js"; export { ns }; export const d = "DROPPED";`,
+      "/c.js": `export const foo = 1, bar = 2;`,
+    },
+    stdout: "1 2",
+  });
+
+  // A `"sideEffects": false` barrel: the names the pattern reads without
+  // binding them (a default value, a nested pattern) keep their re-exports.
+  itBundled("dynamic_import_dce/BarrelKeepsUnboundNames", {
+    files: {
+      "/entry.js": /* js */ `
+        const { a, b = "default", c: { x } } = await import("barrel");
+        console.log(a, b, x);
+      `,
+      "/node_modules/barrel/package.json": `{ "name": "barrel", "sideEffects": false }`,
+      "/node_modules/barrel/index.js": /* js */ `
+        export { a } from "./a.js";
+        export { b } from "./b.js";
+        export { c } from "./c.js";
+      `,
+      "/node_modules/barrel/a.js": `export const a = "A";`,
+      "/node_modules/barrel/b.js": `export const b = "B";`,
+      "/node_modules/barrel/c.js": `export const c = { x: "X" };`,
+    },
+    run: { stdout: "A B X" },
+  });
+
+  // Only the re-exports a tracked call reads are loaded from the barrel.
+  itBundled("dynamic_import_dce/BarrelLoadsOnlyReadNames", {
+    files: {
+      "/entry.js": /* js */ `
+        const { a } = await import("barrel");
+        console.log(a, (await import("barrel")).b);
+      `,
+      "/node_modules/barrel/package.json": `{ "name": "barrel", "sideEffects": false }`,
+      "/node_modules/barrel/index.js": /* js */ `
+        export { a } from "./a.js";
+        export { b } from "./b.js";
+        export { c } from "./c.js";
+      `,
+      "/node_modules/barrel/a.js": `export const a = "A";`,
+      "/node_modules/barrel/b.js": `export const b = "B";`,
+      "/node_modules/barrel/c.js": `export const c = "DROPPED";`,
+    },
+    run: { stdout: "A B" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("DROPPED");
+    },
+  });
+
+  // A direct `eval` in the exporting file can assign the export, so the
+  // destructured name stays a snapshot.
+  itBundled("dynamic_import_dce/EvalAssignedExportStaysSnapshot", {
+    files: {
+      "/entry.js": /* js */ `
+        const { a, set } = await import("./b.js");
+        set();
+        console.log(a);
+      `,
+      "/b.js": `export let a = 1; export function set() { eval("a = 2"); }`,
+    },
+    run: { stdout: "1" },
+  });
+
+  // A CommonJS module lifted to ESM keeps its exports in assignment order.
+  itBundled("dynamic_import_dce/LiftedCommonJSNamespaceReads", {
+    files: {
+      "/entry.js": /* js */ `
+        const ns = await import("react");
+        console.log(ns.useState(1)[0], ns.useId(), ns.version);
+      `,
+      "/node_modules/react/package.json": `{ "name": "react", "main": "index.js" }`,
+      "/node_modules/react/index.js": /* js */ `
+        "use strict";
+        function useState(i) { return [i]; }
+        function useId() { return "id"; }
+        exports.useState = useState;
+        exports.useId = useId;
+        exports.version = "19.0.0";
+      `,
+    },
+    run: { stdout: "1 id 19.0.0" },
+  });
+
+  // `ns` holds one of two namespaces, so `a` has no single export.
+  itBundled("dynamic_import_dce/DestructureOfEitherNamespace", {
+    files: {
+      "/entry.js": /* js */ `
+        async function f(c) {
+          const ns = c ? await import("./x.js") : await import("./y.js");
+          const { a } = ns;
+          return a;
+        }
+        console.log(await f(true), await f(false));
+      `,
+      "/x.js": `export const a = "x";`,
+      "/y.js": `export const a = "y";`,
+    },
+    run: { stdout: "x y" },
+  });
+
+  itBundled("dynamic_import_dce/DestructureOfFileWithoutExportsIsQuiet", {
+    files: {
+      "/entry.js": `const { foo } = await import("./notes.txt"); console.log(foo);`,
+      "/notes.txt": `hello`,
+    },
+    run: { stdout: "undefined" },
+    bundleWarnings: {},
+  });
+
+  // A lifted CommonJS export changes through `exports.x`, so a destructured
+  // copy of it stays a snapshot.
+  itBundled("dynamic_import_dce/LiftedCommonJSDestructureIsSnapshot", {
+    files: {
+      "/entry.js": `const { count, inc } = await import("react"); inc(); console.log(count);`,
+      "/node_modules/react/package.json": `{ "name": "react", "main": "index.js" }`,
+      "/node_modules/react/index.js": `exports.count = 0; exports.inc = function () { exports.count++; };`,
+    },
+    run: { stdout: "0" },
+  });
+
+  // ── Cases that keep the namespace object ──────────────────────────────
+
+  function itKeepsNamespace(
+    name: string,
+    opts: Omit<BundlerTestInput, "files" | "run" | "onAfterBundle"> & {
+      files: Record<string, string>;
+      stdout?: string;
+      expected: string;
+    },
+  ) {
+    const { files, stdout, expected, ...rest } = opts;
+    itBundled(`dynamic_import_dce/KeepNamespace${name}`, {
+      files,
+      ...rest,
+      run: stdout === undefined ? undefined : { stdout, file: rest.outdir ? "/out/entry.js" : undefined },
+      onAfterBundle(api) {
+        expect(rest.outdir ? readAllOutputs(api.outdir) : api.readFile("/out.js")).toContain(expected);
+      },
+    });
+  }
+
+  itKeepsNamespace("Escapes", {
+    files: {
+      "/entry.js": `const ns = await import("./x.js"); console.log(Object.keys(ns).join());`,
+      "/x.js": `export const a = "a"; export const b = "b";`,
+    },
+    stdout: "a,b",
+    expected: "__export(exports_x",
+  });
+
+  itKeepsNamespace("CommonJS", {
+    files: {
+      "/entry.js": `const { a } = await import("./x.cjs"); console.log(a);`,
+      "/x.cjs": `exports.a = "a";`,
+    },
+    stdout: "a",
+    expected: "__toESM(require_x())",
+  });
+
+  itKeepsNamespace("External", {
+    files: {
+      "/entry.js": `const { a } = await import("ext"); console.log(a);`,
+    },
+    external: ["ext"],
+    expected: `import("ext")`,
+  });
+
+  itKeepsNamespace("ImportStarValue", {
+    files: {
+      "/entry.js": `import "./other.js"; const { a } = await import("./x.js"); console.log(a);`,
+      "/other.js": `import * as ns from "./x.js"; console.log(typeof ns);`,
+      "/x.js": `export const a = "a";`,
+    },
+    stdout: "object\na",
+    expected: "__export(exports_x",
+  });
+
+  // A read with no local to bind (`(await import(x)).a`, `require(x).a`) reads
+  // the namespace object, as does one that `import * as` from the same file
+  // makes a value.
+  itKeepsNamespace("CallMemberRead", {
+    files: {
+      "/entry.js": /* js */ `
+        const { bump } = await import("./x.js");
+        console.log((await import("./x.js")).b, require("./x.js").b);
+        bump();
+        console.log(require("./x.js")["b"]);
+      `,
+      "/x.js": `export let b = 1; export function bump() { b++; }`,
+    },
+    stdout: "1 1\n2",
+    expected: "__export(exports_x",
+  });
+
+  // A local that may hold either namespace, or null.
+  itKeepsNamespace("ConditionalLocal", {
+    files: {
+      "/entry.js": `const ns = process.argv.length > 99 ? null : require("./x.js"); if (ns) console.log(ns.a);`,
+      "/x.js": `export const a = "a";`,
+    },
+    stdout: "a",
+    expected: "__export(exports_x",
+  });
+
+  // `require()` of an ES module reads `__esModule` off the `__toCommonJS()` copy.
+  itKeepsNamespace("RequireEsModuleMarker", {
+    files: {
+      "/entry.js": `console.log(require("./x.js").__esModule, require("./x.js").a);`,
+      "/x.js": `export const a = "a";`,
+    },
+    stdout: "true a",
+    expected: "__toCommonJS(exports_x)",
+  });
+
+  // With splitting, the importee is its own chunk and a real ES module.
+  itKeepsNamespace("Splitting", {
+    files: {
+      "/entry.js": `const { a } = await import("./x.js"); console.log(a);`,
+      "/x.js": `export const a = "a"; export const b = "DROPPED";`,
+    },
+    splitting: true,
+    outdir: "/out",
+    stdout: "a",
+    expected: `import("./x-`,
   });
 });

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -142,15 +142,15 @@ describe("bundler", () => {
 
         // AsyncEntryPoint.ts
         async function AsyncEntryPoint() {
-          const {} = await init_BaseElement().then(() => ({}));
+          await init_BaseElement();
           console.log("Launching AsyncEntryPoint", BaseElement());
         }
 
         // entry.ts
-        var {} = await Promise.resolve().then(() => ({}));
+        await Promise.resolve();
         AsyncEntryPoint();
 
-        //# debugId=C0EAF906A3A61FA864756E2164756E21
+        //# debugId=B9EF7E5F2ACBD11D64756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -371,15 +371,15 @@ describe("bundler", () => {
 
         // AsyncEntryPoint.ts
         async function AsyncEntryPoint() {
-          const {} = await Promise.resolve().then(() => (init_BaseElement(), {}));
+          await Promise.resolve().then(() => init_BaseElement());
           console.log("Launching AsyncEntryPoint", BaseElement());
         }
 
         // entry.ts
-        var {} = await Promise.resolve().then(() => ({}));
+        await Promise.resolve();
         AsyncEntryPoint();
 
-        //# debugId=FF7C8811411E545B64756E2164756E21
+        //# debugId=6678C3B13A630A4064756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -75,21 +75,17 @@ describe("bundler", () => {
       const bundled = api.readFile("out.js");
 
       expect(bundled).toMatchInlineSnapshot(`
-        "var __defProp = Object.defineProperty;
-        var __returnValue = (v) => v;
-        function __exportSetter(name, newValue) {
-          this[name] = __returnValue.bind(null, newValue);
-        }
-        var __export = (target, all) => {
-          for (var name in all)
-            __defProp(target, name, {
-              get: all[name],
-              enumerable: true,
-              configurable: true,
-              set: __exportSetter.bind(all, name)
-            });
+        "var __esm = (fn, res, err) => () => {
+          if (fn)
+            try {
+              res = fn(fn = 0);
+            } catch (e) {
+              err = [e];
+            }
+          if (err)
+            throw err[0];
+          return res;
         };
-        var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
         var __promiseAll = (args) => Promise.all(args);
 
         // StoreDependencyAsync.ts
@@ -125,11 +121,6 @@ describe("bundler", () => {
         });
 
         // BaseElement.ts
-        var exports_BaseElement = {};
-        __export(exports_BaseElement, {
-          BaseElement: () => BaseElement,
-          formValue: () => formValue
-        });
         function BaseElement() {
           console.log("BaseElement called", BaseElementImport());
           return BaseElementImport();
@@ -150,20 +141,16 @@ describe("bundler", () => {
         });
 
         // AsyncEntryPoint.ts
-        var exports_AsyncEntryPoint = {};
-        __export(exports_AsyncEntryPoint, {
-          AsyncEntryPoint: () => AsyncEntryPoint
-        });
         async function AsyncEntryPoint() {
-          const { BaseElement: BaseElement2 } = await init_BaseElement().then(() => exports_BaseElement);
-          console.log("Launching AsyncEntryPoint", BaseElement2());
+          const {} = await init_BaseElement().then(() => ({}));
+          console.log("Launching AsyncEntryPoint", BaseElement());
         }
 
         // entry.ts
-        var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
-        AsyncEntryPoint2();
+        var {} = await Promise.resolve().then(() => ({}));
+        AsyncEntryPoint();
 
-        //# debugId=58A499A633D13E2364756E2164756E21
+        //# debugId=C0EAF906A3A61FA864756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -339,21 +326,17 @@ describe("bundler", () => {
       const bundled = api.readFile("out.js");
 
       expect(bundled).toMatchInlineSnapshot(`
-        "var __defProp = Object.defineProperty;
-        var __returnValue = (v) => v;
-        function __exportSetter(name, newValue) {
-          this[name] = __returnValue.bind(null, newValue);
-        }
-        var __export = (target, all) => {
-          for (var name in all)
-            __defProp(target, name, {
-              get: all[name],
-              enumerable: true,
-              configurable: true,
-              set: __exportSetter.bind(all, name)
-            });
+        "var __esm = (fn, res, err) => () => {
+          if (fn)
+            try {
+              res = fn(fn = 0);
+            } catch (e) {
+              err = [e];
+            }
+          if (err)
+            throw err[0];
+          return res;
         };
-        var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
 
         // SecondElementImport.ts
         function SecondElementImport() {
@@ -374,11 +357,6 @@ describe("bundler", () => {
         });
 
         // BaseElement.ts
-        var exports_BaseElement = {};
-        __export(exports_BaseElement, {
-          BaseElement: () => BaseElement,
-          formValue: () => formValue
-        });
         function BaseElement() {
           console.log("BaseElement called", BaseElementImport());
           return BaseElementImport();
@@ -392,20 +370,16 @@ describe("bundler", () => {
         });
 
         // AsyncEntryPoint.ts
-        var exports_AsyncEntryPoint = {};
-        __export(exports_AsyncEntryPoint, {
-          AsyncEntryPoint: () => AsyncEntryPoint
-        });
         async function AsyncEntryPoint() {
-          const { BaseElement: BaseElement2 } = await Promise.resolve().then(() => (init_BaseElement(), exports_BaseElement));
-          console.log("Launching AsyncEntryPoint", BaseElement2());
+          const {} = await Promise.resolve().then(() => (init_BaseElement(), {}));
+          console.log("Launching AsyncEntryPoint", BaseElement());
         }
 
         // entry.ts
-        var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
-        AsyncEntryPoint2();
+        var {} = await Promise.resolve().then(() => ({}));
+        AsyncEntryPoint();
 
-        //# debugId=90661D76D5B7686664756E2164756E21
+        //# debugId=FF7C8811411E545B64756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -3381,7 +3381,7 @@ describe("bundler", () => {
   itBundled("dce/IgnoreAnnotationsDoesNotApplyToRuntime", {
     files: {
       "/entry.js": /* js */ `
-        import("./other.js").then(m => m.foo());
+        import("./other.js").then(m => Object.keys(m));
       `,
       "/other.js": /* js */ `
         export function foo() { }

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -339,7 +339,7 @@ describe.concurrent("require.cache", () => {
         expect(exitCode).toBe(0);
       },
       // TODO: Investigate why this is so slow on Windows
-      isWindows ? 60000 : 30000,
+      isWindows || isASAN ? 60000 : 30000,
     );
   });
 });

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -158,15 +158,15 @@ test("cyclic imports with async dependencies should generate async wrappers", as
 
     // src/RecursiveDependencies/AsyncEntryPoint.ts
     async function AsyncEntryPoint() {
-      const {} = await init_BaseElement().then(() => ({}));
+      await init_BaseElement();
       console.log("Launching AsyncEntryPoint", BaseElement());
     }
 
     // src/entryBuild.ts
-    var {} = await Promise.resolve().then(() => ({}));
+    await Promise.resolve();
     AsyncEntryPoint();
 
-    //# debugId=6281112B9F1E1D7B64756E2164756E21
+    //# debugId=5B573DC06E466ACE64756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -91,21 +91,17 @@ test("cyclic imports with async dependencies should generate async wrappers", as
   const bundled = await Bun.file(bundledPath).text();
 
   expect(bundled).toMatchInlineSnapshot(`
-    "var __defProp = Object.defineProperty;
-    var __returnValue = (v) => v;
-    function __exportSetter(name, newValue) {
-      this[name] = __returnValue.bind(null, newValue);
-    }
-    var __export = (target, all) => {
-      for (var name in all)
-        __defProp(target, name, {
-          get: all[name],
-          enumerable: true,
-          configurable: true,
-          set: __exportSetter.bind(all, name)
-        });
+    "var __esm = (fn, res, err) => () => {
+      if (fn)
+        try {
+          res = fn(fn = 0);
+        } catch (e) {
+          err = [e];
+        }
+      if (err)
+        throw err[0];
+      return res;
     };
-    var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);
     var __promiseAll = (args) => Promise.all(args);
 
     // src/RecursiveDependencies/StoreDependencyAsync.ts
@@ -141,11 +137,6 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     });
 
     // src/RecursiveDependencies/BaseElement.ts
-    var exports_BaseElement = {};
-    __export(exports_BaseElement, {
-      BaseElement: () => BaseElement,
-      formValue: () => formValue
-    });
     function BaseElement() {
       console.log("BaseElement called", BaseElementImport());
       return BaseElementImport();
@@ -166,20 +157,16 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     });
 
     // src/RecursiveDependencies/AsyncEntryPoint.ts
-    var exports_AsyncEntryPoint = {};
-    __export(exports_AsyncEntryPoint, {
-      AsyncEntryPoint: () => AsyncEntryPoint
-    });
     async function AsyncEntryPoint() {
-      const { BaseElement: BaseElement2 } = await init_BaseElement().then(() => exports_BaseElement);
-      console.log("Launching AsyncEntryPoint", BaseElement2());
+      const {} = await init_BaseElement().then(() => ({}));
+      console.log("Launching AsyncEntryPoint", BaseElement());
     }
 
     // src/entryBuild.ts
-    var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
-    AsyncEntryPoint2();
+    var {} = await Promise.resolve().then(() => ({}));
+    AsyncEntryPoint();
 
-    //# debugId=CDA89BED21DB7D2D64756E2164756E21
+    //# debugId=6281112B9F1E1D7B64756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
### What does this PR do?

Without `--splitting`, `import()` and `require()` of an ES module no longer build an `__export` namespace object when every read of the result is named. `const { z } = await import("zod"); z.object()` now tree-shakes like `import { z } from "zod"`.

```js
// is.ts exports isNumber, isOdd, isEven. main.ts:
const { isOdd } = await import("./is");
console.log(isOdd(3));

// before
var exports_is = {};
__export(exports_is, { isOdd: () => isOdd });
var { isOdd: isOdd2 } = await Promise.resolve().then(() => exports_is);

// after
await Promise.resolve();
console.log(isOdd(3));
```

It reuses the machinery static imports already have:

- `ns.a` off a local from `import()` or `require()` becomes an import item through the `import * as ns` rewrite. If it isn't bound, it prints `ns.a`.
- A `const`, `let`, or `.then` parameter bound by a pattern is an import item of the call's record. If it isn't bound, it stays the local.
- A call whose items are all bound doesn't depend on `exports_x`. So tree shaking drops `__export`. A pattern with only bound names prints as the load, such as `await init_x();`.

Minified, `import()` form:

| | before | after |
|---|---:|---:|
| zod 4.5 | 377.9 KB | 78.2 KB |
| effect 3.22 | 248.1 KB | 125.7 KB |

The namespace object is kept when any read isn't bound. That covers an escaping value, a CommonJS or external importee, a read with no local (`require(x).a`), and a destructured export that can change. `--splitting` output is unchanged.

Behavior changes:

- A `then` export is not called by `await`.
- `this` in `ns.f()` is undefined, as for `import * as ns`.
- `__esm` rethrows a cached init error on later imports.

### How did you verify your code works?

- `bundler_dynamic_import_dce.test.ts` has 270 tests. The new cases run as ESM and CJS, minified and not.
- The esbuild, barrel, cjs, splitting, edgecase, and minify suites pass.
- Instruction counts for building three.js ×10 (no `import()`): +0.06% vs main. Wall time is within noise.
