### PR TITLE
node:repl: expose REPLServer and writer as data properties

### DIFF
--- a/src/js/node/repl.js
+++ b/src/js/node/repl.js
@@ -90,6 +90,7 @@ const {
 // destructures `{start, Recoverable, REPL_MODE_*}` at import time pays
 // nothing until start() is actually called.
 const { REPL_MODE_SLOPPY, REPL_MODE_STRICT } = require("internal/repl/mode");
+const { defineLazyProperties } = require("internal/shared");
 
 class Recoverable extends SyntaxError {
   constructor(err) {
@@ -106,9 +107,6 @@ function isValidSyntax() {
   return loadImpl().isValidSyntax.$apply(this, arguments);
 }
 
-// REPLServer / writer / repl / builtinModules stay accessors: REPLServer extends
-// readline.Interface so reading it means loading anyway, and writer carries a
-// mutable `.options` that references util.inspect.defaultOptions.
 let _loaded;
 function loadImpl() {
   if (_loaded) return _loaded;
@@ -404,7 +402,7 @@ class REPLServer extends Interface {
     if (options[kStandaloneREPL]) {
       // It is possible to introspect the running REPL accessing this variable
       // from inside the REPL. This is useful for anyone working on the REPL.
-      _loaded.repl = this;
+      __node_module__.exports.repl = this;
     } else {
       addProcessNewListener();
       this.once("exit", removeProcessNewListener);
@@ -723,7 +721,7 @@ class REPLServer extends Interface {
     defineDefaultCommands(this);
 
     // Figure out which "writer" function to use
-    self.writer = options.writer || _loaded.writer;
+    self.writer = options.writer || __node_module__.exports.writer;
 
     if (self.writer === writer) {
       // Conditionally turn on ANSI coloring.
@@ -1509,18 +1507,8 @@ ObjectAssign(__node_module__.exports, {
   REPL_MODE_STRICT,
   isValidSyntax,
 });
-// Accessors for what can't be hollow: REPLServer extends readline.Interface,
-// writer carries a mutable .options bound to util.inspect.defaultOptions, and
-// repl is assigned by createInternalRepl.
-for (const name of ["REPLServer", "writer", "repl"]) {
-  ObjectDefineProperty(__node_module__.exports, name, {
-    __proto__: null,
-    get: () => loadImpl()[name],
-    set: v => { loadImpl()[name] = v; },
-    enumerable: true,
-    configurable: true,
-  });
-}
+// Data properties, as in node. REPLServer needs node:readline and writer needs inspect, so both load on first read.
+defineLazyProperties(__node_module__.exports, ["REPLServer", "writer"], name => loadImpl()[name]);
 for (const name of ["builtinModules", "_builtinLibs"]) {
   ObjectDefineProperty(__node_module__.exports, name, {
     __proto__: null,

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -2143,19 +2143,33 @@ describe.concurrent("--interactive", () => {
 });
 
 // ts-node does `require("repl")` at import time but only touches
-// repl.start/repl.Recoverable inside createRepl(); those (plus the REPL_MODE
-// symbols and isValidSyntax) are data properties so the destructure is free,
-// and only calling start() or reading REPLServer/writer loads the body.
+// repl.start/repl.Recoverable inside createRepl(), so reading those (plus the
+// REPL_MODE symbols and isValidSyntax) must not load the body. REPLServer and
+// writer are data properties, as in node, and the first read of either loads it.
+// The readout is the number of functions on the heap: the body adds several hundred.
 test.concurrent("require('node:repl') is hollow until start() or REPLServer is used", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
+        const { heapStats } = require("bun:jsc");
+        const functions = () => heapStats().objectTypeCounts.Function;
         const repl = require("node:repl");
+        const beforeRead = functions();
+        const {start, Recoverable, REPL_MODE_SLOPPY, REPL_MODE_STRICT, isValidSyntax} = repl;
+        const keys = Object.keys(repl).sort();
+        // As in node, repl.repl exists only after a standalone REPL starts.
+        const hasRepl = "repl" in repl;
+        const afterCheap = functions();
+        const REPLServer = repl.REPLServer;
+        const afterLoad = functions();
         const shape = n => "value" in Object.getOwnPropertyDescriptor(repl, n) ? "data" : "accessor";
         console.log(JSON.stringify({
-          keys: Object.keys(repl).sort(),
+          cheapLoaded: afterCheap - beforeRead > 100,
+          bodyLoaded: afterLoad - afterCheap > 100,
+          keys,
+          hasRepl,
           desc: {
             start: shape("start"),
             Recoverable: shape("Recoverable"),
@@ -2165,8 +2179,6 @@ test.concurrent("require('node:repl') is hollow until start() or REPLServer is u
             writer: shape("writer"),
           },
         }));
-        // Reading the cheap five must not throw and must not require readline.
-        const {start, Recoverable, REPL_MODE_SLOPPY, REPL_MODE_STRICT, isValidSyntax} = repl;
         console.log(JSON.stringify({
           start: typeof start,
           Recoverable: typeof Recoverable,
@@ -2174,8 +2186,7 @@ test.concurrent("require('node:repl') is hollow until start() or REPLServer is u
           isValidSyntax: typeof isValidSyntax,
         }));
         console.log("recoverable-is-error=" + (new Recoverable(new SyntaxError("m")) instanceof SyntaxError));
-        // Now force the full load and check REPLServer is real.
-        console.log("REPLServer=" + typeof repl.REPLServer);
+        console.log("REPLServer=" + typeof REPLServer);
         // Recoverable identity: the one exposed before load is the one the impl uses.
         console.log("same-Recoverable=" + (repl.Recoverable === Recoverable));
         repl.repl = "x";
@@ -2190,23 +2201,17 @@ test.concurrent("require('node:repl') is hollow until start() or REPLServer is u
   expect(stderr).toBe("");
   const lines = stdout.trim().split("\n");
   expect(JSON.parse(lines[0])).toEqual({
-    keys: [
-      "REPLServer",
-      "REPL_MODE_SLOPPY",
-      "REPL_MODE_STRICT",
-      "Recoverable",
-      "isValidSyntax",
-      "repl",
-      "start",
-      "writer",
-    ],
+    cheapLoaded: false,
+    bodyLoaded: true,
+    keys: ["REPLServer", "REPL_MODE_SLOPPY", "REPL_MODE_STRICT", "Recoverable", "isValidSyntax", "start", "writer"],
+    hasRepl: false,
     desc: {
       start: "data",
       Recoverable: "data",
       REPL_MODE_SLOPPY: "data",
       isValidSyntax: "data",
-      REPLServer: "accessor",
-      writer: "accessor",
+      REPLServer: "data",
+      writer: "data",
     },
   });
   expect(JSON.parse(lines[1])).toEqual({
@@ -2221,6 +2226,36 @@ test.concurrent("require('node:repl') is hollow until start() or REPLServer is u
     "same-Recoverable=true",
     "repl.repl=x",
   ]);
+  expect(exitCode).toBe(0);
+});
+
+// As in node, the REPLServer constructor reads the default writer from the exports object.
+test.concurrent("a writer stored on node:repl is the default writer of a new REPLServer", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const repl = require("node:repl");
+        const { PassThrough } = require("node:stream");
+        const writer = value => "custom " + value;
+        repl.writer = writer;
+        const input = new PassThrough();
+        const output = new PassThrough();
+        let text = "";
+        output.setEncoding("utf8").on("data", chunk => (text += chunk));
+        const server = repl.start({ input, output, prompt: "", terminal: false });
+        server.on("exit", () => console.log(JSON.stringify({ same: server.writer === writer, text })));
+        input.end("1 + 1\\n");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ same: true, text: "custom 2\n" });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -423,6 +423,44 @@ test.concurrent("node:util: a spy on the exports object does not reach the ESM b
   expect(exitCode).toBe(0);
 });
 
+// node:repl defines REPLServer and writer with defineLazyProperties. The REPL body adds several hundred functions.
+test.concurrent("node:repl: importing does not load the REPL, and the export names match node", async () => {
+  const result = await runEntry(`
+    import { heapStats } from "bun:jsc";
+    import { createRequire } from "node:module";
+    import { print } from "./helper.mjs";
+    const repl = createRequire(import.meta.url)("node:repl");
+    const functions = () => heapStats().objectTypeCounts.Function;
+    const beforeImport = functions();
+    const ns = await import("node:repl");
+    const afterImport = functions();
+    const { REPLServer } = ns;
+    const afterRead = functions();
+    print({
+      importLoaded: afterImport - beforeImport > 100,
+      readLoaded: afterRead - afterImport > 100,
+      same: REPLServer === repl.REPLServer && ns.writer === repl.writer,
+      // repl.repl is not an export: the REPLServer constructor sets it for a standalone REPL.
+      names: Object.keys(ns),
+    });
+  `);
+  expect(result).toEqual({
+    importLoaded: false,
+    readLoaded: true,
+    same: true,
+    names: [
+      "REPLServer",
+      "REPL_MODE_SLOPPY",
+      "REPL_MODE_STRICT",
+      "Recoverable",
+      "default",
+      "isValidSyntax",
+      "start",
+      "writer",
+    ],
+  });
+});
+
 test.concurrent('"bun": re-exports construct the properties that get bound, not the rest of the object', async () => {
   const result = await runEntry(
     `


### PR DESCRIPTION
Stacked on #41206, which adds `defineLazyProperties`. #41258 does the same for `node:assert`.

### Problem
- `repl.REPLServer` and `repl.writer` are get/set accessors (`src/js/node/repl.js:1515`). Node defines them as data properties. `spyOn(repl, "writer")` throws `spyOn(target, prop) does not support accessor properties yet`.
- `repl.repl` is an accessor too. Node has no `repl` property until a standalone REPL starts (`lib/repl.js:400`).

### Fix
- Define `REPLServer` and `writer` with `defineLazyProperties`. Each key is a data property, and its first read loads the REPL implementation.
- Remove the `repl` accessor. As in Node (`lib/repl.js:400`, `:709`), the `REPLServer` constructor sets `repl` and reads the default `writer` on the exports object. So `repl` leaves `Object.keys(repl)`, `import { repl } from "node:repl"` is a `SyntaxError`, and `repl.writer = fn` still sets the default writer.
- Verified: `test/js/bun/repl/repl.test.ts` and `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`. Each file fails on the base branch. The vendored `test-repl-*` tests pass, except two that fail without this commit too.
- Self-reviewed: 11 concerns raised, 7 addressed. The other 4 ask for follow-ups outside this change, for example `os.tmpdir` as a data property.

### Background
- `defineLazyProperties(target, keys, loader)` comes from #41206. It makes each key a JSC `CustomValue`. JS sees a data property, and the first read stores `loader(key)`.
- `node:repl` keeps the REPL implementation in `loadImpl()`. `REPLServer` extends `readline.Interface`, and `writer.options` copies `util.inspect.defaultOptions`. So neither can exist before the load.
- The old accessors forwarded each read and write to the object that `loadImpl()` returns.

<details><summary>Notes</summary>

**Node 26.3.0 comparison.** Checked on the debug build: the descriptors, `Object.keys(repl)`, the names of the ESM namespace, `import { repl }`, a custom `repl.writer`, and `Object.freeze(repl)` before the first read. All match Node. In `bun --interactive`, `repl.repl` is still the running REPL (`test-repl-options.js` covers it).

**Laziness.** `heapStats().objectTypeCounts.Function` on the debug build: `require("node:repl")` adds 65 functions. The first read of `REPLServer` adds 1075. The accessor version gives the same numbers. `require("node:repl")` and a read of `start`, `Recoverable`, the `REPL_MODE_*` symbols or `isValidSyntax` still load nothing. ts-node depends on this.

**Interop.** `Object.getOwnPropertyDescriptor` on a lazy property loads it, as with V8's lazy data properties. TypeScript's `__importStar` reads each descriptor, so a compiled `import * as repl from "repl"` loads the REPL. Named imports do not.

**Failures that also occur without this commit.** `test-repl-completion-on-getters-disabled.js` times out at 5 s under ASAN. `test-repl-tab-complete-nested-repls.js` prints `Uncaught Error` with no message on the debug build.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->