### PR TITLE
Remove dead code from bun_collections, bun_core, the JSC bindings, and 37 re-exports

### DIFF
--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -917,9 +917,6 @@ unsafe extern "C" {
         cb: Option<unsafe extern "C" fn(ssl: *const SSL, line: *const c_char)>,
     );
     pub fn SSL_CTX_set_early_data_enabled(ctx: *mut SSL_CTX, enabled: c_int);
-    pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
-    pub fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void;
-    pub fn SSL_set_ex_data(ssl: *mut SSL, idx: c_int, data: *mut c_void) -> c_int;
     pub fn SSL_set_tlsext_host_name(ssl: *mut SSL, name: *const c_char) -> c_int;
     pub fn SSL_set_alpn_protos(ssl: *mut SSL, protos: *const u8, protos_len: usize) -> c_int;
     pub fn SSL_get0_alpn_selected(ssl: *const SSL, out_data: *mut *const u8, out_len: *mut c_uint);

--- a/src/bun_alloc/baby_vec.rs
+++ b/src/bun_alloc/baby_vec.rs
@@ -153,25 +153,6 @@ impl<'a, T> BabyVec<'a, T> {
         self.len += 1;
     }
 
-    pub fn swap_remove(&mut self, index: usize) -> T {
-        let len = self.len as usize;
-        assert!(
-            index < len,
-            "BabyVec::swap_remove index {index} >= len {len}"
-        );
-        // SAFETY: `index < len`; reading the hole then overwriting with the
-        // last element (possibly itself) is the standard swap-remove. Len is
-        // decremented before the read of `last` so the moved-from tail slot
-        // is no longer considered initialized.
-        unsafe {
-            let p = self.ptr.as_ptr();
-            let v = p.add(index).read();
-            self.len -= 1;
-            ptr::copy(p.add(self.len as usize), p.add(index), 1);
-            v
-        }
-    }
-
     /// `Vec::remove` parity — order-preserving removal.
     pub fn remove(&mut self, index: usize) -> T {
         let len = self.len as usize;

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -3420,7 +3420,6 @@ pub trait Integer: Copy + Default {
     fn from_f64(v: f64) -> Self;
     fn from_i64(v: i64) -> Self;
     fn from_u64(v: u64) -> Self;
-    fn to_f64(self) -> f64;
 }
 macro_rules! impl_integer {
     ($($t:ty: $signed:expr),* $(,)?) => { $(
@@ -3433,7 +3432,6 @@ macro_rules! impl_integer {
             #[inline] fn from_f64(v: f64) -> Self { v as Self }
             #[inline] fn from_i64(v: i64) -> Self { v as Self }
             #[inline] fn from_u64(v: u64) -> Self { v as Self }
-            #[inline] fn to_f64(self) -> f64 { self as f64 }
         }
     )* };
 }
@@ -3450,8 +3448,6 @@ pub trait NativeEndianInt: Copy + 'static {
     const SIZE: usize;
     /// Reinterpret `b[..SIZE]` as `Self` (native endian).
     fn from_ne_slice(b: &[u8]) -> Self;
-    /// Write `self.to_ne_bytes()` into `out[..SIZE]`.
-    fn encode_ne(self, out: &mut [u8]);
 }
 
 macro_rules! impl_native_endian_int {
@@ -3463,10 +3459,6 @@ macro_rules! impl_native_endian_int {
                 let mut a = [0u8; core::mem::size_of::<$t>()];
                 a.copy_from_slice(&b[..core::mem::size_of::<$t>()]);
                 <$t>::from_ne_bytes(a)
-            }
-            #[inline]
-            fn encode_ne(self, out: &mut [u8]) {
-                out[..core::mem::size_of::<$t>()].copy_from_slice(&self.to_ne_bytes());
             }
         }
     )*};
@@ -5464,5 +5456,3 @@ pub mod form_data {
         }
     }
 }
-/// `bun.FormData` — capitalized namespace alias.
-pub use form_data as FormData;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1372,8 +1372,6 @@ pub mod bv2_impl {
     bun_core::declare_scope!(ReachableFiles, visible);
     bun_core::declare_scope!(watcher, visible);
 
-    pub use bun_js_printer::MangledProps;
-
     // ══════════════════════════════════════════════════════════════════════════
     // CYCLEBREAK §Dispatch — vtables/hooks for T6 GENUINE deps (jsc/bake/runtime).
     // Low tier (bundler) names no high-tier types. High tier (runtime) provides
@@ -7985,9 +7983,6 @@ pub mod bv2_impl {
     // Re-export the canonical defs so `bundle_v2::` and `BundleThread::` paths
     // resolve to the same nominal type.
     pub use crate::BundleThread::{BuildResult, BundleV2Result, CompletionStruct, singleton};
-
-    // re-exports
-    pub use bun_ast::Loc;
 
     // C++ binding for lazy metafile getter (defined in BundlerMetafile.cpp)
     // Uses jsc.conv (SYSV_ABI on Windows x64) for proper calling convention

--- a/src/bundler/entry_points.rs
+++ b/src/bundler/entry_points.rs
@@ -11,12 +11,9 @@ use crate::Transpiler;
 use bun_js_parser as js_ast;
 
 // `Path`/`PathName` come from the lower-tier `bun_paths::fs` shim
-// (lifetime-erased `'static` slices) so `bun_ast::Source` field types line up;
-// `FileSystem` is the real `bun_resolver::fs` singleton now that
-// `bun_resolver` is in this crate's dep set.
+// (lifetime-erased `'static` slices) so `bun_ast::Source` field types line up.
 pub mod Fs {
     pub use bun_paths::fs::{Path, PathName};
-    pub use bun_resolver::fs::FileSystem;
 }
 
 #[derive(Default)]

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -191,12 +191,6 @@ pub mod linker_context {
 
     #[path = "StaticRouteVisitor.rs"]
     pub mod static_route_visitor;
-
-    // ── Re-exports so `crate::linker_context::{debug, LinkerContext, …}`
-    //    resolves at every submodule call-site.
-    pub use crate::linker_context_mod::{
-        ChunkMeta, GenerateChunkCtx, LinkerContext, PendingPartRange,
-    };
 }
 
 // ---------------------------------------------------------------------------
@@ -209,8 +203,6 @@ pub use bundle_v2::BundleV2;
 /// See `chunk` module.
 pub use chunk::Chunk;
 pub use defines::{Define, DefineDataExt, DefineExt};
-/// See `linker` module.
-pub use linker::Linker;
 /// See `linker_context_mod` module.
 pub use linker_context_mod::LinkerContext;
 /// See `linker_graph` module.
@@ -218,8 +210,6 @@ pub use linker_graph::LinkerGraph;
 /// `EntryPoint::Kind` is an inherent associated type on the struct (not a
 /// sibling module — that would collide with this re-export).
 pub use linker_graph::entry_point::EntryPoint;
-/// See `options_impl`.
-pub use options_impl::BundleOptions;
 pub use output_file::OutputFile;
 /// See `parse_task` module.
 pub use parse_task::ParseTask;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -188,8 +188,6 @@ pub use bun_resolve_builtins::node_builtins::{
 // NODE_BUILTINS_MAP removed: dead — `is_node_builtin` (line 142) already delegates to
 // `bun_resolve_builtins::Alias::has`; no other reader. See node_builtins.rs header.
 
-pub use bun_options_types::BundlePackage;
-
 // Re-export of `bun_options_types::bundle_enums::ModuleType`.
 // Re-exported so `crate::options_impl::ModuleType` and `js_ast::parser::options::ModuleType`
 // (which also re-exports the BundleEnums def) are the *same* nominal type — kills the

--- a/src/bunfig/lib.rs
+++ b/src/bunfig/lib.rs
@@ -12,5 +12,4 @@ pub mod arguments;
 pub mod bunfig;
 pub mod error;
 
-pub use arguments::{load_config, load_config_path, load_config_with_cmd_args};
 pub use error::{Error, Result};

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -26,10 +26,8 @@ pub mod linear_fifo;
 
 pub mod bit_set;
 pub mod pool;
-pub use pool::{ObjectPool, ObjectPoolType, PoolGuard};
 #[path = "StaticHashMap.rs"]
 pub mod static_hash_map;
-pub use static_hash_map::StaticHashMap;
 
 pub use bounded_array::BoundedArray;
 pub use hive_array::{

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -96,7 +96,6 @@ pub trait VecExt<T>: Sized {
     fn ensure_total_capacity(&mut self, n: usize);
     fn ensure_unused_capacity(&mut self, n: usize);
     fn shrink_retaining_capacity(&mut self, new_len: usize);
-    fn shrink_and_free(&mut self, new_len: usize);
     fn clear_retaining_capacity(&mut self);
     fn clear_and_free(&mut self);
     /// Drop the first `n` elements in place via `copy_within(n.., 0)` +
@@ -106,9 +105,6 @@ pub trait VecExt<T>: Sized {
     where
         T: Copy;
     fn ordered_remove(&mut self, index: usize) -> T;
-    fn insert_slice(&mut self, index: usize, vals: &[T])
-    where
-        T: Clone;
     /// # Safety
     /// Exposes `self[len..capacity]` as initialized. Every element must be
     /// overwritten before any read (including Drop). Prefer
@@ -150,11 +146,8 @@ pub trait VecExt<T>: Sized {
     /// Non-owning header alias.  For `Vec` this is `from_raw_parts` into a
     /// `ManuallyDrop` — same UB-if-dropped contract as before.
     fn shallow_copy(&self) -> ManuallyDrop<Self>;
-    fn shallow_clone(&self) -> ManuallyDrop<Self>;
 
     // ── misc ──────────────────────────────────────────────────────────────
-    fn unused_capacity_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>];
-    fn allocated_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>];
     fn memory_cost(&self) -> usize;
     fn deep_clone_with<F>(&self, clone_one: F) -> Self
     where
@@ -340,11 +333,6 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
         self.truncate(new_len);
     }
     #[inline]
-    fn shrink_and_free(&mut self, new_len: usize) {
-        self.truncate(new_len);
-        self.shrink_to_fit();
-    }
-    #[inline]
     fn clear_retaining_capacity(&mut self) {
         self.clear();
     }
@@ -362,13 +350,6 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
     #[inline]
     fn ordered_remove(&mut self, index: usize) -> T {
         self.remove(index)
-    }
-    #[inline]
-    fn insert_slice(&mut self, index: usize, vals: &[T])
-    where
-        T: Clone,
-    {
-        self.splice(index..index, vals.iter().cloned());
     }
     #[inline]
     unsafe fn expand_to_capacity(&mut self) {
@@ -449,25 +430,7 @@ impl<T, A: Allocator + Default + 'static> VecExt<T> for Vec<T, A> {
             )
         })
     }
-    #[inline]
-    fn shallow_clone(&self) -> ManuallyDrop<Self> {
-        self.shallow_copy()
-    }
 
-    #[inline]
-    fn unused_capacity_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
-        self.spare_capacity_mut()
-    }
-    #[inline]
-    fn allocated_slice(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
-        // SAFETY: ptr[0..cap] is the full allocation.
-        unsafe {
-            core::slice::from_raw_parts_mut(
-                self.as_mut_ptr().cast::<core::mem::MaybeUninit<T>>(),
-                self.capacity(),
-            )
-        }
-    }
     #[inline]
     fn memory_cost(&self) -> usize {
         self.capacity() * core::mem::size_of::<T>()

--- a/src/collections/vec_ext.rs
+++ b/src/collections/vec_ext.rs
@@ -108,12 +108,12 @@ pub trait VecExt<T>: Sized {
     /// # Safety
     /// Exposes `self[len..capacity]` as initialized. Every element must be
     /// overwritten before any read (including Drop). Prefer
-    /// [`unused_capacity_slice`] for `T` with validity invariants.
+    /// `spare_capacity_mut()` for `T` with validity invariants.
     unsafe fn expand_to_capacity(&mut self);
     /// # Safety
     /// Returns `&mut [T]` over `additional` uninitialized elements. Caller
     /// must fully initialize the slice before any read/drop. Prefer
-    /// [`unused_capacity_slice`] + `set_len` for non-POD `T`.
+    /// [`reserve_spare`] + `set_len` for non-POD `T`.
     unsafe fn writable_slice(&mut self, additional: usize) -> &mut [T];
     /// # Safety
     /// As [`writable_slice`] but uses `reserve_exact` so the allocation grows

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -577,13 +577,11 @@ mod draft {
     /// The counter is incremented/decremented atomically.
     /// Shared with bun_core::PANICKING so T0 callers see the same state.
     use bun_core::PANICKING;
-    // D131: dedup — these read the shared `PANICKING` atomic and were byte-identical
-    // to the bun_core (T0) copies. Re-export so `bun_crash_handler::{is_panicking,
-    // sleep_forever_if_another_thread_is_crashing}` keeps resolving for any
-    // out-of-tree callers. `dump_current_stack_trace` is intentionally NOT deduped:
-    // the bun_core version is an `extern "Rust"` dispatch shim, this crate's is the
-    // real impl (linked via `__bun_crash_handler_dump_stack_trace`).
-    pub use bun_core::{is_panicking, sleep_forever_if_another_thread_is_crashing};
+    // D131: dedup — `is_panicking` and `sleep_forever_if_another_thread_is_crashing`
+    // read the shared `PANICKING` atomic, so they live in bun_core (T0) only.
+    // `dump_current_stack_trace` is intentionally NOT deduped: the bun_core version
+    // is an `extern "Rust"` dispatch shim, this crate's is the real impl (linked via
+    // `__bun_crash_handler_dump_stack_trace`).
 
     // Locked to avoid interleaving panic messages from multiple threads.
     // TODO: I don't think it's safe to lock/unlock a mutex inside a signal handler.

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -577,11 +577,6 @@ mod draft {
     /// The counter is incremented/decremented atomically.
     /// Shared with bun_core::PANICKING so T0 callers see the same state.
     use bun_core::PANICKING;
-    // D131: dedup — `is_panicking` and `sleep_forever_if_another_thread_is_crashing`
-    // read the shared `PANICKING` atomic, so they live in bun_core (T0) only.
-    // `dump_current_stack_trace` is intentionally NOT deduped: the bun_core version
-    // is an `extern "Rust"` dispatch shim, this crate's is the real impl (linked via
-    // `__bun_crash_handler_dump_stack_trace`).
 
     // Locked to avoid interleaving panic messages from multiple threads.
     // TODO: I don't think it's safe to lock/unlock a mutex inside a signal handler.

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -33,8 +33,7 @@ pub use crate::error::{
     MinifyError, MinifyErrorKind, ParseError, ParserError, PrinterError, PrinterErrorKind,
     SelectorError,
 };
-pub use crate::generics::{self as generic, implement_deep_clone, implement_hash};
-pub use crate::logical::{self, PropertyCategory};
+pub use crate::generics as generic;
 pub use crate::prefixes;
 pub use crate::printer::{self as css_printer, ImportInfo, Printer, PrinterOptions};
 pub use crate::small_list::SmallList;
@@ -54,7 +53,7 @@ pub use crate::values::{
 // expose.
 pub(crate) use crate::context::PropertyHandlerContext;
 pub use crate::declaration::{self, DeclarationBlock, DeclarationHandler, DeclarationList};
-pub use crate::media_query::{self, MediaFeatureType, MediaList};
+pub use crate::media_query::{self, MediaList};
 pub use crate::properties::{
     self as css_properties, Property, PropertyId, PropertyIdTag,
     css_modules::Composes,
@@ -70,7 +69,7 @@ pub use crate::rules::{
     unknown::UnknownAtRule,
 };
 pub use crate::selectors::{
-    parser::{Component, PseudoClass, PseudoElement, Selector, SelectorList},
+    parser::{Component, PseudoClass, Selector, SelectorList},
     selector,
 };
 pub use crate::values::ident::{CustomIdentFns, DashedIdentFns};

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -128,7 +128,7 @@ pub use values::string::{CssString as CSSString, CssStringFns as CSSStringFns};
 // reflection helpers in `generics`; alias both spellings so value/property
 // modules can use `crate::generic::partial_cmp_f32` etc.
 pub use generics as generic;
-pub use generics::{implement_deep_clone, implement_hash};
+pub use generics::implement_deep_clone;
 // Same-name trait + derive macro re-export so `#[derive(bun_css::DeepClone)]`
 // (and `use bun_css::DeepClone;` at leaf sites) brings both into scope.
 pub use generics::{CssEql, DeepClone};
@@ -136,9 +136,7 @@ pub use generics::{CssEql, DeepClone};
 // re-exported above from `css_parser`; the *derive* of the same name lives in
 // the proc-macro crate.
 pub use bun_css_derive::{DefineEnumProperty, Parse, ToCss};
-// Serializer + dtoa helpers live in the parser hub but are referenced as
-// `css::serializer` / `css::f32_length_with_5_digits` from value modules.
-pub use css_parser::{dtoa_short, f32_length_with_5_digits, serializer, to_css};
+pub use css_parser::to_css;
 
 #[path = "generics.rs"]
 pub mod generics;

--- a/src/css/properties/mod.rs
+++ b/src/css/properties/mod.rs
@@ -122,7 +122,6 @@ pub mod outline;
 pub mod overflow;
 pub mod position;
 pub mod prefix_handler;
-pub mod shape;
 pub mod size;
 pub mod text;
 pub mod transform;

--- a/src/css/properties/shape.rs
+++ b/src/css/properties/shape.rs
@@ -1,1 +1,0 @@
-pub use crate::css_parser as css;

--- a/src/css/selectors/mod.rs
+++ b/src/css/selectors/mod.rs
@@ -22,7 +22,7 @@ pub mod parser;
 #[path = "selector.rs"]
 pub mod selector;
 
-pub use parser::{Component, PseudoClass, PseudoElement, Selector, SelectorList};
+pub use parser::SelectorList;
 
 /// Our implementation of the `SelectorImpl` interface. Defined in the hub
 /// (not in `selector.rs`) to break the parser↔selector dependency cycle:

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -66,7 +66,6 @@ pub use signals::Signals;
 pub use thread_safe_stream_buffer::ThreadSafeStreamBuffer;
 #[path = "ssl_config.rs"]
 pub mod ssl_config;
-pub use ssl_config::SSLConfig;
 // SSLWrapper was MOVE_DOWN to bun_uws (tier 4); re-export here so
 // `crate::ssl_wrapper::SSLWrapper` resolves for ProxyTunnel/HTTPContext.
 pub use bun_uws::ssl_wrapper;

--- a/src/http_types/lib.rs
+++ b/src/http_types/lib.rs
@@ -10,7 +10,6 @@ pub mod URLPath;
 pub mod h2;
 pub mod mime_type_list_enum;
 mod mime_type_list_sorted;
-pub use ETag::wtf;
 
 // `mime_type_list_enum::MimeTypeList` is a hand-generated `&'static str`
 // newtype (PERF: stand-in for a packed-u14 table), so

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -82,7 +82,7 @@ fn deregistration_already_gone(errno: sys::E) -> bool {
     matches!(errno, sys::E::ENOENT | sys::E::EBADF)
 }
 
-pub use crate::{EventLoopCtx, EventLoopCtxKind, OpaqueCallback};
+pub use crate::{EventLoopCtx, OpaqueCallback};
 
 unsafe extern "Rust" {
     /// Defined `#[no_mangle]` in `bun_runtime::jsc_hooks`.

--- a/src/js/internal/streams/iter/push.ts
+++ b/src/js/internal/streams/iter/push.ts
@@ -312,10 +312,6 @@ class PushQueue {
     }
   }
 
-  get totalBytesWritten() {
-    return this.#bytesWritten;
-  }
-
   get error() {
     return this.#error;
   }

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -25,7 +25,6 @@ pub mod scan;
 pub mod typescript;
 pub mod visit;
 
-pub use p::P;
 pub use parse::parse_entry::{Options as ParserOptions, Parser};
 
 // Full impl lives in *_jsc; this stub re-exposes the JSC-free constants and a

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -148,7 +148,6 @@ pub mod options {
     }
 }
 pub use crate::parse::parse_entry::{Options as ParserOptions, Parser};
-pub use crate::renamer;
 pub use crate::scan::scan_side_effects::SideEffects;
 
 pub(crate) use bun_ast::base::Ref;
@@ -419,8 +418,6 @@ pub mod Runtime {
 }
 pub type RuntimeFeatures = Runtime::Features;
 pub(crate) type RuntimeImports = Runtime::Imports;
-
-pub use crate::p::P;
 
 // NOTE(b0): `pub use bun_js_printer as js_printer;` removed — js_printer is same-tier mutual
 // (js_printer depends on js_parser). Downstream callers import bun_js_printer directly.

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -18,7 +18,6 @@ use crate::{
 // Re-exports.
 pub use crate::runtime_transpiler_store::RuntimeTranspilerStore;
 pub use bun_resolve_builtins::HardcodedModule;
-pub use bun_resolver::node_fallbacks;
 
 bun_core::declare_scope!(ModuleLoader, hidden);
 

--- a/src/jsc/bindings/BufferStringSearch.h
+++ b/src/jsc/bindings/BufferStringSearch.h
@@ -24,7 +24,6 @@ public:
     }
 
     size_t length() const { return length_; }
-    bool forward() const { return is_forward_; }
 
     T operator[](size_t index) const
     {

--- a/src/jsc/bindings/DOMWrapperWorld-class.h
+++ b/src/jsc/bindings/DOMWrapperWorld-class.h
@@ -14,9 +14,9 @@ public:
         Internal, // WebKit Internal (e.g. Media Controls)
     };
 
-    static Ref<DOMWrapperWorld> create(JSC::VM& vm, Type type = Type::Internal, const String& name = {})
+    static Ref<DOMWrapperWorld> create(JSC::VM& vm, Type type = Type::Internal)
     {
-        return adoptRef(*new DOMWrapperWorld(vm, type, name));
+        return adoptRef(*new DOMWrapperWorld(vm, type));
     }
     WEBCORE_EXPORT ~DOMWrapperWorld();
 
@@ -25,12 +25,11 @@ public:
     JSC::VM& vm() const { return m_vm; }
 
 protected:
-    DOMWrapperWorld(JSC::VM&, Type, const String& name);
+    DOMWrapperWorld(JSC::VM&, Type);
 
 private:
     JSC::VM& m_vm;
 
-    String m_name;
     Type m_type { Type::Internal };
 };
 

--- a/src/jsc/bindings/DOMWrapperWorld-class.h
+++ b/src/jsc/bindings/DOMWrapperWorld-class.h
@@ -20,10 +20,7 @@ public:
     }
     WEBCORE_EXPORT ~DOMWrapperWorld();
 
-    Type type() const { return m_type; }
     bool isNormal() const { return m_type == Type::Normal; }
-
-    const String& name() const { return m_name; }
 
     JSC::VM& vm() const { return m_vm; }
 

--- a/src/jsc/bindings/DOMWrapperWorld.cpp
+++ b/src/jsc/bindings/DOMWrapperWorld.cpp
@@ -29,9 +29,8 @@ namespace WebCore {
 
 using namespace JSC;
 
-DOMWrapperWorld::DOMWrapperWorld(JSC::VM& vm, Type type, const String& name)
+DOMWrapperWorld::DOMWrapperWorld(JSC::VM& vm, Type type)
     : m_vm(vm)
-    , m_name(name)
     , m_type(type)
 {
     VM::ClientData* clientData = m_vm.clientData;

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -75,10 +75,6 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
     auto inst = code->instructionAt(bc);
 
     /// JavaScriptCore places error divots at different places than v8
-    // Uncomment to debug this:
-    // printf("lc = %d : %d (byte = %d)\n", pos.line.oneBasedInt(), pos.column.oneBasedInt(), expr.divot);
-    // printf("off = %d : %d\n", expr.startOffset, expr.endOffset);
-    // printf("name = %s\n", inst->name());
 
     switch (inst->opcodeID()) {
     case op_construct:

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -88,15 +88,10 @@ public:
     bool isAsync() const { return m_isAsync; }
 
     bool hasBytecodeIndex() const { return (m_bytecodeIndex.offset() != UINT_MAX) && !m_isWasmFrame; }
-    JSC::BytecodeIndex bytecodeIndex() const
-    {
-        return m_bytecodeIndex;
-    }
 
     // Returns null if can't retrieve the source positions
     SourcePositions* getSourcePositions();
 
-    bool isWasmFrame() const { return m_isWasmFrame; }
     bool isEval()
     {
         if (m_codeBlock) {
@@ -167,10 +162,7 @@ public:
     }
 
     size_t size() const { return m_frames.size(); }
-    bool isEmpty() const { return m_frames.isEmpty(); }
     JSCStackFrame& at(size_t i) { return m_frames.at(i); }
-
-    WTF::Vector<JSCStackFrame>&& frames() { return WTF::move(m_frames); }
 
     // Drops private-visibility frames (present when Options::showPrivateScriptsInStackTraces() is on), so the result does not index like existingFrames.
     static JSCStackTrace fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames);

--- a/src/jsc/bindings/Exception.h
+++ b/src/jsc/bindings/Exception.h
@@ -38,11 +38,9 @@ public:
     explicit Exception(ExceptionCode, String = {}, String = {});
 
     ExceptionCode code() const { return m_code; }
-    const String& message() const { return m_message; }
     String&& releaseMessage() { return WTF::move(m_message); }
     // Optional secondary payload for codes that need more than one string to
     // shape the JS error (currently InvalidURLError's `error.base`).
-    const String& extra() const { return m_extra; }
     String&& releaseExtra() { return WTF::move(m_extra); }
 
     Exception isolatedCopy() const

--- a/src/jsc/bindings/GlobalEventScope.h
+++ b/src/jsc/bindings/GlobalEventScope.h
@@ -30,11 +30,6 @@ public:
     using RefCounted::deref;
     using RefCounted::ref;
 
-    static Ref<GlobalEventScope> create(ScriptExecutionContext* context)
-    {
-        return adoptRef(*new GlobalEventScope(context));
-    }
-
     ~GlobalEventScope() = default;
 
     EventTargetInterface eventTargetInterface() const final { return EventTargetInterface::DOMWindowEventTargetInterfaceType; }

--- a/src/jsc/bindings/InspectorBunFrontendDevServerAgent.h
+++ b/src/jsc/bindings/InspectorBunFrontendDevServerAgent.h
@@ -13,7 +13,6 @@
 namespace Inspector {
 
 class FrontendRouter;
-class BackendDispatcher;
 class BunFrontendDevServerFrontendDispatcher;
 
 class InspectorBunFrontendDevServerAgent final : public InspectorAgentBase, public Inspector::BunFrontendDevServerBackendDispatcherHandler {

--- a/src/jsc/bindings/InspectorLifecycleAgent.h
+++ b/src/jsc/bindings/InspectorLifecycleAgent.h
@@ -12,7 +12,6 @@
 namespace Inspector {
 
 class FrontendRouter;
-class BackendDispatcher;
 class LifecycleReporterFrontendDispatcher;
 enum class DisconnectReason;
 

--- a/src/jsc/bindings/InspectorTestReporterAgent.h
+++ b/src/jsc/bindings/InspectorTestReporterAgent.h
@@ -12,7 +12,6 @@
 namespace Inspector {
 
 class FrontendRouter;
-class BackendDispatcher;
 class TestReporterFrontendDispatcher;
 enum class DisconnectReason;
 

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -138,8 +138,6 @@ public:
 
     ~JSNodePerformanceHooksHistogram();
 
-    hdr_histogram& histogram() { return *m_histogramData.histogram; }
-
     bool record(int64_t value);
     uint64_t recordDelta(JSGlobalObject* globalObject);
     void reset();

--- a/src/jsc/bindings/WebCoreOpaqueRoot.h
+++ b/src/jsc/bindings/WebCoreOpaqueRoot.h
@@ -53,13 +53,4 @@ inline void addWebCoreOpaqueRoot(Visitor&, ImplType*);
 template<typename Visitor, typename ImplType>
 inline void addWebCoreOpaqueRoot(Visitor&, ImplType&);
 
-template<typename Visitor>
-inline bool containsWebCoreOpaqueRoot(Visitor&, WebCoreOpaqueRoot);
-
-template<typename Visitor, typename ImplType>
-inline bool containsWebCoreOpaqueRoot(Visitor&, ImplType&);
-
-template<typename Visitor, typename ImplType>
-inline bool containsWebCoreOpaqueRoot(Visitor&, ImplType*);
-
 } // namespace WebCore

--- a/src/jsc/bindings/WebCoreOpaqueRootInlines.h
+++ b/src/jsc/bindings/WebCoreOpaqueRootInlines.h
@@ -47,22 +47,4 @@ ALWAYS_INLINE void addWebCoreOpaqueRoot(Visitor& visitor, ImplType& impl)
     addWebCoreOpaqueRoot(visitor, root(&impl));
 }
 
-template<typename Visitor>
-ALWAYS_INLINE bool containsWebCoreOpaqueRoot(Visitor& visitor, WebCoreOpaqueRoot root)
-{
-    return visitor.containsOpaqueRoot(root.pointer());
-}
-
-template<typename Visitor, typename ImplType>
-ALWAYS_INLINE bool containsWebCoreOpaqueRoot(Visitor& visitor, ImplType& impl)
-{
-    return containsWebCoreOpaqueRoot(visitor, root(&impl));
-}
-
-template<typename Visitor, typename ImplType>
-ALWAYS_INLINE bool containsWebCoreOpaqueRoot(Visitor& visitor, ImplType* impl)
-{
-    return containsWebCoreOpaqueRoot(visitor, root(impl));
-}
-
 } // namespace WebCore

--- a/src/jsc/bindings/v8/shim/FunctionTemplate.h
+++ b/src/jsc/bindings/v8/shim/FunctionTemplate.h
@@ -61,9 +61,6 @@ public:
     // Lazily create the prototype ObjectTemplate if unset.
     ObjectTemplate* ensurePrototypeTemplate(JSC::JSGlobalObject* globalObject);
 
-    WTF::Vector<TemplateProperty>& properties() { return m_properties; }
-    WTF::Vector<TemplateAccessor>& accessors() { return m_accessors; }
-
     void addProperty(JSC::VM& vm, JSC::JSValue name, JSC::JSValue value, unsigned attributes);
     void addAccessor(JSC::VM& vm, JSC::JSValue name, AccessorNameGetterCallback getter, AccessorNameSetterCallback setter, JSC::JSValue data, unsigned attributes);
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -342,7 +342,6 @@ impl<'a> ConsoleFormatter for self::console_object::Formatter<'a> {
     }
 }
 
-pub use self::counters::Counters;
 pub use self::decoded_js_value::DecodedJSValue;
 pub use self::deprecated_strong::DeprecatedStrong;
 pub use self::js_array::JSArray;
@@ -1174,7 +1173,6 @@ pub use self::js_string::{JSString, JSStringView};
 
 #[path = "RefString.rs"]
 pub mod ref_string;
-pub use self::ref_string as RefString;
 
 pub mod jsc_abi;
 
@@ -1183,7 +1181,6 @@ pub mod debugger;
 pub use self::debugger as Debugger;
 #[path = "SavedSourceMap.rs"]
 pub mod saved_source_map;
-pub use self::saved_source_map as SavedSourceMap;
 
 // ──────────────────────────────────────────────────────────────────────────
 // VirtualMachine / ModuleLoader / event_loop. Downstream-compat re-exports
@@ -1333,7 +1330,6 @@ pub mod codegen {
         }
     }
 }
-pub use self::codegen as Codegen;
 
 /// Extension trait providing JSC-aware methods on `bun_sys::Error` (`bun.sys.Error`).
 pub trait SysErrorJsc {

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -47,7 +47,6 @@ pub mod visitors;
 use crate::collections::IndexMap;
 use crate::collections::IndexSet;
 pub use crate::diagnostics::CompilerDiagnostic;
-pub use crate::diagnostics::ErrorCategory;
 pub use crate::diagnostics::GENERATED_SOURCE;
 pub use crate::diagnostics::Position;
 pub use crate::diagnostics::SourceLocation;

--- a/src/react_compiler/lib.rs
+++ b/src/react_compiler/lib.rs
@@ -18,9 +18,6 @@ pub mod typeinference;
 pub mod utils;
 pub mod validation;
 
-pub use hir::environment;
-pub use hir::environment_config::EnvironmentConfig;
-
 mod compile_result;
 mod imports;
 mod options;

--- a/src/simdutf_sys/lib.rs
+++ b/src/simdutf_sys/lib.rs
@@ -1,11 +1,3 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
 pub mod simdutf;
-
-// Top-level re-exports of the safe slice-taking wrappers in `simdutf::validate`.
-// These are the canonical UTF-8 validation entry points for the codebase —
-// `core::str::from_utf8` is NOT used at runtime (PORTING.md §Strings: digits
-// and identifiers are ASCII; genuine validation goes through simdutf, which
-// is ~3-10× faster than the std byte-by-byte DFA on AVX2/NEON hardware).
-pub use simdutf::validate::ascii as validate_ascii;
-pub use simdutf::validate::utf8 as validate_utf8;

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -639,7 +639,6 @@ pub mod codegen {
             target
         }
     );
-    pub use js_mysql_query as JSMySQLQuery;
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -753,11 +753,6 @@ pub mod ntdll {
         pub fn RtlWakeAddressSingle(Address: *const c_void);
         pub fn RtlWakeAddressAll(Address: *const c_void);
 
-        /// `RtlExitUserProcess` (ntdll). The Win32 `ExitProcess` forwards to
-        /// this; the freestanding `bun_shim_impl` calls it directly to avoid
-        /// linking kernel32 in the standalone PE.
-        pub fn RtlExitUserProcess(ExitStatus: u32) -> !;
-
         /// `NtQueryInformationProcess` (`winternl.h`). With
         /// `ProcessBasicInformation` (0), fills a [`PROCESS_BASIC_INFORMATION`].
         pub fn NtQueryInformationProcess(
@@ -836,8 +831,6 @@ pub mod kernel32 {
     unsafe extern "system" {
         /// No preconditions; reads thread-local Win32 error slot.
         pub safe fn GetLastError() -> DWORD;
-        /// No preconditions; writes the thread-local Win32 error slot.
-        pub safe fn SetLastError(dwErrCode: DWORD);
         pub fn VirtualQuery(
             lpAddress: LPCVOID,
             lpBuffer: *mut MEMORY_BASIC_INFORMATION,


### PR DESCRIPTION
### Problem
- Code that nothing uses: 13 Rust items, 30 `pub use` statements plus names from 7 more, 20 C++ members and declarations in the JSC bindings, and one JS getter.
- `dead_code = "deny"` cannot report them. The Rust items are `pub` items or trait methods, and a `pub use` counts as an export.

### Fix
- Delete each item. The added lines are shorter `use` lists, one constructor, and three reworded comment lines.
- Each Rust item got a `#[deprecated]` attribute, then `cargo check` ran on 14 target and cfg combinations. rustc reports each use of a deprecated item, including uses inside macro expansions. No check reported a use of these items.
- Each re-export was made `pub(crate)` on the same 14 combinations. It is removed only where rustc reported it unused in all of them, and where the removal left no item unreachable.
- Verified: `bun bd` builds. `cargo check` passes with no warnings on all 14 combinations. The suites in the Notes pass.

### Background
- A delete-and-build check is not safe here. A type can have an inherent method and a trait method with the same name. If the inherent one is deleted, a macro call such as `Self::m(self)` still compiles, but it now calls the trait method, which calls itself. The probe shows that no call site exists.
- rustc does not report deprecated uses inside `#[derive]` output. Items whose names appear in the workspace's proc-macro crates were kept.

<details><summary>Notes</summary>

**Method.** rust-analyzer indexed the workspace three times (Linux, Windows, and macOS cfgs). An item was a candidate when no reference lay outside the item, or every such reference lay inside another candidate. That gave about 1,600 candidates. Each got a `#[deprecated(note = "DEADPROBE:<id>")]` attribute, and the checks below ran with `--force-warn=deprecated`. Only items with no reported use in any check remain in this diff.

An earlier attempt deleted the candidates and kept what still built. On every target, that version deleted inherent methods in `NativeZlib`, `NativeBrotli`, `NativeZstd`, `MySQLConnection`, and `PostgresSQLConnection`. Their callers are `Self::m(self)` calls in macro-generated trait impls, so they then called the trait method and recursed. rustc reported only `unconditional_recursion` warnings. Those methods are live, and this diff does not touch them.

**Checks.** `cargo check --workspace` with the build's cfgs (`bun_debug`, `bun_asan`, `socket_fault_injection` for debug; `bun_codegen_embed` and `-C debug-assertions=off` for release) on: `x86_64-unknown-linux-gnu` (debug, debug `--tests`, release), `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `aarch64-linux-android`, `x86_64-linux-android`, `x86_64-pc-windows-msvc` (debug, release), `aarch64-pc-windows-msvc`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-freebsd`.

**Removed, Rust items**
- `src/collections/vec_ext.rs`: `VecExt::{shrink_and_free, insert_slice, shallow_clone, unused_capacity_slice, allocated_slice}` and their `Vec` impls.
- `src/bun_core/util.rs`: `Integer::to_f64` and `NativeEndianInt::encode_ne`, with the lines in `impl_integer!` and `impl_native_endian_int!`. The `to_f64` calls in the file are on `f16`, which has its own inherent `to_f64`.
- `src/bun_alloc/baby_vec.rs`: `BabyVec::swap_remove`.
- `src/boringssl_sys/boringssl.rs`: the `SSL_get_SSL_CTX`, `SSL_get_ex_data`, and `SSL_set_ex_data` declarations. Callers use other declarations of the same symbols.
- `src/windows_sys/externs.rs`: the `RtlExitUserProcess` and `SetLastError` declarations. `windows-shim` and `bun_sys::windows::kernel32` declare their own.

**Removed, re-exports** (the whole statement unless a name is given): `bun_core::FormData`; `bun_bundler::{Linker, BundleOptions}`, `linker_context::{ChunkMeta, GenerateChunkCtx, LinkerContext, PendingPartRange}`, `bundle_v2::{MangledProps, Loc}`, `entry_points::FileSystem`, `options::BundlePackage`; `bun_bunfig::{load_config, load_config_path, load_config_with_cmd_args}`; `bun_collections::{ObjectPool, ObjectPoolType, PoolGuard, StaticHashMap}`; `bun_crash_handler::{is_panicking, sleep_forever_if_another_thread_is_crashing}`; `bun_css::{implement_hash, dtoa_short, f32_length_with_5_digits, serializer}`, `css_parser::{implement_deep_clone, implement_hash, logical, PropertyCategory, MediaFeatureType, PseudoElement}`, `selectors::{Component, PseudoClass, PseudoElement, Selector}`, and `properties::shape` (its only item was an unused alias, so the module goes too); `bun_http::SSLConfig`; `bun_http_types::wtf`; `bun_io::posix_event_loop::EventLoopCtxKind`; `bun_js_parser::P`, `parser::{renamer, P}`; `bun_jsc::{RefString, SavedSourceMap, Codegen, Counters}`, `ModuleLoader::node_fallbacks`; `bun_react_compiler::{environment, EnvironmentConfig}`, `hir::ErrorCategory`; `bun_simdutf_sys::{validate_ascii, validate_utf8}`; `bun_sql_jsc::jsc::JSMySQLQuery`.

**Removed, C++** (`src/jsc/bindings/`): the three `containsWebCoreOpaqueRoot` overloads and their declarations; `GlobalEventScope::create`; `JSCStackFrame::{bytecodeIndex, isWasmFrame}` and `JSCStackTrace::{isEmpty, frames}` (the callers of those names hold `JSC::StackFrame` values); `DOMWrapperWorld::{type, name}`, and the `m_name` field that only `name()` read, with its constructor parameter; `Exception::{message, extra}` (callers use the `release*` forms); `JSNodePerformanceHooksHistogram::histogram`; `v8::shim::FunctionTemplate::{properties, accessors}`; `bun::stringsearch::Vector::forward`; three unused `class BackendDispatcher;` forward declarations; a commented-out debug block in `ErrorStackFrame.cpp`.

**Removed, JS**: the `totalBytesWritten` getter of `PushQueue` in `src/js/internal/streams/iter/push.ts`. The queue never leaves the module.

**Kept on purpose**
- `InternalModuleRegistry::allocationSize` has no direct caller. It corrects the base class, whose version returns `sizeof(JSInternalFieldObjectImpl)`.
- `macro(mockedFunction)` in `BunBuiltinNames.h`. `BunCommonStrings.cpp` reaches it by token pasting.
- The `eql`, `deep_clone`, `to_css`, `from_js`, and `ref_` items the probe reported. Derive macros call them.
- `PosixStreamingWriterParent::on_ready`. Nothing calls it on POSIX, but `impl_streaming_writer_parent!` also feeds the Windows `on_writable`.
- The outbound API of the `node:http2` engine in `src/runtime/api/bun/h2/`. It is unused because the binding does not use the engine yet.
- 28 re-exports that are unused but whose removal would make an item unreachable (`unreachable_pub`), or that overlap a hunk in an open PR.

**Scanned with nothing to add**: `src/js` (oxlint already enforces `no-unused-vars`, and every builtin is reachable) and the C++ bindings outside the files that open PRs touch.

**Why this is small.** About twenty open dead-code PRs hold the easy finds, and this diff avoids every hunk they touch. The compiler lints already reject unused private items, so what remains is `pub` items and trait items that only a cross-crate check can see.

**Found on the way.** `Bun__Node__CAStore` (`src/runtime/cli/Arguments.rs`) is written and never read, so `--use-openssl-ca` does nothing. That is a bug, not dead code, and it is tracked separately.

**Tests** (`bun bd test`): `test/js/bun/test/mock-fn.test.js`, `test/js/node/v8/capture-stack-trace.test.js`, `test/js/bun/perf_hooks/histogram.test.ts`, `test/js/bun/css/color.test.ts`, `test/internal/source-lints/` (172 pass), and the Node tests `test-stream-iter-push-basic.js`, `-writer.js`, and `-backpressure.js`. `test/js/bun/css/` as a whole: 2377 pass and 4 fail. The 4 are the fuzz tests in `css-fuzz.test.ts`. They hit their 5 s and 10 s timeouts under the debug ASAN build and pass on the release build. The `bun_css` changes here are `pub use` lines only.

</details>

