### PR TITLE
node:util: expose the lazy inspect exports and readline.promises as data properties

### DIFF
--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -113,6 +113,7 @@ using namespace JSC;
     macro(kResistStopPropagation) \
     macro(key) \
     macro(lazy) \
+    macro(lazyPropertyLoaders) \
     macro(lineText) \
     macro(loadEsmIntoCjs) \
     macro(main) \

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -114,6 +114,7 @@ using namespace JSC;
     macro(key) \
     macro(lazy) \
     macro(lazyPropertyLoaders) \
+    macro(lazyPropertyValues) \
     macro(lineText) \
     macro(loadEsmIntoCjs) \
     macro(main) \

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -155,6 +155,12 @@ ObjectFreeze(kInternalSendOptions);
 // https://github.com/nodejs/node/blob/main/src/api/callback.cc
 const reportUncaughtException = $newCppFunction("BunProcess.cpp", "jsFunctionReportUncaughtException", 1);
 
+// defineLazyProperties(target, keys, loader): each key becomes a data property whose value is
+// loader(key), computed on first read. Unlike a get/set pair, Object.getOwnPropertyDescriptor
+// reports `value` from the start, as it does for node's lazy exports (SetLazyDataProperty).
+const defineLazyProperties: (target: object, keys: string[], loader: (key: string) => unknown) => void =
+  $newCppFunction("DefineLazyProperties.cpp", "jsFunctionDefineLazyProperties", 3);
+
 // Wrap a node-style callback so a throw inside it takes the uncaught path. The
 // callback keeps its place in the event loop; only the throw is rerouted. The
 // arity switch avoids materializing `arguments` for the shapes fs and dns use.
@@ -411,6 +417,7 @@ export default {
   ErrnoException,
   once,
   getLazy,
+  defineLazyProperties,
   guardCallback,
   isInsideNodeModules,
   reportUncaughtException,

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -155,9 +155,7 @@ ObjectFreeze(kInternalSendOptions);
 // https://github.com/nodejs/node/blob/main/src/api/callback.cc
 const reportUncaughtException = $newCppFunction("BunProcess.cpp", "jsFunctionReportUncaughtException", 1);
 
-// defineLazyProperties(target, keys, loader): each key becomes a data property whose value is
-// loader(key), computed on first read. Unlike a get/set pair, Object.getOwnPropertyDescriptor
-// reports `value` from the start, as it does for node's lazy exports (SetLazyDataProperty).
+// Data properties (not get/set pairs) whose first read stores loader(key), like node's lazy exports.
 const defineLazyProperties: (target: object, keys: string[], loader: (key: string) => unknown) => void =
   $newCppFunction("DefineLazyProperties.cpp", "jsFunctionDefineLazyProperties", 3);
 

--- a/src/js/node/readline.js
+++ b/src/js/node/readline.js
@@ -41,7 +41,7 @@ const emitKeypressEvents = require("internal/readline/emitKeypressEvents");
 const { AbortError } = require("internal/repl/node-errors");
 // Don't destructure `inspect` — reading it loads internal/util/inspect (99 KB).
 const nodeInspect = require("internal/repl/node-inspect");
-const { kEmptyObject } = require("internal/shared");
+const { kEmptyObject, defineLazyProperties } = require("internal/shared");
 const kCustomPromisifiedSymbol = Symbol.for("nodejs.util.promisify.custom");
 const { validateAbortSignal } = require("internal/validators");
 
@@ -509,18 +509,8 @@ __node_module__.exports = {
   moveCursor,
 };
 
-let promises;
-Object.defineProperty(__node_module__.exports, "promises", {
-  __proto__: null,
-  configurable: true,
-  enumerable: true,
-  get() {
-    return (promises ??= require("node:readline/promises"));
-  },
-  set(value) {
-    Object.defineProperty(__node_module__.exports, "promises", { value, writable: true, enumerable: true, configurable: true });
-  },
-});
+// A data property, as in node, but node:readline/promises loads on first read.
+defineLazyProperties(__node_module__.exports, ["promises"], () => require("node:readline/promises"));
 
 // Bun-internal hook consumed by pre-existing readline tests/utilities.
 // Non-enumerable so it stays off the public node:readline surface.

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -8,7 +8,7 @@ const {
   validateObject,
   validateInteger,
 } = require("internal/validators");
-const { resistStopPropagation, ErrnoException } = require("internal/shared");
+const { resistStopPropagation, ErrnoException, defineLazyProperties } = require("internal/shared");
 const { MIMEType, MIMEParams } = require("internal/util/mime");
 const { deprecate } = require("internal/util/deprecate");
 
@@ -41,6 +41,9 @@ const parseArgs = $newRustFunction("parse_args.rs", "parseArgs", 1);
 let utl;
 function lazyInspectModule() {
   return (utl ??= require("internal/util/inspect"));
+}
+function lazyInspectExport(key) {
+  return lazyInspectModule()[key];
 }
 
 var debugs = {};
@@ -687,7 +690,8 @@ function setTraceSigInt(enable) {
 }
 
 cjs_exports = {
-  // This is in order of `node --print 'Object.keys(util)'`
+  // This is in order of `node --print 'Object.keys(util)'`, except for the
+  // lazy inspect exports defined below.
   _errnoException,
   // _exceptionWithHostPort,
   _extend,
@@ -696,49 +700,15 @@ cjs_exports = {
   debug: debuglog,
   debuglog,
   deprecate,
-  get format() {
-    return lazyInspectModule().format;
-  },
-  set format(value) {
-    Object.defineProperty(cjs_exports, "format", { value, writable: true, enumerable: true, configurable: true });
-  },
   styleText,
-  get formatWithOptions() {
-    return lazyInspectModule().formatWithOptions;
-  },
-  set formatWithOptions(value) {
-    Object.defineProperty(cjs_exports, "formatWithOptions", {
-      value,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
-  },
   getCallSites,
   getSystemErrorMap,
   getSystemErrorName,
   getSystemErrorMessage,
   inherits,
-  get inspect() {
-    return lazyInspectModule().inspect;
-  },
-  set inspect(value) {
-    Object.defineProperty(cjs_exports, "inspect", { value, writable: true, enumerable: true, configurable: true });
-  },
   isDeepStrictEqual,
   promisify,
   setTraceSigInt,
-  get stripVTControlCharacters() {
-    return lazyInspectModule().stripVTControlCharacters;
-  },
-  set stripVTControlCharacters(value) {
-    Object.defineProperty(cjs_exports, "stripVTControlCharacters", {
-      value,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
-  },
   toUSVString,
   // transferableAbortSignal,
   // transferableAbortController,
@@ -769,5 +739,12 @@ cjs_exports = {
   isPrimitive,
   log,
 };
+
+// Data properties (node parity), loaded from internal/util/inspect on first read.
+defineLazyProperties(
+  cjs_exports,
+  ["format", "formatWithOptions", "inspect", "stripVTControlCharacters"],
+  lazyInspectExport,
+);
 
 export default cjs_exports;

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -690,8 +690,7 @@ function setTraceSigInt(enable) {
 }
 
 cjs_exports = {
-  // This is in order of `node --print 'Object.keys(util)'`, except for the
-  // lazy inspect exports defined below.
+  // This is in order of `node --print 'Object.keys(util)'`
   _errnoException,
   // _exceptionWithHostPort,
   _extend,

--- a/src/jsc/bindings/DefineLazyProperties.cpp
+++ b/src/jsc/bindings/DefineLazyProperties.cpp
@@ -14,8 +14,7 @@ namespace Bun {
 
 using namespace JSC;
 
-// A target's lazy properties read a values object (private name lazyPropertyValues), and so do its ESM bindings
-// (ModuleLoader.cpp). Each key of that object is a CustomValue that calls its loader (lazyPropertyLoaders) once.
+// Lazy properties and their ESM bindings (ModuleLoader.cpp) both read the values object, which calls each loader once.
 
 JSObject* lazyPropertyValues(VM& vm, JSObject* target)
 {
@@ -23,8 +22,7 @@ JSObject* lazyPropertyValues(VM& vm, JSObject* target)
     return values ? values.getObject() : nullptr;
 }
 
-// Replaces the CustomValue that `getter` serves with `value`. The other attributes stay: a frozen object keeps
-// ReadOnly, like V8's ReconfigureDataProperty.
+// The other attributes stay, so a frozen object stays ReadOnly, as with V8's ReconfigureDataProperty.
 static void materialize(VM& vm, JSObject* object, PropertyName name, JSValue value, GetValueFunc getter)
 {
     unsigned attributes = 0;

--- a/src/jsc/bindings/DefineLazyProperties.cpp
+++ b/src/jsc/bindings/DefineLazyProperties.cpp
@@ -14,9 +14,7 @@ namespace Bun {
 
 using namespace JSC;
 
-// The loaders live on the target under a private name (invisible to user
-// code), keyed by property name. A CustomGetterSetter carries no payload, so
-// this is how one native getter serves every lazy property.
+// key -> loader, stored on the target under a private name (CustomGetterSetter has no payload).
 static JSObject* lazyPropertyLoaders(VM& vm, JSObject* target)
 {
     JSValue loaders = target->getDirect(vm, WebCore::builtinNames(vm).lazyPropertyLoadersPrivateName());
@@ -46,10 +44,7 @@ JSC_DEFINE_CUSTOM_GETTER(lazyPropertyGetter, (JSGlobalObject * globalObject, Enc
     JSValue value = call(globalObject, loader, getCallData(loader), jsUndefined(), args);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Replace the getter with the value, as a data property with the same
-    // attributes (a frozen target keeps ReadOnly | DontDelete, as V8's
-    // ReconfigureDataProperty does). Skip if the loader redefined the
-    // property itself.
+    // Same attributes minus CustomValue: a frozen target stays ReadOnly, like V8's ReconfigureDataProperty.
     unsigned attributes = 0;
     PropertyOffset offset = thisObject->getDirectOffset(vm, propertyName, attributes);
     if (isValidOffset(offset) && (attributes & PropertyAttribute::CustomValue)) {

--- a/src/jsc/bindings/DefineLazyProperties.cpp
+++ b/src/jsc/bindings/DefineLazyProperties.cpp
@@ -14,28 +14,40 @@ namespace Bun {
 
 using namespace JSC;
 
-// key -> loader, stored on the target under a private name (CustomGetterSetter has no payload).
-static JSObject* lazyPropertyLoaders(VM& vm, JSObject* target)
+// A target's lazy properties read a values object (private name lazyPropertyValues), and so do its ESM bindings
+// (ModuleLoader.cpp). Each key of that object is a CustomValue that calls its loader (lazyPropertyLoaders) once.
+
+JSObject* lazyPropertyValues(VM& vm, JSObject* target)
 {
-    JSValue loaders = target->getDirect(vm, WebCore::builtinNames(vm).lazyPropertyLoadersPrivateName());
-    return loaders ? loaders.getObject() : nullptr;
+    JSValue values = target->getDirect(vm, WebCore::builtinNames(vm).lazyPropertyValuesPrivateName());
+    return values ? values.getObject() : nullptr;
 }
 
-JSC_DEFINE_CUSTOM_GETTER(lazyPropertyGetter, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName propertyName))
+// Replaces the CustomValue that `getter` serves with `value`. The other attributes stay: a frozen object keeps
+// ReadOnly, like V8's ReconfigureDataProperty.
+static void materialize(VM& vm, JSObject* object, PropertyName name, JSValue value, GetValueFunc getter)
+{
+    unsigned attributes = 0;
+    PropertyOffset offset = object->getDirectOffset(vm, name, attributes);
+    if (!isValidOffset(offset) || !(attributes & PropertyAttribute::CustomValue))
+        return;
+    if (uncheckedDowncast<CustomGetterSetter>(object->getDirect(offset))->getter() != getter)
+        return;
+    object->putDirect(vm, name, value, attributesForStructure(attributes) & ~static_cast<unsigned>(PropertyAttribute::CustomValue));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(lazyValueGetter, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName propertyName))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // For a CustomValue, JSC passes the object that owns the property, not the receiver.
-    JSObject* thisObject = JSValue::decode(thisValue).getObject();
-    if (!thisObject) [[unlikely]]
+    JSObject* values = JSValue::decode(thisValue).getObject();
+    if (!values) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
-    JSObject* loaders = lazyPropertyLoaders(vm, thisObject);
-    if (!loaders) [[unlikely]]
-        return JSValue::encode(jsUndefined());
-
-    JSValue loader = loaders->getDirect(vm, propertyName);
+    JSValue loaders = values->getDirect(vm, WebCore::builtinNames(vm).lazyPropertyLoadersPrivateName());
+    JSValue loader = loaders && loaders.isObject() ? asObject(loaders)->getDirect(vm, propertyName) : JSValue();
     if (!loader || !loader.isCallable()) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
@@ -44,20 +56,37 @@ JSC_DEFINE_CUSTOM_GETTER(lazyPropertyGetter, (JSGlobalObject * globalObject, Enc
     JSValue value = call(globalObject, loader, getCallData(loader), jsUndefined(), args);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Same attributes minus CustomValue: a frozen target stays ReadOnly, like V8's ReconfigureDataProperty.
-    unsigned attributes = 0;
-    PropertyOffset offset = thisObject->getDirectOffset(vm, propertyName, attributes);
-    if (isValidOffset(offset) && (attributes & PropertyAttribute::CustomValue)) {
-        thisObject->putDirect(vm, propertyName, value, attributesForStructure(attributes) & ~static_cast<unsigned>(PropertyAttribute::CustomValue));
-    }
-
+    materialize(vm, values, propertyName, value, lazyValueGetter);
     return JSValue::encode(value);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(lazyPropertyGetter, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* target = JSValue::decode(thisValue).getObject();
+    JSObject* values = target ? lazyPropertyValues(vm, target) : nullptr;
+    if (!values) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    JSValue value = values->get(globalObject, propertyName);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    materialize(vm, target, propertyName, value, lazyPropertyGetter);
+    return JSValue::encode(value);
+}
+
+bool isPendingLazyProperty(const PropertySlot& slot)
+{
+    return slot.isCustom() && (slot.attributes() & PropertyAttribute::CustomValue) && slot.customGetter() == GetValueFunc(lazyPropertyGetter);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionDefineLazyProperties, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+    auto& builtinNames = WebCore::builtinNames(vm);
 
     JSObject* target = callFrame->argument(0).getObject();
     JSArray* keys = dynamicDowncast<JSArray>(callFrame->argument(1));
@@ -67,13 +96,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefineLazyProperties, (JSGlobalObject * globa
         return {};
     }
 
-    JSObject* loaders = lazyPropertyLoaders(vm, target);
-    if (!loaders) {
-        loaders = constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
-        target->putDirect(vm, WebCore::builtinNames(vm).lazyPropertyLoadersPrivateName(), loaders, 0);
+    JSObject* values = lazyPropertyValues(vm, target);
+    if (!values) {
+        values = constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
+        JSObject* loaders = constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
+        values->putDirect(vm, builtinNames.lazyPropertyLoadersPrivateName(), loaders, 0);
+        target->putDirect(vm, builtinNames.lazyPropertyValuesPrivateName(), values, 0);
     }
+    JSObject* loaders = asObject(values->getDirect(vm, builtinNames.lazyPropertyLoadersPrivateName()));
 
-    auto* getterSetter = CustomGetterSetter::create(vm, lazyPropertyGetter, nullptr);
+    auto* valueGetter = CustomGetterSetter::create(vm, lazyValueGetter, nullptr);
+    auto* propertyGetter = CustomGetterSetter::create(vm, lazyPropertyGetter, nullptr);
     unsigned length = keys->length();
     for (unsigned i = 0; i < length; i++) {
         JSValue keyValue = keys->getIndex(globalObject, i);
@@ -82,13 +115,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefineLazyProperties, (JSGlobalObject * globa
         RETURN_IF_EXCEPTION(scope, {});
 
         // putDirectCustomAccessor only adds new properties.
-        if (isValidOffset(target->getDirectOffset(vm, key)) || parseIndex(key)) [[unlikely]] {
+        if (isValidOffset(target->getDirectOffset(vm, key)) || isValidOffset(values->getDirectOffset(vm, key)) || parseIndex(key)) [[unlikely]] {
             throwTypeError(globalObject, scope, makeString("defineLazyProperties: \""_s, key.string(), "\" is already defined on the target or is an index"_s));
             return {};
         }
 
         loaders->putDirect(vm, key, loader, 0);
-        target->putDirectCustomAccessor(vm, key, getterSetter, PropertyAttribute::CustomValue | 0);
+        values->putDirectCustomAccessor(vm, key, valueGetter, PropertyAttribute::CustomValue | 0);
+        target->putDirectCustomAccessor(vm, key, propertyGetter, PropertyAttribute::CustomValue | 0);
     }
 
     return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/DefineLazyProperties.cpp
+++ b/src/jsc/bindings/DefineLazyProperties.cpp
@@ -1,0 +1,102 @@
+#include "root.h"
+#include "DefineLazyProperties.h"
+#include "BunClientData.h"
+
+#include <JavaScriptCore/CallData.h>
+#include <JavaScriptCore/CustomGetterSetter.h>
+#include <JavaScriptCore/IdentifierInlines.h>
+#include <JavaScriptCore/JSArray.h>
+#include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/JSObjectInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+
+namespace Bun {
+
+using namespace JSC;
+
+// The loaders live on the target under a private name (invisible to user
+// code), keyed by property name. A CustomGetterSetter carries no payload, so
+// this is how one native getter serves every lazy property.
+static JSObject* lazyPropertyLoaders(VM& vm, JSObject* target)
+{
+    JSValue loaders = target->getDirect(vm, WebCore::builtinNames(vm).lazyPropertyLoadersPrivateName());
+    return loaders ? loaders.getObject() : nullptr;
+}
+
+JSC_DEFINE_CUSTOM_GETTER(lazyPropertyGetter, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // For a CustomValue, JSC passes the object that owns the property, not the receiver.
+    JSObject* thisObject = JSValue::decode(thisValue).getObject();
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    JSObject* loaders = lazyPropertyLoaders(vm, thisObject);
+    if (!loaders) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    JSValue loader = loaders->getDirect(vm, propertyName);
+    if (!loader || !loader.isCallable()) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    MarkedArgumentBuffer args;
+    args.append(identifierToJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
+    JSValue value = call(globalObject, loader, getCallData(loader), jsUndefined(), args);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    // Replace the getter with the value, as a plain data property with the
+    // same enumerable/configurable bits. Skip if the loader redefined the
+    // property itself, or if the object was frozen in the meantime (a
+    // ReadOnly CustomValue must stay read-only).
+    unsigned attributes = 0;
+    PropertyOffset offset = thisObject->getDirectOffset(vm, propertyName, attributes);
+    if (isValidOffset(offset) && (attributes & PropertyAttribute::CustomValue) && !(attributes & PropertyAttribute::ReadOnly)) {
+        thisObject->putDirect(vm, propertyName, value, attributesForStructure(attributes) & ~static_cast<unsigned>(PropertyAttribute::CustomValue));
+    }
+
+    return JSValue::encode(value);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionDefineLazyProperties, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* target = callFrame->argument(0).getObject();
+    JSArray* keys = dynamicDowncast<JSArray>(callFrame->argument(1));
+    JSValue loader = callFrame->argument(2);
+    if (!target || !keys || !loader.isCallable()) [[unlikely]] {
+        throwTypeError(globalObject, scope, "defineLazyProperties(target, keys, loader) expects an object, an array of property names and a function"_s);
+        return {};
+    }
+
+    JSObject* loaders = lazyPropertyLoaders(vm, target);
+    if (!loaders) {
+        loaders = constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
+        target->putDirect(vm, WebCore::builtinNames(vm).lazyPropertyLoadersPrivateName(), loaders, 0);
+    }
+
+    auto* getterSetter = CustomGetterSetter::create(vm, lazyPropertyGetter, nullptr);
+    unsigned length = keys->length();
+    for (unsigned i = 0; i < length; i++) {
+        JSValue keyValue = keys->getIndex(globalObject, i);
+        RETURN_IF_EXCEPTION(scope, {});
+        Identifier key = keyValue.toPropertyKey(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+
+        // putDirectCustomAccessor only adds new properties.
+        if (isValidOffset(target->getDirectOffset(vm, key)) || parseIndex(key)) [[unlikely]] {
+            throwTypeError(globalObject, scope, makeString("defineLazyProperties: \""_s, key.string(), "\" is already defined on the target or is an index"_s));
+            return {};
+        }
+
+        loaders->putDirect(vm, key, loader, 0);
+        target->putDirectCustomAccessor(vm, key, getterSetter, PropertyAttribute::CustomValue | 0);
+    }
+
+    return JSValue::encode(jsUndefined());
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/DefineLazyProperties.cpp
+++ b/src/jsc/bindings/DefineLazyProperties.cpp
@@ -46,13 +46,13 @@ JSC_DEFINE_CUSTOM_GETTER(lazyPropertyGetter, (JSGlobalObject * globalObject, Enc
     JSValue value = call(globalObject, loader, getCallData(loader), jsUndefined(), args);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Replace the getter with the value, as a plain data property with the
-    // same enumerable/configurable bits. Skip if the loader redefined the
-    // property itself, or if the object was frozen in the meantime (a
-    // ReadOnly CustomValue must stay read-only).
+    // Replace the getter with the value, as a data property with the same
+    // attributes (a frozen target keeps ReadOnly | DontDelete, as V8's
+    // ReconfigureDataProperty does). Skip if the loader redefined the
+    // property itself.
     unsigned attributes = 0;
     PropertyOffset offset = thisObject->getDirectOffset(vm, propertyName, attributes);
-    if (isValidOffset(offset) && (attributes & PropertyAttribute::CustomValue) && !(attributes & PropertyAttribute::ReadOnly)) {
+    if (isValidOffset(offset) && (attributes & PropertyAttribute::CustomValue)) {
         thisObject->putDirect(vm, propertyName, value, attributesForStructure(attributes) & ~static_cast<unsigned>(PropertyAttribute::CustomValue));
     }
 

--- a/src/jsc/bindings/DefineLazyProperties.h
+++ b/src/jsc/bindings/DefineLazyProperties.h
@@ -4,12 +4,8 @@
 
 namespace Bun {
 
-// defineLazyProperties(target, keys, loader): defines each key on target as a
-// lazy data property. The first read calls loader(key) and stores the result
-// as a plain writable, enumerable, configurable data property. Until then the
-// property is a JSC CustomValue, which Object.getOwnPropertyDescriptor reports
-// as a data descriptor, so descriptor-based wrappers (sinon, spyOn) see a
-// function `value` and not an accessor. Mirrors node's SetLazyDataProperty.
+// defineLazyProperties(target, keys, loader): CustomValue data properties whose first read
+// stores loader(key). The JSC counterpart of V8's SetLazyDataProperty.
 JSC_DECLARE_HOST_FUNCTION(jsFunctionDefineLazyProperties);
 
 } // namespace Bun

--- a/src/jsc/bindings/DefineLazyProperties.h
+++ b/src/jsc/bindings/DefineLazyProperties.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "root.h"
+
+namespace Bun {
+
+// defineLazyProperties(target, keys, loader): defines each key on target as a
+// lazy data property. The first read calls loader(key) and stores the result
+// as a plain writable, enumerable, configurable data property. Until then the
+// property is a JSC CustomValue, which Object.getOwnPropertyDescriptor reports
+// as a data descriptor, so descriptor-based wrappers (sinon, spyOn) see a
+// function `value` and not an accessor. Mirrors node's SetLazyDataProperty.
+JSC_DECLARE_HOST_FUNCTION(jsFunctionDefineLazyProperties);
+
+} // namespace Bun

--- a/src/jsc/bindings/DefineLazyProperties.h
+++ b/src/jsc/bindings/DefineLazyProperties.h
@@ -4,8 +4,7 @@
 
 namespace Bun {
 
-// defineLazyProperties(target, keys, loader): CustomValue data properties whose first read
-// stores loader(key). The JSC counterpart of V8's SetLazyDataProperty.
+// defineLazyProperties(target, keys, loader): like V8's SetLazyDataProperty, the first read stores loader(key).
 JSC_DECLARE_HOST_FUNCTION(jsFunctionDefineLazyProperties);
 
 } // namespace Bun

--- a/src/jsc/bindings/DefineLazyProperties.h
+++ b/src/jsc/bindings/DefineLazyProperties.h
@@ -1,10 +1,17 @@
 #pragma once
 
 #include "root.h"
+#include <JavaScriptCore/PropertySlot.h>
 
 namespace Bun {
 
 // defineLazyProperties(target, keys, loader): like V8's SetLazyDataProperty, the first read stores loader(key).
 JSC_DECLARE_HOST_FUNCTION(jsFunctionDefineLazyProperties);
+
+// The object that holds the loader result for each lazy property of `target`, or null if it has none.
+JSC::JSObject* lazyPropertyValues(JSC::VM&, JSC::JSObject* target);
+
+// True if the slot is a lazy property that nothing has read or replaced.
+bool isPendingLazyProperty(const JSC::PropertySlot&);
 
 } // namespace Bun

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1532,8 +1532,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
     bool hasValue = object->getPropertySlot(globalObject, propertyKey, slot);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // A CustomValue with no setter (process.env keys, util.inspect) is a data property to JS. One with a
-    // native setter (Error.prepareStackTrace, onmessage) must keep its CustomGetterSetter cell.
+    // A setter-less CustomValue (process.env keys, util.inspect) is a data property to JS; one with a setter is not.
     bool isCustomValue = hasValue && slot.isCustom() && (slot.attributes() & PropertyAttribute::CustomValue) && !slot.customSetter();
     unsigned slotAttributes = hasValue ? (slot.attributes() & ~static_cast<unsigned>(PropertyAttribute::CustomValue)) : 0;
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1532,8 +1532,14 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
     bool hasValue = object->getPropertySlot(globalObject, propertyKey, slot);
     RETURN_IF_EXCEPTION(scope, {});
 
+    // A CustomValue (process.env keys, lazy module exports such as util.inspect) is a data
+    // property to JS: the native getter runs once and stores the value. Treat it like a value.
+    // The attribute bit must not survive into a putDirect of a non-CustomGetterSetter cell.
+    bool isCustomValue = hasValue && slot.isCustom() && (slot.attributes() & PropertyAttribute::CustomValue);
+    unsigned slotAttributes = hasValue ? (slot.attributes() & ~static_cast<unsigned>(PropertyAttribute::CustomValue)) : 0;
+
     // easymode: regular property or missing property
-    if (!hasValue || slot.isValue()) {
+    if (!hasValue || slot.isValue() || isCustomValue) {
         JSValue value = jsUndefined();
         if (hasValue) {
             if (slot.isTaintedByOpaqueObject()) [[unlikely]] {
@@ -1553,12 +1559,12 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
         auto* mock = JSMockFunction::create(vm, globalObject, globalObject->mockModule.mockFunctionStructure.getInitializedOnMainThread(globalObject), CallbackKind::GetterSetter);
         mock->spyTarget = JSC::Weak<JSObject>(object, &weakValueHandleOwner(), nullptr);
         mock->spyIdentifier = propertyKey.isSymbol() ? Identifier::fromUid(vm, propertyKey.uid()) : Identifier::fromString(vm, propertyKey.publicName());
-        mock->spyAttributes = hasValue ? slot.attributes() : 0;
+        mock->spyAttributes = slotAttributes;
         unsigned attributes = 0;
 
         if (hasValue && ((slot.attributes() & PropertyAttribute::Function) != 0 || (value.isCell() && value.isCallable()))) {
             if (hasValue)
-                attributes = slot.attributes();
+                attributes = slotAttributes;
 
             mock->copyNameAndLength(vm, globalObject, value);
             RETURN_IF_EXCEPTION(scope, {});
@@ -1585,7 +1591,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             }
 
             if (hasValue)
-                attributes = slot.attributes();
+                attributes = slotAttributes;
 
             attributes |= PropertyAttribute::Accessor;
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1532,8 +1532,9 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
     bool hasValue = object->getPropertySlot(globalObject, propertyKey, slot);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // A CustomValue (process.env keys, util.inspect) is a data property to JS; strip the bit before putDirect.
-    bool isCustomValue = hasValue && slot.isCustom() && (slot.attributes() & PropertyAttribute::CustomValue);
+    // A CustomValue with no setter (process.env keys, util.inspect) is a data property to JS. One with a
+    // native setter (Error.prepareStackTrace, onmessage) must keep its CustomGetterSetter cell.
+    bool isCustomValue = hasValue && slot.isCustom() && (slot.attributes() & PropertyAttribute::CustomValue) && !slot.customSetter();
     unsigned slotAttributes = hasValue ? (slot.attributes() & ~static_cast<unsigned>(PropertyAttribute::CustomValue)) : 0;
 
     // easymode: regular property or missing property

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1532,8 +1532,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
     bool hasValue = object->getPropertySlot(globalObject, propertyKey, slot);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // A CustomValue (process.env keys, util.inspect) is a data property to JS. Its attribute bit
-    // must not reach a putDirect of a plain value.
+    // A CustomValue (process.env keys, util.inspect) is a data property to JS; strip the bit before putDirect.
     bool isCustomValue = hasValue && slot.isCustom() && (slot.attributes() & PropertyAttribute::CustomValue);
     unsigned slotAttributes = hasValue ? (slot.attributes() & ~static_cast<unsigned>(PropertyAttribute::CustomValue)) : 0;
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1532,9 +1532,8 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
     bool hasValue = object->getPropertySlot(globalObject, propertyKey, slot);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // A CustomValue (process.env keys, lazy module exports such as util.inspect) is a data
-    // property to JS: the native getter runs once and stores the value. Treat it like a value.
-    // The attribute bit must not survive into a putDirect of a non-CustomGetterSetter cell.
+    // A CustomValue (process.env keys, util.inspect) is a data property to JS. Its attribute bit
+    // must not reach a putDirect of a plain value.
     bool isCustomValue = hasValue && slot.isCustom() && (slot.attributes() & PropertyAttribute::CustomValue);
     unsigned slotAttributes = hasValue ? (slot.attributes() & ~static_cast<unsigned>(PropertyAttribute::CustomValue)) : 0;
 

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -96,8 +96,7 @@ static JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator generateIntern
 
         bool hasDefault = false;
         bool hasLazyExports = false;
-        // A module with defineLazyProperties (node:util) defers only its pending lazy properties, and JSC reads them
-        // from the values object, not from `object`. Node's ESM facade also keeps the module's own values.
+        // With defineLazyProperties (node:util), only pending lazy properties defer, and they bind the loader result.
         JSObject* lazyValues = Bun::lazyPropertyValues(vm, object);
 
         for (auto& entry : properties) {

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -40,6 +40,7 @@
 #include "../modules/_NativeModule.h"
 
 #include "JSCommonJSExtensions.h"
+#include "DefineLazyProperties.h"
 
 #include "BunProcess.h"
 
@@ -95,6 +96,9 @@ static JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator generateIntern
 
         bool hasDefault = false;
         bool hasLazyExports = false;
+        // A module with defineLazyProperties (node:util) defers only its pending lazy properties, and JSC reads them
+        // from the values object, not from `object`. Node's ESM facade also keeps the module's own values.
+        JSObject* lazyValues = Bun::lazyPropertyValues(vm, object);
 
         for (auto& entry : properties) {
             if (entry == vm.propertyNames->defaultKeyword) [[unlikely]] {
@@ -107,7 +111,11 @@ static JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator generateIntern
             RETURN_IF_EXCEPTION(throwScope, nullptr);
             // Accessors are how builtins defer loading (fs.ReadStream pulls in node:stream); JSC reads them off `object` on
             // first binding. An accessor user code defined on the exports object is read now instead (see isBunDefinedGetter).
-            if (hasOwn && (slot.isCustom() || (slot.isAccessor() && Zig::isBunDefinedGetter(slot.getterSetter()->getter())))) {
+            bool isLazy = hasOwn
+                && (lazyValues
+                        ? Bun::isPendingLazyProperty(slot)
+                        : slot.isCustom() || (slot.isAccessor() && Zig::isBunDefinedGetter(slot.getterSetter()->getter())));
+            if (isLazy) {
                 exportValues.append(JSValue());
                 hasLazyExports = true;
                 continue;
@@ -123,7 +131,9 @@ static JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator generateIntern
             exportValues.append(object);
         }
 
-        return hasLazyExports ? object : nullptr;
+        if (!hasLazyExports)
+            return nullptr;
+        return lazyValues ? lazyValues : object;
     };
 }
 

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -339,6 +339,90 @@ test.concurrent("spyOn and mock.module on an imported builtin", async () => {
   expect(exitCode).toBe(0);
 });
 
+// node:util and node:readline define their lazy exports with defineLazyProperties (internal/shared). Those are data
+// properties, not accessors, so the readout is the number of functions on the heap: internal/util/inspect adds about
+// 230 when it loads.
+test.concurrent("node:util: importing the module does not load internal/util/inspect", async () => {
+  const result = await runEntry(`
+    import { heapStats } from "bun:jsc";
+    import { createRequire } from "node:module";
+    import { print } from "./helper.mjs";
+    const require = createRequire(import.meta.url);
+    const util = require("node:util");
+    const functions = () => heapStats().objectTypeCounts.Function;
+    const beforeImport = functions();
+    const ns = await import("node:util");
+    const afterImport = functions();
+    const inspect = ns.inspect;
+    const afterRead = functions();
+    const readline = await import("node:readline");
+    print({
+      importLoadedInspect: afterImport - beforeImport > 100,
+      readLoadedInspect: afterRead - afterImport > 100,
+      sameFunction: inspect === util.inspect && ns.format === util.format,
+      readlinePromises: readline.promises === require("node:readline/promises"),
+    });
+  `);
+  expect(result).toEqual({
+    importLoadedInspect: false,
+    readLoadedInspect: true,
+    sameFunction: true,
+    readlinePromises: true,
+  });
+});
+
+// Node's ESM facade for a builtin copies the exports when the facade is created. A value that user code stored
+// before that is what gets bound.
+test.concurrent("node:util: a value stored before the first import is what gets bound", async () => {
+  const result = await runEntry(`
+    import { createRequire } from "node:module";
+    import { print } from "./helper.mjs";
+    const util = createRequire(import.meta.url)("node:util");
+    const stub = () => "stub";
+    util.format = stub;
+    const ns = await import("node:util");
+    print({ format: ns.format === stub, inspect: ns.inspect === util.inspect });
+  `);
+  expect(result).toEqual({ format: true, inspect: true });
+});
+
+// A lazy binding of node:util is read on first use, from the module's own values. So a spy on the exports object does
+// not reach it, during the spy or after mockRestore(). In Node, the facade keeps the module's values too.
+test.concurrent("node:util: a spy on the exports object does not reach the ESM bindings", async () => {
+  const { stderr, exitCode } = await run(
+    {
+      "namespace.mjs": `import * as util from "node:util";\nexport const viaNamespace = (...args) => util.format(...args);\n`,
+      "named.mjs": `import { format } from "node:util";\nexport const viaNamed = (...args) => format(...args);\n`,
+      "spy.test.mjs": `
+        import { expect, spyOn, test } from "bun:test";
+        import util from "node:util";
+        import { viaNamespace } from "./namespace.mjs";
+
+        test("the first read of each binding happens during the spy", async () => {
+          const spy = spyOn(util, "format").mockReturnValue("mocked");
+          try {
+            expect(util.format("%s", "x")).toBe("mocked");
+            expect(viaNamespace("%s", "x")).toBe("x");
+            const { viaNamed } = await import("./named.mjs");
+            expect(viaNamed("%s", "y")).toBe("y");
+          } finally {
+            spy.mockRestore();
+          }
+        });
+
+        test("the bindings still format after mockRestore", async () => {
+          const { viaNamed } = await import("./named.mjs");
+          expect([viaNamespace("%s!", "a"), viaNamed("%s!", "b"), util.format("%s!", "c")]).toEqual(["a!", "b!", "c!"]);
+        });
+      `,
+    },
+    ["test", "./spy.test.mjs"],
+  );
+  expect(stderr).toContain(" 2 pass\n");
+  expect(stderr).toContain(" 0 fail\n");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent('"bun": re-exports construct the properties that get bound, not the rest of the object', async () => {
   const result = await runEntry(
     `

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1219,6 +1219,37 @@ describe("spyOn", () => {
       expect(Bar.prototype()).toBe(7);
       expect(fn).not.toHaveBeenCalled();
     });
+
+    // console.Console is a native lazy property: a getter computes it on the first read and
+    // stores it as a plain value. To JS it is a data property, so spyOn treats it as one.
+    test("spyOn on a native lazy data property", () => {
+      const fn = spyOn(console, "Console").mockImplementation(() => "mocked");
+      expect(console.Console).toBe(fn);
+      expect(console.Console()).toBe("mocked");
+      expect(fn).toHaveBeenCalledTimes(1);
+      fn.mockRestore();
+      expect(console.Console.name).toBe("Console");
+      expect(typeof new console.Console(process.stdout).log).toBe("function");
+      expect(Object.getOwnPropertyDescriptor(console, "Console")).toEqual({
+        value: console.Console,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    });
+
+    // Error.prepareStackTrace has a native setter that feeds stack formatting. Replacing the
+    // property with a mock would detach that setter, so spyOn refuses it.
+    test("spyOn on a native property with a setter throws and leaves it intact", () => {
+      expect(() => spyOn(Error, "prepareStackTrace")).toThrow("does not support accessor properties yet");
+      const previous = Error.prepareStackTrace;
+      Error.prepareStackTrace = (_err, frames) => "custom stack " + frames.length;
+      try {
+        expect(new Error("x").stack).toStartWith("custom stack ");
+      } finally {
+        Error.prepareStackTrace = previous;
+      }
+    });
   }
 
   // spyOn does not work with getters/setters yet.

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1258,6 +1258,37 @@ describe("spyOn", () => {
         Error.prepareStackTrace = previous;
       }
     });
+
+    // A process.env key that nothing has read is a native lazy property, so this needs a fresh process.
+    // On Windows, process.env is a Proxy, and its keys are not native lazy properties.
+    test.skipIf(process.platform === "win32")("spyOn on a process.env key that nothing has read", async () => {
+      const fixture = `
+        const { spyOn } = require("bun:test");
+        const key = "BUN_SPYON_ENV_TEST";
+        const spy = spyOn(process.env, key);
+        const first = process.env[key];
+        spy.mockReturnValue("mocked");
+        const mocked = process.env[key];
+        const calls = spy.mock.calls.length;
+        spy.mockRestore();
+        console.log(JSON.stringify({ first, mocked, calls, descriptor: Object.getOwnPropertyDescriptor(process.env, key) }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [process.execPath, "-e", fixture],
+        env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1", BUN_SPYON_ENV_TEST: "from-env" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        first: "from-env",
+        mocked: "mocked",
+        calls: 2,
+        descriptor: { value: "from-env", writable: true, enumerable: true, configurable: true },
+      });
+      expect(exitCode).toBe(0);
+    });
   }
 
   // spyOn does not work with getters/setters yet.

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1262,6 +1262,8 @@ describe("spyOn", () => {
     // A process.env key that nothing has read is a native lazy property, so this needs a fresh process.
     // On Windows, process.env is a Proxy, and its keys are not native lazy properties.
     test.skipIf(process.platform === "win32")("spyOn on a process.env key that nothing has read", async () => {
+      // Jest and Vitest also run this file, and they cannot resolve "harness" at the top of it.
+      const { bunEnv, bunExe } = require("harness");
       const fixture = `
         const { spyOn } = require("bun:test");
         const key = "BUN_SPYON_ENV_TEST";
@@ -1274,8 +1276,8 @@ describe("spyOn", () => {
         console.log(JSON.stringify({ first, mocked, calls, descriptor: Object.getOwnPropertyDescriptor(process.env, key) }));
       `;
       await using proc = Bun.spawn({
-        cmd: [process.execPath, "-e", fixture],
-        env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1", BUN_SPYON_ENV_TEST: "from-env" },
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, BUN_SPYON_ENV_TEST: "from-env" },
         stdout: "pipe",
         stderr: "pipe",
       });

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1224,10 +1224,13 @@ describe("spyOn", () => {
     // stores it as a plain value. To JS it is a data property, so spyOn treats it as one.
     test("spyOn on a native lazy data property", () => {
       const fn = spyOn(console, "Console").mockImplementation(() => "mocked");
-      expect(console.Console).toBe(fn);
-      expect(console.Console()).toBe("mocked");
-      expect(fn).toHaveBeenCalledTimes(1);
-      fn.mockRestore();
+      try {
+        expect(console.Console).toBe(fn);
+        expect(console.Console()).toBe("mocked");
+        expect(fn).toHaveBeenCalledTimes(1);
+      } finally {
+        fn.mockRestore();
+      }
       expect(console.Console.name).toBe("Console");
       expect(typeof new console.Console(process.stdout).log).toBe("function");
       expect(Object.getOwnPropertyDescriptor(console, "Console")).toEqual({

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1244,7 +1244,12 @@ describe("spyOn", () => {
     // Error.prepareStackTrace has a native setter that feeds stack formatting. Replacing the
     // property with a mock would detach that setter, so spyOn refuses it.
     test("spyOn on a native property with a setter throws and leaves it intact", () => {
-      expect(() => spyOn(Error, "prepareStackTrace")).toThrow("does not support accessor properties yet");
+      let spy;
+      try {
+        expect(() => (spy = spyOn(Error, "prepareStackTrace"))).toThrow("does not support accessor properties yet");
+      } finally {
+        spy?.mockRestore();
+      }
       const previous = Error.prepareStackTrace;
       Error.prepareStackTrace = (_err, frames) => "custom stack " + frames.length;
       try {

--- a/test/js/node/readline/readline.node.test.ts
+++ b/test/js/node/readline/readline.node.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { bunEnv, bunExe } from "harness";
 import { createTest } from "node-harness";
 import { EventEmitter } from "node:events";
 import readline from "node:readline";
@@ -2103,5 +2104,47 @@ describe("readline.createInterface()", () => {
 
     assert.strictEqual(closed, true);
     assert.strictEqual(rl.closed, true);
+  });
+});
+
+describe("module init", () => {
+  it("readline.promises is a data property that loads node:readline/promises on first read", async () => {
+    // A fresh process, so nothing has read `promises` yet.
+    const fixture = `
+      const readline = require("node:readline");
+      const before = Object.getOwnPropertyDescriptor(readline, "promises");
+      const promises = readline.promises;
+      const after = Object.getOwnPropertyDescriptor(readline, "promises");
+      console.log(JSON.stringify({
+        before: { value: typeof before.value, get: typeof before.get, writable: before.writable, enumerable: before.enumerable, configurable: before.configurable },
+        same: promises === require("node:readline/promises") && after.value === promises,
+        createInterface: typeof promises.createInterface,
+        keys: Object.keys(readline),
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    assert.strictEqual(stderr, "");
+    assert.deepStrictEqual(JSON.parse(stdout), {
+      before: { value: "object", get: "undefined", writable: true, enumerable: true, configurable: true },
+      same: true,
+      createInterface: "function",
+      keys: [
+        "Interface",
+        "clearLine",
+        "clearScreenDown",
+        "createInterface",
+        "cursorTo",
+        "emitKeypressEvents",
+        "moveCursor",
+        "promises",
+      ],
+    });
+    assert.strictEqual(exitCode, 0);
   });
 });

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -23,7 +23,7 @@
 
 import assert from "assert";
 import { exposedInternals } from "bun:internal-for-testing";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import util from "util";
 // const context = require('vm').runInNewContext; // TODO: Use a vm polyfill
@@ -662,5 +662,134 @@ describe("util.parseEnv", () => {
     parsed[0] = "set";
     expect(parsed[0]).toBe("set");
     expect(JSON.parse(JSON.stringify(parsed))).toEqual({ 0: "set", 2023: "y", A: "1", 4294967295: "notidx" });
+  });
+});
+
+// format, formatWithOptions, inspect and stripVTControlCharacters come from
+// internal/util/inspect, which loads on first use. Node exposes them as data
+// properties, so descriptor-based wrappers (sinon, spyOn) must see a `value`.
+describe("lazy inspect exports", () => {
+  const lazyKeys = ["format", "formatWithOptions", "inspect", "stripVTControlCharacters"];
+
+  it("are data properties before the first read, and load inspect on that read", async () => {
+    const fixture = `
+      const { heapStats } = require("bun:jsc");
+      const util = require("node:util");
+      const functionsAfterRequire = heapStats().objectTypeCounts.Function;
+      const keys = ${JSON.stringify(lazyKeys)};
+      const shape = d => ({ value: typeof d.value, get: typeof d.get, writable: d.writable, enumerable: d.enumerable, configurable: d.configurable });
+      const before = keys.map(k => shape(Object.getOwnPropertyDescriptor(util, k)));
+      const functionsAfterRead = heapStats().objectTypeCounts.Function;
+      // the descriptor-based wrapper pattern
+      const d = Object.getOwnPropertyDescriptor(util, "inspect");
+      const out = d.value.call(util, { a: 1 });
+      console.log(JSON.stringify({
+        before,
+        out,
+        same: util.inspect === d.value && util.format === require("node:util").format,
+        custom: typeof util.inspect.custom,
+        loadedOnRead: functionsAfterRead - functionsAfterRequire > 20,
+        after: shape(Object.getOwnPropertyDescriptor(util, "inspect")),
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const data = { value: "function", get: "undefined", writable: true, enumerable: true, configurable: true };
+    expect(JSON.parse(stdout)).toEqual({
+      before: [data, data, data, data],
+      out: "{ a: 1 }",
+      same: true,
+      custom: "symbol",
+      loadedOnRead: true,
+      after: data,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("spyOn works before the first read", async () => {
+    const fixture = `
+      const { spyOn } = require("bun:test");
+      const util = require("node:util");
+      const spy = spyOn(util, "format").mockReturnValue("mocked");
+      const mocked = util.format("%s", "x");
+      const calls = spy.mock.calls.length;
+      spy.mockRestore();
+      const d = Object.getOwnPropertyDescriptor(util, "format");
+      console.log(JSON.stringify({ mocked, calls, restored: util.format("%s!", "ok"), value: typeof d.value, get: typeof d.get }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      mocked: "mocked",
+      calls: 1,
+      restored: "ok!",
+      value: "function",
+      get: "undefined",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("spyOn works after the first read", () => {
+    expect(util.inspect({ a: 1 })).toBe("{ a: 1 }");
+    const spy = spyOn(util, "inspect").mockReturnValue("mocked");
+    try {
+      expect(util.inspect({ a: 1 })).toBe("mocked");
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(util.inspect({ a: 1 })).toBe("{ a: 1 }");
+    expect(Object.getOwnPropertyDescriptor(util, "inspect")).toEqual({
+      value: util.inspect,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  it("can be replaced through the descriptor, as sinon does", () => {
+    const original = Object.getOwnPropertyDescriptor(util, "stripVTControlCharacters");
+    expect(typeof original.value).toBe("function");
+    const stub = () => "stubbed";
+    Object.defineProperty(util, "stripVTControlCharacters", { ...original, value: stub });
+    try {
+      expect(util.stripVTControlCharacters("\u001b[31mx\u001b[0m")).toBe("stubbed");
+    } finally {
+      Object.defineProperty(util, "stripVTControlCharacters", original);
+    }
+    expect(util.stripVTControlCharacters("\u001b[31mx\u001b[0m")).toBe("x");
+  });
+
+  it("can be replaced by assignment and deleted", async () => {
+    const fixture = `
+      const util = require("node:util");
+      const stub = () => "stubbed";
+      util.formatWithOptions = stub;
+      const replaced = util.formatWithOptions === stub && Object.getOwnPropertyDescriptor(util, "formatWithOptions").value === stub;
+      const deleted = delete util.inspect;
+      console.log(JSON.stringify({ replaced, deleted, gone: !("inspect" in util), keys: Object.keys(util).filter(k => k === "inspect" || k === "format") }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ replaced: true, deleted: true, gone: true, keys: ["format"] });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -792,4 +792,34 @@ describe("lazy inspect exports", () => {
     expect(JSON.parse(stdout)).toEqual({ replaced: true, deleted: true, gone: true, keys: ["format"] });
     expect(exitCode).toBe(0);
   });
+
+  it("stay read-only on a frozen util, as in node", async () => {
+    const fixture = `
+      const util = require("node:util");
+      Object.freeze(util);
+      const shape = d => ({ value: typeof d.value, writable: d.writable, enumerable: d.enumerable, configurable: d.configurable });
+      const before = shape(Object.getOwnPropertyDescriptor(util, "inspect"));
+      const first = util.inspect;
+      util.inspect = () => "replaced";
+      const after = shape(Object.getOwnPropertyDescriptor(util, "inspect"));
+      console.log(JSON.stringify({ frozen: Object.isFrozen(util), before, after, same: util.inspect === first, out: util.inspect({ a: 1 }) }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const readOnly = { value: "function", writable: false, enumerable: true, configurable: false };
+    expect(JSON.parse(stdout)).toEqual({
+      frozen: true,
+      before: readOnly,
+      after: readOnly,
+      same: true,
+      out: "{ a: 1 }",
+    });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -671,7 +671,7 @@ describe("util.parseEnv", () => {
 describe("lazy inspect exports", () => {
   const lazyKeys = ["format", "formatWithOptions", "inspect", "stripVTControlCharacters"];
 
-  it("are data properties before the first read, and load inspect on that read", async () => {
+  it.concurrent("are data properties before the first read, and load inspect on that read", async () => {
     const fixture = `
       const { heapStats } = require("bun:jsc");
       const util = require("node:util");
@@ -712,7 +712,7 @@ describe("lazy inspect exports", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("spyOn works before the first read", async () => {
+  it.concurrent("spyOn works before the first read", async () => {
     const fixture = `
       const { spyOn } = require("bun:test");
       const util = require("node:util");
@@ -772,7 +772,7 @@ describe("lazy inspect exports", () => {
     expect(util.stripVTControlCharacters("\u001b[31mx\u001b[0m")).toBe("x");
   });
 
-  it("can be replaced by assignment and deleted", async () => {
+  it.concurrent("can be replaced by assignment and deleted", async () => {
     const fixture = `
       const util = require("node:util");
       const stub = () => "stubbed";
@@ -793,7 +793,7 @@ describe("lazy inspect exports", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("stay read-only on a frozen util, as in node", async () => {
+  it.concurrent("stay read-only on a frozen util, as in node", async () => {
     const fixture = `
       const util = require("node:util");
       Object.freeze(util);


### PR DESCRIPTION
### Problem
- Since #39628, `util.format`, `util.formatWithOptions`, `util.inspect`, `util.stripVTControlCharacters` and `readline.promises` are get/set accessors. Node 26 and Bun 1.4.0 define them as data properties. Descriptor-based stubs (sinon) fail, and `spyOn(util, "format")` throws `spyOn(target, prop) does not support accessor properties yet`.
- An ESM binding of these exports reads the exports object on first use (`src/jsc/bindings/ModuleLoader.cpp:110`). So `util.format = stub` before that read reaches `import * as util`. Node keeps the original.

### Fix
- A new internal helper, `defineLazyProperties(target, keys, loader)` in `internal/shared`, makes each key a data property. The first read stores `loader(key)`. `util` and `readline` use it. The alternative is eager exports, which give up the `require("util")` saving from #39628.
- The loader result lives in one values object per target. The ESM namespace binds a pending key from that object, so a stub or a spy on the exports object does not reach the binding.
- `spyOn` now accepts a `CustomValue` slot that has no native setter. `spyOn(Error, "prepareStackTrace")` still throws.
- Verified: 13 new tests in `util.test.js`, `readline.node.test.ts`, `mock-fn.test.js` and `builtin-esm-lazy-exports.test.ts`. 9 fail on the released build.

### Background
- A JSC `CustomValue` property holds a native getter, and JSC reports it as a data descriptor. `process.env` keys use it. Node uses V8's `SetLazyDataProperty`, the same idea.
- The ESM namespace of a builtin is a synthetic module. Bun defers the lazy exports, and JSC reads each one on first use.
- Node's ESM facade copies the exports when it is created.

<details><summary>Notes</summary>

**Scope.** #39628 added other export accessors: `fs.promises`, `net.BlockList` and `net.SocketAddress`. Node defines those as accessors too, so they stay. `assert.AssertionError`, `assert.CallTracker`, `tls.DEFAULT_*`, `os.tmpdir` and three `node:repl` exports were accessors before #39628. They differ from Node, but they did not regress. The `assert` case also copies descriptors at init, and a `CustomValue` would load the module there.

**ESM bindings.** A self-review of an earlier revision found that a binding took whatever the exports object held on its first read. With `spyOn(util, "format")` first, `import * as util` kept the mock, and calls returned `undefined` after `mockRestore()`. The canary build has the same capture with a plain assignment. Now `generateInternalModuleSourceCode` defers only the pending lazy properties of a module that uses the helper, and it returns the values object as the source of the lazy exports. A value stored before the namespace exists is bound, as in Node. Other accessors of such a module are read when the namespace is created. `util` and `readline` have none.

**Behavior checked against Node 26.3.0** (same output on the debug build): descriptor shape before and after the first read, identity with the internal module, `inspect.custom`, assignment and `defineProperty` on an untouched key, `delete`, `Object.freeze` and `Object.seal` before the first read, `{...util}`, `Object.assign`, `getOwnPropertyDescriptors`, `JSON.stringify`, ESM default, named and namespace imports, a stub before the first import, and a spy before the first read of a binding. `require("node:sys")` is the same object as `util`.

**Laziness.** Functions on the heap, debug build: `require("util")` adds about 350, and the first `util.inspect` read adds about 230. The accessor version gives the same numbers. Creating the ESM namespace adds 1 on this branch and 0 on the canary build. The lazy keys now sit at the end of `Object.keys(util)`. Node also appends its lazy exports.

**JSC details.** `putDirectCustomAccessor` with `CustomValue` stores a `CustomGetterSetter`. The getter materializes the value with `putDirect`, with the slot attributes minus `CustomValue`. That is an attribute-change transition, and it keeps `ReadOnly | DontDelete` on a frozen target, as V8's `ReconfigureDataProperty` does. A plain `put` on a `CustomValue` with no setter replaces it with a data property (`JSObject::putInlineSlow`). That is also why `spyOn` treats such a slot as data.

**spyOn.** `spyOn(process.env, key)` on a key that nothing has read and `spyOn(console, "Console")` threw before and work now. `TZ`, the proxy env vars, `onmessage` and `Error.prepareStackTrace` keep their native setter, so `spyOn` still refuses them. The restore path strips the `CustomValue` bit, because `putDirect` of a plain value must not carry it. The open PRs #36394 and #36395 also edit `JSMock__jsSpyOn`. The later one to land needs a small merge.

**Fallback.** If this needs more review than the 1.4.1 cut allows, a revert of the `util.ts` and `readline.js` export hunks of #39628 restores the 1.4.0 behavior. That revert loads `internal/util/inspect` at `require("util")` again.

**Suites run on the debug build.** `test/js/bun/resolve/`, `test/js/node/util/`, `test/js/node/readline/`, `test/js/node/module/`, `test/js/bun/test/mock*`, `spyMatchers.test.ts`, `test/cli/test/isolation.test.ts`, and Node's `test-util-*` and `test-readline-*` parallel tests. The probe scripts also pass with `BUN_JSC_validateExceptionChecks=1`.

**Failures that also occur without this diff.** Under the local debug ASAN build, these time out: `parseArgs` stress, the `util-inspect` "no assertion failures 2" test, and both tests in `load-same-js-file-a-lot.test.ts`, which imports a user file 2,000 times. `stdin-pause-pty` hits its 3 s alarm. `process.test.js` expects `USER` in the environment, and my local environment does not set it.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/mock-fn.test.js

<!-- robobun:evidence:end -->