### PR TITLE
Bump WebKit: start the MarkedBlock warm-up thread after 64 block requests

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "491b5cc236e9ed0bf6247bc466d4b17158311e27";
+export const WEBKIT_VERSION = "e9b43fbbfad8d0d69d5ce343ea4fc70ca23d4731";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -1,7 +1,7 @@
 import { SyncSubprocess } from "bun";
 import { describe, expect, test } from "bun:test";
-import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
+import { readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep } from "path";
 
@@ -347,4 +347,36 @@ test("uncaught error from a CommonJS-sniffed stdin entry reports and exits 1", a
   expect(stderr).toContain("stdin-cjs-uncaught");
   expect(stdout).toBe("");
   expect(exitCode).toBe(1);
+});
+
+// JSC starts its MarkedBlock warm-up thread after 64 block requests. A script
+// that only waits on stdin asks for about 27, for `-e` and for a file alike, so
+// it must run without that thread. The child prints "ready" once it has started,
+// and the test reads the child's thread names from /proc, so this is Linux only.
+test.if(isLinux)("a script that allocates little does not start the JSC warm-up thread", async () => {
+  const waitForStdin = `console.log("ready"); await Bun.stdin.text();`;
+  using dir = tempDir("warmup-thread", { "wait.js": waitForStdin });
+
+  const threadNames = async (cmd: string[]) => {
+    await using proc = Bun.spawn({ cmd, cwd: String(dir), env: bunEnv, stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+    const reader = proc.stdout.getReader();
+    const first = await reader.read();
+    const names = readdirSync(`/proc/${proc.pid}/task`).map(tid =>
+      readFileSync(`/proc/${proc.pid}/task/${tid}/comm`, "utf8").trim(),
+    );
+    proc.stdin.end();
+    reader.releaseLock();
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(new TextDecoder().decode(first.value)).toBe("ready\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return names;
+  };
+
+  const [evalThreads, fileThreads] = await Promise.all([
+    threadNames([bunExe(), "-e", waitForStdin]),
+    threadNames([bunExe(), "wait.js"]),
+  ]);
+  expect(evalThreads).not.toContain("JSCWarmUp");
+  expect(fileThreads).not.toContain("JSCWarmUp");
 });


### PR DESCRIPTION
### Problem
- Since the WebKit bump in #41083, JSC starts its MarkedBlock warm-up thread on the first GC block. mimalloc's scavenger starts with it, as it starts with a process's second thread.
- A VM takes about 30 blocks to start. So each `bun -e` or short script creates two idle threads and faults in unused blocks.

### Fix
- Pins WebKit to e9b43fbb, the merge of oven-sh/WebKit#553 and the only change between the two pins. The warm-up thread starts after 64 block requests (`warmUpMarkedBlockStartAfterBlocks`).
- A script that keeps allocating passes 64 blocks in its first milliseconds and still gets the helper, which makes it about 19% faster.
- Verified: `test/cli/run/run-eval.test.ts`. A script that waits on stdin, run as `-e` and as a file, must have no `JSCWarmUp` thread. It fails on the current canary and passes there with `BUN_JSC_useWarmUpMarkedBlocks=false`. CI runs it on the new pin.

Current canary (release x64 Linux), as it is and with the warm-up thread off, which is what this pin does for these scripts. Interleaved, 400 rounds, median:

| | canary | warm-up off |
|---|---|---|
| `bun -e 1` | 4.01 ms, 1031 faults | 3.72 ms, 908 faults |
| `bun empty.js` | 4.05 ms, 1028 faults | 3.72 ms, 906 faults |

### Background
- A MarkedBlock is a 16 KiB GC heap block. The warm-up thread keeps a supply of blocks whose pages it has touched, so the faults land on it, not on the JS thread.

<details><summary>Notes</summary>

- Block requests, counted with gdb on the canary's profile build: `bun -e 1` makes 28. The test's script makes 27 as `-e` and 26 as a file. A script that loads `node:fs` and lists its threads makes 49.
- CPU time drops by 0.7 ms in the same runs (4.24 to 3.57 ms for `-e 1`). That is the two threads' work.
- The release for e9b43fbb has the same 42 assets as the one for 491b5cc2. `491b5cc2` appears nowhere else in the repo.
- I did not build bun with the new pin locally. The container reset during each long build. CI builds it on every platform.
- Other startup work, measured separately: #41233, #41238, oven-sh/mimalloc#32 and oven-sh/WebKit#554.
</details>
