### PR TITLE
[do not merge] CI bisect: #41190 with WebKit minus oven-sh/WebKit#553

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-552-ed0763a0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-552-287d9c5f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-552-287d9c5f";
+export const WEBKIT_VERSION = "72e75e4ec1f9a8571874328c1502f4d8226bc2bf";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "491b5cc236e9ed0bf6247bc466d4b17158311e27";
+export const WEBKIT_VERSION = "autobuild-preview-pr-552-ed0763a0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "72e75e4ec1f9a8571874328c1502f4d8226bc2bf";
+export const WEBKIT_VERSION = "autobuild-preview-pr-552-287d9c5f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -23,7 +23,6 @@
 // calls to $assert which will verify this invariant (only during bun-debug)
 //
 const setAsyncHooksEnabled = $newCppFunction("NodeAsyncHooks.cpp", "jsSetAsyncHooksEnabled", 1);
-const cleanupLater = $newCppFunction("NodeAsyncHooks.cpp", "jsCleanupLater", 0);
 const { validateFunction, validateString, validateObject } = require("internal/validators");
 // SameValue in pure operators. Node compares stores with the primordial
 // ObjectIs; capturing Object.is here would still inherit a patch applied
@@ -69,6 +68,10 @@ function debugFormatContextValue(value: ReadonlyArray<any> | undefined) {
   return str;
 }
 
+// Bumped whenever a frame is mutated in place (disable()), so run() can tell
+// that the frame it installed changed under it even though its identity did not.
+let frameMutations = 0;
+
 function get(): ReadonlyArray<any> | undefined {
   $debug("get", debugFormatContextValue($getInternalField($asyncContext, 0)));
   return $getInternalField($asyncContext, 0);
@@ -81,8 +84,8 @@ function set(contextValue: ReadonlyArray<any> | undefined) {
 }
 
 // Node parity: dispose() is enterWith(previousStore), which on a fresh ALS
-// installs [als, undefined] instead of splicing like run(). Bun's
-// cleanupAsyncHooksData resets top-level next tick, so residue is bounded.
+// installs [als, undefined] instead of splicing like run(). Like any
+// enterWith() residue, it is dropped at the next top-level checkpoint.
 class RunScope {
   #storage;
   #previousStore;
@@ -153,7 +156,6 @@ class AsyncLocalStorage {
   }
 
   enterWith(store) {
-    cleanupLater();
     // we must renable it when asyncLocalStorage.enterWith() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
     this.#disabled = false;
     var context = get();
@@ -194,18 +196,19 @@ class AsyncLocalStorage {
     if (!this.#disabled && sameValue(this.getStore(), store_value)) {
       return callback.$apply(undefined, args);
     }
-    var context = get() as any[]; // we make sure to .slice() before mutating
+    var prior = get(); // the frame to come back to
+    var mutations = frameMutations;
+    var context: any[]; // the frame installed for the callback
     var hasPrevious = false;
     var previous_value;
     var i = 0;
-    var contextWasAlreadyInit = !context;
     // we must renable it when asyncLocalStorage.run() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
     this.#disabled = false;
-    if (contextWasAlreadyInit) {
+    if (!prior) {
       set((context = [this, store_value]));
     } else {
       // it's safe to mutate context now that it was cloned
-      context = context!.slice();
+      context = prior.slice();
       // Scan even (key) slots only — a value slot can hold this storage when
       // another ALS stored it via enterWith/run.
       i = -1;
@@ -240,9 +243,11 @@ class AsyncLocalStorage {
       // entering a disabled storage must not leave store_value installed after run().
       {
         var context2 = get()! as any[]; // we make sure to .slice() before mutating
-        if (context2 === context && contextWasAlreadyInit) {
-          $assert(context2.length === 2, "context was mutated without copy");
-          set(undefined);
+        if (context2 === context && mutations === frameMutations) {
+          // Nothing inside the callback installed or mutated a frame, so the frame
+          // from before run() is exactly what restoring by value would rebuild.
+          // No allocation on this path.
+          set(prior);
         } else {
           // The context array can change shape during the callback (disable()
           // splices storages out), so re-locate this storage by identity
@@ -303,7 +308,9 @@ class AsyncLocalStorage {
       var { length } = context;
       for (var i = 0; i < length; i += 2) {
         if (context[i] === this) {
+          // In place: this also exits continuations that captured this frame.
           context.splice(i, 2);
+          frameMutations++;
           set(context.length ? context : undefined);
           break;
         }

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -118,7 +118,7 @@ function withoutAll(frame: Frame | undefined, storage: AsyncLocalStorage): Frame
 function copyUntil(from: Frame, stop: Frame, tail: Frame | undefined): Frame | undefined {
   var copied: Frame[] = [];
   for (var f = from; f !== stop; f = f.prev!) {
-    if (f.storage !== undefined) copied.push(f);
+    if (f.storage !== undefined) $arrayPush(copied, f);
   }
   for (var i = copied.length - 1; i >= 0; i--) {
     tail = new Frame(copied[i].storage!, copied[i].value, tail);

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -242,12 +242,12 @@ class AsyncLocalStorage {
         // restore only this storage's binding, re-enabling the storage.
         this.#disabled = false;
         var before = find(prior, this);
-        var current = live(get());
-        // Drop the binding the callback left for this storage (ours, or the one an
-        // enterWith() replaced it with) unless it already is the prior one.
-        if (find(current, this) !== before) current = without(current, this);
-        if (before !== undefined && find(current, this) !== before) current = new Frame(this, before.value, current);
-        set(current);
+        // Frames may have been copied (enterWith() of a storage bound further down
+        // copies everything above it), so go by value, not identity: drop every
+        // binding of this storage and put the prior one back on top. Enclosing
+        // run()s of the same storage restore their own value the same way.
+        var current = withoutAll(live(get()), this);
+        set(before !== undefined ? new Frame(this, before.value, current) : current);
       }
       $assert(
         sameValue(this.getStore(), find(prior, this) !== undefined ? find(prior, this)!.value : this.#defaultValue),
@@ -269,7 +269,10 @@ class AsyncLocalStorage {
     if (top === undefined) return;
     var below = withoutAll(top.prev, this);
     if (top.storage !== this && below === top.prev) return;
-    if (top.storage === this) top.storage = undefined;
+    if (top.storage === this) {
+      top.storage = undefined;
+      top.value = undefined;
+    }
     top.prev = below;
     frameMutations++;
   }

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -83,6 +83,13 @@ function set(frame: Frame | undefined) {
   return $putInternalField($asyncContext, 0, frame);
 }
 
+// `frame` without the exited bindings on top of it. Continuations that captured
+// an exited frame keep holding it; the slot need not.
+function live(frame: Frame | undefined): Frame | undefined {
+  while (frame !== undefined && frame.storage === undefined) frame = frame.prev;
+  return frame;
+}
+
 // The innermost frame binding `storage`, or undefined.
 function find(frame: Frame | undefined, storage: AsyncLocalStorage): Frame | undefined {
   for (var f = frame; f !== undefined; f = f.prev) {
@@ -92,16 +99,26 @@ function find(frame: Frame | undefined, storage: AsyncLocalStorage): Frame | und
 }
 
 // `frame` with the innermost binding of `storage` removed. Frames above it are
-// copied (they are immutable and may be shared); the tail below it is shared.
+// copied (they may be shared with other captures); the tail below it is shared.
 function without(frame: Frame | undefined, storage: AsyncLocalStorage): Frame | undefined {
   var found = find(frame, storage);
   if (found === undefined) return frame;
   return copyUntil(frame!, found, found.prev);
 }
 
+// `frame` with every binding of `storage` removed (nested run() of one storage
+// stacks shadowed bindings).
+function withoutAll(frame: Frame | undefined, storage: AsyncLocalStorage): Frame | undefined {
+  var found = find(frame, storage);
+  if (found === undefined) return frame;
+  return copyUntil(frame!, found, withoutAll(found.prev, storage));
+}
+
+// Copies [from, stop) onto tail, dropping bindings that disable() exited.
 function copyUntil(from: Frame, stop: Frame, tail: Frame | undefined): Frame | undefined {
   if (from === stop) return tail;
-  return new Frame(from.storage!, from.value, copyUntil(from.prev!, stop, tail));
+  var rest = copyUntil(from.prev!, stop, tail);
+  return from.storage === undefined ? rest : new Frame(from.storage, from.value, rest);
 }
 
 // Node parity: dispose() is enterWith(previousStore), which on a fresh ALS
@@ -181,7 +198,7 @@ class AsyncLocalStorage {
     this.#disabled = false;
     // Replace rather than shadow an existing binding so repeated enterWith() calls
     // keep the chain bounded by the number of storages.
-    set(new Frame(this, store, without(get(), this)));
+    set(new Frame(this, store, without(live(get()), this)));
     $assert(sameValue(this.getStore(), store));
   }
 
@@ -220,8 +237,12 @@ class AsyncLocalStorage {
         // restore only this storage's binding, re-enabling the storage.
         this.#disabled = false;
         var before = find(prior, this);
-        var current = without(get(), this);
-        set(before !== undefined ? new Frame(this, before.value, current) : current);
+        var current = live(get());
+        // Drop the binding the callback left for this storage (ours, or the one an
+        // enterWith() replaced it with) unless it already is the prior one.
+        if (find(current, this) !== before) current = without(current, this);
+        if (before !== undefined && find(current, this) !== before) current = new Frame(this, before.value, current);
+        set(current);
       }
       $assert(
         sameValue(this.getStore(), find(prior, this) !== undefined ? find(prior, this)!.value : this.#defaultValue),
@@ -234,13 +255,18 @@ class AsyncLocalStorage {
     $debug("disable " + (this as any).__id__);
     if (this.#disabled) return;
     this.#disabled = true;
-    // Exit the binding in place, so continuations that captured this frame lose
-    // it too (Node deletes from the shared frame object).
-    var found = find(get(), this);
-    if (found !== undefined) {
-      found.storage = undefined;
-      frameMutations++;
-    }
+    // Node deletes the key from the current frame object, so continuations that
+    // captured the current frame lose the binding while older captures keep it.
+    // The innermost Frame is what those continuations hold: exit its own
+    // binding in place and unlink any deeper ones from it, leaving the shared
+    // tail untouched for everyone else.
+    var top = get();
+    if (top === undefined) return;
+    var below = withoutAll(top.prev, this);
+    if (top.storage !== this && below === top.prev) return;
+    if (top.storage === this) top.storage = undefined;
+    top.prev = below;
+    frameMutations++;
   }
 
   get name() {

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -18,9 +18,11 @@
 // other checks to ensure that AsyncLocalStorage has virtually no impact on performance when not in
 // use. But the nature of this approach makes the implementation *itself* very low-impact on performance.
 //
-// AsyncContextData is an immutable array managed in here, formatted [key, value, key, value] where
-// each key is an AsyncLocalStorage object and the value is the associated value. There are a ton of
-// calls to $assert which will verify this invariant (only during bun-debug)
+// AsyncContextData is the innermost Frame of a persistent linked list managed in
+// here: each Frame binds one AsyncLocalStorage to a value and points at the frame
+// it was pushed onto, so run() allocates one three-field object and never copies,
+// getStore() walks the (short) chain, and a captured context is a single
+// reference that shares its tail with every other capture.
 //
 const setAsyncHooksEnabled = $newCppFunction("NodeAsyncHooks.cpp", "jsSetAsyncHooksEnabled", 1);
 const { validateFunction, validateString, validateObject } = require("internal/validators");
@@ -32,59 +34,78 @@ function sameValue(a, b) {
   return a !== a && b !== b;
 }
 
+class Frame {
+  storage: AsyncLocalStorage | undefined; // undefined once disable() has exited it
+  value: unknown;
+  prev: Frame | undefined;
+  constructor(storage: AsyncLocalStorage, value: unknown, prev: Frame | undefined) {
+    this.storage = storage;
+    this.value = value;
+    this.prev = prev;
+  }
+}
+
 // Only run during debug
-function assertValidAsyncContextArray(array: unknown): array is ReadonlyArray<any> | undefined {
-  // undefined is OK
-  if (array === undefined) return true;
-  // Otherwise, it must be an array
-  $assert(
-    Array.isArray(array),
-    "AsyncContextData must be an array or undefined, got",
-    Bun.inspect(array, { depth: 1 }),
-  );
-  // the array has to be even
-  $assert(array.length % 2 === 0, "AsyncContextData should be even-length, got", Bun.inspect(array, { depth: 1 }));
-  // if it is zero-length, use undefined instead
-  $assert(array.length > 0, "AsyncContextData should be undefined if empty, got", Bun.inspect(array, { depth: 1 }));
-  for (var i = 0; i < array.length; i += 2) {
+function assertValidFrame(frame: unknown): boolean {
+  for (var f = frame, n = 0; f !== undefined; f = (f as Frame).prev, n++) {
+    $assert(f instanceof Frame, "AsyncContextData must be a Frame chain or undefined, got", f);
     $assert(
-      array[i] instanceof AsyncLocalStorage,
-      `Odd indexes in AsyncContextData should be an array of AsyncLocalStorage\nIndex %s was %s`,
-      i,
-      array[i],
+      (f as Frame).storage === undefined || (f as Frame).storage instanceof AsyncLocalStorage,
+      "Frame.storage must be an AsyncLocalStorage",
     );
+    $assert(n < 10000, "AsyncContextData chain is unreasonably long (cycle?)");
   }
   return true;
 }
 
 // Only run during debug
-function debugFormatContextValue(value: ReadonlyArray<any> | undefined) {
-  if (value === undefined) return "undefined";
-  let str = "{\n";
-  for (var i = 0; i < value.length; i += 2) {
-    str += `  ${value[i].__id__}: typeof = ${typeof value[i + 1]}\n`;
+function debugFormatContextValue(frame: Frame | undefined) {
+  if (frame === undefined) return "undefined";
+  let str = "{";
+  for (var f: Frame | undefined = frame; f !== undefined; f = f.prev) {
+    str += ` ${f.storage ? (f.storage as any).__id__ : "<exited>"}: ${typeof f.value};`;
   }
-  str += "}";
-  return str;
+  return str + " }";
 }
 
-// Bumped whenever a frame is mutated in place (disable()), so run() can tell
-// that the frame it installed changed under it even though its identity did not.
+// Bumped whenever disable() exits a frame in place, so run() can tell that the
+// chain it installed changed under it even though its identity did not.
 let frameMutations = 0;
 
-function get(): ReadonlyArray<any> | undefined {
+function get(): Frame | undefined {
   $debug("get", debugFormatContextValue($getInternalField($asyncContext, 0)));
   return $getInternalField($asyncContext, 0);
 }
 
-function set(contextValue: ReadonlyArray<any> | undefined) {
-  $assert(assertValidAsyncContextArray(contextValue));
-  $debug("set", debugFormatContextValue(contextValue));
-  return $putInternalField($asyncContext, 0, contextValue);
+function set(frame: Frame | undefined) {
+  $assert(assertValidFrame(frame));
+  $debug("set", debugFormatContextValue(frame));
+  return $putInternalField($asyncContext, 0, frame);
+}
+
+// The innermost frame binding `storage`, or undefined.
+function find(frame: Frame | undefined, storage: AsyncLocalStorage): Frame | undefined {
+  for (var f = frame; f !== undefined; f = f.prev) {
+    if (f.storage === storage) return f;
+  }
+  return undefined;
+}
+
+// `frame` with the innermost binding of `storage` removed. Frames above it are
+// copied (they are immutable and may be shared); the tail below it is shared.
+function without(frame: Frame | undefined, storage: AsyncLocalStorage): Frame | undefined {
+  var found = find(frame, storage);
+  if (found === undefined) return frame;
+  return copyUntil(frame!, found, found.prev);
+}
+
+function copyUntil(from: Frame, stop: Frame, tail: Frame | undefined): Frame | undefined {
+  if (from === stop) return tail;
+  return new Frame(from.storage!, from.value, copyUntil(from.prev!, stop, tail));
 }
 
 // Node parity: dispose() is enterWith(previousStore), which on a fresh ALS
-// installs [als, undefined] instead of splicing like run(). Like any
+// leaves a binding to undefined rather than removing it like run(). Like any
 // enterWith() residue, it is dropped at the next top-level checkpoint.
 class RunScope {
   #storage;
@@ -158,24 +179,9 @@ class AsyncLocalStorage {
   enterWith(store) {
     // we must renable it when asyncLocalStorage.enterWith() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
     this.#disabled = false;
-    var context = get();
-    if (!context) {
-      set([this, store]);
-      return;
-    }
-    var { length } = context;
-    $assert(length > 0);
-    $assert(length % 2 === 0);
-    for (var i = 0; i < length; i += 2) {
-      if (context[i] === this) {
-        $assert(length > i + 1);
-        const clone = context.slice();
-        clone[i + 1] = store;
-        set(clone);
-        return;
-      }
-    }
-    set(context.concat(this, store));
+    // Replace rather than shadow an existing binding so repeated enterWith() calls
+    // keep the chain bounded by the number of storages.
+    set(new Frame(this, store, without(get(), this)));
     $assert(sameValue(this.getStore(), store));
   }
 
@@ -183,8 +189,6 @@ class AsyncLocalStorage {
     return this.run(undefined, cb, ...args);
   }
 
-  // This function is litered with $asserts to ensure that everything that
-  // is assumed to be true is *actually* true.
   run(store_value, callback, ...args) {
     $debug("run " + (this as any).__id__);
     // Node short-circuits when the value is unchanged: no enterWith, no
@@ -196,125 +200,46 @@ class AsyncLocalStorage {
     if (!this.#disabled && sameValue(this.getStore(), store_value)) {
       return callback.$apply(undefined, args);
     }
-    var prior = get(); // the frame to come back to
-    var mutations = frameMutations;
-    var context: any[]; // the frame installed for the callback
-    var hasPrevious = false;
-    var previous_value;
-    var i = 0;
     // we must renable it when asyncLocalStorage.run() is called https://nodejs.org/api/async_context.html#asynclocalstoragedisable
     this.#disabled = false;
-    if (!prior) {
-      set((context = [this, store_value]));
-    } else {
-      // it's safe to mutate context now that it was cloned
-      context = prior.slice();
-      // Scan even (key) slots only — a value slot can hold this storage when
-      // another ALS stored it via enterWith/run.
-      i = -1;
-      for (var j = 0, len = context.length; j < len; j += 2) {
-        if (context[j] === this) {
-          i = j;
-          break;
-        }
-      }
-      if (i > -1) {
-        hasPrevious = true;
-        previous_value = context[i + 1];
-        context[i + 1] = store_value;
-      } else {
-        i = context.length;
-        context.push(this, store_value);
-        $assert(i % 2 === 0);
-        $assert(context.length % 2 === 0);
-      }
-      set(context);
-    }
-    $assert(i > -1, "i was not set");
-    $assert(sameValue(this.getStore(), store_value), "run: store_value was not set");
+    var prior = get();
+    var mutations = frameMutations;
+    // Shadows any outer binding of this storage: lookups stop at the innermost.
+    var frame = new Frame(this, store_value, prior);
+    set(frame);
     try {
       // $apply, not a spread: spreading goes through Array.prototype[Symbol.iterator],
       // which userland can delete (node uses ReflectApply here for the same reason).
       return callback.$apply(undefined, args);
     } finally {
-      // Note: early `return` will prevent `throw` above from working. I think...
-      // Set AsyncContextFrame to undefined if we are out of context values.
-      // Restoration is unconditional, mirroring node's `finally { enterWith(prior) }`:
-      // entering a disabled storage must not leave store_value installed after run().
-      {
-        var context2 = get()! as any[]; // we make sure to .slice() before mutating
-        if (context2 === context && mutations === frameMutations) {
-          // Nothing inside the callback installed or mutated a frame, so the frame
-          // from before run() is exactly what restoring by value would rebuild.
-          // No allocation on this path.
-          set(prior);
-        } else {
-          // The context array can change shape during the callback (disable()
-          // splices storages out), so re-locate this storage by identity
-          // instead of trusting the index captured before the callback ran.
-          // This mirrors node's run(), whose finally is enterWith(prior):
-          // restore by value, re-adding the previous value even after a
-          // disable() during the callback.
-          context2 = context2 ? context2.slice() : []; // array is cloned here
-          // Scan even (key) slots only — a value slot can hold this storage
-          // when another ALS stored it via enterWith/run.
-          let idx = -1;
-          for (let j = 0, len = context2.length; j < len; j += 2) {
-            if (context2[j] === this) {
-              idx = j;
-              break;
-            }
-          }
-          if (idx > -1) {
-            if (hasPrevious) {
-              context2[idx + 1] = previous_value;
-              set(context2);
-            } else {
-              context2.splice(idx, 2);
-              $assert(context2.length % 2 === 0);
-              set(context2.length ? context2 : undefined);
-            }
-          } else if (hasPrevious) {
-            // disable() removed us mid-callback; node still restores the
-            // previous value (and the storage becomes enabled again).
-            this.#disabled = false;
-            context2.push(this, previous_value);
-            set(context2);
-          } else {
-            // idx===-1 && !hasPrevious: disable() removed us; Node's finally
-            // is unconditionally enterWith(prior), which re-enables regardless.
-            this.#disabled = false;
-          }
-        }
-        const expectedStore = hasPrevious ? previous_value : this.#defaultValue;
-        $assert(
-          sameValue(this.getStore(), expectedStore),
-          "run: previous_value",
-          Bun.inspect(expectedStore),
-          "was not restored, i see",
-          this.getStore(),
-        );
+      if (get() === frame && mutations === frameMutations) {
+        set(prior);
+      } else {
+        // enterWith()/disable() ran inside the callback. Node's finally is
+        // enterWith(prior value): keep whatever else the callback installed and
+        // restore only this storage's binding, re-enabling the storage.
+        this.#disabled = false;
+        var before = find(prior, this);
+        var current = without(get(), this);
+        set(before !== undefined ? new Frame(this, before.value, current) : current);
       }
+      $assert(
+        sameValue(this.getStore(), find(prior, this) !== undefined ? find(prior, this)!.value : this.#defaultValue),
+        "run: previous value was not restored",
+      );
     }
   }
 
   disable() {
     $debug("disable " + (this as any).__id__);
-    // In this case, we actually do want to mutate the context state
     if (this.#disabled) return;
     this.#disabled = true;
-    var context = get() as any[];
-    if (context) {
-      var { length } = context;
-      for (var i = 0; i < length; i += 2) {
-        if (context[i] === this) {
-          // In place: this also exits continuations that captured this frame.
-          context.splice(i, 2);
-          frameMutations++;
-          set(context.length ? context : undefined);
-          break;
-        }
-      }
+    // Exit the binding in place, so continuations that captured this frame lose
+    // it too (Node deletes from the shared frame object).
+    var found = find(get(), this);
+    if (found !== undefined) {
+      found.storage = undefined;
+      frameMutations++;
     }
   }
 
@@ -328,12 +253,8 @@ class AsyncLocalStorage {
     // frame impl has no disabled flag; the legacy impl's not-enabled branch
     // is `return this.#defaultValue`.
     if (this.#disabled) return this.#defaultValue;
-    var context = get();
-    if (context) {
-      var { length } = context;
-      for (var i = 0; i < length; i += 2) {
-        if (context[i] === this) return context[i + 1];
-      }
+    for (var f = get(); f !== undefined; f = f.prev) {
+      if (f.storage === this) return f.value;
     }
     return this.#defaultValue;
   }

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -116,9 +116,14 @@ function withoutAll(frame: Frame | undefined, storage: AsyncLocalStorage): Frame
 
 // Copies [from, stop) onto tail, dropping bindings that disable() exited.
 function copyUntil(from: Frame, stop: Frame, tail: Frame | undefined): Frame | undefined {
-  if (from === stop) return tail;
-  var rest = copyUntil(from.prev!, stop, tail);
-  return from.storage === undefined ? rest : new Frame(from.storage, from.value, rest);
+  var copied: Frame[] = [];
+  for (var f = from; f !== stop; f = f.prev!) {
+    if (f.storage !== undefined) copied.push(f);
+  }
+  for (var i = copied.length - 1; i >= 0; i--) {
+    tail = new Frame(copied[i].storage!, copied[i].value, tail);
+  }
+  return tail;
 }
 
 // Node parity: dispose() is enterWith(previousStore), which on a fresh ALS

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -78,20 +78,14 @@ void JSNextTickQueue::discard(JSC::VM& vm)
 void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    bool mustResetContext = false;
     if (isEmpty()) {
         RETURN_IF_EXCEPTION(throwScope, );
         vm.drainMicrotasks();
         RETURN_IF_EXCEPTION(throwScope, );
-        mustResetContext = true;
     }
 
     if (!isEmpty()) {
         RETURN_IF_EXCEPTION(throwScope, );
-        if (mustResetContext) {
-            globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
-            RETURN_IF_EXCEPTION(throwScope, );
-        }
         auto* drainFn = internalField(2).get().getObject();
         if (!drainFn)
             return; // discarded at teardown

--- a/src/jsc/bindings/NodeAsyncHooks.cpp
+++ b/src/jsc/bindings/NodeAsyncHooks.cpp
@@ -10,19 +10,6 @@ namespace Bun {
 
 using namespace JSC;
 
-// `cleanupLayer` is called by js if we set async context in a way we may not
-// clear it, specifically within AsyncLocalStorage.prototype.enterWith.  this
-// function will not clear the async context until the next tick's microtask,
-// where it must inherit the context that scheduled that callback.
-JSC_DEFINE_HOST_FUNCTION(jsCleanupLater, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
-{
-    ASSERT(callFrame->argumentCount() == 0);
-    auto* global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
-    global->asyncHooksNeedsCleanup = true;
-    global->resetOnEachMicrotaskTick();
-    return JSC::JSValue::encode(JSC::jsUndefined());
-}
-
 // This is called when AsyncLocalStorage is constructed.
 JSC_DEFINE_HOST_FUNCTION(jsSetAsyncHooksEnabled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {

--- a/src/jsc/bindings/NodeAsyncHooks.h
+++ b/src/jsc/bindings/NodeAsyncHooks.h
@@ -4,7 +4,6 @@
 
 namespace Bun {
 
-JSC_DECLARE_HOST_FUNCTION(jsCleanupLater);
 JSC_DECLARE_HOST_FUNCTION(jsSetAsyncHooksEnabled);
 
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -402,19 +402,6 @@ static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
     }
 }
 
-static void cleanupAsyncHooksData(JSC::VM& vm)
-{
-    auto* globalObject = defaultGlobalObject();
-    globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
-    globalObject->asyncHooksNeedsCleanup = false;
-    if (!globalObject->m_nextTickQueue) {
-        vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
-        checkIfNextTickWasCalledDuringMicrotask(vm);
-    } else {
-        vm.setOnEachMicrotaskTick(nullptr);
-    }
-}
-
 GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure)
 {
     GlobalObject* ptr = new (NotNull, JSC::allocateCell<GlobalObject>(vm)) GlobalObject(vm, structure, &globalObjectMethodTable());
@@ -453,14 +440,10 @@ JSC::Structure* GlobalObject::createStructure(JSC::VM& vm)
 void Zig::GlobalObject::resetOnEachMicrotaskTick()
 {
     auto& vm = this->vm();
-    if (this->asyncHooksNeedsCleanup) {
-        vm.setOnEachMicrotaskTick(&cleanupAsyncHooksData);
+    if (this->m_nextTickQueue) {
+        vm.setOnEachMicrotaskTick(nullptr);
     } else {
-        if (this->m_nextTickQueue) {
-            vm.setOnEachMicrotaskTick(nullptr);
-        } else {
-            vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
-        }
+        vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
     }
 }
 
@@ -3040,6 +3023,12 @@ uint8_t GlobalObject::drainMicrotasks()
 #endif
     }
     scope.assertNoExceptionExceptTermination();
+
+    // A checkpoint with no script on the stack ends an event loop callback: an
+    // AsyncLocalStorage frame it installed with enterWith() must not leak into
+    // the next one (everything queued runs under the frame it captured).
+    if (!vm.entryScope)
+        m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
 
     if (auto nextTickQueue = this->m_nextTickQueue.get()) {
         nextTickQueue->drain(vm, this);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -430,7 +430,6 @@ public:
         return func;
     }
 
-    bool asyncHooksNeedsCleanup = false;
     double INSPECT_MAX_BYTES = 50;
     bool isInsideErrorPrepareStackTraceCallback = false;
 

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -224,6 +224,74 @@ test("consecutive disable() calls exit continuations that captured the frame", a
   b.disable();
 });
 
+// Verified against Node v26: run()'s finally is enterWith(prior), so a binding
+// the callback installed for the same storage is replaced, not stacked.
+test("run() restores its own binding after enterWith()/withScope()/exit() inside the callback", () => {
+  const a = new AsyncLocalStorage();
+  a.run("outer", () => {
+    a.run("inner", () => {
+      using _ = a.withScope("scoped");
+      expect(a.getStore()).toBe("scoped");
+    });
+    expect(a.getStore()).toBe("outer");
+  });
+  expect(a.getStore()).toBe(undefined);
+  a.run(1, () => {
+    a.run(2, () => {
+      a.enterWith(3);
+    });
+    expect(a.getStore()).toBe(1);
+    a.exit(() => {
+      a.enterWith(4);
+    });
+    expect(a.getStore()).toBe(1);
+  });
+  expect(a.getStore()).toBe(undefined);
+});
+
+test("re-entering a storage inside run() does not grow the context", () => {
+  const als = new AsyncLocalStorage();
+  const other = new AsyncLocalStorage();
+  const objects = () => {
+    Bun.gc(true);
+    return heapStats().objectCount;
+  };
+  als.run(0, () => {
+    const before = objects();
+    for (let i = 0; i < 100_000; i++) {
+      als.run(1, () => {
+        using _ = als.withScope(2);
+      });
+      als.run(1, () => {
+        als.enterWith(3);
+      });
+      other.run(1, () => {
+        other.disable();
+      });
+    }
+    expect(objects() - before).toBeLessThan(1000);
+    expect(als.getStore()).toBe(0);
+  });
+});
+
+// Node's run() enters a fresh frame, so a disable() inside it only reaches
+// continuations captured since; ones captured before keep their binding.
+test("disable() inside another storage's run() does not reach earlier continuations", async () => {
+  const a = new AsyncLocalStorage();
+  const b = new AsyncLocalStorage();
+  const seen = await a.run(1, () => {
+    const earlier = new Promise(resolve => setTimeout(() => resolve(a.getStore()), 1));
+    let during;
+    b.run(2, () => {
+      during = new Promise(resolve => setTimeout(() => resolve(a.getStore()), 1));
+      a.disable();
+    });
+    a.run(5, () => {}); // re-enable
+    return Promise.all([earlier, during]);
+  });
+  expect(seen).toEqual([1, undefined]);
+});
+
 test("AsyncResource", () => {
   const resource = new AsyncResource("prisma-client-request");
   var called = false;

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -202,6 +202,27 @@ describe("AsyncLocalStorage", () => {
   });
 });
 
+// Node's disable() deletes the storage from the current frame object in place,
+// so every disable() reaches continuations that captured that frame.
+test("consecutive disable() calls exit continuations that captured the frame", async () => {
+  const a = new AsyncLocalStorage();
+  const b = new AsyncLocalStorage();
+  a.enterWith(1);
+  b.enterWith(2);
+  const seen = Promise.all([
+    new Promise(resolve => setTimeout(() => resolve([a.getStore(), b.getStore()]), 1)),
+    Promise.resolve().then(() => [a.getStore(), b.getStore()]),
+  ]);
+  a.disable();
+  b.disable();
+  b.enterWith(3);
+  expect(await seen).toEqual([
+    [undefined, undefined],
+    [undefined, undefined],
+  ]);
+  b.disable();
+});
+
 test("AsyncResource", () => {
   const resource = new AsyncResource("prisma-client-request");
   var called = false;
@@ -1248,4 +1269,159 @@ describe("async generators", () => {
     });
     expect(caughtStore).toBe("STORE_X");
   });
+});
+
+// A frame installed with enterWith() inside an event-loop callback belongs to
+// that callback: it must not be inherited by unrelated callbacks that run later
+// (they run under whatever they captured when scheduled, like Node's
+// CallbackScope), and anything it references must become collectable.
+describe("enterWith() does not leak past the callback that called it", () => {
+  async function run(src: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    return { stdout: stdout.trim().split("\n"), exitCode };
+  }
+  const prelude = `const { AsyncLocalStorage } = require("node:async_hooks"); const als = new AsyncLocalStorage(); const seen = []; process.on("exit", () => { seen.push("exit:" + als.getStore()); console.log(seen.join("\\n")); });`;
+
+  test.concurrent("timers, immediates, I/O callbacks", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const fs = require("node:fs");
+        setTimeout(() => { als.enterWith("timer1"); seen.push("timer1:" + als.getStore()); }, 1);
+        setTimeout(() => { seen.push("timer2:" + als.getStore()); }, 20);
+        setImmediate(() => { als.enterWith("immediate1"); });
+        setImmediate(() => { seen.push("immediate2:" + als.getStore()); });
+        setImmediate(() => { queueMicrotask(() => als.enterWith("immediate3-microtask")); process.nextTick(() => als.enterWith("immediate3-tick")); });
+        setImmediate(() => { seen.push("immediate4:" + als.getStore()); });
+        setTimeout(() => { Promise.resolve().then(() => { als.enterWith("timer5-reaction"); }); }, 5);
+        setTimeout(() => { seen.push("timer6:" + als.getStore()); }, 5);
+        fs.readFile(__filename, () => {
+          als.enterWith("readFile");
+          setTimeout(() => { seen.push("timer-in-readFile:" + als.getStore()); }, 1);
+          fs.readFile(__filename, () => { seen.push("readFile2:" + als.getStore()); });
+        });
+        setTimeout(() => { seen.push("timer3:" + als.getStore()); }, 60);
+      `,
+    );
+    expect(stdout.toSorted()).toEqual([
+      "exit:undefined",
+      "immediate2:undefined",
+      "immediate4:undefined",
+      "readFile2:readFile",
+      "timer-in-readFile:readFile",
+      "timer1:timer1",
+      "timer2:undefined",
+      "timer3:undefined",
+      "timer6:undefined",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("promise reactions and microtasks run under the frame they captured", async () => {
+    const { stdout, exitCode } = await run(
+      prelude +
+        `
+        const early = Promise.resolve().then(() => { als.enterWith("reaction1"); seen.push("reaction1:" + als.getStore()); });
+        Promise.resolve().then(() => { seen.push("reaction2:" + als.getStore()); });
+        queueMicrotask(() => { seen.push("microtask:" + als.getStore()); });
+        process.nextTick(() => { seen.push("nextTick:" + als.getStore()); });
+        (async () => { await early; seen.push("after-await:" + als.getStore()); })();
+        als.run("run", () => {
+          Promise.resolve().then(() => { seen.push("reaction-in-run:" + als.getStore()); });
+        });
+        // top-level enterWith after everything above was scheduled: none of it inherits this
+        als.enterWith("top");
+        seen.push("sync:" + als.getStore());
+        setTimeout(() => { seen.push("timer-after-top:" + als.getStore()); });
+      `,
+    );
+    expect(stdout.toSorted()).toEqual([
+      "after-await:undefined",
+      "exit:undefined",
+      "microtask:undefined",
+      "nextTick:undefined",
+      "reaction-in-run:run",
+      "reaction1:reaction1",
+      "reaction2:undefined",
+      "sync:top",
+      "timer-after-top:top",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent(
+    "a server handler's enterWith() is not seen by the next request and its store is collectable",
+    async () => {
+      const { stdout, exitCode } = await run(
+        prelude +
+          `
+        const registry = new FinalizationRegistry(id => { collected++; });
+        let collected = 0;
+        const server = Bun.serve({
+          port: 0,
+          fetch(req) {
+            const inherited = als.getStore();
+            const store = { id: new URL(req.url).pathname, payload: new Uint8Array(1024 * 1024) };
+            registry.register(store, store.id);
+            als.enterWith(store);
+            return new Response(String(inherited && inherited.id));
+          },
+        });
+        (async () => {
+          for (let i = 0; i < 20; i++) {
+            const res = await fetch(server.url + "req" + i);
+            seen.push(await res.text());
+          }
+          server.stop(true);
+          for (let i = 0; i < 20 && collected < 19; i++) { Bun.gc(true); await new Promise(r => setTimeout(r, 10)); }
+          // every store but (at most) the last one must be gone
+          seen.length = 0;
+          seen.push("collected>=19:" + (collected >= 19));
+        })();
+      `,
+      );
+      expect(stdout).toEqual(["collected>=19:true", "exit:undefined"]);
+      expect(exitCode).toBe(0);
+    },
+  );
+});
+
+// With a store active, awaiting and .then() must not allocate side objects to
+// carry the frame (it rides in the reaction / microtask itself).
+test("an active store adds no per-await / per-then helper allocations", () => {
+  const { heapStats } = require("bun:jsc");
+  const als = new AsyncLocalStorage();
+  const N = 5000;
+  const count = () => {
+    Bun.gc(true);
+    return heapStats().objectTypeCounts.InternalFieldTuple ?? 0;
+  };
+  const keep: unknown[] = [];
+  const never = new Promise(() => {});
+  const delta = als.run({ store: 1 }, () => {
+    const before = count();
+    for (let i = 0; i < N; i++) {
+      keep.push(
+        (async () => {
+          await never;
+        })(),
+      );
+      keep.push(never.then(() => {}));
+      keep.push(
+        never.then(
+          () => {},
+          () => {},
+        ),
+      );
+    }
+    return count() - before;
+  });
+  expect(keep.length).toBe(N * 3);
+  expect(delta).toBeLessThan(50);
 });

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
+import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import http2 from "http2";
@@ -1381,12 +1382,14 @@ describe("enterWith() does not leak past the callback that called it", () => {
           server.stop(true);
           for (let i = 0; i < 20 && collected < 19; i++) { Bun.gc(true); await new Promise(r => setTimeout(r, 10)); }
           // every store but (at most) the last one must be gone
+          const inherited = seen.filter(body => body !== "undefined");
           seen.length = 0;
+          seen.push("inherited:" + inherited.length);
           seen.push("collected>=19:" + (collected >= 19));
         })();
       `,
       );
-      expect(stdout).toEqual(["collected>=19:true", "exit:undefined"]);
+      expect(stdout).toEqual(["inherited:0", "collected>=19:true", "exit:undefined"]);
       expect(exitCode).toBe(0);
     },
   );
@@ -1395,7 +1398,6 @@ describe("enterWith() does not leak past the callback that called it", () => {
 // With a store active, awaiting and .then() must not allocate side objects to
 // carry the frame (it rides in the reaction / microtask itself).
 test("an active store adds no per-await / per-then helper allocations", () => {
-  const { heapStats } = require("bun:jsc");
   const als = new AsyncLocalStorage();
   const N = 5000;
   const count = () => {

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -247,6 +247,21 @@ test("run() restores its own binding after enterWith()/withScope()/exit() inside
     expect(a.getStore()).toBe(1);
   });
   expect(a.getStore()).toBe(undefined);
+  // enterWith() of a storage bound below the run() frames copies them; the
+  // restore must still go by value.
+  const b = new AsyncLocalStorage();
+  b.enterWith(0);
+  a.run(1, () => {
+    a.run(2, () => {
+      a.run(3, () => {
+        b.enterWith(9);
+      });
+      expect([a.getStore(), b.getStore()]).toEqual([2, 9]);
+    });
+    expect([a.getStore(), b.getStore()]).toEqual([1, 9]);
+  });
+  expect([a.getStore(), b.getStore()]).toEqual([undefined, 9]);
+  b.disable();
 });
 
 test("re-entering a storage inside run() does not grow the context", () => {


### PR DESCRIPTION
Throwaway draft to bisect the Windows-only `datadog-pprof` TimeProfiler hang seen on #41190: identical branch, but WebKit pinned to `autobuild-preview-pr-552-287d9c5f` (oven-sh/WebKit#552 without oven-sh/WebKit#553's deferred WarmUpBlockProvider helper-thread start). If Windows passes here, the hang comes from #553. Will close after the run.