### PR TITLE
Honor Bun.file().slice() bounds in Bun.write and spawn stdin

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -125,6 +125,9 @@ pub struct Blob {
     pub charset: Cell<AsciiStatus>,
     /// Was it created via the `File` constructor?
     pub is_jsdom_file: Cell<bool>,
+    /// Whether `size` is a window that `slice()` set. On a file Blob, `.size`
+    /// and `exists()` also store the file's size there, and that is not a window.
+    pub size_is_explicit: Cell<bool>,
     /// `bun.ptr.RawRefCount(u32, .single_threaded)` — counts in-flight `*Blob`
     /// borrows handed to async readers; not the JS GC retain count. Zero while
     /// the JS cell is the sole owner.
@@ -161,6 +164,7 @@ impl Default for Blob {
             content_type_was_set: Cell::new(false),
             charset: Cell::new(AsciiStatus::Unknown),
             is_jsdom_file: Cell::new(false),
+            size_is_explicit: Cell::new(false),
             ref_count: bun_ptr::RawRefCount::init(0),
             global_this: Cell::new(core::ptr::null()),
             last_modified: Cell::new(0.0),
@@ -367,6 +371,7 @@ impl Blob {
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
             is_jsdom_file: Cell::new(self.is_jsdom_file.get()),
+            size_is_explicit: Cell::new(self.size_is_explicit.get()),
             ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
             global_this: Cell::new(self.global_this.get()),
             last_modified: Cell::new(self.last_modified.get()),

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -125,8 +125,7 @@ pub struct Blob {
     pub charset: Cell<AsciiStatus>,
     /// Was it created via the `File` constructor?
     pub is_jsdom_file: Cell<bool>,
-    /// Whether `size` is a window that `slice()` set. On a file Blob, `.size`
-    /// and `exists()` also store the file's size there, and that is not a window.
+    /// Whether `size` is a window that `slice()` set, not a file size that `.size` cached.
     pub size_is_explicit: Cell<bool>,
     /// `bun.ptr.RawRefCount(u32, .single_threaded)` — counts in-flight `*Blob`
     /// borrows handed to async readers; not the JS GC retain count. Zero while

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -581,16 +581,13 @@ impl Stdio {
     ) -> JsResult<()> {
         let fd = FdStdio::from_int(i).map(FdStdio::fd);
 
-        // A view of a regular file (`Bun.file(p).slice(start, end)`) cannot
-        // be handed to the child as the file's fd or path: the child would
-        // read the whole file. Read the view and pass it like any other bytes.
-        // Only stdin: at the other indices the child can write to the file.
+        // A sliced file goes to stdin as bytes. At other slots the child may write to it.
         let view = if i == 0 { file_view(&blob) } else { None };
         let blob = match view {
-            Some((offset, len)) => {
+            Some(view) => {
                 let store = blob.store().expect("file_view found a store");
                 let file = store.data.as_file();
-                webcore::blob::Any::from_owned_slice(read_file_view(global, file, offset, len)?)
+                webcore::blob::Any::from_owned_slice(read_file_view(global, file, view)?)
             }
             None => blob,
         };
@@ -666,32 +663,51 @@ impl Stdio {
     }
 }
 
-/// The `(offset, len)` window a sliced file Blob names, clamped to the file.
-/// `None` when the Blob is the whole file, when the file is not a regular
-/// file, or when it cannot be stat'd: those go to the child as an fd or path.
-/// A pipe is not read here: that read could block the JS thread.
-fn file_view(blob: &webcore::blob::Any) -> Option<(u64, usize)> {
+/// The bytes of a sliced regular file that stdin gets.
+#[derive(Clone, Copy)]
+struct FileView {
+    offset: u64,
+    /// `MAX_SIZE` for a window that runs to EOF.
+    len: u64,
+    /// Whether `len` is clamped to the file's stat'd length.
+    clamped: bool,
+}
+
+/// The window of a sliced regular file, or `None` to pass the file to the child.
+fn file_view(blob: &webcore::blob::Any) -> Option<FileView> {
     let webcore::blob::Any::Blob(blob) = blob else {
         return None;
     };
-    blob.file_window()?;
+    let (window_offset, window_len) = blob.file_window()?;
     // Stats the file (once per store) and clamps the window to its length.
     let (offset, size) = blob.resolved_size();
     let file = blob.store()?.data.as_file();
+    // A pipe is passed on: a read here could block the JS thread.
     if file.seekable != Some(true) {
         return None;
+    }
+    // A regular file that reports no size (procfs) is read until the window or the file ends.
+    if file.max_size == 0 {
+        return Some(FileView {
+            offset: window_offset,
+            len: window_len,
+            clamped: false,
+        });
     }
     if offset == 0 && size == file.max_size {
         return None;
     }
-    Some((offset, usize::try_from(size).expect("int cast")))
+    Some(FileView {
+        offset,
+        len: size,
+        clamped: true,
+    })
 }
 
 fn read_file_view(
     global: &JSGlobalObject,
     file: &webcore::blob::store::File,
-    offset: u64,
-    len: usize,
+    view: FileView,
 ) -> JsResult<Vec<u8>> {
     let opened;
     let source: &sys::File = match &file.pathlike {
@@ -709,17 +725,29 @@ fn read_file_view(
             &opened
         }
     };
+    // A clamped window is one read. Any other window is read in chunks until it or the file ends.
+    let chunk = if view.clamped { view.len } else { 64 * 1024 };
     let mut bytes: Vec<u8> = Vec::new();
-    if bytes.try_reserve_exact(len).is_err() {
-        return Err(sys::Error::from_code(sys::E::ENOMEM, sys::Tag::read).throw(global));
+    loop {
+        let done = bytes.len();
+        let want = usize::try_from(chunk.min(view.len - done as u64)).expect("int cast");
+        if want == 0 {
+            break;
+        }
+        if bytes.try_reserve(want).is_err() {
+            return Err(sys::Error::from_code(sys::E::ENOMEM, sys::Tag::read).throw(global));
+        }
+        bytes.resize(done + want, 0);
+        // pread leaves a user-supplied fd's position alone.
+        let read = match source.pread_all(&mut bytes[done..], view.offset + done as u64) {
+            Ok(read) => read,
+            Err(err) => return Err(err.throw(global)),
+        };
+        bytes.truncate(done + read);
+        if read < want {
+            break;
+        }
     }
-    bytes.resize(len, 0);
-    // pread leaves a user-supplied fd's position alone.
-    let read = match source.pread_all(&mut bytes, offset) {
-        Ok(read) => read,
-        Err(err) => return Err(err.throw(global)),
-    };
-    bytes.truncate(read);
     Ok(bytes)
 }
 

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -1,6 +1,6 @@
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use bun_collections::VecExt;
-use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, SysErrorJsc as _};
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
 use bun_sys::{self as sys, Fd, FdExt as _};
@@ -8,6 +8,7 @@ use bun_sys::{self as sys, Fd, FdExt as _};
 // `bun.jsc.WebCore` lives in this crate (not `bun_jsc`); alias so the body can
 // say `webcore::ReadableStream` / `webcore::body::Value`.
 use crate::webcore;
+use crate::webcore::blob::BlobExt as _;
 use crate::webcore::blob::store::Data as StoreData;
 use crate::webcore::node_types::{PathLike, PathOrFileDescriptor};
 
@@ -580,6 +581,20 @@ impl Stdio {
     ) -> JsResult<()> {
         let fd = FdStdio::from_int(i).map(FdStdio::fd);
 
+        // A view of a regular file (`Bun.file(p).slice(start, end)`) cannot
+        // be handed to the child as the file's fd or path: the child would
+        // read the whole file. Read the view and pass it like any other bytes.
+        // Only stdin: at the other indices the child can write to the file.
+        let view = if i == 0 { file_view(&blob) } else { None };
+        let blob = match view {
+            Some((offset, len)) => {
+                let store = blob.store().expect("file_view found a store");
+                let file = store.data.as_file();
+                webcore::blob::Any::from_owned_slice(read_file_view(global, file, offset, len)?)
+            }
+            None => blob,
+        };
+
         if blob.needs_to_read_file() {
             if let Some(store) = blob.store() {
                 if let StoreData::File(ref file) = store.data {
@@ -649,6 +664,68 @@ impl Stdio {
         *self = Stdio::Blob(blob);
         Ok(())
     }
+}
+
+/// The `(offset, len)` window a sliced file Blob names, clamped to the file.
+/// `None` when the Blob is the whole file, when the file is not a regular
+/// file, or when it cannot be stat'd: those go to the child as an fd or path.
+fn file_view(blob: &webcore::blob::Any) -> Option<(u64, usize)> {
+    let webcore::blob::Any::Blob(blob) = blob else {
+        return None;
+    };
+    let store = blob.store()?;
+    if !matches!(store.data, StoreData::File(_)) {
+        return None;
+    }
+    if blob.offset.get() == 0 && blob.size.get() == webcore::blob::MAX_SIZE {
+        return None;
+    }
+    // Stats the file (once per store) and clamps the view to its length.
+    let (offset, size) = blob.resolved_size();
+    let file = store.data.as_file();
+    if file.seekable != Some(true) {
+        return None;
+    }
+    if offset == 0 && size == file.max_size {
+        return None;
+    }
+    Some((offset, usize::try_from(size).expect("int cast")))
+}
+
+fn read_file_view(
+    global: &JSGlobalObject,
+    file: &webcore::blob::store::File,
+    offset: u64,
+    len: usize,
+) -> JsResult<Vec<u8>> {
+    let opened;
+    let source: &sys::File = match &file.pathlike {
+        PathOrFileDescriptor::Fd(fd) => sys::File::borrow(fd),
+        PathOrFileDescriptor::Path(path) => {
+            opened = match sys::File::openat(
+                Fd::cwd(),
+                path.slice(),
+                sys::O::RDONLY | sys::O::CLOEXEC,
+                0,
+            ) {
+                Ok(file) => file,
+                Err(err) => return Err(err.with_path(path.slice()).throw(global)),
+            };
+            &opened
+        }
+    };
+    let mut bytes: Vec<u8> = Vec::new();
+    if bytes.try_reserve_exact(len).is_err() {
+        return Err(sys::Error::from_code(sys::E::ENOMEM, sys::Tag::read).throw(global));
+    }
+    bytes.resize(len, 0);
+    // pread leaves a user-supplied fd's position alone.
+    let read = match source.pread_all(&mut bytes, offset) {
+        Ok(read) => read,
+        Err(err) => return Err(err.throw(global)),
+    };
+    bytes.truncate(read);
+    Ok(bytes)
 }
 
 impl Stdio {

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -669,20 +669,15 @@ impl Stdio {
 /// The `(offset, len)` window a sliced file Blob names, clamped to the file.
 /// `None` when the Blob is the whole file, when the file is not a regular
 /// file, or when it cannot be stat'd: those go to the child as an fd or path.
+/// A pipe is not read here: that read could block the JS thread.
 fn file_view(blob: &webcore::blob::Any) -> Option<(u64, usize)> {
     let webcore::blob::Any::Blob(blob) = blob else {
         return None;
     };
-    let store = blob.store()?;
-    if !matches!(store.data, StoreData::File(_)) {
-        return None;
-    }
-    if blob.offset.get() == 0 && blob.size.get() == webcore::blob::MAX_SIZE {
-        return None;
-    }
-    // Stats the file (once per store) and clamps the view to its length.
+    blob.file_window()?;
+    // Stats the file (once per store) and clamps the window to its length.
     let (offset, size) = blob.resolved_size();
-    let file = store.data.as_file();
+    let file = blob.store()?.data.as_file();
     if file.seekable != Some(true) {
         return None;
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4503,6 +4503,19 @@ pub(crate) fn write_file_with_source_destination(
     }
     // If this is file <> file, we can just copy the file
     else if destination_type == store::DataTag::File && source_type == store::DataTag::File {
+        // The copy reads only the source view. A file Blob's size is
+        // `MAX_SIZE` until it is stat'd, so `slice(start)` leaves
+        // `offset + size == MAX_SIZE`: that view runs to EOF. So does an
+        // unsliced Blob whose size was read: it equals the stat'd size.
+        let source_offset = source_blob.offset.get();
+        let source_size = source_blob.size.get();
+        let source_size = if source_offset.saturating_add(source_size) >= MAX_SIZE
+            || (source_offset == 0 && source_size == source_store.data.as_file().max_size)
+        {
+            MAX_SIZE
+        } else {
+            source_size
+        };
         #[cfg(windows)]
         {
             return Ok(copy_file::CopyFileWindows::init(
@@ -4511,6 +4524,8 @@ pub(crate) fn write_file_with_source_destination(
                 ctx.bun_vm().event_loop_shared(),
                 options.mkdirp_if_not_exists.unwrap_or(true),
                 destination_blob.size.get(),
+                source_offset,
+                source_size,
                 options.mode,
             ));
         }
@@ -4521,6 +4536,8 @@ pub(crate) fn write_file_with_source_destination(
                 source_store,
                 destination_blob.offset.get(),
                 destination_blob.size.get(),
+                source_offset,
+                source_size,
                 ctx,
                 options.mkdirp_if_not_exists.unwrap_or(true),
                 options.mode,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -765,10 +765,14 @@ impl BlobExt for Blob {
                 writer.write_int_le::<u32>(stored_name.len() as u32)?;
                 writer.write_all(stored_name)?;
             } else {
-                // Version 4: a file-backed slice's window end. Written before
-                // resolve_size() so an unresolved blob stays MAX_SIZE (unknown)
-                // on the wire and the receiver stats it locally, like v3.
-                writer.write_int_le::<u64>(self.size.get())?;
+                // Version 4: the window end of a sliced file-backed blob. Any
+                // other blob puts MAX_SIZE (unknown) on the wire, also one that
+                // cached the file's size, and the receiver stats it locally, like v3.
+                writer.write_int_le::<u64>(if self.size_is_explicit.get() {
+                    self.size.get()
+                } else {
+                    MAX_SIZE
+                })?;
                 self.resolve_size();
                 store.serialize(writer)?;
             }
@@ -1895,6 +1899,8 @@ impl BlobExt for Blob {
         let blob = self.dupe();
         blob.offset.set(offset);
         blob.size.set(len);
+        // `slice()` and `slice(0)` of a file whose size is unknown cover the whole file.
+        blob.size_is_explicit.set(len != MAX_SIZE);
 
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified
@@ -2273,18 +2279,18 @@ impl BlobExt for Blob {
     /// The `(offset, size)` that `slice()` set on a file Blob, or `None` for the whole file.
     fn file_window(&self) -> Option<(SizeType, SizeType)> {
         let store = self.store.get().as_ref()?;
-        let store::Data::File(file) = &store.data else {
+        if !matches!(store.data, store::Data::File(_)) {
             return None;
-        };
+        }
         let offset = self.offset.get();
+        let size = self.size.get();
         // An unknown size is `MAX_SIZE`, and `slice(start)` of it ends there.
-        let size = if offset.saturating_add(self.size.get()) >= MAX_SIZE {
-            MAX_SIZE
+        let size = if self.size_is_explicit.get() && offset.saturating_add(size) < MAX_SIZE {
+            size
         } else {
-            self.size.get()
+            MAX_SIZE
         };
-        // `.size` and `exists()` cache the stat'd size, so that size means the whole file.
-        if offset == 0 && (size == MAX_SIZE || size == file.max_size) {
+        if offset == 0 && size == MAX_SIZE {
             return None;
         }
         Some((offset, size))
@@ -3200,6 +3206,7 @@ impl BlobExt for Blob {
                                     ),
                                     charset: Cell::new(blob.charset.get()),
                                     is_jsdom_file: Cell::new(blob.is_jsdom_file.get()),
+                                    size_is_explicit: Cell::new(blob.size_is_explicit.get()),
                                     ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
                                     global_this: Cell::new(blob.global_this.get()),
                                     last_modified: Cell::new(blob.last_modified.get()),
@@ -4038,6 +4045,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         // resolve_size() clamps this to the actual file size on first use.
         if size != MAX_SIZE {
             blob.size.set(size as SizeType);
+            blob.size_is_explicit.set(true);
         }
     }
     if let Some(store) = blob.store.get() {
@@ -4515,6 +4523,8 @@ pub(crate) fn write_file_with_source_destination(
     else if destination_type == store::DataTag::File && source_type == store::DataTag::File {
         // The copy reads only the source's window.
         let (source_offset, source_size) = source_blob.file_window().unwrap_or((0, MAX_SIZE));
+        // Only a window that `slice()` set on the destination caps the copy.
+        let destination_window = destination_blob.file_window().unwrap_or((0, MAX_SIZE));
         #[cfg(windows)]
         {
             return Ok(copy_file::CopyFileWindows::init(
@@ -4522,7 +4532,7 @@ pub(crate) fn write_file_with_source_destination(
                 source_store,
                 ctx.bun_vm().event_loop_shared(),
                 options.mkdirp_if_not_exists.unwrap_or(true),
-                destination_blob.size.get(),
+                destination_window.1,
                 source_offset,
                 source_size,
                 options.mode,
@@ -4533,8 +4543,8 @@ pub(crate) fn write_file_with_source_destination(
             return Ok(copy_file::CopyFile::create(
                 destination_store,
                 source_store,
-                destination_blob.offset.get(),
-                destination_blob.size.get(),
+                destination_window.0,
+                destination_window.1,
                 source_offset,
                 source_size,
                 ctx,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2224,9 +2224,7 @@ impl BlobExt for Blob {
                     let available = store_size - self.offset.get();
                     self.size.set(window_size(self.size.get(), available));
                 }
-                // A pipe or a FIFO has no size. Nor does a file that could
-                // not be stat'd: it may exist by the next call, which stats
-                // it again. The size stays unknown in both cases.
+                // A pipe has no size. A failed stat is tried again on the next call.
             }
             store::DataTag::S3 => self.size.set(0),
         }
@@ -2272,9 +2270,7 @@ impl BlobExt for Blob {
         }
     }
 
-    /// The window that `slice()` set on a file Blob, as `(offset, size)`.
-    /// `None` when the Blob is not a file or names the whole file. `size` is
-    /// `MAX_SIZE` for a window that runs to EOF. Does not stat the file.
+    /// The `(offset, size)` that `slice()` set on a file Blob, or `None` for the whole file.
     fn file_window(&self) -> Option<(SizeType, SizeType)> {
         let store = self.store.get().as_ref()?;
         let store::Data::File(file) = &store.data else {
@@ -2287,7 +2283,7 @@ impl BlobExt for Blob {
         } else {
             self.size.get()
         };
-        // A size equal to the stat'd size came from `.size` or `exists()`.
+        // `.size` and `exists()` cache the stat'd size, so that size means the whole file.
         if offset == 0 && (size == MAX_SIZE || size == file.max_size) {
             return None;
         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -263,6 +263,7 @@ pub trait BlobExt {
     fn get_size(&self, _: &JSGlobalObject) -> JSValue;
     fn resolve_size(&self);
     fn resolved_size(&self) -> (SizeType, SizeType);
+    fn file_window(&self) -> Option<(SizeType, SizeType)>;
     fn constructor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<*mut Blob>
     where
         Self: Sized;
@@ -2170,15 +2171,15 @@ impl BlobExt for Blob {
                 return JSValue::js_number(f64::NAN);
             }
             self.resolve_size();
-            if self.size.get() == MAX_SIZE && self.store.get().is_some() {
-                return JSValue::js_number(f64::INFINITY);
-            } else if self.size.get() == 0 && self.store.get().is_some() {
-                if let store::Data::File(file) =
-                    &self.store().expect("infallible: store present").data
-                {
-                    if !file.seekable.unwrap_or(true) && file.max_size == MAX_SIZE {
-                        return JSValue::js_number(f64::INFINITY);
-                    }
+            if self.size.get() == MAX_SIZE {
+                if let Some(store) = self.store.get() {
+                    // A file that could not be stat'd reads as empty.
+                    return match &store.data {
+                        store::Data::File(file) if file.seekable.is_none() => {
+                            JSValue::js_number(0.0)
+                        }
+                        _ => JSValue::js_number(f64::INFINITY),
+                    };
                 }
             }
         }
@@ -2222,16 +2223,10 @@ impl BlobExt for Blob {
                     self.offset.set(store_size.min(offset));
                     let available = store_size - self.offset.get();
                     self.size.set(window_size(self.size.get(), available));
-                    return;
                 }
-
-                // For non-seekable files (pipes, FIFOs), the size is genuinely
-                // unknown — leave it as max_size so that stream readers don't
-                // treat it as an empty file.
-                if file.seekable == Some(false) {
-                    return;
-                }
-                self.size.set(0);
+                // A pipe or a FIFO has no size. Nor does a file that could
+                // not be stat'd: it may exist by the next call, which stats
+                // it again. The size stays unknown in both cases.
             }
             store::DataTag::S3 => self.size.set(0),
         }
@@ -2271,13 +2266,32 @@ impl BlobExt for Blob {
                     let available = store_size - offset;
                     return (offset, window_size(self.size.get(), available));
                 }
-                if file.seekable == Some(false) {
-                    return (self.offset.get(), self.size.get());
-                }
-                (self.offset.get(), 0)
+                (self.offset.get(), self.size.get())
             }
             store::DataTag::S3 => (self.offset.get(), 0),
         }
+    }
+
+    /// The window that `slice()` set on a file Blob, as `(offset, size)`.
+    /// `None` when the Blob is not a file or names the whole file. `size` is
+    /// `MAX_SIZE` for a window that runs to EOF. Does not stat the file.
+    fn file_window(&self) -> Option<(SizeType, SizeType)> {
+        let store = self.store.get().as_ref()?;
+        let store::Data::File(file) = &store.data else {
+            return None;
+        };
+        let offset = self.offset.get();
+        // An unknown size is `MAX_SIZE`, and `slice(start)` of it ends there.
+        let size = if offset.saturating_add(self.size.get()) >= MAX_SIZE {
+            MAX_SIZE
+        } else {
+            self.size.get()
+        };
+        // A size equal to the stat'd size came from `.size` or `exists()`.
+        if offset == 0 && (size == MAX_SIZE || size == file.max_size) {
+            return None;
+        }
+        Some((offset, size))
     }
     fn constructor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<*mut Blob> {
         let blob: Blob;
@@ -4503,19 +4517,8 @@ pub(crate) fn write_file_with_source_destination(
     }
     // If this is file <> file, we can just copy the file
     else if destination_type == store::DataTag::File && source_type == store::DataTag::File {
-        // The copy reads only the source view. A file Blob's size is
-        // `MAX_SIZE` until it is stat'd, so `slice(start)` leaves
-        // `offset + size == MAX_SIZE`: that view runs to EOF. So does an
-        // unsliced Blob whose size was read: it equals the stat'd size.
-        let source_offset = source_blob.offset.get();
-        let source_size = source_blob.size.get();
-        let source_size = if source_offset.saturating_add(source_size) >= MAX_SIZE
-            || (source_offset == 0 && source_size == source_store.data.as_file().max_size)
-        {
-            MAX_SIZE
-        } else {
-            source_size
-        };
+        // The copy reads only the source's window.
+        let (source_offset, source_size) = source_blob.file_window().unwrap_or((0, MAX_SIZE));
         #[cfg(windows)]
         {
             return Ok(copy_file::CopyFileWindows::init(

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -765,9 +765,7 @@ impl BlobExt for Blob {
                 writer.write_int_le::<u32>(stored_name.len() as u32)?;
                 writer.write_all(stored_name)?;
             } else {
-                // Version 4: the window end of a sliced file-backed blob. Any
-                // other blob puts MAX_SIZE (unknown) on the wire, also one that
-                // cached the file's size, and the receiver stats it locally, like v3.
+                // Version 4: a window's end. MAX_SIZE (unknown) makes the receiver stat the file.
                 writer.write_int_le::<u64>(if self.size_is_explicit.get() {
                     self.size.get()
                 } else {

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -214,8 +214,10 @@ impl ReadableStream {
                     if let Some(offset) = blobby.start_offset {
                         blob.offset.set(offset as webcore::blob::SizeType);
                     }
+                    // The stream reads only `max_size` bytes, so that size is a window.
                     if let Some(size) = blobby.max_size {
                         blob.size.set(size as webcore::blob::SizeType);
+                        blob.size_is_explicit.set(true);
                     }
                     // it should be lazy, file shouldn't have opened yet.
                     debug_assert!(!blobby.started.get());

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -687,8 +687,8 @@ impl CopyFile {
 
                             match self.do_clonefile() {
                                 Ok(()) => {
-                                    let stat_size =
-                                        SizeType::try_from(stat_.unwrap().st_size).expect("int cast");
+                                    let stat_size = SizeType::try_from(stat_.unwrap().st_size)
+                                        .expect("int cast");
                                     let copy_len = self.copy_length(stat_size);
                                     if copy_len < stat_size {
                                         // If this fails...well, there's not much we can do about it.

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -42,8 +42,7 @@ pub struct CopyFile {
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
-    /// The source Blob's view: `Bun.file(p).slice(start, end)` copies only
-    /// `[source_offset, source_offset + source_size)`. `MAX_SIZE` is "to EOF".
+    /// The source Blob's window. `source_size` is `MAX_SIZE` to copy to EOF.
     #[cfg(not(windows))]
     pub(crate) source_offset: SizeType,
     #[cfg(not(windows))]
@@ -175,8 +174,7 @@ impl CopyFile {
         )
     }
 
-    /// Bytes to copy out of a regular source file of `st_size` bytes: the
-    /// source view clamped to the file, then capped by the destination view.
+    /// Bytes to copy from a regular source file of `st_size` bytes.
     #[cfg(not(windows))]
     fn copy_length(&self, st_size: SizeType) -> SizeType {
         let available = st_size.saturating_sub(self.source_offset);
@@ -559,8 +557,7 @@ impl CopyFile {
                     //
                     // bun test bun-write.test | xargs echo
                     //
-                    // The ftruncate that trims a view does nothing to a pipe,
-                    // so the loop stops at `max_length` itself.
+                    // ftruncate cannot trim a pipe, so the loop stops at the window.
                     bun_sys::E::EBADF => {
                         return self.do_read_write_loop_capped(self.max_length);
                     }
@@ -813,9 +810,7 @@ impl CopyFile {
                     );
                 }
             } else if self.source_size != MAX_SIZE {
-                // No length to clamp against (a char device, a socket, a
-                // procfs file), so the view's size is the only bound on a
-                // source that may never hit EOF.
+                // A source with no length (a char device, a socket) ends at the window.
                 self.max_length = self.max_length.min(self.source_size);
                 if self.max_length == 0 {
                     self.do_close();
@@ -823,9 +818,7 @@ impl CopyFile {
                 }
             }
 
-            // Every copy primitive below reads from the source fd's position.
-            // Only a regular file has one to move; a pipe, socket or char
-            // device is read from where it is.
+            // The copy reads from the fd's position, which only a regular file has.
             if is_regular && self.source_offset > 0 {
                 if let bun_sys::Result::Err(err) =
                     bun_sys::set_file_offset(self.source_fd, self.source_offset)
@@ -890,12 +883,9 @@ impl CopyFile {
             {
                 // fcopyfile rewrites dest from offset 0 and the slice trim is
                 // ftruncate; both are only safe for a dest Bun opened O_TRUNC.
-                // It copies the whole source, so it only serves a view that
-                // starts at byte 0 and that the ftruncate can trim: anything
-                // else takes the capped read/write loop from the seeked position.
-                let fcopyfile_serves_view =
-                    self.source_offset == 0 && (is_regular || self.source_size == MAX_SIZE);
-                if fcopyfile_serves_view
+                // fcopyfile copies the whole source, so a window takes the capped loop.
+                let whole_source = self.source_offset == 0 && self.source_size == MAX_SIZE;
+                if whole_source
                     && matches!(
                         self.destination_file_store.pathlike,
                         PathOrFileDescriptor::Path(_)
@@ -925,10 +915,14 @@ impl CopyFile {
 
             #[cfg(target_os = "freebsd")]
             {
-                if matches!(
-                    self.destination_file_store.pathlike,
-                    PathOrFileDescriptor::Path(_)
-                ) {
+                // This loop reads to EOF, so a window takes the capped loop.
+                if self.source_offset == 0
+                    && self.source_size == MAX_SIZE
+                    && matches!(
+                        self.destination_file_store.pathlike,
+                        PathOrFileDescriptor::Path(_)
+                    )
+                {
                     let mut total_written: u64 = 0;
                     match node_fs::NodeFS::copy_file_using_read_write_loop(
                         bun_core::ZStr::EMPTY,
@@ -985,13 +979,9 @@ fn read_write_fallback(
     cap: SizeType,
     total: &mut u64,
 ) -> bun_sys::Result<()> {
-    // `NodeFS::copy_file_using_read_write_loop` treats its length as a
-    // stat hint and drains the source to EOF past it; `cap` is a bound.
     read_write_loop_capped(src_fd, dest_fd, cap, total)?;
     if bun_opened_dest {
-        // Bun opened dest with O_TRUNC, but run_async may have fallocate'd it
-        // to the stat'd length, which is longer than the copy if the source
-        // shrank underneath us.
+        // run_async may have fallocate'd dest past what the loop copied.
         let _ = bun_sys::ftruncate(dest_fd, i64::try_from(*total).expect("int cast"));
     }
     Ok(())
@@ -1095,8 +1085,7 @@ pub struct CopyFileWindows<'a> {
 
     pub(crate) size: SizeType,
 
-    /// The source Blob's view, as on [`CopyFile`]. `uv_fs_copyfile` copies
-    /// a whole file, so any other view goes through the read/write loop.
+    /// The source Blob's window, as on [`CopyFile`].
     pub(crate) source_offset: SizeType,
     pub(crate) source_size: SizeType,
 
@@ -1117,8 +1106,7 @@ pub struct ReadWriteLoop {
     pub(crate) destination_fd: Fd,
     pub(crate) must_close_destination_fd: bool,
     pub(crate) written: usize,
-    /// File position of the next read. `-1` reads from the current position
-    /// (a source that is not a regular file).
+    /// Position of the next read, or `-1` for the fd's current position.
     pub(crate) read_pos: i64,
     /// Bytes left in the source view. `MAX_SIZE` is "to EOF".
     pub(crate) remaining: SizeType,
@@ -1198,8 +1186,7 @@ impl<'a> CopyFileWindows<'a> {
         bun_sys::Result::Ok(())
     }
 
-    /// Whether the copy covers the whole source file, which `uv_fs_copyfile`
-    /// can do in one call. A view with a size needs the file's length to tell.
+    /// Whether `uv_fs_copyfile` can do the copy. It copies whole files only.
     fn source_view_is_whole_file(&self) -> bool {
         if self.source_offset != 0 {
             return false;
@@ -1222,9 +1209,7 @@ impl<'a> CopyFileWindows<'a> {
         }
     }
 
-    /// The loop stops at the end of the source view. A view that starts past
-    /// byte 0 is read from that position, as `CopyFile` seeks to it. Only a
-    /// regular file has a position; anything else is read from where it is.
+    /// Sets where the loop starts and stops. Only a regular file has a position.
     fn apply_source_view(&mut self, source_fd: Fd) {
         self.read_write_loop.remaining = self.source_size;
         if self.source_offset > 0
@@ -1525,8 +1510,7 @@ impl<'a> CopyFileWindows<'a> {
     }
 
     fn prepare_read_write_loop(&mut self) {
-        // Open the source first: opening the destination truncates it, and a
-        // source that cannot be read must leave the destination alone.
+        // A source that cannot be opened must leave the destination untouched.
         self.read_write_loop.source_fd = match Self::prepare_pathlike(
             &mut Store::data_mut(&self.source_file_store)
                 .as_file_mut()
@@ -1551,8 +1535,7 @@ impl<'a> CopyFileWindows<'a> {
             bun_sys::Result::Ok(fd) => fd,
             bun_sys::Result::Err(err) => {
                 if self.mkdirp_if_not_exists && err.get_errno() == bun_sys::E::ENOENT {
-                    // `copyfile()` runs again after mkdirp and opens the
-                    // source again.
+                    // `copyfile()` opens the source again after mkdirp.
                     self.read_write_loop.close();
                     self.mkdirp();
                     return;
@@ -1565,8 +1548,7 @@ impl<'a> CopyFileWindows<'a> {
 
         self.apply_source_view(self.read_write_loop.source_fd);
         if self.read_write_loop.remaining == 0 {
-            // An empty view: the destination was opened (and truncated)
-            // above and nothing is read.
+            // An empty window: the destination is already truncated.
             self.on_complete(0);
             return;
         }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -42,6 +42,12 @@ pub struct CopyFile {
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
+    /// The source Blob's view: `Bun.file(p).slice(start, end)` copies only
+    /// `[source_offset, source_offset + source_size)`. `MAX_SIZE` is "to EOF".
+    #[cfg(not(windows))]
+    pub(crate) source_offset: SizeType,
+    #[cfg(not(windows))]
+    pub(crate) source_size: SizeType,
     #[cfg(not(windows))]
     pub(crate) destination_fd: Fd,
     #[cfg(not(windows))]
@@ -95,6 +101,8 @@ impl CopyFile {
         source_store: RefPtr<Store>,
         off: SizeType,
         max_len: SizeType,
+        source_offset: SizeType,
+        source_size: SizeType,
         global_this: &JSGlobalObject,
         mkdirp_if_not_exists: bool,
         destination_mode: Option<Mode>,
@@ -106,6 +114,8 @@ impl CopyFile {
             source_store: Some(source_store),
             offset: off,
             max_length: max_len,
+            source_offset,
+            source_size,
             mkdirp_if_not_exists,
             destination_mode,
             // defaults:
@@ -163,6 +173,15 @@ impl CopyFile {
             global_this,
             JSValue::js_number_from_uint64(self.read_len as u64),
         )
+    }
+
+    /// Bytes to copy out of a regular source file of `st_size` bytes: the
+    /// source view clamped to the file, then capped by the destination view.
+    #[cfg(not(windows))]
+    fn copy_length(&self, st_size: SizeType) -> SizeType {
+        let available = st_size.saturating_sub(self.source_offset);
+        let source_len = self.source_size.min(available);
+        (source_len.min(self.max_length)).max(self.offset) - self.offset
     }
 
     #[cfg(not(windows))]
@@ -540,24 +559,10 @@ impl CopyFile {
                     //
                     // bun test bun-write.test | xargs echo
                     //
+                    // The ftruncate that trims a view does nothing to a pipe,
+                    // so the loop stops at `max_length` itself.
                     bun_sys::E::EBADF => {
-                        let mut total_written: u64 = 0;
-
-                        // TODO: this should use non-blocking I/O.
-                        match node_fs::NodeFS::copy_file_using_read_write_loop(
-                            bun_core::ZStr::EMPTY,
-                            bun_core::ZStr::EMPTY,
-                            self.source_fd,
-                            self.destination_fd,
-                            0,
-                            &mut total_written,
-                        ) {
-                            bun_sys::Result::Err(err) => {
-                                self.system_error = Some(err.to_system_error());
-                                return Err(bun_errno::from_errno(err.errno as i32).into());
-                            }
-                            bun_sys::Result::Ok(()) => {}
-                        }
+                        return self.do_read_write_loop_capped(self.max_length);
                     }
                     _ => {
                         self.system_error = Some(errno.to_system_error());
@@ -640,6 +645,7 @@ impl CopyFile {
                 #[cfg(target_os = "macos")]
                 {
                     if self.offset == 0
+                        && self.source_offset == 0
                         && matches!(
                             self.source_file_store.pathlike,
                             PathOrFileDescriptor::Path(_)
@@ -681,11 +687,10 @@ impl CopyFile {
 
                             match self.do_clonefile() {
                                 Ok(()) => {
-                                    let stat_size = stat_.unwrap().st_size;
-                                    if self.max_length != MAX_SIZE
-                                        && self.max_length
-                                            < SizeType::try_from(stat_size).expect("int cast")
-                                    {
+                                    let stat_size =
+                                        SizeType::try_from(stat_.unwrap().st_size).expect("int cast");
+                                    let copy_len = self.copy_length(stat_size);
+                                    if copy_len < stat_size {
                                         // If this fails...well, there's not much we can do about it.
                                         // SAFETY: NUL-terminated path in path_buf; libc truncate(2).
                                         let _ = unsafe {
@@ -695,15 +700,11 @@ impl CopyFile {
                                                     .path()
                                                     .slice_z(&mut path_buf)
                                                     .as_ptr(),
-                                                i64::try_from(self.max_length).expect("int cast"),
+                                                i64::try_from(copy_len).expect("int cast"),
                                             )
                                         };
-                                        self.read_len =
-                                            SizeType::try_from(self.max_length).expect("int cast");
-                                    } else {
-                                        self.read_len =
-                                            SizeType::try_from(stat_size).expect("int cast");
                                     }
+                                    self.read_len = copy_len;
                                     // Apply destination mode if specified (clonefile copies source permissions)
                                     if let Some(mode) = self.destination_mode {
                                         match bun_sys::chmod(
@@ -785,14 +786,13 @@ impl CopyFile {
                 return;
             }
 
+            let is_regular = bun_sys::S::ISREG(stat.st_mode as _);
+
             // BSD fstat on a pipe reports bytes currently buffered in st_size;
             // only a regular-file st_size is a length.
-            if stat.st_size != 0 && bun_sys::S::ISREG(stat.st_mode as _) {
-                self.max_length = (SizeType::try_from(stat.st_size)
-                    .expect("int cast")
-                    .min(self.max_length))
-                .max(self.offset)
-                    - self.offset;
+            if stat.st_size != 0 && is_regular {
+                self.max_length =
+                    self.copy_length(SizeType::try_from(stat.st_size).expect("int cast"));
                 if self.max_length == 0 {
                     self.do_close();
                     return;
@@ -811,6 +811,28 @@ impl CopyFile {
                         0,
                         self.max_length as i64,
                     );
+                }
+            } else if self.source_size != MAX_SIZE {
+                // No length to clamp against (a char device, a socket, a
+                // procfs file), so the view's size is the only bound on a
+                // source that may never hit EOF.
+                self.max_length = self.max_length.min(self.source_size);
+                if self.max_length == 0 {
+                    self.do_close();
+                    return;
+                }
+            }
+
+            // Every copy primitive below reads from the source fd's position.
+            // Only a regular file has one to move; a pipe, socket or char
+            // device is read from where it is.
+            if is_regular && self.source_offset > 0 {
+                if let bun_sys::Result::Err(err) =
+                    bun_sys::set_file_offset(self.source_fd, self.source_offset)
+                {
+                    self.system_error = Some(err.to_system_error());
+                    self.do_close();
+                    return;
                 }
             }
 
@@ -868,21 +890,29 @@ impl CopyFile {
             {
                 // fcopyfile rewrites dest from offset 0 and the slice trim is
                 // ftruncate; both are only safe for a dest Bun opened O_TRUNC.
-                if matches!(
-                    self.destination_file_store.pathlike,
-                    PathOrFileDescriptor::Path(_)
-                ) {
+                // It copies the whole source, so it only serves a view that
+                // starts at byte 0 and that the ftruncate can trim: anything
+                // else takes the capped read/write loop from the seeked position.
+                let fcopyfile_serves_view =
+                    self.source_offset == 0 && (is_regular || self.source_size == MAX_SIZE);
+                if fcopyfile_serves_view
+                    && matches!(
+                        self.destination_file_store.pathlike,
+                        PathOrFileDescriptor::Path(_)
+                    )
+                {
                     if self.do_fcopy_file_with_read_write_loop_fallback().is_err() {
                         self.do_close();
                         return;
                     }
-                    if stat.st_size != 0
-                        && SizeType::try_from(stat.st_size).expect("int cast") > self.max_length
-                    {
-                        let _ = bun_sys::ftruncate(
-                            self.destination_fd,
-                            i64::try_from(self.max_length).expect("int cast"),
-                        );
+                    if stat.st_size != 0 && is_regular {
+                        if SizeType::try_from(stat.st_size).expect("int cast") > self.max_length {
+                            let _ = bun_sys::ftruncate(
+                                self.destination_fd,
+                                i64::try_from(self.max_length).expect("int cast"),
+                            );
+                        }
+                        self.read_len = self.max_length;
                     }
                 } else if self.do_read_write_loop_capped(self.max_length).is_err() {
                     self.do_close();
@@ -955,21 +985,16 @@ fn read_write_fallback(
     cap: SizeType,
     total: &mut u64,
 ) -> bun_sys::Result<()> {
+    // `NodeFS::copy_file_using_read_write_loop` treats its length as a
+    // stat hint and drains the source to EOF past it; `cap` is a bound.
+    read_write_loop_capped(src_fd, dest_fd, cap, total)?;
     if bun_opened_dest {
-        let stat_size = if cap == MAX_SIZE { 0 } else { cap as usize };
-        node_fs::NodeFS::copy_file_using_read_write_loop(
-            bun_core::ZStr::EMPTY,
-            bun_core::ZStr::EMPTY,
-            src_fd,
-            dest_fd,
-            stat_size,
-            total,
-        )?;
+        // Bun opened dest with O_TRUNC, but run_async may have fallocate'd it
+        // to the stat'd length, which is longer than the copy if the source
+        // shrank underneath us.
         let _ = bun_sys::ftruncate(dest_fd, i64::try_from(*total).expect("int cast"));
-        Ok(())
-    } else {
-        read_write_loop_capped(src_fd, dest_fd, cap, total)
     }
+    Ok(())
 }
 
 #[inline(never)] // 64 KB stack buffer
@@ -980,6 +1005,12 @@ fn read_write_loop_capped(
     cap: SizeType,
     total: &mut u64,
 ) -> bun_sys::Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    {
+        // SAFETY: `src_fd` is a valid open fd; `posix_fadvise` only reads it.
+        let _ = unsafe { libc::posix_fadvise(src_fd.native(), 0, 0, libc::POSIX_FADV_SEQUENTIAL) };
+    }
+
     let mut stack_buf = bun_core::vec::UninitBuf::<{ 64 * 1024 }>::uninit();
     // SAFETY: `read` is the only writer of `buf`; each iteration reads back only `buf[..amt]`.
     let buf = unsafe { stack_buf.as_bytes_mut() };
@@ -1064,6 +1095,11 @@ pub struct CopyFileWindows<'a> {
 
     pub(crate) size: SizeType,
 
+    /// The source Blob's view, as on [`CopyFile`]. `uv_fs_copyfile` copies
+    /// a whole file, so any other view goes through the read/write loop.
+    pub(crate) source_offset: SizeType,
+    pub(crate) source_size: SizeType,
+
     /// Bytes written, stored for use after async chmod completes
     pub(crate) written_bytes: usize,
 
@@ -1081,6 +1117,11 @@ pub struct ReadWriteLoop {
     pub(crate) destination_fd: Fd,
     pub(crate) must_close_destination_fd: bool,
     pub(crate) written: usize,
+    /// File position of the next read. `-1` reads from the current position
+    /// (a source that is not a regular file).
+    pub(crate) read_pos: i64,
+    /// Bytes left in the source view. `MAX_SIZE` is "to EOF".
+    pub(crate) remaining: SizeType,
     pub(crate) read_buf: Vec<u8>,
     pub(crate) uv_buf: libuv::uv_buf_t,
 }
@@ -1094,6 +1135,8 @@ impl Default for ReadWriteLoop {
             destination_fd: Fd::INVALID,
             must_close_destination_fd: false,
             written: 0,
+            read_pos: -1,
+            remaining: MAX_SIZE,
             read_buf: Vec::new(),
             uv_buf: libuv::uv_buf_t {
                 len: 0,
@@ -1119,11 +1162,13 @@ impl<'a> CopyFileWindows<'a> {
         self.read_write_loop.read_buf.clear();
         // reshaped for borrowck — use the full capacity slice.
         let cap = self.read_write_loop.read_buf.capacity();
+        let want = cap.min(usize::try_from(self.read_write_loop.remaining).unwrap_or(cap));
         self.read_write_loop.uv_buf = libuv::uv_buf_t {
-            len: cap as libuv::ULONG,
+            len: want as libuv::ULONG,
             base: self.read_write_loop.read_buf.as_mut_ptr(),
         };
         let source_fd = self.read_write_loop.source_fd;
+        let read_pos = self.read_write_loop.read_pos;
         let loop_ = self.event_loop.uv_loop();
 
         // This io_request is used for both reading and writing.
@@ -1141,7 +1186,7 @@ impl<'a> CopyFileWindows<'a> {
                 source_fd.uv(),
                 core::ptr::from_mut(&mut self.read_write_loop.uv_buf),
                 1,
-                -1,
+                read_pos,
                 Some(on_read),
             )
         };
@@ -1151,6 +1196,45 @@ impl<'a> CopyFileWindows<'a> {
         }
 
         bun_sys::Result::Ok(())
+    }
+
+    /// Whether the copy covers the whole source file, which `uv_fs_copyfile`
+    /// can do in one call. A view with a size needs the file's length to tell.
+    fn source_view_is_whole_file(&self) -> bool {
+        if self.source_offset != 0 {
+            return false;
+        }
+        if self.source_size == MAX_SIZE {
+            return true;
+        }
+        let source = self.source_file_store.data.as_file();
+        let stat = match &source.pathlike {
+            PathOrFileDescriptor::Fd(fd) => bun_sys::fstat(*fd),
+            PathOrFileDescriptor::Path(path) => {
+                let mut buf = bun_paths::path_buffer_pool::get();
+                bun_sys::stat(path.slice_z(&mut buf))
+            }
+        };
+        match stat {
+            bun_sys::Result::Ok(stat) => self.source_size >= stat.st_size as SizeType,
+            // Let the copy itself report the error.
+            bun_sys::Result::Err(_) => true,
+        }
+    }
+
+    /// The loop stops at the end of the source view. A view that starts past
+    /// byte 0 is read from that position, as `CopyFile` seeks to it. Only a
+    /// regular file has a position; anything else is read from where it is.
+    fn apply_source_view(&mut self, source_fd: Fd) {
+        self.read_write_loop.remaining = self.source_size;
+        if self.source_offset > 0
+            && matches!(
+                bun_sys::File::borrow(&source_fd).kind(),
+                bun_sys::Result::Ok(bun_sys::FileKind::File)
+            )
+        {
+            self.read_write_loop.read_pos = i64::try_from(self.source_offset).expect("int cast");
+        }
     }
 }
 
@@ -1225,6 +1309,12 @@ extern "C" fn on_read(req: *mut libuv::fs_t) {
     // SAFETY: libuv wrote `n` bytes into the buffer's capacity.
     unsafe { read_buf.set_len(n) };
     this.read_write_loop.uv_buf = libuv::uv_buf_t::init(read_buf.as_slice());
+    if this.read_write_loop.read_pos >= 0 {
+        this.read_write_loop.read_pos += i64::try_from(n).expect("int cast");
+    }
+    if this.read_write_loop.remaining != MAX_SIZE {
+        this.read_write_loop.remaining -= n as SizeType;
+    }
 
     if rc.int() == 0 {
         // Handle EOF. We can't read any more.
@@ -1322,6 +1412,11 @@ extern "C" fn on_write(req: *mut libuv::fs_t) {
         return;
     }
 
+    if this.read_write_loop.remaining == 0 {
+        // The source view is fully copied.
+        this.on_read_write_loop_complete();
+        return;
+    }
     this.io_request.deinit();
     match this.read_write_loop_read() {
         bun_sys::Result::Err(err) => {
@@ -1356,6 +1451,8 @@ impl<'a> CopyFileWindows<'a> {
         event_loop: &'a jsc::event_loop::EventLoop,
         mkdirp_if_not_exists: bool,
         size_: SizeType,
+        source_offset: SizeType,
+        source_size: SizeType,
         destination_mode: Option<Mode>,
     ) -> JSValue {
         // destination_file_store.ref() / source_file_store.ref() — Arc clone
@@ -1370,6 +1467,8 @@ impl<'a> CopyFileWindows<'a> {
             mkdirp_if_not_exists,
             destination_mode,
             size: size_,
+            source_offset,
+            source_size,
             written_bytes: 0,
             err: None,
             read_write_loop: ReadWriteLoop::default(),
@@ -1426,28 +1525,8 @@ impl<'a> CopyFileWindows<'a> {
     }
 
     fn prepare_read_write_loop(&mut self) {
-        // Open the destination first, so that if we need to call
-        // mkdirp(), we don't spend extra time opening the file handle for
-        // the source.
-        self.read_write_loop.destination_fd = match Self::prepare_pathlike(
-            &mut Store::data_mut(&self.destination_file_store)
-                .as_file_mut()
-                .pathlike,
-            &mut self.read_write_loop.must_close_destination_fd,
-            false,
-        ) {
-            bun_sys::Result::Ok(fd) => fd,
-            bun_sys::Result::Err(err) => {
-                if self.mkdirp_if_not_exists && err.get_errno() == bun_sys::E::ENOENT {
-                    self.mkdirp();
-                    return;
-                }
-
-                self.throw(err);
-                return;
-            }
-        };
-
+        // Open the source first: opening the destination truncates it, and a
+        // source that cannot be read must leave the destination alone.
         self.read_write_loop.source_fd = match Self::prepare_pathlike(
             &mut Store::data_mut(&self.source_file_store)
                 .as_file_mut()
@@ -1461,6 +1540,36 @@ impl<'a> CopyFileWindows<'a> {
                 return;
             }
         };
+
+        self.read_write_loop.destination_fd = match Self::prepare_pathlike(
+            &mut Store::data_mut(&self.destination_file_store)
+                .as_file_mut()
+                .pathlike,
+            &mut self.read_write_loop.must_close_destination_fd,
+            false,
+        ) {
+            bun_sys::Result::Ok(fd) => fd,
+            bun_sys::Result::Err(err) => {
+                if self.mkdirp_if_not_exists && err.get_errno() == bun_sys::E::ENOENT {
+                    // `copyfile()` runs again after mkdirp and opens the
+                    // source again.
+                    self.read_write_loop.close();
+                    self.mkdirp();
+                    return;
+                }
+
+                self.throw(err);
+                return;
+            }
+        };
+
+        self.apply_source_view(self.read_write_loop.source_fd);
+        if self.read_write_loop.remaining == 0 {
+            // An empty view: the destination was opened (and truncated)
+            // above and nothing is read.
+            self.on_complete(0);
+            return;
+        }
 
         match self.read_write_loop_start() {
             bun_sys::Result::Err(err) => {
@@ -1477,6 +1586,7 @@ impl<'a> CopyFileWindows<'a> {
         if bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE
             .get()
             .unwrap_or(false)
+            || !self.source_view_is_whole_file()
         {
             self.prepare_read_write_loop();
             return;

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -567,7 +567,12 @@ impl CopyFile {
                     }
                 }
             }
-            bun_sys::Result::Ok(()) => {}
+            bun_sys::Result::Ok(()) => {
+                // fcopyfile does not report a count. Bun opened the destination with O_TRUNC.
+                if let bun_sys::Result::Ok(st) = bun_sys::fstat(self.destination_fd) {
+                    self.read_len = SizeType::try_from(st.st_size).expect("int cast");
+                }
+            }
         }
         Ok(())
     }
@@ -1194,15 +1199,7 @@ impl<'a> CopyFileWindows<'a> {
         if self.source_size == MAX_SIZE {
             return true;
         }
-        let source = self.source_file_store.data.as_file();
-        let stat = match &source.pathlike {
-            PathOrFileDescriptor::Fd(fd) => bun_sys::fstat(*fd),
-            PathOrFileDescriptor::Path(path) => {
-                let mut buf = bun_paths::path_buffer_pool::get();
-                bun_sys::stat(path.slice_z(&mut buf))
-            }
-        };
-        match stat {
+        match stat_store_file(self.source_file_store.data.as_file()) {
             bun_sys::Result::Ok(stat) => self.source_size >= stat.st_size as SizeType,
             // Let the copy itself report the error.
             bun_sys::Result::Err(_) => true,
@@ -1219,6 +1216,17 @@ impl<'a> CopyFileWindows<'a> {
             )
         {
             self.read_write_loop.read_pos = i64::try_from(self.source_offset).expect("int cast");
+        }
+    }
+}
+
+#[cfg(windows)]
+fn stat_store_file(file: &store::File) -> bun_sys::Maybe<bun_sys::Stat> {
+    match &file.pathlike {
+        PathOrFileDescriptor::Fd(fd) => bun_sys::fstat(*fd),
+        PathOrFileDescriptor::Path(path) => {
+            let mut buf = bun_paths::path_buffer_pool::get();
+            bun_sys::stat(path.slice_z(&mut buf))
         }
     }
 }
@@ -1953,7 +1961,15 @@ extern "C" fn on_copy_file(req: *mut libuv::fs_t) {
         return;
     }
 
-    let size = this.io_request.statbuf.size();
+    // `CopyFileW` does not fill `statbuf`, so a whole-file copy reads its size from the destination.
+    let mut size = this.io_request.statbuf.size();
+    if size == 0 && this.size == MAX_SIZE {
+        if let bun_sys::Result::Ok(stat) =
+            stat_store_file(this.destination_file_store.data.as_file())
+        {
+            size = stat.st_size;
+        }
+    }
     this.on_complete(size as usize);
 }
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
+import { randomBytes } from "crypto";
 import fs, { mkdirSync } from "fs";
 import {
   bunEnv,
@@ -7,6 +8,7 @@ import {
   exampleSite,
   gcTick,
   isASAN,
+  isLinux,
   isWindows,
   tempDir,
   withoutAggressiveGC,
@@ -512,6 +514,135 @@ const IS_UV_FS_COPYFILE_DISABLED =
         size: 10 + size,
       });
       expect(exitCode).toBe(0);
+    });
+  });
+
+  // A sliced Bun.file() is a view (`offset`, `size`) over a store that names
+  // the whole file. The file-to-file copy took only the store, so it copied
+  // the whole file.
+  describe("Bun.write(dest, Bun.file(src).slice(start, end)) copies only the slice", () => {
+    const content = "abcdefghijklmnopqrstuvwxyz";
+
+    it.each([
+      ["a window in the middle", 10, 20],
+      ["a window at the start", 0, 5],
+      ["a window to EOF", 3, undefined],
+      ["a window that ends past EOF", 20, 100],
+      ["an empty window", 5, 5],
+      ["a window past EOF", 30, 40],
+    ])("%s", async (_, start, end) => {
+      using dir = tempDir("bun-write-src-slice", { "src.txt": content });
+      const dst = join(String(dir), "dst.txt");
+      const expected = content.slice(start, end);
+
+      const written = await Bun.write(dst, Bun.file(join(String(dir), "src.txt")).slice(start, end));
+      expect({ written, copied: fs.readFileSync(dst, "utf8") }).toEqual({
+        written: expected.length,
+        copied: expected,
+      });
+    });
+
+    it("a Response or a stream over the slice", async () => {
+      using dir = tempDir("bun-write-src-slice-body", { "src.txt": content });
+      const src = Bun.file(join(String(dir), "src.txt"));
+      const copy = async (name, body) => {
+        const dst = join(String(dir), name);
+        const written = await Bun.write(dst, body);
+        return [written, fs.readFileSync(dst, "utf8")];
+      };
+
+      expect({
+        response: await copy("a.txt", new Response(src.slice(10, 20))),
+        responseOverStream: await copy("b.txt", new Response(src.slice(10, 20).stream())),
+        stream: await copy("c.txt", src.slice(10, 20).stream()),
+      }).toEqual({
+        response: [10, "klmnopqrst"],
+        responseOverStream: [10, "klmnopqrst"],
+        stream: [10, "klmnopqrst"],
+      });
+    });
+
+    it("a window of a file larger than the preallocation threshold", async () => {
+      const payload = randomBytes(8 * 1024 * 1024);
+      using dir = tempDir("bun-write-src-slice-large", { "src.bin": payload });
+      const dst = join(String(dir), "dst.bin");
+      const start = 1024 * 1024 + 3;
+      const end = 5 * 1024 * 1024 - 7;
+
+      const written = await Bun.write(dst, Bun.file(join(String(dir), "src.bin")).slice(start, end));
+      const copied = fs.readFileSync(dst);
+      expect({ written, size: copied.byteLength, identical: copied.equals(payload.subarray(start, end)) }).toEqual({
+        written: end - start,
+        size: end - start,
+        identical: true,
+      });
+    });
+
+    it("a window of a file descriptor", async () => {
+      using dir = tempDir("bun-write-src-slice-fd", { "src.txt": content });
+      const dst = join(String(dir), "dst.txt");
+      const fd = fs.openSync(join(String(dir), "src.txt"), "r");
+      try {
+        const written = await Bun.write(dst, Bun.file(fd).slice(10, 20));
+        expect({ written, copied: fs.readFileSync(dst, "utf8") }).toEqual({ written: 10, copied: "klmnopqrst" });
+      } finally {
+        fs.closeSync(fd);
+      }
+    });
+
+    it.skipIf(!isLinux)("a window through the read/write fallback", async () => {
+      using dir = tempDir("bun-write-src-slice-fallback", { "src.txt": content });
+      const src = join(String(dir), "src.txt");
+      const dst = join(String(dir), "dst.txt");
+      const script = `process.stdout.write(String(await Bun.write(${JSON.stringify(dst)}, Bun.file(${JSON.stringify(src)}).slice(10, 20))))`;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, BUN_CONFIG_DISABLE_COPY_FILE_RANGE: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, copied: fs.readFileSync(dst, "utf8") }).toEqual({
+        stdout: "10",
+        stderr: "",
+        copied: "klmnopqrst",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    // procfs files are regular files with st_size == 0, so only the view
+    // bounds the copy.
+    it.skipIf(!isLinux)("a window of a file that reports no size", async () => {
+      const version = fs.readFileSync("/proc/version", "utf8");
+      using dir = tempDir("bun-write-src-slice-procfs", {});
+      const dst = join(String(dir), "dst.txt");
+
+      const written = await Bun.write(dst, Bun.file("/proc/version").slice(3, 8));
+      expect({ written, copied: fs.readFileSync(dst, "utf8") }).toEqual({ written: 5, copied: version.slice(3, 8) });
+    });
+
+    it("an unsliced Bun.file() whose size was read copies the whole file", async () => {
+      using dir = tempDir("bun-write-src-size-read", { "src.txt": content });
+      const src = join(String(dir), "src.txt");
+      const dst = join(String(dir), "dst.txt");
+      const file = Bun.file(src);
+      expect(file.size).toBe(content.length);
+      fs.appendFileSync(src, "0123");
+
+      await Bun.write(dst, file);
+      expect(fs.readFileSync(dst, "utf8")).toBe(content + "0123");
+    });
+
+    it("rejects for a missing source and leaves the destination alone", async () => {
+      using dir = tempDir("bun-write-src-slice-missing", { "dst.txt": "keep" });
+      const dst = join(String(dir), "dst.txt");
+
+      const err = await Bun.write(dst, Bun.file(join(String(dir), "missing.txt")).slice(1, 3)).then(
+        () => null,
+        e => e,
+      );
+      expect({ code: err?.code, kept: fs.readFileSync(dst, "utf8") }).toEqual({ code: "ENOENT", kept: "keep" });
     });
   });
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -555,11 +555,48 @@ const IS_UV_FS_COPYFILE_DISABLED =
         response: await copy("a.txt", new Response(src.slice(10, 20))),
         responseOverStream: await copy("b.txt", new Response(src.slice(10, 20).stream())),
         stream: await copy("c.txt", src.slice(10, 20).stream()),
+        streamAtStart: await copy("d.txt", new Response(src.slice(0, 5).stream())),
       }).toEqual({
         response: [10, "klmnopqrst"],
         responseOverStream: [10, "klmnopqrst"],
         stream: [10, "klmnopqrst"],
+        streamAtStart: [5, "abcde"],
       });
+    });
+
+    // A stream has no position to seek to, so only the window's size applies.
+    it("a window of a socket", async () => {
+      using dir = tempDir("bun-write-src-slice-socket", {});
+      const dst = join(String(dir), "dst.txt");
+      const script = `process.stdout.write(String(await Bun.write(${JSON.stringify(dst)}, Bun.file(0).slice(2, 6))))`;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      proc.stdin.write("hello world");
+      proc.stdin.end();
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, copied: fs.readFileSync(dst).byteLength }).toEqual({
+        stdout: "4",
+        stderr: "",
+        copied: 4,
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    // /dev/zero never ends, so only the window stops the copy. The child keeps
+    // a build that does not stop from filling a disk.
+    it.skipIf(isWindows)("a window of a character device", async () => {
+      const script = `process.stdout.write(String(await Bun.write("/dev/null", Bun.file("/dev/zero").slice(0, 10))))`;
+
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr }).toEqual({ stdout: "10", stderr: "" });
+      expect(exitCode).toBe(0);
     });
 
     it("a window of a file larger than the preallocation threshold", async () => {
@@ -632,6 +669,24 @@ const IS_UV_FS_COPYFILE_DISABLED =
 
       await Bun.write(dst, file);
       expect(fs.readFileSync(dst, "utf8")).toBe(content + "0123");
+    });
+
+    // A stat that fails must not leave a size of 0 behind.
+    it.each(["exists()", ".size"])("a Bun.file() whose %s was read before the file existed", async probe => {
+      using dir = tempDir("bun-write-src-created-later", {});
+      const src = join(String(dir), "src.txt");
+      const dst = join(String(dir), "dst.txt");
+      const file = Bun.file(src);
+      expect(probe === "exists()" ? await file.exists() : file.size).toBe(probe === "exists()" ? false : 0);
+      fs.writeFileSync(src, content);
+
+      await Bun.write(dst, file);
+      const copied = fs.readFileSync(dst, "utf8");
+      expect({ copied, size: file.size, text: await file.text() }).toEqual({
+        copied: content,
+        size: content.length,
+        text: content,
+      });
     });
 
     it("rejects for a missing source and leaves the destination alone", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -13,6 +13,7 @@ import {
   tempDir,
   withoutAggressiveGC,
 } from "harness";
+import { mkfifo } from "mkfifo";
 import { once } from "node:events";
 import http from "node:http";
 import path, { join } from "path";
@@ -279,6 +280,157 @@ const IS_UV_FS_COPYFILE_DISABLED =
     }
   });
 
+  // uv_fs_copyfile (Windows) and fcopyfile (macOS) do not report a count.
+  it("Bun.write(dest, Bun.file(src)) resolves with the number of bytes copied", async () => {
+    using dir = tempDir("bun-write-copy-size", { "src.txt": "hello world", "src-empty.txt": "" });
+    const src = join(String(dir), "src.txt");
+    const dst = join(String(dir), "dst.txt");
+    const dstEmpty = join(String(dir), "dst-empty.txt");
+
+    const toPath = await Bun.write(dst, Bun.file(src));
+    const overExisting = await Bun.write(Bun.file(dst), Bun.file(src));
+    const fromEmpty = await Bun.write(dstEmpty, Bun.file(join(String(dir), "src-empty.txt")));
+    expect({
+      toPath,
+      overExisting,
+      fromEmpty,
+      copied: fs.readFileSync(dst, "utf8"),
+      copiedEmpty: fs.readFileSync(dstEmpty, "utf8"),
+    }).toEqual({ toPath: 11, overExisting: 11, fromEmpty: 0, copied: "hello world", copiedEmpty: "" });
+  });
+
+  // The file-to-file copy took the destination Blob's `size` as the number of
+  // bytes to copy. On an unsliced Bun.file(), `.size` and `exists()` store the
+  // file's size there, so the copy stopped at the old length of the
+  // destination: 0 bytes for the `exists()` guard in #4930.
+  describe("Bun.file -> Bun.file is not capped by the destination's cached size", () => {
+    const source = Buffer.alloc(100_000, "S").toString();
+
+    function expectCopiedWhole(destPath, written) {
+      expect({ written, size: fs.statSync(destPath).size }).toEqual({ written: source.length, size: source.length });
+      expect(fs.readFileSync(destPath, "utf8")).toBe(source);
+    }
+
+    // Each primer caches the destination's size on a Blob and returns the Blob
+    // to write to. The size is cached on that Blob, so the clone and the
+    // whole-file slice are the destination.
+    const primers = [
+      [
+        "f.size",
+        (f, size) => {
+          expect(f.size).toBe(size);
+          return f;
+        },
+      ],
+      [
+        "await f.exists()",
+        async f => {
+          expect(await f.exists()).toBe(true);
+          return f;
+        },
+      ],
+      [
+        "expect(f).toHaveLength()",
+        (f, size) => {
+          expect(f).toHaveLength(size);
+          return f;
+        },
+      ],
+      [
+        "structuredClone(f), which stats f while serializing it",
+        f => {
+          structuredClone(f);
+          return f;
+        },
+      ],
+      [
+        "f.size, writing to structuredClone(f)",
+        (f, size) => {
+          expect(f.size).toBe(size);
+          return structuredClone(f);
+        },
+      ],
+      [
+        "f.slice().size, writing to the whole-file slice",
+        (f, size) => {
+          const whole = f.slice();
+          expect(whole.size).toBe(size);
+          return whole;
+        },
+      ],
+    ];
+
+    describe.each([
+      ["shorter", "short"],
+      ["empty", ""],
+    ])("%s existing destination", (_, existing) => {
+      it.each(primers)("primed by %s", async (_, prime) => {
+        using dir = tempDir("bun-write-dest-size-cached", { "src.bin": source, "dest.bin": existing });
+        const destPath = join(String(dir), "dest.bin");
+        const dest = await prime(Bun.file(destPath), existing.length);
+
+        const written = await Bun.write(dest, Bun.file(join(String(dir), "src.bin")));
+        expectCopiedWhole(destPath, written);
+      });
+    });
+
+    it("primed by exists() on a destination that does not exist yet (#4930)", async () => {
+      using dir = tempDir("bun-write-dest-exists-guard", { "in.txt": source });
+      const outPath = join(String(dir), "out.txt");
+      const out = Bun.file(outPath);
+      expect(await out.exists()).toBe(false);
+
+      const written = await Bun.write(out, Bun.file(join(String(dir), "in.txt")));
+      expectCopiedWhole(outPath, written);
+    });
+
+    it("primed by .size on an fd destination", async () => {
+      using dir = tempDir("bun-write-fd-dest-size-cached", { "src.bin": source, "dest.bin": "short" });
+      const destPath = join(String(dir), "dest.bin");
+      const fd = fs.openSync(destPath, "r+");
+      let written;
+      try {
+        const dest = Bun.file(fd);
+        expect(dest.size).toBe(5);
+        written = await Bun.write(dest, Bun.file(join(String(dir), "src.bin")));
+      } finally {
+        fs.closeSync(fd);
+      }
+      expectCopiedWhole(destPath, written);
+    });
+
+    // On Windows, the copy also padded a shorter copy out to the cached size.
+    it("primed by .size, a shorter source replaces a longer destination", async () => {
+      using dir = tempDir("bun-write-dest-shrinks", {
+        "src.bin": "tiny",
+        "dest.bin": Buffer.alloc(1000, "D").toString(),
+      });
+      const destPath = join(String(dir), "dest.bin");
+      const dest = Bun.file(destPath);
+      expect(dest.size).toBe(1000);
+
+      const written = await Bun.write(dest, Bun.file(join(String(dir), "src.bin")));
+      expect({ written, copied: fs.readFileSync(destPath, "utf8") }).toEqual({ written: 4, copied: "tiny" });
+    });
+
+    // A window that slice() set still caps the copy. That holds through
+    // structuredClone, and for a window as long as the size that `.size` cached.
+    it.each([
+      ["f.slice(0, 4)", f => f.slice(0, 4), "SSSS"],
+      ["structuredClone(f.slice(0, 4))", f => structuredClone(f.slice(0, 4)), "SSSS"],
+      ["f.slice(0, f.size)", f => f.slice(0, f.size), "SSSSSSSSSS"],
+    ])("a destination sliced with %s is still bounded by the slice", async (_, slice, expected) => {
+      using dir = tempDir("bun-write-dest-window", { "src.bin": source, "dest.bin": "0123456789" });
+      const destPath = join(String(dir), "dest.bin");
+
+      const written = await Bun.write(slice(Bun.file(destPath)), Bun.file(join(String(dir), "src.bin")));
+      expect({ written, copied: fs.readFileSync(destPath, "utf8") }).toEqual({
+        written: expected.length,
+        copied: expected,
+      });
+    });
+  });
+
   it("Bun.file", async () => {
     const file = path.join(import.meta.dir, "fetch.js.txt");
     await gcTick();
@@ -523,22 +675,34 @@ const IS_UV_FS_COPYFILE_DISABLED =
   describe("Bun.write(dest, Bun.file(src).slice(start, end)) copies only the slice", () => {
     const content = "abcdefghijklmnopqrstuvwxyz";
 
+    // Each window is copied to a new file, and over a longer file that the copy truncates.
     it.each([
       ["a window in the middle", 10, 20],
       ["a window at the start", 0, 5],
       ["a window to EOF", 3, undefined],
       ["a window that ends past EOF", 20, 100],
+      ["a window at the start that ends past EOF", 0, 100],
+      ["a window of the whole file", 0, content.length],
+      ["a window from the start to EOF", 0, undefined],
       ["an empty window", 5, 5],
+      ["an empty window at the start", 0, 0],
       ["a window past EOF", 30, 40],
     ])("%s", async (_, start, end) => {
-      using dir = tempDir("bun-write-src-slice", { "src.txt": content });
-      const dst = join(String(dir), "dst.txt");
-      const expected = content.slice(start, end);
+      using dir = tempDir("bun-write-src-slice", {
+        "src.txt": content,
+        "longer.txt": Buffer.alloc(64, "Z").toString(),
+      });
+      const slice = Bun.file(join(String(dir), "src.txt")).slice(start, end);
+      const copy = async name => {
+        const dst = join(String(dir), name);
+        const written = await Bun.write(dst, slice);
+        return { written, copied: fs.readFileSync(dst, "utf8") };
+      };
+      const expected = { written: content.slice(start, end).length, copied: content.slice(start, end) };
 
-      const written = await Bun.write(dst, Bun.file(join(String(dir), "src.txt")).slice(start, end));
-      expect({ written, copied: fs.readFileSync(dst, "utf8") }).toEqual({
-        written: expected.length,
-        copied: expected,
+      expect({ created: await copy("dst.txt"), overwritten: await copy("longer.txt") }).toEqual({
+        created: expected,
+        overwritten: expected,
       });
     });
 
@@ -599,6 +763,29 @@ const IS_UV_FS_COPYFILE_DISABLED =
       expect(exitCode).toBe(0);
     });
 
+    // A FIFO has no position either, and lseek on one fails with ESPIPE. Linux
+    // does not copy from a FIFO into a file, so the copy fails at the type check.
+    it.skipIf(!isLinux)("a window of a FIFO", async () => {
+      using dir = tempDir("bun-write-src-slice-fifo", {});
+      const fifo = join(String(dir), "src.fifo");
+      mkfifo(fifo);
+      // O_RDWR, so the open does not wait for a writer.
+      const fd = fs.openSync(fifo, fs.constants.O_RDWR);
+      try {
+        fs.writeSync(fd, content);
+        const err = await Bun.write(join(String(dir), "dst.txt"), Bun.file(fd).slice(5, 10)).then(
+          () => null,
+          e => e,
+        );
+        expect({ syscall: err?.syscall, message: err?.message }).toEqual({
+          syscall: "fstat",
+          message: "Non-regular files aren't supported yet",
+        });
+      } finally {
+        fs.closeSync(fd);
+      }
+    });
+
     it("a window of a file larger than the preallocation threshold", async () => {
       const payload = randomBytes(8 * 1024 * 1024);
       using dir = tempDir("bun-write-src-slice-large", { "src.bin": payload });
@@ -627,23 +814,35 @@ const IS_UV_FS_COPYFILE_DISABLED =
       }
     });
 
-    it.skipIf(!isLinux)("a window through the read/write fallback", async () => {
-      using dir = tempDir("bun-write-src-slice-fallback", { "src.txt": content });
-      const src = join(String(dir), "src.txt");
-      const dst = join(String(dir), "dst.txt");
-      const script = `process.stdout.write(String(await Bun.write(${JSON.stringify(dst)}, Bun.file(${JSON.stringify(src)}).slice(10, 20))))`;
+    // The fallback reads 64 KiB at a time. This window takes many reads, and it
+    // is longer than the preallocation threshold.
+    it("a window through the read/write fallback", async () => {
+      const payload = randomBytes(4 * 1024 * 1024);
+      using dir = tempDir("bun-write-src-slice-fallback", { "src.bin": payload });
+      const src = join(String(dir), "src.bin");
+      const dst = join(String(dir), "dst.bin");
+      const start = 512 * 1024 + 7;
+      const end = payload.length - 5;
+      const script = `process.stdout.write(String(await Bun.write(${JSON.stringify(dst)}, Bun.file(${JSON.stringify(src)}).slice(${start}, ${end}))))`;
 
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", script],
-        env: { ...bunEnv, BUN_CONFIG_DISABLE_COPY_FILE_RANGE: "1" },
+        env: { ...bunEnv, BUN_CONFIG_DISABLE_COPY_FILE_RANGE: "1", BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE: "1" },
         stdout: "pipe",
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, stderr, copied: fs.readFileSync(dst, "utf8") }).toEqual({
-        stdout: "10",
+      const copied = fs.readFileSync(dst);
+      expect({
+        stdout,
+        stderr,
+        size: copied.byteLength,
+        identical: copied.equals(payload.subarray(start, end)),
+      }).toEqual({
+        stdout: String(end - start),
         stderr: "",
-        copied: "klmnopqrst",
+        size: end - start,
+        identical: true,
       });
       expect(exitCode).toBe(0);
     });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1287,14 +1287,15 @@ describe("stdin: a sliced Bun.file() sends only the slice", () => {
   });
 
   it.concurrent.each([
-    ["a Response over the slice", (slice: Blob) => new Response(slice)],
-    ["a Response over the slice's stream", (slice: Blob) => new Response(slice.stream())],
-    ["the slice's stream", (slice: Blob) => slice.stream()],
-  ])("%s", async (_, wrap) => {
+    ["a Response over the slice", 10, 20, (slice: Blob) => new Response(slice)],
+    ["a Response over the slice's stream", 10, 20, (slice: Blob) => new Response(slice.stream())],
+    ["the slice's stream", 10, 20, (slice: Blob) => slice.stream()],
+    ["the stream of a window at the start", 0, 5, (slice: Blob) => slice.stream()],
+  ])("%s", async (_, start, end, wrap) => {
     using dir = tempDir("spawn-stdin-slice-body", { "src.txt": content });
-    const slice = Bun.file(join(String(dir), "src.txt")).slice(10, 20);
+    const slice = Bun.file(join(String(dir), "src.txt")).slice(start, end);
 
-    expect(await sendToChild(wrap(slice))).toEqual({ stdout: "klmnopqrst", stderr: "", exitCode: 0 });
+    expect(await sendToChild(wrap(slice))).toEqual({ stdout: content.slice(start, end), stderr: "", exitCode: 0 });
   });
 
   it.concurrent("a window of a file descriptor, without moving its position", async () => {
@@ -1361,6 +1362,17 @@ describe("stdin: a sliced Bun.file() sends only the slice", () => {
     appendFileSync(src, "0123");
 
     expect(await sendToChild(file)).toEqual({ stdout: content + "0123", stderr: "", exitCode: 0 });
+  });
+
+  // A stat that fails must not leave a size of 0 behind.
+  it.concurrent.each(["exists()", ".size"])("a Bun.file() whose %s was read before the file existed", async probe => {
+    using dir = tempDir("spawn-stdin-created-later", {});
+    const src = join(String(dir), "src.txt");
+    const file = Bun.file(src);
+    expect(probe === "exists()" ? await file.exists() : file.size).toBe(probe === "exists()" ? false : 0);
+    writeFileSync(src, content);
+
+    expect(await sendToChild(file)).toEqual({ stdout: content, stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1268,18 +1268,46 @@ describe("stdin: a sliced Bun.file() sends only the slice", () => {
     return { stdout, stderr, exitCode };
   }
 
-  it.concurrent.each([
+  function sendToChildSync(stdin: Blob) {
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", echoStdin],
+      env: bunEnv,
+      stdin,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+  }
+
+  const windows: [name: string, start: number, end: number | undefined][] = [
     ["a window in the middle", 10, 20],
     ["a window at the start", 0, 5],
     ["a window to EOF", 3, undefined],
     ["a window that ends past EOF", 20, 100],
+    ["a window at the start that ends past EOF", 0, 100],
+    ["a window of the whole file", 0, content.length],
+    ["a window from the start to EOF", 0, undefined],
     ["an empty window", 5, 5],
     ["a window past EOF", 30, 40],
-  ])("%s", async (_, start, end) => {
+  ];
+
+  it.concurrent.each(windows)("%s", async (_, start, end) => {
     using dir = tempDir("spawn-stdin-slice", { "src.txt": content });
     const file = Bun.file(join(String(dir), "src.txt"));
 
     expect(await sendToChild(file.slice(start, end))).toEqual({
+      stdout: content.slice(start, end),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Not concurrent: spawnSync blocks the event loop of the concurrent tests.
+  it.each(windows)("spawnSync: %s", (_, start, end) => {
+    using dir = tempDir("spawn-stdin-slice-sync", { "src.txt": content });
+    const file = Bun.file(join(String(dir), "src.txt"));
+
+    expect(sendToChildSync(file.slice(start, end))).toEqual({
       stdout: content.slice(start, end),
       stderr: "",
       exitCode: 0,
@@ -1349,20 +1377,56 @@ describe("stdin: a sliced Bun.file() sends only the slice", () => {
     });
   });
 
-  it("spawnSync", () => {
-    using dir = tempDir("spawn-stdin-slice-sync", { "src.txt": content });
+  it("spawnSync: a window at the end of a large file", () => {
+    const payload = randomBytes(1024 * 1024);
+    using dir = tempDir("spawn-stdin-slice-tail", { "src.bin": payload });
     const { stdout, stderr, exitCode } = spawnSync({
       cmd: [bunExe(), "-e", echoStdin],
       env: bunEnv,
-      stdin: Bun.file(join(String(dir), "src.txt")).slice(10, 20),
+      stdin: Bun.file(join(String(dir), "src.bin")).slice(payload.length - 12, payload.length),
       stdout: "pipe",
       stderr: "pipe",
     });
 
-    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
-      stdout: "klmnopqrst",
+    expect({ stdout: stdout.toString("hex"), stderr: stderr.toString(), exitCode }).toEqual({
+      stdout: payload.subarray(payload.length - 12).toString("hex"),
       stderr: "",
       exitCode: 0,
+    });
+  });
+
+  // A missing file has no window to read. It goes to the child as an unsliced file does.
+  it("a window of a missing file", () => {
+    using dir = tempDir("spawn-stdin-slice-missing", {});
+    const outcome = (stdin: Blob) => {
+      try {
+        return sendToChildSync(stdin);
+      } catch (err) {
+        return { code: (err as NodeJS.ErrnoException).code };
+      }
+    };
+
+    expect(outcome(Bun.file(join(String(dir), "a.txt")).slice(0, 5))).toEqual(
+      outcome(Bun.file(join(String(dir), "b.txt"))),
+    );
+  });
+
+  // The window applies to stdin only. At stdout, the child writes to the file.
+  it.concurrent("a window at stdout", async () => {
+    using dir = tempDir("spawn-stdout-slice", { "out.txt": "" });
+    const out = join(String(dir), "out.txt");
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", "process.stdout.write('written')"],
+      env: bunEnv,
+      stdout: Bun.file(out).slice(0, 2),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect({ stderr, exitCode, written: readFileSync(out, "utf8") }).toEqual({
+      stderr: "",
+      exitCode: 0,
+      written: "written",
     });
   });
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -17,7 +17,8 @@ import {
   tmpdirSync,
   withoutAggressiveGC,
 } from "harness";
-import { closeSync, fstatSync, openSync, readFileSync, readSync, rmSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { appendFileSync, closeSync, fstatSync, openSync, readFileSync, readSync, rmSync, writeFileSync } from "node:fs";
 import path, { join } from "path";
 
 let tmp: string;
@@ -1252,6 +1253,114 @@ describe("close handling", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "PASS", stderr: "", exitCode: 0 });
     });
+  });
+});
+
+// A sliced Bun.file() is a view (`offset`, `size`) over a store that names the
+// whole file. The child got the store's path or fd, so it read the whole file.
+describe("stdin: a sliced Bun.file() sends only the slice", () => {
+  const content = "abcdefghijklmnopqrstuvwxyz";
+  const echoStdin = "process.stdin.pipe(process.stdout)";
+
+  async function sendToChild(stdin: Blob | Response | ReadableStream) {
+    await using proc = spawn({ cmd: [bunExe(), "-e", echoStdin], env: bunEnv, stdin, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent.each([
+    ["a window in the middle", 10, 20],
+    ["a window at the start", 0, 5],
+    ["a window to EOF", 3, undefined],
+    ["a window that ends past EOF", 20, 100],
+    ["an empty window", 5, 5],
+    ["a window past EOF", 30, 40],
+  ])("%s", async (_, start, end) => {
+    using dir = tempDir("spawn-stdin-slice", { "src.txt": content });
+    const file = Bun.file(join(String(dir), "src.txt"));
+
+    expect(await sendToChild(file.slice(start, end))).toEqual({
+      stdout: content.slice(start, end),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent.each([
+    ["a Response over the slice", (slice: Blob) => new Response(slice)],
+    ["a Response over the slice's stream", (slice: Blob) => new Response(slice.stream())],
+    ["the slice's stream", (slice: Blob) => slice.stream()],
+  ])("%s", async (_, wrap) => {
+    using dir = tempDir("spawn-stdin-slice-body", { "src.txt": content });
+    const slice = Bun.file(join(String(dir), "src.txt")).slice(10, 20);
+
+    expect(await sendToChild(wrap(slice))).toEqual({ stdout: "klmnopqrst", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("a window of a file descriptor, without moving its position", async () => {
+    using dir = tempDir("spawn-stdin-slice-fd", { "src.txt": content });
+    const fd = openSync(join(String(dir), "src.txt"), "r");
+    try {
+      const child = await sendToChild(Bun.file(fd).slice(10, 20));
+      const next = Buffer.alloc(5);
+      const n = readSync(fd, next, 0, 5, null);
+
+      expect({ child, next: next.toString("utf8", 0, n) }).toEqual({
+        child: { stdout: "klmnopqrst", stderr: "", exitCode: 0 },
+        next: "abcde",
+      });
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it.concurrent("a window larger than a pipe buffer", async () => {
+    const payload = randomBytes(3 * 1024 * 1024);
+    using dir = tempDir("spawn-stdin-slice-large", { "src.bin": payload });
+    const start = 1024 * 1024 + 3;
+    const end = 2 * 1024 * 1024 + 11;
+
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", echoStdin],
+      env: bunEnv,
+      stdin: Bun.file(join(String(dir), "src.bin")).slice(start, end),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+    expect({
+      size: stdout.byteLength,
+      identical: Buffer.from(stdout).equals(payload.subarray(start, end)),
+      stderr,
+      exitCode,
+    }).toEqual({ size: end - start, identical: true, stderr: "", exitCode: 0 });
+  });
+
+  it("spawnSync", () => {
+    using dir = tempDir("spawn-stdin-slice-sync", { "src.txt": content });
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", echoStdin],
+      env: bunEnv,
+      stdin: Bun.file(join(String(dir), "src.txt")).slice(10, 20),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+      stdout: "klmnopqrst",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("an unsliced Bun.file() whose size was read sends the whole file", async () => {
+    using dir = tempDir("spawn-stdin-size-read", { "src.txt": content });
+    const src = join(String(dir), "src.txt");
+    const file = Bun.file(src);
+    expect(file.size).toBe(content.length);
+    appendFileSync(src, "0123");
+
+    expect(await sendToChild(file)).toEqual({ stdout: content + "0123", stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1337,6 +1337,18 @@ describe("stdin: a sliced Bun.file() sends only the slice", () => {
     }).toEqual({ size: end - start, identical: true, stderr: "", exitCode: 0 });
   });
 
+  // procfs files are regular files with st_size == 0, so only the window bounds the read.
+  it.concurrent.skipIf(!isLinux)("a window of a file that reports no size", async () => {
+    const version = readFileSync("/proc/version", "utf8");
+    const file = Bun.file("/proc/version");
+    const [middle, toEnd] = await Promise.all([sendToChild(file.slice(3, 8)), sendToChild(file.slice(3))]);
+
+    expect({ middle, toEnd }).toEqual({
+      middle: { stdout: version.slice(3, 8), stderr: "", exitCode: 0 },
+      toEnd: { stdout: version.slice(3), stderr: "", exitCode: 0 },
+    });
+  });
+
   it("spawnSync", () => {
     using dir = tempDir("spawn-stdin-slice-sync", { "src.txt": content });
     const { stdout, stderr, exitCode } = spawnSync({


### PR DESCRIPTION
### Problem
- `Bun.file(p).slice(a, b)` loses its window when a consumer turns the Blob back into a path or fd. `Bun.write(dest, slice)` copies the whole source. `Bun.spawn({ stdin: slice })` sends the whole file.
- `write_file_with_source_destination` (`src/runtime/webcore/Blob.rs:4505`) gives `CopyFile` only the destination's offset and size. `Stdio::extract_blob` (`src/runtime/api/bun/spawn/stdio.rs:583`) maps every file Blob to its path or fd.
- `.size` and `exists()` cache the file's size in that field too, so `Bun.write(dst, src)` after `dst.size` copies only the old length. On Windows, a whole-file copy resolves with 0.

### Fix
- `CopyFile` takes the source window. On POSIX it seeks a regular source to the window's start, and every copy path stops at the window's end. On Windows, a partial window takes the read/write loop.
- Stdin reads a window of a regular file with `pread` and sends the bytes.
- `Blob::size_is_explicit` marks a window that `slice()` set. `BlobExt::file_window` reads it for the source, the destination and stdin.
- Verified on Linux and Windows: `test/js/bun/io/bun-write.test.js` (30 fail on 1.4.1) and `test/js/bun/spawn/spawn.test.ts` (20 fail). It replaces #31515, #31931, #33715 and #37877. Self-reviewed twice. Notes name what it does not take.

### Background
- A `Blob` is a view (`offset`, `size`) onto a refcounted store. `slice()` changes only the view. A file store names the whole file.
- A file Blob's `size` is `MAX_SIZE` (unknown) until something stats the file.
- `copy_file_range`, `sendfile` and `fcopyfile` read from the fd's position. `uv_fs_copyfile` copies whole files only and reports no byte count.

Fixes #4930

<details><summary>Notes</summary>

**Replaces four PRs.** The commit 408405ffcb ports what this PR lacked from them, and it credits their authors.

- #31515 (`Bun.write`, conflicts with main): its review asked to seek only regular files and to test a non-seekable source. This PR seeks regular files only. It tests a socket, a FIFO and `/dev/zero`. #31515 also fixed a destination whose `.size` was read, and the count on Windows. This PR fixes both.
- One difference from #31515: it stopped using the destination window. This PR keeps an explicit `Bun.file(dst).slice(0, n)` destination as a cap, as on main, and #37856 relies on that.
- #31931 (stdin, conflicts with main): a comment there noted that an unsliced `Bun.file()` whose `.size` was read must stay on the path/fd fast path, that `pread` fails on a pipe, and that a sliced file at stdout started to throw. This PR keeps all three as on main. Tests cover the first and the third.
- #37877 (destination cached size): its `size_is_explicit` flag, its structured clone change and its tests. This PR also sets the flag on the Blob that `slice().stream()` turns back into.
- #33715 (count): the macOS `fcopyfile` count and its test. On Windows, this PR stats the destination on the JS thread. #33715 chained an async `uv_fs_stat`. The same flow already stats the source and truncates the destination on the JS thread, and #40221 rewrites `on_copy_file`.

**Test cases of the older PRs.** Each has a case here.

- #31515, in the `Bun.write(dest, Bun.file(src).slice(start, end))` block: the windows `(5, 10)`, `(0, 10)`, `(20)`, `(5, 100)`, `(0, 100)` and `(0, 0)`, an unsliced source, a longer destination, an fd source, a window of a large file, a window through the read/write loop, and a FIFO. Its destination case is in the cached-size block.
- #31931, in the stdin block: path and fd sources, `slice(0)`, a window past EOF, and `spawnSync`.
- #33521, closed as a duplicate of #31931: `slice(3)`, `slice(3, 3)`, `slice(0, size)`, `slice(0, past end)`, each window through `spawn` and `spawnSync`, a window larger than a pipe buffer, a window at the end of a 1 MiB file, a `Response` over a slice, a missing file, the fd position, and a slice at stdout. Its `stdio[3]` case tests a change that neither PR makes.
- #37877: all 17 cases, now with the count on every platform. A new case pins `Bun.write(d.slice(0, d.size), src)` as a cap, as on main.
- #33715: its count case.

**Review.** A review of the first version of the last commit found that a size comparison, `size == file.max_size`, is wrong both ways. A structured clone of a primed destination still capped the copy. `d.slice(0, d.size)` stopped capping it. The flag from #37877 fixes both, and tests cover both. The comparison also breaks once #39763 lands, because its `exists()` stats the store again and leaves the Blob's size alone.

**Overlap with open PRs.** A maintainer can pick one shape.

- #33360: the same `size_is_explicit` field, for reads. Whichever PR lands second drops the field hunk.
- #39763: the same `resolve_size` and `.size` change, plus a stat on every `exists()`. This PR carries only that hunk, because the window check needs it. Whichever PR lands second drops the hunk.
- #32859: the same `Bun.write` fix on POSIX only, plus a separate fix for a file copied onto itself. It does not touch the Linux read/write fallback, which still reads to EOF past the window. It also passes the source offset in place of the destination offset.
- #37856: the same `read_write_fallback` change, for destination windows.

**Earlier reviews.** A review of the first version found a regression. `exists()` or `.size` on a file that did not exist yet cached a size of 0. Once the file existed, `Bun.write` copied nothing and stdin sent nothing. The second commit fixes that, and four tests cover it. The bot reviews found two more gaps, which the third commit fixes:

- On macOS, `fcopyfile` copied the whole source for a window and then truncated it. The FreeBSD loop did the same. Both now serve only a whole-file source.
- A procfs file reports a size of 0. So stdin clamped a window of it to nothing and passed the file to the child. Stdin now reads that window until the window or the file ends.

Not taken from the reviews:

- A separate base PR for the stat fix. #39763 is that PR. This PR carries its core hunk, so it does not regress on its own.
- Dropping the macOS `EBADF` hunk. See Costs.
- The destination-window tests of #37856. They test that PR's scope, and it stays open.
- A stat at spawn time. Stdin clamps a window with the size that the store cached, as `.text()` does. #33360 and #39763 change how that size is cached.
- The merge order against #40221, and a 1.4.x release for this change. A maintainer decides those. The #31515 review said that a breaking change of this kind can ship in a minor release.

**Windows.** The read/write loop now opens the source before the destination. A missing source leaves the destination alone, and a test covers it.

**Probe** on a 26-byte file `a..z`, `f = Bun.file(p)`:

```
                                              1.4.1 / main         this PR
Bun.write(dst, f.slice(10, 20))               26, whole file       10, "klmnopqrst"
Bun.write(dst, new Response(f.slice(10,20)))  26, whole file       10
Bun.write(dst, new Response(slice.stream()))  26, whole file       10
Bun.write(dst, f.slice(0, 5)), (3), (20,100)  whole file           the window
Bun.write(dst, 8 MiB.slice(1 MiB+3, 5 MiB-7)) 8 MiB                4194294 bytes, identical
Bun.write("/dev/null", /dev/zero.slice(0,10)) never settles        10
Bun.spawn({ stdin: f.slice(10, 20) })         whole file           "klmnopqrst"
Bun.spawn({ stdin: Bun.file(fd).slice(..) })  whole file, fd moved the window, fd not moved
f.exists(), create p, f.size / f.text()       0 / ""               26 / the file
d = 3-byte file, d.size, Bun.write(d, f)      3, "abc"             26, the file
d.size, Bun.write(d.slice(0, d.size), f)      3                    3
Bun.write(dst, f) on Windows                  resolves 0           resolves 26
```

**Non-seekable sources.** A socket, a pipe or a character device has no position. `Bun.write` copies the window's size from where the stream is. Spawn passes a non-regular file to the child as before, because a read from a pipe on the JS thread can block it.

**Not changed here.**

- `f.slice(20, 100).size` is 80. The size of an unstatted file Blob is lazy (#32794, #33360).
- `Bun.serve` answers 206 with `Content-Range` for a sliced file. `docs/runtime/http/routing.mdx` documents that.
- The shell turns a path-backed file Blob in a template into its path, so `cat < ${f.slice(1, 3)}` still reads the whole file.
- `Bun.spawn({ stdin: Bun.file("/proc/version") })` throws `EACCES` on 1.4.1. The stdin path is opened with `O_CREAT` (`src/spawn_sys/spawn_process.rs:778`). A sliced file is read in the parent now, so the procfs test passes. The unsliced case is a separate fix.
- A negative index on an unstatted file is wrong in `slice()` itself. `f.slice(-5)` gets offset `MAX_SIZE - 5`. On 1.4.1, `text()` returns the first 5 bytes, because the seek fails and the read starts at 0. `Bun.write` copied the whole file. With this PR, `Bun.write` and stdin send nothing. The correct result is the last 5 bytes, which needs a stat in `slice()`. That is a separate fix.

**Costs.**

- A stdin window is read into memory, as an `ArrayBuffer` stdin is. A stream would need the async path, which `spawnSync` does not have.
- The Linux fallback (`EXDEV`, `ENOSYS`) now reads in 64 KiB chunks. The old loop for a Bun-opened destination used chunks up to 8 MB, and it read to EOF past its length. A 256 MB fallback copy takes about 200 ms on a debug build.
- The review called the macOS `EBADF` hunk a no-op. The code comment ties `EBADF` from `fcopyfile` to a destination that cannot seek. The old loop there read to EOF, past the window. The hunk stops it at the window's end.

**Test runs.**

- Linux, debug build, last commit: all of `spawn.test.ts` passes. All of `bun-write.test.js` passes except "Bun.file(0) survives GC", which times out on this machine on the base build too. "copyFileRange is not available > on large files" is near its limit here. Its JS loop and hash take 3.4 s on a debug build, and its fallback copy takes 0.5 s.
- Linux, also green: `structured-clone-blob-file`, `blob`, `blob-write`, `blob-file-name-ownership`, `write.spec`, `bun-file-exists`, `bun-file`, `message-channel`, and regression test 25903. Earlier commits: `body`, `bun-serve-file`, and regression tests 26851, 27099, 27849 and 31652.
- Windows x64, debug build, last commit: all of `bun-write.test.js` passes, also with `BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE=1`. The stdin block of `spawn.test.ts` passes (the procfs case is Linux only). `structured-clone-blob-file`, `blob` and `bun-file` pass.
- Windows, on the commit before the last one, with the first version of the new tests: 7 cases fail. Four are destination cases. Three whole-file copies resolve with 0.
- `bun run rust:check-all` for macOS (x64 and arm64) and FreeBSD: no errors or warnings.
- macOS was not run. The macOS changes are in the `clonefile` and `fcopyfile` branches.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts, test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->
