### PR TITLE
test: cover the s3.write(key, Bun.file(path)) hang when a GC runs during part backpressure

### DIFF
--- a/test/regression/issue/39838.test.ts
+++ b/test/regression/issue/39838.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/39838
+// `s3.write(key, Bun.file(path))` hung forever once the file reached
+// 5 x partSize (the default queueSize). The pump that reads the file parked on
+// part backpressure with nothing in JS referring to the stream, a GC collected
+// it, and no UploadPart response could resume the upload.
+const fixture = `
+  const partSize = 5 * 1024 * 1024;
+  const parts = [];
+  let completed = false;
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (req.method === "POST" && url.searchParams.has("uploads")) {
+        return new Response(
+          "<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>",
+          { headers: { "content-type": "application/xml" } },
+        );
+      }
+      if (req.method === "PUT") {
+        const body = await req.arrayBuffer();
+        parts.push([Number(url.searchParams.get("partNumber")), body.byteLength]);
+        // Every queue slot is in flight. The client reads more of the file
+        // only after this response. Nothing in JS refers to the file stream.
+        Bun.gc(true);
+        return new Response("", { headers: { ETag: '"etag-' + url.searchParams.get("partNumber") + '"' } });
+      }
+      await req.text();
+      completed = true;
+      return new Response(
+        '<CompleteMultipartUploadResult><ETag>"etag-1"</ETag></CompleteMultipartUploadResult>',
+        { headers: { "content-type": "application/xml" } },
+      );
+    },
+  });
+
+  const s3 = new Bun.S3Client({
+    endpoint: "http://127.0.0.1:" + server.port,
+    bucket: "bucket",
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+    region: "us-east-1",
+  });
+
+  // Five full parts: the smallest file that fills the default queue.
+  await Bun.write("payload.bin", new Uint8Array(5 * partSize));
+  const written = await s3.write("repro/payload.bin", Bun.file("payload.bin"));
+  parts.sort((a, b) => a[0] - b[0]);
+  console.log(JSON.stringify({ written, parts, completed }));
+  server.stop(true);
+`;
+
+test("s3.write(key, Bun.file(path)) settles when a GC runs while every part slot is in flight", async () => {
+  using dir = tempDir("issue-39838", {});
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: {
+      ...bunEnv,
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      http_proxy: undefined,
+      https_proxy: undefined,
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(normalizeBunSnapshot(stderr)).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    written: 5 * 5 * 1024 * 1024,
+    parts: [1, 2, 3, 4, 5].map(n => [n, 5 * 1024 * 1024]),
+    completed: true,
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/39838.test.ts
+++ b/test/regression/issue/39838.test.ts
@@ -8,8 +8,13 @@ import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 // it, and no UploadPart response could resume the upload.
 const fixture = `
   const partSize = 5 * 1024 * 1024;
+  const queueSize = 5;
   const parts = [];
   let completed = false;
+  // Every PUT response is held until all five part bodies have arrived. At
+  // that point every queue slot is in flight, none has completed, and the
+  // client's file pump is parked with nothing in JS referring to the stream.
+  const allPartsReceived = Promise.withResolvers();
   const server = Bun.serve({
     port: 0,
     async fetch(req) {
@@ -23,9 +28,11 @@ const fixture = `
       if (req.method === "PUT") {
         const body = await req.arrayBuffer();
         parts.push([Number(url.searchParams.get("partNumber")), body.byteLength]);
-        // Every queue slot is in flight. The client reads more of the file
-        // only after this response. Nothing in JS refers to the file stream.
-        Bun.gc(true);
+        if (parts.length === queueSize) {
+          Bun.gc(true);
+          allPartsReceived.resolve();
+        }
+        await allPartsReceived.promise;
         return new Response("", { headers: { ETag: '"etag-' + url.searchParams.get("partNumber") + '"' } });
       }
       await req.text();
@@ -46,7 +53,7 @@ const fixture = `
   });
 
   // Five full parts: the smallest file that fills the default queue.
-  await Bun.write("payload.bin", new Uint8Array(5 * partSize));
+  await Bun.write("payload.bin", new Uint8Array(queueSize * partSize));
   const written = await s3.write("repro/payload.bin", Bun.file("payload.bin"));
   parts.sort((a, b) => a[0] - b[0]);
   console.log(JSON.stringify({ written, parts, completed }));


### PR DESCRIPTION
### Problem
- #39838: `s3.write(key, Bun.file(path))` never settles on 1.4.0 once the file reaches 5 x `partSize` (the default `queueSize`). 1.3.14 worked. It reproduces against a slow TLS endpoint (real R2, or the mock in the notes), not against loopback.
- The cause is what #40371 fixed. With every queue slot in flight, the file pump parks until a part completes. Nothing in JS refers to the file stream. 1.3.14 held a `ReadableStream.Strong` on it. #36087 replaced that sink, and `upload_stream` (`src/runtime/webcore/s3/client.rs`) kept the Strong only on the native ByteStream path, which `Bun.file()` does not take. The 1 s idle GC timer collects the parked pump, and the next UploadPart response has nothing to resume.

### Fix
- No code change. #40371 (merged, in canary, not released yet) roots the source stream for the life of the upload.
- This PR adds `test/regression/issue/39838.test.ts` with the call shape and size from the issue: `S3Client.write(key, Bun.file(path))`, a 25 MiB file, default options. The in-process mock holds every UploadPart response until all five bodies have arrived, runs `Bun.gc(true)` once, then releases them. So the GC runs while every slot is in flight and none has completed.
- Verified: fails 3/3 on the 1.4.0 release binary (the subprocess hangs, the test times out), passes 3/3 on the debug build at HEAD. `test/js/bun/s3/s3-upload-stream-gc.test.ts` also passes.

### Background
- A `Bun.file()` source goes through the JS pump (`readStreamIntoSink`), not the native ByteStream path. The pump graph hangs off the stream, so the stream is its only root.
- `GarbageCollectionController` runs `collect_async` every second. A remote endpoint keeps the pump parked longer than that. Loopback completes a part in milliseconds.

<details><summary>Notes</summary>

**Reproduction without R2.** A Python TLS server with `SO_RCVBUF` 16 KiB that reads request bodies 64 KiB per 20 ms (so the client's writes stall like they do on a real link). 25 MiB `Bun.file()` upload:

- 1.4.0 release, no extra GC pressure: completes (6.6 s).
- 1.4.0 release, `Bun.gc(true)` every 100 ms: hangs after all 5 parts reach the server. No CompleteMultipartUpload.
- 1.4.0 release, 74 MiB file (the reporter's production size), no forced GC: hangs after 10 of 15 parts.
- canary `a6c4cc276` (has #40371), both cases: completes.

**How a multipart upload parks.** The upload keeps `queueSize` parts in flight. When every slot is taken, the sink returns a pending promise and the pump that reads the source parks until `on_writable` fires.

**Why the earlier attempt on the issue did not reproduce.** It used loopback with response delays only. Bun.serve reads the body at once, so the pump never stayed parked long enough for the idle GC tick.

**What the issue saw.** "No UploadPart completes" and "a same-host fetch un-sticks it" do not follow from this cause. In the reproduction the parts in flight do complete at the server. The part uploads are owned by native code and keep running after the pump is gone. The write promise is what never settles.

**Secondary observation.** `S3Client.write(key, Bun.file(path), { queueSize })` honors `queueSize`: `construct_blob` merges the call options into the S3 blob before `write_file_internal` reads `s3.options`.

Suites run: `test/regression/issue/39838.test.ts` (3 runs), `test/js/bun/s3/s3-upload-stream-gc.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/39838.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/39838.test.ts"
bun test v1.4.1 (a6c4cc276)

test/regression/issue/39838.test.ts:
(pass) s3.write(key, Bun.file(path)) settles when a GC runs while every part slot is in flight [760.33ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [2.77s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/39838.test.ts | 86 +++++++++++++++++++++++++++++++++++++
 1 file changed, 86 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/regression/issue/39838.test.ts      1      3      8
```

</details>

<!-- robobun:evidence:end -->