### PR TITLE
bundler: read ns["a" + "b"] as the export "ab", not "a"

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -997,6 +997,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let unwrapped = e_.index.unwrap_inlined();
                 if let Some(mut s) = unwrapped.data.e_string() {
                     if !s.is_utf16 {
+                        // A folded `"a" + "b"` is a rope whose `data` is only "a".
+                        s.resolve_rope_if_needed(p.arena);
+
                         // "a['b' + '']" => "a.b"
                         // "enum A { B = 'b' }; a[A.B]" => "a.b"
                         if p.options.features.minify_syntax && s.is_identifier(p.arena) {

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -1219,6 +1219,43 @@ describe("bundler", () => {
     },
   });
 
+  // A folded `"a" + "b"` key reads `ab`. The parser keeps the folded string
+  // as a chain of parts, and the first part alone is "a".
+  for (const splitting of [true, false]) {
+    itBundled(`dynamic_import_dce/FoldedStringKey${splitting ? "Splitting" : "NoSplit"}`, {
+      files: {
+        "/entry.js": /* js */ `
+          const ns = await import("./lib.js");
+          console.log(ns["a" + "b"], ns["a" + "-b"], ns["" + "x"]);
+        `,
+        "/lib.js": `export const a = "a", ab = "ab", x = "x"; export { x as "a-b" };`,
+      },
+      splitting,
+      format: "esm",
+      outdir: "/out",
+      run: { file: "/out/entry.js", stdout: "ab x x" },
+    });
+
+    // An enum member is folded without minification too.
+    itBundled(`dynamic_import_dce/FoldedEnumKeyNarrows${splitting ? "Splitting" : "NoSplit"}`, {
+      files: {
+        "/entry.ts": /* ts */ `
+          enum K { AB = "a" + "b", X = "" + "x" }
+          const ns = await import("./lib.js");
+          console.log(ns[K.AB], ns[K.X]);
+        `,
+        "/lib.js": `export const a = "DROPPED", ab = "ab", x = "x";`,
+      },
+      splitting,
+      format: "esm",
+      outdir: "/out",
+      run: { file: "/out/entry.js", stdout: "ab x" },
+      onAfterBundle(api) {
+        expect(readAllOutputs(api.outdir)).not.toContain("DROPPED");
+      },
+    });
+  }
+
   // rolldown: chunk_merging/already_loaded_unexported_read_namespace_extraction
   // — a tracked read of a name the importee does not export stays `undefined`
   // and does not disturb the exports that do exist.

--- a/test/bundler/esbuild/importstar.test.ts
+++ b/test/bundler/esbuild/importstar.test.ts
@@ -1955,6 +1955,19 @@ describe.concurrent("bundler", () => {
     dce: true,
     run: { stdout: "a ext" },
   });
+  // The enum members fold to the keys "ab" and "x". The first part of each
+  // folded string is "a" and "".
+  itBundled("importstar/MemberOfImportFoldedStringKey", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as ns from './lib'
+        enum K { AB = 'a' + 'b', X = '' + 'x' }
+        console.log(ns[K.AB], ns[K.X])
+      `,
+      "/lib.js": `export const a = 'a', ab = 'ab', x = 'x'`,
+    },
+    run: { stdout: "ab x" },
+  });
   for (const deprecatedNamespaceObjectSetters of [true, false]) {
     itBundled(`importstar/NamespaceObjectSetters${deprecatedNamespaceObjectSetters ? "Deprecated" : "Off"}`, {
       files: {


### PR DESCRIPTION
### Problem
- `bun build` reads `ns["a" + "b"]` as the export `a`. With `const ns = await import("./m.mjs")`, the bundle prints `A` where Node prints `AB`. `ns["" + "x"]` prints `undefined`. The build shows no warning.
- The cause is in `e_index` (`src/js_parser/visit/visit_expr.rs:1036`). It gives `s.data` of the key to `maybe_rewrite_property_access` and `record_import_property_use`. For a folded key, `data` holds only the first part.

### Fix
- Flatten the key with `resolve_rope_if_needed` before the visitor reads it.
- The printer already reads the flattened key. So the parser and the printer now use the same name. The minify path already flattened this node through `is_identifier`.
- Verified: five new cases in `test/bundler/bundler_dynamic_import_dce.test.ts` and `test/bundler/esbuild/importstar.test.ts`. All five fail on main. The other bundler suites I ran are in the notes.

### Background
- Constant folding makes `"a" + "b"` one `E::String` and copies no bytes. The node keeps `"a"` in `data` and links `"b"` through `next`. `resolve_rope_if_needed` joins the parts into `data`.
- Folding runs with `--minify-syntax`, in enum initializers, and in the arguments of `import()` and `require()`. `e_import` restores its flag to `true`, so folding stays on after an `import()`. #39018 fixes that flag.
- `import * as ns` has the same bug with an enum key, also in builds from before #32557. #32557 records a key on an `import()` namespace as a use. #41186 binds that key to the export. Together they make the bug reachable from `await import()`.

<details><summary>Notes</summary>

Repro from the report:

```sh
printf 'export const a = "A"; export const ab = "AB"; export const x = "X";\nexport { x as "a-b" };\n' > m.mjs
cat > e.mjs <<'EOF'
const ns = await import("./m.mjs");
const v = ns["" + "x"];
console.log(JSON.stringify({ "ns['a'+'b']": ns["a" + "b"], "ns['a'+'-b']": ns["a" + "-b"], "ns[''+'x']": typeof v === "string" ? v : Object.prototype.toString.call(v) }));
EOF
bun build ./e.mjs --target=bun --outfile=o.js && bun o.js
```

- main (473335d85f): `{"ns['a'+'b']":"A","ns['a'+'-b']":"A","ns[''+'x']":"[object Undefined]"}`. The bundle has `"ns['a'+'b']": a`.
- This branch: `{"ns['a'+'b']":"AB","ns['a'+'-b']":"X","ns[''+'x']":"X"}`, with and without `--splitting`. The unused export `a` is dropped.

Static namespace, on a build from before #32557 (a6c4cc276b):

```ts
import * as ns from "./m.mjs";
enum K { AB = "a" + "b", X = "" + "x" }
console.log(ns[K.AB], ns[K.X]);
```

The bundle prints `A undefined` and warns `Import "" will always be undefined because there is no matching export in "m.mjs"`.

- The `"a" + "b"` tests depend on the flag that stays on after `import()`. If #39018 lands, those keys are not folded without minify, and the namespace stays whole. The output is still correct, so those tests still pass. The enum keys fold in all cases, so the enum tests keep this line covered.
- #38944 (open, conflicts with main) adds the same call as part of a wider change to rope readers. If it lands first, this PR reduces to its tests.
- Two other readers in the same visitor (`"str"[i]` and `"str".charCodeAt(i)`) read only the first part. They compare the index with the length of that part, so the result stays correct.
- Suites run with the debug build, all pass: `bundler_dynamic_import_dce`, `esbuild/importstar`, `esbuild/importstar_ts`, `esbuild/ts`, `esbuild/dce`, `bundler_string`, `bundler_minify`, `transpiler_constant_fold_eqeq`, `bundler_edgecase`, `transpiler/transpiler.test.js`, `bundler_barrel`, `bundler_splitting`.

</details>
