### PR TITLE
bundler: keep this for a method call on a lifted CommonJS export

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -158,8 +158,7 @@ pub struct CommonJSNamedExport {
     pub decl_value: CommonJSExportValue,
 }
 
-/// The value in `exports.name = value`, as far as a call of the export can
-/// read `this`.
+/// The kind of value in `exports.name = value`, for a call of the export.
 #[derive(Clone, Copy, Default)]
 pub enum CommonJSExportValue {
     #[default]

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -163,7 +163,7 @@ pub struct CommonJSNamedExport {
 pub enum CommonJSExportValue {
     #[default]
     Other,
-    /// An arrow function, or a function expression that does not read `this`.
+    /// A function or an arrow function with no `this` inside.
     FunctionIgnoringThis,
     /// An identifier, as in `exports.name = name`.
     Identifier(Ref),

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -152,6 +152,22 @@ impl<'a> Ast<'a> {
 pub struct CommonJSNamedExport {
     pub loc_ref: LocRef,
     pub needs_decl: bool,
+    /// How many times the file assigns `exports.name`.
+    pub assign_count: u32,
+    /// The value of the top-level statement that declares the export.
+    pub decl_value: CommonJSExportValue,
+}
+
+/// The value in `exports.name = value`, as far as a call of the export can
+/// read `this`.
+#[derive(Clone, Copy, Default)]
+pub enum CommonJSExportValue {
+    #[default]
+    Other,
+    /// An arrow function, or a function expression that does not read `this`.
+    FunctionIgnoringThis,
+    /// An identifier, as in `exports.name = name`.
+    Identifier(Ref),
 }
 
 // `Ast` is held in arena-allocated structures whose `Drop` never runs (the

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1090,10 +1090,18 @@ pub enum PartTag {
 pub type PartSymbolUseMap = ArrayHashMap<Ref, symbol::Use, AutoContext, bun_alloc::AstAlloc>;
 pub type PartSymbolPropertyUseMap = ArrayHashMap<
     Ref,
-    StringHashMap<symbol::Use, bun_alloc::AstAlloc>,
+    StringHashMap<PropertyUse, bun_alloc::AstAlloc>,
     AutoContext,
     bun_alloc::AstAlloc,
 >;
+
+/// The reads of one `X.name` in `Part::import_symbol_property_uses`.
+#[derive(Default, Clone, Copy)]
+pub struct PropertyUse {
+    pub count_estimate: u32,
+    /// Some read is called, as in `X.name()`. That call passes `X` as `this`.
+    pub is_call_target: bool,
+}
 
 impl Default for Part {
     fn default() -> Self {

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1099,7 +1099,7 @@ pub type PartSymbolPropertyUseMap = ArrayHashMap<
 #[derive(Default, Clone, Copy)]
 pub struct PropertyUse {
     pub count_estimate: u32,
-    /// Some read is called, as in `X.name()`. That call passes `X` as `this`.
+    /// Some read is called, as `X.name()` or a template tag, with `X` as `this`.
     pub is_call_target: bool,
 }
 

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -116,8 +116,7 @@ bitflags::bitflags! {
         /// Renaming can also break any identifier used inside a "with" statement.
         const MUST_NOT_BE_RENAMED = 1 << 2;
 
-        /// A `var` or a sloppy-mode block function of the same name merged
-        /// into this function declaration, so it can set the binding.
+        /// A `var` of the same name merged into this function declaration.
         const REDECLARED_BY_VAR = 1 << 3;
 
         const REMOVE_OVERWRITTEN_FUNCTION_DECLARATION = 1 << 4;
@@ -130,8 +129,7 @@ bitflags::bitflags! {
         /// An import item for `ns.name` that some use calls, as `ns.name()`.
         const CALLED_AS_METHOD = 1 << 6;
 
-        /// A call of this function declaration, or of this lifted CommonJS
-        /// export, does not read `this`.
+        /// A call of this function declaration or lifted export ignores `this`.
         const CALL_IGNORES_THIS = 1 << 7;
     }
 }

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -116,10 +116,8 @@ bitflags::bitflags! {
         /// Renaming can also break any identifier used inside a "with" statement.
         const MUST_NOT_BE_RENAMED = 1 << 2;
 
-        /// A function declaration that a `var` of the same name merged into,
-        /// from the same scope or a nested one (a sloppy-mode block function
-        /// hoists like a `var`). It can set the binding with no assignment
-        /// expression.
+        /// A `var` or a sloppy-mode block function of the same name merged
+        /// into this function declaration, so it can set the binding.
         const REDECLARED_BY_VAR = 1 << 3;
 
         const REMOVE_OVERWRITTEN_FUNCTION_DECLARATION = 1 << 4;
@@ -129,14 +127,11 @@ bitflags::bitflags! {
         /// chain. Read by HMR live bindings and the printer's same-target fold.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
 
-        /// An import item generated for `ns.name` where some use calls it,
-        /// as in `ns.name()`. That call passes `ns` as `this`.
+        /// An import item for `ns.name` that some use calls, as `ns.name()`.
         const CALLED_AS_METHOD = 1 << 6;
 
-        /// On a function declaration: the function does not read `this`. On a
-        /// lifted CommonJS export (`exports.name = function () {}`): the file
-        /// assigns the export once, to such a function. A call through the
-        /// module namespace can then drop the namespace as `this`.
+        /// A call of this function declaration, or of this lifted CommonJS
+        /// export, does not read `this`.
         const CALL_IGNORES_THIS = 1 << 7;
     }
 }

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -122,6 +122,16 @@ bitflags::bitflags! {
         /// `arguments` object can). Set on the root of the symbol's link
         /// chain. Read by HMR live bindings and the printer's same-target fold.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
+
+        /// An import item generated for `ns.name` where some use calls it,
+        /// as in `ns.name()`. That call passes `ns` as `this`.
+        const CALLED_AS_METHOD = 1 << 6;
+
+        /// On a function declaration: the function does not read `this`. On a
+        /// lifted CommonJS export (`exports.name = function () {}`): the file
+        /// assigns the export once, to such a function. A call through the
+        /// module namespace can then drop the namespace as `this`.
+        const CALL_IGNORES_THIS = 1 << 7;
     }
 }
 
@@ -147,6 +157,8 @@ symbol_flag_accessors! {
     must_not_be_renamed, set_must_not_be_renamed => MUST_NOT_BE_RENAMED;
     remove_overwritten_function_declaration, set_remove_overwritten_function_declaration => REMOVE_OVERWRITTEN_FUNCTION_DECLARATION;
     has_been_assigned_to, set_has_been_assigned_to => HAS_BEEN_ASSIGNED_TO;
+    called_as_method, set_called_as_method => CALLED_AS_METHOD;
+    call_ignores_this, set_call_ignores_this => CALL_IGNORES_THIS;
 }
 
 const _: () = assert!(core::mem::size_of::<Option<bun_alloc::AstBox<G::NamespaceAlias>>>() == 8);

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -116,6 +116,12 @@ bitflags::bitflags! {
         /// Renaming can also break any identifier used inside a "with" statement.
         const MUST_NOT_BE_RENAMED = 1 << 2;
 
+        /// A function declaration that a `var` of the same name merged into,
+        /// from the same scope or a nested one (a sloppy-mode block function
+        /// hoists like a `var`). It can set the binding with no assignment
+        /// expression.
+        const REDECLARED_BY_VAR = 1 << 3;
+
         const REMOVE_OVERWRITTEN_FUNCTION_DECLARATION = 1 << 4;
 
         /// The file assigns this variable after its declaration (or a mapped
@@ -155,6 +161,7 @@ macro_rules! symbol_flag_accessors {
 symbol_flag_accessors! {
     must_start_with_capital_letter_for_jsx, set_must_start_with_capital_letter_for_jsx => MUST_START_WITH_CAPITAL_LETTER_FOR_JSX;
     must_not_be_renamed, set_must_not_be_renamed => MUST_NOT_BE_RENAMED;
+    redeclared_by_var, set_redeclared_by_var => REDECLARED_BY_VAR;
     remove_overwritten_function_declaration, set_remove_overwritten_function_declaration => REMOVE_OVERWRITTEN_FUNCTION_DECLARATION;
     has_been_assigned_to, set_has_been_assigned_to => HAS_BEEN_ASSIGNED_TO;
     called_as_method, set_called_as_method => CALLED_AS_METHOD;

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4283,11 +4283,8 @@ impl<'a> LinkerContext<'a> {
                 })
     }
 
-    /// `X.name()` passes `X` as `this`. Must the call keep `X` when `X.name`
-    /// resolved to export `ref_` of `source_index`? A call through the
-    /// namespace of an ES module drops it. A lifted CommonJS export is a
-    /// property of `module.exports`, so the call keeps it unless the parser
-    /// found that the function does not read `this`.
+    /// Must `X.name()` keep `X` as `this`, where `X.name` is export `ref_`?
+    /// Only a lifted CommonJS export can need it, as a `module.exports` property.
     fn method_call_needs_this(&self, source_index: crate::IndexInt, ref_: Ref) -> bool {
         self.graph.ast.items_flags()[source_index as usize]
             .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
@@ -4298,9 +4295,7 @@ impl<'a> LinkerContext<'a> {
                 .is_some_and(|symbol| symbol.call_ignores_this())
     }
 
-    /// `ns.name()` on `import * as ns` calls the item that the parser made for
-    /// `ns.name`. An item that is not bound prints as `ns.name`, so the call
-    /// keeps `ns` as `this`.
+    /// `ns.name()` for `import * as ns`. An unbound item prints as `ns.name`.
     fn method_call_item_needs_this(
         &self,
         import_ref: Ref,
@@ -4651,11 +4646,9 @@ impl<'a> LinkerContext<'a> {
         }
         let id = source_index as usize;
         let parts_len = self.graph.ast.items_parts()[id].len();
-        // `X.name()` passes `X` as `this`. The printer substitutes a binding at
-        // every `X.name` in the file, so a call that needs that `this` keeps
-        // each `X.name` in the file as written. The first read of an export
-        // that can read `this` builds the set, before any such read is bound.
-        // The loop removes the reads it binds, and those are of other exports.
+        // The printer substitutes a binding at each `X.name` of the file, so a
+        // call `X.name()` that needs `X` as `this` keeps all of them. The set
+        // is built before the loop binds any read that can need `this`.
         let mut called: Option<HashMap<(Ref, bun_ast::StoreStr), ()>> = None;
         let mut accesses: Vec<(Ref, crate::IndexInt, bun_ast::StoreStr, u32)> = Vec::new();
         let mut dependencies: Vec<Dependency> = Vec::new();

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4646,20 +4646,10 @@ impl<'a> LinkerContext<'a> {
         let parts_len = self.graph.ast.items_parts()[id].len();
         // `X.name()` passes `X` as `this`. The printer substitutes a binding at
         // every `X.name` in the file, so a call that needs that `this` keeps
-        // each `X.name` in the file as written.
-        let mut called: HashMap<(Ref, bun_ast::StoreStr), ()> = HashMap::default();
-        for part in self.graph.ast.items_parts()[id].as_slice() {
-            let Some(uses) = part.import_symbol_property_uses.as_ref() else {
-                continue;
-            };
-            for (base, properties) in uses.keys().iter().zip(uses.values()) {
-                for (name, prop_use) in properties.iter() {
-                    if prop_use.is_call_target {
-                        called.insert((*base, bun_ast::StoreStr::new(name)), ());
-                    }
-                }
-            }
-        }
+        // each `X.name` in the file as written. The first read of an export
+        // that can read `this` builds the set, before any such read is bound.
+        // The loop removes the reads it binds, and those are of other exports.
+        let mut called: Option<HashMap<(Ref, bun_ast::StoreStr), ()>> = None;
         let mut accesses: Vec<(Ref, crate::IndexInt, bun_ast::StoreStr, u32)> = Vec::new();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let mut bound_bases: Vec<Ref> = Vec::new();
@@ -4742,8 +4732,10 @@ impl<'a> LinkerContext<'a> {
                 let Some(resolved) = member_resolutions.get(&(target_source, name)).unwrap() else {
                     continue;
                 };
-                if called.contains_key(&(base, name))
-                    && self.method_call_needs_this(resolved.source_index, resolved.r#ref)
+                if self.method_call_needs_this(resolved.source_index, resolved.r#ref)
+                    && called
+                        .get_or_insert_with(|| self.called_import_properties(id))
+                        .contains_key(&(base, name))
                 {
                     continue;
                 }
@@ -4819,6 +4811,24 @@ impl<'a> LinkerContext<'a> {
                 }
             }
         }
+    }
+
+    /// The `X.name` reads in file `id` that some use calls, as in `X.name()`.
+    fn called_import_properties(&self, id: usize) -> HashMap<(Ref, bun_ast::StoreStr), ()> {
+        let mut called = HashMap::default();
+        for part in self.graph.ast.items_parts()[id].as_slice() {
+            let Some(uses) = part.import_symbol_property_uses.as_ref() else {
+                continue;
+            };
+            for (base, properties) in uses.keys().iter().zip(uses.values()) {
+                for (name, prop_use) in properties.iter() {
+                    if prop_use.is_call_target {
+                        called.insert((*base, bun_ast::StoreStr::new(name)), ());
+                    }
+                }
+            }
+        }
+        called
     }
 
     /// Records a `Normal`/`NormalAndNamespace` match for `import_ref`.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4284,7 +4284,6 @@ impl<'a> LinkerContext<'a> {
     }
 
     /// Must `X.name()` keep `X` as `this`, where `X.name` is export `ref_`?
-    /// Only a lifted CommonJS export can need it, as a `module.exports` property.
     fn method_call_needs_this(&self, source_index: crate::IndexInt, ref_: Ref) -> bool {
         self.graph.ast.items_flags()[source_index as usize]
             .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
@@ -4644,101 +4643,135 @@ impl<'a> LinkerContext<'a> {
         if self.options.output_format == Format::InternalBakeDev {
             return;
         }
+        /// One `X.name` read that can bind to an export.
+        struct PropertyAccess {
+            part_index: usize,
+            base: Ref,
+            target_source: crate::IndexInt,
+            name: bun_ast::StoreStr,
+            count: u32,
+            is_call_target: bool,
+        }
+
         let id = source_index as usize;
         let parts_len = self.graph.ast.items_parts()[id].len();
-        // The printer substitutes a binding at each `X.name` of the file, so a
-        // call `X.name()` that needs `X` as `this` keeps all of them. The set
-        // is built before the loop binds any read that can need `this`.
-        let mut called: Option<HashMap<(Ref, bun_ast::StoreStr), ()>> = None;
-        let mut accesses: Vec<(Ref, crate::IndexInt, bun_ast::StoreStr, u32)> = Vec::new();
-        let mut dependencies: Vec<Dependency> = Vec::new();
-        let mut bound_bases: Vec<Ref> = Vec::new();
+        let mut accesses: Vec<PropertyAccess> = Vec::new();
         for part_index in 0..parts_len {
-            accesses.clear();
-            dependencies.clear();
-            bound_bases.clear();
-            {
-                let part = &self.graph.ast.items_parts()[id].as_slice()[part_index];
-                let Some(uses) = part.import_symbol_property_uses.as_ref() else {
+            let part = &self.graph.ast.items_parts()[id].as_slice()[part_index];
+            let Some(uses) = part.import_symbol_property_uses.as_ref() else {
+                continue;
+            };
+            for (base, properties) in uses.keys().iter().zip(uses.values()) {
+                let Some(import_data) = imports_to_bind.get(base) else {
                     continue;
                 };
-                for (base, properties) in uses.keys().iter().zip(uses.values()) {
-                    let Some(import_data) = imports_to_bind.get(base) else {
+                let target = import_data.data;
+                let target_source = target.source_index.get();
+                if !self.is_esm_namespace_ref(target_source, target.import_ref) {
+                    continue;
+                }
+                let resolved_exports =
+                    &self.graph.meta.items_resolved_exports()[target_source as usize];
+                for (name, prop_use) in properties.iter() {
+                    // Not a static export of the target (missing, or only reachable
+                    // through `export *` from CommonJS): keep the property access.
+                    let name = if let Some(index) = resolved_exports.get_index(name) {
+                        bun_ast::StoreStr::new(&resolved_exports.keys()[index])
+                    } else if &**name == b"default"
+                        && self.graph.ast.items_flags()[target_source as usize]
+                            .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+                        && !Self::lifted_default_import_needs_wrapper(
+                            self.graph.ast.items_module_type()[id],
+                            &self.graph.ast.items_named_exports()[target_source as usize],
+                        )
+                    {
+                        // `default` of a lifted CommonJS module is `module.exports`, the
+                        // namespace itself, the same as `ns.default` on `import * as ns`.
+                        let name = bun_ast::StoreStr::new(b"default");
+                        member_resolutions
+                            .entry((target_source, name))
+                            .or_insert_with(|| {
+                                Some(ImportMemberResolution {
+                                    source_index: target_source,
+                                    r#ref: target.import_ref,
+                                    re_exports: Vec::new(),
+                                })
+                            });
+                        name
+                    } else {
                         continue;
                     };
-                    let target = import_data.data;
-                    let target_source = target.source_index.get();
-                    if !self.is_esm_namespace_ref(target_source, target.import_ref) {
-                        continue;
-                    }
-                    let resolved_exports =
-                        &self.graph.meta.items_resolved_exports()[target_source as usize];
-                    for (name, prop_use) in properties.iter() {
-                        // Not a static export of the target (missing, or only reachable
-                        // through `export *` from CommonJS): keep the property access.
-                        if let Some(index) = resolved_exports.get_index(name) {
-                            let name = bun_ast::StoreStr::new(&resolved_exports.keys()[index]);
-                            accesses.push((*base, target_source, name, prop_use.count_estimate));
-                        } else if &**name == b"default"
-                            && self.graph.ast.items_flags()[target_source as usize]
-                                .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
-                            && !Self::lifted_default_import_needs_wrapper(
-                                self.graph.ast.items_module_type()[id],
-                                &self.graph.ast.items_named_exports()[target_source as usize],
-                            )
-                        {
-                            // `default` of a lifted CommonJS module is `module.exports`, the
-                            // namespace itself, the same as `ns.default` on `import * as ns`.
-                            let name = bun_ast::StoreStr::new(b"default");
-                            member_resolutions
-                                .entry((target_source, name))
-                                .or_insert_with(|| {
-                                    Some(ImportMemberResolution {
-                                        source_index: target_source,
-                                        r#ref: target.import_ref,
-                                        re_exports: Vec::new(),
-                                    })
-                                });
-                            accesses.push((*base, target_source, name, prop_use.count_estimate));
-                        }
-                    }
+                    accesses.push(PropertyAccess {
+                        part_index,
+                        base: *base,
+                        target_source,
+                        name,
+                        count: prop_use.count_estimate,
+                        is_call_target: prop_use.is_call_target,
+                    });
                 }
             }
+        }
 
-            for &(base, target_source, name, count) in &accesses {
-                if !member_resolutions.contains_key(&(target_source, name)) {
-                    self.cycle_detector.clear();
-                    let mut re_exports: bun_alloc::AstVec<Dependency> = bun_alloc::AstAlloc::vec();
-                    let result = self.match_import_with_export_inner(
-                        ImportTracker {
-                            source_index: crate::Index::init(target_source),
-                            ..Default::default()
-                        },
-                        Some((target_source, name)),
-                        &mut re_exports,
-                    );
-                    let resolved = match result.kind {
-                        MatchImportKind::Normal | MatchImportKind::NormalAndNamespace => {
-                            Some(ImportMemberResolution {
-                                source_index: result.source_index,
-                                r#ref: result.r#ref,
-                                re_exports: re_exports.to_vec(),
-                            })
-                        }
-                        _ => None,
-                    };
-                    member_resolutions.insert((target_source, name), resolved);
+        for access in &accesses {
+            let key = (access.target_source, access.name);
+            if member_resolutions.contains_key(&key) {
+                continue;
+            }
+            self.cycle_detector.clear();
+            let mut re_exports: bun_alloc::AstVec<Dependency> = bun_alloc::AstAlloc::vec();
+            let result = self.match_import_with_export_inner(
+                ImportTracker {
+                    source_index: crate::Index::init(access.target_source),
+                    ..Default::default()
+                },
+                Some(key),
+                &mut re_exports,
+            );
+            let resolved = match result.kind {
+                MatchImportKind::Normal | MatchImportKind::NormalAndNamespace => {
+                    Some(ImportMemberResolution {
+                        source_index: result.source_index,
+                        r#ref: result.r#ref,
+                        re_exports: re_exports.to_vec(),
+                    })
                 }
-                let Some(resolved) = member_resolutions.get(&(target_source, name)).unwrap() else {
+                _ => None,
+            };
+            member_resolutions.insert(key, resolved);
+        }
+
+        // The printer substitutes a binding at each `X.name` of the file, so a
+        // call that needs `X` as `this` keeps every `X.name` of the file.
+        let mut keeps_this: Vec<(Ref, bun_ast::StoreStr)> = Vec::new();
+        for access in &accesses {
+            if access.is_call_target
+                && let Some(resolved) = member_resolutions
+                    .get(&(access.target_source, access.name))
+                    .unwrap()
+                && self.method_call_needs_this(resolved.source_index, resolved.r#ref)
+            {
+                keeps_this.push((access.base, access.name));
+            }
+        }
+
+        let mut dependencies: Vec<Dependency> = Vec::new();
+        let mut bound_bases: Vec<Ref> = Vec::new();
+        for part_accesses in accesses.chunk_by(|a, b| a.part_index == b.part_index) {
+            let part_index = part_accesses[0].part_index;
+            dependencies.clear();
+            bound_bases.clear();
+            for access in part_accesses {
+                let (base, name, count) = (access.base, access.name, access.count);
+                if keeps_this.contains(&(base, name)) {
+                    continue;
+                }
+                let Some(resolved) = member_resolutions
+                    .get(&(access.target_source, name))
+                    .unwrap()
+                else {
                     continue;
                 };
-                if self.method_call_needs_this(resolved.source_index, resolved.r#ref)
-                    && called
-                        .get_or_insert_with(|| self.called_import_properties(id))
-                        .contains_key(&(base, name))
-                {
-                    continue;
-                }
 
                 if !bound_bases.contains(&base) {
                     // First bound member of `base` in this part: depend on this
@@ -4811,24 +4844,6 @@ impl<'a> LinkerContext<'a> {
                 }
             }
         }
-    }
-
-    /// The `X.name` reads in file `id` that some use calls, as in `X.name()`.
-    fn called_import_properties(&self, id: usize) -> HashMap<(Ref, bun_ast::StoreStr), ()> {
-        let mut called = HashMap::default();
-        for part in self.graph.ast.items_parts()[id].as_slice() {
-            let Some(uses) = part.import_symbol_property_uses.as_ref() else {
-                continue;
-            };
-            for (base, properties) in uses.keys().iter().zip(uses.values()) {
-                for (name, prop_use) in properties.iter() {
-                    if prop_use.is_call_target {
-                        called.insert((*base, bun_ast::StoreStr::new(name)), ());
-                    }
-                }
-            }
-        }
-        called
     }
 
     /// Records a `Normal`/`NormalAndNamespace` match for `import_ref`.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4487,7 +4487,7 @@ impl<'a> LinkerContext<'a> {
         });
 
         // Items of `ns.name()` left unbound, each with its `ns`.
-        let mut method_call_items: Vec<(Ref, Ref)> = Vec::new();
+        let mut method_call_items: HashMap<Ref, Ref> = HashMap::default();
         for &i in &order {
             let i = i as usize;
             // SAFETY: `keys`/`values` point into stable SoA storage (see above); read-only deref.
@@ -4523,7 +4523,7 @@ impl<'a> LinkerContext<'a> {
                 MatchImportKind::Normal
                     if self.method_call_item_needs_this(import_ref, named_import, &result) =>
                 {
-                    method_call_items.push((import_ref, named_import.namespace_ref));
+                    method_call_items.insert(import_ref, named_import.namespace_ref);
                 }
                 MatchImportKind::Normal | MatchImportKind::NormalAndNamespace => {
                     self.bind_matched_import(imports_to_bind, import_ref, &result, re_exports);
@@ -4603,16 +4603,23 @@ impl<'a> LinkerContext<'a> {
 
         // A part that calls such an item reads its namespace.
         if !method_call_items.is_empty() {
+            let mut namespace_uses: Vec<(Ref, u32)> = Vec::new();
             for part in self.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice() {
-                for &(item, namespace_ref) in &method_call_items {
-                    let Some(count) = part
-                        .symbol_uses
-                        .get(&item)
-                        .map(|item_use| item_use.count_estimate)
-                        .filter(|&count| count > 0)
-                    else {
+                namespace_uses.clear();
+                for (item, item_use) in part
+                    .symbol_uses
+                    .keys()
+                    .iter()
+                    .zip(part.symbol_uses.values())
+                {
+                    if item_use.count_estimate == 0 {
                         continue;
-                    };
+                    }
+                    if let Some(&namespace_ref) = method_call_items.get(item) {
+                        namespace_uses.push((namespace_ref, item_use.count_estimate));
+                    }
+                }
+                for &(namespace_ref, count) in &namespace_uses {
                     part.symbol_uses
                         .get_or_put_value(namespace_ref, Default::default())
                         .expect("OOM")

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4283,6 +4283,40 @@ impl<'a> LinkerContext<'a> {
                 })
     }
 
+    /// `X.name()` passes `X` as `this`. Must the call keep `X` when `X.name`
+    /// resolved to export `ref_` of `source_index`? A call through the
+    /// namespace of an ES module drops it. A lifted CommonJS export is a
+    /// property of `module.exports`, so the call keeps it unless the parser
+    /// found that the function does not read `this`.
+    fn method_call_needs_this(&self, source_index: crate::IndexInt, ref_: Ref) -> bool {
+        self.graph.ast.items_flags()[source_index as usize]
+            .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+            && !self
+                .graph
+                .symbols
+                .get_const(ref_)
+                .is_some_and(|symbol| symbol.call_ignores_this())
+    }
+
+    /// `ns.name()` on `import * as ns` calls the item that the parser made for
+    /// `ns.name`. An item that is not bound prints as `ns.name`, so the call
+    /// keeps `ns` as `this`.
+    fn method_call_item_needs_this(
+        &self,
+        import_ref: Ref,
+        named_import: &NamedImport,
+        result: &MatchImport,
+    ) -> bool {
+        self.options.output_format != Format::InternalBakeDev
+            && named_import.namespace_ref.is_valid()
+            && self
+                .graph
+                .symbols
+                .get_const(import_ref)
+                .is_some_and(|symbol| symbol.called_as_method() && symbol.namespace_alias.is_some())
+            && self.method_call_needs_this(result.source_index, result.r#ref)
+    }
+
     fn is_esm_namespace_ref(&self, source_index: crate::IndexInt, ref_: Ref) -> bool {
         let id = source_index as usize;
         id < self.graph.ast.len()
@@ -4452,6 +4486,8 @@ impl<'a> LinkerContext<'a> {
                 .cmp(&(&*keys)[b as usize].inner_index())
         });
 
+        // Items of `ns.name()` left unbound, each with its `ns`.
+        let mut method_call_items: Vec<(Ref, Ref)> = Vec::new();
         for &i in &order {
             let i = i as usize;
             // SAFETY: `keys`/`values` point into stable SoA storage (see above); read-only deref.
@@ -4484,6 +4520,11 @@ impl<'a> LinkerContext<'a> {
             }
 
             match result.kind {
+                MatchImportKind::Normal
+                    if self.method_call_item_needs_this(import_ref, named_import, &result) =>
+                {
+                    method_call_items.push((import_ref, named_import.namespace_ref));
+                }
                 MatchImportKind::Normal | MatchImportKind::NormalAndNamespace => {
                     self.bind_matched_import(imports_to_bind, import_ref, &result, re_exports);
                 }
@@ -4560,6 +4601,27 @@ impl<'a> LinkerContext<'a> {
             }
         }
 
+        // A part that calls such an item reads its namespace.
+        if !method_call_items.is_empty() {
+            for part in self.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice() {
+                for &(item, namespace_ref) in &method_call_items {
+                    let Some(count) = part
+                        .symbol_uses
+                        .get(&item)
+                        .map(|item_use| item_use.count_estimate)
+                        .filter(|&count| count > 0)
+                    else {
+                        continue;
+                    };
+                    part.symbol_uses
+                        .get_or_put_value(namespace_ref, Default::default())
+                        .expect("OOM")
+                        .value_ptr
+                        .count_estimate += count;
+                }
+            }
+        }
+
         self.bind_import_property_accesses(source_index, imports_to_bind, member_resolutions);
     }
 
@@ -4582,6 +4644,22 @@ impl<'a> LinkerContext<'a> {
         }
         let id = source_index as usize;
         let parts_len = self.graph.ast.items_parts()[id].len();
+        // `X.name()` passes `X` as `this`. The printer substitutes a binding at
+        // every `X.name` in the file, so a call that needs that `this` keeps
+        // each `X.name` in the file as written.
+        let mut called: HashMap<(Ref, bun_ast::StoreStr), ()> = HashMap::default();
+        for part in self.graph.ast.items_parts()[id].as_slice() {
+            let Some(uses) = part.import_symbol_property_uses.as_ref() else {
+                continue;
+            };
+            for (base, properties) in uses.keys().iter().zip(uses.values()) {
+                for (name, prop_use) in properties.iter() {
+                    if prop_use.is_call_target {
+                        called.insert((*base, bun_ast::StoreStr::new(name)), ());
+                    }
+                }
+            }
+        }
         let mut accesses: Vec<(Ref, crate::IndexInt, bun_ast::StoreStr, u32)> = Vec::new();
         let mut dependencies: Vec<Dependency> = Vec::new();
         let mut bound_bases: Vec<Ref> = Vec::new();
@@ -4664,6 +4742,11 @@ impl<'a> LinkerContext<'a> {
                 let Some(resolved) = member_resolutions.get(&(target_source, name)).unwrap() else {
                     continue;
                 };
+                if called.contains_key(&(base, name))
+                    && self.method_call_needs_this(resolved.source_index, resolved.r#ref)
+                {
+                    continue;
+                }
 
                 if !bound_bases.contains(&base) {
                     // First bound member of `base` in this part: depend on this

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -268,7 +268,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                             // Track how many times we've referenced this symbol
                             p.record_usage(ref_);
-                            if identifier_opts.is_call_target() {
+                            if identifier_opts.is_call_target() || identifier_opts.is_template_tag()
+                            {
                                 p.symbols[ref_.inner_index() as usize].set_called_as_method(true);
                             }
 

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -268,6 +268,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                             // Track how many times we've referenced this symbol
                             p.record_usage(ref_);
+                            if identifier_opts.is_call_target() {
+                                p.symbols[ref_.inner_index() as usize].set_called_as_method(true);
+                            }
 
                             return Some(
                                 p.handle_identifier(
@@ -485,6 +488,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                                     ref_: new_ref,
                                                 },
                                                 needs_decl: true,
+                                                assign_count: 0,
+                                                decl_value: Default::default(),
                                             },
                                         )
                                         .expect("unreachable");
@@ -494,6 +499,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     }
                                     new_ref
                                 };
+                                if identifier_opts.assign_target() != js_ast::AssignTarget::None {
+                                    p.count_commonjs_export_assignment(name);
+                                }
 
                                 p.ignore_usage(id.ref_);
                                 p.record_usage(ref_);
@@ -696,6 +704,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                                         ref_: new_ref,
                                                     },
                                                     needs_decl: true,
+                                                    assign_count: 0,
+                                                    decl_value: Default::default(),
                                                 },
                                             )
                                             .expect("unreachable");
@@ -705,6 +715,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         }
                                         new_ref
                                     };
+                                    if identifier_opts.assign_target() != js_ast::AssignTarget::None
+                                    {
+                                        p.count_commonjs_export_assignment(name);
+                                    }
 
                                     p.record_usage(ref_);
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -520,6 +520,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // syntactic constructs as appropriate.
     pub(crate) stmt_expr_value: js_ast::ExprData,
     pub(crate) call_target: js_ast::ExprData,
+    pub(crate) template_tag: js_ast::ExprData,
     pub(crate) delete_target: js_ast::ExprData,
     pub(crate) loop_body: js_ast::StmtData,
     pub(crate) module_scope: js_ast::StoreRef<js_ast::Scope>,
@@ -6439,7 +6440,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .get_or_put_value(name, Default::default())
             .expect("unreachable");
         inner_use.count_estimate += 1;
-        inner_use.is_call_target |= opts.is_call_target();
+        inner_use.is_call_target |= opts.is_call_target() || opts.is_template_tag();
         true
     }
 
@@ -9436,6 +9437,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             allow_in: true,
 
             call_target: null_expr_data(),
+            template_tag: null_expr_data(),
             delete_target: null_expr_data(),
             stmt_expr_value: null_expr_data(),
             loop_body: null_stmt_data(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -348,6 +348,9 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) commonjs_named_exports_needs_conversion: u32,
     pub(crate) had_commonjs_named_exports_this_visit: bool,
     pub(crate) commonjs_replacement_stmts: StmtNodeList,
+    /// How many `this` expressions the visit pass has seen. A statement that
+    /// lifts `exports.name = function () {}` compares it before and after.
+    pub(crate) this_expr_count: u32,
 
     pub(crate) parse_pass_symbol_uses: ParsePassSymbolUsageType<'a>,
 
@@ -5713,6 +5716,65 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.commonjs_named_exports_deoptimized = true;
     }
 
+    pub(crate) fn count_commonjs_export_assignment(&mut self, name: &[u8]) {
+        if let Some(export) = self.commonjs_named_exports.get_mut(name) {
+            export.assign_count = export.assign_count.saturating_add(1);
+        }
+    }
+
+    /// Sets `CALL_IGNORES_THIS` on each lifted export that the file assigns
+    /// once, to a function that does not read `this`.
+    fn mark_commonjs_exports_that_ignore_this(
+        &mut self,
+        top_level_symbols_to_parts: &bun_ast::ast_result::TopLevelSymbolToParts,
+    ) {
+        use bun_ast::ast_result::CommonJSExportValue;
+
+        // `exports.name = name`, where `name` is a function declaration:
+        // (export, function) pairs.
+        let mut declared_functions: Vec<(Ref, Ref)> = Vec::new();
+        for export in self.commonjs_named_exports.values() {
+            if export.assign_count != 1 {
+                continue;
+            }
+            match export.decl_value {
+                CommonJSExportValue::Other => {}
+                CommonJSExportValue::FunctionIgnoringThis => {
+                    self.symbols[export.loc_ref.ref_.inner_index() as usize]
+                        .set_call_ignores_this(true);
+                }
+                CommonJSExportValue::Identifier(function) => {
+                    let symbol = &self.symbols[function.inner_index() as usize];
+                    // An assignment or a second declaration (a `var` of the
+                    // same name) can change the value of the binding.
+                    if symbol.kind.is_function()
+                        && symbol.call_ignores_this()
+                        && !symbol.has_link()
+                        && !symbol.has_been_assigned_to()
+                        && top_level_symbols_to_parts
+                            .get(&function)
+                            .is_some_and(|parts| parts.len() == 1)
+                    {
+                        declared_functions.push((export.loc_ref.ref_, function));
+                    }
+                }
+            }
+        }
+        if declared_functions.is_empty() {
+            return;
+        }
+        // A `var` in a nested scope is linked to the function of the same name.
+        for symbol in self.symbols.iter() {
+            let link = symbol.link.get();
+            if link.is_valid() {
+                declared_functions.retain(|&(_, function)| function != link);
+            }
+        }
+        for (export, _) in declared_functions {
+            self.symbols[export.inner_index() as usize].set_call_ignores_this(true);
+        }
+    }
+
     pub(crate) fn maybe_keep_expr_symbol_name(
         &mut self,
         expr: Expr,
@@ -6396,6 +6458,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .get_or_put_value(name, Default::default())
             .expect("unreachable");
         inner_use.count_estimate += 1;
+        inner_use.is_call_target |= opts.is_call_target();
         true
     }
 
@@ -9064,6 +9127,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .unwrap_or(self.require_ref);
         let runtime_imports = core::mem::take(&mut self.runtime_imports);
 
+        if !self.commonjs_named_exports_deoptimized {
+            self.mark_commonjs_exports_that_ignore_this(&top_level_symbols_to_parts);
+        }
+
         // Re-tag the arena-backed buffer
         // into the `Ast` and leave the parser-side slot empty — a pointer move,
         // no realloc/memcpy. `Ast.{symbols,parts,import_records}` are now
@@ -9470,6 +9537,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             commonjs_named_exports_needs_conversion: u32::MAX,
             had_commonjs_named_exports_this_visit: false,
             commonjs_replacement_stmts: js_ast::StmtNodeList::EMPTY,
+            this_expr_count: 0,
             parse_pass_symbol_uses: None,
             has_commonjs_export_names: false,
             should_fold_typescript_constant_expressions: false,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3510,6 +3510,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             {
                                 // Silently merge this symbol into the existing symbol
                                 self.symbols[symbol_idx].link.set(member_in_scope.ref_);
+                                if Symbol::is_kind_function(existing_kind) {
+                                    self.symbols[existing_idx].set_redeclared_by_var(true);
+                                }
                                 // `StringHashMap` get_or_put already stores the key on insert and
                                 // cannot hand out `&mut K` (see StringHashMapGetOrPut docs), so
                                 // no key write is needed here.
@@ -5011,6 +5014,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // If these are both functions, remove the overwritten declaration
                     if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
                         self.symbols[symbol_idx].set_remove_overwritten_function_declaration(true);
+                    } else if kind.is_function() {
+                        self.symbols[ref_.inner_index() as usize].set_redeclared_by_var(true);
                     }
                 }
                 MR::BecomePrivateGetSetPair => {
@@ -5724,54 +5729,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// Sets `CALL_IGNORES_THIS` on each lifted export that the file assigns
     /// once, to a function that does not read `this`.
-    fn mark_commonjs_exports_that_ignore_this(
-        &mut self,
-        top_level_symbols_to_parts: &bun_ast::ast_result::TopLevelSymbolToParts,
-    ) {
+    fn mark_commonjs_exports_that_ignore_this(&mut self) {
         use bun_ast::ast_result::CommonJSExportValue;
 
-        // `exports.name = name`, where `name` is a function declaration:
-        // (export, function) pairs.
-        let mut declared_functions: Vec<(Ref, Ref)> = Vec::new();
         for export in self.commonjs_named_exports.values() {
             if export.assign_count != 1 {
                 continue;
             }
-            match export.decl_value {
-                CommonJSExportValue::Other => {}
-                CommonJSExportValue::FunctionIgnoringThis => {
-                    self.symbols[export.loc_ref.ref_.inner_index() as usize]
-                        .set_call_ignores_this(true);
-                }
-                CommonJSExportValue::Identifier(function) => {
-                    let symbol = &self.symbols[function.inner_index() as usize];
-                    // An assignment or a second declaration (a `var` of the
-                    // same name) can change the value of the binding.
-                    if symbol.kind.is_function()
+            let ignores_this = match export.decl_value {
+                CommonJSExportValue::Other => false,
+                CommonJSExportValue::FunctionIgnoringThis => true,
+                // `exports.name = name`: an assignment or a `var` of the same
+                // name can change the value of the binding.
+                CommonJSExportValue::Identifier(binding) => {
+                    let symbol = &self.symbols[binding.inner_index() as usize];
+                    symbol.kind.is_function()
                         && symbol.call_ignores_this()
-                        && !symbol.has_link()
+                        && !symbol.redeclared_by_var()
                         && !symbol.has_been_assigned_to()
-                        && top_level_symbols_to_parts
-                            .get(&function)
-                            .is_some_and(|parts| parts.len() == 1)
-                    {
-                        declared_functions.push((export.loc_ref.ref_, function));
-                    }
                 }
+            };
+            if ignores_this {
+                self.symbols[export.loc_ref.ref_.inner_index() as usize]
+                    .set_call_ignores_this(true);
             }
-        }
-        if declared_functions.is_empty() {
-            return;
-        }
-        // A `var` in a nested scope is linked to the function of the same name.
-        for symbol in self.symbols.iter() {
-            let link = symbol.link.get();
-            if link.is_valid() {
-                declared_functions.retain(|&(_, function)| function != link);
-            }
-        }
-        for (export, _) in declared_functions {
-            self.symbols[export.inner_index() as usize].set_call_ignores_this(true);
         }
     }
 
@@ -9128,7 +9109,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let runtime_imports = core::mem::take(&mut self.runtime_imports);
 
         if !self.commonjs_named_exports_deoptimized {
-            self.mark_commonjs_exports_that_ignore_this(&top_level_symbols_to_parts);
+            self.mark_commonjs_exports_that_ignore_this();
         }
 
         // Re-tag the arena-backed buffer

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -348,8 +348,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) commonjs_named_exports_needs_conversion: u32,
     pub(crate) had_commonjs_named_exports_this_visit: bool,
     pub(crate) commonjs_replacement_stmts: StmtNodeList,
-    /// How many `this` expressions the visit pass has seen. A statement that
-    /// lifts `exports.name = function () {}` compares it before and after.
+    /// How many `this` expressions the visit pass has seen.
     pub(crate) this_expr_count: u32,
 
     pub(crate) parse_pass_symbol_uses: ParsePassSymbolUsageType<'a>,
@@ -5728,8 +5727,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Sets `CALL_IGNORES_THIS` on each lifted export that the file assigns
-    /// once, to a function that does not read `this`.
+    /// Sets `CALL_IGNORES_THIS` on each lifted export whose calls ignore `this`.
     fn mark_commonjs_exports_that_ignore_this(&mut self) {
         use bun_ast::ast_result::CommonJSExportValue;
 
@@ -5740,8 +5738,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let ignores_this = match export.decl_value {
                 CommonJSExportValue::Other => false,
                 CommonJSExportValue::FunctionIgnoringThis => true,
-                // `exports.name = name`: an assignment or a `var` of the same
-                // name can change the value of the binding.
+                // An assignment or a `var` of the same name can change `name`.
                 CommonJSExportValue::Identifier(binding) => {
                     let symbol = &self.symbols[binding.inner_index() as usize];
                     symbol.kind.is_function()

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -910,6 +910,7 @@ impl IdentifierOpts {
     const IS_DELETE_TARGET: u8 = 1 << 2;
     const WAS_ORIGINALLY_IDENTIFIER: u8 = 1 << 3;
     const IS_CALL_TARGET: u8 = 1 << 4;
+    const IS_TEMPLATE_TAG: u8 = 1 << 5;
 
     #[inline]
     pub(crate) const fn assign_target(self) -> js_ast::AssignTarget {
@@ -937,6 +938,11 @@ impl IdentifierOpts {
     pub(crate) const fn is_call_target(self) -> bool {
         self.0 & Self::IS_CALL_TARGET != 0
     }
+    /// The tag of a tagged template, which passes `this` like a call target.
+    #[inline]
+    pub(crate) const fn is_template_tag(self) -> bool {
+        self.0 & Self::IS_TEMPLATE_TAG != 0
+    }
 
     // Builder-style helpers (this stays a packed u8 rather than a
     // named-field struct).
@@ -962,6 +968,11 @@ impl IdentifierOpts {
     #[inline]
     pub(crate) const fn with_is_call_target(mut self, v: bool) -> Self {
         self.0 = (self.0 & !Self::IS_CALL_TARGET) | ((v as u8) << 4);
+        self
+    }
+    #[inline]
+    pub(crate) const fn with_is_template_tag(mut self, v: bool) -> Self {
+        self.0 = (self.0 & !Self::IS_TEMPLATE_TAG) | ((v as u8) << 5);
         self
     }
 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -102,6 +102,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn e_this(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        p.this_expr_count = p.this_expr_count.wrapping_add(1);
         if let Some(exp) = p.value_for_this(e.loc) {
             *e = exp;
             return;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -687,8 +687,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let expr = *e;
         let _ = in_;
         let mut e_ = expr.data.e_template().expect("infallible: variant checked");
-        if e_.tag.is_some() {
-            p.visit_expr(e_.tag.as_mut().unwrap());
+        if let Some(tag) = e_.tag.as_mut() {
+            p.template_tag = tag.data;
+            p.visit_expr(tag);
         }
 
         // Visit the interpolation values before the macro dispatch below: its
@@ -880,6 +881,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let expr = *e;
         let mut e_ = expr.data.e_index().expect("infallible: variant checked");
         let is_call_target = matches!(p.call_target, Data::EIndex(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
+        let is_template_tag = matches!(p.template_tag, Data::EIndex(tag) if core::ptr::eq(&raw const *e_, &raw const *tag));
         let is_delete_target = matches!(p.delete_target, Data::EIndex(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
 
         // "a['b']" => "a.b"
@@ -1034,7 +1036,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if e_.optional_chain.is_none() {
                             let opts = IdentifierOpts::default()
                                 .with_is_call_target(is_call_target)
-                                // .is_template_tag = is_template_tag,
+                                .with_is_template_tag(is_template_tag)
                                 .with_is_delete_target(is_delete_target)
                                 .with_assign_target(in_.assign_target);
                             if let Some(rewrite) = p.maybe_rewrite_property_access(
@@ -1345,6 +1347,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = expr.data.e_dot().expect("infallible: variant checked");
         let is_delete_target = matches!(p.delete_target, Data::EDot(dt) if core::ptr::eq(&raw const *e_, &raw const *dt));
         let is_call_target = matches!(p.call_target, Data::EDot(ct) if core::ptr::eq(&raw const *e_, &raw const *ct));
+        let is_template_tag = matches!(p.template_tag, Data::EDot(tag) if core::ptr::eq(&raw const *e_, &raw const *tag));
 
         // `p.define: &'a Define` is `Copy`; hoist so the `dots.get` borrow is
         // tied to `'a`, not `&*p`, and `&mut self` helpers below can be called
@@ -1458,6 +1461,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if e_.optional_chain.is_none() {
             let opts = IdentifierOpts::default()
                 .with_is_call_target(is_call_target)
+                .with_is_template_tag(is_template_tag)
                 .with_assign_target(in_.assign_target)
                 .with_is_delete_target(is_delete_target);
             if let Some(_expr) = p.maybe_rewrite_property_access(
@@ -1466,7 +1470,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 e_.name.slice(),
                 e_.name_loc,
                 opts,
-                // .is_template_tag = p.template_tag != null,
             ) {
                 *e = _expr;
                 return;

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1459,13 +1459,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     &p.commonjs_named_exports.keys()[to_convert as usize][..],
                                 )
                                 .slice();
-                                // An arrow function has no `this` of its own, and a
-                                // `this` at the top level of the file stops the lifting.
                                 let decl_value = match bin.right.data {
-                                    js_ast::ExprData::EArrow(_) => {
-                                        CommonJSExportValue::FunctionIgnoringThis
-                                    }
-                                    js_ast::ExprData::EFunction(_)
+                                    js_ast::ExprData::EArrow(_)
+                                    | js_ast::ExprData::EFunction(_)
                                         if p.this_expr_count == this_expr_count_before =>
                                     {
                                         CommonJSExportValue::FunctionIgnoringThis

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -7,6 +7,7 @@ use crate::parser::{
     statement_cares_about_scope,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
+use bun_ast::ast_result::CommonJSExportValue;
 use bun_ast::flags;
 use bun_ast::stmt::Data as StmtData;
 use bun_ast::{self as js_ast, B, Binding, E, Expr, G, S, Stmt};
@@ -905,11 +906,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.react_compiler_candidate_name = data.func.name.map(|n| n.ref_);
         }
         let open_parens_loc = data.func.open_parens_loc;
+        let this_expr_count_before = p.this_expr_count;
         data.func = p.visit_func(core::mem::take(&mut data.func), open_parens_loc);
         p.react_compiler_candidate_name = None;
 
         let name_ref = data.func.name.expect("infallible: name checked").ref_;
         debug_assert!(name_ref.is_symbol());
+        if p.this_expr_count == this_expr_count_before {
+            p.symbols[name_ref.inner_index() as usize].set_call_ignores_this(true);
+        }
         let name_symbol = &p.symbols[name_ref.inner_index() as usize];
         let original_name: &'a [u8] = name_symbol.original_name.slice();
         let remove_overwritten = name_symbol.remove_overwritten_function_declaration();
@@ -1376,6 +1381,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.react_compiler_candidate_name = Some(js_ast::Ref::NONE);
             p.react_compiler_in_react_hoc = in_hoc;
         }
+        let this_expr_count_before = p.this_expr_count;
         p.visit_expr(&mut data.value);
         p.react_compiler_candidate_name = None;
         p.react_compiler_in_react_hoc = false;
@@ -1453,12 +1459,29 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     &p.commonjs_named_exports.keys()[to_convert as usize][..],
                                 )
                                 .slice();
+                                // An arrow function has no `this` of its own, and a
+                                // `this` at the top level of the file stops the lifting.
+                                let decl_value = match bin.right.data {
+                                    js_ast::ExprData::EArrow(_) => {
+                                        CommonJSExportValue::FunctionIgnoringThis
+                                    }
+                                    js_ast::ExprData::EFunction(_)
+                                        if p.this_expr_count == this_expr_count_before =>
+                                    {
+                                        CommonJSExportValue::FunctionIgnoringThis
+                                    }
+                                    js_ast::ExprData::EIdentifier(id) => {
+                                        CommonJSExportValue::Identifier(id.ref_)
+                                    }
+                                    _ => CommonJSExportValue::Other,
+                                };
                                 let last =
                                     &mut p.commonjs_named_exports.values_mut()[to_convert as usize];
                                 if !last.needs_decl {
                                     break 'convert;
                                 }
                                 last.needs_decl = false;
+                                last.decl_value = decl_value;
                                 let last_loc = last.loc_ref.loc;
 
                                 let mut decls = G::DeclList::init_capacity(1);

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1305,19 +1305,22 @@ describe("bundler", () => {
       exports._helper = function (s) {
         return "helped:" + s;
       };
+      exports.tag = function (strings) {
+        return this._helper(strings[0]);
+      };
     `,
   };
   itBundled("cjs2esm/DefaultImportMethodCallKeepsThis", {
     files: {
       "/entry.js": /* js */ `
         import st from "./lib.cjs";
-        console.log(st.parse("x"), st["parse"]("y"));
+        console.log(st.parse("x"), st["parse"]("y"), st.tag\`z\`);
       `,
       ...thisReadingLib,
     },
     cjs2esm: true,
     run: {
-      stdout: "helped:x helped:y",
+      stdout: "helped:x helped:y helped:z",
     },
   });
   itBundled("cjs2esm/StarImportMethodCallKeepsThis", {
@@ -1325,13 +1328,13 @@ describe("bundler", () => {
       "/entry.js": /* js */ `
         import * as ns from "./lib.cjs";
         const parse = ns.parse;
-        console.log(ns.parse("x"), ns["parse"]("y"), parse === ns.parse);
+        console.log(ns.parse("x"), ns["parse"]("y"), ns["tag"]\`z\`, parse === ns.parse);
       `,
       ...thisReadingLib,
     },
     cjs2esm: true,
     run: {
-      stdout: "helped:x helped:y true",
+      stdout: "helped:x helped:y helped:z true",
     },
   });
   itBundled("cjs2esm/StarImportMethodCallThroughExportStarKeepsThis", {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1295,6 +1295,137 @@ describe("bundler", () => {
       stdout: "p id",
     },
   });
+  // A method call through the default import or the namespace of a CommonJS
+  // module passes `module.exports` as `this`. The `stack-trace` package reads it.
+  const thisReadingLib = {
+    "/lib.cjs": /* js */ `
+      exports.parse = function (s) {
+        return this._helper(s);
+      };
+      exports._helper = function (s) {
+        return "helped:" + s;
+      };
+    `,
+  };
+  itBundled("cjs2esm/DefaultImportMethodCallKeepsThis", {
+    files: {
+      "/entry.js": /* js */ `
+        import st from "./lib.cjs";
+        console.log(st.parse("x"), st["parse"]("y"));
+      `,
+      ...thisReadingLib,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "helped:x helped:y",
+    },
+  });
+  itBundled("cjs2esm/StarImportMethodCallKeepsThis", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./lib.cjs";
+        const parse = ns.parse;
+        console.log(ns.parse("x"), ns["parse"]("y"), parse === ns.parse);
+      `,
+      ...thisReadingLib,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "helped:x helped:y true",
+    },
+  });
+  itBundled("cjs2esm/StarImportMethodCallThroughExportStarKeepsThis", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./barrel.js";
+        import lib from "./lib.cjs";
+        console.log(ns.parse("x"), lib.parse("y"));
+      `,
+      "/barrel.js": /* js */ `
+        export * from "./lib.cjs";
+      `,
+      ...thisReadingLib,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "helped:x helped:y",
+    },
+  });
+  itBundled("cjs2esm/MethodCallKeepsThisWhenTheValueCanReadIt", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from "./lib.cjs";
+        console.log(lib.decl(), lib.reassigned(), lib.value());
+      `,
+      "/lib.cjs": /* js */ `
+        function decl() { return this.name; }
+        exports.decl = decl;
+        exports.reassigned = function () { return "first"; };
+        exports.reassigned = function () { return this.name; };
+        exports.value = [function () { return this.name; }][0];
+        exports.name = "lib";
+      `,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "lib lib lib",
+    },
+  });
+  // A `var` with the name of a function declaration can change the value of the
+  // binding. An ES module cannot declare a function and a `var` with one name,
+  // so this output does not load. The test reads the printed calls.
+  itBundled("cjs2esm/MethodCallKeepsThisWhenAVarRedeclaresTheFunction", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from "./lib.cjs";
+        console.log(lib.nested(), lib.top(), lib.top2());
+      `,
+      "/lib.cjs": /* js */ `
+        function nested() { return "declaration"; }
+        if (Math.random() < 2) { var nested = function () { return this.name; }; }
+        exports.nested = nested;
+        function top() { return "declaration"; }
+        var top = function () { return this.name; };
+        exports.top = top;
+        var top2 = function () { return this.name; };
+        function top2() { return "declaration"; }
+        exports.top2 = top2;
+        exports.name = "lib";
+      `,
+    },
+    cjs2esm: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("console.log(exports_lib.nested(), exports_lib.top(), exports_lib.top2());");
+    },
+  });
+  itBundled("cjs2esm/MethodCallWithoutThisBindsDirectly", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from "./lib.cjs";
+        import * as ns from "./lib.cjs";
+        console.log(lib.expr(), lib.arrow(), lib.decl(), ns.expr(), ns.decl(), lib.nested()());
+      `,
+      "/lib.cjs": /* js */ `
+        exports.expr = function () { return "expr"; };
+        exports.arrow = () => "arrow";
+        function decl() { return "decl"; }
+        exports.decl = decl;
+        exports.nested = function () { return () => "nested"; };
+        exports.unused = function () { return this.expr(); };
+      `,
+    },
+    cjs2esm: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toContain("exports_lib");
+      // `unused` reads `this`, but nothing calls it, so it is tree-shaken
+      expect(out).not.toContain("this.expr");
+    },
+    run: {
+      stdout: "expr arrow decl expr decl nested",
+    },
+  });
   itBundled("cjs2esm/DefaultImportJsxClassicRuntime", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1372,13 +1372,14 @@ describe("bundler", () => {
     },
   });
   // A `var` with the name of a function declaration can change the value of the
-  // binding. An ES module cannot declare a function and a `var` with one name,
-  // so this output does not load. The test reads the printed calls.
+  // binding, and so can a block-level function in sloppy mode. An ES module
+  // cannot declare a function and a `var` with one name, so this output does
+  // not load. The test reads the printed calls.
   itBundled("cjs2esm/MethodCallKeepsThisWhenAVarRedeclaresTheFunction", {
     files: {
       "/entry.js": /* js */ `
         import lib from "./lib.cjs";
-        console.log(lib.nested(), lib.top(), lib.top2());
+        console.log(lib.nested(), lib.top(), lib.top2(), lib.block());
       `,
       "/lib.cjs": /* js */ `
         function nested() { return "declaration"; }
@@ -1390,13 +1391,18 @@ describe("bundler", () => {
         var top2 = function () { return this.name; };
         function top2() { return "declaration"; }
         exports.top2 = top2;
+        function block() { return "declaration"; }
+        { function block() { return this.name; } }
+        exports.block = block;
         exports.name = "lib";
       `,
     },
     cjs2esm: true,
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
-      expect(out).toContain("console.log(exports_lib.nested(), exports_lib.top(), exports_lib.top2());");
+      expect(out).toContain(
+        "console.log(exports_lib.nested(), exports_lib.top(), exports_lib.top2(), exports_lib.block());",
+      );
     },
   });
   itBundled("cjs2esm/MethodCallWithoutThisBindsDirectly", {


### PR DESCRIPTION
### Problem
- `import st from "./lib.cjs"; st.parse()` prints as `$parse()`. A CommonJS method that reads `this` then throws `undefined is not an object (evaluating 'this._helper')`. This is a regression from #41162, which binds the default import of a lifted module to its namespace. Bun 1.4.0 is correct.
- `import * as ns from "./lib.cjs"; ns.parse()` has the same fault in 1.4.0.
- The cause: `bind_import_property_accesses` and the `import * as` items (`src/bundler/LinkerContext.rs`) bind `X.name` to the export. A call of that binding has no receiver.

### Fix
- The linker keeps `X.name` as written when the file calls it or tags a template with it, and the export is a lifted CommonJS export. The call then passes the namespace, which stands in for `module.exports`, as `this`.
- The parser marks an export whose only value is a function that does not read `this`: a function expression, an arrow function, or `exports.f = f` for a function declaration. A call of such an export still binds directly. So `React.useState()` keeps the #41162 output.
- Exports of ES modules keep the behavior of #41009.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (6 new tests, 5 fail on main). Also 11 other bundler suites.

### Background
- Lifting turns `exports.foo = x` into `var $foo = x` plus an export. No `module.exports` object exists. The namespace object (`exports_lib`) stands in for it.
- A method call `X.name()` passes `X` as `this`. The call `$name()` passes `undefined`.
- The `stack-trace` package uses this idiom: `exports.parse` calls `this._createParsedCallSite`.

<details><summary>Notes</summary>

Repro:

```sh
printf 'exports.parse = function (s) { return this._helper(s); };\nexports._helper = function (s) { return "helped:" + s; };\n' > lib.cjs
printf 'import st from "./lib.cjs";\nimport * as NS from "./lib.cjs";\nconsole.log(st.parse("x"), NS.parse("y"));\n' > entry.mjs
bun build ./entry.mjs --target=bun --outfile=o.js && bun o.js
```

Main throws. With this change, both calls print as `exports_lib.parse(...)`, and the output is `helped:x helped:y`.

In 1.4.0 the combined file above works, because the default import put the module back in a `__commonJS` wrapper. With only `import * as NS`, 1.4.0 prints `$parse("y")` and tree-shakes `_helper`.

How the parser decides that a call ignores `this`:

- `CommonJSNamedExport.assign_count` counts the assignments to `exports.name`. Only an export with one assignment (its declaration) qualifies.
- The visit pass counts `this` expressions. A function with no `this` inside, at any depth, qualifies. This is conservative: a `this` in a nested function also counts.
- `exports.f = f` qualifies if `f` is a function declaration with no `this` and no assignment, and no `var` of the same name merged into it. `declare_symbol` and `hoist_symbols` set `REDECLARED_BY_VAR` where that merge happens, so the check reads flags only.

Each `X.name` of a file gets one binding in the printer. So one call that needs `this` keeps every `X.name` of that file as written. `bind_import_property_accesses` now collects the reads of all parts first, resolves them, and then binds them part by part. For `import * as ns`, the item of a call that needs `this` stays unbound, and each part that uses it gets a use of `ns`.

A tagged template passes `this` like a call. The parser records the tag in `template_tag`, not in `call_target`, because `e_identifier` reads `call_target` for `require`.

Not in this change:

- `exports.parse()` inside the lifted file itself prints as `$parse()`. It has the same fault since 1.4.0. A fix needs the namespace object inside its own module.
- A `function f` plus a `var f` in a lifted file gives an ES module that throws a `SyntaxError` (also in 1.4.0). That is a separate bug. The test `MethodCallKeepsThisWhenAVarRedeclaresTheFunction` reads the printed calls for this reason.

Checks:

- A production bundle of React 18 has the same bytes before and after.
- `--splitting`, `--minify`, `--format=cjs` and `--keep-names` give the correct output for the repro.
- Suites on the current head: `bundler_cjs2esm`, `bundler_cjs`, `bundler_barrel`, `bundler_splitting`, `bundler_minify`, `bundler_dynamic_import_dce`, `bundler_edgecase`, and `esbuild/{importstar,importstar_ts,default,dce,ts}`. Earlier heads also ran `bundler_regressions`, `bundler_promiseall_deadcode` and `esbuild/splitting`.

</details>
