### PR TITLE
Bun.Archive: read Bun.file() input from disk instead of writing empty bytes

### DIFF
--- a/docs/runtime/archive.mdx
+++ b/docs/runtime/archive.mdx
@@ -58,6 +58,7 @@ File contents can be:
 
 - **Strings** - Text content
 - **Blobs** - Binary data
+- **`Bun.file()`** - Read from disk
 - **ArrayBufferViews** (such as `Uint8Array`) - Raw bytes
 - **ArrayBuffers** - Raw binary data
 
@@ -68,10 +69,13 @@ const arrayBuffer = new ArrayBuffer(8);
 const archive = new Bun.Archive({
   "text.txt": "Plain text",
   "blob.bin": new Blob([data]),
+  "file.txt": Bun.file("./file.txt"),
   "bytes.bin": new Uint8Array([1, 2, 3, 4]),
   "buffer.bin": arrayBuffer,
 });
 ```
+
+A `Bun.file()` entry is read into memory while the constructor runs. An S3 file cannot be read synchronously: pass `await file.bytes()` instead.
 
 ### Writing Archives to Disk
 

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1,10 +1,12 @@
 //! `Bun.Archive` — tar/tgz pack + extract over libarchive.
 
+use std::borrow::Cow;
 use std::ffi::CString;
 
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
 use crate::webcore::blob::Store;
+use crate::webcore::blob::store::Data as StoreData;
 use bun_core::{self, EncodedSlice, Output, Utf8Bytes, ZBox, strings};
 use bun_glob as glob;
 use bun_jsc::{
@@ -173,14 +175,17 @@ impl Archive {
         // Parse compression options
         let compress = parse_compression_options(global, options_arg)?;
 
-        // For Blob/Archive, ref the existing store (zero-copy)
+        // For a Blob that spans its in-memory store, ref the store (zero-copy).
+        // A sliced or file-backed Blob is read into a store of its own.
         if let Some(blob) = blob_from_js(data_arg) {
-            if let Some(store) = blob.store.get().as_ref() {
+            if let Some(store) = whole_in_memory_store(blob) {
                 return Ok(Box::new(Archive {
                     store: store.clone(),
                     compress,
                 }));
             }
+            let data = blob.read_bytes_sync(global)?.into_owned();
+            return Ok(create_archive(data, compress));
         }
 
         // For ArrayBuffer/TypedArray, copy the data
@@ -270,6 +275,17 @@ fn create_archive(data: Vec<u8>, compress: Compression) -> Box<Archive> {
 #[inline]
 fn blob_from_js(value: JSValue) -> Option<&'static Blob> {
     value.as_class_ref::<Blob>()
+}
+
+/// The blob's store when the blob is a full-span view of an in-memory store,
+/// so an archive can share it instead of copying the bytes. `None` for a
+/// sliced, file-backed, or S3-backed blob.
+fn whole_in_memory_store(blob: &Blob) -> Option<&RefPtr<Store>> {
+    let store = blob.store()?;
+    let is_whole = matches!(store.data, StoreData::Bytes(_))
+        && blob.offset.get() == 0
+        && blob.size.get() >= store.size();
+    is_whole.then_some(store)
 }
 
 /// Shared helper that builds tarball bytes from a JS object
@@ -391,10 +407,14 @@ fn get_entry_data<'a>(
     value: JSValue,
     array_buffer: &'a mut Option<bun_jsc::ArrayBuffer>,
 ) -> JsResult<Utf8Bytes<'a>> {
-    // For Blob, use sharedView (no copy needed). The backing store outlives
-    // the returned slice for the duration of the caller's tarball build.
+    // For an in-memory Blob this borrows the store (no copy needed); the store
+    // outlives the returned slice for the duration of the caller's tarball
+    // build. A `Bun.file()` is read from disk here.
     if let Some(blob) = blob_from_js(value) {
-        return Ok(Utf8Bytes::Borrowed(blob.shared_view()));
+        return Ok(match blob.read_bytes_sync(global)? {
+            Cow::Borrowed(bytes) => Utf8Bytes::Borrowed(bytes),
+            Cow::Owned(bytes) => Utf8Bytes::Owned(bytes),
+        });
     }
 
     // For ArrayBuffer/TypedArray, use view (no copy needed)
@@ -447,16 +467,15 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
         );
     }
 
-    // For Blobs, use store reference with options compression
+    // For a Blob that spans its in-memory store, use the store reference
+    // (zero-copy) with options compression. A sliced or file-backed Blob is
+    // read first.
     if let Some(blob) = blob_from_js(data_arg) {
-        if let Some(store) = blob.store.get().as_ref() {
-            return start_write_task(
-                global,
-                WriteData::Store(store.clone()),
-                path_slice.slice(),
-                options_compress,
-            );
-        }
+        let data = match whole_in_memory_store(blob) {
+            Some(store) => WriteData::Store(store.clone()),
+            None => WriteData::Owned(blob.read_bytes_sync(global)?.into_owned()),
+        };
+        return start_write_task(global, data, path_slice.slice(), options_compress);
     }
 
     // For ArrayBuffer/TypedArray, copy the data with options compression

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -7,6 +7,7 @@
 use core::cell::Cell;
 use core::ffi::{c_char, c_void};
 use core::ptr::NonNull;
+use std::borrow::Cow;
 
 use bun_jsc::JsCell;
 
@@ -292,6 +293,11 @@ pub trait BlobExt {
         Self: Sized;
     fn transfer(&self);
     fn shared_view_raw(&self) -> *mut [u8];
+    /// The blob's bytes, read on the calling thread: a borrowed view of an
+    /// in-memory store, or the blob's `offset..offset + size` window of a
+    /// `Bun.file()` read from disk. An S3 file has no synchronous read path
+    /// and throws.
+    fn read_bytes_sync(&self, global: &JSGlobalObject) -> JsResult<Cow<'_, [u8]>>;
     fn set_is_ascii_flag(&self, is_all_ascii: bool);
     /// # Safety
     /// `raw_bytes` must be valid for reads for the duration of the call; when
@@ -2468,6 +2474,45 @@ impl BlobExt for Blob {
                 core::ptr::from_mut::<[u8]>(&mut v[off..off + clamped])
             }
             _ => empty(),
+        }
+    }
+
+    fn read_bytes_sync(&self, global: &JSGlobalObject) -> JsResult<Cow<'_, [u8]>> {
+        let Some(store) = self.store() else {
+            return Ok(Cow::Borrowed(b""));
+        };
+        match &store.data {
+            store::Data::Bytes(_) => Ok(Cow::Borrowed(self.shared_view())),
+            store::Data::File(file) => {
+                let mut node_fs = node::fs::NodeFS::default();
+                // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
+                let mut args = node::fs::args::ReadFile::default();
+                args.path = file.pathlike.clone();
+                args.offset = self.offset.get();
+                // A `Bun.file()` keeps `MAX_SIZE` until something stats it;
+                // only a `.slice()` sets a window to honor.
+                let size = self.size.get();
+                args.max_size = (size != MAX_SIZE).then_some(size);
+                let result = node_fs.read_file_with_options(
+                    &args,
+                    node::fs::Flavor::Sync,
+                    node::fs::ReadFileStringType::NullTerminated,
+                );
+                match result {
+                    Ok(node::fs::ret::ReadFileWithOptions::NullTerminated(bytes)) => {
+                        let mut bytes = bytes.into_vec_with_nul();
+                        bytes.pop();
+                        Ok(Cow::Owned(bytes))
+                    }
+                    Ok(_) => unreachable!(
+                        "ReadFileStringType::NullTerminated always yields the NullTerminated variant"
+                    ),
+                    Err(err) => Err(err.throw(global)),
+                }
+            }
+            store::Data::S3(_) => Err(global.throw_invalid_arguments(format_args!(
+                "S3 files cannot be read synchronously; await file.bytes() first"
+            ))),
         }
     }
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { existsSync, readdirSync, rmSync } from "node:fs";
+import { closeSync, existsSync, openSync, readdirSync, rmSync } from "node:fs";
 import { join } from "path";
 
 // Minimal ustar tarball builder (pathnames must be <100 bytes). `name` accepts
@@ -1923,6 +1923,122 @@ describe("Bun.Archive", () => {
       const readArchive = new Bun.Archive(await bunFile.bytes());
       const files = await readArchive.files();
       expect(await files.get("test.txt")!.text()).toBe("test content");
+    });
+  });
+
+  describe("Bun.file() entries", () => {
+    test("new Archive() reads a Bun.file() entry from disk", async () => {
+      using dir = tempDir("archive-bunfile-entry", {
+        "from-disk.txt": "file content here\n",
+        "data.bin": new Uint8Array([0x00, 0x01, 0xff, 0xfe]),
+      });
+
+      const archive = new Bun.Archive({
+        "from-disk.txt": Bun.file(join(String(dir), "from-disk.txt")),
+        "data.bin": Bun.file(join(String(dir), "data.bin")),
+        "inline.txt": "inline",
+      });
+
+      const files = await new Bun.Archive(await archive.bytes()).files();
+      expect(await files.get("from-disk.txt")!.text()).toBe("file content here\n");
+      expect(await files.get("data.bin")!.bytes()).toEqual(new Uint8Array([0x00, 0x01, 0xff, 0xfe]));
+      expect(await files.get("inline.txt")!.text()).toBe("inline");
+    });
+
+    test("new Archive() honors the window of a sliced Bun.file()", async () => {
+      using dir = tempDir("archive-bunfile-slice", { "digits.txt": "0123456789" });
+      const file = Bun.file(join(String(dir), "digits.txt"));
+
+      const archive = new Bun.Archive({
+        "middle.txt": file.slice(2, 6),
+        "tail.txt": file.slice(7),
+        "past-end.txt": file.slice(8, 100),
+        "empty.txt": file.slice(3, 3),
+      });
+
+      const files = await new Bun.Archive(await archive.bytes()).files();
+      expect(await files.get("middle.txt")!.text()).toBe("2345");
+      expect(await files.get("tail.txt")!.text()).toBe("789");
+      expect(await files.get("past-end.txt")!.text()).toBe("89");
+      expect(await files.get("empty.txt")!.text()).toBe("");
+    });
+
+    test("Archive.write() reads a Bun.file() entry from disk", async () => {
+      using dir = tempDir("archive-bunfile-write", { "src.txt": "written from disk" });
+      const tarPath = join(String(dir), "out.tar");
+
+      await Bun.Archive.write(tarPath, { "src.txt": Bun.file(join(String(dir), "src.txt")) });
+
+      const files = await new Bun.Archive(await Bun.file(tarPath).bytes()).files();
+      expect(await files.get("src.txt")!.text()).toBe("written from disk");
+    });
+
+    test("a missing Bun.file() throws ENOENT instead of writing an empty entry", () => {
+      using dir = tempDir("archive-bunfile-missing", {});
+      const missing = join(String(dir), "missing.txt");
+
+      let thrown: unknown;
+      try {
+        new Bun.Archive({ "missing.txt": Bun.file(missing) });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toMatchObject({ code: "ENOENT", syscall: "open", path: missing });
+    });
+
+    test("new Archive() reads a file descriptor-backed Bun.file() entry", async () => {
+      using dir = tempDir("archive-bunfile-fd", { "a.txt": "fd-backed" });
+      const fd = openSync(join(String(dir), "a.txt"), "r");
+      try {
+        const archive = new Bun.Archive({ "a.txt": Bun.file(fd) });
+        const files = await new Bun.Archive(await archive.bytes()).files();
+        expect(await files.get("a.txt")!.text()).toBe("fd-backed");
+      } finally {
+        closeSync(fd);
+      }
+    });
+
+    test("an S3 file entry throws", () => {
+      const s3 = new Bun.S3Client({
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+        bucket: "bucket",
+        endpoint: "http://127.0.0.1:1",
+      }).file("object.txt");
+
+      expect(() => new Bun.Archive({ "object.txt": s3 })).toThrow(
+        "S3 files cannot be read synchronously; await file.bytes() first",
+      );
+    });
+
+    test("new Archive(Bun.file(tar)) and Archive.write(path, Bun.file(tar)) read the archive from disk", async () => {
+      using dir = tempDir("archive-bunfile-whole", {});
+      const tarPath = join(String(dir), "x.tar");
+      await Bun.write(tarPath, new Bun.Archive({ "a.txt": "hello" }));
+      const tar = await Bun.file(tarPath).bytes();
+
+      const archive = new Bun.Archive(Bun.file(tarPath));
+      expect(await archive.bytes()).toEqual(tar);
+      expect(await (await archive.files()).get("a.txt")!.text()).toBe("hello");
+
+      const outPath = join(String(dir), "out.tar");
+      await Bun.Archive.write(outPath, Bun.file(tarPath));
+      expect(await Bun.file(outPath).bytes()).toEqual(tar);
+    });
+
+    test("new Archive(blob) and Archive.write(path, blob) honor the window of a sliced Blob", async () => {
+      using dir = tempDir("archive-blob-slice", {});
+      const tar = await new Bun.Archive({ "a.txt": "hello" }).bytes();
+      const padded = new Blob(["junk", tar, "junk"]);
+      const sliced = padded.slice(4, 4 + tar.length);
+
+      const archive = new Bun.Archive(sliced);
+      expect(await archive.bytes()).toEqual(tar);
+      expect(await (await archive.files()).get("a.txt")!.text()).toBe("hello");
+
+      const outPath = join(String(dir), "out.tar");
+      await Bun.Archive.write(outPath, sliced);
+      expect(await Bun.file(outPath).bytes()).toEqual(tar);
     });
   });
 


### PR DESCRIPTION
### Problem
- `new Bun.Archive({ "a.txt": Bun.file(path) })` and `Bun.Archive.write()` write a 0-byte entry for every `Bun.file()` value. The docs example "Create Archive from Directory" does this and silently produces empty files. A missing file does not throw.
- `new Bun.Archive(Bun.file("x.tar")).bytes()` returns 0 bytes and `Archive.write(path, Bun.file("x.tar"))` writes a 0-byte file. A sliced Blob as whole-archive input loses its window.
- Cause, in `src/runtime/api/Archive.rs`: every Blob is read with `shared_view()`, which is empty for a file- or S3-backed store, or its whole store is shared, which ignores the slice.

### Fix
- New `BlobExt::read_bytes_sync` (`src/runtime/webcore/Blob.rs`). It borrows an in-memory store, or reads a `Bun.file()` window (`offset`/`size`) through the `node_fs` sync read path that FormData and `SSLConfig` already use. Paths and file descriptors both work. An S3 file throws a `TypeError` that says to await `file.bytes()` first.
- All three Blob sites in `Archive.rs` (object entry, constructor, `Archive.write`) go through it. A full-span in-memory Blob still shares its store zero-copy. A file that cannot be opened throws the system error (`ENOENT` with `path`).
- Verified: `test/js/bun/archive.test.ts`, new `Bun.file() entries` block (8 tests, all fail on bun 1.4.1). The full file (114 tests) passes.
- Self-reviewed: 6 concerns raised, 6 addressed.

### Background
- A `Blob` has a `Store` with one of three `Data` variants: `Bytes` (in memory), `File` (a path or an fd from `Bun.file()`), or `S3`. `shared_view()` returns bytes only for `Bytes`.
- `Blob.slice()` does not copy. It sets `offset` and `size` on a new Blob that shares the store.

Fixes #28459

<details><summary>Notes</summary>

- Issue #28459 has been open since March 2026. PR #28460 was the same focused fix. It was closed in favor of #33318, a zip and streaming-append feature PR that carries this fix as one of its commits. #33318 has merge conflicts and no activity since 2026-07-12. The close note on #28460 says the focused fix can be reopened if #33318 stalls. This PR is that focused fix against current main. On a rebase of #33318, its `Bun.file()` entry commit becomes a swap of this helper call for its streaming `builder.add_file`.
- The self-review asked for: reuse of the existing `node_fs` sync reader instead of a hand-rolled `bun_sys::File::read_from`; the two whole-archive sibling sites; fd support instead of a refusal; one error string for S3; the sliced in-memory window; and issue links in the commit. All six are in this revision.
- `read_bytes_sync` passes `max_size` only when the blob is sliced. An unsliced `Bun.file()` keeps `size == MAX_SIZE`, and `read_file_with_options` reads to EOF in that case, so a pipe or a `/proc` file with `st_size == 0` is read in full.
- `Bun.stdin` as an entry reads stdin to EOF on the JS thread, as `readFileSync(0)` does.
- `new Bun.Archive(new Blob([]))` now wraps 0 bytes, the same as `new Bun.Archive(new Uint8Array(0))`. Before, the store-less Blob fell through to the object form and produced an empty tarball.
- Probed on the debug build: a 1 MB file (past the 256 KB pre-stat read), a middle and a tail slice of it, `Bun.stdin` through a pipe, a directory (`EISDIR`), a missing path (`ENOENT`, `syscall: "open"`, `path`).
- Repro on 1.4.1: `new Bun.Archive({ "a.txt": Bun.file("/tmp/in.txt") })` round-tripped through `files()` gives `""`. A sliced `Bun.file()`, `Bun.file(fd)`, and an S3 file also give `""`. `new Bun.Archive(Bun.file("x.tar")).bytes()` has length 0.
- Also ran: `test/js/web/fetch/blob.test.ts`, `test/js/web/html/FormData-multipart-serialization.test.ts`, `test/js/bun/io/bun-write.test.js`, `cargo clippy -p bun_runtime --no-deps` (clean), `cargo fmt --check` on the changed files.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/archive.test.ts

<!-- robobun:evidence:end -->