### PR TITLE
timers: keep the async context on the Timeout, not in the callback slot

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -884,6 +884,14 @@ impl JSGlobalObject {
         JSC__JSGlobalObject__queueMicrotaskJob(self, function, first, second)
     }
 
+    /// The async context that is active right now (the `AsyncLocalStorage`
+    /// frame), or `undefined` when there is none. Store it on a resource that
+    /// runs a callback later, then install it around the call.
+    #[inline]
+    pub fn async_context(&self) -> JSValue {
+        JSC__JSGlobalObject__asyncContext(self)
+    }
+
     pub fn throw_value(&self, value: JSValue) -> JsError {
         // A termination exception (e.g. stack overflow) may already be
         // pending. Don't try to override it — that would hit
@@ -1531,6 +1539,7 @@ unsafe extern "C" {
         first: JSValue,
         second: JSValue,
     );
+    safe fn JSC__JSGlobalObject__asyncContext(this: &JSGlobalObject) -> JSValue;
 
     fn JSC__JSGlobalObject__createAggregateError(
         global: &JSGlobalObject,

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -884,9 +884,7 @@ impl JSGlobalObject {
         JSC__JSGlobalObject__queueMicrotaskJob(self, function, first, second)
     }
 
-    /// The async context that is active right now (the `AsyncLocalStorage`
-    /// frame), or `undefined` when there is none. Store it on a resource that
-    /// runs a callback later, then install it around the call.
+    /// The active async context (the `AsyncLocalStorage` frame), or `undefined`.
     #[inline]
     pub fn async_context(&self) -> JSValue {
         JSC__JSGlobalObject__asyncContext(self)

--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -97,8 +97,6 @@ extern "C" JSC::EncodedJSValue AsyncContextFrame__withAsyncContextIfNeeded(JSGlo
     return JSValue::encode(AsyncContextFrame::withAsyncContextIfNeeded(globalObject, JSValue::decode(callback)));
 }
 
-// The async context that is active right now, for a resource that stores it
-// separately from its callback (the timers) instead of in an AsyncContextFrame.
 extern "C" JSC::EncodedJSValue JSC__JSGlobalObject__asyncContext(JSGlobalObject* globalObject)
 {
     JSValue asyncContext = globalObject->m_asyncContextData.get()->getInternalField(0);

--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -97,6 +97,17 @@ extern "C" JSC::EncodedJSValue AsyncContextFrame__withAsyncContextIfNeeded(JSGlo
     return JSValue::encode(AsyncContextFrame::withAsyncContextIfNeeded(globalObject, JSValue::decode(callback)));
 }
 
+// The async context that is active right now, for a resource that stores it
+// separately from its callback (the timers) instead of in an AsyncContextFrame.
+extern "C" JSC::EncodedJSValue JSC__JSGlobalObject__asyncContext(JSGlobalObject* globalObject)
+{
+    JSValue asyncContext = globalObject->m_asyncContextData.get()->getInternalField(0);
+    if (asyncContext.isEmpty()) {
+        asyncContext = jsUndefined();
+    }
+    return JSValue::encode(asyncContext);
+}
+
 #define ASYNCCONTEXTFRAME_CALL_IMPL(...)                                            \
     if (!functionObject.isCell())                                                   \
         return jsUndefined();                                                       \

--- a/src/jsc/bindings/NodeTimerObject.cpp
+++ b/src/jsc/bindings/NodeTimerObject.cpp
@@ -17,8 +17,6 @@
 namespace Bun {
 using namespace JSC;
 
-// `asyncContext` is the AsyncLocalStorage frame the timer captured when it was
-// created. It is installed around the callback and restored afterwards.
 static bool call(JSGlobalObject* globalObject, JSValue timerObject, JSValue callbackValue, JSValue argumentsValue, JSValue asyncContext)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/NodeTimerObject.cpp
+++ b/src/jsc/bindings/NodeTimerObject.cpp
@@ -13,12 +13,13 @@
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include "JavaScriptCore/JSCJSValue.h"
-#include "AsyncContextFrame.h"
 
 namespace Bun {
 using namespace JSC;
 
-static bool call(JSGlobalObject* globalObject, JSValue timerObject, JSValue callbackValue, JSValue argumentsValue)
+// `asyncContext` is the AsyncLocalStorage frame the timer captured when it was
+// created. It is installed around the callback and restored afterwards.
+static bool call(JSGlobalObject* globalObject, JSValue timerObject, JSValue callbackValue, JSValue argumentsValue, JSValue asyncContext)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -26,11 +27,10 @@ static bool call(JSGlobalObject* globalObject, JSValue timerObject, JSValue call
     JSValue restoreAsyncContext {};
     JSC::InternalFieldTuple* asyncContextData = nullptr;
 
-    if (auto* wrapper = dynamicDowncast<AsyncContextFrame>(callbackValue)) {
-        callbackValue = wrapper->callback.get();
+    if (!asyncContext.isUndefined()) {
         asyncContextData = globalObject->m_asyncContextData.get();
         restoreAsyncContext = asyncContextData->getInternalField(0);
-        asyncContextData->putInternalField(vm, 0, wrapper->context.get());
+        asyncContextData->putInternalField(vm, 0, asyncContext);
     }
 
     if (auto* promise = dynamicDowncast<JSPromise>(callbackValue)) {
@@ -40,6 +40,9 @@ static bool call(JSGlobalObject* globalObject, JSValue timerObject, JSValue call
         auto callData = JSC::getCallData(callbackValue);
         if (callData.type == CallData::Type::None) {
             Bun__reportUnhandledError(globalObject, JSValue::encode(createNotAFunctionError(globalObject, callbackValue)));
+            if (asyncContextData) {
+                asyncContextData->putInternalField(vm, 0, restoreAsyncContext);
+            }
             return true;
         }
 
@@ -79,14 +82,14 @@ static bool call(JSGlobalObject* globalObject, JSValue timerObject, JSValue call
 }
 
 // Returns true if an exception was thrown.
-extern "C" bool Bun__JSTimeout__call(JSGlobalObject* globalObject, EncodedJSValue timerObject, EncodedJSValue callbackValue, EncodedJSValue argumentsValue)
+extern "C" bool Bun__JSTimeout__call(JSGlobalObject* globalObject, EncodedJSValue timerObject, EncodedJSValue callbackValue, EncodedJSValue argumentsValue, EncodedJSValue asyncContext)
 {
     auto& vm = globalObject->vm();
     if (vm.hasPendingTerminationException() || WebCore::clientData(vm)->isStoppingOrStopped(vm)) [[unlikely]] {
         return true;
     }
 
-    return call(globalObject, JSValue::decode(timerObject), JSValue::decode(callbackValue), JSValue::decode(argumentsValue));
+    return call(globalObject, JSValue::decode(timerObject), JSValue::decode(callbackValue), JSValue::decode(argumentsValue), JSValue::decode(asyncContext));
 }
 
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5789,15 +5789,6 @@ extern "C" size_t JSC__VM__externalMemorySize(JSC::VM* vm)
 #endif
 }
 
-extern "C" JSC::EncodedJSValue JSC__JSGlobalObject__asyncContext(JSC::JSGlobalObject* globalObject)
-{
-    JSValue asyncContext = globalObject->m_asyncContextData.get()->getInternalField(0);
-    if (asyncContext.isEmpty()) {
-        asyncContext = jsUndefined();
-    }
-    return JSValue::encode(asyncContext);
-}
-
 extern "C" void JSC__JSGlobalObject__queueMicrotaskJob(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, JSC::EncodedJSValue JSValue3, JSC::EncodedJSValue JSValue4)
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(arg0);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5789,6 +5789,15 @@ extern "C" size_t JSC__VM__externalMemorySize(JSC::VM* vm)
 #endif
 }
 
+extern "C" JSC::EncodedJSValue JSC__JSGlobalObject__asyncContext(JSC::JSGlobalObject* globalObject)
+{
+    JSValue asyncContext = globalObject->m_asyncContextData.get()->getInternalField(0);
+    if (asyncContext.isEmpty()) {
+        asyncContext = jsUndefined();
+    }
+    return JSValue::encode(asyncContext);
+}
+
 extern "C" void JSC__JSGlobalObject__queueMicrotaskJob(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, JSC::EncodedJSValue JSValue3, JSC::EncodedJSValue JSValue4)
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(arg0);

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -1076,8 +1076,8 @@ macro_rules! js_class_module {
     };
 }
 
-js_class_module!(JSTimeout   = "Timeout"   { callback, arguments, idleTimeout, repeat, idleStart });
-js_class_module!(JSImmediate = "Immediate" { callback, arguments });
+js_class_module!(JSTimeout   = "Timeout"   { callback, arguments, idleTimeout, repeat, idleStart, asyncContext });
+js_class_module!(JSImmediate = "Immediate" { callback, arguments, asyncContext });
 // Payload `Blob` lives in this crate (`webcore_types`) — pass it so the extern
 // signatures unify with the typed declarations there.
 js_class_module!(JSBlob      = "Blob"      as crate::webcore_types::Blob { name, stream });

--- a/src/runtime/node/node.classes.ts
+++ b/src/runtime/node/node.classes.ts
@@ -194,7 +194,7 @@ export default [
         invalidThisBehavior: InvalidThisBehavior.NoOp,
       },
     },
-    values: ["arguments", "callback", "idleTimeout", "repeat", "idleStart"],
+    values: ["arguments", "callback", "idleTimeout", "repeat", "idleStart", "asyncContext"],
   }),
   define({
     name: "Immediate",
@@ -235,7 +235,7 @@ export default [
         invalidThisBehavior: InvalidThisBehavior.NoOp,
       },
     },
-    values: ["arguments", "callback"],
+    values: ["arguments", "callback", "asyncContext"],
   }),
   define({
     name: "NodeJSFS",

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -202,13 +202,12 @@ impl All {
 
         let countdown_int =
             all.js_value_to_countdown(global, countdown, CountdownOverflowBehavior::Clamp, true)?;
-        let wrapped_promise = promise.with_async_context_if_needed(global);
         Ok(TimeoutObject::init(
             global,
             id,
             Kind::SetTimeout,
             countdown_int,
-            wrapped_promise,
+            promise,
             JSValue::UNDEFINED,
         ))
     }
@@ -224,13 +223,7 @@ impl All {
         let id = all.last_id;
         all.last_id = all.last_id.wrapping_add(1);
 
-        let wrapped_callback = callback.with_async_context_if_needed(global);
-        Ok(ImmediateObject::init(
-            global,
-            id,
-            wrapped_callback,
-            arguments,
-        ))
+        Ok(ImmediateObject::init(global, id, callback, arguments))
     }
 
     pub(crate) fn set_timeout(
@@ -245,7 +238,6 @@ impl All {
         let id = all.last_id;
         all.last_id = all.last_id.wrapping_add(1);
 
-        let wrapped_callback = callback.with_async_context_if_needed(global);
         let countdown_int =
             all.js_value_to_countdown(global, countdown, CountdownOverflowBehavior::OneMs, true)?;
         Ok(TimeoutObject::init(
@@ -253,7 +245,7 @@ impl All {
             id,
             Kind::SetTimeout,
             countdown_int,
-            wrapped_callback,
+            callback,
             arguments,
         ))
     }
@@ -270,7 +262,6 @@ impl All {
         let id = all.last_id;
         all.last_id = all.last_id.wrapping_add(1);
 
-        let wrapped_callback = callback.with_async_context_if_needed(global);
         let countdown_int =
             all.js_value_to_countdown(global, countdown, CountdownOverflowBehavior::OneMs, true)?;
         Ok(TimeoutObject::init(
@@ -278,7 +269,7 @@ impl All {
             id,
             Kind::SetInterval,
             countdown_int,
-            wrapped_callback,
+            callback,
             arguments,
         ))
     }

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -304,9 +304,8 @@ impl TimerObjectInternals {
             this_value: JsCell::new(JsRef::empty()),
         };
 
-        // Node binds the async context to the timer resource, not to the
-        // callback (`initAsyncResource`), so `_onTimeout` can read back and
-        // replace the bare function. `fire` installs it around the call.
+        // Kept on the timer, not wrapped around the callback, so `_onTimeout`
+        // reads and writes the bare function as in Node's `initAsyncResource`.
         let async_context = global.async_context();
 
         if kind == Kind::SetImmediate {

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -78,6 +78,7 @@ unsafe extern "C" {
         timer: JSValue,
         callback: JSValue,
         arguments: JSValue,
+        async_context: JSValue,
     ) -> bool;
 }
 
@@ -231,6 +232,7 @@ impl TimerObjectInternals {
         timer: JSValue,
         callback: JSValue,
         arguments: JSValue,
+        async_context: JSValue,
         async_id: u64,
         vm: *mut VirtualMachine,
     ) -> bool {
@@ -250,7 +252,7 @@ impl TimerObjectInternals {
         // `Cell<Flags>` RMW so the `in_callback` write reaches memory before JS
         // runs (re-entrant `_destroyed` getter reads it via a different pointer).
         s.update_flags(|f| f.set_in_callback(true));
-        let result = Bun__JSTimeout__call(global, timer, callback, arguments);
+        let result = Bun__JSTimeout__call(global, timer, callback, arguments, async_context);
         // No early returns between the `in_callback` set and this clear.
         // `Cell<Flags>` RMW: must reload `flags` from memory — re-entrant
         // `cancel()` may have set `has_cleared_timer` / cleared
@@ -302,9 +304,15 @@ impl TimerObjectInternals {
             this_value: JsCell::new(JsRef::empty()),
         };
 
+        // Node binds the async context to the timer resource, not to the
+        // callback (`initAsyncResource`), so `_onTimeout` can read back and
+        // replace the bare function. `fire` installs it around the call.
+        let async_context = global.async_context();
+
         if kind == Kind::SetImmediate {
             JSImmediate::arguments_set_cached(timer, global, arguments);
             JSImmediate::callback_set_cached(timer, global, callback);
+            JSImmediate::async_context_set_cached(timer, global, async_context);
             // `flags.kind` was just set to `SetImmediate` above.
             let TimerParent::Immediate(parent) = self.parent_ptr() else {
                 unreachable!()
@@ -319,6 +327,7 @@ impl TimerObjectInternals {
         } else {
             JSTimeout::arguments_set_cached(timer, global, arguments);
             JSTimeout::callback_set_cached(timer, global, callback);
+            JSTimeout::async_context_set_cached(timer, global, async_context);
             JSTimeout::idle_timeout_set_cached(
                 timer,
                 global,
@@ -408,14 +417,26 @@ impl TimerObjectInternals {
             JSImmediate::callback_get_cached(timer).expect("ImmediateObject callback slot");
         let arguments =
             JSImmediate::arguments_get_cached(timer).expect("ImmediateObject arguments slot");
+        let async_context = JSImmediate::async_context_get_cached(timer)
+            .expect("ImmediateObject asyncContext slot");
 
         let exception_thrown = {
             s.ref_();
             let async_id = s.async_id();
             // SAFETY: `this` is the live `internals` per fn contract; `ref_()`
             // above pins the parent across re-entrancy.
-            let result =
-                unsafe { Self::run(this, global_this, timer, callback, arguments, async_id, vm) };
+            let result = unsafe {
+                Self::run(
+                    this,
+                    global_this,
+                    timer,
+                    callback,
+                    arguments,
+                    async_context,
+                    async_id,
+                    vm,
+                )
+            };
             // `Self::run` has no early return so the deref ordering below is
             // preserved. After the second `deref()` `*this` may be
             // freed; do not touch it past this block.
@@ -504,7 +525,8 @@ impl TimerObjectInternals {
             return;
         };
 
-        let (callback, arguments, mut idle_timeout, mut repeat): (
+        let (callback, arguments, async_context, mut idle_timeout, mut repeat): (
+            JSValue,
             JSValue,
             JSValue,
             JSValue,
@@ -515,12 +537,16 @@ impl TimerObjectInternals {
                     .expect("ImmediateObject callback slot"),
                 JSImmediate::arguments_get_cached(this_object)
                     .expect("ImmediateObject arguments slot"),
+                JSImmediate::async_context_get_cached(this_object)
+                    .expect("ImmediateObject asyncContext slot"),
                 JSValue::UNDEFINED,
                 JSValue::UNDEFINED,
             ),
             KindBig::SetTimeout | KindBig::SetInterval => (
                 JSTimeout::callback_get_cached(this_object).expect("TimeoutObject callback slot"),
                 JSTimeout::arguments_get_cached(this_object).expect("TimeoutObject arguments slot"),
+                JSTimeout::async_context_get_cached(this_object)
+                    .expect("TimeoutObject asyncContext slot"),
                 JSTimeout::idle_timeout_get_cached(this_object)
                     .expect("TimeoutObject idleTimeout slot"),
                 JSTimeout::repeat_get_cached(this_object).expect("TimeoutObject repeat slot"),
@@ -579,6 +605,7 @@ impl TimerObjectInternals {
                     this_object,
                     callback,
                     arguments,
+                    async_context,
                     async_id.async_id(),
                     vm,
                 )

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -304,8 +304,7 @@ impl TimerObjectInternals {
             this_value: JsCell::new(JsRef::empty()),
         };
 
-        // Kept on the timer, not wrapped around the callback, so `_onTimeout`
-        // reads and writes the bare function as in Node's `initAsyncResource`.
+        // Stored on the timer, not around the callback, so `_onTimeout` is the bare function.
         let async_context = global.async_context();
 
         if kind == Kind::SetImmediate {

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -331,8 +331,7 @@ describe("_onTimeout", () => {
     }
   });
 
-  // A timer created inside AsyncLocalStorage.run() stores its callback wrapped
-  // with the async context. The wrapper must not leak through `_onTimeout`.
+  // The async context a timer captures must not show up in `_onTimeout`.
   it("is the callback that was passed in, inside AsyncLocalStorage.run()", () => {
     const als = new AsyncLocalStorage<string>();
     const fn = () => {};

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,6 +1,7 @@
 import jsc from "bun:jsc";
 import { describe, expect, it, mock, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, isWindows } from "harness";
+import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
 import { clearInterval, clearTimeout, promises, setImmediate, setInterval, setTimeout } from "node:timers";
 import { promisify } from "util";
@@ -313,6 +314,92 @@ describe("_idleStart", () => {
     t1._idleStart = -Number.MAX_VALUE;
     expect(t1._idleStart).toBe(-Number.MAX_VALUE);
     clearTimeout(t1);
+  });
+});
+
+describe("_onTimeout", () => {
+  it("is the callback that was passed in", () => {
+    const fn = () => {};
+    const timeout = setTimeout(fn, 1000) as any;
+    const interval = setInterval(fn, 1000) as any;
+    try {
+      expect(timeout._onTimeout).toBe(fn);
+      expect(interval._onTimeout).toBe(fn);
+    } finally {
+      clearTimeout(timeout);
+      clearInterval(interval);
+    }
+  });
+
+  // A timer created inside AsyncLocalStorage.run() stores its callback wrapped
+  // with the async context. The wrapper must not leak through `_onTimeout`.
+  it("is the callback that was passed in, inside AsyncLocalStorage.run()", () => {
+    const als = new AsyncLocalStorage<string>();
+    const fn = () => {};
+    als.run("store", () => {
+      const timeout = setTimeout(fn, 1000) as any;
+      const interval = setInterval(fn, 1000) as any;
+      try {
+        expect(typeof timeout._onTimeout).toBe("function");
+        expect(timeout._onTimeout).toBe(fn);
+        expect(interval._onTimeout).toBe(fn);
+      } finally {
+        clearTimeout(timeout);
+        clearInterval(interval);
+      }
+    });
+  });
+
+  // Node binds the async context to the Timeout when it is created, so a
+  // replacement callback runs with the creation-time store no matter where
+  // the assignment happens, and no matter what was assigned before it.
+  it("a replaced callback keeps the creation-time async context", async () => {
+    const als = new AsyncLocalStorage<string>();
+    const seen: (string | undefined)[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const original = () => seen.push("original");
+
+    let replacedInside!: any;
+    let replacedAfterNull!: any;
+    let replacedOutside!: any;
+    als.run("creator", () => {
+      replacedInside = setTimeout(original, 1);
+      replacedAfterNull = setTimeout(original, 1);
+      replacedOutside = setTimeout(original, 1);
+    });
+    als.run("other", () => {
+      replacedInside._onTimeout = () => seen.push(als.getStore());
+      replacedAfterNull._onTimeout = null;
+      replacedAfterNull._onTimeout = () => seen.push(als.getStore());
+    });
+    replacedOutside._onTimeout = () => {
+      seen.push(als.getStore());
+      resolve();
+    };
+    expect(replacedInside._onTimeout).not.toBe(original);
+    expect(replacedAfterNull._onTimeout).not.toBe(original);
+    expect(replacedOutside._onTimeout).not.toBe(original);
+
+    await promise;
+    expect(seen).toEqual(["creator", "creator", "creator"]);
+  });
+
+  it("a null callback inside AsyncLocalStorage.run() disables the timer", async () => {
+    const als = new AsyncLocalStorage<string>();
+    const { promise, resolve } = Promise.withResolvers<void>();
+    let fired = false;
+    let timeout!: any;
+    als.run("store", () => {
+      timeout = setTimeout(() => {
+        fired = true;
+      }, 1);
+      timeout._onTimeout = null;
+    });
+    expect(timeout._onTimeout).toBeNull();
+    setTimeout(resolve, 5);
+    await promise;
+    expect(fired).toBeFalse();
+    expect(timeout._destroyed).toBeTrue();
   });
 });
 


### PR DESCRIPTION
### Problem
- Inside `AsyncLocalStorage.run()`, `setTimeout(fn)._onTimeout` is not `fn`. `typeof` gives `"object"` and a call throws `is not a function`. Node returns `fn`.
- The cause: `set_timeout` (`src/runtime/timer/Timer.rs:248`) stored the `AsyncContextFrame` wrapper from `with_async_context_if_needed` in the `callback` slot. The getter returned that slot as is.
- The setter had the reverse problem. `t._onTimeout = g` stored a bare function, so `g` fired with no store. Node keeps the creation-time context.

### Fix
- Timeout and Immediate get an `asyncContext` cached slot. `TimerObjectInternals::init` fills it from the new `JSGlobalObject::async_context()`. The `callback` slot holds the user value.
- `fire` and `run_immediate_task` pass the slot to `Bun__JSTimeout__call`. The C++ side installs that context around the call and restores the previous one, also on the not-a-function path.
- Node does the same: `initAsyncResource` binds the context to the `Timeout` object, and `_onTimeout` is a plain property. Every reassignment fires with the creation-time store.
- Verified: `test/js/node/timers/node-timers.test.ts` (4 new cases, 2 fail on main). Also `test/js/node/async_hooks/`, `test/js/web/timers/`, the fake timer suites, and the `test-timers-*.js` node tests.

### Background
- Bun keeps the active `AsyncLocalStorage` frame in `m_asyncContextData` on the global object. A callback stored for later captures that frame and installs it when it runs.
- `AsyncContextFrame` (`src/jsc/bindings/AsyncContextFrame.cpp`) is a JS cell that pairs a callback with its frame. Timers used it until now. Microtasks carry the frame as a separate value (`QueuedTask` in `bindings.cpp`). Timers now do the same.
- `values` in `node.classes.ts` are GC-visited slots on the C++ wrapper. `js_class_module!` in `src/jsc/generated.rs` declares their Rust accessors.

<details><summary>Notes</summary>

Repro, bun 1.4.1 vs node v26.3.0:

```js
const { AsyncLocalStorage } = require("node:async_hooks");
const als = new AsyncLocalStorage();
const fn = () => {};
als.run({ x: 1 }, () => {
  const t = setTimeout(fn, 1000);
  console.log(typeof t._onTimeout, t._onTimeout === fn); // bun: object false, node: function true
  clearTimeout(t);
});
let t3;
als.run({ x: 3 }, () => { t3 = setTimeout(() => {}, 1); });
t3._onTimeout = () => console.log(als.getStore()); // bun: undefined, node: { x: 3 }
```

A first version of this change kept the wrapper in the slot and unwrapped it in the getter, with the setter re-wrapping a callable with the stored frame. That left one divergence: `t._onTimeout = null; t._onTimeout = g` lost the frame, where Node fires `g` with the creation-time store. The slot model removes the special case and the new test covers the null-then-reassign order.

Node semantics checked against `lib/internal/timers.js`: `Timeout` stores `AsyncContextFrame.current()` on the resource in `initAsyncResource`, and `listOnTimeout` exchanges that frame in before it calls `timer._onTimeout()`. `listOnTimeout` also skips a timer whose `_onTimeout` is falsy, which `fire()` mirrors with `!callback.to_boolean()`.

Side effects of the slot model: a timer inside a store no longer allocates an `AsyncContextFrame` cell. Every timer carries one more 8-byte slot. The `_onTimeout = 42` case (truthy non-callable) now restores the previous frame after it reports the error. Before, the early return left the timer's frame installed.

Related open PRs: #33092 (refresh re-captures the context for a fired timer) becomes a write to the `asyncContext` slot on top of this. #31802 (`Immediate._onImmediate`) reads the `callback` slot as is, which is correct with this change.

Checked manually against node v26.3.0: setTimeout, setInterval, setImmediate, `timers/promises`, `refresh()` from another store, the ambient context after a callback, and a non-callable `_onTimeout` all match. `Bun.sleep()` inside a store still resolves with the store.

Under `bun bd` (debug, ASAN) the RSS leak fixtures in `test/js/web/timers/` and the Postgres fixture in `timer-gc-roots.test.ts` fail the same way on main (97 MB delta versus the 10 MB non-ASAN threshold, and a 6.5 s run against a 5 s test timeout). They are not related to this change.

Self-reviewed: the review asked for this slot model instead of an unwrap at the accessor, and the diff now follows it.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts

<!-- robobun:evidence:end -->