### PR TITLE
node:http2: write latin-1 header values as one byte per code unit

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -545,6 +545,26 @@ fn is_valid_header_value(value: &[u8]) -> bool {
     !strings::contains_any(value, b"\0\n\r")
 }
 
+/// The wire bytes of an outbound header value. A value whose code units all fit
+/// in one byte is written one byte per code unit. Node does the same
+/// (`StringBytes::Write(..., LATIN1)` in `NgHeaders`), and the inbound side
+/// reads the bytes back as latin-1. A value with a wider code unit is written as
+/// UTF-8. Bun has no single rule above 0xFF: Node truncates such a code unit to
+/// its low byte, and object-form `respond()` drops the value in JS
+/// (`headerValueIsUnsendable`).
+fn header_value_bytes<'a>(value: &'a bun_jsc::JSStringView<'_>) -> Cow<'a, [u8]> {
+    if !value.is_utf16() {
+        return Cow::Borrowed(value.latin1());
+    }
+    let units = value.utf16();
+    if units.iter().any(|&unit| unit > 0xFF) {
+        return Cow::Owned(value.to_owned_slice());
+    }
+    let mut bytes = vec![0u8; units.len()];
+    strings::copy_u16_into_u8(&mut bytes, units);
+    Cow::Owned(bytes)
+}
+
 #[inline]
 pub(crate) fn is_malformed_field_name(name: &[u8]) -> bool {
     let rest = match name.split_first() {
@@ -5817,8 +5837,8 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_view.to_utf8();
-                    let value = value_slice.slice();
+                    let value_bytes = header_value_bytes(&value_view);
+                    let value = value_bytes.as_ref();
 
                     if let Some(ret) = handle_encode(this, value, never_index)? {
                         return Ok(ret);
@@ -5851,8 +5871,8 @@ impl H2FrameParser {
                     }
                 };
 
-                let value_slice = value_view.to_utf8();
-                let value = value_slice.slice();
+                let value_bytes = header_value_bytes(&value_view);
+                let value = value_bytes.as_ref();
                 bun_output::scoped_log!(
                     H2FrameParser,
                     "encode header {} {}",
@@ -6216,8 +6236,8 @@ impl H2FrameParser {
                 };
                 let mut encode_value = |item: JSValue| -> JsResult<Option<JSValue>> {
                     let value_view = item.to_js_string_view(global_object)?;
-                    let value_slice = value_view.to_utf8();
-                    let value = value_slice.slice();
+                    let value_bytes = header_value_bytes(&value_view);
+                    let value = value_bytes.as_ref();
                     if !is_valid_header_value(value) {
                         return Err(global_object
                             .err(
@@ -6691,8 +6711,8 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_view.to_utf8();
-                    let value = value_slice.slice();
+                    let value_bytes = header_value_bytes(&value_view);
+                    let value = value_bytes.as_ref();
                     if !is_valid_header_value(value) {
                         return Err(global_object
                             .err(
@@ -6861,8 +6881,8 @@ impl H2FrameParser {
                             }
                         };
 
-                        let value_slice = value_view.to_utf8();
-                        let value = value_slice.slice();
+                        let value_bytes = header_value_bytes(&value_view);
+                        let value = value_bytes.as_ref();
                         if !is_valid_header_value(value) {
                             return Err(global_object
                                 .err(
@@ -6931,8 +6951,8 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_view.to_utf8();
-                    let value = value_slice.slice();
+                    let value_bytes = header_value_bytes(&value_view);
+                    let value = value_bytes.as_ref();
                     if !is_valid_header_value(value) {
                         return Err(global_object
                             .err(

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3283,6 +3283,159 @@ describe("http2 header values are latin-1 byte strings", () => {
       server.close();
     }
   });
+
+  // The outbound side writes one byte per code unit too. Node's NgHeaders
+  // writes the header string with StringBytes::Write(..., LATIN1), so obs-text
+  // round-trips between two peers. UTF-8 makes the peer read two code units
+  // per byte above 0x7F. JSC stores a string as 8-bit or 16-bit, so each
+  // encode path gets both forms.
+  const latin1 = "caf\xe9-\x80\xff";
+  const latin1In16Bit = new TextDecoder("utf-16le").decode(Buffer.from(latin1, "utf16le"));
+
+  it.each(["object", "raw array"])(
+    "client and server write header values and trailers as latin-1 (%s form)",
+    async form => {
+      expect(jscDescribe(latin1In16Bit)).toContain("8Bit:(0)");
+      const withFields = pseudo =>
+        form === "object"
+          ? { ...pseudo, "x-latin1": latin1, "x-latin1-16bit": latin1In16Bit, "x-list": [latin1, latin1In16Bit] }
+          : [
+              ...Object.entries(pseudo).flat(),
+              ...["x-latin1", latin1, "x-latin1-16bit", latin1In16Bit, "x-list", latin1, "x-list", latin1In16Bit],
+            ];
+      const trailerFields = {
+        "x-trailer": latin1,
+        "x-trailer-16bit": latin1In16Bit,
+        "x-trailer-list": [latin1, latin1In16Bit],
+      };
+      const expected = {
+        headers: { "x-latin1": latin1, "x-latin1-16bit": latin1, "x-list": `${latin1}, ${latin1}` },
+        trailers: { "x-trailer": latin1, "x-trailer-16bit": latin1, "x-trailer-list": `${latin1}, ${latin1}` },
+      };
+      const received = (headers, names) => Object.fromEntries(names.map(name => [name, headers[name]]));
+
+      const request = Promise.withResolvers();
+      const requestTrailers = Promise.withResolvers();
+      const server = http2.createServer();
+      server.on("error", request.reject);
+      server.on("stream", (stream, headers) => {
+        request.resolve(headers);
+        stream.on("trailers", requestTrailers.resolve);
+        stream.on("wantTrailers", () => stream.sendTrailers(trailerFields));
+        stream.respond(withFields({ ":status": "200" }), { waitForTrailers: true });
+        stream.end();
+      });
+      await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      try {
+        const response = Promise.withResolvers();
+        const responseTrailers = Promise.withResolvers();
+        const fail = err => {
+          request.reject(err);
+          requestTrailers.reject(err);
+          response.reject(err);
+          responseTrailers.reject(err);
+        };
+        client.on("error", fail);
+        const req = client.request(withFields({ ":method": "POST", ":path": "/" }), { waitForTrailers: true });
+        req.on("error", fail);
+        req.on("wantTrailers", () => req.sendTrailers(trailerFields));
+        req.on("response", response.resolve);
+        req.on("trailers", responseTrailers.resolve);
+        req.on("close", () => fail(new Error(`stream closed without trailers (rstCode ${req.rstCode})`)));
+        req.resume();
+        req.end("body");
+
+        const headerNames = Object.keys(expected.headers);
+        const trailerNames = Object.keys(expected.trailers);
+        expect({
+          request: received(await request.promise, headerNames),
+          requestTrailers: received(await requestTrailers.promise, trailerNames),
+          response: received(await response.promise, headerNames),
+          responseTrailers: received(await responseTrailers.promise, trailerNames),
+        }).toEqual({
+          request: expected.headers,
+          requestTrailers: expected.trailers,
+          response: expected.headers,
+          responseTrailers: expected.trailers,
+        });
+      } finally {
+        client.close();
+        server.close();
+      }
+    },
+  );
+
+  it("server writes push promise header values as latin-1", async () => {
+    const blocks = await pushedHeaderBlocks(stream => {
+      stream.pushStream({ ":path": "/pushed", "x-latin1": latin1, "x-latin1-16bit": latin1In16Bit }, (err, push) => {
+        if (err) {
+          stream.destroy(err);
+          return;
+        }
+        push.respond({ ":status": 200 });
+        push.end();
+      });
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    expect(blocks.map(block => block.fields)).toEqual([["x-latin1", latin1, "x-latin1-16bit", latin1]]);
+  });
+
+  // Bun has no single rule for a code unit above 0xFF. Node truncates it to its
+  // low byte, and object-form respond() drops the value (headerValueIsUnsendable).
+  // request() and sendTrailers() send the UTF-8 bytes, and this test pins them.
+  // Truncation turns U+4E0D into a CR byte, which request() rejects.
+  it("request() and sendTrailers() send the UTF-8 bytes of a value with a code unit above 0xFF", async () => {
+    const wide = "\u4e0d\u4e2d";
+    const mixed = "caf\xe9 \u4e2d";
+    const utf8AsLatin1 = value => Buffer.from(value, "utf8").toString("latin1");
+
+    const delivered = Promise.withResolvers();
+    const server = http2.createServer();
+    server.on("error", delivered.reject);
+    server.on("stream", (stream, headers) => {
+      stream.on("trailers", trailers => {
+        delivered.resolve({
+          headers: { "x-wide": headers["x-wide"], "x-mixed": headers["x-mixed"] },
+          trailers: { "x-wide-trailer": trailers["x-wide-trailer"] },
+        });
+        stream.respond({ ":status": 200 });
+        stream.end();
+      });
+      stream.resume();
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      const response = Promise.withResolvers();
+      const fail = err => {
+        delivered.reject(err);
+        response.reject(err);
+      };
+      client.on("error", fail);
+      const req = client.request(
+        { ":method": "POST", ":path": "/", "x-wide": wide, "x-mixed": mixed },
+        { waitForTrailers: true },
+      );
+      req.on("error", fail);
+      req.on("wantTrailers", () => req.sendTrailers({ "x-wide-trailer": wide }));
+      req.on("response", headers => response.resolve(headers[":status"]));
+      req.resume();
+      req.end("body");
+
+      expect(await delivered.promise).toEqual({
+        headers: { "x-wide": utf8AsLatin1(wide), "x-mixed": utf8AsLatin1(mixed) },
+        trailers: { "x-wide-trailer": utf8AsLatin1(wide) },
+      });
+      expect(await response.promise).toBe(200);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
 });
 
 it("http2 server rejects requests carrying connection-specific or repeated pseudo-headers", async () => {


### PR DESCRIPTION
### Problem
- On the canary, a node:http2 proxy changes each non-ASCII header byte at every hop. A client sends `é` as `c3 a9`. The proxy reads `Ã©` and forwards `c3 83 c2 a9`.
- The cause: `request()`, `respond()`, `sendTrailers()` and `pushStream()` encode each value with `to_utf8()` (`src/runtime/api/bun/h2_frame_parser.rs`). Since #40687 the inbound side reads one code unit per byte. #40687 is in no release yet, so both can ship together.

### Fix
- A new helper, `header_value_bytes`, writes one byte per code unit when every code unit of a value is 0xFF or less. All six encode sites use it. Node writes the same bytes (`StringBytes::Write(..., LATIN1)` in `NgHeaders`), and the inbound side reads them back.
- A value with a code unit above 0xFF still goes out as UTF-8, as before. This PR does not decide that case. Node truncates such a code unit to its low byte, which turns `不` (U+4E0D) into a CR byte that `request()` rejects.
- Verified: four new tests in `test/js/node/http2/node-http2.test.js` cover all six sites. Three fail on the canary. Also `test/js/node/http2/` and 42 vendored `test-http2-*.js` files.
- Self-reviewed: 4 concerns raised, 3 addressed (see Notes).

### Background
- HTTP/2 header values are bytes. RFC 9110 allows 0x80 to 0xFF (obs-text) in a value.
- JSC stores a string as 8-bit (latin-1) or 16-bit. The helper gives the same bytes for both forms.
- Bun 1.4.0 wrote and read UTF-8. Bun-to-Bun round-tripped, but a Node peer read `café` as `cafÃ©`.

<details><summary>Notes</summary>

Found by a comparison of the canary with 1.4.0. No user reported it.

Client, proxy and upstream, all node:http2, header `x-v: caf\xe9`. Bytes as each hop reads them:

```
1.4.1-canary:  proxy 63 61 66 c3 a9 | upstream 63 61 66 c3 83 c2 a9
this branch:   proxy 63 61 66 e9    | upstream 63 61 66 e9
node v26.3.0:  proxy 63 61 66 e9    | upstream 63 61 66 e9
```

Values above 0xFF, request header `x-cr: 不` (U+4E0D):

```
node v26.3.0:  the request succeeds, the field is absent at the server (nghttp2 ignores a value with CR)
canary:        the request succeeds, the server reads the UTF-8 bytes e4 b8 8d as three code units
truncation:    ERR_HTTP2_INVALID_HEADER_VALUE, the stream fails
this branch:   same as the canary
```

U+4E00, U+4E0A and U+AC00 have the same low-byte problem. Bun 1.4.0 round-tripped these values between Bun peers. Since #40687 it does not, and this PR does not change that. Node does not round-trip them either.

Tests:
- Object form and raw array form (one `it.each`), and push promise: fail on the canary, pass here. I reverted the three sites that the old tests did not reach (array trailers, raw pairs, push) to `to_utf8()` and rebuilt. Each of those tests then failed at its own site.
- Above 0xFF: records the current UTF-8 bytes for `request()` and `sendTrailers()`. It passes on both builds.

Suites with the debug build of this commit: `test/js/node/http2/` (493 pass, 6 skip), and the 42 vendored `test-http2-*.js` files whose names contain header, trailer, push, splitting, sensitive or altsvc. All 256 vendored `test-http2-*.js` files passed on the previous revision of this branch. It differs from this one only in the helper's parameter type and doc comment.

Self-review. Addressed: tests for all six encode sites, the Node citation, and the wording for values above 0xFF. Not addressed: one more implementation finding, which I have only as a severity, without its text. A manual check of the likely areas found nothing. HPACK encoding of bytes above 0x7F is covered by the round-trip tests. A lone surrogate is above 0xFF, so it takes the UTF-8 path, as before.

Follow-ups, not in this PR:
- ALTSVC values are UTF-8 in both directions. Node uses latin-1 there too. A separate change covers them.
- One rule above 0xFF. Node truncates, object-form `respond()` drops the value in JS (`headerValueIsUnsendable`), and `request()` sends UTF-8.

Suggested release note, next to the #35338 entry in #28792: "node:http2 reads and writes latin-1 header values one byte per code unit, as Node does (#40687, #41245)."

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (a6c4cc276)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [885.34ms]
(pass) node none > Client Basics > should be able to send a POST request [586.29ms]
(pass) node none > Client Basics > constants [18.98ms]
(pass) node none > Client Basics > getDefaultSettings [7.66ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [19.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.81ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.18ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.64ms]
(pass) node none > Client Basics > should be able to send data using end [611.76ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [603.45ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release without fix: 11 failed, 6 skipped
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.84ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.28ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.06ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.08ms]
(pass) node none > Client Basics > is possible to abort request [1.62ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.73ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.69ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.17ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [29.46ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (a6c4cc276)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [866.64ms]
(pass) node none > Client Basics > should be able to send a POST request [566.63ms]
(pass) node none > Client Basics > constants [18.30ms]
(pass) node none > Client Basics > getDefaultSettings [7.05ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.45ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.56ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.13ms]
(pass) node none > Client Basics > should be able to send data using end [589.81ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [579.58ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     64ff746719
  features     baseline

23 deps, 131 codegen, 1172 objects in 664ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 25 installs across 62 packages (no changes) [14.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [2.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] fetch zlib
[zlib] up to date
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 21ms

  react-refresh.js  4.81
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs |  44 +++++++---
 test/js/node/http2/node-http2.test.js  | 153 +++++++++++++++++++++++++++++++++
 2 files changed, 185 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs      7      8     26
test/js/node/http2/node-http2.test.js       5      4     26
```

</details>

<!-- robobun:evidence:end -->