### PR TITLE
bundler: keep the CommonJS wrapper when a var has the name of a top-level function

### DIFF
--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -116,9 +116,6 @@ bitflags::bitflags! {
         /// Renaming can also break any identifier used inside a "with" statement.
         const MUST_NOT_BE_RENAMED = 1 << 2;
 
-        /// A `var` of the same name merged into this function declaration.
-        const REDECLARED_BY_VAR = 1 << 3;
-
         const REMOVE_OVERWRITTEN_FUNCTION_DECLARATION = 1 << 4;
 
         /// The file assigns this variable after its declaration (or a mapped
@@ -154,7 +151,6 @@ macro_rules! symbol_flag_accessors {
 symbol_flag_accessors! {
     must_start_with_capital_letter_for_jsx, set_must_start_with_capital_letter_for_jsx => MUST_START_WITH_CAPITAL_LETTER_FOR_JSX;
     must_not_be_renamed, set_must_not_be_renamed => MUST_NOT_BE_RENAMED;
-    redeclared_by_var, set_redeclared_by_var => REDECLARED_BY_VAR;
     remove_overwritten_function_declaration, set_remove_overwritten_function_declaration => REMOVE_OVERWRITTEN_FUNCTION_DECLARATION;
     has_been_assigned_to, set_has_been_assigned_to => HAS_BEEN_ASSIGNED_TO;
     called_as_method, set_called_as_method => CALLED_AS_METHOD;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3517,9 +3517,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             {
                                 // Silently merge this symbol into the existing symbol
                                 self.symbols[symbol_idx].link.set(member_in_scope.ref_);
-                                if Symbol::is_kind_function(existing_kind) {
-                                    self.symbols[existing_idx].set_redeclared_by_var(true);
-                                }
                                 // `StringHashMap` get_or_put already stores the key on insert and
                                 // cannot hand out `&mut K` (see StringHashMapGetOrPut docs), so
                                 // no key write is needed here.
@@ -5031,16 +5028,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // If these are both functions, remove the overwritten declaration
                     if kind.is_function() && existing_kind.is_function() {
                         self.symbols[symbol_idx].set_remove_overwritten_function_declaration(true);
-                    } else if kind.is_function() {
-                        self.symbols[ref_.inner_index() as usize].set_redeclared_by_var(true);
-                    }
-
-                    // "var foo; function foo() {}" or "function foo() {} var foo;"
-                    if self.current_scope == self.module_scope
+                    } else if self.current_scope == self.module_scope
                         && ((existing_kind == js_ast::symbol::Kind::Hoisted && kind.is_function())
                             || (existing_kind.is_function()
                                 && kind == js_ast::symbol::Kind::Hoisted))
                     {
+                        // "var foo; function foo() {}" or "function foo() {} var foo;"
                         self.has_top_level_function_merged_with_var = true;
                     }
                 }
@@ -5764,12 +5757,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let ignores_this = match export.decl_value {
                 CommonJSExportValue::Other => false,
                 CommonJSExportValue::FunctionIgnoringThis => true,
-                // An assignment or a `var` of the same name can change `name`.
+                // An assignment can change `name`. A `var` of the same name can too,
+                // but `has_top_level_function_merged_with_var` keeps that file wrapped.
                 CommonJSExportValue::Identifier(binding) => {
                     let symbol = &self.symbols[binding.inner_index() as usize];
                     symbol.kind.is_function()
                         && symbol.call_ignores_this()
-                        && !symbol.redeclared_by_var()
                         && !symbol.has_been_assigned_to()
                 }
             };

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -304,6 +304,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // Used for forcing CommonJS
     pub(crate) has_with_scope: bool,
 
+    /// A `var` in the module scope has the name of a top-level function
+    /// declaration. Module code makes that function lexical, so a `var` with
+    /// its name is an early error there. CommonJS code with it is not lifted.
+    pub(crate) has_top_level_function_merged_with_var: bool,
+
     pub(crate) is_file_considered_to_have_esm_exports: bool,
 
     pub(crate) has_called_runtime: bool,
@@ -3521,6 +3526,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 *_scope
                                     .get_or_put_member_with_hash(name, hash.unwrap())
                                     .value_ptr = member_in_scope;
+
+                                // "function foo() {} { var foo; }"
+                                if _scope_ptr == self.module_scope
+                                    && self.symbols[symbol_idx].kind
+                                        == js_ast::symbol::Kind::Hoisted
+                                    && Symbol::is_kind_function(existing_kind)
+                                {
+                                    self.has_top_level_function_merged_with_var = true;
+                                }
                                 continue 'next_member;
                             }
 
@@ -5013,11 +5027,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 MR::ReplaceWithNew => {
                     self.symbols[symbol_idx].link.set(ref_);
 
+                    let existing_kind = self.symbols[symbol_idx].kind;
                     // If these are both functions, remove the overwritten declaration
-                    if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
+                    if kind.is_function() && existing_kind.is_function() {
                         self.symbols[symbol_idx].set_remove_overwritten_function_declaration(true);
                     } else if kind.is_function() {
                         self.symbols[ref_.inner_index() as usize].set_redeclared_by_var(true);
+                    }
+
+                    // "var foo; function foo() {}" or "function foo() {} var foo;"
+                    if self.current_scope == self.module_scope
+                        && ((existing_kind == js_ast::symbol::Kind::Hoisted && kind.is_function())
+                            || (existing_kind.is_function()
+                                && kind == js_ast::symbol::Kind::Hoisted))
+                    {
+                        self.has_top_level_function_merged_with_var = true;
                     }
                 }
                 MR::BecomePrivateGetSetPair => {
@@ -9499,6 +9523,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             macro_call_count: 0,
             hoisted_ref_for_sloppy_mode_block_fn: Default::default(),
             has_with_scope: false,
+            has_top_level_function_merged_with_var: false,
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,
             symbol_uses,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -304,9 +304,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // Used for forcing CommonJS
     pub(crate) has_with_scope: bool,
 
-    /// A `var` in the module scope has the name of a top-level function
-    /// declaration. Module code makes that function lexical, so a `var` with
-    /// its name is an early error there. CommonJS code with it is not lifted.
+    /// A module-scope `var` has the name of a top-level function. Module code
+    /// rejects that, so a CommonJS file with it keeps its wrapper.
     pub(crate) has_top_level_function_merged_with_var: bool,
 
     pub(crate) is_file_considered_to_have_esm_exports: bool,
@@ -5757,8 +5756,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let ignores_this = match export.decl_value {
                 CommonJSExportValue::Other => false,
                 CommonJSExportValue::FunctionIgnoringThis => true,
-                // An assignment can change `name`. A `var` of the same name can too,
-                // but `has_top_level_function_merged_with_var` keeps that file wrapped.
+                // An assignment can change `name`. A merged `var` keeps the file wrapped.
                 CommonJSExportValue::Identifier(binding) => {
                     let symbol = &self.symbols[binding.inner_index() as usize];
                     symbol.kind.is_function()

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -304,8 +304,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // Used for forcing CommonJS
     pub(crate) has_with_scope: bool,
 
-    /// A module-scope `var` has the name of a top-level function. Module code
-    /// rejects that, so a CommonJS file with it keeps its wrapper.
+    /// A module-scope `var` has the name of a top-level function, which module code rejects.
     pub(crate) has_top_level_function_merged_with_var: bool,
 
     pub(crate) is_file_considered_to_have_esm_exports: bool,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1459,7 +1459,7 @@ impl<'a> Parser<'a> {
                             }
                         }
 
-                        if needs_decl_count > 0 {
+                        if needs_decl_count > 0 || p.has_top_level_function_merged_with_var {
                             p.symbols.as_mut_slice()[p.exports_ref.inner_index() as usize]
                                 .use_count_estimate += export_refs_len as u32;
                             p.deoptimize_commonjs_named_exports();
@@ -1609,6 +1609,7 @@ impl<'a> Parser<'a> {
             && p.commonjs_named_exports.count() == 0
             && !p.has_top_level_return
             && !p.has_with_scope
+            && !p.has_top_level_function_merged_with_var
             && p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate == 1
             && p.symbols.as_slice()[p.exports_ref.inner_index() as usize].use_count_estimate == 0
         {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1376,8 +1376,8 @@ describe("bundler", () => {
   });
   // A `var` with the name of a function declaration can change the value of the
   // binding, and so can a block-level function in sloppy mode. An ES module
-  // cannot declare a function and a `var` with one name, so this output does
-  // not load. The test reads the printed calls.
+  // cannot declare a function and a `var` with one name, so this file keeps its
+  // `__commonJS` wrapper, and each call passes `module.exports` as `this`.
   itBundled("cjs2esm/MethodCallKeepsThisWhenAVarRedeclaresTheFunction", {
     files: {
       "/entry.js": /* js */ `
@@ -1400,12 +1400,9 @@ describe("bundler", () => {
         exports.name = "lib";
       `,
     },
-    cjs2esm: true,
-    onAfterBundle(api) {
-      const out = api.readFile("/out.js");
-      expect(out).toContain(
-        "console.log(exports_lib.nested(), exports_lib.top(), exports_lib.top2(), exports_lib.block());",
-      );
+    cjs2esm: { unhandled: ["/lib.cjs"] },
+    run: {
+      stdout: "lib lib lib lib",
     },
   });
   itBundled("cjs2esm/MethodCallWithoutThisBindsDirectly", {
@@ -2046,6 +2043,120 @@ describe("bundler", () => {
     cjs2esm: true,
     run: {
       stdout: "1 2 false",
+    },
+  });
+  // Module code makes a top-level function declaration lexical, so a `var`
+  // with the same name is a SyntaxError there. A function body allows it, so
+  // these files keep their `__commonJS` wrapper.
+  itBundled("cjs2esm/VarWithTheNameOfATopLevelFunctionKeepsWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        import { top as a } from "./decl-then-var.cjs";
+        import { top as b } from "./var-then-decl.cjs";
+        import { top as c } from "./var-in-block.cjs";
+        import { top as d } from "./block-function.cjs";
+        import { top as e } from "./generator.cjs";
+        import lib from "./default-import.cjs";
+        console.log(a(), b(), c(), d(), e(), lib.top());
+      `,
+      "/decl-then-var.cjs": /* js */ `
+        function top() { return "declaration"; }
+        var top = function () { return "var"; };
+        exports.top = top;
+      `,
+      "/var-then-decl.cjs": /* js */ `
+        var top = function () { return "var"; };
+        function top() { return "declaration"; }
+        exports.top = top;
+      `,
+      "/var-in-block.cjs": /* js */ `
+        function top() { return "declaration"; }
+        if (typeof top === "function") {
+          var top = function () { return "var"; };
+        }
+        exports.top = top;
+      `,
+      "/block-function.cjs": /* js */ `
+        function top() { return "declaration"; }
+        {
+          function top() { return "block"; }
+        }
+        exports.top = top;
+      `,
+      "/generator.cjs": /* js */ `
+        function* top() {}
+        var top = function () { return "var"; };
+        exports.top = top;
+      `,
+      "/default-import.cjs": /* js */ `
+        function top() { return "declaration"; }
+        var top = function () { return "var"; };
+        exports.top = top;
+      `,
+    },
+    cjs2esm: {
+      unhandled: [
+        "/decl-then-var.cjs",
+        "/var-then-decl.cjs",
+        "/var-in-block.cjs",
+        "/block-function.cjs",
+        "/generator.cjs",
+        "/default-import.cjs",
+      ],
+    },
+    run: {
+      stdout: "var var var block var var",
+    },
+  });
+  // A repeated `var` and a `var` in a nested function are valid module code.
+  // Of two top-level functions with one name, the parser drops the first. So
+  // this file is still lifted.
+  itBundled("cjs2esm/OtherRedeclarationsAreStillLifted", {
+    files: {
+      "/entry.js": /* js */ `
+        import { top, count, wrap } from "./lib.cjs";
+        console.log(top(), count, wrap());
+      `,
+      "/lib.cjs": /* js */ `
+        function top() { return "first"; }
+        function top() { return "second"; }
+        var count = 1;
+        var count = 2;
+        function wrap() {
+          var top = function () { return "inner"; };
+          return top();
+        }
+        exports.top = top;
+        exports.count = count;
+        exports.wrap = wrap;
+      `,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "second 2 inner",
+    },
+  });
+  // `module.exports = require()` in an unwrapped package becomes
+  // `export * from`, which is module code too.
+  itBundled("cjs2esm/ReactSpecificUnwrappingVarWithTheNameOfAFunctionKeepsWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        import { value } from "react";
+        console.log(value);
+      `,
+      "/node_modules/react/index.js": /* js */ `
+        function load() { return "declaration"; }
+        var load = function () { return "var"; };
+        console.log(load());
+        module.exports = require('./main');
+      `,
+      "/node_modules/react/main.js": /* js */ `
+        exports.value = "main";
+      `,
+    },
+    cjs2esm: { unhandled: ["/node_modules/react/index.js"] },
+    run: {
+      stdout: "var\nmain",
     },
   });
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -2047,7 +2047,9 @@ describe("bundler", () => {
   });
   // Module code makes a top-level function declaration lexical, so a `var`
   // with the same name is a SyntaxError there. A function body allows it, so
-  // these files keep their `__commonJS` wrapper.
+  // these files keep their `__commonJS` wrapper. In sloppy mode the bundler
+  // prints a block-level function with a `var` of its name, so
+  // block-function.cjs has the same conflict.
   itBundled("cjs2esm/VarWithTheNameOfATopLevelFunctionKeepsWrapper", {
     files: {
       "/entry.js": /* js */ `
@@ -2108,9 +2110,9 @@ describe("bundler", () => {
       stdout: "var var var block var var",
     },
   });
-  // A repeated `var` and a `var` in a nested function are valid module code.
-  // Of two top-level functions with one name, the parser drops the first. So
-  // this file is still lifted.
+  // Module code allows a `var` that repeats a `var`, and a function and a `var`
+  // with one name inside a nested function. Of two top-level functions with one
+  // name, the parser drops the first. So this file is still lifted.
   itBundled("cjs2esm/OtherRedeclarationsAreStillLifted", {
     files: {
       "/entry.js": /* js */ `
@@ -2121,10 +2123,18 @@ describe("bundler", () => {
         function top() { return "first"; }
         function top() { return "second"; }
         var count = 1;
-        var count = 2;
+        if (count) {
+          var count = 2;
+        }
         function wrap() {
-          var top = function () { return "inner"; };
-          return top();
+          var top = function () { return "shadow"; };
+          function inner() { return "declaration"; }
+          var inner = function () { return "inner"; };
+          function other() { return "declaration"; }
+          {
+            var other = function () { return "other"; };
+          }
+          return [top(), inner(), other()].join(" ");
         }
         exports.top = top;
         exports.count = count;
@@ -2133,7 +2143,7 @@ describe("bundler", () => {
     },
     cjs2esm: true,
     run: {
-      stdout: "second 2 inner",
+      stdout: "second 2 shadow inner other",
     },
   });
   // `module.exports = require()` in an unwrapped package becomes


### PR DESCRIPTION
### Problem
- With ES module output, `bun build` lifts a CommonJS file out of its `__commonJS` wrapper. With a top-level `function top() {}` and `var top`, the bundle throws: `SyntaxError: Cannot declare a var variable that shadows a let/const/class variable: 'top'.`
- In a function, the two declarations share one binding. In module code, a top-level function is lexical, so the `var` is an early error. The lifts (`src/js_parser/parse/parse_entry.rs:1441`, `:1605`) do not check this.
- A named import fails in 1.4.0. Since #41162, a default import fails too.

### Fix
- `declare_symbol` and `hoist_symbols` now set `has_top_level_function_merged_with_var` when a `var` and a function declaration in the module scope share one symbol. A repeated `var` or function, or a merge inside a nested function, does not set it.
- With the flag, the `exports.foo` lift takes its existing `needs_decl_count > 0` deoptimization, and the `export *` lift does not run. That leaves `REDECLARED_BY_VAR` (#41251) unused, so this PR removes it.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (three new tests, one changed), and 13 suites listed in the Notes.
- Self-reviewed: 11 concerns raised, 8 addressed. The other 3 are older bugs, in the Notes.

### Background
- The lift turns `exports.foo = value` into `var $foo = value` plus an ES export, only for ESM output (`src/bundler/ParseTask.rs:2503`).
- A symbol merge binds two declarations to one symbol.
- For a sloppy-mode `{ function f() {} }`, the parser emits `let f2 = function () {}; var f = f2;`. That `var` conflicts too.

<details><summary>Notes</summary>

I found this by reading the output of a lifted file. No issue reports it.

Repro (a 1.4.1 canary, and main):

```js
// lib.cjs
function top() { return "declaration"; }
var top = function () { return "var"; };
exports.top = top;
```

```js
// entry.mjs
import { top } from "./lib.cjs";
console.log(top());
```

`bun build ./entry.mjs --target=bun --outfile=o.js && bun o.js` throws. Node prints `var`.

The same error occurs for the reverse order, for a `var` in an `if` block, for a sloppy block-level function next to a top-level one, and for `function*`. The first new test covers each case, and a default import. `--format=cjs` and `--format=iife` do not lift, so they are not affected.

Test results:

| Test | `USE_SYSTEM_BUN=1` (1.4.1 canary, before #41162) | debug build of main | `bun bd` with this PR |
| --- | --- | --- | --- |
| `VarWithTheNameOfATopLevelFunctionKeepsWrapper` | fail (1 of 6 wrappers) | fail (0 of 6) | pass |
| `OtherRedeclarationsAreStillLifted` | pass | pass | pass |
| `ReactSpecificUnwrappingVarWithTheNameOfAFunctionKeepsWrapper` | pass (predates #41188) | fail | pass |

On the debug build of main, the default-import case and the `export *` case both throw the `SyntaxError` at load.

`OtherRedeclarationsAreStillLifted` guards the checks. I removed the module-scope check in `declare_symbol` on a local build, and this test failed.

This PR also changes `MethodCallKeepsThisWhenAVarRedeclaresTheFunction` from #41251. That test read the printed calls, because the bundle did not load. The file now keeps its wrapper, so the test runs the bundle. The output `lib lib lib lib` shows that each call gets `module.exports` as `this`. On main this test fails too.

`REDECLARED_BY_VAR` marked a function declaration that a `var` merged into. Its only reader, `mark_commonjs_exports_that_ignore_this`, runs only for a file that is not deoptimized. A file with that merge is now deoptimized, so the flag can no longer change the output. The #41251 tests still pass.

Other suites that pass on this branch: `bundler_cjs`, `bundler_barrel`, `bundler_splitting`, `bundler_minify`, `bundler_dynamic_import_dce`, `bundler_regressions`, `bundler_edgecase`, `esbuild/default`, `esbuild/dce`, `esbuild/importstar`, `esbuild/importstar_ts`, `esbuild/ts`, and `transpiler/transpiler.test.js`.

Follow-ups that this PR does not change: bun runs a `.js` file with no module syntax and no CommonJS features as module code. So `bun plain.js` fails on the same two declarations. An HTML entry has the same problem, because the bundler emits a classic `<script src>` as `type="module"`. That is a separate decision about plain scripts. A top-level `return`, `new.target`, or `arguments` in a lifted file also fails at load. #40840 covers the `return` case.

Alternative that I did not take: keep the lift, and print the merged `var top = x` as the assignment `top = x`. Module code allows an assignment to a function binding. That keeps tree shaking for these files, but each `var` form (declaration lists, `for` heads, destructuring) needs a rewrite. I found no real package with this pattern, so the wrapper costs nothing in practice.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [720.52ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [336.99ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [401.76ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [382.10ms]
(pass) bundler > cjs2esm/ExportsFunction [319.42ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [389.00ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [320.29ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [358.71ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [446.21ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [444.19ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [401.64ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [511.62ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [593
... (truncated)

release without fix: 45 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [19.88ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [9.13ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [8.11ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [7.37ms]
(pass) bundler > cjs2esm/ExportsFunction [7.41ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [7.45ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [7.14ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [8.64ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [9.85ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [9.44ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [9.54ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [10.98ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [10.61ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [9.39ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [8.74ms]
(pass) bundler > cjs2esm/UnwrappedModuleReq
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [719.29ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [405.07ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [405.58ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [315.27ms]
(pass) bundler > cjs2esm/ExportsFunction [320.61ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [324.47ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [321.18ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [366.12ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [399.89ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [380.48ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [336.30ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [464.06ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [502
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     cf871f6c7a
  features     baseline

23 deps, 131 codegen, 1172 objects in 983ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 25 installs across 62 packages (no changes) [5.00ms]
[2/1244] gen bindgenv2
[3/1244] gen .bind.ts → GeneratedBindings.cpp
[4/1244] fetch zlib
[zlib] up to date
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] fetch tinycc
[tinycc] up to date
[7/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1216] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [1.00ms]
[9/1216] gen ErrorCode+*.h
[10/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 instal
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/symbol.rs                    |   4 -
 src/js_parser/p.rs                   |  31 ++++++--
 src/js_parser/parse/parse_entry.rs   |   3 +-
 test/bundler/bundler_cjs2esm.test.ts | 137 +++++++++++++++++++++++++++++++++--
 4 files changed, 154 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/ast/symbol.rs                         1      2     35
src/js_parser/p.rs                        8     12     35
src/js_parser/parse/parse_entry.rs        3      2     34
test/bundler/bundler_cjs2esm.test.ts      6      7     34
```

</details>

<!-- robobun:evidence:end -->