### PR TITLE
docs: fix bun:sqlite sticky-params examples for get() and all()

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -624,11 +624,14 @@ declare module "bun:sqlite" {
      * ```ts
      * const stmt = db.prepare("SELECT * FROM foo WHERE bar = ?");
      *
+     * stmt.all();
+     * // => []
+     *
      * stmt.all("baz");
      * // => [{bar: "baz"}]
      *
      * stmt.all();
-     * // => []
+     * // => [{bar: "baz"}]
      *
      * stmt.all("foo");
      * // => [{bar: "foo"}]
@@ -647,11 +650,14 @@ declare module "bun:sqlite" {
      * ```ts
      * const stmt = db.prepare("SELECT * FROM foo WHERE bar = ?");
      *
+     * stmt.get();
+     * // => null
+     *
      * stmt.get("baz");
      * // => {bar: "baz"}
      *
      * stmt.get();
-     * // => null
+     * // => {bar: "baz"}
      *
      * stmt.get("foo");
      * // => {bar: "foo"}


### PR DESCRIPTION
Fixes #26622.

The get() and ll() examples claimed a bare call after a bound call returns 
ull / [], contradicting the documented @param behavior (If omitted, the statement is run with the last bound values). Reordered both examples to the sequence from the issue: bare call first, then bound, then bare again showing the sticky values.