### PR TITLE
bundler: give each entry point its own output and module order without --splitting

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -275,6 +275,13 @@ impl Chunk {
         self.entry_point.is_entry_point()
     }
 
+    /// Whether `source_index` is the entry point of this chunk. Without code
+    /// splitting, the files of other entry points can print in this chunk too.
+    #[inline]
+    pub(crate) fn is_entry_point_file(&self, source_index: u32) -> bool {
+        self.entry_point.is_entry_point() && self.entry_point.source_index() == source_index
+    }
+
     /// Stable short name for this chunk in generated code: its final content hash, as `[hash]` prints it.
     pub(crate) fn id(&self) -> [u8; CHUNK_ID_LEN] {
         bun_core::fmt::truncated_hash32_bytes(

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -687,39 +687,26 @@ impl<'a> LinkerGraph<'a> {
                     + server_component_boundaries.list.len()
                     + dynamic_import_entry_points.len(),
             )?;
-            // SAFETY: capacity reserved; columns initialized below.
-            unsafe { self.entry_points.set_len(entry_points.len()) };
-
-            // Note: `source_indices` / `path_strings` are disjoint columns of
-            // the same `MultiArrayList`. `split_mut()` hands out both at once;
-            // `self.entry_points` is not
-            // reallocated until after `path_strings`/`source_indices` are done
-            // with (the next `append_assume_capacity` is within the
-            // pre-reserved capacity, so no realloc).
-            let mut ep_slice = self.entry_points.slice();
-            let ep_cols = ep_slice.split_mut();
-            let source_indices: &mut [index::Int] = ep_cols.source_index;
-            let path_strings: &mut [RawSlice<u8>] = ep_cols.output_path;
-
-            debug_assert_eq!(entry_points.len(), path_strings.len());
-            debug_assert_eq!(entry_points.len(), source_indices.len());
-            for ((i, path_string), source_index) in entry_points
-                .iter()
-                .zip(path_strings.iter_mut())
-                .zip(source_indices.iter_mut())
-            {
+            for i in entry_points {
                 let source = &sources[i.get() as usize];
                 debug_assert!(source.index.0 == i.get());
+
+                // Two entry points can name one file, e.g. when an onResolve plugin
+                // maps two names to it. The file gets one entry point and one output.
+                if entry_point_kinds[source.index.0 as usize] != entry_point::Kind::None {
+                    continue;
+                }
                 entry_point_kinds[source.index.0 as usize] = entry_point::Kind::UserSpecified;
 
                 // Check if this entry point has an original name (from virtual entry resolution)
-                if let Some(original_name) = entry_point_original_names.get(i.get()) {
-                    *path_string = RawSlice::new(original_name);
-                } else {
-                    *path_string = RawSlice::new(source.path.text);
-                }
-
-                *source_index = source.index.0;
+                let output_path = match entry_point_original_names.get(i.get()) {
+                    Some(original_name) => RawSlice::new(original_name),
+                    None => RawSlice::new(source.path.text),
+                };
+                self.entry_points.append_assume_capacity(EntryPoint {
+                    source_index: source.index.0,
+                    output_path,
+                });
             }
 
             for &id in dynamic_import_entry_points {

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -1,5 +1,4 @@
 use crate::mal_prelude::*;
-use bun_alloc::ArenaVecExt as _;
 use core::sync::atomic::AtomicUsize;
 
 use bun_alloc::Arena; // bumpalo::Bump re-export
@@ -109,28 +108,16 @@ pub(crate) fn compute_chunks(
 
         let has_html_chunk = loaders[source_index as usize] == Loader::Html;
 
-        // For code splitting, entry point chunks should be keyed by ONLY the entry point's
-        // own bit, not the full entry_bits. This ensures that if an entry point file is
-        // reachable from other entry points (e.g., via re-exports), its content goes into
-        // a shared chunk rather than staying in the entry point's chunk.
+        // Entry point chunks are keyed by ONLY the entry point's own bit, not the full
+        // entry_bits. Entry points that reach each other have the same entry_bits, and
+        // each one still needs its own chunk. With code splitting, an entry point file
+        // that other entry points reach (e.g., via re-exports) goes into a shared chunk.
         // https://github.com/evanw/esbuild/blob/cd832972927f1f67b6d2cc895c06a8759c1cf309/internal/linker/linker.go#L3882
         let mut entry_point_chunk_bits = AutoBitSet::init_empty(this.graph.entry_points.len())?;
         entry_point_chunk_bits.set(entry_bit as usize);
 
-        let js_chunk_key: &[u8] = 'brk: {
-            if code_splitting {
-                break 'brk temp
-                    .alloc_slice_copy(entry_point_chunk_bits.bytes(this.graph.entry_points.len()));
-            } else {
-                // Force HTML chunks to always be generated, even if there's an identical JS file.
-                // Build the byte key directly since
-                // entry_bits is arbitrary bytes (not UTF-8) and cannot go through fmt::Display.
-                let mut v = bun_alloc::ArenaVec::new_in(temp);
-                v.push((!has_html_chunk) as u8);
-                v.extend_from_slice(entry_bits.bytes(this.graph.entry_points.len()));
-                break 'brk v.into_bump_slice();
-            }
-        };
+        let js_chunk_key: &[u8] =
+            temp.alloc_slice_copy(entry_point_chunk_bits.bytes(this.graph.entry_points.len()));
 
         // Put this early on in this loop so that CSS-only entry points work.
         if has_html_chunk {
@@ -162,9 +149,7 @@ pub(crate) fn compute_chunks(
             // Create a chunk for the entry point here to ensure that the chunk is
             // always generated even if the resulting file is empty
             let hash_to_use = if !this.options.css_chunking {
-                bun_wyhash::hash(
-                    temp.alloc_slice_copy(entry_bits.bytes(this.graph.entry_points.len())),
-                )
+                bun_wyhash::hash(entry_point_chunk_bits.bytes(this.graph.entry_points.len()))
             } else {
                 let mut hasher = Wyhash::init(5);
                 bun_core::write_any_to_hasher(&mut hasher, order.len());
@@ -203,6 +188,7 @@ pub(crate) fn compute_chunks(
         // Create a chunk for the entry point here to ensure that the chunk is
         // always generated even if the resulting file is empty
         let js_chunk_entry = js_chunks.get_or_put(js_chunk_key)?;
+        debug_assert!(!js_chunk_entry.found_existing);
         entry_point_to_js_chunk_idx[entry_id_] =
             u32::try_from(js_chunk_entry.index).expect("int cast");
         *js_chunk_entry.value_ptr = Chunk {

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -62,15 +62,15 @@ pub(crate) fn convert_stmts_for_chunk(
 
     let output_format = c.options.output_format;
 
-    // If this file is a CommonJS entry point, double-write re-exports to the
-    // external CommonJS "module.exports" object in addition to our internal ESM
+    // If this file is the CommonJS entry point of this chunk, double-write re-exports
+    // to the external CommonJS "module.exports" object in addition to our internal ESM
     // export namespace object. The difference between these two objects is that
     // our internal one must not have the "__esModule" marker while the external
     // one must have the "__esModule" marker. This is done because an ES module
     // importing itself should not see the "__esModule" marker but a CommonJS module
     // importing us should see the "__esModule" marker.
     let mut module_exports_for_export: Option<Expr> = None;
-    if output_format == Format::Cjs && chunk.is_entry_point() {
+    if output_format == Format::Cjs && chunk.is_entry_point_file(source_index) {
         module_exports_for_export = Some(Expr::allocate(
             bump,
             E::Dot {

--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -758,6 +758,8 @@ impl LinkerContext<'_> {
         // instead of by mutating the exports object because other modules in the
         // bundle (including the entry point module) may do "import * as" to get
         // access to the exports object and should NOT see the "__esModule" flag.
+        // This stays the last statement of the part: `generate_code_for_file_in_chunk_js`
+        // drops it when another entry point's chunk prints this file.
         if force_include_exports_for_entry_point {
             let to_common_js_ref = self.runtime_function(b"__toCommonJS");
             emit_export_stmt!(Stmt::assign(

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -106,6 +106,20 @@ pub(crate) fn find_imported_parts_in_js_order(
 
     Order::sort(&mut chunk_order_array);
 
+    // Without code splitting, a chunk holds every file that its entry point reaches.
+    // Distances are the minimum over all entry points, so other entry points in this
+    // chunk also sort at distance 0. Visit this chunk's own entry point first, so the
+    // files print in the order that this entry point imports them.
+    if !this.graph.code_splitting && chunk.entry_point.is_entry_point() {
+        let entry_point = chunk.entry_point.source_index();
+        if let Some(i) = chunk_order_array
+            .iter()
+            .position(|order| order.source_index == entry_point)
+        {
+            chunk_order_array[..=i].rotate_right(1);
+        }
+    }
+
     part_ranges_shared.clear();
     parts_prefix_shared.clear();
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -286,8 +286,17 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         && parts_live.is_set(namespace_export_part_index as usize)
     {
         // SAFETY: see `parts` raw-pointer note above; index bounded by the range check just above.
-        let ns_part_stmts: &[Stmt] =
+        let mut ns_part_stmts: &[Stmt] =
             unsafe { (*parts)[namespace_export_part_index as usize].stmts }.slice();
+        // Step 5 ends this part of a CommonJS entry point with
+        // `module.exports = __toCommonJS(exports)`. Only the chunk of that entry point runs it.
+        if output_format == OutputFormat::Cjs
+            && flags.force_include_exports_for_entry_point
+            && !chunk.is_entry_point_file(source_index as u32)
+            && let Some((_module_exports, rest)) = ns_part_stmts.split_last()
+        {
+            ns_part_stmts = rest;
+        }
         if let Err(err) = convert_stmts_for_chunk(
             c,
             source_index as u32,

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -1224,7 +1224,9 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                         ),
                     ));
                 }
-                crate::WrapKind::Esm => {
+                // A file without a wrapper symbol prints unwrapped (`needs_wrapper_ref`
+                // in the parser), so there is no `init_foo` to call.
+                crate::WrapKind::Esm if ast.wrapper_ref.is_valid() => {
                     // "init_foo();"
                     stmts.push(Stmt::alloc(
                         S::SExpr {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -401,6 +401,26 @@ describe("bundler", () => {
       },
     });
   }
+  // Two entry points that import() each other: the executable runs the first one.
+  itBundled("compile/EntryPointsImportEachOther", {
+    compile: true,
+    files: {
+      "/main.ts": /* js */ `
+        import("./plugin.ts").then(plugin => console.log("main loaded", plugin.name));
+      `,
+      "/plugin.ts": /* js */ `
+        export const name = "plugin";
+        export const loadMain = () => import("./main.ts");
+      `,
+    },
+    entryPointsRaw: ["./main.ts", "./plugin.ts"],
+    outfile: "dist/out",
+    run: {
+      stdout: "main loaded plugin",
+      file: "dist/out",
+      setCwd: true,
+    },
+  });
   // https://github.com/oven-sh/bun/issues/8697
   itBundled("compile/EmbeddedFileOutfile", {
     compile: true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -83,7 +83,7 @@ describe("bundler", () => {
         process.exitCode = 1;
         process.versions.bun = "bun!";
         if (process.versions.bun === "bun!") throw new Error("fail");
-        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version.replaceAll("-debug", "")}") {
+        if (require("./${process.platform}-${process.arch}.js").replaceAll("-debug", "") === "${Bun.version.replaceAll("-debug", "")}") {
           process.exitCode = 0;
         }
       `,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3662,6 +3662,37 @@ describe("bundler", () => {
       api.expectFile("/out/b.css").toEqualIgnoringWhitespace(".a{color:red}.b{color:#00f}");
     },
   });
+  // With --format=cjs, the module.exports of each output holds the exports of its
+  // own entry point, also when the file of another entry point prints in it.
+  itBundled("edgecase/EntryPointsImportEachOtherCommonJS", {
+    files: {
+      "/a.ts": `import { b } from "./b.ts"; export function a() { return b(); }`,
+      "/b.ts": `import { a } from "./a.ts"; export function b() { return "b"; } export const useA = () => a;`,
+    },
+    runtimeFiles: {
+      "/check.js": `console.log(JSON.stringify([require("./out/a.js"), require("./out/b.js")].map(Object.keys)));`,
+    },
+    entryPoints: ["/a.ts", "/b.ts"],
+    outdir: "/out",
+    format: "cjs",
+    run: { file: "/check.js", stdout: `[["a"],["b","useA"]]` },
+  });
+  itBundled("edgecase/EntryPointImportsEntryPointCommonJS", {
+    files: {
+      "/index.ts": `import { x } from "./lib.ts"; export const y = x + 1;`,
+      "/lib.ts": `export * from "ext"; export const x = 1;`,
+    },
+    runtimeFiles: {
+      "/node_modules/ext/index.js": `module.exports = { fromExt: true };`,
+      "/check.js": `console.log(JSON.stringify([require("./out/index.js"), require("./out/lib.js")]));`,
+    },
+    entryPoints: ["/index.ts", "/lib.ts"],
+    outdir: "/out",
+    external: ["ext"],
+    target: "node",
+    format: "cjs",
+    run: { file: "/check.js", stdout: `[{"y":2},{"x":1,"fromExt":true}]` },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3611,6 +3611,57 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+
+  // Without code splitting, each entry point gets its own output file, even when
+  // entry points import each other. Each file runs its modules in the order that
+  // its own entry point imports them, so it prints what the unbundled entry prints.
+  itBundled("edgecase/EntryPointsImportEachOther", {
+    files: {
+      "/a.ts": /* ts */ `
+        import { b } from "./b.ts";
+        export function a() { return "a"; }
+        console.log("a runs, b() is", b());
+      `,
+      "/b.ts": /* ts */ `
+        import { a } from "./a.ts";
+        export function b() { return "b"; }
+        console.log("b runs, a() is", a());
+      `,
+    },
+    entryPoints: ["/a.ts", "/b.ts"],
+    outdir: "/out",
+    run: [
+      { file: "/out/a.js", stdout: "b runs, a() is a\na runs, b() is b" },
+      { file: "/out/b.js", stdout: "a runs, b() is b\nb runs, a() is a" },
+    ],
+  });
+  itBundled("edgecase/EntryPointImportsEntryPointModuleOrder", {
+    files: {
+      "/a.ts": `import "./c.ts"; import "./b.ts"; console.log("a");`,
+      "/b.ts": `import "./d.ts"; console.log("b");`,
+      "/c.ts": `console.log("c");`,
+      "/d.ts": `console.log("d");`,
+    },
+    entryPoints: ["/a.ts", "/b.ts"],
+    outdir: "/out",
+    run: [
+      { file: "/out/a.js", stdout: "c\nd\nb\na" },
+      { file: "/out/b.js", stdout: "d\nb" },
+    ],
+  });
+  itBundled("edgecase/CSSEntryPointsImportEachOther", {
+    files: {
+      "/a.css": `@import "./b.css"; .a { color: red }`,
+      "/b.css": `@import "./a.css"; .b { color: blue }`,
+    },
+    entryPoints: ["/a.css", "/b.css"],
+    outdir: "/out",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      api.expectFile("/out/a.css").toEqualIgnoringWhitespace(".b{color:#00f}.a{color:red}");
+      api.expectFile("/out/b.css").toEqualIgnoringWhitespace(".a{color:red}.b{color:#00f}");
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3693,6 +3693,33 @@ describe("bundler", () => {
     format: "cjs",
     run: { file: "/check.js", stdout: `[{"y":2},{"x":1,"fromExt":true}]` },
   });
+  // A file that something require()s gets an ESM wrapper. When all of its
+  // top-level statements hoist, the wrapper is empty and is not printed, so the
+  // output of that entry point has no wrapper to call.
+  itBundled("edgecase/EntryPointRequiredByEntryPointCommonJS", {
+    files: {
+      "/a.ts": `const b = require("./b.ts"); export const fromA = b.x;`,
+      "/b.ts": `export const x = 1; export const y = 2;`,
+    },
+    runtimeFiles: {
+      "/check.js": `console.log(JSON.stringify([require("./out/a.js"), require("./out/b.js")]));`,
+    },
+    entryPoints: ["/a.ts", "/b.ts"],
+    outdir: "/out",
+    format: "cjs",
+    run: { file: "/check.js", stdout: `[{"fromA":1},{"x":1,"y":2}]` },
+  });
+  itBundled("edgecase/RequiredEntryPointWithoutWrapperCommonJS", {
+    files: {
+      "/entry.ts": `export function load() { return require("./c.ts"); } export const x = 1;`,
+      "/c.ts": `module.exports = require("./entry.ts");`,
+    },
+    runtimeFiles: {
+      "/check.js": `const m = require("./out.js"); console.log(JSON.stringify(m), m.load() === m);`,
+    },
+    format: "cjs",
+    run: { file: "/check.js", stdout: `{"x":1} true` },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -226,6 +226,29 @@ export const padZero = (num) => String(num).padStart(2, '0');`,
     },
   });
 
+  // A script that is also an entry point still runs in its place on the page.
+  itBundled("html/script-that-is-also-an-entry-point", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="./first.js"></script>
+    <script type="module" src="./second.js"></script>
+  </head>
+</html>`,
+      "/first.js": `console.log("first");`,
+      "/second.js": `console.log("second");`,
+    },
+    entryPoints: ["/index.html", "/second.js"],
+    onAfterBundle(api) {
+      const jsMatch = api.readFile("out/index.html").match(/src="(.*\.js)"/);
+      expect(api.readFile("out/" + jsMatch![1])).toMatch(/"first"[\s\S]*"second"/);
+      api.expectFile("out/second.js").toContain('console.log("second")');
+    },
+  });
+
   // Test CSS imports
   itBundled("html/css-imports", {
     outdir: "out/",

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1865,4 +1865,32 @@ describe("bundler", () => {
     });
     expect(exitCode).toBe(0);
   });
+
+  // Two entry point names that onResolve maps to one file make one output file.
+  for (const splitting of [false, true]) {
+    test.concurrent(`plugin/two entry points that resolve to one file (splitting: ${splitting})`, async () => {
+      using dir = tempDir("plugin-two-entry-points-one-file", {
+        "entry.ts": `console.log("entry");`,
+      });
+      const result = await Bun.build({
+        entrypoints: ["first-name", "second-name"],
+        outdir: join(String(dir), "out"),
+        splitting,
+        throw: false,
+        plugins: [
+          {
+            name: "alias",
+            setup(build) {
+              build.onResolve({ filter: /-name$/ }, () => ({ path: join(String(dir), "entry.ts") }));
+            },
+          },
+        ],
+      });
+      expect({
+        success: result.success,
+        logs: result.logs.map(log => log.message),
+        outputs: result.outputs.map(output => path.basename(output.path)),
+      }).toEqual({ success: true, logs: [], outputs: ["second-name.js"] });
+    });
+  }
 });

--- a/test/bundler/esbuild/importstar.test.ts
+++ b/test/bundler/esbuild/importstar.test.ts
@@ -1434,7 +1434,7 @@ describe.concurrent("bundler", () => {
     },
     run: {
       file: "/test.js",
-      stdout: '{"inner":{"b":456},"a":123,"b":456}',
+      stdout: '{"inner":{"b":456},"a":123}',
     },
   });
   itBundled("importstar/ReExportStarEntryPointAndInnerFile", {


### PR DESCRIPTION
### Problem
- Without `--splitting`, `bun build --outdir out ./a.ts ./b.ts` silently writes only `out/b.js` when the files import each other. CSS entry points lose a file the same way. A `--compile` executable can run nothing.
- Cause: `compute_chunks` keys an entry chunk by the full `entry_bits` of its file (`src/bundler/linker_context/computeChunks.rs:120`). Entry points that reach each other get equal keys, so the second overwrites the first.
- Same root: when entry `a` imports entry `b`, `out/a.js` can run `b`'s imports too early.

### Fix
- Key each entry chunk and CSS entry by the entry point's own bit, as code splitting does (#26089). `LinkerGraph::load` keeps one entry point per file.
- Without code splitting, `find_imported_parts_in_js_order` starts its walk at the chunk's own entry point. HTML scripts now run in page order.
- In cjs output, only the entry point of a chunk writes `module.exports`, as in esbuild. This also fixes a re-export leak in single-entry builds. A missing ESM wrapper is no longer called (`__INVALID__REF__();`).
- Verified: 11 new tests in `test/bundler/`. 9 fail on the base. Self-review: 3 concerns, all addressed.

### Background
- `entry_bits` is the set of entry points that reach a file.
- Without code splitting, Bun links all entry points in one pass (esbuild links each alone). An entry chunk holds every file its entry point reaches.
- A chunk prints files in the order of an import walk. It starts at the smallest `distance_from_entry_point`, which is 0 for every entry point.

<details><summary>Notes</summary>

**Repro**

```ts
// a.ts
import { b } from "./b.ts"; export const a = "a"; console.log("a sees", b);
// b.ts
import { a } from "./a.ts"; export const b = "b"; console.log("b sees", a);
```

`bun build --outdir out ./a.ts ./b.ts` prints only `b.js (entry point)`. With `--splitting`, both files are written. Two CSS files that `@import` each other lose one output, with and without `--splitting`.

For `--compile`: `main.ts` does `import("./plugin.ts")` and `plugin.ts` does `import("./main.ts")`. `bun build --compile ./main.ts ./plugin.ts --outfile app` makes an executable whose main module is the chunk of `plugin.ts`. The code of `main.ts` sits in an `init_main` wrapper that nothing calls, so `./app` prints nothing and exits 0.

**Module order**

`a.ts` imports `c.ts`, then `b.ts`. `b.ts` imports `d.ts`. Both `a.ts` and `b.ts` are entry points. Unbundled, `bun a.ts` prints `c d b a`. On 1.4.1, `out/a.js` prints `d b c a`: `b.ts` also has distance 0 and a lower stable index, so the walk starts there. esbuild prints `c d b a`. An HTML page with `<script src="./first.js">` and `<script src="./second.js">` runs `second` first when `second.js` is also an entry point.

With only the key change, the cycle's `out/a.js` would get the module order of `out/b.js`. So the key change and the walk change stay together.

**`module.exports` in cjs output**

Two writes to `module.exports` come from the linker, not from user code:

- Step 5 puts `module.exports = __toCommonJS(exports)` at the end of part 0 of each entry point file (`doStep5.rs`).
- `export * from` a module that needs a run-time re-export prints `__reExport(exports, mod, module.exports)` (`convertStmtsForChunk.rs`).

Both are per file, and the file of one entry point can print in the chunk of another. The walk emits part 0 of a file when it enters the file, before its imports. On 1.4.1 the other entry point's file came first, so its writes came before the chunk's own assignment and did no harm. With the walk change, they come last. For `index.ts` that imports `utils.ts`, both entry points, `require("./out/index.js")` returned the exports of `utils.ts`. In a cycle, 1.4.1 already got this wrong: its one output, `b.js`, exported the names of `a.ts`.

Now both writes happen only when the file is the entry point of the chunk (`Chunk::is_entry_point_file`). esbuild has the same rule (`file.IsEntryPoint()`, in a link of one entry point). The part 0 write is the last statement of that part, and the printer drops it in other chunks.

The re-export rule also changes single-entry builds. On 1.4.1, a file that the entry point imports, but does not re-export, still wrote its `export * from "ext"` names onto `module.exports`. esbuild does not. A re-export chain still works, because each file in it re-exports the next file at run time, and the entry point file writes to `module.exports` (checked with a chain of three files).

`importstar/ReExportStarEntryPointAndInnerFileExternal` expected the leak. Before 2f7ff95e5c, the harness threw for every cjs test, and this test expected the value that esbuild prints. That commit set the current value when cjs output first ran. The same commit added `ReExportStarEntryPointAndInnerFile`, without externals, which expects no top-level `b`. This PR restores the esbuild value.

**Two entry points that name one file**

An onResolve plugin can map two entry point names to one file. The plugin path adds the file to the entry points twice. On 1.4.1, the full-bits key merged the two chunks without `--splitting`, so the build wrote `second-name.js`. With `--splitting`, it failed with "Multiple files share the same output path". `LinkerGraph::load` now skips a file that is already an entry point, as its loop for `import()` targets does. Both modes write `second-name.js`. The name comes from `entry_point_original_names`, which keeps the last name.

When a plugin declines an entry point and the default resolver finds a file that is already an entry point, `enqueue_entry_item` returns `None` and records no name. This PR does not change that path. #38600 works on it.

**Output order**

The old non-split key started with a byte that was 0 for an HTML entry point and 1 for the others. It sorted HTML entry chunks before JS entry chunks. The own-bit key has no such byte. For `bun build ./index.html ./b.ts ./c.html`, the outputs are now listed as `index.html`, `b.js`, `c.html` (with their chunks), in the order of the entry points. The files and their contents do not change. Entry point 0 still sorts first, so `--compile` picks the same main module.

**Tests**

New, and failing on the base commit:

- `edgecase/EntryPointsImportEachOther`, `edgecase/EntryPointImportsEntryPointModuleOrder`, `edgecase/CSSEntryPointsImportEachOther`, `edgecase/EntryPointsImportEachOtherCommonJS`
- `html/script-that-is-also-an-entry-point`
- `compile/EntryPointsImportEachOther`
- `plugin/two entry points that resolve to one file (splitting: true)`
- `edgecase/EntryPointRequiredByEntryPointCommonJS`, `edgecase/RequiredEntryPointWithoutWrapperCommonJS`

New, and passing on the base commit: `edgecase/EntryPointImportsEntryPointCommonJS` and the `splitting: false` plugin case. Both fail if either cjs write or the dedupe is removed.

Changed: `importstar/ReExportStarEntryPointAndInnerFileExternal` (above) and `compile/HelloWorldWithProcessVersionsBun`. A debug build inlines `process.versions.bun` as `1.4.1-debug`. That test removed `-debug` only from the expected value, so it failed on every debug build. The API variant of the test removes it from both values, and now this one does too.

**Checked by hand**

Against esbuild 0.25.1 (run output and `module.exports` compared): a ring of three entry points in `esm`, `cjs`, and `iife`, a CommonJS cycle, `export * from` another entry point, re-export chains of two and three files in cjs, and a named import from a file that re-exports a `node:` module. Also rings of 10 and 130 entry points (130 uses the heap bit set), `Bun.build` with `metafile` and `sourcemap: "external"`, an HTML entry point whose script is in a cycle of two JS entry points, and `--no-bundle --format=cjs` (byte-identical output).

**Suites run with the debug build**

`bundler_edgecase`, `bundler_html`, `bundler_html_server`, `bundler_plugin`, `bundler_cjs`, `bundler_compile`, `bundler_compile_splitting`, `bundler_splitting`, `esbuild/{default,importstar,importstar_ts,dce,splitting,css,metafile,loader,lower,ts,extra,packagejson}`, `metafile`, `bundler_naming`, `html-import-manifest`, `bundler_cjs2esm`, `bundler_regressions`, `bun-build-api`, `bundler_browser`, `bundler_bun`, `cli`, `bundler_loader`, `bundler_files`, `bundler_barrel`, `bundler_minify`, `regression/issue/5344`, and `bake/{dev/production,dev-and-prod,dev/ssg-pages-router}`. An earlier round also ran `bun-build-compile`, `compile-asset-bunfs`, `native-plugin`, and `regression/issue/{10004,10139,22317,25716,27431,32686}`.

Some tests time out at 5 s on the debug build. Each of them builds one entry point, and each passes with a longer timeout.

**`__INVALID__REF__();` in cjs output**

A file that something `require()`s gets an ESM wrapper (`init_foo`). When all of its top-level statements hoist, the parser gives it no wrapper symbol (`needs_wrapper_ref`), and the printer prints the file with no wrapper. The esm tail of an entry point checks for the symbol. The cjs tail did not, so it printed `__INVALID__REF__();`, and loading the output threw `ReferenceError: __INVALID__REF__ is not defined`. The cjs tail now has the same check.

One entry point is enough: `entry.ts` has `export function load() { return require("./c.ts"); }`, and `c.ts` requires `entry.ts`. With two entry points, `a.ts` does `require("./b.ts")`, and `b.ts` has only `export const` lines. 1.2.0, 1.3.0, 1.4.0, and 1.4.1 all print the bad call.

#37843 has the same check, and it also adds the missing iife tail. `bun build --format=iife` of a CommonJS entry point runs none of its code (1.2.0 through main), because nothing calls `require_entry()`. This PR does not change iife output.

**Related**

- #30544 made the same key change in the Zig source. It was closed because the Rust port removed those files.
- #40601 changes where an entry point's module goes with `--splitting`. It does not touch the non-split key.
- #41235 changes how `import.meta.main` prints when a build has several entry points.
- #37843 adds the iife tail and has the same cjs check as this PR.
</details>
