### PR TITLE
test: call matchers once per loop in structured-clone-fastpath.test.ts

### DIFF
--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { isASAN, rss } from "harness";
 
+// CI sets BUN_GARBAGE_COLLECTOR_LEVEL=1. Then each matcher call requests a GC,
+// and on the macOS arm64 runners each GC takes about 35 ms. So a test with a
+// loop collects its results and calls a matcher once, after the loop.
 describe("Structured Clone Fast Path", () => {
   test("structuredClone should work with empty object", () => {
     const object = {};
@@ -27,46 +30,65 @@ describe("Structured Clone Fast Path", () => {
     expect(cloned).toStrictEqual("");
   });
 
-  const deOptimizations = [
+  // An accessor, a non-enumerable property, or a non-configurable property
+  // sends the object to the slow path. Object.create() makes a property
+  // non-enumerable unless the descriptor says otherwise.
+  test.each([
     {
-      get accessor() {
-        return 1;
+      name: "an enumerable getter",
+      input: {
+        get accessor() {
+          return 1;
+        },
       },
+      expected: { accessor: 1 },
     },
-    Object.create(Object.prototype, {
-      data: {
-        value: 1,
-        writable: false,
-        configurable: false,
-      },
-    }),
-    Object.create(Object.prototype, {
-      data: {
-        value: 1,
-        writable: true,
-        configurable: false,
-      },
-    }),
-    Object.create(Object.prototype, {
-      data: {
-        get: () => 1,
-        configurable: true,
-      },
-    }),
-    Object.create(Object.prototype, {
-      data: {
-        set: () => {},
-        enumerable: true,
-        configurable: true,
-      },
-    }),
-  ];
-
-  for (const deOptimization of deOptimizations) {
-    test("structuredCloneDeOptimization", () => {
-      structuredClone(deOptimization);
-    });
-  }
+    {
+      name: "a non-configurable read-only data property",
+      input: Object.create(Object.prototype, {
+        data: {
+          value: 1,
+          writable: false,
+          configurable: false,
+        },
+      }),
+      expected: {},
+    },
+    {
+      name: "a non-configurable writable data property",
+      input: Object.create(Object.prototype, {
+        data: {
+          value: 1,
+          writable: true,
+          configurable: false,
+        },
+      }),
+      expected: {},
+    },
+    {
+      name: "a non-enumerable getter",
+      input: Object.create(Object.prototype, {
+        data: {
+          get: () => 1,
+          configurable: true,
+        },
+      }),
+      expected: {},
+    },
+    {
+      name: "an enumerable setter without a getter",
+      input: Object.create(Object.prototype, {
+        data: {
+          set: () => {},
+          enumerable: true,
+          configurable: true,
+        },
+      }),
+      expected: { data: undefined },
+    },
+  ])("structuredClone of an object with $name", ({ input, expected }) => {
+    expect(structuredClone(input)).toStrictEqual(expected);
+  });
 
   test("structuredClone should use a constant amount of memory for string inputs", () => {
     const clones: Array<string> = [];
@@ -131,11 +153,8 @@ describe("Structured Clone Fast Path", () => {
   });
 
   test("structuredClone should work with array of special numbers", () => {
-    const cloned = structuredClone([-0, NaN, Infinity, -Infinity]);
-    expect(Object.is(cloned[0], -0)).toBe(true);
-    expect(cloned[1]).toBeNaN();
-    expect(cloned[2]).toBe(Infinity);
-    expect(cloned[3]).toBe(-Infinity);
+    // toEqual() compares numbers with Object.is(), so -0 does not match 0.
+    expect(structuredClone([-0, NaN, Infinity, -Infinity])).toEqual([-0, NaN, Infinity, -Infinity]);
   });
 
   test("structuredClone should work with large array of numbers", () => {
@@ -197,10 +216,9 @@ describe("Structured Clone Fast Path", () => {
   test("structuredClone should fallback for arrays with holes", () => {
     const input = [1, , 3]; // sparse
     const cloned = structuredClone(input);
-    // structured clone spec: holes become undefined
-    expect(cloned[0]).toBe(1);
-    expect(cloned[1]).toBe(undefined);
-    expect(cloned[2]).toBe(3);
+    // A hole stays a hole. toStrictEqual() does not match a hole to undefined.
+    expect(cloned).toStrictEqual([1, , 3]);
+    expect(1 in cloned).toBe(false);
   });
 
   test("structuredClone should work with array of doubles", () => {
@@ -257,12 +275,10 @@ describe("Structured Clone Fast Path", () => {
   });
 
   test("structuredClone of array with deleted element (hole via delete)", () => {
-    const input = [1, 2, 3];
-    delete (input as any)[1];
+    const input: (number | undefined)[] = [1, 2, 3];
+    delete input[1];
     const cloned = structuredClone(input);
-    expect(cloned[0]).toBe(1);
-    expect(cloned[1]).toBe(undefined);
-    expect(cloned[2]).toBe(3);
+    expect(cloned).toStrictEqual([1, , 3]);
     expect(1 in cloned).toBe(false); // holes remain holes after structuredClone
   });
 
@@ -271,18 +287,13 @@ describe("Structured Clone Fast Path", () => {
     input.length = 6;
     const cloned = structuredClone(input);
     expect(cloned.length).toBe(6);
-    expect(cloned[0]).toBe(1);
-    expect(cloned[1]).toBe(2);
-    expect(cloned[2]).toBe(3);
-    expect(cloned[3]).toBe(undefined);
+    // Indexes 3 to 5 are holes in the input and in the clone.
+    expect(cloned).toStrictEqual(input);
   });
 
   test("structuredClone of single element arrays", () => {
-    expect(structuredClone([42])).toEqual([42]);
-    expect(structuredClone([3.14])).toEqual([3.14]);
-    expect(structuredClone(["hello"])).toEqual(["hello"]);
-    expect(structuredClone([true])).toEqual([true]);
-    expect(structuredClone([null])).toEqual([null]);
+    const inputs = [[42], [3.14], ["hello"], [true], [null]];
+    expect(inputs.map(input => structuredClone(input))).toEqual(inputs);
   });
 
   test("structuredClone of array with named properties on Int32 array", () => {
@@ -370,13 +381,10 @@ describe("Structured Clone Fast Path", () => {
     clones[5][1] = 888;
     // All other clones and the original should be unaffected
     expect(input).toEqual([1, 2, 3]);
-    for (let i = 1; i < 10; i++) {
-      if (i === 5) {
-        expect(clones[i]).toEqual([1, 888, 3]);
-      } else {
-        expect(clones[i]).toEqual([1, 2, 3]);
-      }
-    }
+    const expected = Array.from({ length: 10 }, () => [1, 2, 3]);
+    expected[0][0] = 999;
+    expected[5][1] = 888;
+    expect(clones).toEqual(expected);
   });
 
   test("structuredClone of Array subclass loses subclass identity", () => {
@@ -398,12 +406,9 @@ describe("Structured Clone Fast Path", () => {
   test("structuredClone of array with only undefined values", () => {
     const input = [undefined, undefined, undefined];
     const cloned = structuredClone(input);
-    expect(cloned).toEqual([undefined, undefined, undefined]);
-    expect(cloned.length).toBe(3);
+    expect(cloned).toStrictEqual([undefined, undefined, undefined]);
     // Ensure they are actual values, not holes
-    expect(0 in cloned).toBe(true);
-    expect(1 in cloned).toBe(true);
-    expect(2 in cloned).toBe(true);
+    expect(Object.keys(cloned)).toEqual(["0", "1", "2"]);
   });
 
   test("structuredClone of array with only null values", () => {
@@ -414,26 +419,20 @@ describe("Structured Clone Fast Path", () => {
 
   test("structuredClone of dense double array preserves -0 and NaN", () => {
     const input = [-0, NaN, -0, NaN];
-    const cloned = structuredClone(input);
-    expect(Object.is(cloned[0], -0)).toBe(true);
-    expect(cloned[1]).toBeNaN();
-    expect(Object.is(cloned[2], -0)).toBe(true);
-    expect(cloned[3]).toBeNaN();
+    // toEqual() compares numbers with Object.is(), so -0 does not match 0.
+    expect(structuredClone(input)).toEqual([-0, NaN, -0, NaN]);
   });
 
   test("structuredClone on object with simple properties can exceed JSFinalObject::maxInlineCapacity", () => {
-    let largeValue = {};
+    const largeValue: Record<string, number> = {};
     for (let i = 0; i < 100; i++) {
       largeValue["property" + i] = i;
     }
+    const expected = Array(100).fill(largeValue);
 
-    for (let i = 0; i < 100; i++) {
-      expect(structuredClone(largeValue)).toStrictEqual(largeValue);
-    }
+    expect(Array.from({ length: 100 }, () => structuredClone(largeValue))).toStrictEqual(expected);
     Bun.gc(true);
-    for (let i = 0; i < 100; i++) {
-      expect(structuredClone(largeValue)).toStrictEqual(largeValue);
-    }
+    expect(Array.from({ length: 100 }, () => structuredClone(largeValue))).toStrictEqual(expected);
   });
 
   // === DenseArray fast path edge case tests ===
@@ -455,11 +454,7 @@ describe("Structured Clone Fast Path", () => {
 
   test("objects with special number property values", () => {
     const input = [{ a: NaN, b: Infinity, c: -Infinity, d: -0 }];
-    const cloned = structuredClone(input);
-    expect(cloned[0].a).toBeNaN();
-    expect(cloned[0].b).toBe(Infinity);
-    expect(cloned[0].c).toBe(-Infinity);
-    expect(Object.is(cloned[0].d, -0)).toBe(true);
+    expect(structuredClone(input)).toEqual([{ a: NaN, b: Infinity, c: -Infinity, d: -0 }]);
   });
 
   test("objects with null and undefined property values", () => {
@@ -468,9 +463,7 @@ describe("Structured Clone Fast Path", () => {
       { a: null, b: undefined },
     ];
     const cloned = structuredClone(input);
-    expect(cloned).toEqual(input);
-    expect(cloned[0].a).toBeNull();
-    expect(cloned[0].b).toBeUndefined();
+    expect(cloned).toStrictEqual(input);
     expect("b" in cloned[0]).toBe(true);
   });
 
@@ -537,7 +530,7 @@ describe("Structured Clone Fast Path", () => {
   test("fallback: array with Map", () => {
     const input = [new Map([["key", "value"]])];
     const cloned = structuredClone(input);
-    expect(cloned[0].get("key")).toBe("value");
+    expect(cloned).toEqual([new Map([["key", "value"]])]);
   });
 
   test("fallback: array with Set", () => {
@@ -550,16 +543,16 @@ describe("Structured Clone Fast Path", () => {
     const obj = Object.defineProperty({}, "x", { get: () => 42, enumerable: true, configurable: true });
     const input = [obj];
     const cloned = structuredClone(input);
-    expect(cloned[0].x).toBe(42);
+    expect(cloned).toEqual([{ x: 42 }]);
   });
 
   test("fallback: object with non-enumerable property in array", () => {
     const obj = Object.defineProperty({ a: 1 }, "hidden", { value: 2, enumerable: false });
     const input = [obj];
     const cloned = structuredClone(input);
-    expect(cloned[0].a).toBe(1);
+    expect(cloned).toEqual([{ a: 1 }]);
     // non-enumerable property should not be cloned by structuredClone
-    expect(cloned[0].hidden).toBeUndefined();
+    expect(Object.getOwnPropertyNames(cloned[0])).toEqual(["a"]);
   });
 
   test("frozen objects in array produce non-frozen clones", () => {
@@ -632,8 +625,9 @@ describe("Structured Clone Fast Path", () => {
     new Uint8Array(buf).set([1, 2, 3, 4, 5, 6, 7, 8]);
     const input = [{ a: 1 }, buf];
     const cloned = structuredClone(input);
-    expect(cloned[0]).toEqual({ a: 1 });
-    expect(new Uint8Array(cloned[1] as ArrayBuffer)).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    // toEqual() fails unless cloned[1] is an ArrayBuffer with the same bytes.
+    expect(cloned).toEqual(input);
+    expect(cloned[1]).not.toBe(buf);
   });
 
   test("fallback: object created with Object.create(null) in array", () => {
@@ -642,8 +636,9 @@ describe("Structured Clone Fast Path", () => {
     obj.b = "hello";
     const input = [obj];
     const cloned = structuredClone(input);
-    expect(cloned[0].a).toBe(1);
-    expect(cloned[0].b).toBe("hello");
+    expect(cloned).toEqual([{ a: 1, b: "hello" }]);
+    // toEqual() ignores the prototype. The clone gets Object.prototype.
+    expect(Object.getPrototypeOf(cloned[0])).toBe(Object.prototype);
   });
 
   test("fallback: class instance in array", () => {
@@ -663,8 +658,6 @@ describe("Structured Clone Fast Path", () => {
     ];
     const cloned = structuredClone(input);
     expect(cloned).toEqual(input);
-    expect(cloned[0].enabled).toBe(true);
-    expect(cloned[1].visible).toBe(true);
   });
 
   test("object with only string values in array", () => {
@@ -709,8 +702,6 @@ describe("Structured Clone Fast Path", () => {
     ];
     const cloned = structuredClone(input);
     expect(cloned).toEqual(input);
-    expect(cloned[0].data.length).toBe(10000);
-    expect(cloned[1].data.length).toBe(10000);
   });
 
   test("objects with unicode property names and values", () => {
@@ -755,8 +746,8 @@ describe("Structured Clone Fast Path", () => {
     const input = [obj];
     // structuredClone should handle this correctly (Symbols are not cloned)
     const cloned = structuredClone(input);
-    expect(cloned[0].a).toBe(1);
-    expect(cloned[0][sym]).toBeUndefined();
+    expect(cloned).toEqual([{ a: 1 }]);
+    expect(Object.getOwnPropertySymbols(cloned[0])).toEqual([]);
   });
 
   test("fallback: object with BigInt property value in array", () => {
@@ -773,12 +764,10 @@ describe("Structured Clone Fast Path", () => {
       if (i % 10 === 0) Bun.gc(true);
     }
     Bun.gc(true);
-    // Verify all clones are still valid after GC
-    for (const clone of clones) {
-      expect(clone.length).toBe(100);
-      expect(clone[0]).toEqual({ id: 0, name: "item-0", flag: true });
-      expect(clone[99]).toEqual({ id: 99, name: "item-99", flag: false });
-    }
+    // Verify that every clone is still valid after GC. toEqual() ignores extra
+    // trailing undefined slots, so the lengths get their own check.
+    expect(clones.map(clone => clone.length)).toEqual(Array(50).fill(100));
+    expect(clones).toEqual(Array(50).fill(input));
   });
 
   test("structuredClone of array of objects does not crash under repeated GC", () => {
@@ -787,11 +776,16 @@ describe("Structured Clone Fast Path", () => {
       name: `item-${i}`,
       active: i % 2 === 0,
     }));
+    // The loop keeps no clone, so the GC can free each one. A matcher call
+    // requests a GC, so the loop checks each clone without one.
+    // Bun.deepEquals() ignores extra trailing undefined slots, as toEqual() does.
+    const mismatches: unknown[] = [];
     for (let i = 0; i < 200; i++) {
       const cloned = structuredClone(input);
-      expect(cloned.length).toBe(50);
+      if (cloned.length !== input.length || !Bun.deepEquals(cloned, input)) mismatches.push(cloned);
       if (i % 20 === 0) Bun.gc(true);
     }
+    expect(mismatches).toEqual([]);
   });
 
   test("SerializedScriptValue can be deserialized multiple times (postMessage to two ports)", async () => {
@@ -850,8 +844,8 @@ describe("Structured Clone Fast Path", () => {
   test("fallback: array containing both simple objects and TypedArray", () => {
     const input = [{ a: 1 }, new Uint8Array([1, 2, 3])];
     const cloned = structuredClone(input);
-    expect(cloned[0]).toEqual({ a: 1 });
-    expect(new Uint8Array(cloned[1] as any)).toEqual(new Uint8Array([1, 2, 3]));
+    // toEqual() fails unless cloned[1] is a Uint8Array with the same bytes.
+    expect(cloned).toEqual([{ a: 1 }, new Uint8Array([1, 2, 3])]);
   });
 
   test("fallback: array containing object with function-like structure", () => {


### PR DESCRIPTION
### Problem
- `test/js/web/structured-clone-fastpath.test.ts` takes 30 to 32 s on darwin aarch64. Other lanes take 2.7 s or less.
- CI sets `BUN_GARBAGE_COLLECTOR_LEVEL=1` (`scripts/runner.node.mjs:1912`). Then each matcher call requests a GC (`src/runtime/test_runner/expect.rs:1683`). The file runs 875 GC cycles.
- CI runs 4 test files at once. On a busy darwin aarch64 runner, one GC cycle costs about 35 ms. Three tests call matchers in loops, 550 times. They take 26.9 s of the 31.9 s (build 109708).

### Fix
- Each loop collects its results and calls a matcher once. The `Bun.gc(true)` calls stay. GC cycles: 875 before, 181 after.
- The five deoptimization tests had no assertion. They now check the cloned value. Other tests compare whole clones.
- Each old check is still made, by the same matcher or a stronger one. With 20 deliberate `structuredClone` bugs, the new file fails every test that the old file fails.
- Verified: `bun bd test test/js/web/structured-clone-fastpath.test.ts`, 93 pass. Linux, CI env vars, 64 busy processes on 16 cores: 10 s before, 2.5 s after. darwin aarch64 on this PR: 0.23 s, run alone.

### Background
- With `BUN_GARBAGE_COLLECTOR_LEVEL=1`, the test runner calls `collectAsync()` after each matcher call. The JS thread waits for that GC later.
- CI runs a file that the PR changes alone, before the batch. Alone, the old file took 0.17 s (build 108838). The batch time shows after the merge.
- `toEqual()` compares numbers with `Object.is()`. `toStrictEqual()` also fails when a hole meets `undefined`.

<details><summary>Notes</summary>

**Per-test times, darwin aarch64, build 109708** (junit artifact, shard 0, macOS 26.4, in the parallel batch):

| Test | Time | Matcher calls |
| --- | --- | --- |
| can exceed JSFinalObject::maxInlineCapacity | 13.8 s | 200 |
| does not crash under repeated GC | 6.6 s | 200 |
| array of objects survives GC | 6.5 s | 150 |
| the two RSS tests (old lines 71 and 92) | 0.13 s each | 2 and 1 |
| the other 88 tests | about 30 ms per matcher call | 0 to 10 |

The same build on darwin x64 takes 1.8 s for the file, about 1.5 ms per matcher call.

**GC cycles.** Linux, release build, `BUN_JSC_logGC=1`, with the CI env vars: 875 cycles before, 181 after. Without `BUN_GARBAGE_COLLECTOR_LEVEL=1` there are 21. Those 21 are the `Bun.gc(true)` calls in the file, and this PR keeps them.

**The cost per cycle depends on load.**
- The first deoptimization test makes no matcher call. In the batch on darwin aarch64 it still takes 36 ms: it pays for the GC that the test before it requested.
- The same host (`darwin-arm64-challah-tart-26-1`) ran the old file in the batch in 9.4 s (build 109692) and in 32 s (build 109708).
- Alone, before the batch, the file is fast on darwin. Old file, build 108838: 0.17 s on aarch64 and 0.33 s on x64. New file, this PR (build 109725): 0.23 s on aarch64 and 0.25 s on x64.
- Linux, 16 cores, CI env vars, release build, with busy processes (`bun -e 'for (;;) {}'`) beside the test:

| Busy processes | Old file | New file |
| --- | --- | --- |
| 0 | 0.28 to 0.36 s | 0.14 to 0.18 s |
| 32 | 5.1 to 6.1 s | 1.4 to 3.1 s |
| 64 | 7.2 to 11.1 s | 2.4 to 3.7 s |

With 64 busy processes, the old "can exceed JSFinalObject::maxInlineCapacity" test timed out once (5 s limit). I have no macOS machine, so I cannot say why a cycle waits 35 ms there. Every test file in the batch pays this cost for each matcher call. This PR does not change that. In the batch, I expect about 6 s for the new file (181 of 875 cycles). The main builds after the merge will show the real time.

**Debug build.** `bun bd test` with the CI env vars: 9.5 s before, 6.6 s after. Without them: 5.7 s before, 5.8 s after.

**GC in the loops.** In CI, the old loops requested a GC on each iteration. That was a side effect of the env var. The tests keep their own `Bun.gc(true)` calls. The loop in "does not crash under repeated GC" checks each clone with `Bun.deepEquals()` and a length check. Neither is a matcher call, so the loop requests no GC. The loop keeps no clone, as before.

**Lengths.** `toEqual()` and `Bun.deepEquals()` ignore extra trailing `undefined` slots. The old GC tests checked the length of each clone, so the new ones do too. The strict forms also catch a clone that is too long, but in the debug build they are 5 times slower for this data (760 ms against 155 ms).

**Assertion changes.**
- Deoptimization tests: a `test.each` with one name per property kind. Each row checks the clone with `toStrictEqual()`.
- Holes: `toStrictEqual()` checks that a hole stays a hole, for the literal hole, the deleted element, and the array with a longer `length`. The old comment "holes become undefined" was wrong.
- "survives GC" compares all 100 elements of all 50 clones. The old test compared elements 0 and 99.
- "repeated GC" compares each clone with the input. The old test checked only the length.
- Typed array and ArrayBuffer: the old checks wrapped the clone in `new Uint8Array()`, so a plain array also passed. `toEqual()` checks the type.
- Map: `toEqual()` checks all entries. The old test read one key.
- Non-enumerable and symbol keys: `Object.getOwnPropertyNames()` and `Object.getOwnPropertySymbols()` check the own keys.
- `Object.create(null)` input: the clone has `Object.prototype`, as the structured clone spec says.
- Removed four `toBe()` calls that repeated a `toEqual()` on the same value.
- Matcher calls: 724 before, 147 after.

**Mutation check.** A preload wraps `structuredClone` with one bug at a time: holes to `undefined`, -0 to 0, drop `undefined` values, one wrong element in a long array, typed array to plain array, ArrayBuffer to Uint8Array, keep a null prototype, skip a getter, skip a setter-only accessor, copy non-enumerable keys, an extra Map entry, drop the last of 100 keys, drop the last element, add a trailing hole, add a trailing `undefined`, copy symbol keys, an extra hidden key, grow a one-element array, Infinity to `Number.MAX_VALUE`, booleans to numbers. Seven of the 20 bugs pass the old file and fail the new one. No bug fails only the old file.

**Pre-existing flake.** The RSS test "constant amount of memory for simple object inputs" fails in about 1 of 10 release runs on my machine. The delta is exactly 1 MiB, and the bound is "less than 1 MiB". The old file fails the same way (4 of 40 runs). This PR does not change that test.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/structured-clone-fastpath.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/structured-clone-fastpath.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/web/structured-clone-fastpath.test.ts:
(pass) Structured Clone Fast Path > structuredClone should work with empty object [15.04ms]
(pass) Structured Clone Fast Path > structuredClone({}) result is spreadable after adding a property [5.86ms]
(pass) Structured Clone Fast Path > structuredClone should work with empty string [1.27ms]
(pass) Structured Clone Fast Path > structuredClone of an object with an enumerable getter [3.10ms]
(pass) Structured Clone Fast Path > structuredClone of an object with a non-configurable read-only data property [0.57ms]
(pass) Structured Clone Fast Path > structuredClone of an object with a non-configurable writable data property [0.45ms]
(pass) Structured Clone Fast Path > structuredClone of an object with a non-enumerable getter [0.45ms]
(pass) Structured Clone Fast Path > structuredClone of an object with an enumerable setter without a getter [0.91ms]
(pass) Structured Clone Fast Path > structuredClone should use a constant amount of memory for string inputs [269.03ms]
(pass) Structured Clone Fast Path > structuredClone should use a constant amount of memory for simple object inputs [725.90ms]
(pass) Structured Clone Fast Path > structuredClone should work with empty array [2.09ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of numbers [1.73ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of strings [1.87ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of mixed primitives [1.47ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of special numbers [1.66ms]
(pass) Structured Clone Fast Path > structuredClone should work with large array of numbers [28.04ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of simple objects [2
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/structured-clone-fastpath.test.ts | 224 +++++++++++++-------------
 1 file changed, 109 insertions(+), 115 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/web/structured-clone-fastpath.test.ts      4     30     29
```

</details>

<!-- robobun:evidence:end -->
