### PR TITLE
bun:test: settle .resolves/.rejects in toSatisfy and toIncludeRepeated

### DIFF
--- a/src/runtime/test_runner/expect/toIncludeRepeated.rs
+++ b/src/runtime/test_runner/expect/toIncludeRepeated.rs
@@ -9,11 +9,9 @@ impl Expect {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        // toIncludeRepeated bypasses get_value (reads `captured_value_get_cached` directly,
-        // no `.resolves`/`.rejects` handling), so cannot use the full `matcher_prelude`.
-        let this = self.post_match_guard(global);
+        let (this, expect_string, not) =
+            self.matcher_prelude(global, frame.this(), "toIncludeRepeated", "<green>expected<r>")?;
 
-        let this_value = frame.this();
         let arguments = frame.arguments();
 
         if arguments.len() < 2 {
@@ -21,8 +19,6 @@ impl Expect {
                 "toIncludeRepeated() requires 2 arguments"
             )));
         }
-
-        this.increment_expect_call_counter();
 
         let substring = arguments[0];
         substring.ensure_still_alive();
@@ -44,19 +40,11 @@ impl Expect {
 
         let count_as_num = count.to_u32();
 
-        let Some(expect_string) = super::js::captured_value_get_cached(this_value) else {
-            return Err(global.throw(format_args!(
-                "Internal consistency error: the expect(value) was garbage collected but it should not have been!"
-            )));
-        };
-
         if !expect_string.is_string() {
             return Err(global.throw(format_args!(
                 "toIncludeRepeated() requires the expect(value) to be a string"
             )));
         }
-
-        let not = this.flags.get().not();
 
         let expect_string_as_str_owned = expect_string.to_utf8(global)?;
         let sub_string_as_str_owned = substring.to_utf8(global)?;

--- a/src/runtime/test_runner/expect/toSatisfy.rs
+++ b/src/runtime/test_runner/expect/toSatisfy.rs
@@ -5,18 +5,13 @@ use super::get_signature;
 use super::throw;
 
 pub(crate) fn to_satisfy(this: &Expect, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    // toSatisfy bypasses get_value (no .resolves/.rejects handling), so it cannot use
-    // the full `matcher_prelude`; only the post_match guard mechanism unifies.
-    let _guard = this.post_match_guard(global);
+    let (this, value, not) = this.matcher_prelude(global, frame.this(), "toSatisfy", "<green>expected<r>")?;
 
-    let this_value = frame.this();
     let arguments = frame.arguments();
 
     if arguments.len() < 1 {
         return Err(global.throw_invalid_arguments(format_args!("toSatisfy() requires 1 argument")));
     }
-
-    this.increment_expect_call_counter();
 
     let predicate = arguments[0];
     predicate.ensure_still_alive();
@@ -25,16 +20,8 @@ pub(crate) fn to_satisfy(this: &Expect, global: &JSGlobalObject, frame: &CallFra
         return Err(global.throw(format_args!("toSatisfy() argument must be a function")));
     }
 
-    let Some(value) = super::js::captured_value_get_cached(this_value) else {
-        return Err(global.throw(format_args!(
-            "Internal consistency error: the expect(value) was garbage collected but it should not have been!"
-        )));
-    };
-    value.ensure_still_alive();
-
     let result = predicate.call(global, JSValue::UNDEFINED, &[value])?;
 
-    let not = this.flags.get().not();
     let pass = (result.is_boolean() && result.to_boolean()) != not;
 
     if pass {

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -190,6 +190,24 @@ describe("jest-extended", () => {
     ).toThrow("Bun!");
   });
 
+  test("toSatisfy() with .resolves and .rejects", async () => {
+    const promise = Promise.resolve(42);
+    await expect(promise).resolves.toSatisfy(value => value === 42);
+    await expect(promise).resolves.not.toSatisfy(value => value === promise);
+    await expect(Promise.reject(7)).rejects.toSatisfy(value => value === 7);
+    await expect(Promise.reject(7)).rejects.not.toSatisfy(value => value === 8);
+
+    // Failure messages report the settled value, not the promise
+    if (isBun) {
+      await expect(async () => {
+        await expect(Promise.resolve(42)).resolves.toSatisfy(value => value === 1);
+      }).toThrow("Received: 42");
+      await expect(async () => {
+        await expect(Promise.reject(7)).rejects.toSatisfy(value => value === 1);
+      }).toThrow("Received: 7");
+    }
+  });
+
   // Array
 
   test("toBeArray()", () => {
@@ -638,6 +656,20 @@ describe("jest-extended", () => {
     expect(() => tstErr(null)).toThrow();
     expect(() => tstErr(undefined)).toThrow();
     expect(() => tstErr({})).toThrow();
+  });
+
+  test("toIncludeRepeated() with .resolves and .rejects", async () => {
+    await expect(Promise.resolve("abc abc abc")).resolves.toIncludeRepeated("abc", 3);
+    await expect(Promise.resolve("abc abc abc")).resolves.not.toIncludeRepeated("abc", 2);
+    await expect(Promise.reject("abc abc")).rejects.toIncludeRepeated("abc", 2);
+    await expect(Promise.reject("abc abc")).rejects.not.toIncludeRepeated("abc", 1);
+
+    // Failure messages report the settled value, not the promise
+    if (isBun) {
+      await expect(async () => {
+        await expect(Promise.resolve("abc abc")).resolves.toIncludeRepeated("abc", 3);
+      }).toThrow('Received: "abc abc"');
+    }
   });
 
   // test("toIncludeMultiple()")


### PR DESCRIPTION
### What does this PR do?

Fixes #15428.

`toSatisfy` and `toIncludeRepeated` read the captured `expect()` value directly instead of going through `get_value`, so the `.resolves` / `.rejects` flags were ignored. The predicate in `expect(promise).resolves.toSatisfy(fn)` received the Promise object itself, and `expect(promise).resolves.toIncludeRepeated(...)` threw `toIncludeRepeated() requires the expect(value) to be a string`. Every other matcher settles the promise first via `matcher_prelude`.

The fix is the `matcher_prelude` call at the top of each matcher. The removed lines are the `post_match_guard`, `increment_expect_call_counter`, `captured_value_get_cached` and `flags.not()` reads that `matcher_prelude` already performs. These two were the only matchers still bypassing it (`grep captured_value_get_cached src/runtime/test_runner/expect/`).

The bypass predates the Rust port (same shape in the Zig `toSatisfy.zig` / `toIncludeRepeated.zig`), so this is not a regression. The tests are added alongside the existing `toSatisfy()` and `toIncludeRepeated()` tests in `jest-extended.test.js`.

### How did you verify your code works?

Added `toSatisfy() with .resolves and .rejects` and `toIncludeRepeated() with .resolves and .rejects` to `test/js/bun/test/jest-extended.test.js`. They cover `.resolves`, `.rejects` and `.not` for both matchers, and assert that the failure message reports the settled value instead of the Promise.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/test/jest-extended.test.js -t "resolves and .rejects"`: both new tests fail with the errors from the issue (checked on 1.3.14 and 1.4.0).
- `bun bd test test/js/bun/test/jest-extended.test.js`: 60 pass, 0 fail.
- `bun bd test test/js/bun/test/expect.test.js`: 416 pass, 2 todo, 0 fail.
- `bun bd test test/js/bun/test/expect-extend.test.js` and `expect-assertions.test.ts`: pass.
- Changing the expected `Received:` text in the new tests makes them fail on the fixed build, so the message assertions are live.
