### PR TITLE
bundler: keep this for a call of an export in its own lifted file

### DIFF
--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -126,8 +126,7 @@ bitflags::bitflags! {
         /// chain. Read by HMR live bindings and the printer's same-target fold.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
 
-        /// An import item for `ns.name`, or a lifted export for `exports.name`,
-        /// that some use calls as a method.
+        /// An import item (`ns.name`) or a lifted export that a use calls as a method.
         const CALLED_AS_METHOD = 1 << 6;
 
         /// A call of this function declaration or lifted export ignores `this`.

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -126,7 +126,8 @@ bitflags::bitflags! {
         /// chain. Read by HMR live bindings and the printer's same-target fold.
         const HAS_BEEN_ASSIGNED_TO = 1 << 5;
 
-        /// An import item for `ns.name` that some use calls, as `ns.name()`.
+        /// An import item for `ns.name`, or a lifted export for `exports.name`,
+        /// that some use calls as a method.
         const CALLED_AS_METHOD = 1 << 6;
 
         /// A call of this function declaration or lifted export ignores `this`.

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -501,9 +501,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     }
                                     new_ref
                                 };
-                                if identifier_opts.assign_target() != js_ast::AssignTarget::None {
-                                    p.count_commonjs_export_assignment(name);
-                                }
+                                p.note_commonjs_export_use(name, ref_, identifier_opts);
 
                                 p.ignore_usage(id.ref_);
                                 p.record_usage(ref_);
@@ -717,10 +715,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         }
                                         new_ref
                                     };
-                                    if identifier_opts.assign_target() != js_ast::AssignTarget::None
-                                    {
-                                        p.count_commonjs_export_assignment(name);
-                                    }
+                                    p.note_commonjs_export_use(name, ref_, identifier_opts);
 
                                     p.record_usage(ref_);
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5737,6 +5737,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         if opts.is_call_target() || opts.is_template_tag() {
             self.symbols[ref_.inner_index() as usize].set_called_as_method(true);
+            // The call can print as `exports.name()`. `to_ast` drops this use
+            // from a part whose calls all ignore `this`.
+            if !self.is_revisit_for_substitution {
+                self.symbol_uses
+                    .get_or_put(self.exports_ref)
+                    .expect("OOM")
+                    .value_ptr
+                    .count_estimate += 1;
+            }
         }
     }
 
@@ -5767,8 +5776,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// A method call of an export that can read `this` reads the namespace object.
-    fn use_namespace_for_method_calls(&self, parts: &mut [js_ast::Part]) {
+    /// Only a method call of an export that can read `this` reads the namespace
+    /// object. Drops the `exports_ref` use of a part that has no such call.
+    fn drop_namespace_uses_of_calls_that_ignore_this(&self, parts: &mut [js_ast::Part]) {
         let mut method_exports = RefMap::default();
         for export in self.commonjs_named_exports.values() {
             let symbol = &self.symbols[export.loc_ref.ref_.inner_index() as usize];
@@ -5776,24 +5786,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 method_exports.insert(export.loc_ref.ref_, ());
             }
         }
-        if method_exports.is_empty() {
-            return;
-        }
         for part in parts {
-            let count: u32 = part
+            if part.symbol_uses.get(&self.exports_ref).is_none() {
+                continue;
+            }
+            let calls_method_export = part
                 .symbol_uses
                 .keys()
                 .iter()
-                .zip(part.symbol_uses.values())
-                .filter(|(ref_, _)| method_exports.contains_key(ref_))
-                .map(|(_, symbol_use)| symbol_use.count_estimate)
-                .sum();
-            if count > 0 {
-                part.symbol_uses
-                    .get_or_put_value(self.exports_ref, Default::default())
-                    .expect("OOM")
-                    .value_ptr
-                    .count_estimate += count;
+                .any(|ref_| method_exports.contains_key(ref_));
+            if !calls_method_export {
+                let _ = part.symbol_uses.swap_remove(&self.exports_ref);
             }
         }
     }
@@ -9152,8 +9155,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if !self.commonjs_named_exports_deoptimized {
             self.mark_commonjs_exports_that_ignore_this();
-            if self.options.bundle {
-                self.use_namespace_for_method_calls(parts.as_mut_slice());
+            // With no read of `exports` itself, each `exports_ref` use in a part
+            // is a method call that `note_commonjs_export_use` recorded.
+            if self.symbols[self.exports_ref.inner_index() as usize].use_count_estimate == 0 {
+                self.drop_namespace_uses_of_calls_that_ignore_this(parts.as_mut_slice());
             }
         }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5769,16 +5769,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// A method call of an export that can read `this` reads the namespace object.
     fn use_namespace_for_method_calls(&self, parts: &mut [js_ast::Part]) {
-        let method_exports: Vec<Ref> = self
-            .commonjs_named_exports
-            .values()
-            .iter()
-            .map(|export| export.loc_ref.ref_)
-            .filter(|&ref_| {
-                let symbol = &self.symbols[ref_.inner_index() as usize];
-                symbol.called_as_method() && !symbol.call_ignores_this()
-            })
-            .collect();
+        let mut method_exports = RefMap::default();
+        for export in self.commonjs_named_exports.values() {
+            let symbol = &self.symbols[export.loc_ref.ref_.inner_index() as usize];
+            if symbol.called_as_method() && !symbol.call_ignores_this() {
+                method_exports.insert(export.loc_ref.ref_, ());
+            }
+        }
         if method_exports.is_empty() {
             return;
         }
@@ -5788,7 +5785,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .keys()
                 .iter()
                 .zip(part.symbol_uses.values())
-                .filter(|(ref_, _)| method_exports.contains(ref_))
+                .filter(|(ref_, _)| method_exports.contains_key(ref_))
                 .map(|(_, symbol_use)| symbol_use.count_estimate)
                 .sum();
             if count > 0 {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5737,8 +5737,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         if opts.is_call_target() || opts.is_template_tag() {
             self.symbols[ref_.inner_index() as usize].set_called_as_method(true);
-            // The call can print as `exports.name()`. `to_ast` drops this use
-            // from a part whose calls all ignore `this`.
+            // `to_ast` drops this use if the part's calls all ignore `this`.
             if !self.is_revisit_for_substitution {
                 self.symbol_uses
                     .get_or_put(self.exports_ref)
@@ -5776,8 +5775,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Only a method call of an export that can read `this` reads the namespace
-    /// object. Drops the `exports_ref` use of a part that has no such call.
+    /// Drops the `exports_ref` use of each part with no call that can read `this`.
     fn drop_namespace_uses_of_calls_that_ignore_this(&self, parts: &mut [js_ast::Part]) {
         let mut method_exports = RefMap::default();
         for export in self.commonjs_named_exports.values() {
@@ -9155,8 +9153,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if !self.commonjs_named_exports_deoptimized {
             self.mark_commonjs_exports_that_ignore_this();
-            // With no read of `exports` itself, each `exports_ref` use in a part
-            // is a method call that `note_commonjs_export_use` recorded.
+            // When nothing reads `exports`, each `exports_ref` use is a recorded call.
             if self.symbols[self.exports_ref.inner_index() as usize].use_count_estimate == 0 {
                 self.drop_namespace_uses_of_calls_that_ignore_this(parts.as_mut_slice());
             }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -470,6 +470,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) import_records: ImportRecordList<'a>,
     pub(crate) import_records_for_current_part: List<'a, u32>,
     pub(crate) export_star_import_records: List<'a, u32>,
+    /// Also holds the calls of `exports.name` under `exports_ref`, until `to_ast`.
     pub(crate) import_symbol_property_uses: SymbolPropertyUseMap,
 
     // These are for handling ES6 imports and exports
@@ -5737,13 +5738,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         if opts.is_call_target() || opts.is_template_tag() {
             self.symbols[ref_.inner_index() as usize].set_called_as_method(true);
-            // `to_ast` drops this use if the part's calls all ignore `this`.
             if !self.is_revisit_for_substitution {
-                self.symbol_uses
-                    .get_or_put(self.exports_ref)
+                let call = self
+                    .import_symbol_property_uses
+                    .get_or_put_value(self.exports_ref, Default::default())
                     .expect("OOM")
                     .value_ptr
-                    .count_estimate += 1;
+                    .get_or_put_value(name, Default::default())
+                    .expect("OOM");
+                call.count_estimate += 1;
+                call.is_call_target = true;
             }
         }
     }
@@ -5775,26 +5779,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Drops the `exports_ref` use of each part with no call that can read `this`.
-    fn drop_namespace_uses_of_calls_that_ignore_this(&self, parts: &mut [js_ast::Part]) {
-        let mut method_exports = RefMap::default();
-        for export in self.commonjs_named_exports.values() {
-            let symbol = &self.symbols[export.loc_ref.ref_.inner_index() as usize];
-            if symbol.called_as_method() && !symbol.call_ignores_this() {
-                method_exports.insert(export.loc_ref.ref_, ());
-            }
-        }
+    /// Takes the calls that `note_commonjs_export_use` recorded out of each part.
+    /// A call of an export that can read `this` prints as `exports.name()`.
+    fn use_namespace_for_method_calls(&self, parts: &mut [js_ast::Part]) {
         for part in parts {
-            if part.symbol_uses.get(&self.exports_ref).is_none() {
+            let Some(uses) = part.import_symbol_property_uses.as_mut() else {
                 continue;
+            };
+            let Some(calls) = uses.remove(&self.exports_ref) else {
+                continue;
+            };
+            if uses.is_empty() {
+                part.import_symbol_property_uses = None;
             }
-            let calls_method_export = part
-                .symbol_uses
-                .keys()
+            let count: u32 = calls
                 .iter()
-                .any(|ref_| method_exports.contains_key(ref_));
-            if !calls_method_export {
-                let _ = part.symbol_uses.swap_remove(&self.exports_ref);
+                .filter(|(name, _)| {
+                    self.commonjs_named_exports.get(name).is_some_and(|export| {
+                        !self.symbols[export.loc_ref.ref_.inner_index() as usize]
+                            .call_ignores_this()
+                    })
+                })
+                .map(|(_, call)| call.count_estimate)
+                .sum();
+            if count > 0 {
+                part.symbol_uses
+                    .get_or_put_value(self.exports_ref, Default::default())
+                    .expect("OOM")
+                    .value_ptr
+                    .count_estimate += count;
             }
         }
     }
@@ -9153,10 +9166,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if !self.commonjs_named_exports_deoptimized {
             self.mark_commonjs_exports_that_ignore_this();
-            // When nothing reads `exports`, each `exports_ref` use is a recorded call.
-            if self.symbols[self.exports_ref.inner_index() as usize].use_count_estimate == 0 {
-                self.drop_namespace_uses_of_calls_that_ignore_this(parts.as_mut_slice());
-            }
+        }
+        if self.should_unwrap_common_js_to_esm() {
+            self.use_namespace_for_method_calls(parts.as_mut_slice());
         }
 
         // Re-tag the arena-backed buffer

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5767,9 +5767,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// The printer prints `exports.name()` as a call on the namespace object
-    /// when the export can read `this`, so each part that uses such an export
-    /// also uses `exports_ref`.
+    /// A method call of an export that can read `this` reads the namespace object.
     fn use_namespace_for_method_calls(&self, parts: &mut [js_ast::Part]) {
         let method_exports: Vec<Ref> = self
             .commonjs_named_exports

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5723,9 +5723,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.commonjs_named_exports_deoptimized = true;
     }
 
-    pub(crate) fn count_commonjs_export_assignment(&mut self, name: &[u8]) {
-        if let Some(export) = self.commonjs_named_exports.get_mut(name) {
+    /// Records an assignment to `exports.name`, or a call of it.
+    pub(crate) fn note_commonjs_export_use(
+        &mut self,
+        name: &[u8],
+        ref_: Ref,
+        opts: IdentifierOpts,
+    ) {
+        if opts.assign_target() != js_ast::AssignTarget::None
+            && let Some(export) = self.commonjs_named_exports.get_mut(name)
+        {
             export.assign_count = export.assign_count.saturating_add(1);
+        }
+        if opts.is_call_target() || opts.is_template_tag() {
+            self.symbols[ref_.inner_index() as usize].set_called_as_method(true);
         }
     }
 
@@ -5752,6 +5763,42 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if ignores_this {
                 self.symbols[export.loc_ref.ref_.inner_index() as usize]
                     .set_call_ignores_this(true);
+            }
+        }
+    }
+
+    /// The printer prints `exports.name()` as a call on the namespace object
+    /// when the export can read `this`, so each part that uses such an export
+    /// also uses `exports_ref`.
+    fn use_namespace_for_method_calls(&self, parts: &mut [js_ast::Part]) {
+        let method_exports: Vec<Ref> = self
+            .commonjs_named_exports
+            .values()
+            .iter()
+            .map(|export| export.loc_ref.ref_)
+            .filter(|&ref_| {
+                let symbol = &self.symbols[ref_.inner_index() as usize];
+                symbol.called_as_method() && !symbol.call_ignores_this()
+            })
+            .collect();
+        if method_exports.is_empty() {
+            return;
+        }
+        for part in parts {
+            let count: u32 = part
+                .symbol_uses
+                .keys()
+                .iter()
+                .zip(part.symbol_uses.values())
+                .filter(|(ref_, _)| method_exports.contains(ref_))
+                .map(|(_, symbol_use)| symbol_use.count_estimate)
+                .sum();
+            if count > 0 {
+                part.symbol_uses
+                    .get_or_put_value(self.exports_ref, Default::default())
+                    .expect("OOM")
+                    .value_ptr
+                    .count_estimate += count;
             }
         }
     }
@@ -9110,6 +9157,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if !self.commonjs_named_exports_deoptimized {
             self.mark_commonjs_exports_that_ignore_this();
+            if self.options.bundle {
+                self.use_namespace_for_method_calls(parts.as_mut_slice());
+            }
         }
 
         // Re-tag the arena-backed buffer

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5779,8 +5779,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Takes the calls that `note_commonjs_export_use` recorded out of each part.
-    /// A call of an export that can read `this` prints as `exports.name()`.
+    /// Moves the recorded calls out of each part. A call that reads `this` uses `exports_ref`.
     fn use_namespace_for_method_calls(&self, parts: &mut [js_ast::Part]) {
         for part in parts {
             let Some(uses) = part.import_symbol_property_uses.as_mut() else {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3429,60 +3429,7 @@ pub(crate) mod __gated_printer {
                     }
                 },
                 ExprData::ECommonjsExportIdentifier(id) => {
-                    self.print_space_before_identifier();
-                    self.add_source_mapping(expr.loc);
-
-                    // reshaped for borrowck — find the matching index first,
-                    // then drop the immutable iter borrow before printing.
-                    let mut found: Option<usize> = None;
-                    if let Some(exports) = self.options.commonjs_named_exports {
-                        for (idx, value) in exports.values().iter().enumerate() {
-                            if value.loc_ref.ref_.eql(id.ref_) {
-                                found = Some(idx);
-                                break;
-                            }
-                        }
-                    }
-                    if let Some(idx) = found {
-                        let exports = self.options.commonjs_named_exports.unwrap();
-                        // `commonjs_named_exports` keys borrow `'a` (Options<'a>); capture
-                        // as `BackRef<[u8]>` so the `&self` borrow is dropped before the
-                        // `&mut self` print calls below.
-                        let key = BackRef::<[u8]>::new(&exports.keys()[idx][..]);
-                        let value_loc_ref = exports.values()[idx].loc_ref;
-                        let value_needs_decl = exports.values()[idx].needs_decl;
-                        struct V {
-                            loc_ref: js_ast::LocRef,
-                            needs_decl: bool,
-                        }
-                        let value = V {
-                            loc_ref: value_loc_ref,
-                            needs_decl: value_needs_decl,
-                        };
-                        if self.options.commonjs_named_exports_deoptimized || value.needs_decl {
-                            if self.options.commonjs_module_exports_assigned_deoptimized
-                                && id.base() == E::CommonJSExportIdentifierBase::ModuleDotExports
-                                && self.options.commonjs_module_ref.is_valid()
-                            {
-                                self.print_symbol(self.options.commonjs_module_ref);
-                                self.print(b".exports");
-                            } else {
-                                self.print_symbol(self.options.commonjs_named_exports_ref);
-                            }
-
-                            let key: &[u8] = key.get();
-                            if lexer::is_identifier(key) {
-                                self.print(b".");
-                                self.print(key);
-                            } else {
-                                self.print(b"[");
-                                self.print_string_literal_utf8(key, false);
-                                self.print(b"]");
-                            }
-                        } else {
-                            self.print_symbol(value.loc_ref.ref_);
-                        }
-                    }
+                    self.print_commonjs_export_identifier(*id, expr.loc, false);
                 }
                 ExprData::ENew(e) => {
                     let has_pure_comment = e.can_be_unwrapped_if_unused == E::CallUnwrap::IfUnused
@@ -3565,6 +3512,8 @@ pub(crate) mod __gated_printer {
                         self.print_space();
                         self.print_expr(e.target, Level::Postfix, ExprFlag::none());
                         self.print(b")");
+                    } else if let ExprData::ECommonjsExportIdentifier(id) = e.target.data {
+                        self.print_commonjs_export_identifier(id, e.target.loc, true);
                     } else {
                         self.print_expr(e.target, Level::Postfix, target_flags);
                     }
@@ -4251,6 +4200,8 @@ pub(crate) mod __gated_printer {
                             self.print(b"(");
                             self.print_expr(*tag, Level::Lowest, ExprFlag::none());
                             self.print(b")");
+                        } else if let ExprData::ECommonjsExportIdentifier(id) = tag.data {
+                            self.print_commonjs_export_identifier(id, tag.loc, true);
                         } else {
                             self.print_expr(*tag, Level::Postfix, ExprFlag::none());
                         }
@@ -4662,6 +4613,65 @@ pub(crate) mod __gated_printer {
             } else {
                 self.print(b"[");
                 self.print_string_literal_utf8(namespace.alias.slice(), false);
+                self.print(b"]");
+            }
+        }
+
+        /// `exports.name`, which prints as the lifted binding `$name` or as a
+        /// property of the exports object. A call that can read `this` uses the
+        /// property, so that `this` is the exports object.
+        fn print_commonjs_export_identifier(
+            &mut self,
+            id: E::CommonJSExportIdentifier,
+            loc: bun_ast::Loc,
+            is_call_target: bool,
+        ) {
+            self.print_space_before_identifier();
+            self.add_source_mapping(loc);
+
+            let Some(exports) = self.options.commonjs_named_exports else {
+                return;
+            };
+            let Some(idx) = exports
+                .values()
+                .iter()
+                .position(|value| value.loc_ref.ref_.eql(id.ref_))
+            else {
+                return;
+            };
+            // `commonjs_named_exports` keys borrow `'a` (Options<'a>); capture
+            // as `BackRef<[u8]>` so the `&self` borrow is dropped before the
+            // `&mut self` print calls below.
+            let key = BackRef::<[u8]>::new(&exports.keys()[idx][..]);
+            let value = &exports.values()[idx];
+            let (binding, needs_decl) = (value.loc_ref.ref_, value.needs_decl);
+            let call_needs_this = is_call_target
+                && self
+                    .symbols()
+                    .get_const(id.ref_)
+                    .is_some_and(|symbol| symbol.called_as_method() && !symbol.call_ignores_this());
+
+            if !(self.options.commonjs_named_exports_deoptimized || needs_decl || call_needs_this) {
+                self.print_symbol(binding);
+                return;
+            }
+            if self.options.commonjs_module_exports_assigned_deoptimized
+                && id.base() == E::CommonJSExportIdentifierBase::ModuleDotExports
+                && self.options.commonjs_module_ref.is_valid()
+            {
+                self.print_symbol(self.options.commonjs_module_ref);
+                self.print(b".exports");
+            } else {
+                self.print_symbol(self.options.commonjs_named_exports_ref);
+            }
+
+            let key: &[u8] = key.get();
+            if lexer::is_identifier(key) {
+                self.print(b".");
+                self.print(key);
+            } else {
+                self.print(b"[");
+                self.print_string_literal_utf8(key, false);
                 self.print(b"]");
             }
         }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4617,9 +4617,7 @@ pub(crate) mod __gated_printer {
             }
         }
 
-        /// `exports.name`, which prints as the lifted binding `$name` or as a
-        /// property of the exports object. A call that can read `this` uses the
-        /// property, so that `this` is the exports object.
+        /// `exports.name`: the binding `$name`, or a property for a call that reads `this`.
         fn print_commonjs_export_identifier(
             &mut self,
             id: E::CommonJSExportIdentifier,

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1435,6 +1435,50 @@ describe("bundler", () => {
       stdout: "expr arrow decl expr decl nested",
     },
   });
+  // A call of `exports.name()` in the file itself passes `module.exports` as `this`.
+  itBundled("cjs2esm/SelfMethodCallKeepsThis", {
+    files: {
+      "/entry.js": /* js */ `
+        import st from "./lib.cjs";
+        import * as ns from "./lib.cjs";
+        console.log(st.internal(), ns.viaModule(), st.viaTag());
+      `,
+      "/lib.cjs": /* js */ `
+        exports.parse = function (s) { return this._helper(s); };
+        exports._helper = function (s) { return "helped:" + s; };
+        exports.tag = function (strings) { return this._helper(strings[0]); };
+        exports.internal = function () { return exports.parse("in"); };
+        exports.viaModule = function () { return module.exports.parse("module"); };
+        exports.viaTag = function () { return exports.tag\`tag\`; };
+      `,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "helped:in helped:module helped:tag",
+    },
+  });
+  itBundled("cjs2esm/SelfMethodCallWithoutThisBindsDirectly", {
+    files: {
+      "/entry.js": /* js */ `
+        import { run } from "./lib.cjs";
+        console.log(run());
+      `,
+      "/lib.cjs": /* js */ `
+        exports.free = function (s) { return "free:" + s; };
+        exports.run = function () { return exports.free("x"); };
+        exports.unused = function () { return this.free("y"); };
+      `,
+    },
+    cjs2esm: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain('$free("x")');
+      expect(out).not.toContain("exports_lib");
+    },
+    run: {
+      stdout: "free:x",
+    },
+  });
   itBundled("cjs2esm/DefaultImportJsxClassicRuntime", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1484,6 +1484,30 @@ describe("bundler", () => {
       stdout: "free:x",
     },
   });
+  itBundled("cjs2esm/SelfMethodCallInUnusedExportKeepsNoNamespace", {
+    files: {
+      "/entry.js": /* js */ `
+        import { parse } from "./lib.cjs";
+        console.log(typeof parse);
+      `,
+      "/lib.cjs": /* js */ `
+        exports.parse = function (s) { return this._helper(s); };
+        exports._helper = function (s) { return "helped:" + s; };
+        exports.run = function () { return exports.parse("x"); };
+        exports.other = "tree-shaken";
+      `,
+    },
+    cjs2esm: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // Only the call in `run` needs the namespace object, and `run` is unused.
+      expect(out).not.toContain("exports_lib");
+      expect(out).not.toContain("tree-shaken");
+    },
+    run: {
+      stdout: "function",
+    },
+  });
   itBundled("cjs2esm/DefaultImportJsxClassicRuntime", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1508,6 +1508,33 @@ describe("bundler", () => {
       stdout: "function",
     },
   });
+  itBundled("cjs2esm/SelfMethodCallNextToAReadKeepsNoNamespace", {
+    files: {
+      "/entry.js": /* js */ `
+        import { mixed } from "./lib.cjs";
+        console.log(mixed());
+      `,
+      "/lib.cjs": /* js */ `
+        exports.parse = function (s) { return this._helper(s); };
+        exports._helper = function (s) { return "helped:" + s; };
+        exports.run = function () { return exports.parse("x"); };
+        exports.pure = function (f) { return typeof f; };
+        exports.mixed = function () { return exports.pure(exports.parse); };
+        exports.other = "tree-shaken";
+      `,
+    },
+    cjs2esm: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // `mixed` reads `parse` and calls `pure`. Neither needs the namespace object.
+      expect(out).toContain("return $pure($parse);");
+      expect(out).not.toContain("exports_lib");
+      expect(out).not.toContain("tree-shaken");
+    },
+    run: {
+      stdout: "function",
+    },
+  });
   itBundled("cjs2esm/DefaultImportJsxClassicRuntime", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1436,12 +1436,12 @@ describe("bundler", () => {
     },
   });
   // A call of `exports.name()` in the file itself passes `module.exports` as `this`.
+  // The entry uses named imports, so only those calls keep the namespace object.
   itBundled("cjs2esm/SelfMethodCallKeepsThis", {
     files: {
       "/entry.js": /* js */ `
-        import st from "./lib.cjs";
-        import * as ns from "./lib.cjs";
-        console.log(st.internal(), ns.viaModule(), st.viaTag());
+        import { internal, viaModule, viaTag } from "./lib.cjs";
+        console.log(internal(), viaModule(), viaTag());
       `,
       "/lib.cjs": /* js */ `
         exports.parse = function (s) { return this._helper(s); };
@@ -1453,6 +1453,11 @@ describe("bundler", () => {
       `,
     },
     cjs2esm: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain('return exports_lib.parse("in");');
+      expect(out).toContain("console.log($internal(), $viaModule(), $viaTag());");
+    },
     run: {
       stdout: "helped:in helped:module helped:tag",
     },


### PR DESCRIPTION
### Problem
- A lifted CommonJS file prints a call of one of its own exports, `exports.parse("in")`, as `$parse("in")`. A method that reads `this` then throws `undefined is not an object (evaluating 'this._helper')`.
- This is a regression from #41162 for a file that is reached through its default import. Bun 1.4.0 kept such a file in a `__commonJS` wrapper. Through `import * as`, the fault is also in 1.4.0.
- #41251 fixed the calls from other files. This is the same fault inside the lifted file.

### Fix
- The parser marks an export that the file calls as a method, with `CALLED_AS_METHOD`. This covers `exports.x()`, `module.exports.x()` and a template tag.
- If such an export can read `this` (no `CALL_IGNORES_THIS` from #41251), the printer prints the call as `exports_lib.parse("in")`. The part that holds the call also uses the namespace object.
- A call of an export that ignores `this` still prints as `$free("x")`, and no namespace object is made.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (4 new tests, the first fails on main). Also 10 other bundler suites.

### Background
- Lifting turns `exports.foo = x` into `var $foo = x` plus an export. The namespace object (`exports_lib`) stands in for `module.exports` when something needs the object.
- A part is one top-level statement. A part that uses a symbol depends on the part that declares it, so a use of `exports_lib` keeps the namespace object.

<details><summary>Notes</summary>

Repro:

```js
// lib.cjs
exports.parse = function (s) { return this._helper(s); };
exports._helper = function (s) { return "helped:" + s; };
exports.internal = function () { return exports.parse("in"); };
// entry.mjs
import st from "./lib.cjs";
console.log(st.internal());
```

`bun build ./entry.mjs --target=bun --outfile=o.js && bun o.js` throws on main and prints `helped:in` with this change.

The printer decides at the call: the `ECall` and `ETemplate` arms pass the callee to `print_commonjs_export_identifier` with `is_call_target`. A flag on `ExprFlag` would reach the operands of `(0, x)()` and `a ? b : c`, which are not method calls.

`note_commonjs_export_use` records each call of `exports.name` in the part that holds it, under `exports_ref` in the property-use map. `to_ast` moves these entries out of each part, so the linker never sees them. Only a call of an export that can read `this` adds a use of `exports_ref`. So the part that declares `$parse` gets no use (`cjs2esm/SelfMethodCallInUnusedExportKeepsNoNamespace`), and a read of `exports.parse` next to a call of `exports.pure()` gets none either (`cjs2esm/SelfMethodCallNextToAReadKeepsNoNamespace`).

The namespace object keeps every export of the file alive. So a live call of a `this`-reading export of the same file keeps all of its exports. That is the cost of a correct `this`.

Checks:

- A production bundle of React 18 has the same bytes before and after.
- Suites: `bundler_cjs2esm`, `bundler_cjs`, `bundler_barrel`, `bundler_splitting`, `bundler_minify`, `bundler_dynamic_import_dce`, `bundler_edgecase`, `transpiler/transpiler`, and `esbuild/{importstar,default,dce}`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [939.44ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [450.71ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [358.73ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [418.80ms]
(pass) bundler > cjs2esm/ExportsFunction [348.09ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [404.42ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [434.15ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [413.36ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [499.79ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [414.35ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [455.17ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [465.77ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [550
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (ad31f6240)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [18.44ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [8.89ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [8.03ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [7.25ms]
(pass) bundler > cjs2esm/ExportsFunction [7.24ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [8.71ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [7.90ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [7.73ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [8.31ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [8.23ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [8.42ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [10.03ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [10.66ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [9.39ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [9.80ms]
(pass) bundler > cjs2esm/UnwrappedModuleReq
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [745.84ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [360.89ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [430.17ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [355.98ms]
(pass) bundler > cjs2esm/ExportsFunction [340.09ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [376.52ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [367.19ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [426.65ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [418.43ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [441.84ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [362.81ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [567.39ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [556
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 584ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/symbol.rs                    |   2 +-
 src/js_parser/fold.rs                |   9 +--
 src/js_parser/p.rs                   |  62 ++++++++++++++++++-
 src/js_printer/lib.rs                | 116 +++++++++++++++++++----------------
 test/bundler/bundler_cjs2esm.test.ts | 100 ++++++++++++++++++++++++++++++
 5 files changed, 225 insertions(+), 64 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/ast/symbol.rs                         6     12     35
src/js_parser/fold.rs                     8      6     35
src/js_parser/p.rs                       36     37     35
src/js_printer/lib.rs                    14      7     35
test/bundler/bundler_cjs2esm.test.ts      8     11     35
```

</details>

<!-- robobun:evidence:end -->