### PR TITLE
bundler: read .default of a split require() whose target is CommonJS at link time

### DIFF
--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -101,6 +101,11 @@ bitflags::bitflags! {
         /// `import()` / `require()` whose value nothing reads: the linker bound
         /// every name read off it to an export, so it evaluates to `{}`.
         const NAMESPACE_UNUSED = 1 << 17;
+
+        /// A split `require()` whose target is CommonJS at link time: the
+        /// chunk's namespace is `{ default: module.exports }`, so the call
+        /// reads `.default` to return `module.exports`.
+        const CROSS_CHUNK_REQUIRE_DEFAULT = 1 << 18;
     }
 }
 

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1113,6 +1113,24 @@ pub(crate) fn scan_imports_and_exports(
                                     runtime_require_uses += 1;
                                 }
 
+                                // A split `require()` whose target is CommonJS at link
+                                // time (for example a lifted `module.exports = require()`
+                                // file the linker wrapped again): the chunk exports only
+                                // `default: module.exports`, so the printed call reads
+                                // `.default` to return `module.exports`, the same value
+                                // an unsplit `require()` returns.
+                                if kind == ImportKind::Require
+                                    && is_external_dyn
+                                    && rec_source_index.is_valid()
+                                    && col_ref!(exports_kind)[rec_source_index.get() as usize]
+                                        == ExportsKind::Cjs
+                                {
+                                    col!(import_records_list)[id].as_mut_slice()
+                                        [import_record_index as usize]
+                                        .flags
+                                        .insert(ImportRecordFlags::CROSS_CHUNK_REQUIRE_DEFAULT);
+                                }
+
                                 // If this wasn't originally a "require()" call, then we may need
                                 // to wrap this in a call to the "__toESM" wrapper to convert from
                                 // CommonJS semantics to ESM semantics.

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2961,6 +2961,15 @@ pub(crate) mod __gated_printer {
                 self.print_import_record_path(record);
                 self.print(b")");
 
+                // A split `require()` of a module that is CommonJS at link
+                // time: the chunk's only export is `default: module.exports`.
+                if record
+                    .flags
+                    .contains(ImportRecordFlags::CROSS_CHUNK_REQUIRE_DEFAULT)
+                {
+                    self.print(b".default");
+                }
+
                 if wrap_with_to_esm {
                     self.print_to_esm_suffix();
                 }

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -2395,6 +2395,74 @@ describe("bundler", () => {
     run: { file: "/out/main.js", stdout: "cjs value called" },
   });
 
+  // A split require() of a lifted `module.exports = require()` file that the
+  // linker wraps again because its target is CommonJS: the chunk's only
+  // export is `default: module.exports`, so the call reads `.default` and
+  // returns `module.exports`, not the chunk namespace.
+  // https://github.com/oven-sh/bun/issues/41236
+  itBundled("splitting/SplitRequireOfRewrappedLiftedCommonJS#41236", {
+    files: {
+      "/main.ts": /* ts */ `
+        let m;
+        try {
+          m = require("react-dom");
+        } catch {}
+        console.log(typeof m, m.version, m.default());
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        module.exports = function render() { return "rendered"; };
+        module.exports.version = "19.0.0";
+      `,
+    },
+    entryPoints: ["/main.ts"],
+    splitting: true,
+    target: "bun",
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      const chunk = chunkContaining(api, "side effect");
+      api.expectFile("/out/main.js").toContain(`import.meta.require("./${chunk}").default`);
+    },
+    run: { file: "/out/main.js", stdout: "side effect\nobject 19.0.0 rendered" },
+  });
+
+  // When the lift target is itself lifted, the chunk stays an ES module and
+  // the split require() returns its namespace with no `.default` read.
+  itBundled("splitting/SplitRequireOfLiftedCommonJSStaysEsm", {
+    files: {
+      "/main.ts": /* ts */ `
+        let m;
+        try {
+          m = require("react-dom");
+        } catch {}
+        console.log(m.version, m.render());
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        exports.render = function render() { return "rendered"; };
+        exports.version = "19.0.0";
+      `,
+    },
+    entryPoints: ["/main.ts"],
+    splitting: true,
+    target: "bun",
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      const chunk = chunkContaining(api, "side effect");
+      api.expectFile("/out/main.js").toContain(`import.meta.require("./${chunk}")`);
+      api.expectFile("/out/main.js").not.toContain(".default");
+    },
+    run: { file: "/out/main.js", stdout: "side effect\n19.0.0 rendered" },
+  });
+
   // A top-level require() in a module that the required chunk imports back
   // (the registry ↔ tool shape): the chunk is evaluated while the entry is
   // still evaluating and sees the entry's hoisted functions through live


### PR DESCRIPTION
### Problem
- With `--splitting --target=bun`, a split `require()` of a file that is CommonJS at link time returns the chunk namespace `{ default: module.exports }` and not `module.exports`. In the repro of #41236, `require("react-dom").version` is `undefined`. With npm react-dom 18.3.1 in development, `createPortal` is `undefined`.
- The cause: since #41188 the parser lifts `module.exports = require("./impl")` into `export * from "./impl"`, so the file is ESM at parse time and `ReachableFileVisitor` splits the `require()` (`src/bundler/bundle_v2.rs:1998`). The linker then wraps the file again because `./impl` is CommonJS (`scanImportsAndExports.rs:422`). Its chunk is `export default require_x()`, and `import.meta.require()` of that chunk returns the namespace. This is a regression on main only. No release has it.

### Fix
- `scan_imports_and_exports` sets a new record flag, `CROSS_CHUNK_REQUIRE_DEFAULT`, on a split `require()` whose target has `exports_kind == Cjs` at link time. The printer then prints `import.meta.require("./chunk.js").default`.
- Correct because splitting is ESM output only, where a CommonJS entry chunk exports exactly one thing: `default: module.exports`. A target that stays ESM at link time keeps the bare call and gets its namespace, as before.
- The split output now matches the unsplit bundle: `typeof m, m.version, typeof m.default` print `object 19.0.0 function` in both.
- Verified: two new cases in `test/bundler/bundler_splitting.test.ts` (`SplitRequireOfRewrappedLiftedCommonJS#41236` fails on main). Also bundler_splitting, bundler_cjs2esm, bundler_cjs, esbuild/splitting, bundler_compile_splitting, bundler_edgecase, bundler_regressions, bundler_bun, all green with the debug build.

### Background
- A split `require()` (target bun, `--splitting`) makes its target an entry point with its own chunk and prints the call as `import.meta.require(path)`. The linker decides this at parse time from `ExportsKind::Esm`.
- Lifting: in an ESM bundle the parser turns top-level `exports.foo = ...` or `module.exports = require()` into ES exports. The lifted file can still become CommonJS at link time, for example when the target of its export star has no static exports.
- #41237 fixes the same shape for a split `import()`. This PR changes only `require()` records.

<details><summary>Notes</summary>

Repro from the issue, in an empty directory:

```sh
mkdir -p node_modules/react-dom
printf "console.log('side effect');\nmodule.exports = require('./impl');\n" > node_modules/react-dom/index.js
printf 'module.exports = function render() { return "rendered"; };\nmodule.exports.version = "19.0.0";\n' > node_modules/react-dom/impl.js
printf 'let m;\ntry {\n  m = require("react-dom");\n} catch {}\nconsole.log(m.version);\n' > entry.js
bun build ./entry.js --splitting --target=bun --outdir=out && bun out/entry.js
```

Main prints `side effect` then `undefined`. With this change it prints `19.0.0`. The entry chunk now has `m = import.meta.require("./index-<hash>.js").default`.

`module.exports` of the re-wrapped lifted file is `__toESM(require_impl())`, an object with `default` set to the function. That is the #41188 lift behavior and is the same in the unsplit bundle, so the test reads `m.default()`.

The second test, `SplitRequireOfLiftedCommonJSStaysEsm`, pins the other side: when `./impl` uses `exports.x = ...` and is lifted too, the chunk stays ESM and the call has no `.default`.

The alternative, to not split a `require()` of a lifted file with an export star, would keep the wrapper in the importer's chunk. The link-time check is the smaller change and covers every way a parse-time ESM target becomes CommonJS at link time, not only the lift case.

`cargo clippy -p bun_bundler -p bun_js_printer` is clean.
</details>
