### PR TITLE
Bun.serve: report a rejection from a handler that upgraded before it returned

### DIFF
--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -429,5 +429,8 @@ pub enum Unwrapped {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum UnwrapMode {
     MarkHandled,
+    /// Does not leave every rejection unhandled. `result()` marks a rejected promise handled
+    /// when JSC settled it without its resolving functions, as a `then()` reaction does. To
+    /// leave a rejection unhandled, branch on `status()` and do not read the result.
     LeaveUnhandled,
 }

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -429,8 +429,5 @@ pub enum Unwrapped {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum UnwrapMode {
     MarkHandled,
-    /// Does not leave every rejection unhandled. `result()` marks a rejected promise handled
-    /// when JSC settled it without its resolving functions, as a `then()` reaction does. To
-    /// leave a rejection unhandled, branch on `status()` and do not read the result.
     LeaveUnhandled,
 }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -757,19 +757,16 @@ where
             Self::discard_response_body(global_this, result);
             return;
         };
-        // While `resp` is held, a pending promise is subscribed and the `on_abort` that follows
-        // reclaims the cell, so a later rejection is dropped. Drop a settled one the same way.
-        // Once `resp` is gone (upgraded, or aborted already), nothing subscribes and a rejection
-        // stays unhandled, so it reaches `unhandledRejection`.
         let resp_held = self.resp.get().is_some();
-        // `status()`, not `unwrap()`: `result()` marks a rejected promise handled when JSC
-        // settled it without its resolving functions, as a `then()` reaction does.
         match promise.status() {
+            // Only while `resp` is held: the `on_abort` that follows then reclaims the cell.
             jsc::PromiseStatus::Pending if resp_held => {
                 let cell = self.create_promise_cell(global_this);
                 result.then_with_value(global_this, cell, Self::ON_RESOLVE, Self::ON_REJECT);
             }
+            // A subscribed promise that rejects later is dropped. Drop this one the same way.
             jsc::PromiseStatus::Rejected if resp_held => promise.set_handled(global_this.vm()),
+            // Nothing subscribes, so a rejection stays unhandled and reaches `unhandledRejection`.
             jsc::PromiseStatus::Pending | jsc::PromiseStatus::Rejected => {}
             jsc::PromiseStatus::Fulfilled => {
                 Self::discard_response_body(global_this, promise.result(global_this.vm()));

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -757,15 +757,22 @@ where
             Self::discard_response_body(global_this, result);
             return;
         };
-        match promise.unwrap(global_this.vm(), jsc::PromiseUnwrapMode::MarkHandled) {
-            // Only while `resp` is held: the `on_abort` that follows then reclaims the cell.
-            jsc::PromiseResult::Pending if self.resp.get().is_some() => {
+        // While `resp` is held, a pending promise is subscribed and the `on_abort` that follows
+        // reclaims the cell, so a later rejection is dropped. Drop a settled one the same way.
+        // Once `resp` is gone (upgraded, or aborted already), nothing subscribes and a rejection
+        // stays unhandled, so it reaches `unhandledRejection`.
+        let resp_held = self.resp.get().is_some();
+        // `status()`, not `unwrap()`: `result()` marks a rejected promise handled when JSC
+        // settled it without its resolving functions, as a `then()` reaction does.
+        match promise.status() {
+            jsc::PromiseStatus::Pending if resp_held => {
                 let cell = self.create_promise_cell(global_this);
                 result.then_with_value(global_this, cell, Self::ON_RESOLVE, Self::ON_REJECT);
             }
-            jsc::PromiseResult::Pending | jsc::PromiseResult::Rejected(_) => {}
-            jsc::PromiseResult::Fulfilled(fulfilled) => {
-                Self::discard_response_body(global_this, fulfilled);
+            jsc::PromiseStatus::Rejected if resp_held => promise.set_handled(global_this.vm()),
+            jsc::PromiseStatus::Pending | jsc::PromiseStatus::Rejected => {}
+            jsc::PromiseStatus::Fulfilled => {
+                Self::discard_response_body(global_this, promise.result(global_this.vm()));
             }
         }
     }

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1717,7 +1717,7 @@ it.concurrent("server.upgrade() from the error() handler after fetch() threw com
 // returns or not. The server subscribes to the promise of a handler that
 // upgrades after an await, so that case is not covered here.
 describe.concurrent("a handler that calls server.upgrade() before it returns", () => {
-  async function stdoutOf(handlers: string) {
+  async function runChild(handlers: string) {
     await using proc = spawn({
       cmd: [
         bunExe(),
@@ -1741,9 +1741,7 @@ describe.concurrent("a handler that calls server.upgrade() before it returns", (
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-    return stdout;
+    return { stdout, stderr, exitCode };
   }
 
   // A then() or catch() promise is rejected by a reaction job. It is a
@@ -1780,8 +1778,10 @@ describe.concurrent("a handler that calls server.upgrade() before it returns", (
        error(err) { server.upgrade(err.req); return Promise.reject(new Error("E")); },`,
     ],
   ])("reports a rejection to unhandledRejection when %s", async (_, handlers) => {
-    const lines = (await stdoutOf(handlers)).trim().split("\n").sort();
-    expect(lines).toEqual(["unhandledRejection: E", "ws got: hi"]);
+    const { stdout, stderr, exitCode } = await runChild(handlers);
+    expect(stdout.trim().split("\n").sort()).toEqual(["unhandledRejection: E", "ws got: hi"]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1710,6 +1710,81 @@ it.concurrent("server.upgrade() from the error() handler after fetch() threw com
   expect(exitCode).toBe(0);
 });
 
+// A handler that calls server.upgrade() before it returns leaves the server no
+// response to send, so the server does not subscribe to the handler's promise.
+// A rejection of that promise must stay unhandled and reach
+// process.on("unhandledRejection"), whether it has settled when the handler
+// returns or not. The server subscribes to the promise of a handler that
+// upgrades after an await, so that case is not covered here.
+describe.concurrent("a handler that calls server.upgrade() before it returns", () => {
+  async function stdoutOf(handlers: string) {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("unhandledRejection", e => console.log("unhandledRejection:", e.message));
+         const server = Bun.serve({
+           port: 0,
+           ${handlers}
+           websocket: {
+             open(ws) { ws.send("hi"); },
+             message() {},
+           },
+         });
+         const ws = new WebSocket(server.url.href.replace(/^http/, "ws"));
+         ws.onerror = () => { console.log("ws error"); process.exit(1); };
+         ws.onmessage = e => { console.log("ws got:", e.data); ws.close(); };
+         ws.onclose = () => server.stop(true);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  // A then() or catch() promise is rejected by a reaction job. It is a
+  // separate case: JSC does not set its first-resolving-function flag.
+  it.each([
+    [
+      "fetch() is async and throws after an await",
+      `async fetch(req, srv) { srv.upgrade(req); await 0; throw new Error("E"); },
+       error(e) { console.log("error() saw:", e.message); },`,
+    ],
+    [
+      "fetch() returns Promise.reject()",
+      `fetch(req, srv) { srv.upgrade(req); return Promise.reject(new Error("E")); },
+       error(e) { console.log("error() saw:", e.message); },`,
+    ],
+    [
+      "fetch() returns a then() promise that throws",
+      `fetch(req, srv) { srv.upgrade(req); return Promise.resolve().then(() => { throw new Error("E"); }); },
+       error(e) { console.log("error() saw:", e.message); },`,
+    ],
+    [
+      "fetch() returns a catch() promise that rethrows",
+      `fetch(req, srv) { srv.upgrade(req); return Promise.reject(new Error("E")).catch(e => { throw e; }); },
+       error(e) { console.log("error() saw:", e.message); },`,
+    ],
+    [
+      "fetch() returns a then() promise that passes a rejection through",
+      `fetch(req, srv) { srv.upgrade(req); return Promise.reject(new Error("E")).then(x => x); },
+       error(e) { console.log("error() saw:", e.message); },`,
+    ],
+    [
+      "error() upgrades and returns Promise.reject()",
+      `fetch(req) { throw Object.assign(new Error("boom"), { req }); },
+       error(err) { server.upgrade(err.req); return Promise.reject(new Error("E")); },`,
+    ],
+  ])("reports a rejection to unhandledRejection when %s", async (_, handlers) => {
+    const lines = (await stdoutOf(handlers)).trim().split("\n").sort();
+    expect(lines).toEqual(["unhandledRejection: E", "ws got: hi"]);
+  });
+});
+
 it("server.upgrade() does not blank the Request's url/headers read afterwards", async () => {
   // req.url and req.headers are lifted lazily from the uws request. upgrade()
   // detaches that context, so fields not touched before the call must be

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1779,9 +1779,11 @@ describe.concurrent("a handler that calls server.upgrade() before it returns", (
     ],
   ])("reports a rejection to unhandledRejection when %s", async (_, handlers) => {
     const { stdout, stderr, exitCode } = await runChild(handlers);
-    expect(stdout.trim().split("\n").sort()).toEqual(["unhandledRejection: E", "ws got: hi"]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
+    expect({ stdoutLines: stdout.trim().split("\n").sort(), stderr, exitCode }).toEqual({
+      stdoutLines: ["unhandledRejection: E", "ws got: hi"],
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- A handler calls `server.upgrade(req)`, then its promise rejects in the same dispatch. The rejection vanishes: no `error()` call, no `unhandledRejection`. Bun 1.4.0 reports it. The regression is from #41011 and is in canary builds only.
- Cause: `discard_handler_result` (`src/runtime/server/RequestContext.rs:755`) unwraps the handler's promise with `PromiseUnwrapMode::MarkHandled`, which marks the rejection handled.

### Fix
- Mark a settled rejection handled only while the context holds its uWS response. A pending promise is subscribed under the same condition, so a settled rejection now gets what a later one gets.
- Branch on `status()`. `unwrap(LeaveUnhandled)` is not enough: `result()` marks some rejected promises handled (see Background). Read `result()` only for a fulfilled promise.
- Verified: `test/js/bun/websocket/websocket-server.test.ts`, 6 new cases, each fails on main. Also the `serve-*` abort and error suites and the upgrade suites.
- Self-reviewed: the review found the `then()` case above and asked for the scope notes below. Both are in this PR.

### Background
- `server.upgrade()` hands the socket to the WebSocket and clears the context's uWS response. The server cannot send a response or run `error()` after that.
- The server subscribes to a pending handler promise only while it holds the response. An abort then reclaims the subscription, and `on_reject` drops the rejection.
- JSC reports a promise that rejects with no handler. `markAsHandled()` stops that report.
- `JSC__JSPromise__result` (`src/jsc/bindings/bindings.cpp:3981`) marks a rejected promise handled when JSC settled it without its resolving functions. A `then()` or `catch()` reaction settles a promise that way.

<details><summary>Notes</summary>

**Bisect.** I read the `abe2ad4f0..326ec468a` window for `src/runtime/server`. `MarkHandled` entered `discard_handler_result` in 936bf867aa (#41011). Before that, the upgraded path returned and did not touch the promise. `bun-v1.4.0` does not contain #41011.

**Matrix.** Each shape calls `server.upgrade()` and then fails. "reported" means `unhandledRejection` fires. All three columns are measured: the a6c4cc276 canary, and debug builds of this branch with and without the `src/` change.

| shape | a6c4cc276 (before #41011) | main | this PR |
| --- | --- | --- | --- |
| `upgrade(); return Promise.reject(e)` | reported | silent | reported |
| `upgrade(); await 0; throw e` | reported | silent | reported |
| `upgrade(); return Promise.resolve().then(() => { throw e })` | reported | silent | reported |
| `upgrade(); return Promise.reject(e).catch(e => { throw e })` | reported | silent | reported |
| `upgrade(); return Promise.reject(e).then(x => x)` | reported | silent | reported |
| `error()` upgrades, returns `Promise.reject(e)` | reported | silent | reported |
| `upgrade(); await Bun.sleep(5); throw e` | reported | reported | reported |
| `upgrade(); throw e` (sync) | silent | silent | silent |
| `await Bun.sleep(5); upgrade(); throw e` | silent | silent | silent |

The last two rows are silent on 1.4.0 too, and this PR does not change them. A sync throw never becomes a promise. A handler that upgrades after an `await` has its promise subscribed before the upgrade, so `on_reject` drops the rejection. #33525 is an older open PR about those shapes.

**Paths that keep the response.** `on_connection_closed_during_dispatch` (#40034) and `server.stop(true)` inside the handler still hold the response, so they still subscribe and still drop a rejection, settled or later. This PR does not change them. #41011 changed the `stop(true)` case: a6c4cc276 reports a rejection there. `stop(true)` aborts the request and fires `request.signal`, and an abort drops a later rejection, so the drop matches. If the report is wanted, that is a separate change.

**Paths without the response, other than an upgrade.** `on_abort` is armed only by `set_abort_handler()`, which runs after the dispatch. So during a synchronous dispatch, the response is gone only after an upgrade. One more state exists: an `error()` call after the dispatch that calls `server.stop(true)`, which runs `on_abort`. There, main drops a settled rejection and reports a later one. With this PR both are reported, as on a6c4cc276.

**`discard_response_body`** keeps its `unwrap(MarkHandled)`. Its callers pass a fulfilled value, not a promise.

**The test** sorts the two output lines, so it does not depend on the order of the two events.

**Suites run** on a debug build: `serve-pending-promise-abort-leak` (the #41011 tests), `bun-serve-propagate-errors`, `serve-error-handler-stream`, `serve-async-stream-client-abort`, `serve-stream-body-error`, `async-iterator-stream`, `serve-stream-reject-flush-leak`, `websocket-server-upgrade-reentrant`, `websocket-upgrade-signal-gc`, `web/websocket/websocket-upgrade`, `serve.test.ts`, `bun-server.test.ts`, and all of `websocket-server.test.ts`.

Failures unrelated to this change, in this container:
- Four `websocket-server.test.ts` tests in `send()` and `sendBinary()` time out after 10 s when the whole file runs on a debug build. The copy of the file on main fails the same four. Each passes alone.
- `serve.test.ts` root range port and `/bun:info` loopback, and `bun-server.test.ts` IPv6 listen. They fail on the a6c4cc276 canary too. The container runs as root and has no IPv6.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->
