### PR TITLE
node:fs: report ENOTDIR from rmdir recursive on a file instead of removing it

### DIFF
--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -121,9 +121,25 @@ function getValidatedFsPath(p: any, propName: string = "path") {
   throw $ERR_INVALID_ARG_TYPE(propName, ["string", "Buffer", "URL"], p);
 }
 
+const validateInt32 = $newCppFunction("NodeValidator.cpp", "jsFunction_validateInt32", 0);
+const validateUint32 = $newCppFunction("NodeValidator.cpp", "jsFunction_validateUint32", 0);
+
+/**
+ * The options check of `rmdir(path, { recursive: true })` in Node 16 to 24. It fills in the
+ * `rm` defaults and pins `force` to false, because rmdir never honored it. Call it before the
+ * path is read, so that a bad option wins over ENOENT. Returns the new options object.
+ */
+function validateRmdirRecursiveOptions(options) {
+  options = { recursive: false, retryDelay: 100, maxRetries: 0, ...options, force: false };
+  validateBoolean(options.recursive, "options.recursive");
+  validateInt32(options.retryDelay, "options.retryDelay", 0);
+  validateUint32(options.maxRetries, "options.maxRetries");
+  return options;
+}
+
 hideFromStack(validateLinkHeaderValue);
 hideFromStack(validateString, validateFunction, validateBoolean);
-hideFromStack(getValidatedPath, getValidatedFsPath, throwIfNullBytesInFileName);
+hideFromStack(getValidatedPath, getValidatedFsPath, throwIfNullBytesInFileName, validateRmdirRecursiveOptions);
 
 // Must match jsFunction_validateObject in NodeValidator.cpp. The values are node's:
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L224-L227
@@ -162,9 +178,9 @@ export default {
   /** `(value, name, minLength = 0)` */
   validateArray: $newCppFunction("NodeValidator.cpp", "jsFunction_validateArray", 0),
   /** `(value, name, min = -2147483648, max = 2147483647)` */
-  validateInt32: $newCppFunction("NodeValidator.cpp", "jsFunction_validateInt32", 0),
+  validateInt32,
   /** `(value, name, positive = false)` */
-  validateUint32: $newCppFunction("NodeValidator.cpp", "jsFunction_validateUint32", 0),
+  validateUint32,
   /** `(data, encoding)` */
   validateEncoding: $newCppFunction("NodeValidator.cpp", "jsFunction_validateEncoding", 0),
   /** `(buffer, name = 'buffer')` */
@@ -177,4 +193,6 @@ export default {
   getValidatedFsPath,
   /** `(filename)` */
   throwIfNullBytesInFileName,
+  /** `(options)`: returns the options with the defaults filled in */
+  validateRmdirRecursiveOptions,
 };

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -8,6 +8,7 @@ const {
   validateObject,
   validateAbortSignal,
   validateEncoding,
+  validateRmdirRecursiveOptions,
 } = require("internal/validators");
 
 const constants = $processBindingConstants.fs;
@@ -360,8 +361,13 @@ const exports = {
     return fs.rm(path, options);
   },
   rmdir: async function rmdir(path, options) {
-    // Node 26 removed `recursive` (DEP0147), but packages still pass it. Keep it working through `rm`.
-    if (options?.recursive) return exports.rm(path, options);
+    // Node 26 removed `recursive` (DEP0147), but packages still pass it. Node 16 to 24 sent only a
+    // directory to `rm`. Anything else went to the plain rmdir, which fails (ENOTDIR for a file).
+    if (options?.recursive) {
+      options = validateRmdirRecursiveOptions(options);
+      if (!(await fs.lstat(path)).isDirectory()) return fs.rmdir(path);
+      return exports.rm(path, options);
+    }
     return fs.rmdir(path, options);
   },
   writev: async (fd, buffers, position) => {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -5,6 +5,7 @@ const {
   validateFunction,
   validateInteger,
   validateEncoding,
+  validateRmdirRecursiveOptions,
   getValidatedPath,
   throwIfNullBytesInFileName,
 } = require("internal/validators");
@@ -101,8 +102,8 @@ var access = function access(path, mode, callback) {
     }
     callback = ensureCallback(callback);
 
-    // Node 26 removed `recursive` (DEP0147), but packages still pass it. Keep it working through `rm`.
-    (options?.recursive ? require("node:fs/promises").rm(path, options) : fs.rmdir(path, options)).then(
+    // Node 26 removed `recursive` (DEP0147), but packages still pass it. See promises.rmdir.
+    (options?.recursive ? require("node:fs/promises").rmdir(path, options) : fs.rmdir(path, options)).then(
       nullcallback(callback),
       callback,
     );
@@ -581,8 +582,13 @@ var access = function access(path, mode, callback) {
     return fs.rmSync(path, options);
   },
   rmdirSync = function rmdirSync(path, options) {
-    // Node 26 removed `recursive` (DEP0147), but packages still pass it. Keep it working through `rm`.
-    if (options?.recursive) return rmSync(path, options);
+    // Node 26 removed `recursive` (DEP0147), but packages still pass it. Node 16 to 24 sent only a
+    // directory to `rm`. Anything else went to the plain rmdir, which fails (ENOTDIR for a file).
+    if (options?.recursive) {
+      options = validateRmdirRecursiveOptions(options);
+      if (!fs.lstatSync(path).isDirectory()) return fs.rmdirSync(path);
+      return rmSync(path, options);
+    }
     return fs.rmdirSync(path, options);
   },
   writev = function writev(fd, buffers, position, callback) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3715,6 +3715,23 @@ describe("rmdir", () => {
     rmdir(join(String(dir), "missing"), { recursive: true }, resolve);
     expect(await promise).toMatchObject({ code: "ENOENT" });
   });
+  // Node 16 to 24 semantics: rmdir never honors `force`, and a file goes to the plain
+  // rmdir(2) instead of rm.
+  it("does not remove a file with recursive: true", async () => {
+    using dir = tempDir("rmdir-recursive-cb-file", { "file.txt": "x" });
+    const file = join(String(dir), "file.txt");
+    const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException | null>();
+    rmdir(file, { recursive: true }, resolve);
+    expect(await promise).toMatchObject({ code: isWindows ? "ENOENT" : "ENOTDIR", syscall: "rmdir", path: file });
+    expect(existsSync(file)).toBe(true);
+  });
+  it("reports ENOENT for a missing path with recursive: true and force: true", async () => {
+    using dir = tempDir("rmdir-recursive-cb-force", {});
+    const missing = join(String(dir), "missing");
+    const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException | null>();
+    rmdir(missing, { recursive: true, force: true }, resolve);
+    expect(await promise).toMatchObject({ code: "ENOENT", syscall: "lstat", path: missing });
+  });
 });
 
 describe("rmdirSync", () => {
@@ -3744,6 +3761,41 @@ describe("rmdirSync", () => {
     rmdirSync(a, { recursive: true, maxRetries: 1, retryDelay: 0 });
     expect(readdirSync(String(dir))).toEqual(["e"]);
     expect(() => rmdirSync(a, { recursive: true })).toThrow(expect.objectContaining({ code: "ENOENT" }));
+  });
+  // Node 16 to 24 semantics: rmdir never honors `force`, and a file goes to the plain
+  // rmdir(2) instead of rm.
+  it("does not remove a file with recursive: true", () => {
+    using dir = tempDir("rmdirsync-recursive-file", { "file.txt": "x" });
+    const file = join(String(dir), "file.txt");
+    expect(() => rmdirSync(file, { recursive: true })).toThrow(
+      expect.objectContaining({ code: isWindows ? "ENOENT" : "ENOTDIR", syscall: "rmdir", path: file }),
+    );
+    expect(() => rmdirSync(file, { recursive: true, force: true })).toThrow(
+      expect.objectContaining({ code: isWindows ? "ENOENT" : "ENOTDIR", syscall: "rmdir" }),
+    );
+    expect(existsSync(file)).toBe(true);
+  });
+  it("reports ENOENT for a missing path with recursive: true and force: true", () => {
+    using dir = tempDir("rmdirsync-recursive-force", {});
+    const missing = join(String(dir), "missing");
+    expect(() => rmdirSync(missing, { recursive: true, force: true })).toThrow(
+      expect.objectContaining({ code: "ENOENT", syscall: "lstat", path: missing }),
+    );
+  });
+  it("validates the options before it looks at the path with recursive: true", () => {
+    using dir = tempDir("rmdirsync-recursive-validate", { "file.txt": "x" });
+    const file = join(String(dir), "file.txt");
+    const missing = join(String(dir), "missing");
+    expect(() => rmdirSync(missing, { recursive: 1 })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => rmdirSync(missing, { recursive: true, maxRetries: -1 })).toThrow(
+      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    );
+    expect(() => rmdirSync(file, { recursive: true, retryDelay: "1" })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(existsSync(file)).toBe(true);
   });
 });
 
@@ -4934,6 +4986,35 @@ describe("fs/promises", () => {
       await rmdir(a, { recursive: true });
       expect(readdirSync(String(dir))).toEqual(["e"]);
       await expect(rmdir(a, { recursive: true })).rejects.toMatchObject({ code: "ENOENT" });
+    });
+    // Node 16 to 24 semantics: rmdir never honors `force`, and a file goes to the plain
+    // rmdir(2) instead of rm.
+    it("does not remove a file with recursive: true", async () => {
+      using dir = tempDir("rmdir-recursive-promises-file", { "file.txt": "x" });
+      const file = join(String(dir), "file.txt");
+      await expect(rmdir(file, { recursive: true })).rejects.toMatchObject({
+        code: isWindows ? "ENOENT" : "ENOTDIR",
+        syscall: "rmdir",
+        path: file,
+      });
+      expect(existsSync(file)).toBe(true);
+    });
+    it("reports ENOENT for a missing path with recursive: true and force: true", async () => {
+      using dir = tempDir("rmdir-recursive-promises-force", {});
+      const missing = join(String(dir), "missing");
+      await expect(rmdir(missing, { recursive: true, force: true })).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "lstat",
+        path: missing,
+      });
+    });
+    it("validates the options before it looks at the path with recursive: true", async () => {
+      using dir = tempDir("rmdir-recursive-promises-validate", {});
+      const missing = join(String(dir), "missing");
+      await expect(rmdir(missing, { recursive: 1 })).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+      await expect(rmdir(missing, { recursive: true, maxRetries: -1 })).rejects.toMatchObject({
+        code: "ERR_OUT_OF_RANGE",
+      });
     });
   });
 


### PR DESCRIPTION
### Problem
- `fs.rmdirSync(file, { recursive: true })` removes the file. So do `fs.rmdir` and `fs.promises.rmdir`. `fs.rmdirSync(missing, { recursive: true, force: true })` succeeds. Node 16 to 24 report `ENOTDIR: not a directory, rmdir '<file>'` and `ENOENT`.
- The cause is #39809. It sends a truthy `recursive` to `rm` in `src/js/node/fs.ts` and `src/js/node/fs.promises.ts`. `rm` unlinks a file and honors `force`. Node's `rmdir` did neither. #16612 was closed with "`fs.rmdir` does not support the `force: true` option".
- #39809 landed after the `bun-v1.4.0` tag, so no release has this bug. The canary has it.

### Fix
- As in Node 16 to 24, the wrappers now validate the options with `force` pinned to false, then `lstat` the path. A directory goes to `rm`. Anything else goes to the plain `rmdir` binding, which fails with `ENOTDIR` (`ENOENT` on Windows, as in node).
- Both modules share the option check, `validateRmdirRecursiveOptions` in `src/js/internal/validators.ts`. It runs first, so a bad option still wins over `ENOENT`.
- Verified: `test/js/node/fs/fs.test.ts` (6 new cases fail on main). Also `fs/promises.test.js` and the vendored `test-fs-rm*.js`, `test-fs-rmdir-*.js`, `test-fs-mkdir-rmdir.js`.
- Self-reviewed: 9 concerns raised, 6 addressed. Notes explain the other 3.

### Background
- DEP0147 deprecates `fs.rmdir(path, { recursive: true })`. Node 26 removed the option. Bun reports Node v26, but keeps the option for published packages that still use it (#39809).
- In Node 16 to 24, `rmdirSync` validated the options, ran `lstatSync`, and sent only a directory to the recursive remover. Anything else went to `binding.rmdir(path)`, which is `rmdir(2)`.

<details><summary>Notes</summary>

- Probe with the debug build (Linux). All three forms behave the same way:
  - file: `ENOTDIR`, syscall `rmdir`, file kept
  - missing path with `force: true`: `ENOENT`, syscall `lstat`
  - symlink to a directory: `ENOTDIR`, link and target kept
  - tree with `maxRetries: 1, retryDelay: 0`: removed
  - `{ recursive: 1 }` gives `ERR_INVALID_ARG_TYPE` and `{ maxRetries: -1 }` gives `ERR_OUT_OF_RANGE`, both before the path is read
- The 3 self-review concerns that this change does not address:
  - Two concerns are about the recursive branch of the native `rmdir` binding (`NodeFS::rmdir` in `src/runtime/node/node_fs.rs`). One asks to route the wrappers through it. The other asks to delete it. Nothing calls it since #39809. It is not a drop-in: its error has no path, and it tags a missing path `rmdir`, not `lstat`. Its removal is a separate change.
  - For a bad option, Node 16 to 24 throw synchronously from the callback form. Bun passes the error to the callback. The callback `rm` does the same today.
- Node's `promises.rmdir` used `stat`, not `lstat`. So a symlink to a directory reached `rimraf`, which removed the link. The sync and callback forms reported `ENOTDIR`. This change uses `lstat` in all three forms.
- The defaults match Node's `defaultRmOptions`, `recursive: false` included. So an inherited `recursive: true` behaves as in Node 16 to 24: `ERR_FS_EISDIR` for a directory and `ENOTDIR` for a file.
- Node 16 to 24 did not validate `force` on this path, because `{ ...options, force: false }` replaced it. The helper does the same.
- Windows: the canary gives `ENOENT`, syscall `rmdir`, and the path for `rmdirSync(file)`. It gives syscall `lstat` for a missing path. The new tests assert that shape.
- `packages/bun-release/src/fs.ts` calls `rmdirSync(path, { recursive: true })` only after its own `isDirectory()` check. The change does not affect it.
- Suites run: `test/js/node/fs/fs.test.ts` and `test/js/node/fs/promises.test.js` (603 pass), `test-fs-rm.js`, `test-fs-rmSync-special-char.js`, `test-fs-rmdir-throws-on-file.js`, `test-fs-rmdir-throws-not-found.js`, `test-fs-rmdir-type-check.js`, `test-fs-mkdir-rmdir.js`, `test-vm-timeout.js`, `test-dgram-createSocket-type.js`. The last two use the `validateInt32` and `validateUint32` bindings that this change moves.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->