### PR TITLE
resolver: read package.json "type" from the nearest package.json, named or not

### DIFF
--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -119,6 +119,14 @@ pub struct DirInfo {
     // ergonomics. If a write is ever added, retype to `Option<NonNull<_>>`.
     pub enclosing_package_json: Option<&'static PackageJSON>,
 
+    /// The nearest package.json in this directory or above it, with or without
+    /// a "name". The bundler takes the module type of a `.js`-like file in this
+    /// directory from its "type" (`finalize_result`), as esbuild does. The
+    /// lookup does not stop at a "node_modules" directory, so a package with no
+    /// package.json of its own gets the one above it. `enclosing_package_json`
+    /// skips a nameless package.json.
+    pub package_json_for_module_type: Option<&'static PackageJSON>,
+
     // `NonNull` (not `&'static`) so `enqueue_dependency_to_resolve` can write
     // `package_manager_package_id` back through it without a const→mut
     // provenance cast. Read via `.package_json_for_dependencies()`.
@@ -148,6 +156,7 @@ impl Default for DirInfo {
             package_json_for_browser_field: None,
             enclosing_tsconfig_json: None,
             enclosing_package_json: None,
+            package_json_for_module_type: None,
             package_json_for_dependencies: None,
             abs_path: b"",
             entries: Index::default(),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1520,11 +1520,21 @@ impl<'a> Resolver<'a> {
 
         let mut iter = result.path_pair.iter();
         let mut module_type = result.module_type;
+        let mut is_primary = true;
         while let Some(path) = iter.next() {
             let name = path.name();
+            let primary = core::mem::take(&mut is_primary);
             let Ok(Some(dir)) = self.read_dir_info(name.dir) else {
                 continue;
             };
+
+            // Node reads "type" from the nearest package.json, named or not.
+            if primary && !kind.is_from_css() && module_type == options::ModuleType::Unknown {
+                if let Some(pkg) = dir.package_json_for_module_type {
+                    module_type = pkg.module_type;
+                }
+            }
+
             let mut needs_side_effects = true;
             if let Some(existing) = Result::deref_package_json(result.package_json) {
                 // if we don't have it here, they might put it in a sideEfffects
@@ -1662,12 +1672,6 @@ impl<'a> Resolver<'a> {
 
                     path.set_realpath(symlink);
                 }
-            }
-        }
-
-        if !kind.is_from_css() && module_type == options::ModuleType::Unknown {
-            if let Some(pkg) = result.package_json_ref() {
-                module_type = pkg.module_type;
             }
         }
 
@@ -6377,6 +6381,10 @@ impl<'a> Resolver<'a> {
                 }
             }
         }
+
+        info.package_json_for_module_type = info
+            .package_json()
+            .or_else(|| parent.and_then(|parent_| parent_.package_json_for_module_type));
 
         // Record if this directory has a tsconfig.json or jsconfig.json file
         if self.opts.load_tsconfig_json {

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -225,19 +225,12 @@ pub enum ResultUnion {
 }
 
 impl Result {
-    /// Read-only view of `package_json`. The field stores `Option<*const _>`
+    /// Read-only view of the `package_json` field. It stores `Option<*const _>`
     /// (rather than `Option<&'static _>`) so [`Default`] / zeroed-init stays
-    /// bit-valid; callers that only read go through here. Single deref site
-    /// for the ARENA-backed pointer — same invariant as
+    /// bit-valid. Takes the `Copy` field, not `&self`, so a site that already
+    /// borrows `self` mutably (e.g. while iterating `path_pair`) can read it.
+    /// Single deref site for the ARENA-backed pointer — same invariant as
     /// [`dir_info::DirInfo::package_json`].
-    #[inline]
-    pub(crate) fn package_json_ref(&self) -> Option<&'static PackageJSON> {
-        Self::deref_package_json(self.package_json)
-    }
-
-    /// Field-value form of [`package_json_ref`] for sites where `self` is
-    /// already mutably borrowed (e.g. while iterating `path_pair`). Takes the
-    /// `Copy` field directly so the borrow checker only sees a field read.
     #[inline]
     pub(crate) fn deref_package_json(
         ptr: Option<*const PackageJSON>,

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -669,8 +669,6 @@ describe("bundler", () => {
   });
 
   // Test 32: package.json "type": "module" makes a `.ts` importer ESM.
-  // The resolver reads "type" from the enclosing package.json, and it only
-  // treats a package.json with a "name" as enclosing.
   itBundled("cjs/__toESM_type_module_importer_node_mode", {
     files: {
       "/entry.ts": logDefaultAndNamed,
@@ -1055,6 +1053,186 @@ describe("bundler", () => {
     },
     run: {
       stdout: "undefined 0",
+    },
+  });
+
+  // ============================================================================
+  // The nearest package.json decides "type", with or without a "name". A dual
+  // package marks its ESM build with a nameless `dist/esm/package.json` that
+  // holds only `{ "type": "module" }`. Node and esbuild read that file whatever
+  // the path that reached it.
+  //
+  // `seen` tells the interops apart: Node's gives the whole `module.exports`
+  // ("object/function"), the other gives `exports.default` ("function/undefined").
+  // ============================================================================
+
+  const seenFromCjsDep = /* js */ `
+    import d from "cjs-dep";
+    export const seen = typeof d + "/" + typeof d.default;
+  `;
+  const logSeen = /* ts */ `
+    import { seen } from "pkg";
+    console.log(seen);
+  `;
+
+  // Test 53: the nested marker is reached through "main"
+  itBundled("cjs/__toESM_nested_nameless_type_module_via_main", {
+    files: {
+      "/entry.ts": logSeen,
+      "/node_modules/pkg/package.json": `{ "name": "pkg", "main": "./dist/esm/index.js" }`,
+      "/node_modules/pkg/dist/esm/package.json": `{ "type": "module" }`,
+      "/node_modules/pkg/dist/esm/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    target: "node",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__toESM(require_cjs_dep(), 1)");
+    },
+    run: {
+      stdout: "object/function",
+    },
+  });
+
+  // Test 54: a nested package.json with a "name" counts the same way
+  itBundled("cjs/__toESM_nested_named_type_module_via_main", {
+    files: {
+      "/entry.ts": logSeen,
+      "/node_modules/pkg/package.json": `{ "name": "pkg", "main": "./dist/esm/index.js" }`,
+      "/node_modules/pkg/dist/esm/package.json": `{ "name": "pkg-esm", "type": "module" }`,
+      "/node_modules/pkg/dist/esm/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object/function",
+    },
+  });
+
+  // Test 55: the nameless marker, reached through "module"
+  itBundled("cjs/__toESM_nested_nameless_type_module_via_module_field", {
+    files: {
+      "/entry.ts": logSeen,
+      "/node_modules/pkg/package.json": `{
+        "name": "pkg",
+        "main": "./dist/cjs/index.js",
+        "module": "./dist/esm/index.js"
+      }`,
+      "/node_modules/pkg/dist/cjs/index.js": /* js */ `exports.seen = "cjs build";`,
+      "/node_modules/pkg/dist/esm/package.json": `{ "type": "module" }`,
+      "/node_modules/pkg/dist/esm/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object/function",
+    },
+  });
+
+  // Test 56: the nameless marker, reached through a relative path
+  itBundled("cjs/__toESM_nested_nameless_type_module_via_relative_path", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { seen } from "./lib/esm/index.js";
+        console.log(seen);
+      `,
+      "/package.json": `{ "name": "app" }`,
+      "/lib/esm/package.json": `{ "type": "module" }`,
+      "/lib/esm/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object/function",
+    },
+  });
+
+  // Test 57: the marker applies to every file below it, not only to the
+  // directory that holds it
+  itBundled("cjs/__toESM_nested_nameless_type_module_in_subdirectory", {
+    files: {
+      "/entry.ts": logSeen,
+      "/node_modules/pkg/package.json": `{ "name": "pkg", "main": "./dist/esm/index.js" }`,
+      "/node_modules/pkg/dist/esm/package.json": `{ "type": "module" }`,
+      "/node_modules/pkg/dist/esm/index.js": /* js */ `export { seen } from "./inner/seen.js";`,
+      "/node_modules/pkg/dist/esm/inner/seen.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object/function",
+    },
+  });
+
+  // Test 58: a project package.json with "type" and no "name" counts too
+  itBundled("cjs/__toESM_nameless_project_type_module", {
+    files: {
+      "/entry.ts": logDefaultAndNamed,
+      "/dep.cjs": esModuleDep,
+      "/package.json": `{ "type": "module" }`,
+    },
+    run: {
+      stdout: "object 1",
+    },
+  });
+
+  // Test 59: the nearest package.json wins. A nameless "type": "commonjs"
+  // marker below a "type": "module" package keeps the __esModule interop.
+  itBundled("cjs/__toESM_nested_nameless_type_commonjs_under_type_module", {
+    files: {
+      "/entry.ts": logSeen,
+      "/node_modules/pkg/package.json": `{ "name": "pkg", "type": "module", "main": "./dist/cjs/index.js" }`,
+      "/node_modules/pkg/dist/cjs/package.json": `{ "type": "commonjs" }`,
+      "/node_modules/pkg/dist/cjs/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "function/undefined",
+    },
+  });
+
+  // Test 60: the nearest package.json is the scope even when it has no "type".
+  // The lookup does not continue to the "type": "module" package root.
+  itBundled("cjs/__toESM_nearest_package_json_without_type_is_the_scope", {
+    files: {
+      "/entry.ts": logSeen,
+      "/node_modules/pkg/package.json": `{ "name": "pkg", "type": "module", "main": "./dist/index.js" }`,
+      "/node_modules/pkg/dist/package.json": `{ "sideEffects": false }`,
+      "/node_modules/pkg/dist/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "function/undefined",
+    },
+  });
+
+  // Test 61: the lookup does not stop at a node_modules directory. A package
+  // without a package.json of its own takes the "type" of the one above it.
+  itBundled("cjs/__toESM_nameless_type_module_above_node_modules", {
+    files: {
+      "/entry.ts": logSeen,
+      "/package.json": `{ "type": "module" }`,
+      "/node_modules/pkg/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "object/function",
+    },
+  });
+
+  // Test 62: only the file in the bundle decides. With the default target,
+  // "module" wins and "main" is the fallback for require(). The fallback's
+  // package.json does not give the "module" file its "type".
+  itBundled("cjs/__toESM_type_from_module_field_not_main_fallback", {
+    files: {
+      "/entry.ts": logSeen,
+      "/node_modules/pkg/package.json": `{
+        "name": "pkg",
+        "main": "./lib/index.js",
+        "module": "./esm/index.js"
+      }`,
+      "/node_modules/pkg/lib/package.json": `{ "type": "module" }`,
+      "/node_modules/pkg/lib/index.js": /* js */ `export const seen = "main build";`,
+      "/node_modules/pkg/esm/index.js": seenFromCjsDep,
+      ...cjsDepFiles,
+    },
+    run: {
+      stdout: "function/undefined",
     },
   });
 });


### PR DESCRIPTION
### Problem
- Regression on main from #41150. No release has it. `bun build` reads `"type"` from the wrong package.json, so it misses a `{ "type": "module" }` that has no `"name"`. Two common places: a project root, and a dual package's `dist/esm/package.json`.
- A `.js` or `.ts` file there gets `exports.default` for the default import of a CommonJS module with `__esModule`. Node, esbuild and bun 1.4.0 give the whole `module.exports`. The bundle has `__toESM(require_tsdep())`, without `, 1`.
- Cause: `finalize_result` (`src/resolver/resolver.rs:1669`) read `"type"` from the package root, or else from `enclosing_package_json`. `dir_info_uncached` (`src/resolver/resolver.rs:6357`) sets that field only for a named package.json (#229).

### Fix
- `DirInfo` gets `package_json_for_module_type`: the nearest package.json in the directory or above it, named or not. `finalize_result` reads `"type"` from it for the primary path. The extension still wins.
- Correct because esbuild uses this rule, and Node ignores `"name"` too.
- Only the bundler reads `Result.module_type`. `enclosing_package_json` does not change. The four runtime lookups in `src/runtime/jsc_hooks.rs` are out of scope.
- Verified: `test/bundler/bundler_cjs.test.ts`, 10 new cases, 9 fail on main. Self-reviewed: 3 concerns raised, 3 addressed. Other suites in Notes.

### Background
- `__toESM(mod, isNodeMode)` builds the ESM view of a CommonJS module. With `, 1` (Node mode), `default` is the whole `module.exports`. Without it, `default` is `mod.default` when `__esModule` is set.
- `DirInfo` is the resolver's cached record for one directory. Its "enclosing" fields come from the parent.
- Open PRs in this area: #33883, #33807, #33890, #40940. This PR supersedes none. Notes cover #40940.

<details><summary>Notes</summary>

Found by comparing `bun build` on main with bun 1.4.0, Node 26 and esbuild 0.25. No issue is open for it.

Repro for the dual-package face:

```sh
D=$(mktemp -d); cd $D; mkdir -p node_modules/pkg/dist/esm node_modules/tsdep
echo '{"name":"tsdep","version":"1.0.0","main":"index.js"}' > node_modules/tsdep/package.json
echo 'Object.defineProperty(exports,"__esModule",{value:true}); exports.default=function styled(){}; exports.css="css";' > node_modules/tsdep/index.js
echo '{"name":"pkg","version":"1.0.0","main":"./dist/esm/index.js"}' > node_modules/pkg/package.json
echo '{"type":"module"}' > node_modules/pkg/dist/esm/package.json
echo 'import styled from "tsdep"; export const seen = typeof styled + "/" + typeof styled.default;' > node_modules/pkg/dist/esm/index.js
echo 'import { seen } from "pkg"; console.log(seen);' > app.mjs
node app.mjs                                                              # object/function
bun build ./app.mjs --target=node --outfile=out.mjs && node out.mjs       # main: function/undefined, this PR: object/function
```

For the project-root face, put `{ "type": "module" }` (no `"name"`) in the project's package.json and bundle a `.js` file that imports `tsdep`.

Faces of the bug on main. Each has a test:

- A project package.json with `"type"` and no `"name"` (case 58).
- The nested marker reached through `"main"`, `"module"` or a relative path (cases 53, 55, 56). Through an exports map it worked, because `handle_esm_resolution` reads the file's own directory.
- A nested package.json with a `"name"`, reached through `"main"` (case 54). `result.package_json` was the package root, so the nested file was not read at all.
- A file in a subdirectory of the marker (case 57).

Why a new field instead of widening `enclosing_package_json`: that field also names the package for `sideEffects`, the auto-install version gate and `bun run` script discovery. #33883 widens it for every consumer and had to rework the `sideEffects` loop in `finalize_result` to keep the DCE tests passing.

Four cases pin the lookup rule. Each result matches esbuild 0.25.1:

- Case 59: a nameless `{ "type": "commonjs" }` below a `"type": "module"` package wins, because it is the nearest.
- Case 60: a nearest package.json without `"type"` is the scope. The lookup does not continue to a typed package root, so the importer is not ESM by type. Main read the root's `"type"` here. Node prints `object/function` for this shape, but only because it detects ESM syntax in a file with no `"type"`. #41150 chose the esbuild rule for such files.
- Case 61: the lookup does not stop at a `node_modules` directory. A package without a package.json of its own takes the `"type"` above it. Node prints the same result.
- Case 62: only the primary path decides. With the default target, `"module"` is the primary path and `"main"` is the fallback for `require()`. The fallback's package.json does not count. esbuild has the same check. The case fails when the check is removed.

Overlap with #40940: it adds a field with the same name, but its lookup stops at `node_modules`, and the runtime reads it too. If #40940 lands after this PR, it must choose one rule for the field. Case 61 pins the crossing for the bundler. Node's stop can still apply at the runtime read sites. #40940 also calls the lookup for the fallback path, which case 62 rejects.

Out of scope: the runtime's four lookups (`src/runtime/jsc_hooks.rs` lines 1474, 2972, 3220 and 4071) keep `package_json().or(enclosing_package_json)`. So `bun run` still skips a nameless package.json above the file's own directory. That gap predates #41150. For this import, `bun run` 1.4.1 gives `exports.default` for every importer, even `.mjs`.

Self-review, the three concerns and what changed:

- Document the `node_modules` rule on the field. Done in `src/resolver/dir_info.rs`.
- Add a default-target case with both `"main"` and `"module"`. That is case 62.
- Say in this body that no release has the bug, lead with the project-root face, and name the runtime lookups that stay.

Suites run with the fix on a debug ASAN build, after a rebase on main: `bundler_cjs` (62), `esbuild/packagejson`, `esbuild/dce`, `esbuild/default`, `bundler_cjs2esm`, `bundler_npm`, `bundler_edgecase`, `bundler_regressions`, `bundler_splitting`, `bundler_barrel`, `cli/run/run-cjs`, `test/js/bun/resolve`. All pass except the second case of `test/js/bun/resolve/load-same-js-file-a-lot.test.ts`. It times out at 5 s on this build with and without this change (back-to-back runs on the same machine).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [945.38ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [445.45ms]
(pass) bundler > cjs/__toESM_import_syntax_function [371.94ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [387.72ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [361.78ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [367.76ms]
(pass) bundler > cjs/__toESM_target_node [455.64ms]
(pass) bundler > cjs/__toESM_target_browser [413.38ms]
(pass) bundler > cjs/__toESM_target_bun [455.22ms]
(pass) bundler > cjs/__toESM_format_esm [462.40ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [377.93ms]
(pass) bundler > cjs/__toESM_mjs_reexport [431.60ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [432.63ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [368.70ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [443.84ms]
(pass) bundler > cjs/__toESM_default_prop
... (truncated)

release without fix: 20 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bundler/bundler_cjs.test.ts:
runtime failed file: /tmp/bun-build-tests/bun-4t1lr0/cjs/__toESM_import_syntax_with_esModule/out.js
stdout output:
{"__esModule":true,"default":{"value":"default export"},"named":"named export"}
---
expected stdout:
{"value":"default export"}
---
1913 |               console.log(`---`);
1914 |               console.log(`expected ${name}:`);
1915 |               console.log(expected);
1916 |               console.log(`---`);
1917 |             }
1918 |             expect(result).toBe(expected);
                                  ^
error: expect(received).toBe(expected)

Expected: "{"value":"default export"}"
Received: "{"__esModule":true,"default":{"value":"default export"},"named":"named export"}"

      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1918:28)
(fail) bundler > cjs/__toESM_import_syntax_with_esModule [29.17ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [11.71ms]
(pass) bundler > cjs/__toESM_import_syntax_function [9.90ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [9.43ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [9.97ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1024.06ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [473.45ms]
(pass) bundler > cjs/__toESM_import_syntax_function [489.71ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [494.25ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [388.89ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [381.97ms]
(pass) bundler > cjs/__toESM_target_node [389.92ms]
(pass) bundler > cjs/__toESM_target_browser [453.17ms]
(pass) bundler > cjs/__toESM_target_bun [481.14ms]
(pass) bundler > cjs/__toESM_format_esm [415.53ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [376.77ms]
(pass) bundler > cjs/__toESM_mjs_reexport [451.67ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [380.06ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [453.02ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [430.08ms]
(pass) bundler > cjs/__toESM_default_pro
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     822e3b27f1
  features     baseline

23 deps, 131 codegen, 1172 objects in 647ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 25 installs across 62 packages (no changes) [10.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [3.00ms]
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1217] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [15.00
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/dir_info.rs         |   9 ++
 src/resolver/resolver.rs         |  20 +++--
 src/resolver/result.rs           |  15 +---
 test/bundler/bundler_cjs.test.ts | 182 ++++++++++++++++++++++++++++++++++++++-
 4 files changed, 207 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/resolver/dir_info.rs              3      4     33
src/resolver/resolver.rs              8      5     34
src/resolver/result.rs                1      1     33
test/bundler/bundler_cjs.test.ts      3     11     33
```

</details>

<!-- robobun:evidence:end -->