### PR TITLE
node:http2: write and read ALTSVC and ORIGIN strings as latin-1

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4404,7 +4404,9 @@ class ServerHttp2Session extends Http2Session {
       throw $ERR_INVALID_CHAR("alt");
     }
     origin = origin || "";
-    if (Buffer.byteLength(origin) + Buffer.byteLength(alt) > MAX_LENGTH) {
+    // The frame carries one byte per code unit, so node counts code units:
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1760
+    if (origin.length + alt.length > MAX_LENGTH) {
       throw $ERR_HTTP2_ALTSVC_LENGTH();
     }
     parser.altsvc(origin, alt, stream);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4404,7 +4404,6 @@ class ServerHttp2Session extends Http2Session {
       throw $ERR_INVALID_CHAR("alt");
     }
     origin = origin || "";
-    // The frame carries one byte per code unit, so node counts code units:
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1760
     if (origin.length + alt.length > MAX_LENGTH) {
       throw $ERR_HTTP2_ALTSVC_LENGTH();

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3341,9 +3341,7 @@ impl H2FrameParser {
         }
     }
 
-    /// One code unit per byte, as node builds the ALTSVC and ORIGIN strings:
-    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1665-L1666
-    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1689
+    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1665-L1689
     fn latin1_to_js(&self, payload: &[u8]) -> JsResult<JSValue> {
         let global = self.handlers.get().global();
         bun_core::String::clone_latin1(payload).into_js(&global)
@@ -4763,10 +4761,8 @@ impl H2FrameParser {
             return Ok(JSValue::UNDEFINED);
         }
 
-        // node writes each origin with `WriteOneByteV2`:
         // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L486-L489
         if origin_arg.is_string() {
-            // No copy: the view keeps the string alive while `write()` runs transport JS.
             let origin_view = origin_arg.to_js_string_view(global_object)?;
             let origin_bytes = header_value_bytes(&origin_view);
             let slice: &[u8] = &origin_bytes;
@@ -4881,9 +4877,7 @@ impl H2FrameParser {
                 return Ok(JSValue::UNDEFINED);
             }
         }
-        // node writes both strings with `WriteOneByteV2`:
         // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L3233-L3239
-        // No copy: the views keep the strings alive while `write()` runs transport JS.
         let origin_bytes = origin_view.as_ref().map(header_value_bytes);
         let value_bytes = value_view.as_ref().map(header_value_bytes);
         this.send_alt_svc(

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -21,9 +21,9 @@ use bun_core::strings;
 use bun_http::lshpack;
 use bun_jsc::AbortSignal;
 use bun_jsc::ErrorCode as JscErrorCode;
+use bun_jsc::StringJsc as _;
 use bun_jsc::abort_signal::AbortListener;
 use bun_jsc::array_buffer::BinaryType;
-use bun_jsc::bun_string_jsc;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsClass, JsRef, JsResult, StrongOptional,
@@ -551,7 +551,7 @@ fn is_valid_header_value(value: &[u8]) -> bool {
 /// reads the bytes back as latin-1. A value with a wider code unit is written as
 /// UTF-8. Bun has no single rule above 0xFF: Node truncates such a code unit to
 /// its low byte, and object-form `respond()` drops the value in JS
-/// (`headerValueIsUnsendable`).
+/// (`headerValueIsUnsendable`). ALTSVC and ORIGIN strings use the same rule.
 fn header_value_bytes<'a>(value: &'a bun_jsc::JSStringView<'_>) -> Cow<'a, [u8]> {
     if !value.is_utf16() {
         return Cow::Borrowed(value.latin1());
@@ -3341,9 +3341,12 @@ impl H2FrameParser {
         }
     }
 
-    fn string_or_empty_to_js(&self, payload: &[u8]) -> JsResult<JSValue> {
+    /// One code unit per byte, as node builds the ALTSVC and ORIGIN strings:
+    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1665-L1666
+    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1689
+    fn latin1_to_js(&self, payload: &[u8]) -> JsResult<JSValue> {
         let global = self.handlers.get().global();
-        bun_string_jsc::create_utf8_for_js(&global, payload)
+        bun_core::String::clone_latin1(payload).into_js(&global)
     }
 
     /// Returned *Stream is heap-allocated and stable for the lifetime of this H2FrameParser.
@@ -3736,8 +3739,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_too_many_invalid_frames(&self) {
         // The peer exceeded maxSessionInvalidFrames: surface a session error. The JS error handler
         // recognizes the string code and destroys the session with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
-        let Some(code_js) =
-            self.or_stop(self.string_or_empty_to_js(b"ERR_HTTP2_TOO_MANY_INVALID_FRAMES"))
+        let Some(code_js) = self.or_stop(self.latin1_to_js(b"ERR_HTTP2_TOO_MANY_INVALID_FRAMES"))
         else {
             return;
         };
@@ -3899,10 +3901,10 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     }
 
     fn on_altsvc(&self, stream_id: u32, origin: &[u8], value: &[u8]) {
-        let Some(origin_js) = self.or_stop(self.string_or_empty_to_js(origin)) else {
+        let Some(origin_js) = self.or_stop(self.latin1_to_js(origin)) else {
             return;
         };
-        let Some(value_js) = self.or_stop(self.string_or_empty_to_js(value)) else {
+        let Some(value_js) = self.or_stop(self.latin1_to_js(value)) else {
             return;
         };
         self.dispatch_with_2_extra(
@@ -3958,7 +3960,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 break;
             }
             let origin = &rest[2..2 + len];
-            let Some(origin_js) = self.or_stop(self.string_or_empty_to_js(origin)) else {
+            let Some(origin_js) = self.or_stop(self.latin1_to_js(origin)) else {
                 return;
             };
             if count == 0 {
@@ -4761,9 +4763,13 @@ impl H2FrameParser {
             return Ok(JSValue::UNDEFINED);
         }
 
+        // node writes each origin with `WriteOneByteV2`:
+        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L486-L489
         if origin_arg.is_string() {
-            let origin_string = origin_arg.to_utf8(global_object)?;
-            let slice = origin_string.slice();
+            // Owned: `write()` can run transport JS before it reads the bytes.
+            let origin_bytes =
+                header_value_bytes(&origin_arg.to_js_string_view(global_object)?).into_owned();
+            let slice = origin_bytes.as_slice();
             if slice.len() + 2 > 16384 {
                 let exception = global_object.to_type_error(
                     bun_jsc::ErrorCode::HTTP2_ORIGIN_LENGTH,
@@ -4800,8 +4806,9 @@ impl H2FrameParser {
                         "Expected origin to be a string or an array of strings"
                     )));
                 }
-                let origin_string = item.to_utf8(global_object)?;
-                let slice = origin_string.slice();
+                let origin_view = item.to_js_string_view(global_object)?;
+                let origin_bytes = header_value_bytes(&origin_view);
+                let slice = origin_bytes.as_ref();
                 let fits = u16::try_from(slice.len()).is_ok_and(|len| {
                     stream.write_all(&len.to_be_bytes()).is_ok() && stream.write_all(slice).is_ok()
                 });
@@ -4834,11 +4841,11 @@ impl H2FrameParser {
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let mut origin_slice: Option<bun_core::Utf8Bytes> = None;
-        let mut value_slice: Option<bun_core::Utf8Bytes> = None;
-
-        let mut origin_str: &[u8] = b"";
-        let mut value_str: &[u8] = b"";
+        // node writes both strings with `WriteOneByteV2`:
+        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L3233-L3239
+        // Owned: `write()` can run transport JS before it reads the bytes.
+        let mut origin_bytes: Vec<u8> = Vec::new();
+        let mut value_bytes: Vec<u8> = Vec::new();
         let mut stream_id: u32 = 0;
         let origin_string = callframe.argument(0);
         if !origin_string.is_empty_or_undefined_or_null() {
@@ -4849,8 +4856,8 @@ impl H2FrameParser {
                     origin_string,
                 ));
             }
-            origin_slice = Some(origin_string.to_utf8(global_object)?);
-            origin_str = origin_slice.as_ref().unwrap().slice();
+            origin_bytes =
+                header_value_bytes(&origin_string.to_js_string_view(global_object)?).into_owned();
         }
 
         let value_string = callframe.argument(1);
@@ -4862,8 +4869,8 @@ impl H2FrameParser {
                     value_string,
                 ));
             }
-            value_slice = Some(value_string.to_utf8(global_object)?);
-            value_str = value_slice.as_ref().unwrap().slice();
+            value_bytes =
+                header_value_bytes(&value_string.to_js_string_view(global_object)?).into_owned();
         }
 
         let stream_id_js = callframe.argument(2);
@@ -4879,9 +4886,7 @@ impl H2FrameParser {
                 return Ok(JSValue::UNDEFINED);
             }
         }
-        this.send_alt_svc(stream_id, origin_str, value_str);
-        // origin_slice/value_slice dropped here
-        let _ = (origin_slice, value_slice);
+        this.send_alt_svc(stream_id, &origin_bytes, &value_bytes);
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4766,10 +4766,10 @@ impl H2FrameParser {
         // node writes each origin with `WriteOneByteV2`:
         // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L486-L489
         if origin_arg.is_string() {
-            // Owned: `write()` can run transport JS before it reads the bytes.
-            let origin_bytes =
-                header_value_bytes(&origin_arg.to_js_string_view(global_object)?).into_owned();
-            let slice = origin_bytes.as_slice();
+            // No copy: the view keeps the string alive while `write()` runs transport JS.
+            let origin_view = origin_arg.to_js_string_view(global_object)?;
+            let origin_bytes = header_value_bytes(&origin_view);
+            let slice: &[u8] = &origin_bytes;
             if slice.len() + 2 > 16384 {
                 let exception = global_object.to_type_error(
                     bun_jsc::ErrorCode::HTTP2_ORIGIN_LENGTH,
@@ -4841,11 +4841,8 @@ impl H2FrameParser {
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // node writes both strings with `WriteOneByteV2`:
-        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L3233-L3239
-        // Owned: `write()` can run transport JS before it reads the bytes.
-        let mut origin_bytes: Vec<u8> = Vec::new();
-        let mut value_bytes: Vec<u8> = Vec::new();
+        let mut origin_view = None;
+        let mut value_view = None;
         let mut stream_id: u32 = 0;
         let origin_string = callframe.argument(0);
         if !origin_string.is_empty_or_undefined_or_null() {
@@ -4856,8 +4853,7 @@ impl H2FrameParser {
                     origin_string,
                 ));
             }
-            origin_bytes =
-                header_value_bytes(&origin_string.to_js_string_view(global_object)?).into_owned();
+            origin_view = Some(origin_string.to_js_string_view(global_object)?);
         }
 
         let value_string = callframe.argument(1);
@@ -4869,8 +4865,7 @@ impl H2FrameParser {
                     value_string,
                 ));
             }
-            value_bytes =
-                header_value_bytes(&value_string.to_js_string_view(global_object)?).into_owned();
+            value_view = Some(value_string.to_js_string_view(global_object)?);
         }
 
         let stream_id_js = callframe.argument(2);
@@ -4886,7 +4881,16 @@ impl H2FrameParser {
                 return Ok(JSValue::UNDEFINED);
             }
         }
-        this.send_alt_svc(stream_id, &origin_bytes, &value_bytes);
+        // node writes both strings with `WriteOneByteV2`:
+        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L3233-L3239
+        // No copy: the views keep the strings alive while `write()` runs transport JS.
+        let origin_bytes = origin_view.as_ref().map(header_value_bytes);
+        let value_bytes = value_view.as_ref().map(header_value_bytes);
+        this.send_alt_svc(
+            stream_id,
+            origin_bytes.as_deref().unwrap_or_default(),
+            value_bytes.as_deref().unwrap_or_default(),
+        );
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3737,7 +3737,9 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_too_many_invalid_frames(&self) {
         // The peer exceeded maxSessionInvalidFrames: surface a session error. The JS error handler
         // recognizes the string code and destroys the session with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
-        let Some(code_js) = self.or_stop(self.latin1_to_js(b"ERR_HTTP2_TOO_MANY_INVALID_FRAMES"))
+        let global = self.global();
+        let Some(code_js) = self
+            .or_stop(bun_core::String::static_("ERR_HTTP2_TOO_MANY_INVALID_FRAMES").to_js(&global))
         else {
             return;
         };

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3341,6 +3341,14 @@ impl H2FrameParser {
         }
     }
 
+    /// Whether `dispatch*` has a JS wrapper with a context to call into; it no-ops otherwise.
+    fn can_dispatch(&self) -> bool {
+        self.strong_this
+            .get()
+            .try_get()
+            .is_some_and(|this_value| JSH2FrameParser::Gc::context.get(this_value).is_some())
+    }
+
     /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1665-L1689
     fn latin1_to_js(&self, payload: &[u8]) -> JsResult<JSValue> {
         let global = self.handlers.get().global();
@@ -3737,6 +3745,9 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_too_many_invalid_frames(&self) {
         // The peer exceeded maxSessionInvalidFrames: surface a session error. The JS error handler
         // recognizes the string code and destroys the session with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
+        if !self.can_dispatch() {
+            return;
+        }
         let global = self.global();
         let Some(code_js) = self
             .or_stop(bun_core::String::static_("ERR_HTTP2_TOO_MANY_INVALID_FRAMES").to_js(&global))
@@ -3901,6 +3912,9 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     }
 
     fn on_altsvc(&self, stream_id: u32, origin: &[u8], value: &[u8]) {
+        if !self.can_dispatch() {
+            return;
+        }
         let Some(origin_js) = self.or_stop(self.latin1_to_js(origin)) else {
             return;
         };
@@ -3950,6 +3964,9 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_origin(&self, payload: &[u8]) {
         // Match the legacy dispatch shape: a single origin is passed as a string, multiple origins
         // as an array — one onOrigin dispatch per ORIGIN frame.
+        if !self.can_dispatch() {
+            return;
+        }
         let g = self.global();
         let mut origin_value = JSValue::UNDEFINED;
         let mut count: u32 = 0;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3341,12 +3341,12 @@ impl H2FrameParser {
         }
     }
 
-    /// Whether `dispatch*` has a JS wrapper with a context to call into; it no-ops otherwise.
-    fn can_dispatch(&self) -> bool {
-        self.strong_this
-            .get()
-            .try_get()
-            .is_some_and(|this_value| JSH2FrameParser::Gc::context.get(this_value).is_some())
+    /// Whether `dispatch*(event, ..)` reaches JS: the wrapper, its context and the handler exist.
+    fn can_dispatch(&self, event: JSH2FrameParser::Gc) -> bool {
+        self.strong_this.get().try_get().is_some_and(|this_value| {
+            JSH2FrameParser::Gc::context.get(this_value).is_some()
+                && event.get(this_value).is_some()
+        })
     }
 
     /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1665-L1689
@@ -3745,7 +3745,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_too_many_invalid_frames(&self) {
         // The peer exceeded maxSessionInvalidFrames: surface a session error. The JS error handler
         // recognizes the string code and destroys the session with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
-        if !self.can_dispatch() {
+        if !self.can_dispatch(JSH2FrameParser::Gc::onError) {
             return;
         }
         let global = self.global();
@@ -3912,7 +3912,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     }
 
     fn on_altsvc(&self, stream_id: u32, origin: &[u8], value: &[u8]) {
-        if !self.can_dispatch() {
+        if !self.can_dispatch(JSH2FrameParser::Gc::onAltSvc) {
             return;
         }
         let Some(origin_js) = self.or_stop(self.latin1_to_js(origin)) else {
@@ -3964,7 +3964,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_origin(&self, payload: &[u8]) {
         // Match the legacy dispatch shape: a single origin is passed as a string, multiple origins
         // as an array — one onOrigin dispatch per ORIGIN frame.
-        if !self.can_dispatch() {
+        if !self.can_dispatch(JSH2FrameParser::Gc::onOrigin) {
             return;
         }
         let g = self.global();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3438,6 +3438,229 @@ describe("http2 header values are latin-1 byte strings", () => {
   });
 });
 
+// node:http2 writes the strings of an ALTSVC frame (RFC 7838) and of an ORIGIN
+// frame (RFC 8336) with one byte per code unit, and reads them back with one
+// code unit per byte (node_http2.cc). The quoted-string value of an ALTSVC
+// parameter can carry obs-text (0x80-0xFF). The tests decode wire bytes as
+// latin-1, so a string survives only if each code unit was one byte.
+describe("http2 ALTSVC and ORIGIN frame strings are latin-1", () => {
+  const ALTSVC = 0x0a;
+  const ORIGIN = 0x0c;
+  const origin = "https://caf\xe9.example";
+  const value = 'h2=":443"; x="caf\xe9"';
+  const asUtf8 = str => Buffer.from(str, "utf8").toString("latin1"); // "\xe9" -> "\xc3\xa9"
+
+  const lengthPrefixed = str => {
+    const bytes = Buffer.from(str, "latin1");
+    const prefix = Buffer.alloc(2);
+    prefix.writeUInt16BE(bytes.length);
+    return Buffer.concat([prefix, bytes]);
+  };
+  const frame = (type, payload) => Buffer.concat([new http2utils.Frame(payload.length, type, 0, 0).data, payload]);
+  const altsvcFields = ({ streamId, payload }) => {
+    const originLength = payload.readUInt16BE(0);
+    return {
+      streamId,
+      origin: payload.subarray(2, 2 + originLength).toString("latin1"),
+      value: payload.subarray(2 + originLength).toString("latin1"),
+    };
+  };
+  const originEntries = ({ payload }) => {
+    const entries = [];
+    for (let offset = 0; offset + 2 <= payload.length; ) {
+      const length = payload.readUInt16BE(offset);
+      entries.push(payload.subarray(offset + 2, offset + 2 + length).toString("latin1"));
+      offset += 2 + length;
+    }
+    return entries;
+  };
+
+  // Connects to a node:http2 server as a raw client. Returns the frames of
+  // `type` that arrive before the PING ACK. The server writes its frames in
+  // order, so the ACK follows every frame that its 'session' listener wrote.
+  async function framesBeforePingAck(port, type) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const frames = [];
+    const socket = net.connect(port, "127.0.0.1", () => {
+      socket.write(
+        Buffer.concat([
+          http2utils.kClientMagic,
+          new http2utils.SettingsFrame(false).data,
+          new http2utils.PingFrame(false).data,
+        ]),
+      );
+    });
+    socket.on("error", reject);
+    socket.on("close", () => resolve(frames));
+    let buf = Buffer.alloc(0);
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      while (buf.length >= 9) {
+        const length = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + length) break;
+        const frameType = buf[3];
+        const flags = buf[4];
+        if (frameType === type) {
+          frames.push({
+            streamId: buf.readUInt32BE(5) & 0x7fffffff,
+            payload: Buffer.from(buf.subarray(9, 9 + length)),
+          });
+        }
+        buf = buf.subarray(9 + length);
+        if (frameType === 6 && (flags & 1) !== 0) resolve(frames);
+      }
+    });
+    try {
+      return await promise;
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  // The connection listener of a raw h2 server. After the client preface it
+  // sends SETTINGS and then `frames`. It acks the SETTINGS of the client.
+  const rawServerConnection = frames => socket => {
+    let buf = Buffer.alloc(0);
+    let sawPreface = false;
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      if (!sawPreface) {
+        if (buf.length < http2utils.kClientMagic.length) return;
+        buf = buf.subarray(http2utils.kClientMagic.length);
+        sawPreface = true;
+        socket.write(Buffer.concat([new http2utils.SettingsFrame(false).data, ...frames]));
+      }
+      while (buf.length >= 9) {
+        const length = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + length) break;
+        if (buf[3] === 4 && (buf[4] & 1) === 0) socket.write(new http2utils.SettingsFrame(true).data);
+        buf = buf.subarray(9 + length);
+      }
+    });
+  };
+
+  it("server writes the ALTSVC value with one byte per code unit", async () => {
+    // The same value as a 16-bit string. A utf-16le decode always gives one.
+    const value16 = new TextDecoder("utf-16le").decode(new Uint16Array([...value].map(c => c.charCodeAt(0))));
+    const server = http2.createServer();
+    server.on("session", session => {
+      session.altsvc(value, "https://example.org");
+      session.altsvc(value16, "https://example.org");
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const frames = await framesBeforePingAck(server.address().port, ALTSVC);
+      expect(frames.map(altsvcFields)).toEqual([
+        { streamId: 0, origin: "https://example.org", value },
+        { streamId: 0, origin: "https://example.org", value },
+      ]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("server limits the ALTSVC origin and value to 16382 code units", async () => {
+    const altOrigin = "https://example.org";
+    // A value of `length` code units. Each U+00E9 is one byte on the wire and
+    // two bytes in UTF-8.
+    const alt = length => 'h2="' + Buffer.alloc(length - 5, 0xe9).toString("latin1") + '"';
+    const results = [];
+    const server = http2.createServer();
+    server.on("session", session => {
+      for (const length of [16382 - altOrigin.length, 16383 - altOrigin.length]) {
+        try {
+          session.altsvc(alt(length), altOrigin);
+          results.push("sent");
+        } catch (err) {
+          results.push(err.code);
+        }
+      }
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const frames = await framesBeforePingAck(server.address().port, ALTSVC);
+      expect(results).toEqual(["sent", "ERR_HTTP2_ALTSVC_LENGTH"]);
+      expect(frames.map(({ payload }) => payload.length)).toEqual([2 + 16382]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("server writes ORIGIN entries with one byte per code unit", async () => {
+    const server = http2.createServer();
+    server.on("session", session => {
+      // An object's origin is sent as is. A string is serialized as a URL first.
+      session.origin({ origin });
+      session.origin({ origin }, "https://b.example");
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const frames = await framesBeforePingAck(server.address().port, ORIGIN);
+      expect(frames.map(originEntries)).toEqual([[origin], [origin, "https://b.example"]]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("client reads the ALTSVC origin and value as latin-1", async () => {
+    const server = net.createServer(
+      rawServerConnection([
+        frame(ALTSVC, Buffer.concat([lengthPrefixed(origin), Buffer.from(value, "latin1")])),
+        frame(ALTSVC, Buffer.concat([lengthPrefixed(origin), Buffer.from(value, "utf8")])),
+      ]),
+    );
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      const received = [];
+      client.on("error", reject);
+      client.on("close", () => reject(new Error(`session closed after ${received.length} ALTSVC frames`)));
+      client.on("altsvc", (alt, altOrigin, streamId) => {
+        received.push({ streamId, origin: altOrigin, value: alt });
+        if (received.length === 2) resolve();
+      });
+      await promise;
+      expect(received).toEqual([
+        { streamId: 0, origin, value },
+        { streamId: 0, origin, value: asUtf8(value) },
+      ]);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("client reads ORIGIN entries as latin-1", async () => {
+    // A client emits 'origin' only on a TLS session.
+    const server = tls.createServer(
+      { ...TLS_CERT, ALPNProtocols: ["h2"] },
+      rawServerConnection([
+        frame(ORIGIN, lengthPrefixed(origin)),
+        frame(ORIGIN, Buffer.concat([lengthPrefixed(origin), lengthPrefixed(asUtf8(origin))])),
+      ]),
+    );
+    await new Promise(resolve => server.listen(0, resolve));
+    const client = http2.connect(`https://localhost:${server.address().port}`, TLS_OPTIONS);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      const received = [];
+      client.on("error", reject);
+      client.on("close", () => reject(new Error(`session closed after ${received.length} ORIGIN frames`)));
+      client.on("origin", origins => {
+        received.push(origins);
+        if (received.length === 2) resolve();
+      });
+      await promise;
+      expect(received).toEqual([[origin], [origin, asUtf8(origin)]]);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});
+
 it("http2 server rejects requests carrying connection-specific or repeated pseudo-headers", async () => {
   // RFC 9113 Section 8.2.2: connection-specific fields (transfer-encoding,
   // connection, keep-alive, ...) make an HTTP/2 request malformed, and


### PR DESCRIPTION
### Problem
- A byte in 0x80-0xFF does not survive an ALTSVC or ORIGIN frame between Bun and Node. A Bun server that calls `session.altsvc('h2=":443"; x="caf\xe9"', origin)` sends `c3 a9`, so a Node client reads `cafÃ©`. A Node server sends `e9`, and a Bun client reads `caf\uFFFD`. That value then fails `session.altsvc()` with `ERR_INVALID_CHAR` if the app sends it on.
- The cause is in `src/runtime/api/bun/h2_frame_parser.rs`. `altsvc()` and `origin()` encode the strings with `to_utf8()`. `on_altsvc()` and `on_origin()` decode the payload as UTF-8.

### Fix
- Outbound: `header_value_bytes()`, the helper that HEADERS values use since #41245. Inbound: `String::clone_latin1`.
- `session.altsvc()` checks the 16382 byte limit in code units, as Node does. The old `Buffer.byteLength` check rejected values that Node sends.
- Correct because Node writes these strings with `WriteOneByteV2` and reads them with `OneByteString`. The code comments link the lines.
- Verified: `test/js/node/http2/node-http2.test.js`, five new tests. All five fail on stock bun. Also ran the other http2 suites and Node's ALTSVC and ORIGIN tests. Self-reviewed: 5 concerns raised, 5 addressed.

### Background
- An ALTSVC frame (RFC 7838) carries an origin and an Alt-Svc field value. A parameter in that value can hold obs-text (bytes 0x80 to 0xFF) in a quoted-string.
- An ORIGIN frame (RFC 8336) carries a list of origins.
- Latin-1 maps each byte to the code unit with the same value. UTF-8 writes U+0080 to U+00FF as two bytes, and a lone byte in that range is not valid UTF-8.

<details><summary>Notes</summary>

Found by a comparison with Node v26.3.0. No user reported it. #40687 and #41245 apply the same rule to HEADERS values. Both are in no release yet, so the three changes can ship together.

Repro. The server calls `session.altsvc('h2=":443"; x="caf\xe9"', "https://example.org")`. The client prints the code units of the value:

```
server  client  main                          this branch
node    node    ... 63 61 66 e9 22            (same)
bun     node    ... 63 61 66 c3 a9 22         ... 63 61 66 e9 22
node    bun     ... 63 61 66 fffd 22          ... 63 61 66 e9 22
```

`session.origin({ origin: "https://caf\xe9.example" })` gives the same table for ORIGIN frames.

Relay: a Bun client reads the value above from a Node server, and a Bun server sends it on with `session.altsvc()`. Main throws `ERR_INVALID_CHAR`, because U+FFFD fails the quoted-string check. This branch and Node send `e9`.

Length: a value of 9005 code units, most of them `\xe9`, throws `ERR_HTTP2_ALTSVC_LENGTH` on main. Node sends it. The new test covers the exact limit and one code unit past it.

Code units above 0xFF can reach the native side only as the `origin` of an object that is passed to `session.origin()`. RFC 8336 requires an ASCII origin. `header_value_bytes()` writes such a string as UTF-8, as main does. Node keeps the low byte of each code unit. This PR does not decide that case, the same as #41245.

Not changed: `session.altsvc(alt, { origin })` parses the `origin` with `new URL()`. Node sends it unchanged. So the ALTSVC origin is ASCII in Bun today. #41255 tracks that difference.

No copies: `altsvc()` and `origin()` pass the borrowed bytes from `header_value_bytes()` to `write()`. `write()` can run the JS of a stream transport. The `JSStringView` keeps the string alive during that JS, and JSC keeps the old buffer of a string that it atomizes (`JSString::swapToAtomString`). An 8-bit string allocates nothing. A 16-bit string is narrowed into a new buffer, as for header values. An earlier revision copied the bytes. Review asked to remove the copies.

Inbound: `latin1_to_js()` copies the payload once (`tryCreateUninitialized` plus `memcpy`), because the payload borrows the socket read chunk. `into_js()` adopts that buffer with no second copy. `on_altsvc()`, `on_origin()` and `on_too_many_invalid_frames()` return before they build a value when `dispatch*` cannot reach JS: no wrapper, no context, or no handler for that event (`can_dispatch(event)`). The `ERR_HTTP2_TOO_MANY_INVALID_FRAMES` code is a static atom string. Review asked for both.

Node v26.3.0 runs the five new tests unmodified (as a `node:assert` script with the same bodies) and passes all five. A PR comment has the script and the output.

Suites run with the debug build:

- `test/js/node/http2/node-http2.test.js` (382 pass, 6 skip)
- `h2-conformance.test.ts`, `node-http2-invalid-padding.test.ts`, `node-http2-continuation.test.ts`, `node-http2-streams-rehash.test.ts` (88 pass)
- `test/js/node/test/parallel/`: `test-http2-altsvc.js`, `test-http2-malformed-altsvc.js`, `test-http2-origin.js`, `test-http2-max-invalid-frames.js`, `test-http2-empty-frame-without-eof.js`, `test-http2-reset-flood.js`, `test-http2-createserver-options.js`

Self-review concerns, all addressed: rebase onto #41245, and reuse its helper. Node permalinks in the code comments. An RFC-conformant example value. A tracking issue for the `new URL()` difference. The rule above 0xFF (see above).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
ninja: Entering directory `/workspace/bun/build/debug'
[1/204] install /workspace/bun
FAILED: stamps/install__workspace_bun.stamp ../../node_modules/@lezer/common/package.json ../../node_modules/@lezer/cpp/package.json ../../node_modules/@types/bun/package.json ../../node_modules/esbuild/package.json ../../node_modules/oxlint/package.json ../../node_modules/prettier/package.json ../../node_modules/prettier-plugin-organize-imports/package.json ../../node_modules/react/package.json ../../node_modules/react-dom/package.json ../../node_modules/source-map-js/package.json ../../node_modules/typescript/package.json 
cd /workspace/bun && /workspace/bun/build/release/bun install --frozen-lockfile && touch /workspace/bun/build/debug/stamps/install__workspace_bun.stamp
bun install v1.4.3-canary.1 (4ff919377)
error: the root package depends on workspace "@types/bun" (packages/@types/bun), which is listed in bun.lock but not on disk
note: a pruned checkout must keep every workspace that its remaining workspace
... (truncated)

release without fix: 5 failed, 6 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.88ms]
(pass) node none > Client Basics > getDefaultSettings [0.17ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.32ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.16ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.11ms]
(pass) node none > Client Basics > is possible to abort request [1.83ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.84ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.69ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.82ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [33.87ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (4ff919377)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [958.88ms]
(pass) node none > Client Basics > should be able to send a POST request [672.55ms]
(pass) node none > Client Basics > constants [18.97ms]
(pass) node none > Client Basics > getDefaultSettings [7.55ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [18.55ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.94ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.77ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.28ms]
(pass) node none > Client Basics > should be able to send data using end [699.99ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [689.99ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ab0e5237ad
  features     baseline

23 deps, 131 codegen, 1172 objects in 713ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 25 installs across 62 packages (no changes) [19.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (4ff919377)

Checked 1 install across 2 packages (no changes) [8.00ms]
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff919377)

Checked 111 installs across 104 packages (no changes) [13.00ms]
[6/1244] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                   |   3 +-
 src/runtime/api/bun/h2_frame_parser.rs |  72 +++++++----
 test/js/node/http2/node-http2.test.js  | 223 +++++++++++++++++++++++++++++++++
 3 files changed, 272 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/node/http2.ts                        6      4     33
src/runtime/api/bun/h2_frame_parser.rs     31     35     34
test/js/node/http2/node-http2.test.js       6      4     33
```

</details>

<!-- robobun:evidence:end -->


