### PR TITLE
Remove mitata from the root devDependencies

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,5 +1,7 @@
 ```bash
-npm install
+# run from this directory. bench/ has its own package.json and bun.lock,
+# the repo root does not install benchmark dependencies such as mitata.
+bun install
 
 bun run ffi
 bun run log

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@lezer/cpp": "^1.1.3",
         "@types/bun": "workspace:*",
         "esbuild": "^0.21.5",
-        "mitata": "^0.1.14",
         "oxlint": "1.70.0",
         "prettier": "^3.6.2",
         "prettier-plugin-organize-imports": "^4.3.0",
@@ -142,8 +141,6 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
-
-    "mitata": ["mitata@0.1.14", "", {}, "sha512-8kRs0l636eT4jj68PFXOR2D5xl4m56T478g16SzUPOYgkzQU+xaw62guAQxzBPm+SXb15GQi1cCpDxJfkr4CSA=="],
 
     "oxlint": ["oxlint@1.70.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.70.0", "@oxlint/binding-android-arm64": "1.70.0", "@oxlint/binding-darwin-arm64": "1.70.0", "@oxlint/binding-darwin-x64": "1.70.0", "@oxlint/binding-freebsd-x64": "1.70.0", "@oxlint/binding-linux-arm-gnueabihf": "1.70.0", "@oxlint/binding-linux-arm-musleabihf": "1.70.0", "@oxlint/binding-linux-arm64-gnu": "1.70.0", "@oxlint/binding-linux-arm64-musl": "1.70.0", "@oxlint/binding-linux-ppc64-gnu": "1.70.0", "@oxlint/binding-linux-riscv64-gnu": "1.70.0", "@oxlint/binding-linux-riscv64-musl": "1.70.0", "@oxlint/binding-linux-s390x-gnu": "1.70.0", "@oxlint/binding-linux-x64-gnu": "1.70.0", "@oxlint/binding-linux-x64-musl": "1.70.0", "@oxlint/binding-openharmony-arm64": "1.70.0", "@oxlint/binding-win32-arm64-msvc": "1.70.0", "@oxlint/binding-win32-ia32-msvc": "1.70.0", "@oxlint/binding-win32-x64-msvc": "1.70.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@lezer/cpp": "^1.1.3",
     "@types/bun": "workspace:*",
     "esbuild": "^0.21.5",
-    "mitata": "^0.1.14",
     "oxlint": "1.70.0",
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.3.0",


### PR DESCRIPTION
### Problem
- The root `package.json` lists `mitata@^0.1.14` as a devDependency. Nothing at the root uses it. Only `bench/` imports mitata, through `bench/runner.mjs`.
- `bench/` has its own `package.json` and `bun.lock`. They pin `mitata@1.0.20`. `bench/runner.mjs` uses the 1.x API (`summary`, `format: "json"`). The 0.1.14 copy at the root does not export `summary`, so it never worked for the benchmarks.

### Fix
- Remove `mitata` from the root `devDependencies` and from the root `bun.lock`. The lockfile diff is the two mitata lines, regenerated with `bun install`.
- Update `bench/README.md` to say `bun install` (not `npm install`), because `bench/` has a `bun.lock`.
- Verified: `bun install --frozen-lockfile` at the root passes. `bun bench/snippets/array-of.js` from the repo root runs with `bench/node_modules/mitata@1.0.20` after `cd bench && bun install`.

### Background
- The root `bun install --frozen-lockfile` runs inside every `bun bd` build as a ninja edge (`scripts/build/codegen.ts`, the root install step that provides esbuild and lezer-cpp) and in the lint workflow. The root lockfile has 62 packages.
- `bench/` follows the same layout as `test/`: a standalone package with its own lockfile, not a root workspace. Its lockfile has 341 packages, 31 of them platform-specific native binaries for `@swc/core` and `esbuild@0.14`. This PR keeps that layout. Making `bench/` a root workspace would add those packages to every build and lint install.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->