### PR TITLE
install: keep a self-contained workspace's packages on `bun update`/`dedupe`/`audit fix`

### DIFF
--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -721,26 +721,68 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
     })
 }
 
+/// The dependency types an install lays out for local and for remote packages; `--production` / `--omit` narrow them.
+type InstallFeatures = (Features, Features);
+
+fn install_features(manager: &PackageManager) -> InstallFeatures {
+    (
+        manager.options.local_package_features,
+        manager.options.remote_package_features,
+    )
+}
+
+/// Every dependency type an install can lay out, whatever `--production` / `--omit` say for this run.
+fn full_install_features((mut local, mut remote): InstallFeatures) -> InstallFeatures {
+    local.dev_dependencies = true;
+    for features in [&mut local, &mut remote] {
+        features.optional_dependencies = true;
+        features.peer_dependencies = true;
+    }
+    (local, remote)
+}
+
+fn with_install_features<T>(
+    manager: &mut PackageManager,
+    (local, remote): InstallFeatures,
+    f: impl FnOnce(&mut PackageManager) -> T,
+) -> T {
+    let saved = install_features(manager);
+    manager.options.local_package_features = local;
+    manager.options.remote_package_features = remote;
+    let result = f(manager);
+    (
+        manager.options.local_package_features,
+        manager.options.remote_package_features,
+    ) = saved;
+    result
+}
+
 /// The tree the lockfile saves (`Lockfile::resolve`), held while `manager.lockfile` carries the install tree.
 struct SavedTree {
     trees: tree::List,
     hoisted_dependencies: Vec<DependencyID>,
 }
 
-/// Hoists `manager.lockfile` into the tree an install lays out for every workspace (`Lockfile::filter`):
-/// the self-contained barrier applied, disabled and bundled dependencies left out. Returns the tree it replaced.
-fn hoist_install_tree(manager: &mut PackageManager) -> Result<SavedTree, tree::SubtreeError> {
+/// Hoists `manager.lockfile` into the tree an install of `features` lays out for every workspace
+/// (`Lockfile::filter`): the self-contained barrier applied, disabled and bundled dependencies left out.
+/// Returns the tree it replaced.
+fn hoist_install_tree(
+    manager: &mut PackageManager,
+    features: InstallFeatures,
+) -> Result<SavedTree, tree::SubtreeError> {
     let saved = SavedTree {
         trees: core::mem::take(&mut manager.lockfile.buffers.trees),
         hoisted_dependencies: core::mem::take(&mut manager.lockfile.buffers.hoisted_dependencies),
     };
-    let pm: *mut PackageManager = manager;
-    // SAFETY: same split as `PackageManager::load_lockfile_from_cwd` — `lockfile` is its own `Box` allocation and the Filter builder only reads `manager.options`/`subcommand`/`summary`.
-    let result = unsafe {
-        let lf: *mut Lockfile = &raw mut *(*pm).lockfile;
-        let log: *mut bun_ast::Log = (*pm).log;
-        (*lf).hoist::<{ tree::BuilderMethod::Filter }>(&mut *log, Some(&*pm), true, &[], None)
-    };
+    let result = with_install_features(manager, features, |manager| {
+        let pm: *mut PackageManager = manager;
+        // SAFETY: same split as `PackageManager::load_lockfile_from_cwd` — `lockfile` is its own `Box` allocation and the Filter builder only reads `manager.options`/`subcommand`/`summary`.
+        unsafe {
+            let lf: *mut Lockfile = &raw mut *(*pm).lockfile;
+            let log: *mut bun_ast::Log = (*pm).log;
+            (*lf).hoist::<{ tree::BuilderMethod::Filter }>(&mut *log, Some(&*pm), true, &[], None)
+        }
+    });
     match result {
         Ok(_) => Ok(saved),
         Err(err) => {
@@ -1084,7 +1126,7 @@ fn plan_hoisted(
         return;
     }
 
-    if hoist_install_tree(manager).is_err() {
+    if hoist_install_tree(manager, install_features(manager)).is_err() {
         manager.crash();
     }
 
@@ -1263,9 +1305,11 @@ fn has_bundled_deps(lockfile: &Lockfile, pkg_id: PackageID) -> bool {
 /// Hoisted post-install pass for dedupe / audit fix / update (install_with_manager.rs): removes the copies
 /// `before` placed in a nested or workspace `node_modules` that the install now provides from an ancestor.
 /// The folders are compared with the install tree, not the lockfile's: only the install tree applies the
-/// self-contained barrier, so only it says what a self-contained workspace keeps.
+/// self-contained barrier, so only it says what a self-contained workspace keeps. The tree carries every
+/// dependency type, so a copy under a dependency that `--production` / `--omit` skipped this run stays.
 pub(crate) fn remove_collapsed_copies(manager: &mut PackageManager, before: &Lockfile) {
-    let Ok(saved) = hoist_install_tree(manager) else {
+    let Ok(saved) = hoist_install_tree(manager, full_install_features(install_features(manager)))
+    else {
         return;
     };
     plan_and_remove_collapsed_copies(manager, before);
@@ -1661,37 +1705,17 @@ fn wanted_packages(manager: &PackageManager, selection: Option<&Selection>) -> D
     wanted
 }
 
-type StoreFeatures = (Features, Features);
-
-fn full_store_features((mut local, mut remote): StoreFeatures) -> StoreFeatures {
-    local.dev_dependencies = true;
-    for features in [&mut local, &mut remote] {
-        features.optional_dependencies = true;
-        features.peer_dependencies = true;
-    }
-    (local, remote)
-}
-
-fn build_store_with(manager: &mut PackageManager, (local, remote): StoreFeatures) -> Store {
-    let saved = (
-        manager.options.local_package_features,
-        manager.options.remote_package_features,
-    );
-    manager.options.local_package_features = local;
-    manager.options.remote_package_features = remote;
-    let store = build_store(
-        &*manager,
-        &manager.lockfile,
-        true,
-        &[],
-        None,
-        Timings::Quiet,
-    );
-    (
-        manager.options.local_package_features,
-        manager.options.remote_package_features,
-    ) = saved;
-    handle_oom(store)
+fn build_store_with(manager: &mut PackageManager, features: InstallFeatures) -> Store {
+    with_install_features(manager, features, |manager| {
+        handle_oom(build_store(
+            &*manager,
+            &manager.lockfile,
+            true,
+            &[],
+            None,
+            Timings::Quiet,
+        ))
+    })
 }
 
 fn push_store_entry_names(
@@ -1725,11 +1749,8 @@ fn store_entry_names(manager: &mut PackageManager, wanted: &DynamicBitSet) -> Ve
     if manager.lockfile.packages.len() == 0 {
         return Vec::new();
     }
-    let own: StoreFeatures = (
-        manager.options.local_package_features,
-        manager.options.remote_package_features,
-    );
-    let full = full_store_features(own);
+    let own = install_features(manager);
+    let full = full_install_features(own);
     let mut names: Vec<Box<[u8]>> = Vec::new();
     for features in [Some(full), (own != full).then_some(own)]
         .into_iter()

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -19,7 +19,7 @@ use crate::lockfile_real::package::{Diff, DiffSummary, Package};
 use crate::package_manager::Options::{Enable, LogLevel};
 use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
 use crate::package_manager::workspace_selection::{self, RootSelection};
-use crate::{Features, PackageID, PackageManager, ResolutionTag, invalid_package_id};
+use crate::{DependencyID, Features, PackageID, PackageManager, ResolutionTag, invalid_package_id};
 
 const STORE_DIR: &[u8] = b"node_modules/.bun";
 const ROOT_DIR: &[u8] = b"node_modules";
@@ -557,7 +557,7 @@ pub(crate) fn exit_unless_lockfile_matches_package_json(
     let mut to_root = Package::default();
     let mut resolver: () = ();
     let pm: *mut PackageManager = manager;
-    // SAFETY: same split as `hoist_filtered`; neither call reaches `lockfile` through `pm`.
+    // SAFETY: same split as `hoist_install_tree`; neither call reaches `lockfile` through `pm`.
     let summary = unsafe {
         let parsed = to_root.parse_with_json::<()>(
             &mut to_lockfile,
@@ -721,7 +721,19 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
     })
 }
 
-fn hoist_filtered(manager: &mut PackageManager) {
+/// The tree the lockfile saves (`Lockfile::resolve`), held while `manager.lockfile` carries the install tree.
+struct SavedTree {
+    trees: tree::List,
+    hoisted_dependencies: Vec<DependencyID>,
+}
+
+/// Hoists `manager.lockfile` into the tree an install lays out for every workspace (`Lockfile::filter`):
+/// the self-contained barrier applied, disabled and bundled dependencies left out. Returns the tree it replaced.
+fn hoist_install_tree(manager: &mut PackageManager) -> Result<SavedTree, tree::SubtreeError> {
+    let saved = SavedTree {
+        trees: core::mem::take(&mut manager.lockfile.buffers.trees),
+        hoisted_dependencies: core::mem::take(&mut manager.lockfile.buffers.hoisted_dependencies),
+    };
     let pm: *mut PackageManager = manager;
     // SAFETY: same split as `PackageManager::load_lockfile_from_cwd` — `lockfile` is its own `Box` allocation and the Filter builder only reads `manager.options`/`subcommand`/`summary`.
     let result = unsafe {
@@ -729,9 +741,18 @@ fn hoist_filtered(manager: &mut PackageManager) {
         let log: *mut bun_ast::Log = (*pm).log;
         (*lf).hoist::<{ tree::BuilderMethod::Filter }>(&mut *log, Some(&*pm), true, &[], None)
     };
-    if result.is_err() {
-        manager.crash();
+    match result {
+        Ok(_) => Ok(saved),
+        Err(err) => {
+            restore_tree(&mut manager.lockfile, saved);
+            Err(err)
+        }
     }
+}
+
+fn restore_tree(lockfile: &mut Lockfile, saved: SavedTree) {
+    lockfile.buffers.trees = saved.trees;
+    lockfile.buffers.hoisted_dependencies = saved.hoisted_dependencies;
 }
 
 struct TreeFolder {
@@ -1063,7 +1084,9 @@ fn plan_hoisted(
         return;
     }
 
-    hoist_filtered(manager);
+    if hoist_install_tree(manager).is_err() {
+        manager.crash();
+    }
 
     let quiet = manager.options.log_level == LogLevel::Silent;
     let features = manager.options.local_package_features;
@@ -1237,8 +1260,19 @@ fn has_bundled_deps(lockfile: &Lockfile, pkg_id: PackageID) -> bool {
     (slice.begin() as usize..slice.end() as usize).any(|i| deps[i].behavior.is_bundled())
 }
 
-// Hoisted post-install pass for dedupe / audit fix / update (install_with_manager.rs).
-pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfile) {
+/// Hoisted post-install pass for dedupe / audit fix / update (install_with_manager.rs): removes the copies
+/// `before` placed in a nested or workspace `node_modules` that the install now provides from an ancestor.
+/// The folders are compared with the install tree, not the lockfile's: only the install tree applies the
+/// self-contained barrier, so only it says what a self-contained workspace keeps.
+pub(crate) fn remove_collapsed_copies(manager: &mut PackageManager, before: &Lockfile) {
+    let Ok(saved) = hoist_install_tree(manager) else {
+        return;
+    };
+    plan_and_remove_collapsed_copies(manager, before);
+    restore_tree(&mut manager.lockfile, saved);
+}
+
+fn plan_and_remove_collapsed_copies(manager: &PackageManager, before: &Lockfile) {
     let after: &Lockfile = &manager.lockfile;
     let workspace_names = collect_workspace_names(manager);
     if after.buffers.trees.is_empty()

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -584,6 +584,49 @@ it("--filter pkg-a removes the nested copy whose row it collapsed", async () => 
   expect(code).toBe(0);
 });
 
+// The collapsed-copy pass compares node_modules with a tree of every dependency type, so a copy
+// under a dependency this run skips is not mistaken for one the root now provides.
+it("--omit dev keeps the nested copies of the dev dependencies it skips", async () => {
+  setHandler(
+    dummyRegistry([], { "0.0.3": {}, "0.0.5": {}, "0.1.0": { dependencies: { baz: "0.0.3" } }, latest: "0.0.5" }),
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: { baz: "0.0.5" },
+      devDependencies: { moo: "0.1.0" },
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "pkg-a"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "pkg-a", "package.json"),
+    JSON.stringify({ name: "pkg-a", devDependencies: { baz: "0.0.3" } }),
+  );
+  await runInstall();
+  const mooBazVersion = async () =>
+    (await file(join(package_dir, "node_modules", "moo", "node_modules", "baz", "package.json")).json()).version;
+  expect(await rootBazVersion()).toBe("0.0.5");
+  expect(await mooBazVersion()).toBe("0.0.3");
+  expect(await pkgABazVersion()).toBe("0.0.3");
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update", "--omit", "dev", "--linker=hoisted"],
+    cwd: package_dir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [err, code] = await Promise.all([stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(await rootBazVersion()).toBe("0.0.5");
+  expect(await mooBazVersion()).toBe("0.0.3");
+  expect(await pkgABazVersion()).toBe("0.0.3");
+  expect(code).toBe(0);
+});
+
 it("--filter excluding a workspace leaves that workspace's node_modules alone", async () => {
   await nestedBazRepo("0.0.3", "0.0.5", { root: "~0.0.3" });
   expect(await rootBazVersion()).toBe("0.0.3");

--- a/test/cli/install/bun-workspaces-self-contained.test.ts
+++ b/test/cli/install/bun-workspaces-self-contained.test.ts
@@ -276,6 +276,35 @@ describe.each([
   });
 });
 
+// `bun update` removes copies that an ancestor node_modules now provides. A self-contained
+// workspace takes nothing from its ancestors, so its copies of the root's packages stay.
+it.each(Object.keys(spellings) as (keyof typeof spellings)[])(
+  "bun update keeps the packages of a workspace made self-contained by %s",
+  async spelling => {
+    const [desktopExtra, workspacesExtra] = spellings[spelling];
+    await writeProject(desktopExtra, workspacesExtra);
+    const r = await install(package_dir);
+    expect(r.err).not.toContain("error:");
+    expect(r.code).toBe(0);
+    const desktopNm = join(package_dir, "apps", "desktop", "node_modules");
+    expect(await readdirSorted(desktopNm)).toEqual(["@barn", "bar", "baz", "shared"]);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "update"],
+      cwd: package_dir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+    expect(await readdirSorted(desktopNm)).toEqual(["@barn", "bar", "baz", "shared"]);
+    expect(existsSync(join(desktopNm, "bar", "package.json"))).toBeTrue();
+    expect(existsSync(join(desktopNm, "baz", "package.json"))).toBeTrue();
+  },
+);
+
 it.each(Object.keys(spellings) as (keyof typeof spellings)[])(
   "bun prune keeps the packages of a workspace made self-contained by %s",
   async spelling => {


### PR DESCRIPTION
### Problem
- After #41215, `bun update`, `bun dedupe`, and `bun audit fix` with the hoisted linker delete packages from a self-contained workspace's `node_modules` (`installConfig.hoistingLimits: "workspaces"` / `workspaces.selfContained`). Any package there that the root `node_modules` also holds is removed, so the workspace is no longer self-contained until the next `bun install`.
- The post-install pass `prune::remove_collapsed_copies` removes nested and workspace copies that an ancestor `node_modules` now provides. It compared the folders with `manager.lockfile.buffers.trees`, which `install_hoisted_packages` restores to the lockfile tree (`Lockfile::resolve`) once the install is done. #41215 took the self-contained barrier out of that tree, so in it every dependency of a self-contained workspace hoists to the root, and the pass reads the workspace's own copies as collapsed duplicates.

### Fix
- `remove_collapsed_copies` hoists `manager.lockfile` into the install tree (`Lockfile::filter`, every workspace) for the comparison and puts the lockfile tree back afterwards, the same way `bun pm prune` already plans against the install tree. Only the install tree applies the barrier, so only it says what a self-contained workspace keeps.
- That tree carries every dependency type (`full_install_features`, the set `bun pm prune` already uses for the isolated store), so under `--production` / `--omit` a copy nested under a dependency the run skipped is not mistaken for one the root provides.
- `hoist_filtered` becomes `hoist_install_tree`, shared with `bun pm prune`, and returns the tree it replaced; the feature swap `build_store_with` did inline becomes `with_install_features`, shared too.
- Tests: `--omit dev keeps the nested copies of the dev dependencies it skips` in `test/cli/install/bun-update.test.ts`, and `bun update keeps the packages of a workspace made self-contained by %s` in `test/cli/install/bun-workspaces-self-contained.test.ts`, both spellings. On main the update leaves `["@barn", "shared"]` in `apps/desktop/node_modules`; with this change all four entries stay.

<details><summary>Repro</summary>

```sh
mkdir -p r/packages/{app,lib} && cd r
echo '{"name":"r","private":true,"workspaces":["packages/*"],"dependencies":{"ms":"2.1.3"}}' > package.json
echo '{"name":"lib","version":"1.0.0","dependencies":{"ms":"2.1.3"}}' > packages/lib/package.json
echo '{"name":"app","version":"1.0.0","installConfig":{"hoistingLimits":"workspaces"},"dependencies":{"lib":"workspace:*","ms":"2.1.3"}}' > packages/app/package.json
bun install --linker=hoisted   # node_modules/ms and packages/app/node_modules/ms
bun update --linker=hoisted    # main: packages/app/node_modules/ms is gone
```

</details>
