### PR TITLE
test(urlpattern): speed up urlpattern.test.ts and tighten its assertions

### DIFF
--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -79,6 +79,29 @@ function getExpectedComponentResult(
   return expected_obj;
 }
 
+function getPatternStrings(pattern: URLPattern): Record<Component, string> {
+  return Object.fromEntries(kComponents.map(component => [component, pattern[component]])) as Record<Component, string>;
+}
+
+function getExpectedPatternStrings(entry: TestEntry): Record<Component, string> {
+  return Object.fromEntries(
+    kComponents.map(component => [component, getExpectedPatternString(entry, component)]),
+  ) as Record<Component, string>;
+}
+
+function getExpectedExecResult(entry: TestEntry): URLPatternResult | null {
+  // exec() returns null when the input does not match.
+  if (!entry.expected_match || typeof entry.expected_match !== "object") {
+    return null;
+  }
+
+  const result = { inputs: entry.expected_match.inputs ?? entry.inputs } as URLPatternResult;
+  for (const component of kComponents) {
+    result[component] = getExpectedComponentResult(entry, component);
+  }
+  return result;
+}
+
 describe("URLPattern", () => {
   describe("WPT tests", () => {
     for (const entry of testData as TestEntry[]) {
@@ -92,52 +115,27 @@ describe("URLPattern", () => {
         }
 
         const pattern = new URLPattern(...entry.pattern);
-
-        // Verify compiled pattern properties
-        for (const component of kComponents) {
-          const expected = getExpectedPatternString(entry, component);
-          expect(pattern[component]).toBe(expected);
-        }
+        const inputs = entry.inputs ?? [];
 
         // Test match error
         if (entry.expected_match === "error") {
-          expect(() => pattern.test(...(entry.inputs ?? []))).toThrow(TypeError);
-          expect(() => pattern.exec(...(entry.inputs ?? []))).toThrow(TypeError);
+          expect(getPatternStrings(pattern)).toEqual(getExpectedPatternStrings(entry));
+          expect(() => pattern.test(...inputs)).toThrow(TypeError);
+          expect(() => pattern.exec(...inputs)).toThrow(TypeError);
           return;
         }
 
-        // Test test() method
-        expect(pattern.test(...(entry.inputs ?? []))).toBe(!!entry.expected_match);
-
-        // Test exec() method
-        const exec_result = pattern.exec(...(entry.inputs ?? []));
-
-        if (!entry.expected_match || typeof entry.expected_match !== "object") {
-          expect(exec_result).toBe(entry.expected_match);
-          return;
-        }
-
-        const expected_inputs = entry.expected_match.inputs ?? entry.inputs;
-
-        // Verify inputs
-        expect(exec_result!.inputs.length).toBe(expected_inputs!.length);
-        for (let i = 0; i < exec_result!.inputs.length; i++) {
-          const input = exec_result!.inputs[i];
-          const expected_input = expected_inputs![i];
-          if (typeof input === "string") {
-            expect(input).toBe(expected_input);
-          } else {
-            for (const component of kComponents) {
-              expect(input[component]).toBe(expected_input[component]);
-            }
-          }
-        }
-
-        // Verify component results
-        for (const component of kComponents) {
-          const expected = getExpectedComponentResult(entry, component);
-          expect(exec_result![component]).toEqual(expected);
-        }
+        // Keep this to one expect() per entry. CI sets BUN_GARBAGE_COLLECTOR_LEVEL=1,
+        // which starts a GC after each matcher call. One call per field made this file slow.
+        expect({
+          patternStrings: getPatternStrings(pattern),
+          test: pattern.test(...inputs),
+          exec: pattern.exec(...inputs),
+        }).toStrictEqual({
+          patternStrings: getExpectedPatternStrings(entry),
+          test: !!entry.expected_match,
+          exec: getExpectedExecResult(entry),
+        });
       });
     }
   });
@@ -156,8 +154,17 @@ describe("URLPattern", () => {
     });
 
     test("constructor with undefined arguments", () => {
-      // Should not throw
-      new URLPattern(undefined, undefined);
+      // Both arguments take their defaults, so every component is a wildcard.
+      expect(getPatternStrings(new URLPattern(undefined, undefined))).toEqual({
+        protocol: "*",
+        username: "*",
+        password: "*",
+        hostname: "*",
+        port: "*",
+        pathname: "*",
+        search: "*",
+        hash: "*",
+      });
     });
   });
 


### PR DESCRIPTION
### Problem
- `test/js/web/urlpattern/urlpattern.test.ts` takes 18 s on the darwin x64 lane and 10 s on debian 13 x64-asan. Locally, a release build runs it in 0.1 s.
- Each of the 349 WPT entries made about 18 `expect()` calls, 6336 in total. CI sets `BUN_GARBAGE_COLLECTOR_LEVEL=1` (`scripts/runner.node.mjs:1912`). Then the test runner starts a GC after each matcher call (`post_match`, `src/runtime/test_runner/expect.rs:1683`).

### Fix
- Each WPT entry now makes one `toStrictEqual()` call. The object holds the compiled pattern strings, the `test()` result, and the full `exec()` result. The file makes 410 `expect()` calls. The test count stays at 408.
- The comparison is stricter. It checks the keys of each `groups` object and all fields of each input, `baseURL` included. The old per-field checks missed both.
- "constructor with undefined arguments" now checks the component strings. Before, it only checked that nothing threw.
- Verified with `bun bd test`. Median of 3 runs, linux x64:

| Command | Before | After |
| --- | --- | --- |
| `bun bd test <file>` | 5.4 s | 5.1 s |
| `BUN_GARBAGE_COLLECTOR_LEVEL=1 bun bd test <file>` | 24 s | 9.8 s |
| Release `bun test <file>`, same env | 0.9 s | 0.3 s |

### Background
- `BUN_GARBAGE_COLLECTOR_LEVEL=1` makes `VirtualMachine::auto_garbage_collect` (`src/jsc/VirtualMachine.rs:1411`) call `mi_collect` and `vm.collectAsync()`. So each `expect()` call costs one GC.
- `urlpatterntestdata.json` is the WPT data. The test helpers port the WPT harness, which fills in the values that the data leaves out.

<details><summary>Notes</summary>

- Where the time goes in the debug build without the GC variable: about 1.7 s startup, 1.2 s in URLPattern itself (0.75 s of it in the constructor), and the rest in the test runner.
- With the GC variable, a file of 410 trivial tests with one `expect()` each takes 3.7 s more in the debug build. So 410 calls is the floor for one assertion per test.
- The old checks: `toBe()` for each pattern string and each input field, `toEqual()` for each component result. `toEqual()` treats `{ bar: undefined }` and `{}` as equal.
- Mutation checks with changed copies of the data (old test / new test):
  - Remove a group whose value is null: pass / fail
  - Change the `baseURL` of an input: pass / fail
  - Change a group value, a pattern string, or a null match: fail / fail
- CI time for this file. On this PR, all 12 test lanes pass. The `Ran 408 tests` line in the job logs gives 0.40 s on darwin x64, 0.44 s on windows 2019 x64, and 0.84 s on debian 13 x64-asan. On main (build 109711), the runner logged 7.18 s on darwin 14 x64 and 7.06 s on windows 2019 x64.
- These CI numbers do not come from the same conditions. The runner runs a file that the PR changes alone. On main, this file runs in the parallel batch, with three files at a time.
- The file also passes with `BUN_JSC_validateExceptionChecks=1`, as on the ASAN lanes.
- This is a test-only change. No file under `src/` changes.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/urlpattern/urlpattern.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [36.29ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [7.01ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [5.77ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [6.93ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [11.79ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [8.37ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [9.70ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] [5.19ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] [8.88ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz","baseURL":"https://example.com"}] [4.74ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"pathname":"/foo/bar"}] [9.80ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [6.68ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar"}] [12.04ms]
(pass) URLPattern > WP
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/urlpattern/urlpattern.test.ts | 91 +++++++++++++++++--------------
 1 file changed, 49 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
test/js/web/urlpattern/urlpattern.test.ts      5     10     21
```

</details>

<!-- robobun:evidence:end -->
