### PR TITLE
Bump mimalloc

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "942b8342575bdece649438ca76f32276a019c51e";
+const MIMALLOC_COMMIT = "b20b60d959093b1bc0e24306ec72ccacb3e46fb9";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "b20b60d959093b1bc0e24306ec72ccacb3e46fb9";
+const MIMALLOC_COMMIT = "6a64e1ba7f5b2130d4efccb67ec87fd0003f0f6a";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",


### PR DESCRIPTION
Bumps oven-sh/mimalloc from 942b834 to 6a64e1b (12 commits).

- Allocate the per-bin abandoned-page bitmaps on first abandon (oven-sh/mimalloc#32)
- A heap being released abandons its pages unmapped
- Order the heap delete walk against concurrent frees
- Take the meta-data lock before the arena reserve lock in the fork handlers (oven-sh/mimalloc#33)
- Tests for heap release on many threads