### PR TITLE
node:assert: compare a proxied array's length through its get trap

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -971,6 +971,21 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     if (v1Array != v2Array)
         return false;
 
+    if constexpr (checkPrototypes) {
+        // node compares array lengths with [[Get]] and ===. A Proxy's get trap can report a length
+        // its target does not have, and the own-property walk that compares proxies never reads it.
+        if (v1Array && (o1->isProxy() || o2->isProxy())) {
+            JSValue length1 = o1->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            JSValue length2 = o2->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            bool sameLength = JSC::JSValue::strictEqual(globalObject, length1, length2);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (!sameLength)
+                return false;
+        }
+    }
+
     if (v1Array && v2Array && !(o1->isProxy() || o2->isProxy())) {
         JSC::JSArray* array1 = uncheckedDowncast<JSC::JSArray>(v1);
         JSC::JSArray* array2 = uncheckedDowncast<JSC::JSArray>(v2);

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -70,6 +70,12 @@ function withOwnConstructor(prototype: object | null, constructor: unknown) {
   return Object.create(prototype, { constructor: { value: constructor } });
 }
 
+function withReportedLength(array: unknown[], length: unknown) {
+  return new Proxy(array, {
+    get: (target, key, receiver) => (key === "length" ? length : Reflect.get(target, key, receiver)),
+  });
+}
+
 function seventyProperties<T extends Record<string, unknown>>(object: T): T {
   for (let i = 0; i < 70; i++) (object as Record<string, unknown>)["k" + i] = i;
   return object;
@@ -405,6 +411,45 @@ const cases: Case[] = [
     strict: true,
     loose: true,
     looseBug: "reports not equal",
+  },
+  {
+    name: "a Proxy of [1, 2, 3] and [1, 2, 3]",
+    a: () => new Proxy([1, 2, 3], {}),
+    b: () => [1, 2, 3],
+    strict: true,
+    loose: true,
+  },
+  // node reads an array's length with [[Get]], so a Proxy's get trap decides it.
+  {
+    name: "a Proxy of [1, 2, 3] whose get trap reports length 7 and [1, 2, 3]",
+    a: () => withReportedLength([1, 2, 3], 7),
+    b: () => [1, 2, 3],
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
+    name: "[1, 2, 3] and a Proxy of [1, 2, 3] whose get trap reports length 7",
+    a: () => [1, 2, 3],
+    b: () => withReportedLength([1, 2, 3], 7),
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
+    name: "a Proxy of [1, 2, 3] whose get trap reports length '3' and [1, 2, 3]",
+    a: () => withReportedLength([1, 2, 3], "3"),
+    b: () => [1, 2, 3],
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
+    name: "two Proxies of [1, 2, 3] whose get traps report length 7",
+    a: () => withReportedLength([1, 2, 3], 7),
+    b: () => withReportedLength([1, 2, 3], 7),
+    strict: true,
+    loose: true,
   },
   {
     name: "own constructor: Uint8Array on objects with different prototypes",


### PR DESCRIPTION
### Problem
- `assert.deepStrictEqual` and `util.isDeepStrictEqual` report a Proxy of `[1, 2, 3]` whose get trap returns `7` for `length` as equal to `[1, 2, 3]`. Node and Bun 1.4.0 report them unequal.
- A Proxy skips the array path in `Bun__deepEquals` (`src/jsc/bindings/bindings.cpp:974`). The own-property walk that compares it never reads `length`, because `length` is not enumerable.
- Bun 1.4.0 was correct by accident. Its class-name check rejected every Proxy of an array, also `new Proxy([1, 2, 3], {})`, which node accepts. #40131 removed that check for the node entry point.

### Fix
- In the node entry point, when both values are arrays and one is a Proxy, read `length` from each side with [[Get]] and compare with `===`. This is node's `val1.length !== val2.length` in `objectComparisonStart`.
- Arrays that are not proxies keep the direct length read. `Bun.deepEquals` and `expect()` do not change.
- Verified: `test/js/node/assert/deep-equal.test.ts` (five new cases, stock bun fails three). Also all of `test/js/node/assert/`, the vendored node assert tests, and the `Bun.deepEquals` and `expect()` suites.

### Background
- `Bun__deepEquals` is one native function with template flags. The `checkPrototypes` instantiation serves only `assert.deepStrictEqual` and `util.isDeepStrictEqual`.
- A Proxy sends each internal method to a trap. [[Get]] calls the `get` trap, so the trap decides the `length` that a script sees.
- `assert.deepEqual` (loose) uses `Bun.deepEquals`. It already differed from node for these values in 1.4.0. The new cases mark this with `looseBug`.

<details><summary>Notes</summary>

Strict mode (`util.isDeepStrictEqual`), cross-checked against node v26.3.0:

| case | node | bun 1.4.0 | main | this PR |
|---|---|---|---|---|
| `new Proxy([1,2,3], {})` vs `[1,2,3]` | equal | not equal | equal | equal |
| length 7 Proxy of `[1,2,3]` vs `[1,2,3]` | not equal | not equal | equal | not equal |
| `[1,2,3]` vs length 7 Proxy of `[1,2,3]` | not equal | not equal | equal | not equal |
| length `'3'` Proxy of `[1,2,3]` vs `[1,2,3]` | not equal | not equal | equal | not equal |
| length 7 Proxy vs length 3 Proxy, both of `[1,2,3]` | not equal | equal | equal | not equal |
| two length 7 Proxies of `[1,2,3]` | equal | equal | equal | equal |
| `{ x: <length 7 Proxy> }` vs `{ x: [1,2,3] }` | not equal | not equal | equal | not equal |
| length 2 Proxy of `[]` vs `[]` | not equal | not equal | equal | not equal |
| length 2 Proxy of `[]` vs `[ , ]` | equal | not equal | equal | equal |
| length 3 Proxy of `[1,2,3,4,5]` vs `[1,2,3]` | equal | not equal | not equal | not equal |

The last row is a difference this PR does not change. Node compares only the indexes below the reported length. Bun compares every own enumerable key of the target. Bun 1.4.0 behaves the same way.

The comparison uses `===` and not ToLength, because node uses `!==`. So a trap that returns `'3'` is unequal to an array of length 3.

A `length` trap that throws now propagates its error, as in node. Before this change the trap did not run.

#32948 (open) adds a length check for `Bun.deepEquals` and `expect()`. It uses ToLength, and it does not touch the node entry point.

Suites run with the debug build: `test/js/node/assert/` (all files), `test/js/bun/bun-object/deep-equals.test.ts`, `test/js/bun/test/expect.test.js` (1000 pass, 0 fail), and the vendored `test-assert.js`, `test-assert-checktag.js`, `test-assert-deep-with-error.js`, `test-assert-typedarray-deepequal.js`, `test-assert-class.js`, `test-util-isDeepStrictEqual.js`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [79.86ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [4.33ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [55.54ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [10.88ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [5.47ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [4.49ms]
(pass) assert.deepStrictEqual > rejects '' and false [3.93ms]
(pass) assert.deepStrictEqual > rejects null and undefined [4.03ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [10.66ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [5.63ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [9.35ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [5.10ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [5.27ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [9.40ms]
(pass) assert.dee
... (truncated)

release without fix: 6 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [1.28ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [0.06ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [1.02ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [0.24ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [0.10ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [0.04ms]
(pass) assert.deepStrictEqual > rejects '' and false [0.04ms]
(pass) assert.deepStrictEqual > rejects null and undefined [0.03ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [0.17ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [0.07ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [0.14ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [0.08ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [0.05ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [0.05ms]
(pass) assert.deepStrictEqual > accepts two boxed booleans [0.04ms]
(pass) assert.deepStrictEqual > accepts two boxed symbols [0.04ms]
(pass) assert.deepStrictEqual > accepts two boxe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [79.06ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [4.67ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [55.43ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [11.58ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [5.73ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [4.56ms]
(pass) assert.deepStrictEqual > rejects '' and false [3.88ms]
(pass) assert.deepStrictEqual > rejects null and undefined [4.08ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [10.71ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [5.11ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [9.48ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [4.89ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [4.36ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [9.53ms]
(pass) assert.dee
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     35be164fcf
  features     baseline

23 deps, 131 codegen, 1172 objects in 633ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 25 installs across 62 packages (no changes) [6.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[7/1244] fetch zlib
[zlib] up to date
[8/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1217] gen .bind.ts → GeneratedBindings.cpp
[10/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 3ms

  react-refresh.js  4.81 KB  (entry point)

[11/1217] fetch tinycc
[t
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp          | 15 ++++++++++++
 test/js/node/assert/deep-equal.test.ts | 45 ++++++++++++++++++++++++++++++++++
 2 files changed, 60 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/bindings/bindings.cpp               5      1      6
test/js/node/assert/deep-equal.test.ts      3      2      6
```

</details>

<!-- robobun:evidence:end -->