### PR TITLE
http: report each bad Content-Length with node's code, accept leading zeros

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -73,6 +73,8 @@ struct HttpResponseData;
     enum HttpParserError: uint8_t {
         HTTP_PARSER_ERROR_NONE = 0,
         HTTP_PARSER_ERROR_INVALID_CHUNKED_ENCODING = 1,
+        /* A Content-Length value has a byte that is not a digit (llhttp's
+         * HPE_INVALID_CONTENT_LENGTH "Invalid character in Content-Length"). */
         HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH = 2,
         HTTP_PARSER_ERROR_INVALID_TRANSFER_ENCODING = 3,
         HTTP_PARSER_ERROR_MISSING_HOST_HEADER = 4,
@@ -105,6 +107,16 @@ struct HttpResponseData;
          * body. llhttp reports HPE_INVALID_CONTENT_LENGTH ("Content-Length can't
          * be present with Transfer-Encoding"). node:http compat only. */
         HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH = 17,
+        /* A Content-Length field has an empty value (llhttp's
+         * HPE_INVALID_CONTENT_LENGTH "Empty Content-Length"). */
+        HTTP_PARSER_ERROR_EMPTY_CONTENT_LENGTH = 18,
+        /* A Content-Length value is too large to frame a body (llhttp's
+         * HPE_INVALID_CONTENT_LENGTH "Content-Length overflow"). */
+        HTTP_PARSER_ERROR_CONTENT_LENGTH_OVERFLOW = 19,
+        /* A second Content-Length field has a different value. llhttp reports
+         * every second field as HPE_UNEXPECTED_CONTENT_LENGTH "Duplicate
+         * Content-Length". This parser accepts a second field with the same value. */
+        HTTP_PARSER_ERROR_DUPLICATE_CONTENT_LENGTH = 20,
     };
 
 
@@ -619,22 +631,26 @@ struct HttpResponseData;
          * personality so a client cannot stream unbounded extension bytes. */
         static const uint64_t MAX_CHUNK_EXTENSION_SIZE = 16 * 1024;
 
-        /* Returns UINT64_MAX on error. Maximum 999999999 is allowed. */
-        static uint64_t toUnsignedInteger(std::string_view str) {
-            /* We assume at least 64-bit integer giving us safely 999999999999999999 (18 number of 9s) */
-            if (str.length() > 18) {
-                return UINT64_MAX;
-            }
-
-            uint64_t unsignedIntegerValue = 0;
+        /* Parses a non-empty Content-Length value (RFC 9110 8.6: 1*DIGIT) into value.
+         * Like llhttp, the first byte that is not a digit is an invalid character and
+         * a value that grows past the limit is an overflow. The limit is STATE_SIZE_MASK,
+         * not UINT64_MAX: remainingStreamingBytes holds either this byte count or the
+         * ChunkedEncoding state word, and isParsingChunkedEncoding() tells them apart
+         * by the flag bits above STATE_SIZE_MASK. */
+        static HttpParserError parseContentLength(std::string_view str, uint64_t &value) {
+            uint64_t result = 0;
             for (char c : str) {
-                /* As long as the letter is 0-9 we cannot overflow. */
                 if (c < '0' || c > '9') {
-                    return UINT64_MAX;
+                    return HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH;
                 }
-                unsignedIntegerValue = unsignedIntegerValue * 10ull + ((unsigned int) c - (unsigned int) '0');
+                /* result <= STATE_SIZE_MASK (2^59 - 1) here, so result * 10 + 9 stays below 2^63. */
+                result = result * 10ull + ((unsigned int) c - (unsigned int) '0');
+                if (result > STATE_SIZE_MASK) {
+                    return HTTP_PARSER_ERROR_CONTENT_LENGTH_OVERFLOW;
+                }
             }
-            return unsignedIntegerValue;
+            value = result;
+            return HTTP_PARSER_ERROR_NONE;
         }
 
         static inline uint64_t hasLess(uint64_t x, uint64_t n) {
@@ -1186,23 +1202,32 @@ struct HttpResponseData;
             * the Transfer-Encoding overrides the Content-Length. Such a message might indicate an attempt
             * to perform request smuggling (Section 11.2) or response splitting (Section 11.1) and
             * ought to be handled as an error. */
-            /* RFC 9110 8.6 + RFC 9112 6.3: locate the Content-Length header and, in the
-             * same pass, verify every Content-Length header carries the same non-empty
-             * value. A single empty value or multiple differing values are ambiguous and
-             * must be rejected to prevent request smuggling. The bloom filter short-circuits
-             * the common "no Content-Length" case. */
+            /* RFC 9110 8.6 + RFC 9112 6.3: locate the Content-Length header and parse its
+             * value. An empty, non-numeric or oversized value, or a second field with a
+             * different value, is ambiguous and must be rejected to prevent request
+             * smuggling. A second field with the same value is accepted (RFC 9110 8.6
+             * allows that, llhttp rejects it). The fields are checked in wire order, so the
+             * first bad field decides the error, as in llhttp. A bad value is reported
+             * before the Transfer-Encoding and Host checks below. llhttp does the same when
+             * Content-Length comes first. When Transfer-Encoding comes first, llhttp rejects
+             * the Content-Length field by its name. The bloom filter short-circuits the
+             * common "no Content-Length" case. */
             std::string_view contentLengthString;
+            uint64_t contentLength = 0;
             if (req->bf.mightHave("content-length")) {
                 for (HttpRequest::Header *h = req->headers; (++h)->key.length(); ) {
                     if (h->key.length() == 14 && !strncasecmp(h->key.data(), "content-length", 14)) {
+                        if (h->value.length() == 0) {
+                            return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_EMPTY_CONTENT_LENGTH);
+                        }
                         if (contentLengthString.data() == nullptr) {
-                            if (h->value.length() == 0) {
-                                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH);
+                            if (HttpParserError contentLengthError = parseContentLength(h->value, contentLength)) [[unlikely]] {
+                                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, contentLengthError);
                             }
                             contentLengthString = h->value;
                         } else if (h->value.length() != contentLengthString.length() ||
                                    strncmp(h->value.data(), contentLengthString.data(), contentLengthString.length())) {
-                            return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH);
+                            return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_DUPLICATE_CONTENT_LENGTH);
                         }
                     }
                 }
@@ -1279,17 +1304,10 @@ struct HttpResponseData;
             const char *querySeparatorPtr = (const char *) memchr(req->headers->value.data(), '?', req->headers->value.length());
             req->querySeparator = (unsigned int) ((querySeparatorPtr ? querySeparatorPtr : req->headers->value.data() + req->headers->value.length()) - req->headers->value.data());
 
-            // lets check if content len is valid before calling requestHandler
+            /* Set before calling requestHandler. parseContentLength() already kept the
+             * value at or below STATE_SIZE_MASK, so it cannot reach a chunked flag bit. */
             if(contentLengthStringLen) {
-                remainingStreamingBytes = toUnsignedInteger(contentLengthString);
-                /* remainingStreamingBytes is overloaded: for Content-Length it holds the raw byte
-                 * count, for Transfer-Encoding: chunked it holds the ChunkedEncoding state word.
-                 * isParsingChunkedEncoding() distinguishes the two by testing the flag bits, so a
-                 * Content-Length value must never reach a flag bit. UINT64_MAX (parse error) is
-                 * also caught by this since UINT64_MAX > STATE_SIZE_MASK. */
-                if (remainingStreamingBytes > STATE_SIZE_MASK) [[unlikely]] {
-                    return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH);
-                }
+                remainingStreamingBytes = contentLength;
             }
 
             /* If returned socket is not what we put in we need

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1209,6 +1209,9 @@ enum HttpParserError {
   HTTP_PARSER_ERROR_TRAILER_FIELDS_TOO_LARGE = 15,
   HTTP_PARSER_ERROR_CHUNK_TERMINATOR_EXPECTED = 16,
   HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH = 17,
+  HTTP_PARSER_ERROR_EMPTY_CONTENT_LENGTH = 18,
+  HTTP_PARSER_ERROR_CONTENT_LENGTH_OVERFLOW = 19,
+  HTTP_PARSER_ERROR_DUPLICATE_CONTENT_LENGTH = 20,
 }
 // Native callback fired when the HTTP parser rejects incoming bytes. Builds
 // the same error object Node's parser produces and routes it through
@@ -1234,19 +1237,37 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
     return;
   }
 
-  let err;
+  // Node sets err.reason to the llhttp reason string and the message to
+  // "Parse Error: <reason>". The Content-Length arms set reason. Each of their
+  // parser errors stands for exactly one llhttp code and reason, so the reason
+  // is right for every input. The other arms leave reason unset.
+  let err, reason;
   switch (errorCode) {
     case HttpParserError.HTTP_PARSER_ERROR_INVALID_CHUNKED_ENCODING:
       err = $HPE_INVALID_CHUNK_SIZE("Parse Error: Invalid character in chunk size");
       break;
     case HttpParserError.HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH:
-      err = $HPE_UNEXPECTED_CONTENT_LENGTH("Parse Error");
+      reason = "Invalid character in Content-Length";
+      err = $HPE_INVALID_CONTENT_LENGTH(`Parse Error: ${reason}`);
+      break;
+    case HttpParserError.HTTP_PARSER_ERROR_EMPTY_CONTENT_LENGTH:
+      reason = "Empty Content-Length";
+      err = $HPE_INVALID_CONTENT_LENGTH(`Parse Error: ${reason}`);
+      break;
+    case HttpParserError.HTTP_PARSER_ERROR_CONTENT_LENGTH_OVERFLOW:
+      reason = "Content-Length overflow";
+      err = $HPE_INVALID_CONTENT_LENGTH(`Parse Error: ${reason}`);
+      break;
+    case HttpParserError.HTTP_PARSER_ERROR_DUPLICATE_CONTENT_LENGTH:
+      reason = "Duplicate Content-Length";
+      err = $HPE_UNEXPECTED_CONTENT_LENGTH(`Parse Error: ${reason}`);
       break;
     case HttpParserError.HTTP_PARSER_ERROR_INVALID_TRANSFER_ENCODING:
       err = $HPE_INVALID_TRANSFER_ENCODING("Parse Error: Request has invalid `Transfer-Encoding`");
       break;
     case HttpParserError.HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH:
-      err = $HPE_INVALID_CONTENT_LENGTH("Parse Error: Content-Length can't be present with Transfer-Encoding");
+      reason = "Content-Length can't be present with Transfer-Encoding";
+      err = $HPE_INVALID_CONTENT_LENGTH(`Parse Error: ${reason}`);
       break;
     case HttpParserError.HTTP_PARSER_ERROR_INVALID_REQUEST:
       err = $HPE_INVALID_CONSTANT("Parse Error: Expected HTTP/");
@@ -1289,6 +1310,7 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
       err = $HPE_INTERNAL("Parse Error");
       break;
   }
+  if (reason !== undefined) err.reason = reason;
   err.rawPacket = Buffer.from(rawPacket);
   socketOnError.$call(nodeSocket, err);
 }

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -353,6 +353,39 @@ test("rejects empty-valued Content-Length followed by smuggled Content-Length", 
   expect(seen).not.toContain("GET /admin");
 });
 
+test("frames a Content-Length with leading zeros by its digits", async () => {
+  // RFC 9110 8.6: Content-Length = 1*DIGIT, so leading zeros are valid. This
+  // 19-byte value is 5: the body is "hello" and the pipelined GET is served.
+  const seen: string[] = [];
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      seen.push(`${req.method} ${new URL(req.url).pathname} body=${await req.text()}`);
+      return new Response("OK");
+    },
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const client = net.connect(server.port, "127.0.0.1", () => {
+    client.write(
+      "POST /a HTTP/1.1\r\nHost: x\r\nContent-Length: 0000000000000000005\r\n\r\nhello" +
+        "GET /b HTTP/1.1\r\nHost: x\r\n\r\n",
+    );
+  });
+  let raw = "";
+  client.on("data", data => {
+    raw += data;
+    if (raw.match(/HTTP\/1\.1 200/g)?.length === 2) resolve(raw);
+  });
+  client.on("error", reject);
+  client.on("close", () => resolve(raw));
+  const response = await promise;
+  client.destroy();
+
+  expect(seen.sort()).toEqual(["GET /b body=", "POST /a body=hello"]);
+  expect(response.match(/HTTP\/1\.1 200/g)).toHaveLength(2);
+});
+
 test("accepts valid Transfer-Encoding: chunked", async () => {
   let receivedBody = "";
 

--- a/test/js/bun/test/parallel/test-http-should-emit-clientError-when-Content-Length-is-invalid.ts
+++ b/test/js/bun/test/parallel/test-http-should-emit-clientError-when-Content-Length-is-invalid.ts
@@ -25,4 +25,6 @@ const client = connect(server.address().port, () => {
 });
 
 const err = (await promise) as Error;
-expect(err.code).toBe("HPE_UNEXPECTED_CONTENT_LENGTH");
+// Node reports a non-numeric value as HPE_INVALID_CONTENT_LENGTH. Only a second
+// Content-Length field is HPE_UNEXPECTED_CONTENT_LENGTH.
+expect(err.code).toBe("HPE_INVALID_CONTENT_LENGTH");

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -387,12 +387,106 @@ test("insecureHTTPParser accepts a CTL byte in a trailer value like node", async
   expect(result).toEqual({ trailers: { "x-t": "a\bb" }, raw: ["X-T", "a\bb"] });
 });
 
+// Sends a POST with the given header lines and resolves with the clientError it
+// causes. Rejects if the request is dispatched or the socket closes first.
+async function contentLengthClientError(headers: string) {
+  const { promise, resolve, reject } = Promise.withResolvers<object>();
+  await using server = createServer((req, res) => {
+    reject(new Error(`request ${req.url} was dispatched`));
+    res.end();
+  });
+  server.on("clientError", (err: any, socket) => {
+    socket.destroy();
+    resolve({ code: err.code, reason: err.reason, message: err.message });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write(`POST /a HTTP/1.1\r\n${headers}\r\nhello`);
+  });
+  socket.resume();
+  socket.on("error", () => {});
+  socket.on("close", () => reject(new Error("socket closed without clientError")));
+  try {
+    return await promise;
+  } finally {
+    socket.destroy();
+  }
+}
+
+// llhttp gives each Content-Length failure its own reason. Only a second field
+// is HPE_UNEXPECTED_CONTENT_LENGTH. Bun accepts a second field with the same
+// value, so the rows below repeat a different one. llhttp checks the fields in
+// wire order while it reads the head, so the first bad field decides, and a bad
+// value that comes first is reported before a Transfer-Encoding conflict or a
+// missing Host.
+describe("bad Content-Length fires clientError with node's code and reason", () => {
+  const invalid = "HPE_INVALID_CONTENT_LENGTH";
+  const duplicate = "HPE_UNEXPECTED_CONTENT_LENGTH";
+  const empty = "Empty Content-Length";
+  const badChar = "Invalid character in Content-Length";
+  const overflow = "Content-Length overflow";
+  const repeated = "Duplicate Content-Length";
+  test.each([
+    ["empty value", "Host: x\r\nContent-Length:\r\n", invalid, empty],
+    ["whitespace-only value", "Host: x\r\nContent-Length:   \r\n", invalid, empty],
+    ["non-digit value", "Host: x\r\nContent-Length: abc\r\n", invalid, badChar],
+    ["signed value", "Host: x\r\nContent-Length: +5\r\n", invalid, badChar],
+    ["two numbers", "Host: x\r\nContent-Length: 5 5\r\n", invalid, badChar],
+    ["23-digit value", "Host: x\r\nContent-Length: 99999999999999999999999\r\n", invalid, overflow],
+    ["second field, other value", "Host: x\r\nContent-Length: 5\r\nContent-Length: 6\r\n", duplicate, repeated],
+    ["second field, non-digit", "Host: x\r\nContent-Length: 5\r\nContent-Length: x\r\n", duplicate, repeated],
+    ["second field, empty", "Host: x\r\nContent-Length: 5\r\nContent-Length:\r\n", invalid, empty],
+    ["first field non-digit", "Host: x\r\nContent-Length: x\r\nContent-Length: 5\r\n", invalid, badChar],
+    ["non-digit, then chunked", "Host: x\r\nContent-Length: x\r\nTransfer-Encoding: chunked\r\n", invalid, badChar],
+    ["non-digit, no Host", "Content-Length: x\r\n", invalid, badChar],
+  ])("%s", async (_, headers, code, reason) => {
+    expect(await contentLengthClientError(headers)).toEqual({ code, reason, message: `Parse Error: ${reason}` });
+  });
+});
+
+// Content-Length is 1*DIGIT, so leading zeros are valid and node reads this
+// 19-byte value as 5. Bun used to reject every value longer than 18 bytes.
+test("Content-Length with leading zeros frames the body like node", async () => {
+  const events: string[] = [];
+  await using server = createServer((req, res) => {
+    let body = "";
+    req.on("data", d => (body += d));
+    req.on("end", () => {
+      events.push(`request ${req.url} body=${body}`);
+      res.end("ok");
+    });
+  });
+  server.on("clientError", (err: any, socket) => {
+    events.push(`clientError ${err.code}`);
+    socket.destroy();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write(
+      "POST /p HTTP/1.1\r\nHost: x\r\nContent-Length: 0000000000000000005\r\nConnection: close\r\n\r\nhello",
+    );
+  });
+  let raw = "";
+  socket.on("data", chunk => (raw += chunk.toString()));
+  socket.on("error", () => {});
+  socket.on("close", () => resolve(raw));
+  const response = await promise;
+  expect(events).toEqual(["request /p body=hello"]);
+  expect(response).toStartWith("HTTP/1.1 200");
+});
+
 // RFC 9110 6.5.1: framing fields (Content-Length, Transfer-Encoding) are forbidden
 // in trailers. llhttp runs trailers through the same header state machine and the
 // already-set F_CHUNKED collides, so node rejects both before the body completes.
-for (const { field, value, code } of [
-  { field: "Content-Length", value: "5", code: "HPE_INVALID_CONTENT_LENGTH" },
-  { field: "content-length", value: "5", code: "HPE_INVALID_CONTENT_LENGTH" },
+const trailerContentLengthReason = "Content-Length can't be present with Transfer-Encoding";
+for (const { field, value, code, reason } of [
+  { field: "Content-Length", value: "5", code: "HPE_INVALID_CONTENT_LENGTH", reason: trailerContentLengthReason },
+  { field: "content-length", value: "5", code: "HPE_INVALID_CONTENT_LENGTH", reason: trailerContentLengthReason },
   { field: "Transfer-Encoding", value: "chunked", code: "HPE_INVALID_TRANSFER_ENCODING" },
   { field: "Transfer-Encoding", value: "gzip", code: "HPE_INVALID_TRANSFER_ENCODING" },
   { field: "transfer-encoding", value: "chunked", code: "HPE_INVALID_TRANSFER_ENCODING" },
@@ -423,6 +517,7 @@ for (const { field, value, code } of [
     const result = await promise;
     socket.destroy();
     expect(result.err?.code).toBe(code);
+    if (reason !== undefined) expect(result.err?.reason).toBe(reason);
     expect(result.trailers).toBeUndefined();
   });
 }


### PR DESCRIPTION
### Problem
- A `node:http` server emits `clientError` with `err.code` `HPE_UNEXPECTED_CONTENT_LENGTH` for every bad `Content-Length`. Node uses that code only for a second field. Node reports an empty, non-numeric, or oversized value as `HPE_INVALID_CONTENT_LENGTH`, and it sets `err.reason`.
- The parser has one error value for all of these cases (`packages/bun-uws/src/HttpParser.h:1200`, `:1205`, `:1291`). `src/js/node/_http_server.ts:1243` maps that value to `HPE_UNEXPECTED_CONTENT_LENGTH("Parse Error")`.

### Fix
- The parser has one error value for each failure: invalid character, empty, overflow, and duplicate. It checks the fields in wire order, like llhttp, so the first bad field decides. `node:http` maps each one to the llhttp code and reason (`Parse Error: Empty Content-Length`).
- The parser reads the value by its digits. So `Bun.serve` and `node:http` now accept leading zeros past 18 bytes (`0000000000000000005`), like Node. All other rejected requests stay rejected.
- Verified: `node-http-transfer-encoding.test.ts` (stock bun fails 15 of 49) and a new `Bun.serve` case in `request-smuggling.test.ts`.
- Self-reviewed: 9 concerns raised, 7 addressed. Not taken: reject a second field with the same value (a new rejection rule), and HTTP/3 (another parser).

### Background
- `clientError` is the `http.Server` event for a request that the parser rejects. In Node, `err.code` is the llhttp error name and `err.reason` is the llhttp reason string.
- One uWS parser (`HttpParser.h`) serves `Bun.serve` and `node:http`. It reports a failure as an `HttpParserError` value. `onServerClientError` builds the Node error from that value.
- `remainingStreamingBytes` holds a `Content-Length` or the chunked decoder state. A `Content-Length` must stay at or below `STATE_SIZE_MASK` (2^59 - 1), as before.

<details><summary>Notes</summary>

**Probe.** A raw socket sends `POST / HTTP/1.1\r\n<headers>\r\nhello` to `http.createServer()`. A `clientError` listener logs `err.code` and `err.reason`. "bun before" is 1.4.1-canary.1+a6c4cc276. "bun after" is this branch (debug build). The `HPE_` prefix is left out.

Content-Length fields only (each row also has `Host: x`):

| Headers | node v26.3.0 | bun before | bun after |
|---|---|---|---|
| empty | INVALID_CONTENT_LENGTH (Empty Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Empty Content-Length) |
| space only | INVALID_CONTENT_LENGTH (Empty Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Empty Content-Length) |
| abc | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| 5 then 6 | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) |
| 5 then 5 | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) | request dispatched | request dispatched |
| 5 then empty | INVALID_CONTENT_LENGTH (Empty Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Empty Content-Length) |
| empty then 5 | INVALID_CONTENT_LENGTH (Empty Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Empty Content-Length) |
| abc then 5 | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| 5 then abc | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) |
| abc then abc | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| overflow 23 digits | INVALID_CONTENT_LENGTH (Content-Length overflow) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Content-Length overflow) |
| 19 digits | request dispatched | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Content-Length overflow) |
| 2^59 | request dispatched | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Content-Length overflow) |
| -1 | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| +5 | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| 5 5 | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| 5,5 | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| 5 trailing space | request dispatched | request dispatched | request dispatched |
| 00005 | request dispatched | request dispatched | request dispatched |

With Transfer-Encoding (TE), a missing Host, or a large value:

| Headers | node v26.3.0 | bun before | bun after |
|---|---|---|---|
| CL abc + TE chunked | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| TE chunked + CL abc | INVALID_CONTENT_LENGTH (Content-Length can't be present with Transfer-Encoding) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| TE chunked + CL 5 | INVALID_CONTENT_LENGTH (Content-Length can't be present with Transfer-Encoding) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_TRANSFER_ENCODING (no reason) |
| CL 5 + TE chunked | INVALID_TRANSFER_ENCODING (Transfer-Encoding can't be present with Content-Length) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_TRANSFER_ENCODING (no reason) |
| CL empty + TE chunked | INVALID_CONTENT_LENGTH (Empty Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Empty Content-Length) |
| TE chunked + CL empty | INVALID_CONTENT_LENGTH (Content-Length can't be present with Transfer-Encoding) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Empty Content-Length) |
| CL 5,6 + TE chunked | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) |
| TE chunked + CL 5,6 | INVALID_CONTENT_LENGTH (Content-Length can't be present with Transfer-Encoding) | UNEXPECTED_CONTENT_LENGTH (no reason) | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) |
| CL overflow + TE chunked | INVALID_CONTENT_LENGTH (Content-Length overflow) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_CONTENT_LENGTH (Content-Length overflow) |
| TE gzip + CL abc | INVALID_CONTENT_LENGTH (Content-Length can't be present with Transfer-Encoding) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| CL abc + TE gzip | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| TE chunkedchunked + CL abc | INVALID_CONTENT_LENGTH (Content-Length can't be present with Transfer-Encoding) | INVALID_TRANSFER_ENCODING (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| no host + CL abc | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | no clientError, HTTP/1.1 400 Bad Request | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |
| no host + CL empty | INVALID_CONTENT_LENGTH (Empty Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Empty Content-Length) |
| no host + CL 5,6 | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | UNEXPECTED_CONTENT_LENGTH (Duplicate Content-Length) |
| no host + CL overflow | INVALID_CONTENT_LENGTH (Content-Length overflow) | no clientError, HTTP/1.1 400 Bad Request | INVALID_CONTENT_LENGTH (Content-Length overflow) |
| no host + CL 2^59 | no clientError, HTTP/1.1 400 Bad Request | no clientError, HTTP/1.1 400 Bad Request | INVALID_CONTENT_LENGTH (Content-Length overflow) |
| CL 2^59-1 | request dispatched | request dispatched | request dispatched |
| CL 19 zeros+5 | request dispatched | UNEXPECTED_CONTENT_LENGTH (no reason) | request dispatched |
| CL tab 5 | request dispatched | request dispatched | request dispatched |
| CL 5 tab | request dispatched | request dispatched | request dispatched |
| Connection close + CL abc | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) | UNEXPECTED_CONTENT_LENGTH (no reason) | INVALID_CONTENT_LENGTH (Invalid character in Content-Length) |

**Differences that stay.** This PR does not change these:

- A second Content-Length field with the same value. Bun accepts it (RFC 9110 8.6 allows that). llhttp rejects it as "Duplicate Content-Length". So for `5`, `5`, and an empty third field, Bun reports "Empty Content-Length", and Node reports "Duplicate Content-Length" at the second field. To reject the second field in `node:http` is a new rejection rule, so this PR does not do it.
- Transfer-Encoding before Content-Length. llhttp rejects the Content-Length field by its name ("Content-Length can't be present with Transfer-Encoding"). Bun reports the value error, or its own Transfer-Encoding error. The Transfer-Encoding checks are under rework in #40505.
- A value from 2^59 to 2^64 - 1. Node accepts it. Bun rejects it as "Content-Length overflow", because `remainingStreamingBytes` keeps the chunked state flags in its high bits. Before this PR, Bun rejected it with the wrong code. With no Host, this value now fires `clientError`, where Node sends the missing-Host 400.
- The other parse errors still have no `err.reason`. Some of their messages are not llhttp strings (for example "Invalid header token encountered"), so each one needs a check against llhttp first.
- `err.bytesParsed` is still not set for these errors.
- HTTP/2 and HTTP/3 requests do not go through this parser. Their Content-Length handling does not change.

**Behavior change in the parser.** The Content-Length value is parsed in the header scan, before the Transfer-Encoding and Host checks. Before, only the empty and duplicate checks ran there, and the number was parsed after the Host check. For a request with one fault, only the error value changes. For a request with two faults, the Content-Length error now wins. `Bun.serve` sends the same 400 for all of these errors, so its responses change only for the leading-zero values.

**Related PRs.**

- #40505 changes `getTransferEncoding()` and the empty Transfer-Encoding block in `HttpParser.h`. It does not touch the lines in this diff.
- #34960 calls `HttpParser::toUnsignedInteger`. This PR replaces that function with `parseContentLength`. #34960 already conflicts with main.

**Suites run on the debug build.**

- `test/js/node/http/node-http-transfer-encoding.test.ts`: 49 pass
- `test/js/bun/http/request-smuggling.test.ts`: 90 pass
- `test/js/bun/http/http-server-chunking.test.ts`: 13 pass
- `test/js/bun/http/hspec.test.ts`: 1 pass
- `test/js/node/http/node-http.test.ts`: 154 pass, 1 skip
- `test/js/node/http/node-http-connect.test.ts`: 22 pass with `--timeout=90000`, the timeout that CI uses. One test spawns a nested `bun test` that takes 5 s on a debug build, so the 5 s default times out.
- `test/js/node/http/node-http-maxHeaderSize.test.ts`: 4 pass
- `test/js/bun/test/parallel/test-http-should-emit-clientError-when-Content-Length-is-invalid.ts`: passes. It expected the old code, so this PR updates it.
- Upstream `test/js/node/test/parallel/`: the 17 `test-http*` files that use `clientError` pass, and `test-http-double-content-length.js` still passes. Of the 135 `test-http-(server|request|body|parser|chunked|content-length)*` files, 128 pass. The 7 that fail are proxy tests that fail the same way on stock bun in this environment.

</details>
