### PR TITLE
expect: fix spelling in the toHaveReturned failure message

### DIFF
--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -90,7 +90,7 @@ interface JSCommonJSModule {
  * Binding files are located in `src/jsc/bindings`
  *
  * @see {@link $rust} for native Rust bindings.
- * @see `src/codegen/replacements.ts` for the script that performs replacement of this funciton.
+ * @see `src/codegen/replacements.ts` for the script that performs replacement of this function.
  *
  * @param filename name of the c++ file containing the function. Do not pass a path.
  * @param symbol   The name of the binding function to call. Use `dot.notation` to access
@@ -107,7 +107,7 @@ declare function $cpp<T = any>(filename: NativeFilenameCPP, symbol: string): T;
  * as Foo` instead.
  *
  * @see {@link $cpp} for native c++ bindings.
- * @see `src/codegen/replacements.ts` for the script that performs replacement of this funciton.
+ * @see `src/codegen/replacements.ts` for the script that performs replacement of this function.
  *
  * @param filename identifier of the Rust module containing the function (see
  *                 `rustIdentifierPaths` in `src/codegen/generate-js2native.ts`).

--- a/src/runtime/test_runner/expect/toHaveReturned.rs
+++ b/src/runtime/test_runner/expect/toHaveReturned.rs
@@ -99,9 +99,9 @@ fn to_have_returned_times_fn(
         global,
         signature,
         "\n\n\
-         Expected number of succesful returns: {}<green>{}<r>\n\
-         Received number of succesful returns: {}<red>{}<r>\n\
-         Received number of calls:             {}<red>{}<r>\n",
+         Expected number of successful returns: {}<green>{}<r>\n\
+         Received number of successful returns: {}<red>{}<r>\n\
+         Received number of calls:              {}<red>{}<r>\n",
         str_, expected_success_count, spc, actual_success_count, spc, total_call_count,
     )
 }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -167,9 +167,9 @@ describe("mock()", () => {
       expect(e.message.replaceAll(/\x1B\[[0-9;]*m/g, "")).toMatchInlineSnapshot(`
         "expect(received).toHaveReturned(expected)
 
-        Expected number of succesful returns: >= 1
-        Received number of succesful returns:    0
-        Received number of calls:                1
+        Expected number of successful returns: >= 1
+        Received number of successful returns:    0
+        Received number of calls:                 1
         "
       `);
     }


### PR DESCRIPTION
### Problem
- The `toHaveReturned` and `toHaveReturnedTimes` failure message prints "succesful returns" on two lines (`src/runtime/test_runner/expect/toHaveReturned.rs:102-103`). This text is user visible in `bun test` output.
- Two JSDoc comments in `src/js/private.d.ts` (lines 93 and 110) say "funciton".
- #26763 fixed both typos. Four of its five files were Zig sources that the Rust rewrite (#30412) removed, so that branch can no longer apply.

### Fix
- Spell "successful" on both message lines. Add one space to the "Received number of calls:" line so the three values stay aligned.
- Spell "function" in the two JSDoc comments.
- Update the inline snapshot in `test/js/bun/test/mock-fn.test.js` that asserts the message text. The snapshot fails on the current release and passes with this change.
- Verified: `bun bd test test/js/bun/test/mock-fn.test.js` (87 pass).

### Background
- `toHaveReturned` is the `bun:test` matcher for `jest.fn()` mocks. When it fails, it prints the expected and received counts of calls that returned without a throw.
- `src/js/private.d.ts` declares the `$cpp` and `$rust` macros that the builtin JS modules use to call native bindings. The comments are for contributors only.
- The original fix is from FrankFMY in #26763. The commit carries a Co-authored-by trailer for them.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.64ms]
(pass) mock() > mock [7.80ms]
(pass) mock() > checks the this value > mock [6.94ms]
(pass) mock() > checks the this value > _protoImpl [0.75ms]
(pass) mock() > checks the this value > getMockImplementation [1.09ms]
(pass) mock() > checks the this value > getMockName [0.80ms]
(pass) mock() > checks the this value > mockClear [0.59ms]
(pass) mock() > checks the this value > mockReset [0.62ms]
(pass) mock() > checks the this value > mockRestore [0.86ms]
(pass) mock() > checks the this value > mockImplementation [0.83ms]
(pass) mock() > checks the this value > mockImplementationOnce [1.15ms]
(pass) mock() > checks the this value > withImplementation [0.93ms]
(pass) mock() > checks the this value > mockName [0.98ms]
(pass) mock() > checks the this value > mockReturnThis [0.87ms]
(pass) mock() > checks the this value > mockReturnValue [0.77ms]
(pass) mock() > checks the this value 
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (ce1a9fe5e)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.02ms]
(pass) mock() > mock [0.09ms]
(pass) mock() > checks the this value > mock [0.12ms]
(pass) mock() > checks the this value > _protoImpl
(pass) mock() > checks the this value > getMockImplementation [0.03ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce [0.02ms]
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the this value > mockRe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.1 (a6c4cc276)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.61ms]
(pass) mock() > mock [6.32ms]
(pass) mock() > checks the this value > mock [7.16ms]
(pass) mock() > checks the this value > _protoImpl [0.74ms]
(pass) mock() > checks the this value > getMockImplementation [1.04ms]
(pass) mock() > checks the this value > getMockName [0.76ms]
(pass) mock() > checks the this value > mockClear [0.84ms]
(pass) mock() > checks the this value > mockReset [0.58ms]
(pass) mock() > checks the this value > mockRestore [0.60ms]
(pass) mock() > checks the this value > mockImplementation [0.61ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.73ms]
(pass) mock() > checks the this value > withImplementation [0.56ms]
(pass) mock() > checks the this value > mockName [0.56ms]
(pass) mock() > checks the this value > mockReturnThis [0.55ms]
(pass) mock() > checks the this value > mockReturnValue [0.47ms]
(pass) mock() > checks the this value 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 610ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (7425ms)
Bundle modules (48ms)
Postprocesss modules (42ms)
Bundle Functions (483ms)
Generate Code (25ms)

[8.03s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/private.d.ts                              | 4 ++--
 src/runtime/test_runner/expect/toHaveReturned.rs | 6 +++---
 test/js/bun/test/mock-fn.test.js                 | 6 +++---
 3 files changed, 8 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/js/private.d.ts                                   1      1      5
src/runtime/test_runner/expect/toHaveReturned.rs      1      1      5
test/js/bun/test/mock-fn.test.js                      1      1      5
```

</details>

<!-- robobun:evidence:end -->