### PR TITLE
ci: keep only the flaky-list gate in the test runner

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -172,7 +172,7 @@ const { values: options, positionals: filters } = parseArgs({
     },
     ["retries"]: {
       type: "string",
-      default: isCI ? "3" : "0", // N retries = N+1 attempts, only for files in test/flaky-tests.txt
+      default: isCI ? "3" : "0", // N retries = N+1 attempts
     },
     ["junit"]: {
       type: "boolean",
@@ -380,26 +380,14 @@ const skipsForLeaksan = (() => {
     .filter(line => !line.startsWith("#") && line.length > 0);
 })();
 
-// Test files that the runner may run again when they fail (see --retries).
-// Every other file runs once and a failure is final.
-const flakyTests = (() => {
-  const path = join(cwd, "test/flaky-tests.txt");
-  if (!existsSync(path)) {
-    return new Set();
-  }
-  return new Set(
-    readFileSync(path, "utf-8")
-      .split("\n")
-      .map(line => line.split("#")[0].trim())
-      .filter(line => line.length > 0),
-  );
-})();
-
-/**
- * @param {string} title repo-relative path, as reported in the test output
- * @returns {boolean}
- */
-const isFlakyTest = title => flakyTests.has(title.replaceAll("\\", "/"));
+// The test files that may run again after a failure (see --retries). Every
+// other test file runs once, and its failure is final.
+const flakyTests = new Set(
+  (existsSync(join(cwd, "test/flaky-tests.txt")) ? readFileSync(join(cwd, "test/flaky-tests.txt"), "utf-8") : "")
+    .split("\n")
+    .map(line => line.split("#")[0].trim())
+    .filter(line => line.length > 0),
+);
 
 const parallelAllowlist = (() => {
   try {
@@ -643,7 +631,7 @@ async function runTests() {
   const flakyResultsTitles = [];
   const failedResults = [];
   const failedResultsTitles = [];
-  const retries = Math.max(parseInt(options["retries"], 10) || 0, 0);
+  const maxAttempts = 1 + (parseInt(options["retries"]) || 0);
 
   const parallelism = options["parallel"] ? availableParallelism() : 1;
   console.log("parallelism", parallelism);
@@ -682,20 +670,17 @@ async function runTests() {
    * @param {string} title
    * @param {function} fn
    * @param {boolean} [concurrent] this call may overlap with other runTest calls
-   * @param {TestResult} [priorFailure] the file already failed once, inside the
-   * parallel batch: that run was attempt 1
    * @returns {Promise<TestResult>}
    */
-  const runTest = async (title, fn, concurrent = parallelism > 1, priorFailure = undefined) => {
+  const runTest = async (title, fn, concurrent = parallelism > 1) => {
     const index = ++i;
-    // A test file runs once unless test/flaky-tests.txt lists it. The runner's
-    // own dependency installs (the package.json titles) are setup, not tests,
-    // and keep their retries.
-    const maxAttempts = title.endsWith("package.json") || isFlakyTest(title) ? 1 + retries : 1;
+    // Only a test file in test/flaky-tests.txt gets retries. The runner's own
+    // `bun install` steps (the package.json titles) are setup, and keep theirs.
+    const attempts = title.endsWith("package.json") || flakyTests.has(title.replaceAll("\\", "/")) ? maxAttempts : 1;
 
-    let result, failure;
-    let attempt;
-    for (attempt = priorFailure ? 2 : 1; attempt <= maxAttempts; attempt++) {
+    let result, failure, flaky;
+    let attempt = 1;
+    for (; attempt <= attempts; attempt++) {
       if (attempt > 1) {
         await new Promise(resolve => setTimeout(resolve, 5000 + Math.random() * 10_000));
       }
@@ -711,9 +696,17 @@ async function runTests() {
       }
 
       const { ok, stdoutPreview, error } = result;
-      if (ok) break;
+      if (ok) {
+        if (failure) {
+          flakyResults.push(failure);
+          flakyResultsTitles.push(title);
+        } else {
+          okResults.push(result);
+        }
+        break;
+      }
 
-      const color = attempt >= maxAttempts ? "red" : "yellow";
+      const color = attempt >= attempts ? "red" : "yellow";
       const label = `${getAnsi(color)}[${index}/${total}] ${title} - ${error}${getAnsi("reset")}`;
       if (concurrent) {
         // Don't open a group mid-phase: it would re-anchor the log viewer's
@@ -727,39 +720,20 @@ async function runTests() {
       }
 
       failure ||= result;
-      if (isAlwaysFailure(error)) break;
+      flaky ||= true;
+
+      if (attempt >= attempts || isAlwaysFailure(error)) {
+        flaky = false;
+        failedResults.push(failure);
+        failedResultsTitles.push(title);
+        break;
+      }
     }
 
-    // No attempt ran: the batch failure is the only result.
-    if (result === undefined) failure = priorFailure;
-
     if (!failure) {
-      okResults.push(result);
       return result;
     }
 
-    // The first failure of these attempts is the one reported. It is flaky when a later attempt passed.
-    const flaky = result?.ok === true;
-    if (flaky) {
-      flakyResults.push(failure);
-      flakyResultsTitles.push(title);
-    } else {
-      failedResults.push(failure);
-      failedResultsTitles.push(title);
-    }
-    reportFailure(title, failure, flaky, attempt);
-    return result ?? failure;
-  };
-
-  /**
-   * Reports a failed attempt to CI: a warning when the file later passed
-   * (flaky), an error when the failure is final.
-   * @param {string} title
-   * @param {TestResult} failure
-   * @param {boolean} flaky
-   * @param {number} attempt the attempt that passed, when flaky
-   */
-  function reportFailure(title, failure, flaky, attempt) {
     if (isBuildkite) {
       // Group flaky tests together, regardless of the title
       const context = flaky ? "flaky" : title;
@@ -793,7 +767,9 @@ async function runTests() {
       markBuildkiteStepReported();
       process.exit(getExitCode("fail"));
     }
-  }
+
+    return result;
+  };
 
   if (!isQuiet) {
     for (const path of [cwd, testsPath]) {
@@ -866,7 +842,7 @@ async function runTests() {
       }
     }
 
-    const runOneTest = async (testPath, concurrent, priorFailure = undefined) => {
+    const runOneTest = async (testPath, concurrent) => {
       await awaitNapiPrebuild(testPath);
       const absoluteTestPath = join(testsPath, testPath);
       const title = relative(cwd, absoluteTestPath).replaceAll(sep, "/");
@@ -981,7 +957,6 @@ async function runTests() {
             };
           },
           concurrent,
-          priorFailure,
         );
       } else {
         return runTest(
@@ -993,7 +968,6 @@ async function runTests() {
               stderr: concurrent ? () => {} : pipeTestStdout(process.stderr),
             }),
           concurrent,
-          priorFailure,
         );
       }
     };
@@ -1018,10 +992,6 @@ async function runTests() {
         env.LSAN_OPTIONS = `malloc_context_size=30:print_suppressions=0:suppressions=${process.cwd()}/test/leaksan.supp`;
       }
       if (isAsan) env.BUN_FEATURE_FLAG_NO_ORPHANS = "1";
-
-      // A report left behind by an earlier run on a persistent agent must not
-      // stand in for one this batch failed to write.
-      rmSync(junitPath, { force: true });
 
       const byPath = new Map(bucketFiles.map(t => [join("test", t).replaceAll("\\", "/"), t]));
       const norm = p =>
@@ -1065,33 +1035,18 @@ async function runTests() {
       if (suites.size && isBuildkite) uploadArtifactsToBuildKite(junitPath);
       else rmSync(junitPath, { force: true });
 
-      // A failure in the batch counts as it does in a serial run. A file that
-      // failed, hung, or crashed here runs again alone only when
-      // test/flaky-tests.txt lists it and isAlwaysFailure does not match its
-      // reason. A file with no complete result (the batch never started it, or
-      // a sibling's crash stopped it) runs alone once: that is its first run.
-      const failed = new Map(); // test path -> why it failed in the batch
-      const incomplete = new Set();
-      // Files whose worker died of a fatal signal or a fatal Windows exit code.
-      // The coordinator prints a banner for each one, as the crash handler does
-      // for a serial run, and such a crash is never retried.
-      const crashed = new Set();
-      // The batch as a whole failed: no file explains the exit, or the summary
-      // counts errors between tests, which the junit report does not name.
-      let batchError;
-      if (!ok) {
-        const lines = stripAnsi(stdout).split(/\r?\n/);
-        if (suites.size) {
-          for (const t of bucketFiles) {
-            const suite = suites.get(join("test", t).replaceAll("\\", "/"));
-            if (suite === undefined) incomplete.add(t);
-            else if (suite.failures > 0) failed.set(t, `${suite.failures} failing in the parallel batch`);
-          }
+      const failed = new Set(); // ran and failed (or hung) — a solo pass is a parallel-mode flake
+      const incomplete = new Set(); // never finished/started — re-run quietly
+      let evidence = suites.size > 0;
+      if (!ok && suites.size) {
+        for (const t of bucketFiles) {
+          const suite = suites.get(join("test", t).replaceAll("\\", "/"));
+          if (suite === undefined) incomplete.add(t);
+          else if (suite.failures > 0) failed.add(t);
         }
-        // The coordinator names the files that a hang or a worker death
-        // stopped, and the status of each worker that died.
+      } else if (!ok) {
         let list = null; // "running" | "not-started" while inside an interrupt report list
-        for (const line of lines) {
+        for (const line of stripAnsi(stdout).split(/\r?\n/)) {
           if (line.startsWith("Interrupted while still running:")) {
             list = "running";
             continue;
@@ -1102,66 +1057,21 @@ async function runTests() {
           }
           if (list && /^ {2}\S/.test(line)) {
             const testPath = norm(line);
-            if (!testPath) continue;
-            if (list === "running") {
-              failed.set(testPath, `${error} in the parallel batch`);
-              incomplete.delete(testPath);
-            } else if (!failed.has(testPath)) {
-              incomplete.add(testPath);
-            }
+            if (testPath) (list === "running" ? failed : incomplete).add(testPath);
             continue;
           }
           list = null;
-          const banner = /^error: a test worker process crashed with (.+?) while running (.+)\.$/.exec(line);
-          if (banner) {
-            const testPath = norm(banner[2]);
-            if (!testPath) continue;
-            crashed.add(testPath);
-            failed.set(testPath, `worker crashed with ${banner[1]} in the parallel batch`);
-            incomplete.delete(testPath);
-            continue;
-          }
-          const ended = /^✗ (.+?) \((worker crashed: (.+)|aborted:|no live workers)/.exec(line);
+          const ended = /^✗ (.+?) \((worker crashed|aborted:|no live workers)/.exec(line);
           const testPath = ended && norm(ended[1]);
-          if (!testPath) continue;
-          if (ended[3] !== undefined) {
-            failed.set(testPath, `worker crashed with ${ended[3].replace(/\)$/, "")} in the parallel batch`);
-            incomplete.delete(testPath);
-          } else if (!failed.has(testPath)) {
-            incomplete.add(testPath);
-          }
+          if (testPath) (ended[2] === "worker crashed" ? failed : incomplete).add(testPath);
         }
-        if (!suites.size) {
-          // No junit report: no file has a result.
-          for (const t of bucketFiles) if (!failed.has(t)) incomplete.add(t);
-        }
-        const failAt = lines.findLastIndex(line => /^\s*\d+ fail\s*$/.test(line));
-        const unhandled = failAt === -1 ? null : /^\s*(\d+) errors?\s*$/.exec(lines[failAt + 1] ?? "");
-        if (unhandled) {
-          batchError = `${unhandled[1]} unhandled error(s) between tests in the parallel batch`;
-        } else if (!suites.size) {
-          batchError = `${error} in the parallel batch, with no junit report`;
-        } else if (failed.size === 0) {
-          batchError = `${error} in the parallel batch, and no file failed`;
-        } else if (
-          crashed.size === 0 &&
-          /crashes reported during this test|Stack trace from GDB for/.test(crashes ?? "")
-        ) {
-          // A serial run fails the file for a core dump or a crash report.
-          batchError = "a crash was reported in the parallel batch, and no worker died of it";
-        }
+        evidence = failed.size + incomplete.size > 0;
       }
-      const retried = [...failed.entries()]
-        .filter(
-          ([t, reason]) =>
-            retries > 0 &&
-            !crashed.has(t) &&
-            !isAlwaysFailure(reason) &&
-            isFlakyTest(join("test", t).replaceAll("\\", "/")),
-        )
-        .map(([t]) => t);
-      const retriedSet = new Set(retried);
-      const rerun = [...retried, ...incomplete];
+      // A file that failed in the batch runs again alone only when
+      // test/flaky-tests.txt lists it. Every other failure is final.
+      const listed = t => flakyTests.has(join("test", t).replaceAll("\\", "/"));
+      const retried = [...failed].filter(listed);
+      const rerun = !ok && !evidence ? [...bucketFiles] : [...retried, ...incomplete];
       const rerunSet = new Set(rerun);
 
       for (const t of bucketFiles) {
@@ -1180,65 +1090,46 @@ async function runTests() {
           stdoutPreview: "",
         });
       }
-      const batchFailures = new Map(); // test path -> TestResult, for the files that run again alone
       for (const t of bucketFiles) {
-        const reason = failed.get(t);
-        if (reason === undefined) continue;
+        if (!failed.has(t)) continue;
         const title = join("test", t).replaceAll("\\", "/");
-        const cases = suites.get(title)?.cases ?? [];
-        const printCases = () => {
-          for (const { name, message } of cases) {
-            console.log(`${getAnsi("red")}✗${getAnsi("reset")} ${name}`);
-            if (message) console.log(message.replace(/^/gm, "    "));
-          }
-        };
-        const preview = cases.map(({ name, message }) => `✗ ${name}\n${message}`).join("\n\n") || reason;
-        const result = {
+        const suite = suites.get(title);
+        if (!suite?.cases.length) continue;
+        startGroup(
+          `${title} - ${suite.failures} failing in the parallel batch ${getAnsi("gray")}(${suite.seconds.toFixed(2)}s)${getAnsi("reset")}`,
+          () => {
+            for (const { name, message } of suite.cases) {
+              console.log(`${getAnsi("red")}✗${getAnsi("reset")} ${name}`);
+              if (message) console.log(message.replace(/^/gm, "    "));
+            }
+          },
+        );
+      }
+      for (const t of failed) {
+        if (listed(t)) continue;
+        const title = join("test", t).replaceAll("\\", "/");
+        const suite = suites.get(title);
+        const error = suite ? `${suite.failures} failing in the parallel batch` : "failed in the parallel batch";
+        const preview = (suite?.cases ?? []).map(({ name, message }) => `✗ ${name}\n${message}`).join("\n\n") || error;
+        // The batch run was this file's one attempt: report it like any other failure.
+        await runTest(title, async () => ({
           testPath: title,
           ok: false,
           status: "fail",
-          error: reason,
+          error,
           errors: [],
           tests: [],
           stdout: preview,
           stdoutPreview: preview,
-        };
-        if (retriedSet.has(t)) {
-          startGroup(`${getAnsi("yellow")}${title} - ${reason}${getAnsi("reset")}`, printCases);
-          batchFailures.set(t, result);
-          continue;
-        }
-        startGroup(`${getAnsi("red")}[${++i}/${total}] ${title} - ${reason}${getAnsi("reset")}`, printCases);
-        failedResults.push(result);
-        failedResultsTitles.push(title);
-        reportFailure(title, result, false, 1);
-      }
-      if (batchError) {
-        // No file can hold this failure, so the list cannot hold it either.
-        const preview = `${stripAnsi(stdout).split(/\r?\n/).slice(-50).join("\n")}\n${crashes ?? ""}`.trim();
-        console.log(`${getAnsi("red")}${label} - ${batchError}${getAnsi("reset")}`);
-        const result = {
-          testPath: label,
-          ok: false,
-          status: "fail",
-          error: batchError,
-          errors: [],
-          tests: [],
-          stdout,
-          stdoutPreview: preview,
-        };
-        failedResults.push(result);
-        failedResultsTitles.push(label);
-        reportFailure(label, result, false, 1);
+        }));
       }
       if (rerun.length) {
         console.log(
-          `${getAnsi("yellow")}parallel bucket: running ${retried.length} listed flaky file(s) that failed and ${incomplete.size} file(s) with no result, one at a time${getAnsi("reset")}`,
+          `${getAnsi("yellow")}parallel bucket: ${evidence ? `retrying ${retried.length} failed (listed in test/flaky-tests.txt) and ${incomplete.size} unfinished file(s)${suites.size ? "" : " (from streamed output; no junit)"}` : `no junit and no streamed evidence, re-running all ${rerun.length} file(s)`} one at a time${getAnsi("reset")}`,
         );
         for (const testPath of rerun) {
-          // A listed file's batch run was its first attempt: the solo runs are its retries.
-          const result = await runOneTest(testPath, false, batchFailures.get(testPath));
-          if (result?.ok && batchFailures.has(testPath) && isBuildkite) {
+          const result = await runOneTest(testPath, false);
+          if (result?.ok && failed.has(testPath) && isBuildkite) {
             const title = join("test", testPath).replaceAll("\\", "/");
             const cases = suites.get(title)?.cases ?? [];
             const first = cases[0];
@@ -2992,8 +2883,7 @@ function formatTestToMarkdown(result, concise, retries) {
     }
 
     const testTitle = testPath.replace(/\\/g, "/");
-    // A parallel batch that fails as a whole is reported under its label, not a file.
-    const testUrl = existsSync(join(cwd, testPath)) ? getFileUrl(testPath, errorLine) : undefined;
+    const testUrl = getFileUrl(testPath, errorLine);
 
     if (concise) {
       markdown += "<li>";

--- a/test/flaky-tests.txt
+++ b/test/flaky-tests.txt
@@ -1,6 +1,7 @@
 # Test files that the CI runner may run again when they fail (up to 3 retries,
 # see --retries in scripts/runner.node.mjs). Every other test file runs once,
-# in a serial run and in the parallel batch, and its failure is final.
+# in a serial run and in the parallel batch, and its failure is final. A serial
+# run that crashed (see isAlwaysFailure) is not retried, even for a listed file.
 #
 # One path per line, relative to the repository root, with the reason after
 # `#`. Keep the failing test and its symptom next to the entry so the owner

--- a/test/flaky-tests.txt
+++ b/test/flaky-tests.txt
@@ -1,7 +1,6 @@
 # Test files that the CI runner may run again when they fail (up to 3 retries,
-# see --retries in scripts/runner.node.mjs). Every other file runs once, and a
-# failure is final. A crash is never retried, listed or not. The parallel batch
-# follows the same rules: a failure there counts as it does in a serial run.
+# see --retries in scripts/runner.node.mjs). Every other test file runs once,
+# in a serial run and in the parallel batch, and its failure is final.
 #
 # One path per line, relative to the repository root, with the reason after
 # `#`. Keep the failing test and its symptom next to the entry so the owner


### PR DESCRIPTION
### Problem
- #41204 was meant only to stop the retries of the test files that are not in `test/flaky-tests.txt`. Its change to `scripts/runner.node.mjs` also made the parallel batch count failures as a serial run does.

### Fix
- The runner now differs from the one before #41204 only in the gate: +40 and -6 lines against `dfa2b122c7~1`. An unlisted test file gets one attempt, in a serial run and in the batch. A listed file, and the runner's own `bun install` steps, keep their retries.
- Compared with main, the batch counts as it did before #41204. The changes are in the Notes.
- The list keeps its 156 files. The serial path does not change.
- Verified locally with the system bun: an unlisted failure fails the run (serial and in the batch), a listed file that fails once passes on its retry, and a batch whose coordinator is killed runs every file alone.

### Background
- Each test file runs as its own `bun test` process. Files on `test/parallel-allowlist.json` run as one `bun test --parallel` batch per shard, and its junit report names the files that failed.

<details><summary>Notes: each change against main</summary>

1. A listed file whose batch worker crashed runs again alone. Main never retries a crash.
2. An error between tests is not a failure. Main fails the batch.
3. A non-zero exit with no failing file counts as a pass. Main fails the batch.
4. A core dump that no worker death explains is not a failure. Main fails the batch.
5. No junit report. Main fails the batch, and every file not named as failed runs alone. Here, with no interrupt report either, every file runs alone, and the batch does not fail. With an interrupt report, each file that the report does not name counts as passed.
6. A listed batch file gets up to five runs: the batch run and four solo runs. Main gives four.
7. A file that a sibling's crash stopped counts as passed when its partial junit result has no failure. Main runs it alone.
8. A stale junit report from an earlier job is not deleted before the batch. Main deletes it.
9. `--retries` below 0 skips the listed files, as before #41204. Main treats it as 0.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->