### PR TITLE
bundler: lift module.exports = require() after side effects in unwrapped packages to export *

### DIFF
--- a/src/bun_alloc/baby_vec.rs
+++ b/src/bun_alloc/baby_vec.rs
@@ -172,15 +172,12 @@ impl<'a, T> BabyVec<'a, T> {
         }
     }
 
-    /// `Vec::remove` parity — remove the element at `index` and shift the
-    /// tail down by one, keeping the order of the remaining elements.
+    /// `Vec::remove` parity — order-preserving removal.
     pub fn remove(&mut self, index: usize) -> T {
         let len = self.len as usize;
         assert!(index < len, "BabyVec::remove index {index} >= len {len}");
         // SAFETY: `index < len`; the hole is read out before the tail
-        // `[index+1, len)` is shifted down over it. Len is decremented after
-        // the shift, so the now-duplicated last slot is no longer considered
-        // initialized.
+        // `[index+1, len)` is shifted down over it, then `len` shrinks by one.
         unsafe {
             let p = self.ptr.as_ptr().add(index);
             let v = p.read();

--- a/src/bun_alloc/baby_vec.rs
+++ b/src/bun_alloc/baby_vec.rs
@@ -172,6 +172,24 @@ impl<'a, T> BabyVec<'a, T> {
         }
     }
 
+    /// `Vec::remove` parity — remove the element at `index` and shift the
+    /// tail down by one, keeping the order of the remaining elements.
+    pub fn remove(&mut self, index: usize) -> T {
+        let len = self.len as usize;
+        assert!(index < len, "BabyVec::remove index {index} >= len {len}");
+        // SAFETY: `index < len`; the hole is read out before the tail
+        // `[index+1, len)` is shifted down over it. Len is decremented after
+        // the shift, so the now-duplicated last slot is no longer considered
+        // initialized.
+        unsafe {
+            let p = self.ptr.as_ptr().add(index);
+            let v = p.read();
+            ptr::copy(p.add(1), p, len - index - 1);
+            self.len -= 1;
+            v
+        }
+    }
+
     /// `Vec::append` parity — bitwise-move all elements from `other` to the
     /// end of `self`, leaving `other` empty.
     pub fn append(&mut self, other: &mut Self) {

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -162,13 +162,9 @@ pub(crate) fn convert_stmts_for_chunk(
                         break 'process_stmt;
                     }
 
-                    // The export star of a lifted CommonJS file is the parser's rewrite of
-                    // `module.exports = require("path")` (see `parse_entry.rs`), and this
-                    // file is a CommonJS wrapper after all. Print the assignment again. Its
-                    // value is what the `import * as ns` it replaced stood for: the
-                    // namespace object of a bundled ES module, the wrapper call of a
-                    // bundled CommonJS module (the printer adds `__toESM`), or the
-                    // namespace of an external module.
+                    // A lifted CommonJS file's export star is the parser's rewrite of
+                    // `module.exports = require("path")` (`parse_entry.rs`). Inside a
+                    // `__commonJS` wrapper, print that assignment again.
                     let is_module_exports_of_wrapped_file = wrap == WrapKind::Cjs
                         && ast.flags.contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
                         && !(record.source_index.is_valid()

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -3,13 +3,14 @@ use crate::mal_prelude::*;
 use bun_alloc::Arena as Bump;
 use bun_ast::ImportRecordFlags;
 use bun_ast::Loc;
-use bun_ast::{self as js_ast, Binding, Expr, ExprNodeList, Stmt};
+use bun_ast::{self as js_ast, Binding, ExportsKind, Expr, ExprNodeList, Stmt};
 use bun_ast::{B, E, G, S};
 use bun_collections::VecExt;
 use bun_core::FeatureFlags;
 
 use crate::EntryPoint;
 use crate::WrapKind;
+use crate::bundled_ast::Flags as AstFlags;
 use crate::chunk::Chunk;
 use crate::linker_context_mod::{LinkerContext, LinkerOptionsMode, StmtList, StmtListWhich};
 use crate::options::Format;
@@ -161,10 +162,44 @@ pub(crate) fn convert_stmts_for_chunk(
                         break 'process_stmt;
                     }
 
+                    // The export star of a lifted CommonJS file is the parser's rewrite of
+                    // `module.exports = require("path")` (see `parse_entry.rs`), and this
+                    // file is a CommonJS wrapper after all. Print the assignment again. Its
+                    // value is what the `import * as ns` it replaced stood for: the
+                    // namespace object of a bundled ES module, the wrapper call of a
+                    // bundled CommonJS module (the printer adds `__toESM`), or the
+                    // namespace of an external module.
+                    let is_module_exports_of_wrapped_file = wrap == WrapKind::Cjs
+                        && ast.flags.contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+                        && !(record.source_index.is_valid()
+                            && record.source_index.get() == source_index);
+
                     // Is this export star evaluated at run time?
                     if !record.source_index.is_valid()
                         && c.options.output_format.keep_es6_import_export_syntax()
                     {
+                        if is_module_exports_of_wrapped_file {
+                            stmts.append(
+                                StmtListWhich::OutsideWrapperPrefix,
+                                Stmt::alloc(
+                                    S::Import {
+                                        namespace_ref: s.namespace_ref,
+                                        import_record_index: s.import_record_index,
+                                        star_name_loc: stmt.loc,
+                                        ..Default::default()
+                                    },
+                                    stmt.loc,
+                                ),
+                            );
+                            stmt = assign_module_exports(
+                                bump,
+                                ast.module_ref,
+                                Expr::init_identifier(s.namespace_ref, stmt.loc),
+                                stmt.loc,
+                            );
+                            break 'process_stmt;
+                        }
+
                         if record
                             .flags
                             .contains(ImportRecordFlags::CALLS_RUNTIME_RE_EXPORT_FN)
@@ -241,10 +276,9 @@ pub(crate) fn convert_stmts_for_chunk(
                         }
                     } else {
                         if record.source_index.is_valid() {
-                            let flag =
-                                c.graph.meta.items_flags()[record.source_index.get() as usize];
-                            let wrapper_ref =
-                                c.graph.ast.items_wrapper_ref()[record.source_index.get() as usize];
+                            let other_source_index = record.source_index.get() as usize;
+                            let flag = c.graph.meta.items_flags()[other_source_index];
+                            let wrapper_ref = c.graph.ast.items_wrapper_ref()[other_source_index];
                             if flag.wrap == WrapKind::Esm && wrapper_ref.is_valid() {
                                 stmts
                                     .inside_wrapper_prefix
@@ -268,6 +302,30 @@ pub(crate) fn convert_stmts_for_chunk(
                                         stmt.loc,
                                     ))?;
                             }
+                        }
+
+                        if is_module_exports_of_wrapped_file {
+                            let value = if record.source_index.is_valid()
+                                && c.graph.ast.items_exports_kind()
+                                    [record.source_index.get() as usize]
+                                    != ExportsKind::Cjs
+                            {
+                                Expr::init_identifier(
+                                    c.graph.ast.items_exports_ref()
+                                        [record.source_index.get() as usize],
+                                    stmt.loc,
+                                )
+                            } else {
+                                Expr::init(
+                                    E::RequireString {
+                                        import_record_index: s.import_record_index,
+                                        ..Default::default()
+                                    },
+                                    stmt.loc,
+                                )
+                            };
+                            stmt = assign_module_exports(bump, ast.module_ref, value, stmt.loc);
+                            break 'process_stmt;
                         }
 
                         if record
@@ -600,4 +658,38 @@ pub(crate) fn convert_stmts_for_chunk(
     }
 
     Ok(())
+}
+
+/// `module.exports = value;`
+fn assign_module_exports(bump: &Bump, module_ref: bun_ast::Ref, value: Expr, loc: Loc) -> Stmt {
+    Stmt::alloc(
+        S::SExpr {
+            value: Expr::init(
+                E::Binary {
+                    op: js_ast::OpCode::BinAssign,
+                    left: Expr::allocate(
+                        bump,
+                        E::Dot {
+                            target: Expr::allocate(
+                                bump,
+                                E::Identifier {
+                                    ref_: module_ref,
+                                    ..Default::default()
+                                },
+                                loc,
+                            ),
+                            name: b"exports".into(),
+                            name_loc: loc,
+                            ..Default::default()
+                        },
+                        loc,
+                    ),
+                    right: value,
+                },
+                loc,
+            ),
+            ..Default::default()
+        },
+        loc,
+    )
 }

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -162,9 +162,8 @@ pub(crate) fn convert_stmts_for_chunk(
                         break 'process_stmt;
                     }
 
-                    // A lifted CommonJS file's export star is the parser's rewrite of
-                    // `module.exports = require("path")` (`parse_entry.rs`). Inside a
-                    // `__commonJS` wrapper, print that assignment again.
+                    // A lifted CommonJS file's export star was `module.exports = require("path")`
+                    // (see `parse_entry.rs`): inside a `__commonJS` wrapper, print that again.
                     let is_module_exports_of_wrapped_file = wrap == WrapKind::Cjs
                         && ast.flags.contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
                         && !(record.source_index.is_valid()

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -417,7 +417,22 @@ pub(crate) fn scan_imports_and_exports(
 
                 if dependency_wrapper.export_star_records[id].len() > 0 {
                     dependency_wrapper.export_star_map.clear();
-                    let _ = dependency_wrapper.has_dynamic_exports_due_to_export_star(source_index);
+                    let has_dynamic_exports =
+                        dependency_wrapper.has_dynamic_exports_due_to_export_star(source_index);
+
+                    // A lifted CommonJS file has no export star of its own: the parser
+                    // made one out of `module.exports = require("./b")`. If "./b" has
+                    // dynamic exports (CommonJS or external) after all, named imports of
+                    // this file cannot bind statically, so keep it a CommonJS wrapper
+                    // around the original assignment (see `convert_stmts_for_chunk`).
+                    if has_dynamic_exports
+                        && dependency_wrapper.exports_kind[id] != ExportsKind::Cjs
+                        && col_ref!(ast_flags_list)[id].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+                    {
+                        dependency_wrapper.exports_kind[id] = ExportsKind::Cjs;
+                        dependency_wrapper.flags[id].wrap = WrapKind::Cjs;
+                        dependency_wrapper.wrap(source_index);
+                    }
                 }
 
                 // Even if the output file is CommonJS-like, we may still need to wrap
@@ -1183,6 +1198,44 @@ pub(crate) fn scan_imports_and_exports(
                             [*import_record_index as usize];
                         (record.source_index,)
                     };
+
+                    // The export star of a lifted CommonJS file is the parser's rewrite of
+                    // `module.exports = require("path")`, and this file is a CommonJS
+                    // wrapper after all. `convert_stmts_for_chunk` prints the assignment
+                    // again, so the part needs the "module" parameter and the value: the
+                    // namespace object of a bundled ES module, the wrapper of a bundled
+                    // CommonJS module (an import record use, handled above), or the
+                    // `import * as ns` of an external module.
+                    if wrap == WrapKind::Cjs
+                        && col_ref!(ast_flags_list)[id].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+                        && !(rec_source_index.is_valid() && rec_source_index.get() == source_index)
+                    {
+                        if rec_source_index.is_valid() {
+                            let other_id = rec_source_index.get() as usize;
+                            if col_ref!(exports_kind)[other_id] != ExportsKind::Cjs {
+                                this.graph.generate_symbol_import_and_use(
+                                    source_index,
+                                    part_index as u32,
+                                    col_ref!(exports_refs)[other_id],
+                                    1,
+                                    Index::source(rec_source_index.get()),
+                                )?;
+                            }
+                        } else if output_format.keep_es6_import_export_syntax() {
+                            col!(import_records_list)[id].as_mut_slice()
+                                [*import_record_index as usize]
+                                .flags
+                                .insert(ImportRecordFlags::CONTAINS_IMPORT_STAR);
+                        }
+                        this.graph.generate_symbol_import_and_use(
+                            source_index,
+                            part_index as u32,
+                            col_ref!(module_refs)[id],
+                            1,
+                            Index::source(source_index),
+                        )?;
+                        continue;
+                    }
 
                     let mut happens_at_runtime = rec_source_index.is_invalid()
                         && (!is_entry_point || !output_format.keep_es6_import_export_syntax());

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -420,9 +420,8 @@ pub(crate) fn scan_imports_and_exports(
                     let has_dynamic_exports =
                         dependency_wrapper.has_dynamic_exports_due_to_export_star(source_index);
 
-                    // A lifted CommonJS file's export star stands for `module.exports =
-                    // require("./b")`. With a CommonJS or external "./b", its named imports
-                    // cannot bind statically: keep the wrapper (`convert_stmts_for_chunk`).
+                    // A lifted file's export star was `module.exports = require("./b")`. With no
+                    // static exports in "./b", keep the wrapper (see `convert_stmts_for_chunk`).
                     if has_dynamic_exports
                         && dependency_wrapper.exports_kind[id] != ExportsKind::Cjs
                         && col_ref!(ast_flags_list)[id].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
@@ -1197,9 +1196,8 @@ pub(crate) fn scan_imports_and_exports(
                         (record.source_index,)
                     };
 
-                    // `convert_stmts_for_chunk` prints a wrapped lifted file's export star
-                    // as `module.exports = <value>`: the part needs `module` and the value
-                    // (a namespace object, or the `import * as ns` of an external module).
+                    // `convert_stmts_for_chunk` prints a wrapped lifted file's export star as
+                    // `module.exports = <value>`: the part needs `module` and that value.
                     if wrap == WrapKind::Cjs
                         && col_ref!(ast_flags_list)[id].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
                         && !(rec_source_index.is_valid() && rec_source_index.get() == source_index)

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -420,11 +420,9 @@ pub(crate) fn scan_imports_and_exports(
                     let has_dynamic_exports =
                         dependency_wrapper.has_dynamic_exports_due_to_export_star(source_index);
 
-                    // A lifted CommonJS file has no export star of its own: the parser
-                    // made one out of `module.exports = require("./b")`. If "./b" has
-                    // dynamic exports (CommonJS or external) after all, named imports of
-                    // this file cannot bind statically, so keep it a CommonJS wrapper
-                    // around the original assignment (see `convert_stmts_for_chunk`).
+                    // A lifted CommonJS file's export star stands for `module.exports =
+                    // require("./b")`. With a CommonJS or external "./b", its named imports
+                    // cannot bind statically: keep the wrapper (`convert_stmts_for_chunk`).
                     if has_dynamic_exports
                         && dependency_wrapper.exports_kind[id] != ExportsKind::Cjs
                         && col_ref!(ast_flags_list)[id].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
@@ -1199,13 +1197,9 @@ pub(crate) fn scan_imports_and_exports(
                         (record.source_index,)
                     };
 
-                    // The export star of a lifted CommonJS file is the parser's rewrite of
-                    // `module.exports = require("path")`, and this file is a CommonJS
-                    // wrapper after all. `convert_stmts_for_chunk` prints the assignment
-                    // again, so the part needs the "module" parameter and the value: the
-                    // namespace object of a bundled ES module, the wrapper of a bundled
-                    // CommonJS module (an import record use, handled above), or the
-                    // `import * as ns` of an external module.
+                    // `convert_stmts_for_chunk` prints a wrapped lifted file's export star
+                    // as `module.exports = <value>`: the part needs `module` and the value
+                    // (a namespace object, or the `import * as ns` of an external module).
                     if wrap == WrapKind::Cjs
                         && col_ref!(ast_flags_list)[id].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
                         && !(rec_source_index.is_valid() && rec_source_index.get() == source_index)

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1549,21 +1549,11 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // A file from the unwrap allowlist (react, react-dom, ...) that does
-        // some work and then re-exports one other file:
-        //
-        //    checkDCE();
-        //    module.exports = require('./cjs/react-dom.production.js');
-        //
-        // An example is react-dom/index.js. `transpose_require` already turned
-        // the require() into `import * as ns from '...'`, so the statement now
-        // reads `module.exports = ns`. Replace it with `export * from '...'`,
-        // which makes the file ESM and needs no `__commonJS` wrapper. The file
-        // has no ES module syntax of its own, so the linker knows the export
-        // star of a `COMMONJS_LIFTED_TO_ESM` file is this assignment. When it
-        // wraps the file as CommonJS after all (a re-exported file whose
-        // exports are not statically known), `convert_stmts_for_chunk` prints
-        // the assignment again.
+        // react-dom/index.js in production: `checkDCE(); module.exports = require('./cjs/...')`.
+        // `transpose_require` made the require() an `import * as ns` namespace, so the
+        // statement reads `module.exports = ns`. Replace it with `export * from`: the file
+        // is ESM without a `__commonJS` wrapper. The linker reads the export star of a
+        // `COMMONJS_LIFTED_TO_ESM` file as this assignment if it wraps the file after all.
         if p.options.features.unwrap_commonjs_to_esm
             && p.unwrap_all_requires
             && !p.options.is_entry_point
@@ -1577,9 +1567,8 @@ impl<'a> Parser<'a> {
             struct ModuleExportsOfNamespace {
                 part_idx: usize,
                 stmt_idx: usize,
-                /// `checkDCE(), module.exports = ns`: minification folded the
-                /// `if (process.env.NODE_ENV === 'production')` block into one
-                /// comma expression. This is the part before the assignment.
+                /// `checkDCE(), module.exports = ns` (the `if` block folded by
+                /// minification): the operand before the assignment.
                 leading: Option<Expr>,
                 assign_loc: bun_ast::Loc,
                 namespace_ref: js_ast::Ref,
@@ -1639,8 +1628,7 @@ impl<'a> Parser<'a> {
                 let part = &mut parts[found.part_idx];
                 let stmt_loc = part.stmts.slice()[found.stmt_idx].loc;
 
-                // Like `s_export_star`, the export star declares its own
-                // namespace symbol. `ns` stays with the import statement.
+                // Like `s_export_star`: the export star declares its own namespace symbol.
                 let name = p.load_name_from_ref(found.namespace_ref);
                 let export_star_ref = p.new_symbol(js_ast::symbol::Kind::Other, name);
                 VecExt::append(&mut p.module_scope_mut().generated, export_star_ref);
@@ -1694,10 +1682,8 @@ impl<'a> Parser<'a> {
                         .get(&found.namespace_ref)
                         .is_some_and(|items| items.count() > 0);
                 if ns_is_unused {
-                    // Nothing reads `ns` any more, not even as `ns.prop`. Drop
-                    // its `import * as ns` statement: the export star now owns
-                    // that import record. `remove` (not `swap_remove`) keeps the
-                    // other imports in source order.
+                    // Drop the unused `import * as ns` part. `remove` keeps the other
+                    // imports in source order.
                     if let Some(i) = before.iter().position(|before_part| {
                         before_part.tag == bun_ast::PartTag::ImportToConvertFromRequire
                             && before_part

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1549,11 +1549,9 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // react-dom/index.js in production: `checkDCE(); module.exports = require('./cjs/...')`.
-        // `transpose_require` made the require() an `import * as ns` namespace, so the
-        // statement reads `module.exports = ns`. Replace it with `export * from`: the file
-        // is ESM without a `__commonJS` wrapper. The linker reads the export star of a
-        // `COMMONJS_LIFTED_TO_ESM` file as this assignment if it wraps the file after all.
+        // `checkDCE(); module.exports = require('./cjs/...')` (react-dom/index.js in production).
+        // The unwrapped require() is already an `import * as ns`, so `export * from` replaces
+        // the assignment and the file needs no wrapper (`convert_stmts_for_chunk` undoes it).
         if p.options.features.unwrap_commonjs_to_esm
             && p.unwrap_all_requires
             && !p.options.is_entry_point
@@ -1682,8 +1680,7 @@ impl<'a> Parser<'a> {
                         .get(&found.namespace_ref)
                         .is_some_and(|items| items.count() > 0);
                 if ns_is_unused {
-                    // Drop the unused `import * as ns` part. `remove` keeps the other
-                    // imports in source order.
+                    // Drop the unused `import * as ns` part, keeping the other imports in order.
                     if let Some(i) = before.iter().position(|before_part| {
                         before_part.tag == bun_ast::PartTag::ImportToConvertFromRequire
                             && before_part

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1547,115 +1547,172 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
+        }
 
-            if p.commonjs_named_exports_deoptimized
-                && p.options.features.unwrap_commonjs_to_esm
-                && p.unwrap_all_requires
-                && p.imports_to_convert_from_require.len() == 1
-                && p.import_records.len() == 1
-                && p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate == 1
-            {
-                'outer_part_loop: for part in parts.iter_mut() {
-                    // Specially handle modules shaped like this:
-                    //
-                    //    doSomeStuff();
-                    //    module.exports = require('./foo.js');
-                    //
-                    // An example is react-dom/index.js, which does a DCE check.
-                    // Snapshot the StoreSlice (Copy) so the `&mut` borrow over the
-                    // arena slice doesn't conflict with the `part.stmts = …` rewrite
-                    // below.
-                    let part_stmts_ss = part.stmts;
-                    let part_stmts: &mut [Stmt] = part_stmts_ss.slice_mut();
-                    if part_stmts.len() > 1 {
-                        break;
-                    }
+        // A file from the unwrap allowlist (react, react-dom, ...) that does
+        // some work and then re-exports one other file:
+        //
+        //    checkDCE();
+        //    module.exports = require('./cjs/react-dom.production.js');
+        //
+        // An example is react-dom/index.js. `transpose_require` already turned
+        // the require() into `import * as ns from '...'`, so the statement now
+        // reads `module.exports = ns`. Replace it with `export * from '...'`,
+        // which makes the file ESM and needs no `__commonJS` wrapper. The file
+        // has no ES module syntax of its own, so the linker knows the export
+        // star of a `COMMONJS_LIFTED_TO_ESM` file is this assignment. When it
+        // wraps the file as CommonJS after all (a re-exported file whose
+        // exports are not statically known), `convert_stmts_for_chunk` prints
+        // the assignment again.
+        if p.options.features.unwrap_commonjs_to_esm
+            && p.unwrap_all_requires
+            && !p.options.is_entry_point
+            && !p.has_es_module_syntax
+            && p.commonjs_named_exports.count() == 0
+            && !p.has_top_level_return
+            && !p.has_with_scope
+            && p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate == 1
+            && p.symbols.as_slice()[p.exports_ref.inner_index() as usize].use_count_estimate == 0
+        {
+            struct ModuleExportsOfNamespace {
+                part_idx: usize,
+                stmt_idx: usize,
+                /// `checkDCE(), module.exports = ns`: minification folded the
+                /// `if (process.env.NODE_ENV === 'production')` block into one
+                /// comma expression. This is the part before the assignment.
+                leading: Option<Expr>,
+                assign_loc: bun_ast::Loc,
+                namespace_ref: js_ast::Ref,
+                import_record_index: u32,
+            }
 
-                    for j in 0..part_stmts.len() {
-                        let stmt = &mut part_stmts[j];
-                        if let js_ast::StmtData::SExpr(s_expr) = &stmt.data {
-                            let value: Expr = s_expr.value;
-
-                            if let js_ast::ExprData::EBinary(bin_ptr) = value.data {
-                                let mut bin = bin_ptr;
-                                loop {
-                                    let left = bin.left;
-                                    let right = bin.right;
-
-                                    if bin.op == js_ast::op::Code::BinAssign
-                                        && let js_ast::ExprData::ERequireString(req) = right.data
-                                        && let Some(unwrapped_id) = req.unwrapped_id.get()
-                                        && matches!(&left.data, js_ast::ExprData::EDot(d)
-                                            if d.name == b"exports"
-                                                && matches!(&d.target.data, js_ast::ExprData::EIdentifier(id)
-                                                    if id.ref_.eql(p.module_ref)))
-                                    {
-                                        p.export_star_import_records.push(req.import_record_index);
-                                        let deferred = &p.imports_to_convert_from_require
-                                            [unwrapped_id.get_usize()];
-                                        let namespace_ref = deferred.namespace.ref_;
-
-                                        let stmt_loc = stmt.loc;
-                                        part.stmts = {
-                                            let mut new_stmts = BumpVec::<Stmt>::with_capacity_in(
-                                                part.stmts.len() + 1,
-                                                p.arena,
-                                            );
-                                            new_stmts.extend_from_slice(&part_stmts[0..j]);
-
-                                            new_stmts.push(Stmt::alloc(
-                                                S::ExportStar {
-                                                    import_record_index: req.import_record_index,
-                                                    namespace_ref,
-                                                    alias: None,
-                                                },
-                                                stmt_loc,
-                                            ));
-                                            new_stmts.extend_from_slice(&part_stmts[j + 1..]);
-                                            bun_ast::StoreSlice::from_bump(new_stmts)
-                                        };
-
-                                        part.import_record_indices.push(req.import_record_index);
-                                        p.symbols.as_mut_slice()
-                                            [p.module_ref.inner_index() as usize]
-                                            .use_count_estimate = 0;
-                                        let ns_idx = namespace_ref.inner_index() as usize;
-                                        p.symbols.as_mut_slice()[ns_idx].use_count_estimate =
-                                            p.symbols.as_slice()[ns_idx]
-                                                .use_count_estimate
-                                                .saturating_sub(1);
-                                        let _ = part.symbol_uses.swap_remove(&namespace_ref);
-
-                                        for (i, before_part) in before.iter().enumerate() {
-                                            if before_part.tag
-                                                == bun_ast::PartTag::ImportToConvertFromRequire
-                                            {
-                                                let _ = before.swap_remove(i);
-                                                break;
-                                            }
-                                        }
-
-                                        if p.esm_export_keyword.len == 0 {
-                                            p.esm_export_keyword.loc = stmt_loc;
-                                            p.esm_export_keyword.len = 5;
-                                        }
-                                        p.commonjs_named_exports_deoptimized = false;
-                                        break;
-                                    }
-
-                                    if let js_ast::ExprData::EBinary(rb) = right.data {
-                                        bin = rb;
-                                        continue;
-                                    }
-
-                                    break;
-                                }
-                                let _ = bin_ptr;
+            let found: Option<ModuleExportsOfNamespace> = 'search: {
+                for (part_idx, part) in parts.iter().enumerate() {
+                    for (stmt_idx, stmt) in part.stmts.iter().enumerate() {
+                        let js_ast::StmtData::SExpr(s_expr) = &stmt.data else {
+                            continue;
+                        };
+                        let value: Expr = s_expr.value;
+                        let (leading, assign): (Option<Expr>, Expr) = match value.data {
+                            js_ast::ExprData::EBinary(bin)
+                                if bin.op == js_ast::op::Code::BinComma =>
+                            {
+                                (Some(bin.left), bin.right)
                             }
+                            _ => (None, value),
+                        };
+                        let js_ast::ExprData::EBinary(bin) = assign.data else {
+                            continue;
+                        };
+                        if bin.op != js_ast::op::Code::BinAssign
+                            || !matches!(&bin.left.data, js_ast::ExprData::EDot(d)
+                                if d.name == b"exports"
+                                    && matches!(&d.target.data, js_ast::ExprData::EIdentifier(id)
+                                        if id.ref_.eql(p.module_ref)))
+                        {
+                            continue;
                         }
+                        let js_ast::ExprData::EIdentifier(id) = &bin.right.data else {
+                            continue;
+                        };
+                        let Some(deferred) = p
+                            .imports_to_convert_from_require
+                            .iter()
+                            .find(|deferred| deferred.namespace.ref_.eql(id.ref_))
+                        else {
+                            continue;
+                        };
+                        break 'search Some(ModuleExportsOfNamespace {
+                            part_idx,
+                            stmt_idx,
+                            leading,
+                            assign_loc: assign.loc,
+                            namespace_ref: id.ref_,
+                            import_record_index: deferred.import_record_id,
+                        });
                     }
-                    let _ = &mut *part;
-                    continue 'outer_part_loop;
+                }
+                None
+            };
+
+            if let Some(found) = found {
+                let part = &mut parts[found.part_idx];
+                let stmt_loc = part.stmts.slice()[found.stmt_idx].loc;
+
+                // Like `s_export_star`, the export star declares its own
+                // namespace symbol. `ns` stays with the import statement.
+                let name = p.load_name_from_ref(found.namespace_ref);
+                let export_star_ref = p.new_symbol(js_ast::symbol::Kind::Other, name);
+                VecExt::append(&mut p.module_scope_mut().generated, export_star_ref);
+                part.declared_symbols.append(DeclaredSymbol {
+                    ref_: export_star_ref,
+                    is_top_level: true,
+                })?;
+
+                part.stmts = {
+                    let old_stmts: &[Stmt] = part.stmts.slice();
+                    let mut new_stmts =
+                        BumpVec::<Stmt>::with_capacity_in(old_stmts.len() + 1, p.arena);
+                    new_stmts.extend_from_slice(&old_stmts[..found.stmt_idx]);
+                    if let Some(leading) = found.leading {
+                        new_stmts.push(Stmt::alloc(
+                            S::SExpr {
+                                value: leading,
+                                does_not_affect_tree_shaking: false,
+                            },
+                            stmt_loc,
+                        ));
+                    }
+                    new_stmts.push(Stmt::alloc(
+                        S::ExportStar {
+                            import_record_index: found.import_record_index,
+                            namespace_ref: export_star_ref,
+                            alias: None,
+                        },
+                        found.assign_loc,
+                    ));
+                    new_stmts.extend_from_slice(&old_stmts[found.stmt_idx + 1..]);
+                    bun_ast::StoreSlice::from_bump(new_stmts)
+                };
+
+                // The assignment was the only use of `module` and one use of `ns`.
+                let _ = part.symbol_uses.swap_remove(&p.module_ref);
+                p.symbols.as_mut_slice()[p.module_ref.inner_index() as usize].use_count_estimate =
+                    0;
+                match part.symbol_uses.get_mut(&found.namespace_ref) {
+                    Some(uses) if uses.count_estimate > 1 => uses.count_estimate -= 1,
+                    _ => {
+                        let _ = part.symbol_uses.swap_remove(&found.namespace_ref);
+                    }
+                }
+                let ns_symbol =
+                    &mut p.symbols.as_mut_slice()[found.namespace_ref.inner_index() as usize];
+                ns_symbol.use_count_estimate = ns_symbol.use_count_estimate.saturating_sub(1);
+                let ns_is_unused = ns_symbol.use_count_estimate == 0
+                    && !p
+                        .import_items_for_namespace
+                        .get(&found.namespace_ref)
+                        .is_some_and(|items| items.count() > 0);
+                if ns_is_unused {
+                    // Nothing reads `ns` any more, not even as `ns.prop`. Drop
+                    // its `import * as ns` statement: the export star now owns
+                    // that import record. `remove` (not `swap_remove`) keeps the
+                    // other imports in source order.
+                    if let Some(i) = before.iter().position(|before_part| {
+                        before_part.tag == bun_ast::PartTag::ImportToConvertFromRequire
+                            && before_part
+                                .declared_symbols
+                                .refs()
+                                .iter()
+                                .any(|declared| declared.eql(found.namespace_ref))
+                    }) {
+                        let _ = before.remove(i);
+                    }
+                }
+
+                if p.esm_export_keyword.len == 0 {
+                    p.esm_export_keyword.loc = stmt_loc;
+                    p.esm_export_keyword.len = 5;
                 }
             }
         }

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -401,6 +401,9 @@ describe("bundler", () => {
       stdout: "react\nreact",
     },
   });
+  // `sideEffect(); module.exports = require("./main")` in an unwrapped package
+  // becomes `sideEffect(); export * from "./main"`, so the file needs no
+  // `__commonJS` wrapper and the named import binds to the export directly.
   itBundled("cjs2esm/ReactSpecificUnwrapping", {
     files: {
       "/entry.js": /* js */ `
@@ -419,10 +422,219 @@ describe("bundler", () => {
         }
       `,
     },
+    cjs2esm: true,
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__toESM(");
+    },
     run: {
       stdout: "side effect\nSymbol(pass)",
     },
     minifySyntax: true,
+  });
+  // The real react-dom/index.js and react-dom/client.js shape: a DCE check
+  // runs before `module.exports = require()`, both inside an `if` on
+  // NODE_ENV that minification folds into `checkDCE(), module.exports = ns`.
+  itBundled("cjs2esm/ReactSpecificUnwrappingDCECheck", {
+    files: {
+      "/entry.js": /* js */ `
+        import { createRoot } from "react-dom/client";
+        console.log(createRoot());
+      `,
+      "/node_modules/react-dom/package.json": /* json */ `
+        { "name": "react-dom", "version": "19.0.0", "main": "index.js" }
+      `,
+      "/node_modules/react-dom/client.js": /* js */ `
+        'use strict';
+
+        function checkDCE() {
+          if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+            console.log('checkDCE');
+            return;
+          }
+          if (process.env.NODE_ENV !== 'production') {
+            throw new Error('^_^');
+          }
+        }
+
+        if (process.env.NODE_ENV === 'production') {
+          checkDCE();
+          module.exports = require('./cjs/react-dom-client.production.js');
+        } else {
+          module.exports = require('./cjs/react-dom-client.development.js');
+        }
+      `,
+      "/node_modules/react-dom/cjs/react-dom-client.production.js": /* js */ `
+        exports.createRoot = function createRoot() { return "production root"; };
+        exports.version = "19.0.0";
+      `,
+      "/node_modules/react-dom/cjs/react-dom-client.development.js": /* js */ `
+        exports.createRoot = function createRoot() { return "FAILED"; };
+        exports.version = "19.0.0";
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    env: {
+      NODE_ENV: "production",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__toESM(");
+    },
+    run: {
+      stdout: "checkDCE\nproduction root",
+    },
+  });
+  // A default import of the converted file binds to its namespace, which
+  // holds the re-exported names (the export star resolves at link time).
+  itBundled("cjs2esm/ReactSpecificUnwrappingSideEffectDefaultImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import ReactDOM, { render } from "react-dom";
+        console.log(render(), ReactDOM.render(), ReactDOM.version, typeof ReactDOM.default);
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        exports.render = function render() { return "rendered"; };
+        exports.version = "19.0.0";
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    run: {
+      stdout: "side effect\nrendered rendered 19.0.0 object",
+    },
+  });
+  itBundled("cjs2esm/ReactSpecificUnwrappingSideEffectNamespaceImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ReactDOM from "react-dom";
+        console.log(ReactDOM.render(), Object.keys(ReactDOM).sort().join(","), typeof ReactDOM.default);
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        exports.render = function render() { return "rendered"; };
+        exports.version = "19.0.0";
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    run: {
+      stdout: "side effect\nrendered render,version object",
+    },
+  });
+  // The namespace the require() became stays imported when the file also
+  // reads from it before the `module.exports =` assignment.
+  itBundled("cjs2esm/ReactSpecificUnwrappingNamespaceStillUsed", {
+    files: {
+      "/entry.js": /* js */ `
+        import { render } from "react-dom";
+        console.log(render());
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        var impl = require('./impl');
+        console.log('impl version', impl.version);
+        module.exports = impl;
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        exports.render = function render() { return "rendered"; };
+        exports.version = "19.0.0";
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    run: {
+      stdout: "impl version 19.0.0\nrendered",
+    },
+  });
+  // The re-exported file turns out to be CommonJS (its exports are not
+  // statically known), so the linker keeps the converted file a CommonJS
+  // wrapper around `module.exports = require()`.
+  itBundled("cjs2esm/ReactSpecificUnwrappingTargetIsCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import ReactDOM, { version } from "react-dom";
+        import * as ns from "react-dom";
+        console.log(version, typeof ReactDOM, ReactDOM.version, typeof ReactDOM.default, ns.version, typeof ns.default);
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        module.exports = function render() { return "rendered"; };
+        module.exports.version = "19.0.0";
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/node_modules/react-dom/index.js", "/node_modules/react-dom/impl.js"],
+    },
+    minifySyntax: true,
+    run: {
+      stdout: "side effect\n19.0.0 object 19.0.0 function 19.0.0 object",
+    },
+  });
+  // Same when the re-exported file is external: the wrapper assigns the
+  // `import * as ns` of the external module.
+  itBundled("cjs2esm/ReactSpecificUnwrappingTargetIsExternal", {
+    files: {
+      "/entry.js": /* js */ `
+        import ReactDOM, { unstable_now } from "react-dom";
+        console.log(unstable_now(), ReactDOM.unstable_now(), typeof ReactDOM.default);
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('scheduler');
+      `,
+    },
+    external: ["scheduler"],
+    target: "bun",
+    runtimeFiles: {
+      "/node_modules/scheduler/index.js": /* js */ `
+        exports.unstable_now = function unstable_now() { return 42; };
+      `,
+    },
+    minifySyntax: true,
+    onAfterBundle(api) {
+      // The hoisted import sits between the file comment and the wrapper,
+      // which the `cjs2esm` check does not expect.
+      const code = api.readFile("/out.js");
+      expect(code).toContain('import * as scheduler from "scheduler"');
+      expect(code).toContain("var require_react_dom = __commonJS(");
+      expect(code).toContain("module.exports = scheduler");
+    },
+    run: {
+      stdout: "side effect\n42 42 object",
+    },
+  });
+  // Other `exports` uses next to `module.exports = require()` keep the file
+  // CommonJS: the export star would hide the `exports.foo` assignment.
+  itBundled("cjs2esm/ReactSpecificUnwrappingMixedExportsStaysCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import ReactDOM from "react-dom";
+        console.log(ReactDOM.render(), ReactDOM.foo);
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        exports.foo = 'foo';
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        exports.render = function render() { return "rendered"; };
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/node_modules/react-dom/index.js"],
+    },
+    minifySyntax: true,
+    run: {
+      stdout: "rendered undefined",
+    },
   });
   itBundled("cjs2esm/ReactSpecificUnwrapping2", {
     files: {


### PR DESCRIPTION
### Problem
- `bun build --production` of a React 19 app keeps `react-dom/index.js` and `react-dom/client.js` as `__commonJS` wrappers. Both are `checkDCE(); module.exports = require('./cjs/...production.js')` in production. #41162 handed this shape off.
- The parser block for this shape in `src/js_parser/parse/parse_entry.rs` never fired. It matched an `ERequireString`, but `transpose_require` (`src/js_parser/p.rs:1570`) already makes the unwrapped `require()` the identifier of its `import * as ns` namespace. #35797 activated the block and hit the forced wrapper of a default import.

### Fix
- The parser matches `module.exports = ns` (also behind the comma that minification makes of the folded `if`) and replaces it with `export * from` on the same import record. The file becomes ESM. A lifted CommonJS file has no export star of its own, so the linker knows the export star of a `COMMONJS_LIFTED_TO_ESM` file is this assignment.
- When the re-export target has dynamic exports (CommonJS or external), named imports of a lifted file would bind to `undefined`. The linker then keeps today's `__commonJS` wrapper, and `convert_stmts_for_chunk` prints `module.exports = <value>` inside it instead of dropping the export star: the namespace object, the wrapper call, or the external import.
- Verified: `test/bundler/bundler_cjs2esm.test.ts`, 5 of the new cases fail on the released bun. Also the suites in the notes.

### Background
- The bundler converts CommonJS files of an allowlist of packages (react, react-dom, scheduler, ...) to ESM: `exports.foo = x` becomes a named export, `require("x")` becomes `import * as ns from "x"`. Such files carry `COMMONJS_LIFTED_TO_ESM` (#41162), and a default import of one binds to its namespace.
- `export * from "./b"` resolves at link time. When "./b" has no static exports, the file gets a dynamic fallback object filled by `__reExport`. A lifted file does not use that fallback for unknown named imports (`DynamicFallbackInteropDefault`).
- `convert_stmts_for_chunk` already prints lifted statements in CommonJS form when a file is wrapped after all (`var $foo = x` as `exports.foo = x`). The export star follows the same rule.

<details><summary>Notes</summary>

Numbers, `react@19.0.0` and `react-dom@19.0.0`, entry `import { createRoot } from "react-dom/client"; import { jsx } from "react/jsx-runtime"`, `--target=browser`, measured against a build of main at d6af50f4f0:
- `NODE_ENV=production --minify-syntax`: 2 `__commonJS` + 4 `__esm` wrappers and 2 `__toESM` calls, 472,842 bytes. After: none, 457,960 bytes. The entry reads `$createRoot` directly.
- `--production`: 177,122 to 172,277 bytes.
- With `import ReactDOM from "react-dom"` and `import * as NS from "react-dom"` added: still no wrapper, 463,291 bytes.

Cases checked by hand against the released bun and main, all the same output or the lifted output: default, namespace and named imports; `require()` of the lifted file; `import()` of it (`default` is the namespace, as #41162 prints it); code splitting; `--minify`; `--format=cjs` and development mode (no lift, unchanged); a cycle between the lifted file and its target; the target being `module.exports = function` (wrapper kept, `module.exports = __toESM(require_x())`, identical to before); the target external (wrapper kept, `module.exports = ns`); `exports.foo` next to the assignment (wrapper kept); a chained assignment (wrapper kept); a runtime `if` (wrapper kept); the namespace also read as `ns.version` (import kept, export star added).

The external target case prints `import * as ns` only because this branch sets `CONTAINS_IMPORT_STAR` on the record in step 6. A plain ESM `export * from "external"` in a non-entry file has the same missing binding today (#15997). #36714 fixes that; this PR does not touch it.

Evaluation order is unchanged: the converted `require()` was already hoisted above the side effect as an import.

`BabyVec::remove` is new. The parser needs an order-preserving removal of the dropped import part, since `swap_remove` would reorder the remaining imports.

#12726 reports the unminified `react/index.js` redirect, which stays wrapped without `--minify-syntax`. #35611 handles that shape.

Suites run with the debug build: `bundler_cjs2esm`, `bundler_cjs`, `bundler_edgecase`, `bundler_splitting`, `bundler_regressions`, `bundler_npm`, `bundler_minify`, `bundler_browser`, `bundler_bun`, `bundler_barrel`, `bundler_dynamic_import_dce`, `bundler_defer`, `bundler_loader`, `bundler_promiseall_deadcode`, `esbuild/default`, `esbuild/importstar`, `esbuild/importstar_ts`, `esbuild/dce`, `esbuild/packagejson`, `esbuild/splitting`, `regression/issue/cyclic-imports-async-bundler`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [783.49ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [372.74ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [438.17ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [355.18ms]
(pass) bundler > cjs2esm/ExportsFunction [434.25ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [417.76ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [424.24ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [379.40ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [461.02ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [455.98ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [399.05ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [568.86ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [567
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (b5d92aedd)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [18.19ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [8.95ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [8.53ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [7.38ms]
(pass) bundler > cjs2esm/ExportsFunction [9.69ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [9.32ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [8.80ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [9.27ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [10.60ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [9.94ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [8.90ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [10.51ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [10.28ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [9.21ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [9.75ms]
(pass) bundler > cjs2esm/UnwrappedModuleRe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [972.77ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [430.35ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [382.13ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [434.30ms]
(pass) bundler > cjs2esm/ExportsFunction [449.37ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [398.66ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [395.49ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [434.22ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [568.92ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [492.03ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [440.74ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [737.35ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [664
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 572ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_alloc/baby_vec.rs                          |  15 ++
 src/bundler/linker_context/convertStmtsForChunk.rs |  97 +++++++-
 .../linker_context/scanImportsAndExports.rs        |  47 +++-
 src/js_parser/parse/parse_entry.rs                 | 248 ++++++++++++---------
 test/bundler/bundler_cjs2esm.test.ts               | 212 ++++++++++++++++++
 5 files changed, 509 insertions(+), 110 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bun_alloc/baby_vec.rs                                2      2     15
src/bundler/linker_context/convertStmtsForChunk.rs       7     10     15
src/bundler/linker_context/scanImportsAndExports.rs     14     14     14
src/js_parser/parse/parse_entry.rs                      13     15     14
test/bundler/bundler_cjs2esm.test.ts                     5      5     14
```

</details>

<!-- robobun:evidence:end -->