### PR TITLE
node:assert: expose AssertionError and CallTracker as data properties

### DIFF
--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -24,6 +24,7 @@
 const { isPromise, isRegExp } = require("node:util/types");
 const { innerOk } = require("internal/assert/utils");
 const { validateFunction, validateOneOf } = require("internal/validators");
+const { defineLazyProperties } = require("internal/shared");
 
 const ArrayPrototypeIndexOf = Array.prototype.indexOf;
 const ArrayPrototypeJoin = Array.prototype.join;
@@ -203,18 +204,22 @@ function fail(
 
 Assert.prototype.fail = fail;
 
-// The AssertionError is defined in internal/error.
-Object.defineProperty(assert, "AssertionError", {
-  get() {
+var CallTracker;
+function loadLazyExport(key: string) {
+  if (key === "AssertionError") {
     loadAssertionError();
     return AssertionError;
-  },
-  set(value) {
-    Object.defineProperty(this, "AssertionError", { value, writable: true, enumerable: true, configurable: true });
-  },
-  configurable: true,
-  enumerable: true,
-});
+  }
+  if (CallTracker === undefined) {
+    const { deprecate } = require("internal/util/deprecate");
+    CallTracker = deprecate(require("internal/assert/calltracker"), "assert.CallTracker is deprecated.", "DEP0173");
+  }
+  return CallTracker;
+}
+
+// Data properties, as in node. assertion_error pulls in node:fs, so each loads on first read.
+const lazyExports = ["AssertionError", "CallTracker"];
+defineLazyProperties(assert, lazyExports, loadLazyExport);
 
 /**
  * Pure assertion tests whether a value is truthy, as determined
@@ -907,23 +912,6 @@ Assert.prototype.doesNotMatch = function doesNotMatch(string, regexp, message) {
   internalMatch(string, regexp, message, doesNotMatch);
 };
 
-var CallTracker;
-Object.defineProperty(assert, "CallTracker", {
-  get() {
-    if (CallTracker === undefined) {
-      const { deprecate } = require("internal/util/deprecate");
-      CallTracker = deprecate(require("internal/assert/calltracker"), "assert.CallTracker is deprecated.", "DEP0173");
-    }
-    return CallTracker;
-  },
-  set(value) {
-    Object.defineProperty(this, "CallTracker", { value, writable: true, enumerable: true, configurable: true });
-  },
-  configurable: true,
-  enumerable: true,
-});
-// assert.CallTracker = CallTracker
-
 /**
  * Expose a strict only variant of assert.
  * @param {...any} args
@@ -956,7 +944,10 @@ for (const name of [
   assert[name] = Assert.prototype[name];
 }
 
+// Reading the descriptor of a lazy property loads it, so strict gets its own.
+defineLazyProperties(strict, lazyExports, loadLazyExport);
 for (const key of ObjectKeys(assert)) {
+  if (ArrayPrototypeIndexOf.$call(lazyExports, key) !== -1) continue;
   ObjectDefineProperty(strict, key, ObjectGetOwnPropertyDescriptor(assert, key));
 }
 assert.strict = ObjectAssign(strict, {

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -298,7 +298,7 @@ test.concurrent("accessors on other builtins bind to what require() returns", as
     import { print } from "./helper.mjs";
     const require = createRequire(import.meta.url);
     print({
-      // node:assert's exports object is a function; AssertionError is an accessor defined on it.
+      // node:assert's exports object is a function; AssertionError is a lazy property defined on it.
       assertIsFunction: typeof assert === "function",
       assertionError: typeof AssertionError === "function" && AssertionError === require("node:assert").AssertionError,
       timersPromises: timers.promises === require("node:timers/promises"),
@@ -306,6 +306,35 @@ test.concurrent("accessors on other builtins bind to what require() returns", as
     });
   `);
   expect(result).toEqual({ assertIsFunction: true, assertionError: true, timersPromises: true, streamPromises: true });
+});
+
+// node:assert defines AssertionError and CallTracker with defineLazyProperties (internal/shared). The readout is the
+// number of functions on the heap: internal/assert/assertion_error adds several hundred when it loads.
+test.concurrent("node:assert: importing does not load AssertionError, and a later store is not bound", async () => {
+  const result = await runEntry(`
+    import { heapStats } from "bun:jsc";
+    import { createRequire } from "node:module";
+    import { print } from "./helper.mjs";
+    const require = createRequire(import.meta.url);
+    const assert = require("node:assert");
+    const functions = () => heapStats().objectTypeCounts.Function;
+    const beforeImport = functions();
+    const ns = await import("node:assert");
+    const strictNs = await import("node:assert/strict");
+    const afterImport = functions();
+    // Node's facade copies the exports when the module is imported, so a value stored later does not reach a binding.
+    const stub = function Stub() {};
+    assert.AssertionError = stub;
+    const { AssertionError } = ns;
+    const afterRead = functions();
+    print({
+      importLoaded: afterImport - beforeImport > 100,
+      readLoaded: afterRead - afterImport > 100,
+      bindingIsStub: AssertionError === stub,
+      same: AssertionError === strictNs.AssertionError && strictNs.CallTracker === ns.CallTracker,
+    });
+  `);
+  expect(result).toEqual({ importLoaded: false, readLoaded: true, bindingIsStub: false, same: true });
 });
 
 test.concurrent("spyOn and mock.module on an imported builtin", async () => {

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const { describe, expect, spyOn, test } = require("bun:test");
 const { bunEnv, bunExe } = require("harness");
 
 test("assert from require as a function does not throw", () => assert(true));
@@ -179,5 +180,55 @@ describe("AssertionError diff rendering", () => {
       charDiff(same("'") + added("wö") + removed("😀") + same("rld, hello!'")),
     ]);
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("lazy exports", () => {
+  // A fresh process, so nothing has read AssertionError yet. internal/assert/assertion_error loads
+  // internal/util/inspect, so the readout is the number of functions on the heap: that load adds several hundred.
+  test("AssertionError and CallTracker are data properties that load on first read", async () => {
+    const fixture = `
+      const { heapStats } = require("bun:jsc");
+      const functions = () => heapStats().objectTypeCounts.Function;
+      const assert = require("node:assert");
+      const beforeRead = functions();
+      const AssertionError = assert.AssertionError;
+      const afterRead = functions();
+      const shape = (object, key) => {
+        const { value, get, writable, enumerable, configurable } = Object.getOwnPropertyDescriptor(object, key);
+        return { value: typeof value, get: typeof get, writable, enumerable, configurable };
+      };
+      console.log(JSON.stringify({
+        readLoaded: afterRead - beforeRead > 100,
+        descriptors: [assert, assert.strict].flatMap(object => [shape(object, "AssertionError"), shape(object, "CallTracker")]),
+        same: assert.strict.AssertionError === AssertionError && assert.strict.CallTracker === assert.CallTracker,
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const data = { value: "function", get: "undefined", writable: true, enumerable: true, configurable: true };
+    expect(JSON.parse(stdout)).toEqual({ readLoaded: true, descriptors: [data, data, data, data], same: true });
+    expect(exitCode).toBe(0);
+  });
+
+  // Nothing in this file reads assert.CallTracker first, so the first spy on it replaces a property that has not loaded.
+  test("spyOn accepts AssertionError and CallTracker on assert and assert.strict", () => {
+    for (const [object, other] of [
+      [assert, assert.strict],
+      [assert.strict, assert],
+    ]) {
+      for (const key of ["AssertionError", "CallTracker"]) {
+        const spy = spyOn(object, key);
+        expect(object[key]).toBe(spy);
+        spy.mockRestore();
+        expect(object[key]).toBe(other[key]);
+      }
+    }
   });
 });


### PR DESCRIPTION
Stacked on #41206, which adds `defineLazyProperties`. #41259 does the same for `node:repl`.

### Problem
- `assert.AssertionError` and `assert.CallTracker` are get/set accessors. Node defines them as data properties. `spyOn(assert, "AssertionError")` throws `spyOn(target, prop) does not support accessor properties yet`.
- `assert.strict` regressed after 1.4.0. Bun 1.4.0 copied the values with `Object.assign`, so its two keys were data properties. #39628 changed that to a descriptor copy (`src/js/node/assert.ts:960`), so they are accessors on main.

### Fix
- Define both keys with `defineLazyProperties`. Each key is a data property, and its first read loads the module. The accessors (`assert.ts:207`, `:911`) existed only for that lazy load.
- `assert.strict` defines its own lazy properties, and the copy loop skips them. A descriptor copy of a lazy property loads its value, so the loop would load `assertion_error` at init.
- Verified: `test/js/node/assert/assert.test.cjs` and `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`. Each file fails on the base branch. The suites in the notes pass.
- Self-reviewed: 11 concerns raised, 7 addressed. The other 4 ask for follow-ups outside this change, for example `os.tmpdir` as a data property.

### Background
- `defineLazyProperties(target, keys, loader)` comes from #41206. It makes each key a JSC `CustomValue`. JS sees a data property, and the first read stores `loader(key)`.
- `internal/assert/assertion_error` loads `internal/util/inspect`, colors and `node:fs`. #39628 made it lazy to cut the cost of `require("node:assert")`.
- Node 26 removed `assert.CallTracker`. Node 24 defines it as a data property (`lib/assert.js:826`). #35181 removes it from Bun. The PR that lands second must update `lazyExports`.

<details><summary>Notes</summary>

**Node 26.3.0 comparison.** Checked on the debug build: the descriptor of each key on `assert` and `assert.strict`, `strict.AssertionError === assert.AssertionError`, and assignment, `delete` and `Object.freeze` before the first read. The only difference left is that Bun still has `CallTracker`.

**ESM.** A binding of `node:assert` is now the loader result, as in Node. Before, a value stored on the exports object after the import, but before the first read of the binding, became the binding. The new test in `builtin-esm-lazy-exports.test.ts` covers this.

**Laziness.** `heapStats().objectTypeCounts.Function` on the debug build: `require("node:assert")` adds 175 functions. The first read of `AssertionError` adds 1161. The accessor version gives the same numbers. The tests read this count, so they fail if module init loads `assertion_error`. I also checked that the tests fail when the copy loop does not skip the lazy keys.

**Interop.** `Object.getOwnPropertyDescriptor` on a lazy property loads it, as with V8's lazy data properties. TypeScript's `__importStar` reads each descriptor, so a compiled `import * as assert from "assert"` loads `assertion_error`. Node's exports are eager, so Node does that work in every case.

**Suites run on the debug build.** `test/js/node/assert/` (525 pass), `builtin-esm-lazy-exports.test.ts`, `test/js/node/test_runner/node-test.test.ts`, the vendored `test-assert-*` tests and `test-runner-assert.js`, and the other vendored tests that use `AssertionError` or `CallTracker`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
(pass) importing the module does not run its accessors [507.75ms]
(pass) a namespace export materializes when it is read, not on import or `in` [906.73ms]
(pass) a named import materializes exactly the binding it links [968.22ms]
(pass) import() namespace: same export list as before, enumerating it materializes everything [977.16ms]
(pass) a deferred namespace (import defer) materializes on read as well [1002.57ms]
(pass) the accessors keep working after Object.seal of the exports object [1018.01ms]
(pass) re-exports bind through to the builtin's own binding [922.55ms]
(pass) the accessors keep working after Object.freeze of the exports object [1093.81ms]
(pass) accessors on other builtins bind to what require() returns [1175.95ms]
332 |       readLoaded: afterRead - afterImport > 100,
333 |       bindingIsStub: AssertionError === stub,
334 |       same: AssertionError === strictNs.AssertionError && str
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
(pass) importing the module does not run its accessors [28.81ms]
(pass) a namespace export materializes when it is read, not on import or `in` [27.24ms]
(pass) a deferred namespace (import defer) materializes on read as well [27.16ms]
(pass) a named import materializes exactly the binding it links [28.81ms]
(pass) import() namespace: same export list as before, enumerating it materializes everything [27.68ms]
(pass) the accessors keep working after Object.seal of the exports object [28.52ms]
(pass) re-exports bind through to the builtin's own binding [28.06ms]
445 |         });
446 |       `,
447 |     },
448 |     ["test", "./spy.test.mjs"],
449 |   );
450 |   expect(stderr).toContain(" 2 pass\n");
                       ^
error: expect(received).toContain(expected)

Expected to contain: " 2 pass\n"
Received: "\nspy.test.mjs:\n2 |         import { expect, spyOn, test } from \"bun:test\";\n3 |         import util from \"node:util\";\n4 |         import { viaNamespace } from \"./namespace.mjs\";\n5 | \n6 |         test(\"the first read of each binding happens during the spy\",
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
(pass) importing the module does not run its accessors [576.59ms]
(pass) a named import materializes exactly the binding it links [880.68ms]
(pass) a deferred namespace (import defer) materializes on read as well [891.90ms]
(pass) a namespace export materializes when it is read, not on import or `in` [985.69ms]
(pass) import() namespace: same export list as before, enumerating it materializes everything [1005.03ms]
(pass) the accessors keep working after Object.seal of the exports object [1007.00ms]
(pass) re-exports bind through to the builtin's own binding [929.72ms]
(pass) the accessors keep working after Object.freeze of the exports object [1022.69ms]
(pass) accessors on other builtins bind to what require() returns [1178.97ms]
(pass) node:assert: importing does not load AssertionError, and a later store is not bound [1461.49ms]
(pass) spyOn and mock.module on an imported builtin [1003.54ms]
(pass) 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     caf10a7274
  features     baseline

23 deps, 131 codegen, 1172 objects in 663ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 25 installs across 62 packages (no changes) [5.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [6.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch zlib
[zlib] up to date
[8/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[9/1217] gen .bind.ts → GeneratedBindings.cpp
[10/1217] fetch tinycc
[tinycc] up to date
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/buil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/assert.ts                              | 45 ++++++++-----------
 .../bun/resolve/builtin-esm-lazy-exports.test.ts   | 31 ++++++++++++-
 test/js/node/assert/assert.test.cjs                | 51 ++++++++++++++++++++++
 3 files changed, 99 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/js/node/assert.ts                                     2      4     23
test/js/bun/resolve/builtin-esm-lazy-exports.test.ts      4      7     20
test/js/node/assert/assert.test.cjs                       3      6     32
```

</details>

<!-- robobun:evidence:end -->