### PR TITLE
Bun.CSRF: throw on a NaN expiresIn or maxAge

### DIFF
--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -2,7 +2,7 @@
 //! `generate()`/`verify()` halves stay in `src/csrf/`.
 
 use bun_boringssl_sys as boring;
-use bun_core::Utf8Bytes;
+use bun_core::{Utf8Bytes, fmt as bun_fmt};
 use bun_csrf as csrf;
 use bun_jsc::{CallFrame, IntegerRange, JSGlobalObject, JSValue, JsResult};
 
@@ -21,7 +21,7 @@ fn algorithm_from_js_case_insensitive(
     Ok(evp::lookup_ignore_case(slice.slice()))
 }
 
-/// `expiresIn` / `maxAge`. NaN maps to the default, and `0` would mean "no expiry".
+/// `expiresIn` / `maxAge`. `0` means "no expiry".
 fn get_optional_duration_ms(
     target: JSValue,
     global: &JSGlobalObject,
@@ -30,6 +30,18 @@ fn get_optional_duration_ms(
     let Some(value) = target.get(global, field_name)? else {
         return Ok(None);
     };
+    // validate_integer_range maps NaN to the default. A NaN duration is a
+    // caller-side bug, and the 24h default can be laxer than the intended one.
+    if value.is_number() && value.as_number().is_nan() {
+        return Err(global.throw_range_error(
+            value.as_number(),
+            bun_fmt::OutOfRangeOptions {
+                field_name,
+                msg: b"an integer",
+                ..Default::default()
+            },
+        ));
+    }
     Ok(Some(global.validate_integer_range::<u64>(
         value,
         csrf::DEFAULT_EXPIRATION_MS,

--- a/test/js/bun/util/csrf.test.ts
+++ b/test/js/bun/util/csrf.test.ts
@@ -197,17 +197,26 @@ describe("Bun.CSRF", () => {
       throw new Error(`expected ${field}: ${String(value)} to throw`);
     }
 
-    test("NaN is treated as an absent option", () => {
-      expect(() => call(NaN)).not.toThrow();
-      expect(CSRF.verify(CSRF.generate(secret, { expiresIn: NaN }), { secret, maxAge: NaN })).toBe(true);
+    test("undefined is treated as an absent option", () => {
+      expect(() => call(undefined)).not.toThrow();
 
       // The token embeds expiresIn as a big-endian u64 at bytes 24..32, after
       // the timestamp and the nonce. 0 there means the token never expires.
-      const embeddedExpiresIn = (options?: { expiresIn: number }) =>
+      const embeddedExpiresIn = (options?: { expiresIn?: number }) =>
         Buffer.from(CSRF.generate(secret, options), "base64url").readBigUInt64BE(24);
       expect(embeddedExpiresIn({ expiresIn: 0 })).toBe(0n);
-      expect(embeddedExpiresIn({ expiresIn: NaN })).toBe(embeddedExpiresIn());
-      expect(embeddedExpiresIn({ expiresIn: NaN })).toBe(BigInt(24 * 60 * 60 * 1000));
+      expect(embeddedExpiresIn({ expiresIn: undefined })).toBe(BigInt(24 * 60 * 60 * 1000));
+      expect(embeddedExpiresIn()).toBe(BigInt(24 * 60 * 60 * 1000));
+    });
+
+    // A NaN duration comes from a bug in the caller. It must not select the
+    // 24h default, which can be laxer than the window the caller computed.
+    test("NaN throws RangeError [ERR_OUT_OF_RANGE]", () => {
+      expect(thrown(NaN)).toEqual({
+        constructor: RangeError,
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "${field}" is out of range. It must be an integer. Received NaN`,
+      });
     });
 
     test("out-of-range values throw RangeError [ERR_OUT_OF_RANGE]", () => {


### PR DESCRIPTION
### Problem
- `Bun.CSRF.generate(secret, { expiresIn: NaN })` returns a token, and `Bun.CSRF.verify(token, { secret, maxAge: NaN })` returns `true`. Both calls use the 24 hour default. Bun 1.4.0 threw `TypeError [ERR_INVALID_ARG_TYPE]` for both.
- #40697 made this change on purpose. It reads both options with `validate_integer_range` (`src/jsc/JSGlobalObject.rs:1306`), which returns the default for `NaN`. A `maxAge` that became `NaN` through a parse bug now verifies under a window that can be longer than the one the caller computed.

### Fix
- `get_optional_duration_ms` (`src/runtime/api/csrf_jsc.rs:25`) rejects `NaN` before the validator: `RangeError [ERR_OUT_OF_RANGE]: The value of "expiresIn" is out of range. It must be an integer. Received NaN`.
- Node's `validateInteger` gives this error for `NaN`. `Bun.spawn` rejects a `NaN` `timeout` in the same way.
- All other values keep the behavior from #40697. `undefined` still selects the default.
- Verified: `test/js/bun/util/csrf.test.ts`. All 33 tests pass with the debug build. The 2 new `NaN` tests fail on the 1.4.1 canary.

### Background
- A token embeds its `expiresIn`. `verify` checks the token age against that value and against `maxAge`. A value of `0` disables that check.
- `validate_integer_range` is the shared validator for integer options. It returns the default for `NaN`. Node does this for a few options (the zlib `chunkSize`), but its general `validateInteger` throws.

<details><summary>Notes</summary>

Value matrix with this change. Both options behave the same.

```
NaN        RangeError ERR_OUT_OF_RANGE     It must be an integer. Received NaN
-1         RangeError ERR_OUT_OF_RANGE     It must be >= 0 and <= 9007199254740991. Received -1
Infinity   RangeError ERR_OUT_OF_RANGE     (the same range message)
1.5        TypeError ERR_INVALID_ARG_TYPE  must be of type integer
"100"      TypeError ERR_INVALID_ARG_TYPE  must be of type number
undefined  ok, 24 hour default
0, -0      ok, no expiry
```

History of `NaN` for these two options:

- Zig, before the Rust port: `getOptionalInt` mapped `NaN` to `0`. The token never expired.
- 1.4.0: a local helper threw `TypeError [ERR_INVALID_ARG_TYPE]`.
- #40697, in the 1.4.1 canaries: the 24 hour default.
- This PR: `RangeError [ERR_OUT_OF_RANGE]`.

The review of #40697 offered two choices: reject `NaN`, or map it to the default. That PR took the second. This PR takes the first, so that a bad duration fails closed.

Node reference: `Buffer.alloc(4).readUInt8(NaN)` throws `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be an integer. Received NaN`.

The validator's default argument stays `DEFAULT_EXPIRATION_MS`. `target.get` returns `None` for `undefined`, so no value reaches the default path today. If one does, it gets the 24 hour value, not the `0` that disables expiry.

The test file replaces the `NaN` default test with an `undefined` test. That test keeps the checks on the embedded `expiresIn` field (`0` for `expiresIn: 0`, 24 hours for no value).

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/csrf.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/util/csrf.test.ts:
(pass) Bun.CSRF > CSRF exists [23.03ms]
(pass) Bun.CSRF > generates a token with default options [7.48ms]
(pass) Bun.CSRF > generates a token with different formats [8.11ms]
(pass) Bun.CSRF > verifies a valid token [2.99ms]
(pass) Bun.CSRF > rejects an invalid token [2.97ms]
(pass) Bun.CSRF > token verification is sensitive to the secret [3.55ms]
(pass) Bun.CSRF > tokens expire after the specified time [19.50ms]
(pass) Bun.CSRF > verification respects maxAge parameter [17.11ms]
(pass) Bun.CSRF > token with expiresIn parameter works [121.26ms]
(pass) Bun.CSRF > token format doesn't affect verification [9.76ms]
(pass) Bun.CSRF > test with default algorithm [4.27ms]
(pass) Bun.CSRF > test with algorithm blake2b256 [4.53ms]
(pass) Bun.CSRF > test with algorithm blake2b512 [1.03ms]
(pass) Bun.CSRF > test with algorithm sha256 [0.73ms]
(pass) Bun.CSRF > test with algorithm sha384 [0.75ms]
(pass) Bun.CSRF > test with algorithm sha512 [0.69ms]
(pass) Bun.C
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/util/csrf.test.ts:
(pass) Bun.CSRF > CSRF exists [0.05ms]
(pass) Bun.CSRF > generates a token with default options [0.23ms]
(pass) Bun.CSRF > generates a token with different formats [0.14ms]
(pass) Bun.CSRF > verifies a valid token [0.04ms]
(pass) Bun.CSRF > rejects an invalid token [0.04ms]
(pass) Bun.CSRF > token verification is sensitive to the secret [0.03ms]
(pass) Bun.CSRF > tokens expire after the specified time [10.30ms]
(pass) Bun.CSRF > verification respects maxAge parameter [10.39ms]
(pass) Bun.CSRF > token with expiresIn parameter works [110.71ms]
(pass) Bun.CSRF > token format doesn't affect verification [0.25ms]
(pass) Bun.CSRF > test with default algorithm [0.12ms]
(pass) Bun.CSRF > test with algorithm blake2b256 [0.08ms]
(pass) Bun.CSRF > test with algorithm blake2b512 [0.02ms]
(pass) Bun.CSRF > test with algorithm sha256 [0.05ms]
(pass) Bun.CSRF > test with algorithm sha384 [0.02ms]
(pass) Bun.CSRF > test with algorithm sha512
(pass) Bun.CSRF > test with algorithm sha512-256
(pass) Bun.CSRF > default secret [0.07ms]
(pass) Bun.CSRF > token bound to a sessionId verifies for the same sessionId [0.04ms
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/csrf.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/util/csrf.test.ts:
(pass) Bun.CSRF > CSRF exists [12.95ms]
(pass) Bun.CSRF > generates a token with default options [4.78ms]
(pass) Bun.CSRF > generates a token with different formats [5.54ms]
(pass) Bun.CSRF > verifies a valid token [2.02ms]
(pass) Bun.CSRF > rejects an invalid token [1.98ms]
(pass) Bun.CSRF > token verification is sensitive to the secret [1.87ms]
(pass) Bun.CSRF > tokens expire after the specified time [16.27ms]
(pass) Bun.CSRF > verification respects maxAge parameter [14.72ms]
(pass) Bun.CSRF > token with expiresIn parameter works [117.69ms]
(pass) Bun.CSRF > token format doesn't affect verification [5.16ms]
(pass) Bun.CSRF > test with default algorithm [2.43ms]
(pass) Bun.CSRF > test with algorithm blake2b256 [3.01ms]
(pass) Bun.CSRF > test with algorithm blake2b512 [0.61ms]
(pass) Bun.CSRF > test with algorithm sha256 [0.42ms]
(pass) Bun.CSRF > test with algorithm sha384 [0.43ms]
(pass) Bun.CSRF > test with algorithm sha512 [0.42ms]
(pass) Bun.C
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4e93c18189
  features     baseline

23 deps, 131 codegen, 1172 objects in 682ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 25 installs across 62 packages (no changes) [5.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 12ms

  react-refresh.js  4.81 KB  (entry point)

[8/1244] fetch zlib
[zlib] up to date
[9/1244] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/csrf_jsc.rs   | 16 ++++++++++++++--
 test/js/bun/util/csrf.test.ts | 21 +++++++++++++++------
 2 files changed, 29 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/runtime/api/csrf_jsc.rs        1      2      5
test/js/bun/util/csrf.test.ts      2      2      5
```

</details>

<!-- robobun:evidence:end -->