### PR TITLE
test: make worker_heap_snapshot_gc.test.ts race the parent's StrongSet instead of relying on volume

### DIFF
--- a/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
+++ b/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
@@ -1,59 +1,110 @@
-// Stress getHeapSnapshot() against a parent-thread full GC.
+// Race getHeapSnapshot() round-trips against parent-thread Strong handle churn.
 //
 // Each getHeapSnapshot() round-trip used to capture a parent-VM
 // Strong<JSPromise> by value in a lambda that ran on the worker thread.
-// Strong<T> has no move constructor, so the worker thread would
-// copy-construct (HandleSet::allocate + m_strongList.push) and destruct
-// (HandleSet::deallocate + m_strongList.remove) the handle without holding
-// the parent VM's lock. If the parent VM's GC ran the "Sh" (Strong Handles)
-// marking constraint at the same time it would iterate into a torn
-// SentinelLinkedList node and fault reading HandleNode::m_value at
-// (nullptr + 0x10).
+// Strong<T> has no move constructor, so the worker thread copy-constructed
+// (StrongSet::allocate) and destroyed (StrongSet::deallocate) a handle of the
+// parent VM without holding the parent VM's lock. StrongSet is a plain slab
+// allocator (bump cursor, free list, per-block used count) with no lock check
+// of its own, so a parent-thread allocate or free that overlaps either
+// worker-side call tears it: the next parent allocate faults on a bogus slot
+// (StrongSet::tryAllocateFromCurrent), a RELEASE_ASSERT fires on the torn
+// used count (StrongBlock::decrementUsedCount) or block bookkeeping
+// (StrongSet::didFreeSlot), or two handles share one slot and one of them
+// silently changes value.
 //
-// The fix heap-allocates the Strong once on the parent thread and passes
-// only the raw pointer across, so the worker thread never touches the
-// parent VM's HandleSet.
+// The parent VM's StrongSet only changes when code on the parent thread
+// allocates or frees a handle, so a parent that idles while the snapshot is
+// built never overlaps the worker's two calls. This fixture keeps the parent
+// inside those calls as densely as JS can: convertTransferList
+// (JSStructuredSerializeOptions.cpp) turns every entry of a structuredClone()
+// transfer list into a Strong<JSObject> before SerializedScriptValue::create
+// validates the entries, and a list of plain objects is rejected right after
+// that conversion (DataCloneError). Each call is therefore a burst of Strong
+// allocate/free pairs and little else. If the transfer list is ever validated
+// before it is converted, this churn stops allocating handles and the fixture
+// goes blind without failing, so keep that order in mind when changing it.
+//
+// With the bug reintroduced on a release build (16 cores), a round-trip
+// corrupts the parent VM's StrongSet about half of the time and 100 of 100
+// processes crashed within 10 round-trips. The overlap needs true
+// parallelism: pinned to one core, only 2 of 5 test runs caught it.
+//
+// The fix (#30185, reshaped by #31216) registers the promise in a parent-side
+// map keyed by a request id; only the id crosses threads. This fixture covers
+// the getHeapSnapshot() site only. The durable guard, a lock-held assert in
+// StrongSet::allocate/deallocate, would catch every cross-VM site on the
+// first call in a debug build and is still to be ported (#36958).
 
 import { Worker } from "node:worker_threads";
 
-const src = `import { parentPort } from "node:worker_threads"; parentPort.on("message", () => {});`;
-
-async function makeWorker() {
-  const w = new Worker(src, { eval: true });
-  await new Promise(resolve => w.once("online", resolve));
-  return w;
+const iters = Number(process.env.ITERS);
+if (!Number.isSafeInteger(iters) || iters <= 0) {
+  throw new Error(`invalid ITERS (expected a positive integer): ${JSON.stringify(process.env.ITERS)}`);
 }
 
-let worker = await makeWorker();
+const worker = new Worker(`import { parentPort } from "node:worker_threads"; parentPort.on("message", () => {});`, {
+  eval: true,
+});
+worker.on("error", error => {
+  throw error;
+});
+const workerExit = new Promise(resolve => worker.once("exit", resolve));
+await new Promise(resolve => worker.once("online", resolve));
 
-const iters = Number(process.env.ITERS);
-for (let i = 0; i < iters; i++) {
-  let stream;
+const transferList = Array.from({ length: 64 }, () => ({}));
+function churnStrongHandles() {
   try {
-    stream = await worker.getHeapSnapshot();
-  } catch (e) {
-    // On some CI platforms the worker has been observed to exit on its own
-    // after a few hundred heap snapshots — that surfaces here as a clean
-    // ERR_WORKER_NOT_RUNNING rejection, not the process-level segfault this
-    // fixture is looking for. Recreate the worker and keep going so the
-    // overall round-trip count (and thus the number of race opportunities
-    // against the parent VM's HandleSet) is preserved.
-    if (e?.code === "ERR_WORKER_NOT_RUNNING") {
-      await worker.terminate().catch(() => {});
-      worker = await makeWorker();
-      i--;
-      continue;
-    }
-    throw e;
+    structuredClone(0, { transfer: transferList });
+  } catch (error) {
+    if (error?.name === "DataCloneError") return;
+    throw error;
   }
-  // Right now the worker thread has posted the result (resolving the await
-  // above) but may still be destroying its outer EventLoopTask. Force a
-  // synchronous full GC so the "Sh" constraint walks m_strongList while
-  // the worker would have been removing a node from it.
+  throw new Error("structuredClone() accepted a transfer list of plain objects");
+}
+
+let snapshots = 0;
+let validated = false;
+for (let i = 0; i < iters; i++) {
+  let settled = false;
+  const pending = worker.getHeapSnapshot();
+  pending.then(
+    () => (settled = true),
+    () => (settled = true),
+  );
+  // Churn until the worker has posted the result, yielding to the event loop
+  // so the completion task can run. The worker thread's two touches of the
+  // parent VM's StrongSet happen right after the snapshot JSON is built.
+  while (!settled) {
+    for (let k = 0; k < 100 && !settled; k++) churnStrongHandles();
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  const stream = await pending;
+  snapshots++;
+  // Marking walks every StrongSet slot. A full collection right after the
+  // round-trip makes a slot left holding garbage fail here, while the handle
+  // of this round-trip is still live, instead of at some later collection.
   Bun.gc(true);
-  stream.on("data", () => {});
-  await new Promise(resolve => stream.once("end", resolve));
+
+  const chunks = [];
+  stream.on("data", chunk => chunks.push(chunk));
+  await new Promise((resolve, reject) => {
+    stream.once("end", resolve);
+    stream.once("error", reject);
+  });
+  if (chunks.length === 0) throw new Error(`empty heap snapshot stream on iteration ${i}`);
+  if (!validated) {
+    // Parse one payload per process to prove the round-trip carries a real
+    // V8-format heap snapshot; later iterations only need the non-empty check.
+    const snapshot = JSON.parse(Buffer.concat(chunks).toString());
+    const nodeCount = snapshot.snapshot.node_count;
+    const nodeFields = snapshot.snapshot.meta.node_fields.length;
+    if (!(nodeCount > 0) || snapshot.nodes.length !== nodeCount * nodeFields) {
+      throw new Error(`malformed heap snapshot: node_count=${nodeCount}, nodes.length=${snapshot.nodes.length}`);
+    }
+    validated = true;
+  }
 }
 
 await worker.terminate();
-console.log("ok");
+console.log(`ok snapshots=${snapshots} workerExitCode=${await workerExit}`);

--- a/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
+++ b/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
@@ -1,39 +1,49 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isIntelMacOS, isWindows } from "harness";
+import { bunEnv, bunExe, isDebug, isIntelMacOS, isWindows } from "harness";
 import { join } from "node:path";
 
-// The getHeapSnapshot() round-trip must never let the worker thread touch
-// the parent VM's HandleSet. Before the fix this crashed with a segfault at
-// 0x10 inside the "Sh" (Strong Handles) marking constraint — a parent-VM
-// Strong<JSPromise> was captured by value in a lambda that ran on the worker
-// thread, and Strong<T>'s copy/dtor mutated HandleSet::m_strongList without
-// the parent VM's lock while the collector was iterating it.
+// The getHeapSnapshot() round-trip must never let the worker thread touch the
+// parent VM's Strong handle set (JSC::StrongSet). Before the fix (#30185) a
+// parent-VM Strong<JSPromise> was captured by value in a lambda that ran on
+// the worker thread, so the worker allocated and freed a parent-VM handle
+// without the parent VM's lock. A parent-thread allocate or free that overlaps
+// tears the allocator: the parent then faults in
+// StrongSet::tryAllocateFromCurrent, trips a RELEASE_ASSERT on the used count
+// (StrongBlock::decrementUsedCount) or block bookkeeping
+// (StrongSet::didFreeSlot), or has two handles share one slot.
 //
-// The race window is a handful of instructions after each snapshot
-// completes, so no single run is guaranteed to hit it; we run the fixture
-// repeatedly in release and fail if any attempt crashes. Debug and ASAN
-// builds are several times slower per heap snapshot, so they get a reduced
-// workload as a functional check — plain release CI is where this guards
-// against regressions.
-// Skipped on Windows and Intel (x64) macOS: this branch's always-on per-worker
-// stdio path adds per-spawn overhead that a 15x300-snapshot stress exceeds on
-// those builders. The race it guards is platform-agnostic and still covered on
-// Linux and Apple-Silicon macOS.
+// The fixture makes that overlap likely instead of relying on volume: while
+// each snapshot is in flight, the parent allocates and frees Strong handles
+// as densely as JS can (see the fixture header). With the bug reintroduced on
+// a release build, one round-trip corrupts the parent VM about half of the
+// time and 100 of 100 processes crashed within 10 round-trips; the previous
+// 15x300 idle-parent workload detected nothing in 9000 round-trips. Each
+// attempt is an independent process, so the attempts run concurrently.
+//
+// This is the release-lane backstop for the getHeapSnapshot() site only. The
+// deterministic guard for every cross-VM site, a lock-held assert in
+// StrongSet::allocate/deallocate (#36958), is still to be ported.
+//
+// Skipped on Windows and Intel (x64) macOS, as before: the per-worker stdio
+// path on those builders adds spawn overhead the original stress exceeded,
+// and this workload has not been measured there. The race is platform
+// agnostic and still covered on Linux and Apple Silicon macOS.
 test.skipIf(isWindows || isIntelMacOS)(
-  "worker.getHeapSnapshot() does not race the parent VM's Strong Handles list under GC",
+  "worker.getHeapSnapshot() does not race the parent VM's Strong handle set",
   async () => {
-    const slow = isDebug || isASAN;
-    const attempts = slow ? 1 : 15;
-    const iters = isDebug ? "5" : slow ? "100" : "300";
+    // A debug heap snapshot takes about 3s and the debug churn is less dense
+    // (one debug+ASAN process caught the reintroduced bug in 7 of 16 runs of
+    // 5 round-trips), so the debug lane is a functional check with some teeth.
+    // Release and ASAN release run 5 processes of 10 round-trips each.
+    const attempts = isDebug ? 1 : 5;
+    const iters = isDebug ? 5 : 10;
     const fixture = join(import.meta.dir, "heap-snapshot-gc-race-fixture.js");
 
-    // The attempts are independent processes with no shared state, so run them
-    // all concurrently; the race being guarded is intra-process.
     const results = await Promise.all(
       Array.from({ length: attempts }, async (_, i) => {
         await using proc = Bun.spawn({
           cmd: [bunExe(), fixture],
-          env: { ...bunEnv, ITERS: iters },
+          env: { ...bunEnv, ITERS: String(iters) },
           stdout: "pipe",
           stderr: "pipe",
         });
@@ -42,15 +52,20 @@ test.skipIf(isWindows || isIntelMacOS)(
       }),
     );
     for (const result of results) {
-      // One assertion per attempt so a crash shows stdout/stderr/signal together.
+      // One assertion per attempt so a failure shows stdout, stderr, exit code
+      // and signal together. The fixture prints the summary line only after
+      // every round-trip settled, the first payload parsed as a V8 heap
+      // snapshot with a non-zero node count, and the worker was terminated.
       expect(result).toEqual({
         attempt: result.attempt,
-        stdout: "ok\n",
+        stdout: `ok snapshots=${iters} workerExitCode=1\n`,
         stderr: "",
         exitCode: 0,
         signalCode: null,
       });
     }
   },
-  isDebug || isASAN ? 60_000 : 120_000,
+  // A regression can present as a hang on a torn free list, so the timeout is
+  // the time-to-red for that case. The debug lane needs about 25s of it.
+  60_000,
 );


### PR DESCRIPTION
### Problem
- `worker_heap_snapshot_gc.test.ts` takes 24s on alpine x64 (build 109310): 15 processes x 300 `getHeapSnapshot()` round-trips, a probabilistic guard for #30185.
- That volume detects nothing: with the bug reintroduced (`src/jsc/bindings/webcore/JSWorker.cpp:755`, a by-value `Strong<JSPromise>` capture), 30 of 30 processes survive 300 round-trips. The parent idles during the snapshot, so the worker's unlocked `StrongSet` calls never overlap a parent-side one.

### Fix
- The fixture keeps the parent allocating and freeing Strong handles during each snapshot: `convertTransferList` makes a `Strong<JSObject>` per `structuredClone()` transfer entry before validation, so a plain-object list is pure allocate/free churn.
- Bug reintroduced, release: 43 of 100 processes crash after 1 round-trip, 98 after 5, 100 after 10. The release lane now runs 5 processes of 10 round-trips. Fixed build: 230 of 230.
- The fixture validates `ITERS`, rethrows worker errors, parses the first payload as a V8 heap snapshot with a non-zero node count, and prints `ok snapshots=N workerExitCode=1`, matched exactly.
- Verified: `bun bd test test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts`, 22s to 25s, unchanged (5 debug snapshots of 3s). Release: 0.4s, was 9.4s.

### Background
- `JSC::Strong<T>` is a GC root slot from the VM's `StrongSet`, a slab allocator that expects the VM lock but does not check it. #39371 replaced the old `HandleSet` list with it, so the torn-list crash of #30185 cannot happen today.
- This covers the `getHeapSnapshot()` site only. The deterministic guard for all five cross-VM sites is a lock-held assert in `StrongSet` (#36958, needs a re-port). #35200 and #36952 resized this test without restoring detection. Supersedes #36952.

<details><summary>Notes</summary>

Bug reintroduction used for every measurement (local only, not in this PR): add `JSC::Strong<JSC::JSPromise> bugStrong(vm, promise);` before `postTaskToWorkerGlobalScope` in `jsWorkerPrototypeFunction_getHeapSnapshotBody` and capture `bugStrong` by value in both the worker-side lambda and the completion lambda it posts back.

Release build (local, non-LTO, 16 cores), 100 processes per row unless noted, 10 concurrent:

| fixture | round-trips per process | crashed |
| --- | --- | --- |
| old (idle parent, `Bun.gc(true)` per round-trip) | 300 | 0 of 30 |
| new | 1 | 43 |
| new | 2 | 79 |
| new | 3 | 89 |
| new | 5 | 98 |
| new | 10 | 100 |

What remains after #39371 is allocator against allocator, which only a busy parent exposes. Failure modes seen, all on the parent thread inside `structuredClone()`: `SIGSEGV` in `JSC::StrongSet::tryAllocateFromCurrent` (bogus slot pointer, for example `0x300000B15DE0`), `SIGABRT` from a `RELEASE_ASSERT` reached through `JSC::StrongSet::didFreeSlot` (the used count and block bookkeeping are release-checked in `StrongBlock::decrementUsedCount` and `StrongSet::appendAvailable`), and once a `TypeError` because a corrupted handle changed an unrelated cell.

Churn shapes compared at 5 round-trips, 40 processes each: a transfer list of fresh `ArrayBuffer`s that clone cleanly crashed 15; a transfer list of plain objects (this PR) crashed 40. The clean clone spends most of each call serializing, so the parent is inside the allocator far less often. The plain-object shape depends on `convertTransferList` converting before `SerializedScriptValue::create` validates. The fixture header says so.

Timing detail: `bun bd test` 21.6s and 24.6s after, 20.9s and 24.0s before. Release `bun test` 0.41s to 0.47s after, 9.39s and 9.49s before (16 cores).

Debug+ASAN (`bun bd`) with the bug: 7 of 16 processes crashed at 5 round-trips, 3 of 4 at 10. A debug snapshot takes about 3s, so the debug lane stays at 1 process of 5 round-trips.

Fixed build, test file: 30 of 30 runs pass on 16 cores, 10 of 10 pinned to 2 cores (1.2s to 1.4s). Bugged build: 30 of 30 runs fail on 16 cores, 10 of 10 pinned to 2 cores. Pinned to 1 core the bugged build fails only 2 of 5 runs: without true parallelism the parent has to be preempted inside the few instructions of an allocate, which is rare. CI runners have more than one core (the old 4500 round-trips finished in 24s there).

The assertion changes were checked against a fixture edited to exit after 9 round-trips (`snapshots=9` fails the match) and one that writes a line to stderr (the `stderr: ""` match fails).

Self-reviewed: 4 concerns raised, 4 addressed (assert attribution in both headers, scope and follow-up stated in the headers, the validation-order dependency documented, related PRs cited). Parameterizing the fixture over the other four cross-VM sites is a follow-up, not part of this PR.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts

<!-- robobun:evidence:end -->