### PR TITLE
Bun.serve: pause the file reader while the response is backpressured

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -118,9 +118,11 @@ impl BufferedReaderVTable {
         self.link().has_on_read_chunk()
     }
 
-    /// When the reader has read a chunk of data
-    /// and hasMore is true, it means that there might be more data to read.
-    /// Returning false prevents the reader from reading more data.
+    /// Delivers one chunk. `has_more` says whether the source may have more.
+    /// Returning false ends the current read loop, but it does not stop the
+    /// reader: the POSIX loop still re-arms the poll after a read that ended
+    /// in EAGAIN, and a Windows read completes later. A parent that wants no
+    /// more chunks until it resumes calls `pause()`.
     fn on_read_chunk(&self, chunk: Chunk<'_>, has_more: ReadState) -> bool {
         self.link().on_read_chunk(chunk, has_more)
     }

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -118,8 +118,7 @@ impl BufferedReaderVTable {
         self.link().has_on_read_chunk()
     }
 
-    /// Delivers one chunk. Returning false ends only the current read loop.
-    /// A parent that wants no more chunks until it resumes calls `pause()`.
+    /// Returning false ends only the current read loop. To stop the reader, call `pause()`.
     fn on_read_chunk(&self, chunk: Chunk<'_>, has_more: ReadState) -> bool {
         self.link().on_read_chunk(chunk, has_more)
     }

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -118,11 +118,8 @@ impl BufferedReaderVTable {
         self.link().has_on_read_chunk()
     }
 
-    /// Delivers one chunk. `has_more` says whether the source may have more.
-    /// Returning false ends the current read loop, but it does not stop the
-    /// reader: the POSIX loop still re-arms the poll after a read that ended
-    /// in EAGAIN, and a Windows read completes later. A parent that wants no
-    /// more chunks until it resumes calls `pause()`.
+    /// Delivers one chunk. Returning false ends only the current read loop.
+    /// A parent that wants no more chunks until it resumes calls `pause()`.
     fn on_read_chunk(&self, chunk: Chunk<'_>, has_more: ReadState) -> bool {
         self.link().on_read_chunk(chunk, has_more)
     }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -339,10 +339,8 @@ impl FileResponseStream {
                     },
                     self.as_ptr(),
                 );
-                // `false` alone does not stop an event-driven reader: a pollable
-                // fd re-arms its poll after EAGAIN, and a Windows read completes
-                // later. `on_writable` unpauses it. `pause()` does not call back
-                // into this object.
+                // `false` alone does not stop the reader. `on_writable` unpauses
+                // it, and `pause()` does not call back into this object.
                 self.reader_mut().pause();
                 false
             }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -339,8 +339,8 @@ impl FileResponseStream {
                     },
                     self.as_ptr(),
                 );
-                // `false` alone does not stop the reader. `on_writable` unpauses
-                // it, and `pause()` does not call back into this object.
+                // SAFETY: reader entry point; `pause()` does not call back into
+                // this object.
                 self.reader_mut().pause();
                 false
             }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -339,9 +339,11 @@ impl FileResponseStream {
                     },
                     self.as_ptr(),
                 );
-                #[cfg(not(unix))]
-                // SAFETY: reader entry point; `pause()` does not call back into
-                // this object.
+                // `false` only ends a synchronous read loop. A pollable fd
+                // re-arms its poll after EAGAIN and a Windows read completes
+                // later, so both keep writing into the backpressured response
+                // until the reader is paused. `on_writable` unpauses it.
+                // `pause()` does not call back into this object.
                 self.reader_mut().pause();
                 false
             }
@@ -393,6 +395,8 @@ impl FileResponseStream {
         }
         self.resp.get().timeout(self.idle_timeout.get());
         self.hold_read_ref();
+        // A paused POSIX reader ignores `read()`.
+        self.reader_mut().unpause();
         // SAFETY: `read()` dispatches `on_read_chunk`/`on_reader_done` back
         // into this object through the parent pointer, so no cell borrow
         // spans it.

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -339,11 +339,10 @@ impl FileResponseStream {
                     },
                     self.as_ptr(),
                 );
-                // `false` only ends a synchronous read loop. A pollable fd
-                // re-arms its poll after EAGAIN and a Windows read completes
-                // later, so both keep writing into the backpressured response
-                // until the reader is paused. `on_writable` unpauses it.
-                // `pause()` does not call back into this object.
+                // `false` alone does not stop an event-driven reader: a pollable
+                // fd re-arms its poll after EAGAIN, and a Windows read completes
+                // later. `on_writable` unpauses it. `pause()` does not call back
+                // into this object.
                 self.reader_mut().pause();
                 false
             }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1048,41 +1048,41 @@ function fill() {
   }
 }
 
-// Waits until the server reads from the pipe. Bounded so that a broken build
-// fails with a message instead of a timeout.
+// Fills the pipe, then makes one request to this server. The server shares
+// this event loop and must poll for I/O to answer. The full pipe is readable
+// during that poll, so a reader with an armed poll reads it before the answer
+// arrives. A paused reader leaves the pipe full. Returns the bytes that the
+// server read.
+async function fillAndPoll() {
+  fill();
+  const before = pumped;
+  const res = await fetch("http://127.0.0.1:" + server.port + "/alive");
+  await res.text();
+  fill();
+  return pumped - before;
+}
+
+// Waits for a request during which the server reads from the pipe. The bound
+// on the request count makes a broken build fail with a message, not a hang.
 async function waitForRead(label) {
-  const start = pumped;
-  for (let i = 0; i < 1000 && pumped === start; i++) {
-    await Bun.sleep(5);
-    fill();
+  for (let i = 0; i < 200; i++) {
+    if ((await fillAndPoll()) > 0) return console.log(label);
   }
-  console.log(pumped > start ? label : "no read for " + label);
+  console.log("no read for " + label);
 }
 
-// Refills the pipe each time the server reads from it. This loop and the
-// server share one event loop, and every sleep polls for I/O, so a reader with
-// an armed poll empties the pipe during each sleep and the next fill() makes
-// progress. A paused reader leaves the pipe full. The kernel socket buffers on
-// loopback hold a few MiB, and LIMIT is far above that.
+// Before the kernel socket buffers fill, each request shows a read. A paused
+// reader shows none. The buffers on loopback hold a few MiB, and LIMIT is far
+// above that.
 async function waitForStall() {
-  const start = pumped;
-  let idle = 0;
-  while (idle < 5 && pumped - start < LIMIT) {
-    const before = pumped;
-    fill();
-    if (pumped === before) {
-      idle++;
-      await Bun.sleep(10);
-    } else {
-      idle = 0;
-      await Bun.sleep(0);
-    }
+  let read = 0;
+  while (read < LIMIT) {
+    const n = await fillAndPoll();
+    if (n === 0) return console.log("stalled");
+    read += n;
   }
-  console.log(idle >= 5 ? "stalled" : "still reading after " + (pumped - start) + " bytes");
+  console.log("still reading after " + read + " bytes");
 }
-
-// Fill the pipe before the request exists.
-fill();
 
 // Raw client that sends the request and then does not read the response, so
 // the body writes on the server side end up returning backpressure.
@@ -1101,16 +1101,13 @@ if (then === "resume") {
   socket.resume();
   await waitForRead("resumed");
 } else {
-  // Disconnect the stalled client; the server must survive the abort of the
-  // backpressured file stream and still answer ordinary requests.
+  // Disconnect the stalled client. The server must survive the abort of the
+  // backpressured file stream and still answer requests. The second request
+  // polls with a full pipe, so a poll that the aborted stream left armed fires.
   socket.destroy();
   let res = await fetch("http://127.0.0.1:" + server.port + "/alive");
   console.log(await res.text());
-
-  // Make sure that the pipe has data. A poll that the aborted stream left
-  // armed fires during the sleep.
   fill();
-  await Bun.sleep(10);
   res = await fetch("http://127.0.0.1:" + server.port + "/alive");
   console.log(await res.text());
 }
@@ -1139,7 +1136,6 @@ process.exit(0);
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     },
-    30_000,
   );
 }
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1002,20 +1002,26 @@ describe("Bun.file in serve routes", () => {
 // socket drains. For a pollable fd (FIFO, character device, socket) the read
 // loop re-arms its poll after EAGAIN, so a reader that is not paused keeps
 // moving the source into the response's backpressure buffer, without a bound,
-// while the client reads nothing. FileResponseStream also holds one
-// in-flight-read reference per reader.read(); the backpressure and abort paths
-// must release it exactly once, or the stream is freed while uWS still holds
-// it as callback userdata.
-test.skipIf(isWindows)(
-  "pollable file response stops reading while the client does not read, and survives the disconnect",
-  async () => {
-    using dir = tempDir("serve-fifo-backpressure", {
-      "fixture.ts": `
+// while the client reads nothing. When the client reads again, on_writable
+// must unpause the reader, or the response stalls. A client that disconnects
+// frees the stream. If its poll is still armed, the next readable event reaches
+// the freed reader. Bun.file(fd) keeps the fd open after the response ends, so
+// that event comes as soon as the pipe has data.
+for (const [source, then] of [
+  ["path", "disconnect"],
+  ["fd", "disconnect"],
+  ["path", "resume"],
+] as const) {
+  test.concurrent.skipIf(isWindows)(
+    `pollable Bun.file(${source}) response stops reading while the client does not read, then ${then === "resume" ? "resumes when the client reads" : "survives the disconnect"}`,
+    async () => {
+      using dir = tempDir("serve-fifo-backpressure", {
+        "fixture.ts": `
 import { connect } from "node:net";
 import { constants, openSync, writeSync } from "node:fs";
 
-const fifoPath = process.argv[2];
-const LIMIT = Number(process.argv[3]);
+const [fifoPath, limit, source, then] = process.argv.slice(2);
+const LIMIT = Number(limit);
 
 // Open the FIFO read+write so open() never blocks waiting for the other end
 // and the pipe never reports HUP/EOF. With O_NONBLOCK a write to a full pipe
@@ -1028,7 +1034,7 @@ const server = Bun.serve({
     if (new URL(req.url).pathname === "/alive") {
       return new Response("alive");
     }
-    return new Response(Bun.file(fifoPath));
+    return new Response(source === "fd" ? Bun.file(writerFd) : Bun.file(fifoPath));
   },
 });
 
@@ -1042,11 +1048,43 @@ function fill() {
   }
 }
 
+// Waits until the server reads from the pipe. Bounded so that a broken build
+// fails with a message instead of a timeout.
+async function waitForRead(label) {
+  const start = pumped;
+  for (let i = 0; i < 1000 && pumped === start; i++) {
+    await Bun.sleep(5);
+    fill();
+  }
+  console.log(pumped > start ? label : "no read for " + label);
+}
+
+// Refills the pipe each time the server reads from it. This loop and the
+// server share one event loop, and every sleep polls for I/O, so a reader with
+// an armed poll empties the pipe during each sleep and the next fill() makes
+// progress. A paused reader leaves the pipe full. The kernel socket buffers on
+// loopback hold a few MiB, and LIMIT is far above that.
+async function waitForStall() {
+  const start = pumped;
+  let idle = 0;
+  while (idle < 5 && pumped - start < LIMIT) {
+    const before = pumped;
+    fill();
+    if (pumped === before) {
+      idle++;
+      await Bun.sleep(10);
+    } else {
+      idle = 0;
+      await Bun.sleep(0);
+    }
+  }
+  console.log(idle >= 5 ? "stalled" : "still reading after " + (pumped - start) + " bytes");
+}
+
 // Fill the pipe before the request exists.
 fill();
-const prefill = pumped;
 
-// Raw client that sends the request and then never reads the response, so
+// Raw client that sends the request and then does not read the response, so
 // the body writes on the server side end up returning backpressure.
 const socket = connect({ port: server.port, host: "127.0.0.1", pauseOnConnect: true });
 socket.on("error", () => {});
@@ -1054,65 +1092,56 @@ await new Promise(resolve => socket.once("connect", resolve));
 socket.write("GET /stream HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n");
 socket.pause();
 
-// Wait for the response stream to start reading the pipe. Bounded so that a
-// broken build fails with a message instead of a timeout.
-for (let i = 0; i < 1000 && pumped === prefill; i++) {
-  await Bun.sleep(5);
+await waitForRead("streaming");
+await waitForStall();
+
+if (then === "resume") {
+  // Read the response. The socket drains, and the server reads the pipe again.
+  socket.on("data", () => {});
+  socket.resume();
+  await waitForRead("resumed");
+} else {
+  // Disconnect the stalled client; the server must survive the abort of the
+  // backpressured file stream and still answer ordinary requests.
+  socket.destroy();
+  let res = await fetch("http://127.0.0.1:" + server.port + "/alive");
+  console.log(await res.text());
+
+  // Make sure that the pipe has data. A poll that the aborted stream left
+  // armed fires during the sleep.
   fill();
+  await Bun.sleep(10);
+  res = await fetch("http://127.0.0.1:" + server.port + "/alive");
+  console.log(await res.text());
 }
-console.log(pumped > prefill ? "streaming" : "stuck at " + pumped + " (prefill " + prefill + ")");
-
-// Refill the pipe each time the server reads from it. This loop and the server
-// share one event loop, and every sleep polls for I/O, so a reader with an
-// armed poll empties the pipe during each sleep and the next fill() makes
-// progress. A paused reader leaves the pipe full. The kernel socket buffers
-// hold a few MiB at most, and LIMIT is far above that.
-let idle = 0;
-while (idle < 5 && pumped - prefill < LIMIT) {
-  const before = pumped;
-  fill();
-  if (pumped === before) {
-    idle++;
-    await Bun.sleep(10);
-  } else {
-    idle = 0;
-    await Bun.sleep(0);
-  }
-}
-console.log(idle >= 5 ? "stalled" : "still reading after " + (pumped - prefill) + " bytes");
-
-// Disconnect the stalled client; the server must survive the abort of the
-// backpressured file stream.
-socket.destroy();
-
-// The server must still answer ordinary requests afterwards.
-const res = await fetch("http://127.0.0.1:" + server.port + "/alive");
-console.log(await res.text());
 
 server.stop(true);
 process.exit(0);
 `,
-    });
+      });
 
-    const fifoPath = join(String(dir), "stream.fifo");
-    mkfifo(fifoPath);
+      const fifoPath = join(String(dir), "stream.fifo");
+      mkfifo(fifoPath);
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.ts", fifoPath, String(32 * 1024 * 1024)],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.ts", fifoPath, String(32 * 1024 * 1024), source, then],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout.trim()).toBe("streaming\nstalled\nalive");
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+      expect(stdout.trim()).toBe(
+        then === "resume" ? "streaming\nstalled\nresumed" : "streaming\nstalled\nalive\nalive",
+      );
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
+}
 
 // A FIFO's stat size is 0, but the body length is unknown until EOF. Writing
 // Content-Length from the stat size and then streaming the pipe to EOF puts

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1100,6 +1100,15 @@ if (then === "resume") {
   socket.on("data", () => {});
   socket.resume();
   await waitForRead("resumed");
+
+  // Stop reading again before the disconnect. A stream that waits for pipe
+  // data when its client disconnects stays allocated while the pipe is open,
+  // and the leak check at exit reports it. A paused stream is freed.
+  socket.pause();
+  await waitForStall();
+  socket.destroy();
+  const res = await fetch("http://127.0.0.1:" + server.port + "/alive");
+  await res.text();
 } else {
   // Disconnect the stalled client. The server must survive the abort of the
   // backpressured file stream and still answer requests. The second request
@@ -1131,7 +1140,7 @@ process.exit(0);
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stdout.trim()).toBe(
-        then === "resume" ? "streaming\nstalled\nresumed" : "streaming\nstalled\nalive\nalive",
+        then === "resume" ? "streaming\nstalled\nresumed\nstalled" : "streaming\nstalled\nalive\nalive",
       );
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -998,27 +998,29 @@ describe("Bun.file in serve routes", () => {
   });
 });
 
-// FileResponseStream takes one in-flight-read reference before each
-// reader.read() and must release it exactly once. For pollable fds (FIFO,
-// character device, socket) the armed poll keeps delivering readable events
-// after a body write already returned backpressure; each extra chunk used to
-// release the same reference again, dropping the count to zero and freeing the
-// stream object while uWS still held it as callback userdata. Streaming a FIFO
-// to a client that refuses to read the response produces many reader callbacks
-// while the socket is backpressured, which is exactly that sequence.
+// A body write that returns backpressure must pause the reader until the
+// socket drains. For a pollable fd (FIFO, character device, socket) the read
+// loop re-arms its poll after EAGAIN, so a reader that is not paused keeps
+// moving the source into the response's backpressure buffer, without a bound,
+// while the client reads nothing. FileResponseStream also holds one
+// in-flight-read reference per reader.read(); the backpressure and abort paths
+// must release it exactly once, or the stream is freed while uWS still holds
+// it as callback userdata.
 test.skipIf(isWindows)(
-  "pollable file response survives a client that stops reading and then disconnects",
+  "pollable file response stops reading while the client does not read, and survives the disconnect",
   async () => {
     using dir = tempDir("serve-fifo-backpressure", {
       "fixture.ts": `
 import { connect } from "node:net";
-import { openSync, write } from "node:fs";
+import { constants, openSync, writeSync } from "node:fs";
 
 const fifoPath = process.argv[2];
+const LIMIT = Number(process.argv[3]);
 
 // Open the FIFO read+write so open() never blocks waiting for the other end
-// and the pipe never reports HUP/EOF while the test is still feeding it.
-const writerFd = openSync(fifoPath, "r+");
+// and the pipe never reports HUP/EOF. With O_NONBLOCK a write to a full pipe
+// fails with EAGAIN, so \`pumped\` grows only when the server reads the pipe.
+const writerFd = openSync(fifoPath, constants.O_RDWR | constants.O_NONBLOCK);
 
 const server = Bun.serve({
   port: 0,
@@ -1030,78 +1032,54 @@ const server = Bun.serve({
   },
 });
 
-// Keep the pipe full for the whole test so the reader-side poll always has
-// another readable event to deliver. A blocked write only completes once the
-// server drains the FIFO, so \`pumped\` tracks how far the server has read.
-// The chain is intentionally never awaited to completion: a correctly
-// backpressured server stops draining the pipe once the client stops reading.
-// 8 KiB stays under the 16 KiB macOS FIFO capacity while halving the number of
-// threadpool round-trips needed to fill the kernel socket buffers.
-const CHUNK = Buffer.alloc(8 * 1024, 120);
+const CHUNK = Buffer.alloc(64 * 1024, 120);
 let pumped = 0;
-let stopPumping = false;
-function pump(err, n) {
-  if (err || stopPumping) return;
-  pumped += n || 0;
-  write(writerFd, CHUNK, 0, CHUNK.length, null, pump);
-}
-pump(null, 0);
-
-// Let the pump fill the pipe to capacity before the request exists. The FIFO
-// buffer size is platform-dependent (16 KiB on macOS, 64 KiB on Linux), so
-// measure it instead of assuming it: with no reader, \`pumped\` stops growing
-// once the pipe is full.
-let prefill = -1;
-let prefillStable = 0;
-for (let i = 0; i < 500 && prefillStable < 3; i++) {
-  await Bun.sleep(10);
-  if (pumped > 0 && pumped === prefill) {
-    prefillStable++;
-  } else {
-    prefillStable = 0;
-    prefill = pumped;
+function fill() {
+  try {
+    for (;;) pumped += writeSync(writerFd, CHUNK);
+  } catch (err) {
+    if (err.code !== "EAGAIN") throw err;
   }
 }
 
+// Fill the pipe before the request exists.
+fill();
+const prefill = pumped;
+
 // Raw client that sends the request and then never reads the response, so
-// every body write on the server side ends up returning backpressure.
+// the body writes on the server side end up returning backpressure.
 const socket = connect({ port: server.port, host: "127.0.0.1", pauseOnConnect: true });
 socket.on("error", () => {});
 await new Promise(resolve => socket.once("connect", resolve));
 socket.write("GET /stream HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n");
 socket.pause();
 
-// Wait for the server to start draining the pipe: a blocked write can only
-// complete once the response stream consumes the FIFO, so any growth past the
-// prefill level proves the reader is running, regardless of the platform's
-// pipe capacity.
-for (let i = 0; i < 1000 && pumped <= prefill; i++) {
+// Wait for the response stream to start reading the pipe. Bounded so that a
+// broken build fails with a message instead of a timeout.
+for (let i = 0; i < 1000 && pumped === prefill; i++) {
   await Bun.sleep(5);
+  fill();
 }
 console.log(pumped > prefill ? "streaming" : "stuck at " + pumped + " (prefill " + prefill + ")");
 
-// Now wait for the drain to stall. The client never reads, so the body writes
-// must eventually report backpressure and the reader must park; the pump then
-// stops making progress. The extra readable events delivered between the first
-// backpressured write and the stall are what used to over-release the
-// in-flight-read reference. "Stalled" means the pump advanced by less than one
-// CHUNK across 5 consecutive samples, i.e. body writes are already returning
-// backpressure; waiting for byte-for-byte stability would mean waiting for the
-// kernel socket buffers to fill completely. Bounded poll so a broken build
-// fails instead of hanging.
-let last = -1;
-let stable = 0;
-for (let i = 0; i < 500 && stable < 5; i++) {
-  await Bun.sleep(10);
-  if (last >= 0 && pumped - last < CHUNK.length) {
-    stable++;
+// Refill the pipe each time the server reads from it. This loop and the server
+// share one event loop, and every sleep polls for I/O, so a reader with an
+// armed poll empties the pipe during each sleep and the next fill() makes
+// progress. A paused reader leaves the pipe full. The kernel socket buffers
+// hold a few MiB at most, and LIMIT is far above that.
+let idle = 0;
+while (idle < 5 && pumped - prefill < LIMIT) {
+  const before = pumped;
+  fill();
+  if (pumped === before) {
+    idle++;
+    await Bun.sleep(10);
   } else {
-    stable = 0;
-    last = pumped;
+    idle = 0;
+    await Bun.sleep(0);
   }
 }
-stopPumping = true;
-console.log("stalled");
+console.log(idle >= 5 ? "stalled" : "still reading after " + (pumped - prefill) + " bytes");
 
 // Disconnect the stalled client; the server must survive the abort of the
 // backpressured file stream.
@@ -1120,7 +1098,7 @@ process.exit(0);
     mkfifo(fifoPath);
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.ts", fifoPath],
+      cmd: [bunExe(), "fixture.ts", fifoPath, String(32 * 1024 * 1024)],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",


### PR DESCRIPTION
### Problem
- `Bun.serve` keeps reading a pollable `Bun.file()` body (a FIFO, a character device, a socket) while the client reads nothing. The bytes collect in the response's write buffer, which has no limit.
- A disconnect in this state frees the stream with its poll still armed. With `Bun.file(fd)`, the next readable event reads freed memory: `AddressSanitizer: heap-use-after-free` in `PosixBufferedReader::begin_read`.
- Cause: on backpressure, `on_read_chunk` (`src/runtime/server/FileResponseStream.rs:327`) pauses the reader only on Windows. On POSIX the read loop re-arms the poll after EAGAIN (`src/io/PipeReader.rs:846`).

### Fix
- Pause the reader on backpressure on every platform. `on_writable` unpauses it before the next read. `FileReader` uses the same handshake (`src/runtime/webcore/FileReader.rs:669`).
- A paused POSIX reader unregisters its poll and ignores `read()`. #23341 limited the pause to Windows because `on_writable` did not unpause. On Windows `read()` already unpauses.
- Verified: `test/js/bun/http/bun-serve-file.test.ts`. The server must stop reading a FIFO, for `Bun.file(path)` and `Bun.file(fd)`, and read again when the client does. All three cases fail on main.
- Self-reviewed: 3 concerns raised, 3 addressed. The `on_read_chunk` doc is fixed, the #23341 history is above, and the Notes name the open `FileReader` case and the order with #41204.

### Background
- `FileResponseStream` streams a file descriptor into a uWS response. Without `sendfile`, a `BufferedReader` reads the fd and calls `on_read_chunk` for each chunk.
- `resp.write()` returns `Backpressure` when the socket is full. uWS buffers the rest and calls `on_writable` when the socket drains.
- The event loop reports a pollable fd readable once per arm. The read loop re-arms the poll after a read that ends in EAGAIN.

<details><summary>Notes</summary>

**Measurements (Linux x64)**

- Main, release build: the server read 64 MiB from the FIFO while the client read 0 bytes. The read stopped only at the limit of the probe.
- With the fix, the server stops after about 2.6 MiB. That is the kernel socket buffers plus one chunk.
- On main the test prints `still reading after 33554432 bytes`, on the release build and on the debug build. With the fix each case takes about 1.4 s on the debug build, and about 2.5 s with all cores busy.

**The crash**

- ASAN stacks on main, `Bun.file(fd)` case: the read is in `PosixBufferedReader::begin_read`, from `FilePoll::on_update`. The free is in the drop of `FileResponseStream`, from `on_aborted` (`HttpContext::onClose`). The allocation is in `FileResponseStream::start`, from `RequestContext::do_sendfile`.
- A release build can segfault on the same path. A probe with more requests between the disconnect and the next write crashed in 3 of 3 runs: `panic(main thread): Segmentation fault at address 0x98`.
- The reader's `Drop` does not unregister the poll, because `start()` clears `CLOSE_HANDLE`. #37083 changes that teardown. This PR only makes sure that the poll is not armed when a backpressured stream is freed.

**The test**

- The old fixture printed `stalled` also when the drain never stalled. Its stall loop ended at a time bound, so on main it waited 5 s and passed.
- The new fixture has no sleeps and no timeouts. It opens the FIFO with `O_NONBLOCK`. A write to a full pipe fails with EAGAIN, so the byte count grows only when the server reads.
- Each step fills the FIFO and makes one request to the same server. The server shares the fixture's event loop and must poll for I/O to answer. A reader with an armed poll reads the full FIFO during that poll. On main every request shows a read. With the fix, the first request without a read comes after 2621440 bytes (40 reads of 64 KiB), in every run.
- The limit is 32 MiB. That is far above the kernel socket buffers on loopback.
- The resume case covers the `unpause()` in `on_writable`. With the fix, the server reads again after 5 requests. A build without the unpause fails that case with `no read for resumed`, and passes the other two.
- The resume case stops reading again before the disconnect. A stream that waits for pipe data when its client disconnects stays allocated while the pipe is open (#37083). The leak check on the ASAN lane reports that stream at exit.

**Regular files**

- A regular file body takes the same pause and unpause when it cannot use `sendfile` (TLS, HTTP/3, macOS). A scratch test served a 48 MiB file to slow readers over http and https, through a fetch handler and a static route. All bodies matched by SHA-256, and `on_writable` ran 167 times.

**Keep-alive**

- `pause()` unregisters the poll, and that also releases the poll's hold on the event loop. `unpause()` does not take it back. The sink path of `FileReader` behaves the same way.
- While the response is in flight, the server's pending-request count keeps the process alive. A difference shows only after `server.unref()`.

**Not in this PR**

- `FileReader` still pauses only on Windows when it stops at its high-water mark (`src/runtime/webcore/FileReader.rs:647-655`). So `Bun.file(fifo).stream()` with a stalled consumer can still buffer without a limit on POSIX. That fix needs an unpause before `read_into`, and its own test.
- #41204 adds `test/flaky-tests.txt` with a line for `test/js/bun/http/bun-serve-file.test.ts`, because of the CI timeout that this bug causes. #41204 is not merged. The PR that lands second removes that line.

**Other checks**

- `bun bd test` on `bun-serve-file`, `bun-serve-static`, `serve-directory-routes`, `serve-file-slice-read-error`, `serve-http3`, and `serve.test.ts`. Two tests in `serve.test.ts` fail the same way on the release build (a privileged port, and a loopback-only check). This container runs as root.
- `cargo check` for `x86_64-pc-windows-msvc` passes.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->