### PR TITLE
bun-types: declare memoryPressure in ProcessEventMap, not as Process overloads

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -94,35 +94,11 @@ declare global {
       _exiting: boolean;
       noDeprecation?: boolean | undefined;
 
-      /**
-       * Emitted when the operating system signals that available memory is
-       * running low. Use this to release caches or reap idle resources instead
-       * of polling.
-       *
-       * On macOS `level` distinguishes `"warning"` from `"critical"` based on
-       * the kernel's memorystatus thresholds. On Linux (PSI) and Windows the
-       * event is always emitted with `"critical"`. On Linux, the underlying
-       * PSI trigger requires `CAP_SYS_RESOURCE` on kernels before 6.6; when
-       * unavailable the event is never emitted.
-       *
-       * This listener does not keep the event loop alive.
-       */
-      on(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
-      once(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
-      off(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
-      addListener(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
-      removeListener(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
-      prependListener(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
-      prependOnceListener(event: "memoryPressure", listener: (level: "warning" | "critical") => void): this;
-      emit(event: "memoryPressure", level: "warning" | "critical"): boolean;
-
-      // @types/node <= 24 does not declare `off`/`removeListener` directly on
-      // `Process` (they are only inherited from EventEmitter), so the
-      // `memoryPressure` overloads above would hide the inherited generic
-      // signatures and reject every other event name (#40003). Re-declare the
-      // generic signatures so both stay visible.
-      off(event: string | symbol, listener: (...args: any[]) => void): this;
-      removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+      // Bun's process events go in the `ProcessEventMap` augmentation at the
+      // bottom of this file. Do not declare `on`/`once`/`emit`/... overloads
+      // here: a method declared on this merge hides the one `Process`
+      // inherits, so on @types/node releases where `Process` inherits its
+      // event methods, every other event name is rejected (#39807, #40003).
 
       binding(m: "constants"): {
         os: typeof import("node:os").constants;
@@ -346,6 +322,25 @@ declare global {
 
 declare module "node:fs/promises" {
   function exists(path: Bun.PathLike): Promise<boolean>;
+}
+
+declare module "node:process" {
+  interface ProcessEventMap {
+    /**
+     * Emitted when the operating system signals that available memory is
+     * running low. Use this to release caches or reap idle resources instead
+     * of polling.
+     *
+     * On macOS `level` distinguishes `"warning"` from `"critical"` based on
+     * the kernel's memorystatus thresholds. On Linux (PSI) and Windows the
+     * event is always emitted with `"critical"`. On Linux, the underlying
+     * PSI trigger requires `CAP_SYS_RESOURCE` on kernels before 6.6; when
+     * unavailable the event is never emitted.
+     *
+     * This listener does not keep the event loop alive.
+     */
+    memoryPressure: [level: "warning" | "critical"];
+  }
 }
 
 declare module "node:tls" {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -394,6 +394,46 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // fixture/package.json resolves @types/node to latest, so the runs above
+  // never see the release the repo itself pins (package.json#resolutions),
+  // and a declaration that only breaks on an older release (the "process
+  // event methods" checks below) passes them. This run checks the whole
+  // fixture against that pin.
+  describe("@types/node at the repo's pin", () => {
+    test.skipIf(isDebug)("checks the fixture against the pinned @types/node", async () => {
+      const rootPkg = JSON.parse(readFileSync(join(BUN_REPO_ROOT, "package.json"), "utf8"));
+      const pin: string = rootPkg.resolutions["@types/node"];
+
+      const fixtureDir = await createIsolatedFixture();
+      const fixturePkg = await Bun.file(join(fixtureDir, "package.json")).json();
+      fixturePkg.resolutions["@types/node"] = pin;
+      await Bun.write(join(fixtureDir, "package.json"), JSON.stringify(fixturePkg, null, 2));
+      await $`cd ${fixtureDir} && bun add @types/node@${pin}`.quiet();
+
+      const nodeTypesPkg = await Bun.file(join(fixtureDir, "node_modules", "@types", "node", "package.json")).json();
+      expect(Bun.semver.satisfies(nodeTypesPkg.version, pin)).toBe(true);
+
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.compilerOptions.skipLibCheck = false;
+      tsconfig.include = ["*.ts", "*.tsx"];
+      await Bun.write(join(fixtureDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(fixtureDir, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: fixtureDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   // Runs on debug builds too: spawning tsc over a single file is cheap,
   // unlike the in-process LanguageService runs above.
   describe("Bun.mmap", () => {
@@ -552,29 +592,25 @@ describe("@types/bun integration test", () => {
   });
 
   // Also runs on debug builds: spawned tsc over a single file, like the
-  // Bun.mmap check above. @types/node@24 declares `off`/`removeListener` only
-  // on EventEmitter, not on `Process`, so the `memoryPressure` overloads in
-  // overrides.d.ts used to hide the inherited signatures and reject every
-  // other event name (#40003). @types/node >= 26 declares them on `Process`
-  // directly, which masks the bug, so this check pins @types/node@24 instead
-  // of reusing the base fixture.
-  describe("process event methods with @types/node@24", () => {
-    test("removeListener and off accept other event names", async () => {
-      const checkDir = join(TEMP_DIR, "types-node-24-check");
+  // Bun.mmap check above. A method declared on bun-types' `Process` merge
+  // hides the one `Process` inherits. The `memoryPressure` overloads that
+  // overrides.d.ts used to declare there rejected every other event name for
+  // `off`/`removeListener` on @types/node 24 (#40003) and for every event
+  // method on 25.0.0 through 25.0.9, where `Process` inherits all of them
+  // (#39807). @types/node@latest, which the base fixture resolves, declares
+  // them on `Process` directly and masks both, so these checks pin the version.
+  describe("process event methods", () => {
+    async function checkProcessEvents(name: string, typesNodeSpec: string, versionPrefix: string, source: string) {
+      const checkDir = join(TEMP_DIR, name);
       const tsconfig = structuredClone(sourceTsconfig);
       tsconfig.include = ["index.ts"];
       await mkdir(checkDir, { recursive: true });
       await makeTree(checkDir, {
-        "package.json": JSON.stringify({ name: "types-node-24-check", private: true }),
+        "package.json": JSON.stringify({ name, private: true }),
         "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "index.ts": `process.removeListener("SIGINT", () => {});
-           process.off("unhandledRejection", () => {});
-           process.removeListener("memoryPressure", () => {});
-           process.on("memoryPressure", level => {
-             level satisfies "warning" | "critical";
-           });`,
+        "index.ts": source,
       });
-      await $`cd ${checkDir} && bun add @types/node@24`.quiet();
+      await $`cd ${checkDir} && bun add @types/node@${typesNodeSpec}`.quiet();
       await cp(join(BASE_FIXTURE_DIR, "node_modules", "bun-types"), join(checkDir, "node_modules", "bun-types"), {
         recursive: true,
       });
@@ -584,9 +620,9 @@ describe("@types/bun integration test", () => {
         { recursive: true },
       );
 
-      // Guard against resolution drift silently checking the wrong major.
+      // Guard against resolution drift silently checking the wrong version.
       const nodeTypesPkg = await Bun.file(join(checkDir, "node_modules", "@types", "node", "package.json")).json();
-      expect(nodeTypesPkg.version).toStartWith("24.");
+      expect(nodeTypesPkg.version).toStartWith(versionPrefix);
 
       await using proc = Bun.spawn({
         cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
@@ -601,6 +637,68 @@ describe("@types/bun integration test", () => {
       expect(stderr.trim()).toBe("");
       expect(stdout.trim()).toBe("");
       expect(exitCode).toBe(0);
+    }
+
+    // @types/node 24 has no `ProcessEventMap`, so `memoryPressure` is only an
+    // unknown event name there: accepted, with an untyped listener.
+    test("removeListener and off accept other event names with @types/node@24", async () => {
+      await checkProcessEvents(
+        "types-node-24-check",
+        "24",
+        "24.",
+        `process.removeListener("SIGINT", () => {});
+         process.off("unhandledRejection", () => {});
+         process.removeListener("memoryPressure", () => {});
+         process.on("memoryPressure", () => {});`,
+      );
+    });
+
+    // `NotAny<typeof arg>` is `never` when the listener argument is `any`, and
+    // `any` is not assignable to `never`, so a listener that only type-checks
+    // through the untyped `(...args: any[])` fallback fails here too.
+    test("every event method keeps its typed signatures with @types/node@25.0", async () => {
+      await checkProcessEvents(
+        "types-node-25-0-check",
+        "25.0.0",
+        "25.0.",
+        `type NotAny<T> = 0 extends 1 & T ? never : T;
+         process.on("SIGINT", signal => {
+           const typed: NotAny<typeof signal> = signal;
+           typed satisfies NodeJS.Signals;
+         });
+         process.once("beforeExit", code => {
+           const typed: NotAny<typeof code> = code;
+           typed satisfies number;
+         });
+         process.addListener("exit", code => {
+           const typed: NotAny<typeof code> = code;
+           typed satisfies number;
+         });
+         process.prependListener("uncaughtException", error => {
+           const typed: NotAny<typeof error> = error;
+           typed satisfies Error;
+         });
+         process.prependOnceListener("unhandledRejection", (reason, promise) => {
+           const typed: NotAny<typeof promise> = promise;
+           typed satisfies Promise<unknown>;
+         });
+         process.off("exit", code => {
+           const typed: NotAny<typeof code> = code;
+           typed satisfies number;
+         });
+         process.removeListener("SIGTERM", signal => {
+           const typed: NotAny<typeof signal> = signal;
+           typed satisfies NodeJS.Signals;
+         });
+         process.emit("exit", 0);
+         process.on("memoryPressure", level => {
+           const typed: NotAny<typeof level> = level;
+           typed satisfies "warning" | "critical";
+         });
+         process.emit("memoryPressure", "critical");
+         type Level = process.ProcessEventMap["memoryPressure"][0];
+         "warning" satisfies Level;`,
+      );
     });
   });
 


### PR DESCRIPTION
### Problem
- With @types/node 25.0.0 through 25.0.9, tsc rejects plain process listeners: `error TS2345: Argument of type '"SIGINT"' is not assignable to parameter of type '"memoryPressure"'`. That is #39807, whose triage resolved `@types/node@25` to a later 25.x. The repo's own pin (25.0.0) hits it.
- `packages/bun-types/overrides.d.ts:110` declares `memoryPressure` overloads of `on`/`once`/`emit`/... on the `NodeJS.Process` merge. A method declared on the merge hides the one `Process` inherits, and on those releases `Process` inherits all of them.
- The `off`/`removeListener` fallbacks from #40004 merge ahead of the @types/node overloads, so `process.off("exit", code => ...)` has `code: any` on 24, 25 and 26.

### Fix
- Declare `memoryPressure` as an entry of `ProcessEventMap` through a `declare module "node:process"` augmentation, and remove the overloads and the fallbacks from the merge. Every event method on @types/node 25 and 26 keys off that map.
- Trade-off for @alii: @types/node 24 has no event map, so `memoryPressure` is an unknown event name there. `on`/`once`/`off`/`removeListener` accept it untyped. `emit`/`addListener`/`prepend*` reject it. bun-types targets 25+.
- Verified: `test/integration/bun-types/bun-types.test.ts`. One check pins @types/node@25.0.0 (17 errors on main). One type-checks the whole fixture against the repo's pin (the 4 errors above on main).

### Background
- bun-types declares `interface Process` again and TypeScript merges it with @types/node's. Overloads both sides declare are combined, later declaration first. A method only one side declares hides what the other inherits.
- `ProcessEventMap` (@types/node 25+) maps each process event to its listener argument tuple. Every event method is generic over it, so one entry types the event on all of them.
- #37790 carries this same declaration inside a larger change and conflicts with main since #40004. This PR is the bun-types part alone.

Fixes #39807

<details><summary>Notes</summary>

Where @types/node declares the process event methods, and what the old overloads did there:

| @types/node | event methods | old overloads on the merge |
| --- | --- | --- |
| 24.x | per-event overloads on `Process`, `off`/`removeListener` inherited from `EventEmitter` | `off`/`removeListener` reject every other event (#40003) |
| 25.0.0 to 25.0.9 | all inherited from `InternalEventEmitter<ProcessEventMap>` | every method rejects every other event (#39807) |
| 25.0.10+ | generic overloads over `ProcessEventMap` on `Process` | none hidden, but the #40004 fallbacks make `off`/`removeListener` listeners `any` |

Probe: a file that calls each event method with a Node event and with `memoryPressure`, and fails if a listener argument is `any` (`type NotAny<T> = 0 extends 1 & T ? never : T`), checked with `skipLibCheck: false` against the packed bun-types and each of @types/node 25.0.0, 25.0.1, 25.0.9, 25.0.10, 25.1.0, 25.9.5, 26.4.1, with TypeScript 7.0.2 and 6.0.2. All clean with this change. Also checked `process.ProcessEventMap["memoryPressure"]`, `import type { ProcessEventMap } from "node:process"`, and `listeners("memoryPressure")` on each.

Overload order: bun-types' `index.d.ts` references `node` before `overrides.d.ts`, so @types/node's `Process` is the earlier declaration and the merge's overloads come first. Checked on main with `types` set to `["bun"]`, `["bun-types"]`, `["node", "bun"]`, `["node", "bun-types"]` and `["bun-types", "node"]`: `process.off("exit", code => ...)` is `any` in all of them on 25.0.10 and 26.4.1.

On @types/node 24.0.0 and 24.13.3 with the default `skipLibCheck: true`: Node events typed on every method, and the #40003 cases pass. With `skipLibCheck: false`, the augmentation adds one `TS2671: Cannot augment module 'node:process' because it resolves to a non-module entity` to the three errors the `node:tls` augmentation already produces there (`ConnectionOptions`, `KeyObject`, `TLSSocket`). #37790 asked for a CODEOWNER decision on this same trade-off and got no answer.

Alternative tried: re-declaring the `(event: string | symbol, ...)` fallbacks for the other six methods, like #40004 did for two. The merge's overloads come first, so every Node event listener becomes `any` on every @types/node release, including 26. Keeping the #40004 fallbacks next to the map entry has the same effect on `off`/`removeListener`.

Repo effect: `tsc --noEmit -p scripts/build/tsconfig.json` resolves the pinned @types/node 25.0.0 and reports three `memoryPressure` errors in `scripts/build/ci.ts` on main. With this change, none. Four unrelated `noUncheckedIndexedAccess` errors remain there. #37790 covers those, plus a source lint and a CI step for that typecheck.

The whole-fixture check overrides `fixture/package.json#resolutions` for @types/node, because that field otherwise wins over an explicit `bun add @types/node@<pin>`.

Suites: `bun bd test test/integration/bun-types/bun-types.test.ts` (9 pass, 14 skip on debug), the same file with a release build (23 pass), `tsc -p packages/bun-types/tsconfig.json`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 14 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.1 (a6c4cc276)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.81ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [9.94ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > TypeScript latest > checks without lib.dom.d.ts
(skip) @types/bun integration test > TypeScript 7.1 > checks the fixture and import attributes through ts7.1/index.d.ts
(skip) @types/bun integration test > @types/node at the repo's pin > checks the fixture against the pinned @types/node
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [734.31ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [742.98ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [38.07ms]
(pass) @types/bun
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [0.09ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.19ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [3000.85ms]
(pass) @types/bun integration test > TypeScript latest > checks without lib.dom.d.ts [425.06ms]
(pass) @types/bun integration test > TypeScript 7.1 > checks the fixture and import attributes through ts7.1/index.d.ts [382.72ms]
427 |       });
428 | 
429 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
430 | 
431 |       expect(stderr.trim()).toBe("");
432 |       expect(stdout.trim()).toBe("");
                                  ^
error: expect(received).toBe(expected)

- ""
+ "process.ts(4,12): error TS2345: Argument of type '"SIGINT"' is not assignable to parameter of type '"memoryPressure"'.
+ process.ts(8,12): error TS2345: Argument of type '"beforeExit"' is not assignable to parameter of type '"memoryPressure"'.
+ process.ts(1
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 14 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.1 (a6c4cc276)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.56ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.14ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > TypeScript latest > checks without lib.dom.d.ts
(skip) @types/bun integration test > TypeScript 7.1 > checks the fixture and import attributes through ts7.1/index.d.ts
(skip) @types/bun integration test > @types/node at the repo's pin > checks the fixture against the pinned @types/node
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [709.35ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [692.16ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [37.70ms]
(pass) @types/bun
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 636ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 19s
[1/4] link bun-profile
[3/4] strip bun
[3/4] bun-profile --revision
1.4.1-canary.1+f55402ed5
[build] done
bun test v1.4.1-canary.1 (f55402ed5)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [0.09ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.29ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [2873.13ms]
(pass) @types/bun integration test > TypeScript latest > checks without lib.dom.d.ts [422.46ms]
(pass) @types/bun integration test > TypeScript 7.1 > checks the fixture and import attributes through ts7.1/index.d.ts [389.85ms]
(pass) @types/bun integration test > @types/node at the repo's pin > checks the fixture against the pinne
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/overrides.d.ts            |  53 +++++------
 test/integration/bun-types/bun-types.test.ts | 136 +++++++++++++++++++++++----
 2 files changed, 141 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/overrides.d.ts                 4      6     21
test/integration/bun-types/bun-types.test.ts      5      9     21
```

</details>

<!-- robobun:evidence:end -->