### PR TITLE
ci: run every test file on the darwin PR lanes

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -826,13 +826,6 @@ function getTestBunStep(platform, options, testOptions = {}) {
     args.push("--exclude=internal/source-lints");
   }
 
-  // The untiered darwin lane PR builds get (see prDarwinTestPlatforms) skips
-  // the ~1% of files that take 10s or more; they are ~60% of a shard's wall
-  // time and still run on every other PR lane and on main's darwin lanes.
-  if (os === "darwin" && (!platform.tier || platform.tier === "beta")) {
-    args.push("--skip-slower-than=10000");
-  }
-
   const depends = [];
   if (!buildId) {
     depends.push(`${getTargetKey(platform)}-build-bun`);
@@ -857,7 +850,9 @@ function getTestBunStep(platform, options, testOptions = {}) {
     // PR's own build, and a cancel clears it.
     parallelism: platform.tier === "beta" ? 1 : os === "darwin" ? 2 : os === "windows" ? 8 : 20,
     ...(platform.tier === "beta" ? { soft_fail: true } : {}),
-    timeout_in_minutes: profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,
+    // The beta lane runs the whole suite as one shard on one box (~35 min).
+    timeout_in_minutes:
+      platform.tier === "beta" ? 60 : profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
       // Platform smoke check: runner.node.mjs asserts the agent matches what

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -158,10 +158,6 @@ const { values: options, positionals: filters } = parseArgs({
       multiple: true,
       default: undefined,
     },
-    ["skip-slower-than"]: {
-      type: "string",
-      default: undefined,
-    },
     ["quiet"]: {
       type: "boolean",
       default: false,
@@ -2564,22 +2560,6 @@ function getRelevantTests(cwd, testModifiers, testExpectations) {
       }
       !isQuiet && console.log("Excluding tests:", excludes, excludedTests.length, "/", availableTests.length);
     }
-  }
-
-  // Drop the slowest files by expected duration. Used on lanes that trade a
-  // little coverage for throughput; the same files still run on other lanes.
-  const skipSlowerThan = parseInt(options["skip-slower-than"]);
-  if (skipSlowerThan > 0) {
-    const durations = loadExpectedDurations(cwd);
-    const slow = availableTests.filter(testPath => (durations[testPath.replaceAll("\\", "/")] ?? 0) >= skipSlowerThan);
-    for (const testPath of slow) availableTests.splice(availableTests.indexOf(testPath), 1);
-    !isQuiet &&
-      console.log(
-        `Skipping tests slower than ${skipSlowerThan}ms:`,
-        slow.length,
-        "/",
-        availableTests.length + slow.length,
-      );
   }
 
   const skipExpectations = testExpectations


### PR DESCRIPTION
### Problem

The darwin lanes on PR builds skip every test file whose expected duration is 10s or more (`--skip-slower-than=10000`, from #39215). That is about 1% of the files but about 60% of a shard's time. A PR can break one of those tests and still go green. `main` still runs them.

The skip was a stopgap while the mac pool was small.

### Fix

- Remove the skip from the darwin PR lanes and the beta lane.
- Remove the `--skip-slower-than` runner flag. It had no other caller.
- Raise the beta lane's timeout from 45 to 60 minutes. That lane runs the whole suite as one shard on one box.

`test/expected-durations.json` stays. Shard packing and the parallel allowlist read it.

### Background

The mac pool is back to full size. On 2026-09-02, over about 19 hours:

- Darwin test jobs waited a median of 6s for an agent (p90 11-17s).
- arm64: about 3 of 15 slots busy on average.
- x64: about 3 of 9 slots busy on average.

A PR darwin shard should go from about 9 minutes to about 14, which is what the `main` shards take now.

PR builds keep the one "any macOS" lane per arch (#39195). `main` still runs the three version-specific lanes.
