### PR TITLE
deps: update @lezer/cpp to 1.1.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "bun",
       "devDependencies": {
         "@lezer/common": "^1.2.3",
-        "@lezer/cpp": "^1.1.3",
+        "@lezer/cpp": "^1.1.6",
         "@types/bun": "workspace:*",
         "esbuild": "^0.21.5",
         "mitata": "^0.1.14",
@@ -85,13 +85,13 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "@lezer/common": ["@lezer/common@1.3.0", "", {}, "sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ=="],
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 
-    "@lezer/cpp": ["@lezer/cpp@1.1.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-ykYvuFQKGsRi6IcE+/hCSGUhb/I4WPjd3ELhEblm2wS2cOznDFzO+ubK2c+ioysOnlZ3EduV+MVQFCPzAIoY3w=="],
+    "@lezer/cpp": ["@lezer/cpp@1.1.6", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA=="],
 
     "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
 
-    "@lezer/lr": ["@lezer/lr@1.4.3", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-yenN5SqAxAPv/qMnpWW0AT7l+SxVrgG+u0tNsRQWqbrz66HIl8DnEbBObvy21J5K7+I1v7gsAnlE2VQ5yYVSeA=="],
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.70.0", "", { "os": "android", "cpu": "arm" }, "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "devDependencies": {
     "@lezer/common": "^1.2.3",
-    "@lezer/cpp": "^1.1.3",
+    "@lezer/cpp": "^1.1.6",
     "@types/bun": "workspace:*",
     "esbuild": "^0.21.5",
     "mitata": "^0.1.14",


### PR DESCRIPTION
### Problem
- `@lezer/cpp` is pinned at 1.1.3 (March 2025). The current release is 1.1.6 (May 2026). `src/codegen/cppbind.ts` uses this grammar to find `[[ZIG_EXPORT(...)]]` functions in the C++ sources and emit `cpp.rs`.
- The 1.1.4 to 1.1.6 releases fix the parser for a large expression with several `<` operators, for an unclosed block comment, for comma-separated `using` declarations, and for a line comment after a preprocessor argument.

### Fix
- Bump `@lezer/cpp` to `^1.1.6` in `package.json` and `bun.lock`. The transitive pins `@lezer/common` (1.3.0 to 1.5.2) and `@lezer/lr` (1.4.3 to 1.4.10) move with it. `@lezer/highlight` stays at 1.2.3.
- Verified: `cppbind.ts` over all 573 C++ sources produces a byte-identical `cpp.rs` before and after the bump (md5 `dfa4a09fc4ea9f117b7a3b8d8ad7c3f6`, the same as the checked-in debug build output). `bun install --frozen-lockfile` passes. `tsc` on `cppbind.ts` passes against the new `@lezer/common` types.

### Background
- `cppbind.ts` parses every `.cpp` file that contains `[[ZIG_EXPORT(` with the lezer C++ grammar. It walks `FunctionDefinition` nodes and emits Rust `extern "C"` declarations and wrappers into `build/<profile>/codegen/cpp.rs`, which `bun_jsc::cpp` includes.
- The build depends on the root `bun install` stamp, so a grammar version change retriggers the cppbind step on the next build.

<details><summary>Notes</summary>

Commands used to verify:

```
bun scripts/glob-sources.ts cxx > /tmp/cxx.txt
bun src/codegen/cppbind.ts src /tmp/cppbind-before /tmp/cxx.txt   # with 1.1.3
bun update @lezer/cpp --latest
bun src/codegen/cppbind.ts src /tmp/cppbind-after /tmp/cxx.txt    # with 1.1.6
diff /tmp/cppbind-before/cpp.rs /tmp/cppbind-after/cpp.rs         # no output
```

Upstream changelog for 1.1.4 to 1.1.6 (the repository moved to code.haverbeke.berlin/lezer/cpp):
- 1.1.4: Fix a bug where the parser would get stuck trying to parse a big expression with multiple less-than operators as a template type.
- 1.1.5: Improve handling of unclosed block comments.
- 1.1.6: Support comma-separated identifiers in `using` declarations. Fix highlighting of preprocessor directive arguments. Allow line comments after preprocessor arguments.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->