### PR TITLE
bunx: stop force-reinstalling the cached tree on every dist-tag run

### DIFF
--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1013,9 +1013,8 @@ impl BunxCommand {
         let passthrough: &[Box<[u8]>] = opts.passthrough_list.as_slice();
 
         let mut do_cache_bust = update_request.version.tag == VersionTag::DistTag;
-        // `--force` re-links the whole cached tree (slow on Windows, #41211), so
-        // pass it only when an existing tree must be replaced: stale or untrusted.
-        // A dist-tag run only needs the fresh manifest from `--no-cache` (#4981).
+        // Stale or untrusted tree only: `--force` re-links every cached package,
+        // which is slow on Windows (#41211); `--no-cache` alone keeps #4981 fixed.
         let mut force_reinstall = false;
         let look_for_existing_bin = update_request.version.literal.is_empty()
             || update_request.version.tag != VersionTag::DistTag;

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1013,13 +1013,9 @@ impl BunxCommand {
         let passthrough: &[Box<[u8]>] = opts.passthrough_list.as_slice();
 
         let mut do_cache_bust = update_request.version.tag == VersionTag::DistTag;
-        // `--force` re-links every package in the cached tree. That is cheap on
-        // macOS/Linux but very slow on Windows (per-file copy + AV scanning), so
-        // only request it when the existing tree must be refreshed or replaced:
-        // a stale cache (to renew the mtime the 24h check reads) or an untrusted
-        // cached binary (to overwrite a planted file). A plain dist-tag run only
-        // needs a fresh manifest (`--no-cache`); `bun add pkg@tag` re-resolves
-        // the tag and re-installs the package when it moved (#4981, #41211).
+        // `--force` re-links the whole cached tree (slow on Windows, #41211), so
+        // pass it only when an existing tree must be replaced: stale or untrusted.
+        // A dist-tag run only needs the fresh manifest from `--no-cache` (#4981).
         let mut force_reinstall = false;
         let look_for_existing_bin = update_request.version.literal.is_empty()
             || update_request.version.tag != VersionTag::DistTag;

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1013,6 +1013,14 @@ impl BunxCommand {
         let passthrough: &[Box<[u8]>] = opts.passthrough_list.as_slice();
 
         let mut do_cache_bust = update_request.version.tag == VersionTag::DistTag;
+        // `--force` re-links every package in the cached tree. That is cheap on
+        // macOS/Linux but very slow on Windows (per-file copy + AV scanning), so
+        // only request it when the existing tree must be refreshed or replaced:
+        // a stale cache (to renew the mtime the 24h check reads) or an untrusted
+        // cached binary (to overwrite a planted file). A plain dist-tag run only
+        // needs a fresh manifest (`--no-cache`); `bun add pkg@tag` re-resolves
+        // the tag and re-installs the package when it moved (#4981, #41211).
+        let mut force_reinstall = false;
         let look_for_existing_bin = update_request.version.literal.is_empty()
             || update_request.version.tag != VersionTag::DistTag;
 
@@ -1075,6 +1083,7 @@ impl BunxCommand {
                                 BStr::new(out)
                             );
                             do_cache_bust = true;
+                            force_reinstall = true;
                             break 'try_run_existing;
                         }
                         let is_stale: bool = 'is_stale: {
@@ -1133,6 +1142,7 @@ impl BunxCommand {
                         if is_stale {
                             bun_output::scoped_log!(bunx, "found stale binary: {}", BStr::new(out));
                             do_cache_bust = true;
+                            force_reinstall = true;
                             if opts.no_install {
                                 bun_core::warn!(
                                     "Using a stale installation of <b>{}<r> because --no-install was passed. Run `bunx` without --no-install to use a fresh binary.",
@@ -1246,6 +1256,7 @@ impl BunxCommand {
                                             BStr::new(out)
                                         );
                                         do_cache_bust = true;
+                                        force_reinstall = true;
                                         break 'try_run_existing;
                                     }
                                     let stored = fs.dirname_store.append_slice(out)?;
@@ -1336,8 +1347,9 @@ impl BunxCommand {
             // disable the manifest cache when a tag is specified
             // so that @latest is fetched from the registry
             args.append(b"--no-cache").expect("unreachable"); // upper bound is known
+        }
 
-            // forcefully re-install packages in this mode too
+        if force_reinstall {
             args.append(b"--force").expect("unreachable"); // upper bound is known
         }
 

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
-import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
+import { chmodSync, copyFileSync, readdirSync, symlinkSync, utimesSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
@@ -905,6 +905,7 @@ describe("bunx dist-tag cache", () => {
     setHandler(dummyRegistry([], { "1.0.0": { bin: { [pkg]: "cli.js" }, as: "1.0.0" }, latest: "1.0.0" }, 0, tgzDir));
 
     let [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(err).not.toContain("error:");
     expect(out).toContain(`${pkg} 1.0.0`);
     expect(exited).toBe(0);
 
@@ -914,9 +915,43 @@ describe("bunx dist-tag cache", () => {
     await writeFile(marker, "keep");
 
     [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(err).not.toContain("error:");
     expect(out).toContain(`${pkg} 1.0.0`);
     expect(exited).toBe(0);
     expect(await Bun.file(marker).exists()).toBe(true);
+  });
+
+  it("a stale cached install (>24h) is still force-refreshed", async () => {
+    const pkg = "dist-stale-pkg";
+    const tgzDir = tmpdirSync();
+    await makeTarball(tgzDir, pkg, "1.0.0");
+    setHandler(dummyRegistry([], { "1.0.0": { bin: { [pkg]: "cli.js" }, as: "1.0.0" }, latest: "1.0.0" }, 0, tgzDir));
+
+    // No version: this path runs the cached bin directly unless the cached
+    // .bin entry is older than 24h, in which case it re-installs with --force.
+    let [err, out, exited] = await runBunx(pkg);
+    expect(err).not.toContain("error:");
+    expect(out).toContain(`${pkg} 1.0.0`);
+    expect(exited).toBe(0);
+
+    const cacheDir = findBunxCacheDir(pkg);
+    const marker = join(cacheDir, "node_modules", pkg, "MARKER");
+    await writeFile(marker, "keep");
+
+    // Age every cached file bunx's staleness checks can read (the .bin entry
+    // and the root package.json) past the 24h validity window.
+    const old = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    utimesSync(join(cacheDir, "package.json"), old, old);
+    for (const entry of readdirSync(join(cacheDir, "node_modules", ".bin"))) {
+      utimesSync(join(cacheDir, "node_modules", ".bin", entry), old, old);
+    }
+
+    [err, out, exited] = await runBunx(pkg);
+    expect(err).not.toContain("error:");
+    expect(out).toContain(`${pkg} 1.0.0`);
+    expect(exited).toBe(0);
+    // The stale tree was force-reinstalled, so the planted marker is gone.
+    expect(await Bun.file(marker).exists()).toBe(false);
   });
 
   it("a @latest run picks up a newly published latest version", async () => {
@@ -931,6 +966,7 @@ describe("bunx dist-tag cache", () => {
     setHandler(dummyRegistry([], { ...versions, latest: "1.0.0" }, 0, tgzDir));
 
     let [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(err).not.toContain("error:");
     expect(out).toContain(`${pkg} 1.0.0`);
     expect(exited).toBe(0);
 
@@ -938,6 +974,7 @@ describe("bunx dist-tag cache", () => {
     setHandler(dummyRegistry([], { ...versions, latest: "1.1.0" }, 0, tgzDir));
 
     [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(err).not.toContain("error:");
     expect(out).toContain(`${pkg} 1.1.0`);
     expect(exited).toBe(0);
   });

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -840,6 +840,109 @@ console.log("EXECUTED: multi-tool-alt (alternate binary)");
   });
 });
 
+// `bunx pkg@latest` (any dist-tag) used to spawn `bun add pkg@latest
+// --no-cache --force`. `--force` re-installs every package in the cached tree
+// on every invocation, which is slow on Windows (per-file copy + AV scanning;
+// issues #41211, #23597). Only `--no-cache` is needed for a dist-tag: it
+// re-fetches the manifest, and `bun add pkg@tag` re-installs the package when
+// the tag moved (#4981).
+describe("bunx dist-tag cache", () => {
+  let port: number;
+
+  beforeAll(() => {
+    dummyBeforeAll();
+    port = getPort()!;
+  });
+
+  afterAll(() => {
+    dummyAfterAll();
+  });
+
+  beforeEach(async () => {
+    await dummyBeforeEach();
+  });
+
+  async function makeTarball(tgzDir: string, name: string, version: string) {
+    const pkgRoot = tmpdirSync();
+    const packageDir = join(pkgRoot, "package");
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name, version, bin: { [name]: "cli.js" } }),
+    );
+    await writeFile(join(packageDir, "cli.js"), `#!/usr/bin/env node\nconsole.log(${JSON.stringify(`${name} ${version}`)});\n`);
+    chmodSync(join(packageDir, "cli.js"), 0o755);
+    await Bun.$`cd ${pkgRoot} && tar -czf ${join(tgzDir, `${name}-${version}.tgz`)} package`;
+  }
+
+  const runBunx = async (...args: string[]): Promise<[err: string, out: string, exited: number]> => {
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", ...args],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env: {
+        ...env,
+        npm_config_registry: `http://localhost:${port}/`,
+      },
+    });
+    return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited]);
+  };
+
+  // The bunx cache dir is $TMPDIR/bunx-<uid>-<pkg>@latest; resolve it by
+  // globbing so the test does not depend on how the uid is derived per OS.
+  function findBunxCacheDir(pkg: string): string {
+    const match = readdirSync(env.TMPDIR!).filter(d => d.startsWith("bunx-") && d.endsWith(`-${pkg}@latest`));
+    expect(match).toHaveLength(1);
+    return join(env.TMPDIR!, match[0]);
+  }
+
+  it("a warm @latest run does not re-install the cached packages", async () => {
+    const pkg = "dist-keep-pkg";
+    const tgzDir = tmpdirSync();
+    await makeTarball(tgzDir, pkg, "1.0.0");
+    setHandler(dummyRegistry([], { "1.0.0": { bin: { [pkg]: "cli.js" }, as: "1.0.0" }, latest: "1.0.0" }, 0, tgzDir));
+
+    let [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(out).toContain(`${pkg} 1.0.0`);
+    expect(exited).toBe(0);
+
+    // Plant a marker inside the cached package. A `--force` re-install
+    // replaces the package directory and deletes it.
+    const marker = join(findBunxCacheDir(pkg), "node_modules", pkg, "MARKER");
+    await writeFile(marker, "keep");
+
+    [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(out).toContain(`${pkg} 1.0.0`);
+    expect(exited).toBe(0);
+    expect(await Bun.file(marker).exists()).toBe(true);
+  });
+
+  it("a @latest run picks up a newly published latest version", async () => {
+    const pkg = "dist-move-pkg";
+    const tgzDir = tmpdirSync();
+    await makeTarball(tgzDir, pkg, "1.0.0");
+    await makeTarball(tgzDir, pkg, "1.1.0");
+    const versions = {
+      "1.0.0": { bin: { [pkg]: "cli.js" }, as: "1.0.0" },
+      "1.1.0": { bin: { [pkg]: "cli.js" }, as: "1.1.0" },
+    };
+    setHandler(dummyRegistry([], { ...versions, latest: "1.0.0" }, 0, tgzDir));
+
+    let [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(out).toContain(`${pkg} 1.0.0`);
+    expect(exited).toBe(0);
+
+    // The dist-tag moves; the next run must install and run 1.1.0.
+    setHandler(dummyRegistry([], { ...versions, latest: "1.1.0" }, 0, tgzDir));
+
+    [err, out, exited] = await runBunx(`${pkg}@latest`);
+    expect(out).toContain(`${pkg} 1.1.0`);
+    expect(exited).toBe(0);
+  });
+});
+
 // Regression: `bunx @scope/name` guesses the bin name as `name` (the
 // unscoped portion), then searched the full system $PATH with it. When
 // `name` happened to match an unrelated system binary — e.g.

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -866,11 +866,11 @@ describe("bunx dist-tag cache", () => {
     const pkgRoot = tmpdirSync();
     const packageDir = join(pkgRoot, "package");
     await mkdir(packageDir, { recursive: true });
+    await writeFile(join(packageDir, "package.json"), JSON.stringify({ name, version, bin: { [name]: "cli.js" } }));
     await writeFile(
-      join(packageDir, "package.json"),
-      JSON.stringify({ name, version, bin: { [name]: "cli.js" } }),
+      join(packageDir, "cli.js"),
+      `#!/usr/bin/env node\nconsole.log(${JSON.stringify(`${name} ${version}`)});\n`,
     );
-    await writeFile(join(packageDir, "cli.js"), `#!/usr/bin/env node\nconsole.log(${JSON.stringify(`${name} ${version}`)});\n`);
     chmodSync(join(packageDir, "cli.js"), 0o755);
     await Bun.$`cd ${pkgRoot} && tar -czf ${join(tgzDir, `${name}-${version}.tgz`)} package`;
   }


### PR DESCRIPTION
### Problem

- `bunx <pkg>@latest` (any dist-tag) is slow on every run on Windows, while macOS is fast (#41211, #23597). For shadcn, each warm run re-installs all 252 cached packages.
- The cause: the dist-tag path in `src/runtime/cli/bunx_command.rs` spawns `bun add <pkg>@latest --no-cache --force` on every invocation. `--force` sets `FORCE_INSTALL`, which re-links every package in the cached tree. That re-link is near free on macOS (clonefile) and Linux (hardlink), but on Windows it does per-file work and antivirus software scans each file. Measured warm run of the spawned install: 0.07s plain vs 0.66s forced on Linux, 0.27s vs 1.6s on a fast Windows VM with no antivirus. User machines with Defender report 30s or more.

### Fix

- Split the single `do_cache_bust` flag into `do_cache_bust` (pass `--no-cache`) and a new `force_reinstall` (pass `--force`). A plain dist-tag run now passes only `--no-cache`.
- `--force` stays on the two paths that must refresh or replace an existing tree: a cached binary older than 24 hours (the forced re-link renews the mtime the staleness check reads) and a cached binary not owned by the current user.
- Correct because `--no-cache` already forces a fresh manifest, and `bun add <pkg>@tag` re-resolves the named package and installs the new version when the tag moved. So #4981 (the bug `--force` was added for in #8921) stays fixed. A test proves it against a local registry whose `latest` tag moves between runs.
- Verified: `test/cli/install/bunx.test.ts` (three new tests, the marker test fails on unfixed bun). Full bunx suite run on Linux and Windows. Self-reviewed: the review agreed with the shape and kept `--force` where a tree replacement is mandatory.

### Background

- bunx caches each requested package in `<temp>/bunx-<uid>-<pkg>@<version>/node_modules` and runs the bin from there. For a pinned version it reuses the cache directly. For a dist-tag it cannot trust the cached resolution, so it always spawns a `bun add` into that directory.
- `--no-cache` disables the manifest cache, so the spawned add asks the registry what the tag points at now. `--force` additionally re-installs every package even when the installed version already matches.
- npx and pnpm dlx handle the same case by re-resolving the tag and reusing the cached tree when the version is unchanged. This change gives bunx the same shape.

<details><summary>Notes</summary>

- Repro measurements on a 16 vCPU Windows Server 2019 VM, canary bun: warm `bun x shadcn@latest --help` 2.2s vs 1.0s on Linux. Breakdown of the spawned install in the warm cache dir: `--no-cache --force` 1.61s, `--force` 1.68s, `--no-cache` 0.07s, plain 0.27s. The cost is the forced re-link of 252 packages, which Defender amplifies on user machines.
- Verified the moved-tag semantics empirically before writing the fix: a local mock registry with `latest` flipped from 1.0.0 to 1.1.0; `bun add mypkg@latest --no-cache` without `--force` installs 1.1.0.
- `--force` also wipes files planted in a cached package dir. The new warm-run test uses that as its observable: it plants a marker file in `node_modules/<pkg>/` and asserts a second `bunx <pkg>@latest` run keeps it. On unfixed bun the forced re-install deletes it.
- The stale-path test sets the cached `.bin` entries and root `package.json` mtimes 25h back with `utimesSync` and asserts the marker is wiped, pinning the kept `--force` behavior.
- A follow-up could skip the spawned install entirely when the freshly resolved tag matches the installed version (pnpm caches the tag resolution with a max age). That removes the remaining per-run registry round-trip and process spawn. Out of scope here: this change is a strict improvement with no behavior change for moved tags.
- The `npm_config_user_agent` test in bunx.test.ts fails under a local debug build because `Bun.version` carries a `-debug` suffix. Unrelated to this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->