### PR TITLE
bundler: keep the CommonJS wrapper when a file uses module beyond module.exports

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -428,6 +428,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
 
                             // rewrite `module.exports` to `exports`
+                            p.module_exports_rewrite_count += 1;
                             return Some(Expr {
                                 data: js_ast::ExprData::ESpecial(E::Special::ModuleExports),
                                 loc: name_loc,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -345,6 +345,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) commonjs_named_exports: bun_ast::ast_result::CommonJSNamedExports,
     pub(crate) commonjs_named_exports_deoptimized: bool,
     pub(crate) commonjs_module_exports_assigned_deoptimized: bool,
+    /// Uses of `module` that became `module.exports` and stay in its use count.
+    pub(crate) module_exports_rewrite_count: u32,
     pub(crate) commonjs_named_exports_needs_conversion: u32,
     pub(crate) had_commonjs_named_exports_this_visit: bool,
     pub(crate) commonjs_replacement_stmts: StmtNodeList,
@@ -9514,6 +9516,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             unwrap_all_requires,
             commonjs_named_exports: Default::default(),
             commonjs_module_exports_assigned_deoptimized: false,
+            module_exports_rewrite_count: 0,
             commonjs_named_exports_needs_conversion: u32::MAX,
             had_commonjs_named_exports_this_visit: false,
             commonjs_replacement_stmts: js_ast::StmtNodeList::EMPTY,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1463,6 +1463,12 @@ impl<'a> Parser<'a> {
                             p.symbols.as_mut_slice()[p.exports_ref.inner_index() as usize]
                                 .use_count_estimate += export_refs_len as u32;
                             p.deoptimize_commonjs_named_exports();
+                        } else if p.symbols.as_slice()[p.module_ref.inner_index() as usize]
+                            .use_count_estimate
+                            > p.module_exports_rewrite_count
+                        {
+                            // `module.constructor` and other uses of `module` need the wrapper.
+                            p.deoptimize_commonjs_named_exports();
                         }
                     }
                 }

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -2011,4 +2011,41 @@ describe("bundler", () => {
       { file: "/out/b.js", stdout: "b false" },
     ],
   });
+  itBundled("cjs2esm/OtherModuleMemberKeepsWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib, * as ns from "lib";
+        console.log(lib.addHook(), ns.hot, lib.self === lib);
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        const Module = module.constructor.length > 1 ? module.constructor : null;
+        exports.addHook = function addHook() { return typeof Module; };
+        exports.hot = typeof module.hot;
+        exports.self = module.exports;
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/node_modules/lib/index.js"],
+    },
+    run: {
+      stdout: "object undefined true",
+    },
+  });
+  itBundled("cjs2esm/ModuleExportsMemberStillLifts", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib, * as ns from "lib";
+        console.log(lib.x, ns.y, lib.main);
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        module.exports.x = 1;
+        exports.y = module.exports.x + 1;
+        exports.main = require.main === module;
+      `,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "1 2 false",
+    },
+  });
 });


### PR DESCRIPTION
A CommonJS file with `exports.x = …` assignments was lifted to ESM even when it also used `module` in a way the lift does not rewrite: `module.constructor`, `module.hot`, `module.paths`, or bare `module`. The lifted output referenced an undeclared `module_<name>` and threw at load.

```js
// node_modules/pirates/lib/index.js (used by @babel/register, sucrase, jest)
const Module = module.constructor.length > 1 ? module.constructor : BuiltinModule;
exports.addHook = function addHook() { /* … */ };
```

```js
import pirates from "pirates"; // ReferenceError: module_lib is not defined
```

This existed for `import * as` importers before. #41162 made default importers lift too, so it became much easier to hit.

### Fix

The parser counts the `module.exports` rewrites it handles. If `module` has more uses than that, the named-export lift is deoptimized and the file keeps its `__commonJS` wrapper. Files that only use `module.exports.x`, `module.id`, or `require.main === module` still lift.

### Verification

- New tests in `test/bundler/bundler_cjs2esm.test.ts`. `OtherModuleMemberKeepsWrapper` fails on main and passes here. `ModuleExportsMemberStillLifts` guards the lift.
- `bundler_cjs2esm`, `bundler_cjs`, `bundler_npm` pass.
- React 18.3.1 (react, react-dom, react-dom/server, react/jsx-runtime): bundle output is byte-identical to main for `--target=node` in development and production, and for `--minify --splitting`.