### PR TITLE
test: cover the heap meta data page collect from oven-sh/mimalloc#31

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "942b8342575bdece649438ca76f32276a019c51e";
+const MIMALLOC_COMMIT = "b20b60d959093b1bc0e24306ec72ccacb3e46fb9";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "b20b60d959093b1bc0e24306ec72ccacb3e46fb9";
+const MIMALLOC_COMMIT = "6a64e1ba7f5b2130d4efccb67ec87fd0003f0f6a";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -64,6 +64,58 @@ describe("heapStats() mimalloc integration", () => {
     void before;
   });
 
+  // Every `new Bun.Transpiler(opts)` owns a mimalloc heap (a bun_alloc::Arena). A `define` value that
+  // goes through the JSON parser allocates into that heap, so the heap also gets its per-arena page
+  // bitmaps (`mi_arena_pages_t`, about 150 KiB). The GC finalizes the instances in one batch, so
+  // hundreds of heaps are destroyed while their meta data fills whole pages of the main heap.
+  // mimalloc abandons a page once it is full. A free into an abandoned page has to collect the page
+  // (free it, reclaim it, or re-map it), or the block is stranded: the page stays abandoned and
+  // resident forever. `mi_heap_destroy` used to free the meta data without collecting, so every
+  // destroyed heap leaked about 150 KiB of RSS and left one more abandoned page behind.
+  test("destroying many heaps at once does not strand their meta data", async () => {
+    const heapsPerRound = 200;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { heapStats } from "bun:jsc";
+         const opts = { loader: "ts", define: { A: '"x"' } };
+         const rounds = [];
+         for (let round = 0; round < 4; round++) {
+           for (let i = 0; i < ${heapsPerRound}; i++) new Bun.Transpiler(opts);
+           Bun.gc(true);
+           Bun.gc(true);
+           rounds.push({ abandoned: heapStats().mimalloc.pages_abandoned.current, rss: process.memoryUsage.rss() });
+         }
+         console.log(JSON.stringify(rounds));`,
+      ],
+      env: {
+        ...bunEnv,
+        // ASAN's quarantine pins freed blocks and keeps RSS at peak.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+          .filter(Boolean)
+          .join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const rounds: { abandoned: number; rss: number }[] = JSON.parse(stdout.trim());
+    expect(rounds).toHaveLength(4);
+    expect(exitCode).toBe(0);
+
+    const abandoned = rounds.map(r => r.abandoned);
+    const rssMiB = rounds.map(r => r.rss / 1024 / 1024);
+    // A stranded page stays abandoned, so the count used to grow by about 29 per round: one 4 MiB
+    // page per 28 `mi_arena_pages_t` and one 64 KiB page per 9 `mi_heap_t`. A collected page is
+    // freed, or taken over by the next round's heaps, so the count stays where the first round left it.
+    expect(abandoned[3] - abandoned[0]).toBeLessThan(heapsPerRound / 10);
+    // The stranded pages were resident: about 150 KiB per heap, so a round cost about 30 MiB in a
+    // release build and more in a debug build. A round now reuses the memory the rounds before it freed.
+    expect(rssMiB[3] - rssMiB[2]).toBeLessThan(20);
+  });
+
   // mimalloc tags its arena mmaps with an app-reserved VM tag (240-255). The old default,
   // 100, is VM_MEMORY_IOACCELERATOR, so profilers reported Bun's heap as GPU memory.
   // The tags are read back from the kernel (mach_vm_region's user_tag), not from vmmap's


### PR DESCRIPTION
Stacked on #41253. The base branch is `claude/bump-mimalloc`. When #41253 merges, GitHub moves this PR to `main`.

### Problem
- `new Bun.Transpiler({ define })` leaks about 150 KiB of RSS per instance when 100 or more instances die in one GC. Each instance owns a mimalloc heap. `mi_heap_destroy` frees the heap meta data into a full, abandoned page and does not collect the page.
- oven-sh/mimalloc#31 fixes this. #41253 moves the pin to `6a64e1b`, which contains that fix. No test covers it.

### Fix
- Add the regression test from #41100 to `test/js/bun/jsc/heapStats-mimalloc.test.ts`. This PR changes only the test.
- The test creates 200 instances per round, for 4 rounds. It checks that the abandoned page count and RSS stay flat between rounds.
- Verified: the test fails on bun 1.4.1 and on a debug build with the pin on `main` (84 stranded pages, limit 20). It passes on a debug build with the #41253 pin (`6a64e1b`), in 3 of 3 runs.

### Background
- A mimalloc heap is a set of pages. The meta data of a heap lives in pages of the main heap.
- mimalloc abandons a page once it is full. Only a free into the page brings it back. A free that does not collect the page strands the block, and the page stays resident.
- `heapStats().mimalloc.pages_abandoned.current` counts abandoned pages. The test uses it for an exact count.

<details><summary>Notes</summary>

`heapStats().mimalloc` after each round of 200 instances, linux-x64:

```
bun 1.4.1, pin 942b834:        abandoned 30 -> 58 -> 86 -> 114   rss 68 -> 101 -> 133 -> 163 MiB
debug, pin 942b834 (main):     abandoned 28 -> 56 -> 84 -> 112   rss 376 -> 405 -> 438 -> 466 MiB
debug, pin 6a64e1b (#41253):   abandoned  0 ->  0 ->  0 ->   0   rss 345 -> 346 -> 349 -> 350 MiB
```

The first pin of #41253, `b20b60d`, gave the same result. The two commits from `b20b60d` to `6a64e1b` come from oven-sh/mimalloc#33. They do not touch the heap teardown code.

Pin check with the GitHub compare API:
- `2c98a55` (the merge commit of oven-sh/mimalloc#31) to `6a64e1b` (the #41253 pin): ahead by 10, behind by 0.
- `2c98a55` to `942b834` (the pin on `main`): behind by 2.

The fix is in the pin (`scripts/build/deps/mimalloc.ts`), not under `src/`. A check that reverts `src/` cannot show the failure. The fail-before runs are the released binary and a debug build with the pin set back to `942b834`.

#41100 pinned the head commit of oven-sh/mimalloc#31 and carried this test. It is closed in favor of #41253 and this PR.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/jsc/heapStats-mimalloc.test.ts

<!-- robobun:evidence:end -->