### PR TITLE
StackCheck: compute a thread's stack bounds once

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2738,7 +2738,8 @@ impl VirtualMachine {
             opts.eval_mode,
             opts.worker_ptr,
         );
-        // JSC may mess with the stack size.
+        // Sets this thread's `StackCheck` bound if it has none: a thread-pool thread
+        // (`configure_thread_no_js`) that runs a macro. Other threads set it at start.
         bun_core::StackCheck::configure_thread();
         // SAFETY: write through the raw `vm` ptr (not `vm_ref`) so no
         // `&mut VirtualMachine` is held live across the FFI call above; same

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2738,8 +2738,7 @@ impl VirtualMachine {
             opts.eval_mode,
             opts.worker_ptr,
         );
-        // Sets this thread's `StackCheck` bound if it has none: a thread-pool thread
-        // (`configure_thread_no_js`) that runs a macro. Other threads set it at start.
+        // Sets the bound for a thread that skipped it at start (`configure_thread_no_js`).
         bun_core::StackCheck::configure_thread();
         // SAFETY: write through the raw `vm` ptr (not `vm_ref`) so no
         // `&mut VirtualMachine` is held live across the FFI call above; same

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -297,7 +297,8 @@ static thread_local WTF::StackBounds stackBoundsForCurrentThread = WTF::StackBou
 
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__StackCheck__initialize()
 {
-    // A thread's bounds do not change, and the main thread's cost a parse of /proc/self/maps on Linux.
+    // The bounds are fixed when the thread starts. On Windows they are the reserved range, and the stack grows inside it.
+    // The main thread's bounds cost a parse of /proc/self/maps on Linux.
     if (!stackBoundsForCurrentThread.isEmpty())
         return;
     stackBoundsForCurrentThread = WTF::StackBounds::currentThreadStackBoundsForEmbedder();

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -297,6 +297,9 @@ static thread_local WTF::StackBounds stackBoundsForCurrentThread = WTF::StackBou
 
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__StackCheck__initialize()
 {
+    // A thread's bounds do not change, and the main thread's cost a parse of /proc/self/maps on Linux.
+    if (!stackBoundsForCurrentThread.isEmpty())
+        return;
     stackBoundsForCurrentThread = WTF::StackBounds::currentThreadStackBoundsForEmbedder();
 }
 

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -297,8 +297,7 @@ static thread_local WTF::StackBounds stackBoundsForCurrentThread = WTF::StackBou
 
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__StackCheck__initialize()
 {
-    // The bounds are fixed when the thread starts. On Windows they are the reserved range, and the stack grows inside it.
-    // The main thread's bounds cost a parse of /proc/self/maps on Linux.
+    // A thread's bounds are fixed. On Windows they are the reserved range, and the stack grows inside it.
     if (!stackBoundsForCurrentThread.isEmpty())
         return;
     stackBoundsForCurrentThread = WTF::StackBounds::currentThreadStackBoundsForEmbedder();


### PR DESCRIPTION
### Problem
- `Bun__StackCheck__initialize` (`src/jsc/bindings/wtf-bindings.cpp:298`) computes the thread's stack bounds each time it is called. The main thread calls it twice: from `main`, and again from `VirtualMachine::init`.
- For the main thread on Linux, `pthread_getattr_np` reads and parses all of `/proc/self/maps`. So each `bun file.js` and `bun -e` start parses it once for nothing.

### Fix
- The function returns when this thread's bounds are already set. A thread's bounds are fixed. On Windows they are the reserved range of the stack, and the stack grows inside that range.
- The call in `VirtualMachine::init` stays. It sets the bound for a thread that skipped it at start (`configure_thread_no_js`). Its old comment said JSC may change the stack size, which it does not.
- Verified on release builds (numbers below). CI runs the stack tests: `test/js/bun/test/expect-stack-overflow-crash.test.ts`, `test/js/bun/toml/toml.test.ts`, `test/js/bun/yaml/yaml.test.ts`, and `test/regression/issue/26142.test.ts`.

Release x64 Linux, against `main`, interleaved, 600 rounds, median:

| | main | this PR |
|---|---|---|
| `/proc/self/maps` opens, `bun empty.js` | 3 | 2 |
| syscalls, `bun empty.js` | 312 | 300 |
| `bun empty.js` | 4.41 ms | 4.36 ms |

### Background
- `StackCheck` is bun's recursion guard for its own parsers (JS, JSON, TOML, YAML). JSC's stack limit is separate.
- WTF computes the main thread's bounds once more for itself, with the same `/proc/self/maps` parse. A change to `StackBounds.cpp` in oven-sh/WebKit can remove both remaining parses. That is a separate change.

<details><summary>Notes</summary>

- Windows: `WTF::StackBounds` calls `GetCurrentThreadStackLimits`. A probe linked with bun's `/STACK:0x1200000,0x200000` read the same range at start and 10 MB deep in a recursion. Only the committed part grew, from 2 MB to 10 MB. The output is in the conversation below.
- WTF makes the same assumption: `Thread::initializeInThread` computes a thread's bounds once, and JSC's stack limit uses that value.
- I found no thread that creates a VM and skips the bound at start. Each `ThreadPool` sets it (`needs_stack_bounds` is `true` in all pools), and the watcher thread runs no JS. So the call in `VirtualMachine::init` is one thread-local check today.
- `bun --version` is unchanged: it never creates a VM, so it computes the bounds once.
- A forked child inherits the thread-local bounds of the thread that forked, and that thread's stack is the child's stack. So the early return holds there too.
- The syscall and `/proc/self/maps` counts are from `strace -f` on the two release builds.
- My local debug build and test run of this change were cut off twice by container resets. An earlier version of this change, which moved the same bound computation, passed the same stack tests.
- Other startup work, measured separately: #41233 (cpuid without the libgcc constructor), oven-sh/mimalloc#32, oven-sh/WebKit#553 (merged) and oven-sh/WebKit#554.
</details>
