### PR TITLE
docs: Bun.serve development mode is the default; explain what the error page sends

### DIFF
--- a/docs/runtime/http/error-handling.mdx
+++ b/docs/runtime/http/error-handling.mdx
@@ -3,20 +3,25 @@ title: Error Handling
 description: Learn how to handle errors in Bun's development server
 ---
 
-To activate development mode, set `development: true`.
+`Bun.serve()` runs in development mode by default. It is turned off when `NODE_ENV=production` is set, when Bun is run with `--production`, or when you pass `development: false`.
 
 ```ts title="server.ts" icon="/icons/typescript.svg"
 Bun.serve({
-  development: true, // [!code ++]
+  development: false, // [!code ++]
   fetch(req) {
     throw new Error("woops!");
   },
 });
 ```
 
-In development mode, Bun surfaces errors in-browser with a built-in error page.
+In development mode, when a request handler throws and no `error` handler returns a response, Bun responds with a built-in error page that includes the error message, stack trace, source code around each frame, and file paths. This is meant for debugging locally.
 
 <Frame>![Bun's built-in 500 page](/images/exception_page.png)</Frame>
+
+<Warning>
+  The development error page sends source code and file paths to whoever made the request. Set `NODE_ENV=production` (or
+  `development: false`) when deploying so uncaught errors return a plain `500` instead.
+</Warning>
 
 ### `error` callback
 


### PR DESCRIPTION
The error-handling page said "To activate development mode, set `development: true`", which reads as if it were off by default. It is on unless `NODE_ENV=production`, `--production`, or `development: false` — this was only stated in the `serve.d.ts` JSDoc.

This rewrites the intro to state the default, lists what the built-in error page includes (message, stack, source lines, file paths), and adds a warning to set `NODE_ENV=production` when deploying.