### PR TITLE
test(net): ask the OS for a free port in server.address() tests

### DIFF
--- a/test/js/node/net/server.spec.ts
+++ b/test/js/node/net/server.spec.ts
@@ -161,7 +161,10 @@ describe("server.address()", () => {
   // port can already be in use on the machine, so ask the OS for a free one.
   async function getFreePort(host?: string): Promise<number> {
     const probe = net.createServer();
-    await new Promise<void>(resolve => probe.listen({ port: 0, host }, resolve));
+    await new Promise<void>((resolve, reject) => {
+      probe.once("error", reject);
+      probe.listen({ port: 0, host }, resolve);
+    });
     const { port } = probe.address() as net.AddressInfo;
     await new Promise<void>(resolve => probe.close(() => resolve()));
     return port;

--- a/test/js/node/net/server.spec.ts
+++ b/test/js/node/net/server.spec.ts
@@ -157,6 +157,16 @@ describe("new net.Server()", () => {
 describe("server.address()", () => {
   let server: net.Server;
 
+  // Some tests check that address() reports the port given to listen(). A fixed
+  // port can already be in use on the machine, so ask the OS for a free one.
+  async function getFreePort(host?: string): Promise<number> {
+    const probe = net.createServer();
+    await new Promise<void>(resolve => probe.listen({ port: 0, host }, resolve));
+    const { port } = probe.address() as net.AddressInfo;
+    await new Promise<void>(resolve => probe.close(() => resolve()));
+    return port;
+  }
+
   beforeEach(() => {
     server = net.createServer(() => {});
   });
@@ -191,29 +201,32 @@ describe("server.address()", () => {
   }); // </when the server listens to an unspecified port>
 
   it("when listening on a specified port, returns an AddressInfo object with the same port", async () => {
+    const port = await getFreePort();
     const { promise, resolve } = Promise.withResolvers<void>();
-    server.listen(6543, resolve);
+    server.listen(port, resolve);
     await promise;
-    expect(server.address()).toEqual({ address: "::", port: 6543, family: "IPv6" });
+    expect(server.address()).toEqual({ address: "::", port, family: "IPv6" });
   });
 
   // FIXME: hostname is not resolved
   it.skip("when server.listen(port, hostname), returns an AddressInfo object with the same port and hostname", async () => {
+    const port = await getFreePort("localhost");
     const { promise, resolve } = Promise.withResolvers<void>();
-    server.listen(1234, "localhost", resolve);
+    server.listen(port, "localhost", resolve);
     await promise;
     expect(server.address()).toEqual({
       address: "127.0.0.1",
-      port: 1234,
+      port,
       family: "IPv4",
     });
   });
 
   it("when listening on a specified host and port, returns an AddressInfo object with the same host and port", async () => {
+    const port = await getFreePort("127.0.0.1");
     const { promise, resolve } = Promise.withResolvers<void>();
-    server.listen({ port: 1234, host: "127.0.0.1" }, resolve);
+    server.listen({ port, host: "127.0.0.1" }, resolve);
     await promise;
-    expect(server.address()).toEqual({ address: "127.0.0.1", port: 1234, family: "IPv4" });
+    expect(server.address()).toEqual({ address: "127.0.0.1", port, family: "IPv4" });
   });
 }); // </server.address()>
 


### PR DESCRIPTION
### Problem
- `test/js/node/net/server.spec.ts` failed on the macOS 14 x64 lane with `listen EADDRINUSE: address already in use 127.0.0.1:1234`.
- Two `server.address()` tests listen on fixed ports: `6543` (`server.spec.ts:195`) and `1234` on `127.0.0.1` (`server.spec.ts:214`). If another process holds one of these ports, the test fails.

### Fix
- A new helper, `getFreePort(host)`, listens on port 0 on the same host, reads the port, and closes. Each test then listens on that port.
- The tests still check that `address()` reports the port given to `listen()`. A plain `port: 0` would remove that check.
- Verified: `test/js/node/net/server.spec.ts`, with a second process that holds both ports. Main fails 2 tests with `EADDRINUSE`. This branch passes all 40 tests.

### Background
- `EADDRINUSE` is the error from `bind(2)` when another socket already uses the address and port.
- `listen()` with port 0 makes the OS pick a free port. `server.address().port` returns that port.
- A listening socket that accepted no connections leaves no `TIME_WAIT` state. After `close()`, a new socket can listen on the same port at once.

<details><summary>Notes</summary>

- Another process can take the port between the probe's `close()` and the test's `listen()`. The interval is short, and the OS picks the port from the ephemeral range. A fixed port is in use for the whole run.
- The skipped test at `server.spec.ts:201` also used port 1234. It now uses the helper, so the fixed port does not come back when someone enables the test.
- I did not find another test in `test/` that listens on port 1234.
- Runs on Linux x64: the release build (1.4.1, the file 50 times with `--rerun-each 50`, 0 failures) and a debug ASAN build (40 pass, 3 skip).
- Repro: run `node hold-ports.mjs` (it listens on `127.0.0.1:1234` and `[::]:6543`). Then run `bun test test/js/node/net/server.spec.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->