### PR TITLE
test: await server.stop() instead of sleeping in the dev server deinitialization fixture

### DIFF
--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -1,21 +1,50 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import path from "node:path";
 
-test("dev server deinitializes itself", () => {
-  const result = Bun.spawnSync({
-    cmd: [bunExe(), "test", path.join(import.meta.dir, "fixtures/deinitialization/test.ts")],
+// The fixture is a `bun test` suite of its own: the bunfig.toml in its
+// directory registers the serve plugin, and the heap counts it asserts on need
+// a process without other servers in it. The child takes a few seconds under
+// ASAN, so it gets a timeout above the 5s default.
+async function runDeinitializationSuite() {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./test.ts"],
     env: bunEnv,
-    stdio: ["inherit", "inherit", "inherit"],
     cwd: path.join(import.meta.dir, "fixtures/deinitialization"),
+    stdout: "pipe",
+    stderr: "pipe",
   });
-  expect(result.signalCode).toBeUndefined();
-  expect(result.exitCode).toBe(0);
-  // The child runs a whole `bun test` suite (nine GC-heavy cases plus leak
-  // reporting at exit), which takes longer than the 5s default under ASAN.
-}, 60_000);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error(stderr);
 
-test("dev server is deinitialized before its arena when listen fails", async () => {
+  // The per-test results and the summary. The dev server's own log lines and
+  // the expect() call count are left out: they change with unrelated edits.
+  const report = normalizeBunSnapshot(stderr)
+    .split("\n")
+    .filter(line => /^\((pass|fail|skip|todo)\) |^ \d+ (pass|fail)$|^Ran /.test(line))
+    .join("\n");
+  expect(report).toMatchInlineSnapshot(`
+    "(pass) baseline: stopped server wrapper collects
+    (pass) flags: none
+    (pass) flags: websocket=1
+    (pass) flags: closeActiveConnections websocket=1
+    (pass) flags: sendAnyRequests
+    (pass) flags: sendAnyRequests websocket=1
+    (pass) flags: closeActiveConnections sendAnyRequests
+    (pass) flags: closeActiveConnections sendAnyRequests websocket=1
+    (pass) flags: websocket=8
+    (pass) flags: closeActiveConnections websocket=8
+     10 pass
+     0 fail
+    Ran 10 tests across 1 file."
+  `);
+  expect(normalizeBunSnapshot(stdout)).toBe("bun test <version> (<revision>)");
+  expect(exitCode).toBe(0);
+}
+
+test.concurrent("dev server deinitializes itself", runDeinitializationSuite, 30_000);
+
+test.concurrent("dev server is deinitialized before its arena when listen fails", async () => {
   using dir = tempDir("dev-server-listen-fails", {
     "index.html": `<!DOCTYPE html><html><body></body></html>`,
     "listen-fails-fixture.ts": `

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -38,7 +38,7 @@ async function runDeinitializationSuite() {
      0 fail
     Ran 10 tests across 1 file."
   `);
-  expect(normalizeBunSnapshot(stdout)).toBe("bun test <version> (<revision>)");
+  expect(normalizeBunSnapshot(stdout)).toContain("bun test <version> (<revision>)");
   expect(exitCode).toBe(0);
 }
 

--- a/test/bake/fixtures/deinitialization/test.ts
+++ b/test/bake/fixtures/deinitialization/test.ts
@@ -5,102 +5,118 @@ import { fullGC, heapStats } from "bun:jsc";
 
 expect(process.cwd()).toBe(import.meta.dir);
 
-let promise;
+// plugin.ts (registered in bunfig.toml) awaits `globalThis.callback` from its
+// onLoad hook, so a case can stop the server while its bundle is in flight.
+let callbackCalls = 0;
 
-async function run({ closeActiveConnections = false, sendAnyRequests = true, websocket = 0 }) {
-  let lastDevServerDeinitCount = getDevServerDeinitCount();
-
-  async function main() {
-    globalThis.pluginLoaded = undefined;
-
-    const server = Bun.serve({
-      routes: {
-        "/": html,
-      },
-      fetch(req, server) {
-        return new Response("FAIL");
-      },
-      port: 0,
-    });
-
-    expect(globalThis.pluginLoaded).toBeUndefined();
-
-    let sockets: WebSocket[] = [];
-    if (websocket > 0) {
-      const opens: Promise<void>[] = [];
-      for (let i = 0; i < websocket; i++) {
-        const { promise, resolve, reject } = Promise.withResolvers<void>();
-        const ws = new WebSocket(server.url.origin + "/_bun/hmr");
-        let opened = false;
-        ws.onopen = () => {
-          opened = true;
-          console.log("WebSocket opened");
-          resolve();
-        };
-        ws.onerror = e => {
-          e.preventDefault();
-          if (!opened) reject(new Error(`websocket ${i} failed before open`));
-        };
-        ws.onclose = () => {
-          console.log("WebSocket closed");
-          if (!opened) reject(new Error(`websocket ${i} closed before open`));
-        };
-        sockets.push(ws);
-        opens.push(promise);
-      }
-      await Promise.all(opens);
-    }
-
-    globalThis.callback = async () => {
-      server.stop(closeActiveConnections);
-      await (promise = new Promise(resolve => setTimeout(resolve, 250)));
-    };
-
-    if (sendAnyRequests) {
-      if (closeActiveConnections) {
-        expect(fetch(server.url.origin, { keepalive: false })).rejects.toThrow("closed unexpectedly");
-      } else {
-        const response = await fetch(server.url.origin, { keepalive: false });
-        expect(response.status).toBe(200);
-      }
-    } else {
-      server.stop(closeActiveConnections);
-    }
-
-    // Server is closed
-    expect(fetch(server.url.origin, { keepalive: false })).rejects.toThrow("Unable to connect");
-  }
-
+// Resolves with the fetch error's `code`. `expect(...).rejects` is not used
+// here: it spins a nested event loop synchronously, and most waits in `run`
+// start inside a WebSocket callback.
+async function fetchErrorCode(request: Promise<Response>): Promise<string> {
   try {
-    await main();
-  } finally {
-    // The closure assigned to `globalThis.callback` inside `main()` captures
-    // `server`; left in place it roots the JS Server wrapper through every GC
-    // below, so the wrapper never finalizes and the native NewServer box (and
-    // everything its config owns) is still live at process exit.
-    globalThis.callback = undefined;
+    await request;
+    return "fulfilled";
+  } catch (e: any) {
+    return e.code;
   }
-
-  if (closeActiveConnections) {
-    await promise;
-    await new Promise(resolve => setTimeout(resolve, 250));
-  }
-
-  const targetCount = lastDevServerDeinitCount + 1;
-  let attempts = 0;
-  while (getDevServerDeinitCount() === lastDevServerDeinitCount) {
-    Bun.gc(true);
-    fullGC();
-    await new Promise(resolve => setTimeout(resolve, 100));
-    attempts++;
-    if (attempts > 10) {
-      throw new Error("Failed to trigger deinit");
-    }
-  }
-  expect(getDevServerDeinitCount()).toBe(targetCount);
 }
 
-// baseline do nothing
+async function run({
+  closeActiveConnections,
+  sendAnyRequests,
+  websocket,
+}: {
+  closeActiveConnections: boolean;
+  sendAnyRequests: boolean;
+  websocket: number;
+}) {
+  const deinitsBefore = getDevServerDeinitCount();
+  const pluginLoadedBefore = globalThis.pluginLoaded;
+  callbackCalls = 0;
+
+  const server = Bun.serve({
+    routes: {
+      "/": html,
+    },
+    fetch() {
+      return new Response("FAIL");
+    },
+    port: 0,
+  });
+  const origin = server.url.origin;
+
+  // Serve plugins load on the first bundle, not when the server starts.
+  expect(globalThis.pluginLoaded).toBe(pluginLoadedBefore);
+
+  const opens: Promise<void>[] = [];
+  const closes: Promise<CloseEvent>[] = [];
+  for (let i = 0; i < websocket; i++) {
+    const ws = new WebSocket(origin + "/_bun/hmr");
+    const open = Promise.withResolvers<void>();
+    const close = Promise.withResolvers<CloseEvent>();
+    ws.onopen = () => open.resolve();
+    ws.onclose = event => {
+      open.reject(new Error(`websocket ${i} closed before it opened (code ${event.code})`));
+      close.resolve(event);
+    };
+    opens.push(open.promise);
+    closes.push(close.promise);
+  }
+  await Promise.all(opens);
+
+  let stopped: Promise<void> | undefined;
+  try {
+    if (sendAnyRequests) {
+      const request = fetch(origin, { keepalive: false });
+      const requestErrorCode = closeActiveConnections ? fetchErrorCode(request) : undefined;
+
+      globalThis.callback = async () => {
+        callbackCalls++;
+        stopped = server.stop(closeActiveConnections);
+        // The listener is closed synchronously. Prove it from a client while
+        // the bundle that serves `request` is still in flight.
+        expect(await fetchErrorCode(fetch(origin, { keepalive: false }))).toBe("ConnectionRefused");
+        if (requestErrorCode) {
+          // An abrupt stop also closed the socket of the in-flight request.
+          expect(await requestErrorCode).toBe("ECONNRESET");
+        }
+      };
+
+      if (requestErrorCode) {
+        expect(await requestErrorCode).toBe("ECONNRESET");
+      } else {
+        const response = await request;
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("text/html;charset=utf-8");
+        expect(await response.text()).toContain('<script type="module" crossorigin src="/_bun/client/index-');
+      }
+      expect(globalThis.pluginLoaded).toBe(true);
+    } else {
+      stopped = server.stop(closeActiveConnections);
+    }
+  } finally {
+    // The closure captures `server`. Left in place it would root the JS Server
+    // wrapper through every GC below.
+    globalThis.callback = undefined;
+  }
+  expect(callbackCalls).toBe(sendAnyRequests ? 1 : 0);
+
+  expect(await fetchErrorCode(fetch(origin, { keepalive: false }))).toBe("ConnectionRefused");
+
+  // `stop()` resolves once the last request, connection and listener are gone.
+  // The DevServer is dropped in that same pass, before the promise settles, so
+  // the count must be exact here without any GC.
+  await stopped;
+  expect(getDevServerDeinitCount()).toBe(deinitsBefore + 1);
+
+  // Dropping the DevServer closes every HMR socket it still had (an abrupt
+  // stop closed them earlier). The clients see an abnormal closure.
+  const closeEvents = await Promise.all(closes);
+  expect(closeEvents.map(event => ({ code: event.code, wasClean: event.wasClean }))).toEqual(
+    Array.from({ length: websocket }, () => ({ code: 1006, wasClean: false })),
+  );
+}
+
 const cases = [
   { closeActiveConnections: false, sendAnyRequests: false, websocket: 0 },
   { closeActiveConnections: false, sendAnyRequests: false, websocket: 1 },
@@ -161,14 +177,10 @@ afterAll(async () => {
 });
 
 for (const { closeActiveConnections, sendAnyRequests, websocket } of cases) {
-  test(
-    "flags: " +
-      Object.entries({ closeActiveConnections, sendAnyRequests, websocket })
-        .filter(([key, value]) => value)
-        .map(([key, value]) => (key === "websocket" ? `websocket=${value}` : key))
-        .join(" "),
-    async () => {
-      await run({ closeActiveConnections, sendAnyRequests, websocket });
-    },
-  );
+  const flags = Object.entries({ closeActiveConnections, sendAnyRequests, websocket })
+    .filter(([, value]) => value)
+    .map(([key, value]) => (key === "websocket" ? `websocket=${value}` : key));
+  test("flags: " + (flags.join(" ") || "none"), async () => {
+    await run({ closeActiveConnections, sendAnyRequests, websocket });
+  });
 }

--- a/test/bake/fixtures/deinitialization/test.ts
+++ b/test/bake/fixtures/deinitialization/test.ts
@@ -47,6 +47,10 @@ async function run({
 
   const closes: Promise<CloseEvent>[] = [];
   let stopped: Promise<void> | undefined;
+  // Recorded inside the plugin callback and asserted after the bundle. A throw
+  // inside the callback only fails the bundle, and after an abrupt stop there
+  // is no client left to report that to.
+  let refusedWhileBundling: string | undefined;
   try {
     // Serve plugins load on the first bundle, not when the server starts.
     expect(globalThis.pluginLoaded).toBe(pluginLoadedBefore);
@@ -73,13 +77,11 @@ async function run({
       globalThis.callback = async () => {
         callbackCalls++;
         stopped = server.stop(closeActiveConnections);
-        // The listener is closed synchronously. Prove it from a client while
-        // the bundle that serves `request` is still in flight.
-        expect(await fetchErrorCode(fetch(origin, { keepalive: false }))).toBe("ConnectionRefused");
-        if (requestErrorCode) {
-          // An abrupt stop also closed the socket of the in-flight request.
-          expect(await requestErrorCode).toBe("ECONNRESET");
-        }
+        // The bundle that serves `request` stays in flight until this returns.
+        refusedWhileBundling = await fetchErrorCode(fetch(origin, { keepalive: false }));
+        // An abrupt stop also closed the socket of `request`. Let the client
+        // see that before the bundle completes.
+        if (requestErrorCode) await requestErrorCode;
       };
 
       if (requestErrorCode) {
@@ -110,6 +112,8 @@ async function run({
   // the count must be exact here without any GC.
   await stopped;
   expect(getDevServerDeinitCount()).toBe(deinitsBefore + 1);
+  // `stop()` closed the listener synchronously, while the bundle was in flight.
+  expect(refusedWhileBundling).toBe(sendAnyRequests ? "ConnectionRefused" : undefined);
 
   // Dropping the DevServer closes every HMR socket it still had (an abrupt
   // stop closed them earlier). The clients see an abnormal closure.

--- a/test/bake/fixtures/deinitialization/test.ts
+++ b/test/bake/fixtures/deinitialization/test.ts
@@ -17,7 +17,7 @@ async function fetchErrorCode(request: Promise<Response>): Promise<string> {
     await request;
     return "fulfilled";
   } catch (e: any) {
-    return e.code;
+    return e.code ?? String(e);
   }
 }
 
@@ -45,27 +45,27 @@ async function run({
   });
   const origin = server.url.origin;
 
-  // Serve plugins load on the first bundle, not when the server starts.
-  expect(globalThis.pluginLoaded).toBe(pluginLoadedBefore);
-
-  const opens: Promise<void>[] = [];
   const closes: Promise<CloseEvent>[] = [];
-  for (let i = 0; i < websocket; i++) {
-    const ws = new WebSocket(origin + "/_bun/hmr");
-    const open = Promise.withResolvers<void>();
-    const close = Promise.withResolvers<CloseEvent>();
-    ws.onopen = () => open.resolve();
-    ws.onclose = event => {
-      open.reject(new Error(`websocket ${i} closed before it opened (code ${event.code})`));
-      close.resolve(event);
-    };
-    opens.push(open.promise);
-    closes.push(close.promise);
-  }
-  await Promise.all(opens);
-
   let stopped: Promise<void> | undefined;
   try {
+    // Serve plugins load on the first bundle, not when the server starts.
+    expect(globalThis.pluginLoaded).toBe(pluginLoadedBefore);
+
+    const opens: Promise<void>[] = [];
+    for (let i = 0; i < websocket; i++) {
+      const ws = new WebSocket(origin + "/_bun/hmr");
+      const open = Promise.withResolvers<void>();
+      const close = Promise.withResolvers<CloseEvent>();
+      ws.onopen = () => open.resolve();
+      ws.onclose = event => {
+        open.reject(new Error(`websocket ${i} closed before it opened (code ${event.code})`));
+        close.resolve(event);
+      };
+      opens.push(open.promise);
+      closes.push(close.promise);
+    }
+    await Promise.all(opens);
+
     if (sendAnyRequests) {
       const request = fetch(origin, { keepalive: false });
       const requestErrorCode = closeActiveConnections ? fetchErrorCode(request) : undefined;
@@ -98,6 +98,8 @@ async function run({
     // The closure captures `server`. Left in place it would root the JS Server
     // wrapper through every GC below.
     globalThis.callback = undefined;
+    // A case that failed before its own stop() must not leave a server behind.
+    stopped ??= server.stop(true);
   }
   expect(callbackCalls).toBe(sendAnyRequests ? 1 : 0);
 


### PR DESCRIPTION
### Problem
- `test/bake/deinitialization.test.ts` took 63s on the Windows 11 arm64 lane of build 109310 and 2.1s elsewhere. Its child `bun test` hung until the 60s timeout (`Received: "SIGTERM"`). The retry passed in 2.1s.
- The 2.1s is fixed waits: `setTimeout(250)` after every `server.stop()` plus a 100ms GC poll.
- The hang is the usockets bug of #39643 and #40023: `expect(p).rejects` waits with a nested event loop (`src/runtime/test_runner/expect.rs:496`), entered here from a WebSocket callback. The old fixture fails 6 of 6 canary runs on Windows arm64 and on x64.

### Fix
- The fixture awaits the promise `server.stop()` returns. `deinit_if_we_can` (`src/runtime/server/mod.rs:1846-1902`) drops the DevServer in the pass that schedules that resolution, so the count is asserted exactly, without GC.
- Connection failures are awaited as plain promises and checked by error code. No wait nests an event loop, so the fixture no longer reproduces the usockets bug. #39643 carries its own test for it.
- New assertions: the request outcome (`ECONNRESET` or a 200 `text/html` page), a refused connection mid-bundle, one onLoad call per request case, a 1006 close per HMR socket. The outer test snapshots the child's report.
- Verified: `bun bd test test/bake/deinitialization.test.ts` (ASAN) 7.85s and 8.01s before, 4.63s and 4.73s after. Release: 2.16s to 0.13s. Windows arm64 and x64: 30 of 30 runs.

### Background
- An HTML route gives `Bun.serve` a Bake DevServer. The native `NewServer` drops it once the server is drained: no listener, no pending request (a bundle in flight is one), no open connection.
- `server.stop()` resolves one task after the drain. The fixture's `plugin.ts` awaits `globalThis.callback` from onLoad, so a case can stop the server mid-bundle.

<details><summary>Notes</summary>

Self-reviewed: 3 concerns raised, 2 addressed (the commit message no longer blames the fixture for the Windows crash, and the report snapshot keeps only the per-test lines and the summary). The third asks for the same change in the graceful-exit loop of `test/bake/bake-harness.ts:2065-2073`. That loop is shared by the bake dev tests and is out of this PR's scope. It is a candidate follow-up.

CI log of build 109310, Windows 11 arm64 lane, attempt 1:

```
(pass) flags: closeActiveConnections sendAnyRequests websocket=1 [508.03ms]
killed 1 dangling process
error: expect(received).toBeUndefined()
Received: "SIGTERM"
(fail) dev server deinitializes itself [60009.27ms]
  ^ this test timed out after 60000ms.
```

Attempt 2 on the same lane: `Ran 10 tests across 1 file. [2.11s]`.

Old fixture on canary `d6af50f4f`, 6 runs each. Windows 11 arm64: 4 crashes with `panic(main thread): Segmentation fault at address 0x0` in the `closeActiveConnections websocket=1` case, 2 hangs until the 60s timeout. Windows Server 2019 x64: 6 hangs. New fixture on the same machines: 30 of 30 runs each, about 190ms and 130ms per run.

Why the old waits were never load-bearing: the old GC loop only ran while the count had not moved, and the CI per-case times (5 to 10ms for the cases without a sleep) show it never iterated. The DevServer drop needs no GC. It happens inside `stop()` for the cases without a request, and inside the bundle-completion task for the cases with one.

Per-case time in CI before (Windows arm64, attempt 2): 5.65, 5.64, 256, 263, 258, 506, 507, 8, 258 ms. After, on a Linux release build, the whole child suite runs in about 60ms.

CI time of the whole file on build 109408 with this PR: Windows 11 arm64 183ms, Windows 2019 x64 160ms, Linux x64 ASAN 506ms, macOS arm64 202ms, macOS x64 113ms. On build 109310 without it: 63s on Windows 11 arm64 (the hang plus a retry) and 2.1s to 2.4s on every other lane.

Assertion changes in the fixture, old to new:
- deinit count: `toBe(target)` after a GC loop with a 100ms sleep per attempt, to `toBe(before + 1)` right after `await stopped`, no GC.
- abrupt stop with a request: `.rejects.toThrow("closed unexpectedly")`, not awaited, to the awaited error code `ECONNRESET`, checked inside the onLoad callback and after it.
- graceful stop with a request: status 200 only, to status, `content-type: text/html;charset=utf-8`, and the client script tag in the body.
- stopped listener: `.rejects.toThrow("Unable to connect")`, not awaited, to the awaited error code `ConnectionRefused`, also checked inside the onLoad callback while the bundle is in flight.
- plugin: `pluginLoaded` reset and `toBeUndefined()`, to `toBe(pluginLoadedBefore)` after `Bun.serve()` and `toBe(true)` after a request, plus `callbackCalls` equal to 1 or 0.
- HMR sockets: `console.log` on open and close, to awaited close events equal to `{ code: 1006, wasClean: false }` for each socket.
- outer test: `signalCode` and `exitCode` with inherited stdio, to a snapshot of the child's per-test lines and summary, an exact stdout, then the exit code. Timeout 60s to 30s. Both outer tests run concurrently.

Suites run: `test/bake/deinitialization.test.ts` with `bun bd test` (ASAN debug, 8 runs plus 2 with `BUN_GARBAGE_COLLECTOR_LEVEL=2`), with `USE_SYSTEM_BUN=1` on Linux, and the fixture alone 10 times with the debug build.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bake/deinitialization.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bake/deinitialization.test.ts
bun test v1.4.1 (a6c4cc276)

test/bake/deinitialization.test.ts:
(pass) dev server is deinitialized before its arena when listen fails [1308.46ms]
(pass) dev server deinitializes itself [2698.13ms]

 2 pass
 0 fail
 1 snapshots, 6 expect() calls
Ran 2 tests across 1 file. [4.61s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bake/deinitialization.test.ts          |  51 +++++--
 test/bake/fixtures/deinitialization/test.ts | 204 +++++++++++++++-------------
 2 files changed, 151 insertions(+), 104 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
test/bake/deinitialization.test.ts               5      7     35
test/bake/fixtures/deinitialization/test.ts      8     10     37
```

</details>

<!-- robobun:evidence:end -->
