### PR TITLE
File: convert the name argument to a USVString

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1344,6 +1344,12 @@ pub fn is_valid_utf8(slice: &[u8]) -> bool {
     simdutf::validate::utf8(slice)
 }
 
+/// SIMD-validated UTF-16 check: `false` iff `slice` has an unpaired surrogate.
+#[inline]
+pub fn is_valid_utf16(slice: &[u16]) -> bool {
+    simdutf::validate::utf16le(slice)
+}
+
 /// SIMD-validated `&str` view of `bytes`; `None` if not valid UTF-8.
 ///
 /// This is the codebase-wide replacement for `core::str::from_utf8` — every

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -586,9 +586,10 @@ impl String {
         debug_assert!(self.is_thread_shareable());
     }
     /// WebIDL `USVString` conversion: every unpaired surrogate becomes
-    /// U+FFFD. Returns `self` as is when it is well-formed (an 8-bit string
-    /// holds no surrogate) and `OUT_OF_MEMORY` when WTF could not allocate
-    /// the replacement.
+    /// U+FFFD. Returns `self` as is when it has none, and `OUT_OF_MEMORY`
+    /// when WTF could not allocate the replacement. Only UTF-16 is checked:
+    /// Latin-1 cannot hold a surrogate, and JSC decodes an encoded surrogate
+    /// in UTF-8 to U+FFFD.
     pub fn into_well_formed(self) -> Self {
         if !self.is_utf16() {
             return self;

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -585,6 +585,38 @@ impl String {
         }
         debug_assert!(self.is_thread_shareable());
     }
+    /// WebIDL `USVString` conversion: every unpaired surrogate becomes
+    /// U+FFFD. Returns `self` as is when it is well-formed (an 8-bit string
+    /// holds no surrogate) and `OUT_OF_MEMORY` when WTF could not allocate
+    /// the replacement.
+    pub fn into_well_formed(self) -> Self {
+        if !self.is_utf16() {
+            return self;
+        }
+        let units = self.utf16();
+        if strings::is_valid_utf16(units) {
+            return self;
+        }
+        // An unpaired surrogate and U+FFFD are one unit each, so the length
+        // does not change.
+        let (out, buf) = Self::create_uninitialized_utf16(units.len());
+        if out.is_dead() {
+            return out;
+        }
+        let mut i = 0;
+        while i < units.len() {
+            let (cp, adv) = strings::decode_utf16_with_fffd(&units[i..]);
+            let adv = usize::from(adv);
+            if adv == 2 {
+                buf[i..i + 2].copy_from_slice(&units[i..i + 2]);
+            } else {
+                // One unit: a BMP code unit, or U+FFFD for an unpaired surrogate.
+                buf[i] = cp as u16;
+            }
+            i += adv;
+        }
+        out
+    }
     /// What [`thread_isolated_copy`] yields: no thread-affine state (not an
     /// atom, symbol or substring), so the value may be handed to one other
     /// thread. Non-WTF tags are inert and always qualify.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5464,7 +5464,11 @@ pub(crate) fn jsdom_file_construct(
             "new File(bits, name) expects at least 2 arguments"
         )));
     }
-    let name = BunString::from_js(args[1], global_this)?;
+    // `fileName` is a WebIDL `USVString`: an unpaired surrogate becomes U+FFFD.
+    let name = BunString::from_js(args[1], global_this)?.into_well_formed();
+    if name.is_dead() {
+        return Err(global_this.throw_memory_allocation_failed());
+    }
     let blob = Blob::get::<false, true>(global_this, args[0])?;
     // The store may be shared with the source blob (`dupe()`); never rename it.
     blob.name.set(name);

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -318,21 +318,29 @@ test("new File([file], name) does not rename the source", () => {
 });
 
 test("new File(bits, name) converts the name to a USVString", async () => {
-  // `fileName` is a WebIDL USVString: an unpaired surrogate becomes U+FFFD.
-  const loneHigh = new File(["x"], "a\uD800b.txt");
-  const loneLow = new File(["x"], "a\uDC00b.txt");
-  const pairSplit = new File(["x"], "\uDC00\uD800");
-  expect([loneHigh.name, loneLow.name, pairSplit.name]).toEqual(["a\uFFFDb.txt", "a\uFFFDb.txt", "\uFFFD\uFFFD"]);
+  // `fileName` is a WebIDL USVString: each unpaired surrogate becomes U+FFFD.
+  const cases = [
+    ["a\uD800b.txt", "a\uFFFDb.txt"],
+    ["a\uDC00b.txt", "a\uFFFDb.txt"],
+    ["\uDC00\uD800", "\uFFFD\uFFFD"],
+    // a valid pair next to an unpaired surrogate stays as it is
+    ["\uD800\uD83D\uDE00", "\uFFFD\uD83D\uDE00"],
+    ["\uD800\uD800\uDC00", "\uFFFD\uD800\uDC00"],
+    ["\u{1F600}\uD800", "\u{1F600}\uFFFD"],
+    // a well-formed name does not change
+    ["\u{1F600}é.txt", "\u{1F600}é.txt"],
+  ];
+  const names = cases.map(([input]) => new File(["x"], input).name);
+  // JSON.stringify escapes an unpaired surrogate, so a failure shows which one is left.
+  expect(JSON.stringify(names)).toBe(JSON.stringify(cases.map(([, expected]) => expected)));
 
-  // a well-formed pair and a BMP character stay as they are
-  const wellFormed = new File(["x"], "\u{1F600}é.txt");
-  expect(wellFormed.name).toBe("\u{1F600}é.txt");
+  // a file-backed File converts its name too
+  expect(new File([Bun.file(import.meta.path)], "a\uD800b.txt").name).toBe("a\uFFFDb.txt");
 
   // the entry FormData hands back keeps the converted name
   const formData = new FormData();
-  formData.append("f", loneHigh);
-  const entry = formData.get("f") as File;
-  expect(entry.name).toBe("a\uFFFDb.txt");
+  formData.append("f", new File(["x"], "a\uD800b.txt"));
+  expect((formData.get("f") as File).name).toBe("a\uFFFDb.txt");
   expect(await new Response(formData).text()).toContain('filename="a\uFFFDb.txt"');
 });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -317,6 +317,25 @@ test("new File([file], name) does not rename the source", () => {
   expect([d.name, e.name]).toEqual(["d.txt", "e.txt"]);
 });
 
+test("new File(bits, name) converts the name to a USVString", async () => {
+  // `fileName` is a WebIDL USVString: an unpaired surrogate becomes U+FFFD.
+  const loneHigh = new File(["x"], "a\uD800b.txt");
+  const loneLow = new File(["x"], "a\uDC00b.txt");
+  const pairSplit = new File(["x"], "\uDC00\uD800");
+  expect([loneHigh.name, loneLow.name, pairSplit.name]).toEqual(["a\uFFFDb.txt", "a\uFFFDb.txt", "\uFFFD\uFFFD"]);
+
+  // a well-formed pair and a BMP character stay as they are
+  const wellFormed = new File(["x"], "\u{1F600}é.txt");
+  expect(wellFormed.name).toBe("\u{1F600}é.txt");
+
+  // the entry FormData hands back keeps the converted name
+  const formData = new FormData();
+  formData.append("f", loneHigh);
+  const entry = formData.get("f") as File;
+  expect(entry.name).toBe("a\uFFFDb.txt");
+  expect(await new Response(formData).text()).toContain('filename="a\uFFFDb.txt"');
+});
+
 test("dupeWithContentType does not alias the source's allocated content_type", async () => {
   // Regression: #23015 refactored Blob to be ref-counted and moved
   // `setNotHeapAllocated()` before the `isHeapAllocated()` guard in


### PR DESCRIPTION
### Problem
- `new File(bits, name).name` keeps an unpaired surrogate. `new File(["x"], "a\uD800b.txt").name` is `"a\uD800b.txt"`. Node and Bun 1.4.0 return `"a\uFFFDb.txt"`, because the File API declares `fileName` as a `USVString`. The entry from `FormData.get()` has the same name.
- The cause is `jsdom_file_construct` (`src/runtime/webcore/Blob.rs:5467`). Since #40436 it stores the JS string as is. Before that, a name on a byte store went through UTF-8 (`to_owned_slice()`), which replaced the surrogate.

### Fix
- Add `String::into_well_formed()` to `bun_core`. It validates UTF-16 with simdutf. Only a string with an unpaired surrogate gets a new copy, with U+FFFD in place of each one.
- Call it on the name in the File constructor. If the copy cannot be allocated, the constructor throws `ERR_MEMORY_ALLOCATION_FAILED`. The Bun-only `name` setter does not change. It stored its value as is in 1.4.0 too.
- This is correct because WebIDL converts a `USVString` argument this way. The FormData bindings do the same (`src/jsc/bindings/DOMFormData.cpp:102`).
- Verified: `test/js/web/fetch/blob.test.ts` (the new test fails on canary). Also the FormData, multipart, structured clone, and worker blob suites.

### Background
- A `USVString` holds only Unicode scalar values. When JS passes a string to a `USVString` argument, WebIDL replaces each unpaired surrogate (U+D800 to U+DFFF without its pair) with U+FFFD.
- `bun_core::String` is the Rust handle for a JSC string. A string from JS is Latin-1 or UTF-16. Only UTF-16 can hold a surrogate.

<details><summary>Notes</summary>

- Bisect: abe2ad4f0 returns U+FFFD, 326ec468a keeps U+D800. The change is 97420a74fb (#40436).
- 1.4.0 converted only a name on a byte store. A File on a `Bun.file()` or S3 store kept the surrogate. Now every File converts its name. The test covers a file-backed File.
- The test also covers names that mix an unpaired surrogate with a valid pair. Only those names reach the pair-copy branch of `into_well_formed()`.
- The `name` setter is not standard (Node has no setter). It stores and caches the value it gets, as in 1.4.0. So `file.name = x` keeps an unpaired surrogate, and `file.name === x` stays true.
- The multipart bytes were correct on every build. The serializer reads the name from the C++ FormData entry, which `DOMFormData::append` converts.
- `new File([], "").name` is `""` on canary and `undefined` on 1.4.0. This change keeps `""`, which matches Node.
- Open PR #37680 has the same conversion as a UTF-8 round trip. It conflicts with main now, because #40436 landed its per-Blob name storage. Its FormData file name override is also in #35079. Other FormData file name differences from Node are in #35439.
- Suites run with the debug build: `test/js/web/fetch/blob.test.ts`, `test/js/web/html/FormData.test.ts`, `test/js/web/html/FormData-multipart-serialization.test.ts`, `test/js/web/fetch/blob-file-name-ownership.test.ts`, `test/js/web/structured-clone-blob-file.test.ts`, `test/js/web/workers/worker_blob.test.ts`.
- Self-reviewed: 3 concerns raised, 3 addressed. The test now covers the pair-copy branch and a file-backed File. The setter stays as is, for the reason above. This body links #37680. #37680 stays open, because this PR does not include its FormData override.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->