### PR TITLE
Bun.file().slice(): count a negative index back from the file's real end

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1929,11 +1929,6 @@ impl BlobExt for Blob {
             return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
         }
 
-        // If the optional start parameter is not used as a parameter, let relativeStart be 0.
-        let mut relative_start: i64 = 0;
-        // If the optional end parameter is not used, let relativeEnd be size.
-        let mut relative_end: i64 = i64::try_from(self.size.get()).expect("int cast");
-
         // Mutate the fixed-3 args array in place to shift the string arg into [2].
         if args[0].is_string() {
             args[2] = args[0];
@@ -1945,31 +1940,34 @@ impl BlobExt for Blob {
         }
 
         let mut args_iter = jsc::ArgumentsSlice::init(global_this.bun_vm(), &arguments_[..3]);
-        if let Some(start_) = args_iter.next_eat() {
-            if start_.is_number() {
-                let start = start_.to_int64();
-                if start < 0 {
-                    relative_start = (start
-                        .wrapping_add(i64::try_from(self.size.get()).expect("int cast")))
-                    .max(0);
-                } else {
-                    relative_start = start.min(i64::try_from(self.size.get()).expect("int cast"));
-                }
-            }
-        }
+        let start = args_iter
+            .next_eat()
+            .filter(|v| v.is_number())
+            .map(|v| v.to_int64());
+        let end = args_iter
+            .next_eat()
+            .filter(|v| v.is_number())
+            .map(|v| v.to_int64());
 
-        if let Some(end_) = args_iter.next_eat() {
-            if end_.is_number() {
-                let end = end_.to_int64();
-                if end < 0 {
-                    relative_end = (end
-                        .wrapping_add(i64::try_from(self.size.get()).expect("int cast")))
-                    .max(0);
-                } else {
-                    relative_end = end.min(i64::try_from(self.size.get()).expect("int cast"));
-                }
-            }
-        }
+        let size = if start.is_some_and(|i| i < 0) || end.is_some_and(|i| i < 0) {
+            size_for_relative_index(self)
+        } else {
+            self.size.get()
+        };
+        let size = i64::try_from(size).expect("int cast");
+
+        // If the optional start parameter is not used as a parameter, let relativeStart be 0.
+        let relative_start = match start {
+            Some(start) if start < 0 => start.wrapping_add(size).max(0),
+            Some(start) => start.min(size),
+            None => 0,
+        };
+        // If the optional end parameter is not used, let relativeEnd be size.
+        let relative_end = match end {
+            Some(end) if end < 0 => end.wrapping_add(size).max(0),
+            Some(end) => end.min(size),
+            None => size,
+        };
 
         let mut content_type = BlobContentType::default();
         if let Some(content_type_) = args_iter.next_eat() {
@@ -6003,44 +6001,63 @@ fn window_size(current: SizeType, available: SizeType) -> SizeType {
     }
 }
 
+/// The size that a negative `slice()` index counts back from. Until something
+/// stats a `Bun.file()`, its end is unknown: `offset + size` reaches
+/// `MAX_SIZE`, and counting back from that sentinel gives an offset near 2^52.
+/// So count back from the current size of a regular file. The stat is not
+/// cached in the store, so what `.size` and reads of the parent see does not
+/// change. A pipe or a device has no end and keeps the unknown size.
+fn size_for_relative_index(blob: &Blob) -> SizeType {
+    let (offset, size) = (blob.offset.get(), blob.size.get());
+    if offset.saturating_add(size) < MAX_SIZE {
+        return size;
+    }
+    let Some(store) = blob.store.get() else {
+        return size;
+    };
+    let store::Data::File(file) = &store.data else {
+        return size;
+    };
+    match stat_file(&file.pathlike) {
+        bun_sys::Result::Ok(stat) if bun_sys::S::ISREG(stat.st_mode as _) => {
+            (((stat.st_size.max(0)) as u64) as SizeType).saturating_sub(offset)
+        }
+        bun_sys::Result::Ok(_) => size,
+        // `.size` reports 0 for a missing file. A read still rejects with the
+        // open error.
+        bun_sys::Result::Err(_) => 0,
+    }
+}
+
+/// `stat()` the path or `fstat()` the fd of a file store.
+fn stat_file(pathlike: &PathOrFileDescriptor<'_>) -> bun_sys::Result<bun_sys::Stat> {
+    match pathlike {
+        PathOrFileDescriptor::Path(path) => {
+            let mut buffer = bun_paths::PathBuffer::uninit();
+            bun_sys::stat(path.slice_z(&mut buffer))
+        }
+        PathOrFileDescriptor::Fd(fd) => bun_sys::fstat(*fd),
+    }
+}
+
 /// resolve file stat like size, last_modified
 fn resolve_file_stat(store: &RefPtr<Store>) {
     // `Store::data_mut` encapsulates the raw-pointer deref under the
     // `RefPtr<Store>` liveness invariant; the caller holds the only ref across
     // this call, so an exclusive borrow is sound.
     let file = Store::data_mut(store).as_file_mut();
-    match &file.pathlike {
-        PathOrFileDescriptor::Path(path) => {
-            let mut buffer = bun_paths::PathBuffer::uninit();
-            match bun_sys::stat(path.slice_z(&mut buffer)) {
-                bun_sys::Result::Ok(stat) => {
-                    file.max_size = if bun_sys::S::ISREG(stat.st_mode as _) || stat.st_size > 0 {
-                        ((stat.st_size.max(0)) as u64) as SizeType
-                    } else {
-                        MAX_SIZE
-                    };
-                    file.mode = stat.st_mode as bun_sys::Mode;
-                    file.seekable = Some(bun_sys::S::ISREG(stat.st_mode as _));
-                    file.last_modified = stat_to_js_mtime(&stat);
-                }
-                // the file may not exist yet. That's okay.
-                _ => {}
-            }
-        }
-        PathOrFileDescriptor::Fd(fd) => match bun_sys::fstat(*fd) {
-            bun_sys::Result::Ok(stat) => {
-                file.max_size = if bun_sys::S::ISREG(stat.st_mode as _) || stat.st_size > 0 {
-                    ((stat.st_size.max(0)) as u64) as SizeType
-                } else {
-                    MAX_SIZE
-                };
-                file.mode = stat.st_mode as bun_sys::Mode;
-                file.seekable = Some(bun_sys::S::ISREG(stat.st_mode as _));
-                file.last_modified = stat_to_js_mtime(&stat);
-            }
-            _ => {}
-        },
-    }
+    // the file may not exist yet. That's okay.
+    let bun_sys::Result::Ok(stat) = stat_file(&file.pathlike) else {
+        return;
+    };
+    file.max_size = if bun_sys::S::ISREG(stat.st_mode as _) || stat.st_size > 0 {
+        ((stat.st_size.max(0)) as u64) as SizeType
+    } else {
+        MAX_SIZE
+    };
+    file.mode = stat.st_mode as bun_sys::Mode;
+    file.seekable = Some(bun_sys::S::ISREG(stat.st_mode as _));
+    file.last_modified = stat_to_js_mtime(&stat);
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2271,6 +2271,12 @@ describe("should support Content-Range with Bun.file()", () => {
     [full.byteLength - 10, full.byteLength - 1],
     [full.byteLength - 1, full.byteLength],
     [0, full.byteLength],
+    // A negative index counts back from the end of the file.
+    [-10, Infinity],
+    [-(full.byteLength / 2) | 0, Infinity],
+    [-10, -1],
+    [0, -10],
+    [-full.byteLength, Infinity],
   ] as const;
 
   for (const [start, end] of good) {
@@ -2279,8 +2285,9 @@ describe("should support Content-Range with Bun.file()", () => {
         const response = await fetch(`${server.url.origin}/?start=${start}&end=${end}`, {
           verbose: true,
         });
-        expect(await response.arrayBuffer()).toEqual(full.buffer.slice(start, end));
-        expect(response.status).toBe(start > 0 || end < full.byteLength ? 206 : 200);
+        const expected = full.buffer.slice(start, end);
+        expect(await response.arrayBuffer()).toEqual(expected);
+        expect(response.status).toBe(expected.byteLength < full.byteLength ? 206 : 200);
       });
     });
   }
@@ -2292,8 +2299,9 @@ describe("should support Content-Range with Bun.file()", () => {
           verbose: true,
         });
         expect(parseInt(response.headers.get("Content-Range")?.split("/")[1])).toEqual(full.byteLength);
-        expect(await response.arrayBuffer()).toEqual(full.buffer.slice(start, end));
-        expect(response.status).toBe(start > 0 || end < full.byteLength ? 206 : 200);
+        const expected = full.buffer.slice(start, end);
+        expect(await response.arrayBuffer()).toEqual(expected);
+        expect(response.status).toBe(expected.byteLength < full.byteLength ? 206 : 200);
       });
     });
   }
@@ -2324,7 +2332,6 @@ describe("should support Content-Range with Bun.file()", () => {
   const badRanges = [
     [10, NaN],
     [10, -Infinity],
-    [-(full.byteLength / 2) | 0, Infinity],
     [-(full.byteLength / 2) | 0, -Infinity],
     [full.byteLength + 100, full.byteLength],
     [full.byteLength + 100, full.byteLength + 100],

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import type { BlobOptions } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
+import { appendFileSync } from "node:fs";
 import path from "node:path";
 
 test("blob: imports have sourcemapped stacktraces", async () => {
@@ -764,6 +765,122 @@ describe("file-backed slice bounds are respected when streaming and serving", ()
       expect(file.size).toBe(size);
       expectWindow(await collect(file.stream()), 0, size);
     });
+  });
+});
+
+// A negative index counts back from the end of the file. Every case slices a
+// fresh Bun.file(): nothing has read its .size, so slice() has to find the end.
+describe("Bun.file(path).slice() with a negative index", () => {
+  const content = "abcdefghijklmnopqrstuvwxyz";
+  const cases: [start: number, end: number | undefined, expected: string][] = [
+    [-5, undefined, "vwxyz"],
+    [0, -1, "abcdefghijklmnopqrstuvwxy"],
+    [1, -1, "bcdefghijklmnopqrstuvwxy"],
+    [-5, -2, "vwx"],
+    [-100, undefined, content],
+    [-100, -1, "abcdefghijklmnopqrstuvwxy"],
+    [0, -100, ""],
+    [-Infinity, undefined, content],
+  ];
+
+  test.each(cases)("slice(%p, %p)", async (start, end, expected) => {
+    using dir = tempDir("blob-file-slice-negative", { "data.txt": content });
+    const slice = () => Bun.file(`${dir}/data.txt`).slice(start, end);
+    expect(await new Blob([content]).slice(start, end).text()).toBe(expected);
+    expect({
+      size: slice().size,
+      text: await slice().text(),
+      bytes: Buffer.from(await slice().bytes()).toString(),
+      stream: await new Response(slice().stream()).text(),
+      response: await new Response(slice()).text(),
+    }).toEqual({
+      size: expected.length,
+      text: expected,
+      bytes: expected,
+      stream: expected,
+      response: expected,
+    });
+  });
+
+  test("a slice with an offset and an unknown end", async () => {
+    using dir = tempDir("blob-file-slice-negative", { "data.txt": content });
+    const file = () => Bun.file(`${dir}/data.txt`);
+    expect({
+      tail: await file().slice(3).slice(-5).text(),
+      inner: await file().slice(3).slice(1, -1).text(),
+      twice: await file().slice(1, -1).slice(1, -1).text(),
+    }).toEqual({
+      tail: "vwxyz",
+      inner: "efghijklmnopqrstuvwxy",
+      twice: "cdefghijklmnopqrstuvwx",
+    });
+  });
+
+  test("Bun.serve sends the window", async () => {
+    using dir = tempDir("blob-file-slice-negative", { "data.txt": content });
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(Bun.file(`${dir}/data.txt`).slice(-5)),
+    });
+    const res = await fetch(server.url);
+    expect({
+      body: await res.text(),
+      length: res.headers.get("content-length"),
+      status: res.status,
+    }).toEqual({
+      body: "vwxyz",
+      length: "5",
+      status: 206,
+    });
+  });
+
+  test("fetch() and FormData upload the window", async () => {
+    using dir = tempDir("blob-file-slice-negative", { "data.txt": content });
+    await using server = Bun.serve({
+      port: 0,
+      fetch: async req =>
+        new Response(req.url.endsWith("/form") ? await (await req.formData()).get("file")!.text() : await req.text()),
+    });
+    const form = new FormData();
+    form.append("file", Bun.file(`${dir}/data.txt`).slice(-5));
+    expect({
+      body: await (await fetch(server.url, { method: "POST", body: Bun.file(`${dir}/data.txt`).slice(-5) })).text(),
+      form: await (await fetch(new URL("/form", server.url), { method: "POST", body: form })).text(),
+    }).toEqual({ body: "vwxyz", form: "vwxyz" });
+  });
+
+  // slice() does not cache its stat in the store. So the parent Bun.file still
+  // sees the whole file after it grows.
+  test("the parent Bun.file still sees a later append", async () => {
+    using dir = tempDir("blob-file-slice-negative", { "data.txt": content });
+    const file = Bun.file(`${dir}/data.txt`);
+    const tail = file.slice(-5);
+    appendFileSync(`${dir}/data.txt`, "0123456789");
+    expect({
+      tail: await tail.text(),
+      stream: (await Bun.readableStreamToBytes(new Response(file).body!)).length,
+      size: file.size,
+      text: await file.text(),
+    }).toEqual({
+      tail: "vwxyz",
+      stream: 36,
+      size: 36,
+      text: content + "0123456789",
+    });
+  });
+
+  // slice() handles an index that is not a number in the same way for every Blob.
+  test("an object index gives the same bytes as an in-memory Blob", async () => {
+    using dir = tempDir("blob-file-slice-negative", { "data.txt": content });
+    const index = { valueOf: () => -5 } as unknown as number;
+    expect(await Bun.file(`${dir}/data.txt`).slice(index).text()).toBe(await new Blob([content]).slice(index).text());
+  });
+
+  test("a missing file still rejects with ENOENT", async () => {
+    using dir = tempDir("blob-file-slice-negative", {});
+    const slice = Bun.file(`${dir}/missing.txt`).slice(-5);
+    expect(slice.size).toBe(Bun.file(`${dir}/missing.txt`).size);
+    await expect(slice.text()).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.file(path).slice(-5).text()` returns the first 5 bytes, not the last 5. `slice(0, -1)` keeps the last byte. Reproduced on 1.4.1.
- `Blob::get_slice` (`src/runtime/webcore/Blob.rs:1919`) counts a negative index back from `self.size`. Until something stats a `Bun.file()`, that size is `MAX_SIZE` (unknown). So `slice(-5)` gets the offset `MAX_SIZE - 5`. The read seeks there, ignores the `EINVAL` (`src/runtime/webcore/blob/read_file.rs:727`), and reads from byte 0.

### Fix
- `get_slice` reads `start` and `end` first. If one is negative and the end of a file Blob is unknown, the new `size_for_relative_index` stats the file and counts back from its current size. All consumers read this window, also `fetch()` uploads.
- The stat is not cached, so the parent `Bun.file()` does not change. A positive index and an S3 store take the old path.
- A pipe keeps the unknown size. A missing file gets the size 0, as `.size` reports, and its read still rejects with `ENOENT`.
- Verified: `test/js/web/fetch/blob.test.ts` (new describe, 12 of 14 tests fail on 1.4.1). `serve.test.ts` had `slice(-n, Infinity)` as a bad range. It is now a good range.

### Background
- A Blob is a window (`offset`, `size`) on a store. A `Bun.file()` store reads the file lazily.
- `MAX_SIZE` is `(1 << 52) - 1`. As a size it means "not known, read to EOF". `.size` stats the file, caches the stat in the store, and replaces the sentinel.
- The W3C `slice()` algorithm counts a negative index back from the Blob's size: `max(size + index, 0)`.

<details><summary>Notes</summary>

- I found the bug by reading the code for #41209. The one external report is #1311 (2022): `slice(-32)` returned an empty string. It was closed in 2023 as fixed, but its repro read `.size` first, and that hides the bug.
- #33601 fixed the same bug. It called `resolve_size()` on every slice of a file that was not stat'd, also for a positive index. It was closed without a comment after #39201 merged. This change stats only for a negative index.
- Self-review: 7 points raised, 5 done. Two are not done:
  - A shared unknown-end check in `get_size`, so that `Bun.file(p).slice(3).size` is 23, not 4503599627370492. That is a positive index and it fails on 1.4.1 too. The check would change S3 and pipe sizes and conflict with #33687, so it is a follow-up.
  - A test that pins `Bun.file(p).slice(0, 100).size === 100` for a small file. That value is the over-report that #32794 and #33360 are about.
- The review also asked to reuse `resolved_size()`. That call caches the stat. With the cache, `f.slice(-5)` followed by an append made `f.size`, `f.text()`, and `new Response(f).body` stop at the old size (26 bytes, where 1.4.1 reads 36). So `size_for_relative_index` shares only the stat call (`stat_file`) with `resolve_file_stat`. The test "the parent Bun.file still sees a later append" covers this.
- A matrix of 2166 cases compares `Bun.file()` slices with in-memory `Blob` slices: 6 parents (fresh, stat'd, and four slices) by 19 values for `start` and `end`. It checks `text()`, `stream()`, and `.size` when an index is negative. On 1.4.1 there are 650 mismatches. On this branch there are 0.
- `Bun.serve` with `Bun.file(fd).slice(0, 5)` stalls on 1.4.1 and on this branch, for a positive index too. The server sends a `Content-Length` for the whole file. That is a separate bug in the sendfile path.
- On 1.4.1, `new Response(Bun.file(p).slice(-N))` from `Bun.serve` stalls when `N` is the file size. The server sends `Content-Length: N` and no body. This branch sends the bytes. The `serve.test.ts` case `[-full.byteLength, Infinity]` covers it.
- The status check in the good-range loops now comes from the expected body length. The server sends 206 when the body is shorter than the file. For every range that was in the list before, the result is the same.
- `Bun.stdin.slice(-5)` over a pipe gives the same result as on 1.4.1. When stdin is a regular file, it now gives the last 5 bytes.
- #39390 and #33687 edit the same lines in `get_slice`. Their logic does not overlap with this change.
- Also ran with the debug build: `serve.test.ts`, `bun-serve-file.test.ts`, `serve-file-slice-read-error.test.ts`, `bun-file-read.test.ts`, `bun-file-fd-read.test.ts`, `bun-file.test.ts`, `bun-file-exists.test.js`, `bun-stdin-slice.test.ts`, `structured-clone-blob-file.test.ts`, `bun-write.test.js`, `body.test.ts`. Three tests fail in my environment with and without this change: the port 1003 test (it runs as root), the `/bun:info` test (an egress proxy answers), and `bun-write.test.js` "on large files" (it takes about 5 s on a debug build, and 2 of 3 runs on main time out).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts, test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->