### PR TITLE
docs: document onResolve re-entrancy and the re-entry guard pattern

### DIFF
--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -198,7 +198,7 @@ plugin({
 
 #### Resolving inside `onResolve`
 
-At runtime, module resolution re-enters the plugin pipeline. When an `onResolve()` callback calls `Bun.resolveSync()`, `require.resolve()`, or `import.meta.resolve()`, every matching `onResolve()` callback runs again, including the one that is currently running. Node.js `module.registerHooks()` resolve hooks behave the same way.
+At runtime, module resolution re-enters the plugin pipeline. When an `onResolve()` callback calls `Bun.resolveSync()`, `require.resolve()`, or `import.meta.resolve()`, every matching `onResolve()` callback runs again, including the one that is currently running. Node.js behaves the same way: a synchronous `module.registerHooks()` resolve hook that calls `require.resolve()` or `import.meta.resolve()` instead of its `nextResolve()` argument re-enters itself.
 
 A callback that resolves its own matched specifier therefore recurses until it throws `RangeError: Maximum call stack size exceeded`:
 

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -196,6 +196,37 @@ plugin({
 });
 ```
 
+#### Resolving inside `onResolve`
+
+At runtime, module resolution re-enters the plugin pipeline. When an `onResolve()` callback calls `Bun.resolveSync()`, `require.resolve()`, or `import.meta.resolve()`, every matching `onResolve()` callback runs again, including the one that is currently running. Node.js `module.registerHooks()` resolve hooks behave the same way.
+
+A callback that resolves its own matched specifier therefore recurses until it throws `RangeError: Maximum call stack size exceeded`:
+
+```ts
+// Do not do this: Bun.resolveSync() re-enters this callback.
+build.onResolve({ filter: /^my-pkg\// }, args => {
+  return { path: Bun.resolveSync(args.path, process.cwd()) };
+});
+```
+
+To fall back to Bun's default resolver, guard against re-entry with a `Set` keyed on the specifier. Return `undefined` on re-entry, which passes the specifier through to default resolution:
+
+```ts
+const resolving = new Set<string>();
+
+build.onResolve({ filter: /^my-pkg\// }, args => {
+  if (resolving.has(args.path)) return; // re-entry: use the default resolver
+  resolving.add(args.path);
+  try {
+    return { path: Bun.resolveSync(args.path, process.cwd()) };
+  } finally {
+    resolving.delete(args.path);
+  }
+});
+```
+
+Key the guard on `args.path`, not on a boolean flag. A boolean guard also suppresses re-entry for a different specifier that the filter matches, which silently skips legitimate redirects.
+
 ### `onLoad`
 
 ```ts

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -203,22 +203,26 @@ At runtime, module resolution re-enters the plugin pipeline. When an `onResolve(
 A callback that resolves its own matched specifier therefore recurses until it throws `RangeError: Maximum call stack size exceeded`:
 
 ```ts
+import path from "node:path";
+
 // Do not do this: Bun.resolveSync() re-enters this callback.
 build.onResolve({ filter: /^my-pkg\// }, args => {
-  return { path: Bun.resolveSync(args.path, process.cwd()) };
+  return { path: Bun.resolveSync(args.path, path.dirname(args.importer)) };
 });
 ```
 
 To fall back to Bun's default resolver, guard against re-entry with a `Set` keyed on the specifier. Return `undefined` on re-entry, which passes the specifier through to default resolution:
 
 ```ts
+import path from "node:path";
+
 const resolving = new Set<string>();
 
 build.onResolve({ filter: /^my-pkg\// }, args => {
   if (resolving.has(args.path)) return; // re-entry: use the default resolver
   resolving.add(args.path);
   try {
-    return { path: Bun.resolveSync(args.path, process.cwd()) };
+    return { path: Bun.resolveSync(args.path, path.dirname(args.importer)) };
   } finally {
     resolving.delete(args.path);
   }


### PR DESCRIPTION
### Problem
- A runtime `Bun.plugin` `onResolve` hook that falls back to `Bun.resolveSync` on its own matched specifier recurses until `RangeError: Maximum call stack size exceeded` (#41201, earlier #16671).
- The re-entry is intentional and matches Node: `module.registerHooks()` resolve hooks in Node v26 also re-enter on the identical input. `docs/runtime/plugins.mdx` does not mention it, so users hit the overflow without a documented way out.

### Fix
- Add a "Resolving inside `onResolve`" section to `docs/runtime/plugins.mdx`. It states that `Bun.resolveSync`, `require.resolve`, and `import.meta.resolve` re-enter the plugin pipeline, shows the recursing anti-pattern, and shows the guard: a `Set` keyed on `args.path`, return `undefined` on re-entry to fall through to the default resolver.
- The section explains why the guard keys on the specifier and not a boolean flag: a boolean also suppresses re-entry for a different specifier the filter matches.
- Verified: both snippets run against bun 1.4.1. The unguarded one throws the RangeError, the guarded one returns the correct `file://` URL.

### Background
- Bun raises the overflow deliberately (PR #19227, fixes #16671). Tests at `test/js/bun/plugin/plugins.test.ts:734` and `:778` assert the RangeError. This PR does not change that behavior.
- Explicit delegation APIs are in flight elsewhere: `module.registerHooks` with `nextResolve` chaining in #35690, and the stubbed `build.resolve()` tracked by #2771. Docs are the right fix until one of those lands.
- The other half of #41201 (corrupted `file:file:...` output on 1.3.14) was fixed in #33409 and is correct on 1.4.0+.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->