### PR TITLE
bundler: wrap a split import() with __toESM when the target is CommonJS at link time

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1113,88 +1113,78 @@ pub(crate) fn scan_imports_and_exports(
                             || !output_format.keep_es6_import_export_syntax()
                             || kind == ImportKind::Dynamic
                         {
-                            if rec_source_index.is_valid()
-                                && kind == ImportKind::Dynamic
-                                && col_ref!(ast_flags_list)[other_id]
-                                    .contains(AstFlags::FORCE_CJS_TO_ESM)
+                            // We should use "__require" instead of "require" if we're not
+                            // generating a CommonJS output file, since it won't exist otherwise.
+                            // An `import()` is printed as-is and never becomes `__require()`,
+                            // nor does a split `require()` (`import.meta.require`).
+                            if kind != ImportKind::Dynamic
+                                && !is_external_dyn
+                                && should_call_runtime_require(output_format)
                             {
-                                // The chunk of a module converted to ESM provides `default` itself.
-                                continue;
-                            } else {
-                                // We should use "__require" instead of "require" if we're not
-                                // generating a CommonJS output file, since it won't exist otherwise.
-                                // An `import()` is printed as-is and never becomes `__require()`,
-                                // nor does a split `require()` (`import.meta.require`).
-                                if kind != ImportKind::Dynamic
-                                    && !is_external_dyn
-                                    && should_call_runtime_require(output_format)
-                                {
-                                    runtime_require_uses += 1;
-                                }
+                                runtime_require_uses += 1;
+                            }
 
-                                // A split `require()` whose target is CommonJS at link
-                                // time (for example a lifted `module.exports = require()`
-                                // file the linker wrapped again): the chunk exports only
-                                // `default: module.exports`, so the printed call reads
-                                // `.default` to return `module.exports`, the same value
-                                // an unsplit `require()` returns.
-                                if kind == ImportKind::Require
+                            // A split `require()` whose target is CommonJS at link
+                            // time (for example a lifted `module.exports = require()`
+                            // file the linker wrapped again): the chunk exports only
+                            // `default: module.exports`, so the printed call reads
+                            // `.default` to return `module.exports`, the same value
+                            // an unsplit `require()` returns.
+                            if kind == ImportKind::Require
+                                && is_external_dyn
+                                && rec_source_index.is_valid()
+                                && col_ref!(exports_kind)[rec_source_index.get() as usize]
+                                    == ExportsKind::Cjs
+                            {
+                                col!(import_records_list)[id].as_mut_slice()
+                                    [import_record_index as usize]
+                                    .flags
+                                    .insert(ImportRecordFlags::CROSS_CHUNK_REQUIRE_DEFAULT);
+                            }
+
+                            // If this wasn't originally a "require()" call, then we may need
+                            // to wrap this in a call to the "__toESM" wrapper to convert from
+                            // CommonJS semantics to ESM semantics.
+                            //
+                            // Unfortunately this adds some additional code since the conversion
+                            // is somewhat complex. As an optimization, we can avoid this if the
+                            // following things are true:
+                            //
+                            // - The import is an ES module statement (e.g. not an "import()" expression)
+                            // - The ES module namespace object must not be captured
+                            // - The "default" and "__esModule" exports must not be accessed
+                            //
+                            if kind != ImportKind::Require
+                                && (kind != ImportKind::Stmt
+                                    || rec_flags.contains(ImportRecordFlags::CONTAINS_IMPORT_STAR)
+                                    || rec_flags
+                                        .contains(ImportRecordFlags::CONTAINS_DEFAULT_ALIAS)
+                                    || rec_flags
+                                        .contains(ImportRecordFlags::CONTAINS_ES_MODULE_ALIAS))
+                            {
+                                // For dynamic imports to cross-chunk CJS modules, we need extra
+                                // unwrapping in js_printer (.then((m)=>__toESM(m.default))).
+                                // For other cases (static imports, truly external), use standard wrapping.
+                                if rec_source_index.is_valid()
                                     && is_external_dyn
-                                    && rec_source_index.is_valid()
                                     && col_ref!(exports_kind)[rec_source_index.get() as usize]
                                         == ExportsKind::Cjs
                                 {
+                                    // Cross-chunk dynamic import to CJS - needs special handling in printer
                                     col!(import_records_list)[id].as_mut_slice()
                                         [import_record_index as usize]
                                         .flags
-                                        .insert(ImportRecordFlags::CROSS_CHUNK_REQUIRE_DEFAULT);
+                                        .insert(ImportRecordFlags::WRAP_WITH_TO_ESM);
+                                    to_esm_uses += 1;
+                                } else if kind != ImportKind::Dynamic {
+                                    // Static imports to external CJS modules need __toESM wrapping
+                                    col!(import_records_list)[id].as_mut_slice()
+                                        [import_record_index as usize]
+                                        .flags
+                                        .insert(ImportRecordFlags::WRAP_WITH_TO_ESM);
+                                    to_esm_uses += 1;
                                 }
-
-                                // If this wasn't originally a "require()" call, then we may need
-                                // to wrap this in a call to the "__toESM" wrapper to convert from
-                                // CommonJS semantics to ESM semantics.
-                                //
-                                // Unfortunately this adds some additional code since the conversion
-                                // is somewhat complex. As an optimization, we can avoid this if the
-                                // following things are true:
-                                //
-                                // - The import is an ES module statement (e.g. not an "import()" expression)
-                                // - The ES module namespace object must not be captured
-                                // - The "default" and "__esModule" exports must not be accessed
-                                //
-                                if kind != ImportKind::Require
-                                    && (kind != ImportKind::Stmt
-                                        || rec_flags
-                                            .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR)
-                                        || rec_flags
-                                            .contains(ImportRecordFlags::CONTAINS_DEFAULT_ALIAS)
-                                        || rec_flags
-                                            .contains(ImportRecordFlags::CONTAINS_ES_MODULE_ALIAS))
-                                {
-                                    // For dynamic imports to cross-chunk CJS modules, we need extra
-                                    // unwrapping in js_printer (.then((m)=>__toESM(m.default))).
-                                    // For other cases (static imports, truly external), use standard wrapping.
-                                    if rec_source_index.is_valid()
-                                        && is_external_dyn
-                                        && col_ref!(exports_kind)[rec_source_index.get() as usize]
-                                            == ExportsKind::Cjs
-                                    {
-                                        // Cross-chunk dynamic import to CJS - needs special handling in printer
-                                        col!(import_records_list)[id].as_mut_slice()
-                                            [import_record_index as usize]
-                                            .flags
-                                            .insert(ImportRecordFlags::WRAP_WITH_TO_ESM);
-                                        to_esm_uses += 1;
-                                    } else if kind != ImportKind::Dynamic {
-                                        // Static imports to external CJS modules need __toESM wrapping
-                                        col!(import_records_list)[id].as_mut_slice()
-                                            [import_record_index as usize]
-                                            .flags
-                                            .insert(ImportRecordFlags::WRAP_WITH_TO_ESM);
-                                        to_esm_uses += 1;
-                                    }
-                                    // Dynamic imports to truly external modules: no wrapping (preserve native format)
-                                }
+                                // Dynamic imports of an ES module chunk or a truly external module: no wrapping
                             }
                         }
                         continue;

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1550,6 +1550,101 @@ describe("bundler", () => {
     },
     run: { file: "/out/entry.js", stdout: "true true true patched patched" },
   });
+  // A module in the unwrap list that assigns `module.exports` is not lifted and
+  // keeps its `__commonJS` wrapper, so its chunk is `export default require_x()`.
+  // A cross-chunk `import()` of it needs the same `__toESM` as any other
+  // CommonJS chunk, or the named exports are `undefined`.
+  itBundled("cjs2esm/DynamicImportSplittingOfWrappedCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import React from "react";
+        const m = await import("react");
+        console.log(m.useState(1)[0], m.version, m.default === React, typeof m.default.useState);
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        { "name": "react", "version": "19.0.0", "main": "index.js" }
+      `,
+      "/node_modules/react/index.js": /* js */ `
+        'use strict';
+        if (globalThis.USE_PROD) {
+          module.exports = require('./cjs/react.production.js');
+        } else {
+          module.exports = require('./cjs/react.development.js');
+        }
+      `,
+      "/node_modules/react/cjs/react.production.js": /* js */ `
+        'use strict';
+        function useState(initial) {
+          return [initial, function setState() {}];
+        }
+        exports.useState = useState;
+        exports.version = "production";
+      `,
+      "/node_modules/react/cjs/react.development.js": /* js */ `
+        'use strict';
+        function useState(initial) {
+          return [initial, function setState() {}];
+        }
+        exports.useState = useState;
+        exports.version = "development";
+      `,
+    },
+    outdir: "/out",
+    splitting: true,
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("__toESM(m.default");
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "1 development true function",
+    },
+  });
+  // The same for a lifted module that the linker wraps again, because the
+  // target of its `module.exports = require()` stays CommonJS.
+  itBundled("cjs2esm/DynamicImportSplittingOfRewrappedLiftedCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        const m = await import("react-dom");
+        console.log(m.version, m.default.version);
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        module.exports = function render() { return "rendered"; };
+        module.exports.version = "19.0.0";
+      `,
+    },
+    outdir: "/out",
+    splitting: true,
+    minifySyntax: true,
+    run: {
+      file: "/out/entry.js",
+      stdout: "side effect\n19.0.0 19.0.0",
+    },
+  });
+  // Outside the unwrap list too: the `exports.foo = ...` of "./lib.js" are
+  // lifted, but a `require()` of it makes it CommonJS again.
+  itBundled("cjs2esm/DynamicImportSplittingOfRequiredLiftedCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require("./lib.js");
+        const m = await import("./lib.js");
+        console.log(lib.foo, m.foo, m.default === lib);
+      `,
+      "/lib.js": /* js */ `
+        exports.foo = "foo";
+        exports.bar = "bar";
+      `,
+    },
+    outdir: "/out",
+    splitting: true,
+    run: {
+      file: "/out/entry.js",
+      stdout: "foo foo true",
+    },
+  });
   // `import()` of a lifted CommonJS module resolves to a view of its namespace
   // whose `default` is the namespace itself (`module.exports`), as in Node.
   // https://github.com/oven-sh/bun/issues/14061


### PR DESCRIPTION
### Problem
- With `--splitting`, a cross-chunk `import()` of a module that is CommonJS at link time resolves to the bare chunk namespace `{ default: module.exports }`. With npm react-dom 18.3.1, `(await import("react-dom/client")).createRoot` is `undefined`. Unsplit builds give the function.
- Cause: the skip at `src/bundler/linker_context/scanImportsAndExports.rs:1116` drops the `__toESM` wrap for every `import()` target with `FORCE_CJS_TO_ESM`. Such a target can still be CommonJS at link time, with the chunk `export default require_x()`.

### Fix
- Remove the skip. The existing cross-chunk branch then adds `.then((m) => __toESM(m.default))` for a CommonJS target, and nothing for an ESM target.
- Correct because splitting is ESM output only, where `exports_kind == Cjs` means the chunk exports only `default: module.exports`. Since #41231 the skip did nothing else, so ESM targets print the same.
- Verified: three new cases in `test/bundler/bundler_cjs2esm.test.ts` fail on 1.4.1 and on main, and pass with this change.
- Self-reviewed: 3 concerns raised, 3 addressed. Most of the diff is re-indentation. Hide whitespace to see the change.

### Background
- Lifting: in an ESM bundle, the parser turns top-level `exports.foo = ...` into ES module exports and sets `FORCE_CJS_TO_ESM`. Every file of the unwrap list (react, react-dom, ...) gets the flag, lifted or not.
- A flagged file is CommonJS at link time when it assigns `module.exports`, when a `require()` of it wraps it, or when the target of its lifted `module.exports = require()` is CommonJS (#41188).
- With code splitting, each `import()` target gets its own entry point chunk.

<details><summary>Notes</summary>

No issue reports this. It was found during work on the nearby CommonJS lifting code.

An earlier version of this PR narrowed the skip to `exports_kind != Cjs`. After the rebase on #41231, the body of the skip was only `continue`, so the narrowed skip did nothing. This version removes it. The self-review found a wrong comment about `FORCE_CJS_TO_ESM` (now removed with the code). It also asked for a test outside the unwrap list and for a fuller description.

Real packages (react 18.3.1, react-dom 18.3.1, scheduler 0.23.2), entry:

```js
const { createRoot } = await import("react-dom/client");
const React = await import("react");
const Scheduler = await import("scheduler");
console.log(typeof createRoot, typeof React.useState, typeof Scheduler.unstable_scheduleCallback);
```

| build | 1.4.1 | this branch |
| --- | --- | --- |
| `--splitting`, browser or bun target, development or production | `undefined undefined undefined` | `function function function` |
| `--splitting --minify`, production | `undefined function undefined` | `function function function` |
| `--splitting --minify`, development | `undefined undefined undefined` | `function function function` |
| no `--splitting` | `function function function` | `function function function` |

`bun run` of the entry prints `function function function`.

Minimal repro in an empty directory. Same output on 1.4.1 and main:

```sh
mkdir -p node_modules/react/cjs
echo '{ "name": "react", "version": "19.0.0", "main": "index.js" }' > node_modules/react/package.json
printf "'use strict';\nif (process.env.NODE_ENV === 'production') {\n  module.exports = require('./cjs/react.production.js');\n} else {\n  module.exports = require('./cjs/react.development.js');\n}\n" > node_modules/react/index.js
printf "'use strict';\nfunction useState(i) { return [i, function () {}]; }\nexports.useState = useState;\nexports.version = '19.0.0';\n" > node_modules/react/cjs/react.production.js
cp node_modules/react/cjs/react.production.js node_modules/react/cjs/react.development.js
printf 'import React from "react";\nconst m = await import("react");\nconsole.log(m.useState(1)[0], m.default === React);\n' > entry.mjs
NODE_ENV=production bun build ./entry.mjs --splitting --target=bun --outdir=out && bun out/entry.js
```

Before: `TypeError: m.useState is not a function`. After: `1 true`. The importer now prints `await import("./index-<hash>.js").then((m)=>__toESM(m.default,1))`.

The three new cases, one for each way to be CommonJS at link time:
- `cjs2esm/DynamicImportSplittingOfWrappedCommonJS`: `react/index.js` is a run-time `if` over two `module.exports = require()` calls, so it is never lifted.
- `cjs2esm/DynamicImportSplittingOfRewrappedLiftedCommonJS`: the `ReactSpecificUnwrappingTargetIsCommonJS` fixture from #41188. The linker wraps `react-dom/index.js` again because `impl.js` assigns `module.exports = function`. It prints `m.default.version`, not `typeof m.default`, so it does not depend on #35722.
- `cjs2esm/DynamicImportSplittingOfRequiredLiftedCommonJS`: a user file with `exports.foo = ...`, outside `node_modules`. The entry `require()`s it and `import()`s it. Before: `foo undefined true`. The unsplit build and `bun run` print `foo foo true`.

The `require()` side of the same shape was a regression from #41188 (#41236). #41243 fixed it on main, in the same block. This PR changes only `import()` records.

Not changed (each reproduces with and without this change):
- `const { useState } = require("react")` throws `ReferenceError: exports is not defined` in a bundle, split or not. #39184 fixes it.
- With `--splitting`, `import()` of a file that does `export * from "<cjs>"` reads `undefined` for the names of the CommonJS module. This happens for any CommonJS package.
- #41231 (merged) made the chunk of a lifted target export its namespace as `default`. It keeps the skip for a CommonJS target, so it does not cover this bug. This branch is rebased on it, and its tests pass here.

The unwrap list is `DEFAULT_UNWRAP_COMMONJS_PACKAGES` in `src/bundler/options.rs`: react, react-dom, scheduler, react-is, react-refresh, react-client, react-server.

Also checked with the debug build under `--splitting`: `module.exports = { ... }`, `module.exports = function`, an importer whose only `__toESM` use is the `import()` (it gets the runtime import), and a `.js` importer (`__toESM(m.default)` without the node-mode flag, as on the existing path). A user file that is only `import()`ed, and a real `module.exports` file, print the same before and after.

Suites run with the debug build on main 1d1f4319b8 (after #41231 and #41243), with this version of the fix: bundler_cjs2esm and bundler_splitting (188 pass), and bundler_cjs, bundler_dynamic_import_dce, esbuild/splitting (358 pass, 0 fail). Before those rebases, on main e8c8d8150a: the same suites plus esbuild/default, bundler_edgecase, bundler_regressions, bundler_npm, bundler_compile_splitting, bundler_bun, bundler_browser (904 pass, 0 fail). `cargo clippy -p bun_bundler` is clean.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [808.95ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [428.20ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [378.09ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [467.65ms]
(pass) bundler > cjs2esm/ExportsFunction [371.77ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [454.02ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [429.96ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [371.66ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [479.66ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [494.23ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [407.11ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [706.09ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [575
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (b36f032e7)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [19.49ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [9.57ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [8.62ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [7.87ms]
(pass) bundler > cjs2esm/ExportsFunction [8.03ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [8.04ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [7.78ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [8.72ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [9.61ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [9.77ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [9.36ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [11.65ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [11.04ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [10.16ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [9.16ms]
(pass) bundler > cjs2esm/UnwrappedModuleRe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [835.93ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [485.38ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [375.10ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [342.95ms]
(pass) bundler > cjs2esm/ExportsFunction [429.44ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [433.97ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [347.36ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [436.35ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [424.28ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [513.08ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [375.98ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [674.86ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [643
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 635ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/1] reconfigure
[1/10] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[2/10] gen cpp.rs (cppbind)
[2/10] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/scanImportsAndExports.rs        | 134 ++++++++++-----------
 test/bundler/bundler_cjs2esm.test.ts               |  95 +++++++++++++++
 2 files changed, 157 insertions(+), 72 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/linker_context/scanImportsAndExports.rs      8      4     41
test/bundler/bundler_cjs2esm.test.ts                     4      3     40
```

</details>

<!-- robobun:evidence:end -->