### PR TITLE
bundler: add bun build --check to report circular dependencies

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1557,7 +1557,7 @@ interface BuildMetafile {
 
 ### check
 
-Check the module graph for circular dependencies. Bun resolves and parses every module, then stops before it links or prints output. It writes no files.
+Check the module graph for circular dependencies. Bun resolves and parses each module that the entry points import, then stops before it links or prints output. It writes no files.
 
 A circular dependency is a chain of imports that leads back to the file where it starts. When a module in a cycle runs, it can read a binding from another module in the cycle before that binding is initialized. For a `let`, `const`, or `class` binding, this throws a `ReferenceError`.
 
@@ -1604,11 +1604,14 @@ Bun follows the imports that run a module when the importing module runs:
 
 Bun skips these imports:
 
-- Type-only imports. TypeScript removes them, so they do not exist at runtime.
+- Imports of types only: `import type`, and an import whose names are only used as types. Bun removes these imports when it transpiles, so they do not run in Bun. Node's type stripping keeps an import that has no `type` keyword.
 - `import()` and `import defer`. These do not run the module when the importing module runs.
 - Imports of files in `node_modules`. Bun still checks a workspace package, because it resolves the link in `node_modules` to the directory of the package.
+- Imports that the build keeps external. See [`external`](#external) and [`packages`](#packages).
 
-The CLI exits with code 1 when it finds a cycle. In the JavaScript API, the cycles are errors in `result.logs`, and the promise rejects unless you set `throw: false`. You cannot use `check` with `outdir`, `metafile`, or `compile`.
+The check also reports the errors that Bun finds when it resolves and parses a module, for example an import that does not resolve. It does not report the errors that the link step finds, for example an import of a name that a module does not export. So a build can fail after the check passes.
+
+The CLI exits with code 1 when it finds an error. In the JavaScript API, the errors are in `result.logs`, and the promise rejects unless you set `throw: false`. You cannot use `check` with `outdir`, `metafile`, or `compile`.
 
 ## Outputs
 

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1555,6 +1555,61 @@ interface BuildMetafile {
 }
 ```
 
+### check
+
+Check the module graph for circular imports. Bun resolves and parses every module, then stops before it links or prints output. It writes no files.
+
+A circular import is a chain of imports that leads back to the file where it starts. When a module in a cycle runs, it can read a binding from another module in the cycle before that binding is initialized. For a `let`, `const`, or `class` binding, this throws a `ReferenceError`.
+
+<Tabs>
+  <Tab title="JavaScript">
+    ```ts title="build.ts" icon="/icons/typescript.svg"
+    const result = await Bun.build({
+      entrypoints: ["./src/index.ts"],
+      check: true,
+      throw: false,
+    });
+
+    for (const message of result.logs) {
+      console.error(message.message); // "Circular import: src/a.ts -> src/b.ts -> src/a.ts"
+    }
+    ```
+
+  </Tab>
+  <Tab title="CLI">
+    ```bash terminal icon="terminal"
+    bun build ./src/index.ts --check
+    ```
+  </Tab>
+</Tabs>
+
+Each cycle is one error. The error points at the first import in the cycle. A note points at each of the other imports.
+
+```txt
+1 | import { b } from "./b";
+                      ^
+error: Circular import: src/a.ts -> src/b.ts -> src/a.ts
+    at /project/src/a.ts:1:19
+
+1 | import { a } from "./a";
+                      ^
+note: src/b.ts imports src/a.ts here:
+   at /project/src/b.ts:1:19
+```
+
+Bun follows the imports that run a module when the importing module runs:
+
+- `import` and `export ... from` statements, including imports for side effects such as `import "./setup"`
+- `require()` calls
+
+Bun skips the imports that cannot read a binding too early:
+
+- Type-only imports. TypeScript removes them, so they do not exist at runtime.
+- `import()` and `import defer`. These do not run the module when the importing module runs.
+- Imports of files in `node_modules`.
+
+The CLI exits with code 1 when it finds a cycle. In the JavaScript API, the cycles are errors in `result.logs`, and the promise rejects unless you set `throw: false`. You cannot use `check` with `outdir`, `metafile`, or `compile`.
+
 ## Outputs
 
 The `Bun.build` function returns a `Promise<BuildOutput>`, defined as:

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1557,9 +1557,9 @@ interface BuildMetafile {
 
 ### check
 
-Check the module graph for circular imports. Bun resolves and parses every module, then stops before it links or prints output. It writes no files.
+Check the module graph for circular dependencies. Bun resolves and parses every module, then stops before it links or prints output. It writes no files.
 
-A circular import is a chain of imports that leads back to the file where it starts. When a module in a cycle runs, it can read a binding from another module in the cycle before that binding is initialized. For a `let`, `const`, or `class` binding, this throws a `ReferenceError`.
+A circular dependency is a chain of imports that leads back to the file where it starts. When a module in a cycle runs, it can read a binding from another module in the cycle before that binding is initialized. For a `let`, `const`, or `class` binding, this throws a `ReferenceError`.
 
 <Tabs>
   <Tab title="JavaScript">
@@ -1571,7 +1571,7 @@ A circular import is a chain of imports that leads back to the file where it sta
     });
 
     for (const message of result.logs) {
-      console.error(message.message); // "Circular import: src/a.ts -> src/b.ts -> src/a.ts"
+      console.error(message.message); // "Circular dependency: src/a.ts -> src/b.ts -> src/a.ts"
     }
     ```
 
@@ -1588,7 +1588,7 @@ Each cycle is one error. The error points at the first import in the cycle. A no
 ```txt
 1 | import { b } from "./b";
                       ^
-error: Circular import: src/a.ts -> src/b.ts -> src/a.ts
+error: Circular dependency: src/a.ts -> src/b.ts -> src/a.ts
     at /project/src/a.ts:1:19
 
 1 | import { a } from "./a";
@@ -1602,11 +1602,11 @@ Bun follows the imports that run a module when the importing module runs:
 - `import` and `export ... from` statements, including imports for side effects such as `import "./setup"`
 - `require()` calls
 
-Bun skips the imports that cannot read a binding too early:
+Bun skips these imports:
 
 - Type-only imports. TypeScript removes them, so they do not exist at runtime.
 - `import()` and `import defer`. These do not run the module when the importing module runs.
-- Imports of files in `node_modules`.
+- Imports of files in `node_modules`. Bun still checks a workspace package, because it resolves the link in `node_modules` to the directory of the package.
 
 The CLI exits with code 1 when it finds a cycle. In the JavaScript API, the cycles are errors in `result.logs`, and the promise rejects unless you set `throw: false`. You cannot use `check` with `outdir`, `metafile`, or `compile`.
 

--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -125,6 +125,11 @@ bun build <entry points>
   Transpile only — do not bundle
 </ParamField>
 
+<ParamField path="--check" type="boolean">
+  Resolve and parse every module, report circular imports as errors, and write no files. Exits with code 1 when there is
+  a cycle
+</ParamField>
+
 <ParamField path="--css-chunking" type="boolean">
   Chunk CSS files together to reduce duplication (only when multiple entry points import CSS)
 </ParamField>

--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -126,8 +126,8 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--check" type="boolean">
-  Resolve and parse every module, report circular dependencies as errors, and write no files. Exits with code 1 when
-  there is a cycle
+  Resolve and parse each module that the entry points import, report circular dependencies as errors, and write no
+  files. Exits with code 1 when there is an error
 </ParamField>
 
 <ParamField path="--css-chunking" type="boolean">

--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -126,8 +126,8 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--check" type="boolean">
-  Resolve and parse every module, report circular imports as errors, and write no files. Exits with code 1 when there is
-  a cycle
+  Resolve and parse every module, report circular dependencies as errors, and write no files. Exits with code 1 when
+  there is a cycle
 </ParamField>
 
 <ParamField path="--css-chunking" type="boolean">

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3480,16 +3480,19 @@ declare module "bun" {
     /**
      * Check the module graph for circular dependencies, and write no files.
      *
-     * Bun resolves and parses every module, then stops before it links or
-     * prints output. Each circular dependency is an error in
-     * {@link BuildOutput.logs}. The message names the files in the cycle,
-     * for example `Circular dependency: a.ts -> b.ts -> a.ts`. With
+     * Bun resolves and parses each module that the entry points import, then
+     * stops before it links or prints output. Each circular dependency is an
+     * error in {@link BuildOutput.logs}. The message names the files in the
+     * cycle, for example `Circular dependency: a.ts -> b.ts -> a.ts`. With
      * `throw: true` (the default), the promise rejects with these errors.
-     * When there is no cycle, the build succeeds with no outputs.
+     * When there is no error, the build succeeds with no outputs.
      *
      * Bun follows `import` and `export ... from` statements and `require()`
-     * calls. It skips type-only imports, `import()`, `import defer`, and files
-     * in `node_modules`.
+     * calls. It skips imports of types only, `import()`, `import defer`,
+     * external modules, and files in `node_modules`.
+     *
+     * The check also reports resolve and parse errors. It does not run the
+     * link step, so a build can fail after the check passes.
      *
      * Cannot be used with `outdir`, `metafile`, or `compile`. Equivalent to
      * `--check` in the CLI.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3478,6 +3478,27 @@ declare module "bun" {
     throw?: boolean;
 
     /**
+     * Check the module graph for circular imports, and write no files.
+     *
+     * Bun resolves and parses every module, then stops before it links or
+     * prints output. Each circular import is an error in
+     * {@link BuildOutput.logs}. The message names the files in the cycle, for
+     * example `Circular import: a.ts -> b.ts -> a.ts`. With `throw: true` (the
+     * default), the promise rejects with these errors. When there is no
+     * cycle, the build succeeds with no outputs.
+     *
+     * Bun follows `import` and `export ... from` statements and `require()`
+     * calls. It skips type-only imports, `import()`, `import defer`, and files
+     * in `node_modules`.
+     *
+     * Cannot be used with `outdir`, `metafile`, or `compile`. Equivalent to
+     * `--check` in the CLI.
+     *
+     * @default false
+     */
+    check?: boolean;
+
+    /**
      * Custom tsconfig.json file path to use for path resolution.
      * Equivalent to `--tsconfig-override` in the CLI.
      * @example

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3478,14 +3478,14 @@ declare module "bun" {
     throw?: boolean;
 
     /**
-     * Check the module graph for circular imports, and write no files.
+     * Check the module graph for circular dependencies, and write no files.
      *
      * Bun resolves and parses every module, then stops before it links or
-     * prints output. Each circular import is an error in
-     * {@link BuildOutput.logs}. The message names the files in the cycle, for
-     * example `Circular import: a.ts -> b.ts -> a.ts`. With `throw: true` (the
-     * default), the promise rejects with these errors. When there is no
-     * cycle, the build succeeds with no outputs.
+     * prints output. Each circular dependency is an error in
+     * {@link BuildOutput.logs}. The message names the files in the cycle,
+     * for example `Circular dependency: a.ts -> b.ts -> a.ts`. With
+     * `throw: true` (the default), the promise rejects with these errors.
+     * When there is no cycle, the build succeeds with no outputs.
      *
      * Bun follows `import` and `export ... from` statements and `require()`
      * calls. It skips type-only imports, `import()`, `import defer`, and files

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2500,8 +2500,12 @@ pub mod parse_worker {
         opts.package_version = task.package_version.slice();
 
         opts.features.allow_runtime = !task.source_index.is_runtime();
-        opts.features.unwrap_commonjs_to_esm =
-            output_format == options::Format::Esm && FeatureFlags::UNWRAP_COMMONJS_TO_ESM;
+        // `check` reads the graph as written. Unwrapping turns a file that is
+        // only `module.exports = require(x)` into a redirect to `x`, and the
+        // graph then loses that file.
+        opts.features.unwrap_commonjs_to_esm = output_format == options::Format::Esm
+            && FeatureFlags::UNWRAP_COMMONJS_TO_ESM
+            && !topts.check;
         opts.features.top_level_await = output_format == options::Format::Esm
             || output_format == options::Format::InternalBakeDev;
         opts.features.auto_import_jsx = task.jsx.parse && topts.auto_import_jsx;

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2500,8 +2500,7 @@ pub mod parse_worker {
         opts.package_version = task.package_version.slice();
 
         opts.features.allow_runtime = !task.source_index.is_runtime();
-        // Unwrapping turns a file that is only `module.exports = require(x)`
-        // into a redirect to `x`, and the scanned graph then loses that file.
+        // Unwrapping turns `module.exports = require(x)` files into redirects, which drop edges.
         opts.features.unwrap_commonjs_to_esm = output_format == options::Format::Esm
             && FeatureFlags::UNWRAP_COMMONJS_TO_ESM
             && !topts.scan_graph_as_written;

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2500,12 +2500,11 @@ pub mod parse_worker {
         opts.package_version = task.package_version.slice();
 
         opts.features.allow_runtime = !task.source_index.is_runtime();
-        // `check` reads the graph as written. Unwrapping turns a file that is
-        // only `module.exports = require(x)` into a redirect to `x`, and the
-        // graph then loses that file.
+        // Unwrapping turns a file that is only `module.exports = require(x)`
+        // into a redirect to `x`, and the scanned graph then loses that file.
         opts.features.unwrap_commonjs_to_esm = output_format == options::Format::Esm
             && FeatureFlags::UNWRAP_COMMONJS_TO_ESM
-            && !topts.check;
+            && !topts.scan_graph_as_written;
         opts.features.top_level_await = output_format == options::Format::Esm
             || output_format == options::Format::InternalBakeDev;
         opts.features.auto_import_jsx = task.jsx.parse && topts.auto_import_jsx;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2265,12 +2265,15 @@ pub mod bv2_impl {
         }
 
         /// `check` mode ends the build after the scan phase. It logs an error
-        /// for each circular dependency. The link and print steps do not run, so
-        /// the result has no output files.
+        /// for each circular dependency. The walk also runs when the scan
+        /// logged errors, so one run reports both. The link and print steps do
+        /// not run, so the result has no output files.
         fn check_module_graph(&self) -> Result<BuildResult, Error> {
-            if crate::circular_imports::report_circular_imports(self) > 0 {
+            crate::circular_imports::report_circular_imports(self);
+            if self.transpiler.log().has_errors() {
                 return Err(crate::Error::BuildFailed);
             }
+            self.fail_if_no_entry_points()?;
             Ok(BuildResult {
                 output_files: Vec::new(),
                 metafile: None,
@@ -4071,19 +4074,20 @@ pub mod bv2_impl {
                     / (bun_core::time::NS_PER_MS as i64)) as u64;
                 *source_code_size = this.source_code_length as u64;
 
+                if this.transpiler.options.check {
+                    let result = this.check_module_graph()?;
+                    this.scan_for_secondary_paths();
+                    let reachable_files = this.find_reachable_files()?;
+                    *reachable_files_count = reachable_files.len().saturating_sub(1); // - 1 for the runtime
+                    return Ok(result);
+                }
+
                 if this.transpiler.log().has_errors() {
                     return Err(crate::Error::BuildFailed);
                 }
                 this.fail_if_no_entry_points()?;
 
                 this.scan_for_secondary_paths();
-
-                if this.transpiler.options.check {
-                    let result = this.check_module_graph();
-                    let reachable_files = this.find_reachable_files()?;
-                    *reachable_files_count = reachable_files.len().saturating_sub(1); // - 1 for the runtime
-                    return result;
-                }
 
                 this.process_server_component_manifest_files()?;
 
@@ -5269,16 +5273,16 @@ pub mod bv2_impl {
 
             /* arena: help_catch_memory_issues — no-op (mimalloc TLH check) */
 
+            if self.transpiler.options.check {
+                return self.check_module_graph();
+            }
+
             if self.transpiler.log().errors > 0 {
                 return Err(crate::Error::BuildFailed);
             }
             self.fail_if_no_entry_points()?;
 
             self.scan_for_secondary_paths();
-
-            if self.transpiler.options.check {
-                return self.check_module_graph();
-            }
 
             self.process_server_component_manifest_files()?;
 
@@ -6072,11 +6076,11 @@ pub mod bv2_impl {
 
         /// Returns true when barrel optimization is enabled. Barrel optimization
         /// can apply to any package with sideEffects: false or listed in
-        /// optimize_imports, so it is enabled for every build except `check`.
-        /// A check must follow each re-export: the unbundled program runs all
-        /// of them, so a cycle through one that a build defers is still real.
+        /// optimize_imports, so it is enabled unless the caller reads the
+        /// scanned graph: the unbundled program runs each re-export, so an
+        /// edge that a build defers is still an edge.
         fn is_barrel_optimization_enabled(&self) -> bool {
-            !self.transpiler.options.check
+            !self.transpiler.options.scan_graph_as_written
         }
 
         // TODO: remove ResolveQueue

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2265,7 +2265,7 @@ pub mod bv2_impl {
         }
 
         /// `check` mode ends the build after the scan phase. It logs an error
-        /// for each circular import. The link and print steps do not run, so
+        /// for each circular dependency. The link and print steps do not run, so
         /// the result has no output files.
         fn check_module_graph(&self) -> Result<BuildResult, Error> {
             if crate::circular_imports::report_circular_imports(self) > 0 {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2264,6 +2264,20 @@ pub mod bv2_impl {
             Err(crate::Error::BuildFailed)
         }
 
+        /// `check` mode ends the build after the scan phase. It logs an error
+        /// for each circular import. The link and print steps do not run, so
+        /// the result has no output files.
+        fn check_module_graph(&self) -> Result<BuildResult, Error> {
+            if crate::circular_imports::report_circular_imports(self) > 0 {
+                return Err(crate::Error::BuildFailed);
+            }
+            Ok(BuildResult {
+                output_files: Vec::new(),
+                metafile: None,
+                metafile_markdown: None,
+            })
+        }
+
         /// `BUN_THREADPOOL_STATS=1` instrumentation hook — dump aggregate worker
         /// idle/busy time since the previous call. No-op when env var unset.
         #[inline]
@@ -4064,6 +4078,13 @@ pub mod bv2_impl {
 
                 this.scan_for_secondary_paths();
 
+                if this.transpiler.options.check {
+                    let result = this.check_module_graph();
+                    let reachable_files = this.find_reachable_files()?;
+                    *reachable_files_count = reachable_files.len().saturating_sub(1); // - 1 for the runtime
+                    return result;
+                }
+
                 this.process_server_component_manifest_files()?;
 
                 let reachable_files = this.find_reachable_files()?;
@@ -5255,6 +5276,10 @@ pub mod bv2_impl {
 
             self.scan_for_secondary_paths();
 
+            if self.transpiler.options.check {
+                return self.check_module_graph();
+            }
+
             self.process_server_component_manifest_files()?;
 
             /* arena: help_catch_memory_issues — no-op (mimalloc TLH check) */
@@ -6047,9 +6072,11 @@ pub mod bv2_impl {
 
         /// Returns true when barrel optimization is enabled. Barrel optimization
         /// can apply to any package with sideEffects: false or listed in
-        /// optimize_imports, so it is always enabled during bundling.
+        /// optimize_imports, so it is enabled for every build except `check`.
+        /// A check must follow each re-export: the unbundled program runs all
+        /// of them, so a cycle through one that a build defers is still real.
         fn is_barrel_optimization_enabled(&self) -> bool {
-            true
+            !self.transpiler.options.check
         }
 
         // TODO: remove ResolveQueue
@@ -7186,7 +7213,9 @@ pub mod bv2_impl {
             let mut process_log = true;
 
             if matches!(parse_result.value, parse_task::ResultValue::Success(_)) {
-                barrel_imports::apply_barrel_optimization(this, parse_result);
+                if this.is_barrel_optimization_enabled() {
+                    barrel_imports::apply_barrel_optimization(this, parse_result);
+                }
                 resolve_queue = Self::run_resolution_for_parse_task(parse_result, this);
                 if matches!(parse_result.value, parse_task::ResultValue::Err(_)) {
                     process_log = false;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2264,10 +2264,7 @@ pub mod bv2_impl {
             Err(crate::Error::BuildFailed)
         }
 
-        /// `check` mode ends the build after the scan phase. It logs an error
-        /// for each circular dependency. The walk also runs when the scan
-        /// logged errors, so one run reports both. The link and print steps do
-        /// not run, so the result has no output files.
+        /// Ends a `check` build after the scan. The walk runs even if the scan logged errors.
         fn check_module_graph(&self) -> Result<BuildResult, Error> {
             crate::circular_imports::report_circular_imports(self);
             if self.transpiler.log().has_errors() {
@@ -6074,11 +6071,7 @@ pub mod bv2_impl {
         // take `&mut BundleV2` directly — callers reach them as free functions.
         // (was: pub use barrel_imports::{apply_barrel_optimization, schedule_barrel_deferred_imports})
 
-        /// Returns true when barrel optimization is enabled. Barrel optimization
-        /// can apply to any package with sideEffects: false or listed in
-        /// optimize_imports, so it is enabled unless the caller reads the
-        /// scanned graph: the unbundled program runs each re-export, so an
-        /// edge that a build defers is still an edge.
+        /// Barrel deferral drops edges, so it is off when the caller reads the scanned graph.
         fn is_barrel_optimization_enabled(&self) -> bool {
             !self.transpiler.options.scan_graph_as_written
         }

--- a/src/bundler/circular_imports.rs
+++ b/src/bundler/circular_imports.rs
@@ -1,4 +1,4 @@
-//! Circular import detection for `bun build --check` and `Bun.build({ check: true })`.
+//! Circular dependency detection for `bun build --check` and `Bun.build({ check: true })`.
 //!
 //! The walk reads the graph that the scan phase produced, before
 //! `find_reachable_files` runs. A check turns off the two scan-time rewrites
@@ -182,6 +182,6 @@ fn log_cycle(
         Some(&sources[cycle[0].source_index as usize]),
         range(&cycle[0]),
         notes,
-        format_args!("Circular import: {}", BStr::new(&chain)),
+        format_args!("Circular dependency: {}", BStr::new(&chain)),
     );
 }

--- a/src/bundler/circular_imports.rs
+++ b/src/bundler/circular_imports.rs
@@ -1,9 +1,4 @@
 //! Circular dependency detection for `bun build --check` and `Bun.build({ check: true })`.
-//!
-//! The walk reads the graph that the scan phase produced, before
-//! `find_reachable_files` runs. A check sets `scan_graph_as_written`, which
-//! turns off the scan-time rewrites that remove an edge from that graph. So
-//! each cycle names the files and the import statements that the user wrote.
 
 use std::io::Write;
 
@@ -29,10 +24,7 @@ struct Frame {
     record: u32,
 }
 
-/// The file that `record` runs when its importer runs. `import()` and
-/// `import defer` do not run the target at that point, so a cycle through
-/// them cannot read a binding before it is initialized. An unused record (a
-/// TypeScript import that is only used as a type) does not exist at runtime.
+/// `import()` and `import defer` do not run the target when the importer runs, so they are not edges.
 fn followed_target(record: &ImportRecord, sources: &[Source]) -> Option<u32> {
     if !matches!(record.kind, ImportKind::Stmt | ImportKind::Require) {
         return None;
@@ -54,10 +46,7 @@ fn followed_target(record: &ImportRecord, sources: &[Source]) -> Option<u32> {
     Some(target.get())
 }
 
-/// Walks the graph depth-first from each entry point and logs one error for
-/// each import that leads back to a file on the current path. Each file is
-/// expanded once, so the number of errors is at most the number of imports,
-/// and the order follows the entry points and the import order in each file.
+/// Logs one error for each import that leads back to a file on the depth-first path.
 pub(crate) fn report_circular_imports(this: &BundleV2<'_>) {
     let sources = this.graph.input_files.items_source();
     let all_records = this.graph.ast.items_import_records();
@@ -133,9 +122,7 @@ fn records_of<'r>(
         .map_or(&[], |records| records.as_slice())
 }
 
-/// `cycle[i].record` imports `cycle[i + 1]`, and the record of the last frame
-/// imports `cycle[0]`. The error points at the first import. Each later import
-/// is a note.
+/// The record of each frame imports the next frame. The record of the last frame imports `cycle[0]`.
 fn log_cycle(
     log: &mut Log,
     sources: &[Source],

--- a/src/bundler/circular_imports.rs
+++ b/src/bundler/circular_imports.rs
@@ -1,0 +1,187 @@
+//! Circular import detection for `bun build --check` and `Bun.build({ check: true })`.
+//!
+//! The walk reads the graph that the scan phase produced, before
+//! `find_reachable_files` runs. A check turns off the two scan-time rewrites
+//! that remove an edge from that graph: barrel deferral
+//! (`is_barrel_optimization_enabled`) and CommonJS redirects
+//! (`unwrap_commonjs_to_esm`). So each cycle names the files and the import
+//! statements that the user wrote.
+
+use std::io::Write;
+
+use bstr::BStr;
+use bun_ast::{Data, ImportKind, ImportRecord, ImportRecordFlags, Log, Source, import_record};
+
+use crate::bundle_v2::BundleV2;
+use crate::mal_prelude::*;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Visit {
+    New,
+    /// The file is on the current path, at this depth.
+    Active(u32),
+    Done,
+}
+
+struct Frame {
+    source_index: u32,
+    /// The next import record of this file to examine.
+    next_record: u32,
+    /// The import record that leads to the next frame on the path.
+    record: u32,
+}
+
+/// The file that `record` runs when its importer runs. `import()` and
+/// `import defer` do not run the target at that point, so a cycle through
+/// them cannot read a binding before it is initialized. An unused record (a
+/// TypeScript import that is only used as a type) does not exist at runtime.
+fn followed_target(record: &ImportRecord, sources: &[Source]) -> Option<u32> {
+    if !matches!(record.kind, ImportKind::Stmt | ImportKind::Require) {
+        return None;
+    }
+    if record
+        .flags
+        .intersects(ImportRecordFlags::IS_UNUSED | ImportRecordFlags::PHASE_DEFER)
+    {
+        return None;
+    }
+    let target = record.source_index;
+    if !target.is_valid() || target.is_runtime() {
+        return None;
+    }
+    let source = sources.get(target.get() as usize)?;
+    if source.path.is_node_module() {
+        return None;
+    }
+    Some(target.get())
+}
+
+/// Walks the graph depth-first from each entry point and logs one error for
+/// each import that leads back to a file on the current path. Each file is
+/// expanded once, so the number of errors is at most the number of imports,
+/// and the order follows the entry points and the import order in each file.
+/// Returns the number of errors.
+pub(crate) fn report_circular_imports(this: &BundleV2<'_>) -> usize {
+    let sources = this.graph.input_files.items_source();
+    let all_records = this.graph.ast.items_import_records();
+    let log = this.transpiler.log_mut();
+
+    let mut visits = vec![Visit::New; sources.len()];
+    let mut path: Vec<Frame> = Vec::new();
+    let mut cycles = 0;
+
+    for entry_point in this.graph.entry_points.iter() {
+        let entry = entry_point.get();
+        let Some(source) = sources.get(entry as usize) else {
+            continue;
+        };
+        if visits[entry as usize] != Visit::New || source.path.is_node_module() {
+            continue;
+        }
+        visits[entry as usize] = Visit::Active(0);
+        path.push(Frame {
+            source_index: entry,
+            next_record: 0,
+            record: 0,
+        });
+
+        while let Some(last) = path.len().checked_sub(1) {
+            let source_index = path[last].source_index;
+            let records = records_of(all_records, source_index);
+            let mut child = None;
+            while let Some(record) = records.get(path[last].next_record as usize) {
+                let record_index = path[last].next_record;
+                path[last].next_record += 1;
+                let Some(target) = followed_target(record, sources) else {
+                    continue;
+                };
+                match visits[target as usize] {
+                    Visit::New => {
+                        path[last].record = record_index;
+                        child = Some(target);
+                        break;
+                    }
+                    Visit::Active(depth) => {
+                        path[last].record = record_index;
+                        log_cycle(log, sources, all_records, &path[depth as usize..]);
+                        cycles += 1;
+                    }
+                    Visit::Done => {}
+                }
+            }
+
+            match child {
+                Some(target) => {
+                    visits[target as usize] =
+                        Visit::Active(u32::try_from(path.len()).expect("int cast"));
+                    path.push(Frame {
+                        source_index: target,
+                        next_record: 0,
+                        record: 0,
+                    });
+                }
+                None => {
+                    visits[source_index as usize] = Visit::Done;
+                    path.pop();
+                }
+            }
+        }
+    }
+
+    cycles
+}
+
+fn records_of<'r>(
+    all_records: &'r [import_record::List<'_>],
+    source_index: u32,
+) -> &'r [ImportRecord] {
+    all_records
+        .get(source_index as usize)
+        .map_or(&[], |records| records.as_slice())
+}
+
+/// `cycle[i].record` imports `cycle[i + 1]`, and the record of the last frame
+/// imports `cycle[0]`. The error points at the first import. Each later import
+/// is a note.
+fn log_cycle(
+    log: &mut Log,
+    sources: &[Source],
+    all_records: &[import_record::List<'_>],
+    cycle: &[Frame],
+) {
+    let pretty = |frame: &Frame| BStr::new(sources[frame.source_index as usize].path.pretty);
+    let range =
+        |frame: &Frame| records_of(all_records, frame.source_index)[frame.record as usize].range;
+
+    let mut chain: Vec<u8> = Vec::new();
+    for frame in cycle {
+        write!(chain, "{} -> ", pretty(frame)).expect("infallible: in-memory write");
+    }
+    write!(chain, "{}", pretty(&cycle[0])).expect("infallible: in-memory write");
+
+    let notes: Box<[Data]> = cycle
+        .iter()
+        .enumerate()
+        .skip(1)
+        .map(|(i, frame)| {
+            let imported = &cycle[(i + 1) % cycle.len()];
+            bun_ast::range_data(
+                Some(&sources[frame.source_index as usize]),
+                range(frame),
+                bun_ast::alloc_print(format_args!(
+                    "{} imports {} here:",
+                    pretty(frame),
+                    pretty(imported)
+                )),
+            )
+            .clone_line_text(log.clone_line_text)
+        })
+        .collect();
+
+    log.add_range_error_fmt_with_notes(
+        Some(&sources[cycle[0].source_index as usize]),
+        range(&cycle[0]),
+        notes,
+        format_args!("Circular import: {}", BStr::new(&chain)),
+    );
+}

--- a/src/bundler/circular_imports.rs
+++ b/src/bundler/circular_imports.rs
@@ -1,11 +1,9 @@
 //! Circular dependency detection for `bun build --check` and `Bun.build({ check: true })`.
 //!
 //! The walk reads the graph that the scan phase produced, before
-//! `find_reachable_files` runs. A check turns off the two scan-time rewrites
-//! that remove an edge from that graph: barrel deferral
-//! (`is_barrel_optimization_enabled`) and CommonJS redirects
-//! (`unwrap_commonjs_to_esm`). So each cycle names the files and the import
-//! statements that the user wrote.
+//! `find_reachable_files` runs. A check sets `scan_graph_as_written`, which
+//! turns off the scan-time rewrites that remove an edge from that graph. So
+//! each cycle names the files and the import statements that the user wrote.
 
 use std::io::Write;
 
@@ -60,15 +58,13 @@ fn followed_target(record: &ImportRecord, sources: &[Source]) -> Option<u32> {
 /// each import that leads back to a file on the current path. Each file is
 /// expanded once, so the number of errors is at most the number of imports,
 /// and the order follows the entry points and the import order in each file.
-/// Returns the number of errors.
-pub(crate) fn report_circular_imports(this: &BundleV2<'_>) -> usize {
+pub(crate) fn report_circular_imports(this: &BundleV2<'_>) {
     let sources = this.graph.input_files.items_source();
     let all_records = this.graph.ast.items_import_records();
     let log = this.transpiler.log_mut();
 
     let mut visits = vec![Visit::New; sources.len()];
     let mut path: Vec<Frame> = Vec::new();
-    let mut cycles = 0;
 
     for entry_point in this.graph.entry_points.iter() {
         let entry = entry_point.get();
@@ -104,7 +100,6 @@ pub(crate) fn report_circular_imports(this: &BundleV2<'_>) -> usize {
                     Visit::Active(depth) => {
                         path[last].record = record_index;
                         log_cycle(log, sources, all_records, &path[depth as usize..]);
-                        cycles += 1;
                     }
                     Visit::Done => {}
                 }
@@ -127,8 +122,6 @@ pub(crate) fn report_circular_imports(this: &BundleV2<'_>) -> usize {
             }
         }
     }
-
-    cycles
 }
 
 fn records_of<'r>(

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -96,6 +96,7 @@ pub use bundled_ast::BundledAst;
 pub mod barrel_imports;
 #[path = "Chunk.rs"]
 pub mod chunk;
+pub(crate) mod circular_imports;
 pub mod defines;
 pub mod linker;
 #[path = "LinkerGraph.rs"]

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1272,14 +1272,9 @@ pub struct BundleOptions<'a> {
     pub transform_options: std::sync::Arc<api::TransformOptions>,
     pub(crate) polyfill_node_globals: bool,
     pub transform_only: bool,
-    /// `bun build --check` / `Bun.build({ check: true })`: stop after the scan
-    /// phase, report circular dependencies, and produce no output files.
+    /// `--check`: report circular dependencies after the scan, and write nothing.
     pub check: bool,
-    /// The scan keeps each file and each import that the source code has. A
-    /// barrel file does not defer a re-export, and a file that is only
-    /// `module.exports = require(x)` does not redirect its importers to `x`.
-    /// Each of these rewrites removes an edge, so a caller that reads the
-    /// scanned graph (`check`) sets this.
+    /// Turns off the scan-time rewrites that drop edges: barrel deferral and CommonJS redirects.
     pub scan_graph_as_written: bool,
     pub load_tsconfig_json: bool,
     pub(crate) load_package_json: bool,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1275,6 +1275,12 @@ pub struct BundleOptions<'a> {
     /// `bun build --check` / `Bun.build({ check: true })`: stop after the scan
     /// phase, report circular dependencies, and produce no output files.
     pub check: bool,
+    /// The scan keeps each file and each import that the source code has. A
+    /// barrel file does not defer a re-export, and a file that is only
+    /// `module.exports = require(x)` does not redirect its importers to `x`.
+    /// Each of these rewrites removes an edge, so a caller that reads the
+    /// scanned graph (`check`) sets this.
+    pub scan_graph_as_written: bool,
     pub load_tsconfig_json: bool,
     pub(crate) load_package_json: bool,
 
@@ -1498,6 +1504,7 @@ impl<'a> BundleOptions<'a> {
             polyfill_node_globals: self.polyfill_node_globals,
             transform_only: self.transform_only,
             check: self.check,
+            scan_graph_as_written: self.scan_graph_as_written,
             load_tsconfig_json: self.load_tsconfig_json,
             load_package_json: self.load_package_json,
             rewrite_jest_for_tests: self.rewrite_jest_for_tests,
@@ -1748,6 +1755,7 @@ impl<'a> BundleOptions<'a> {
             polyfill_node_globals: false,
             transform_only: false,
             check: false,
+            scan_graph_as_written: false,
             load_tsconfig_json: true,
             load_package_json: true,
             rewrite_jest_for_tests: false,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1272,6 +1272,9 @@ pub struct BundleOptions<'a> {
     pub transform_options: std::sync::Arc<api::TransformOptions>,
     pub(crate) polyfill_node_globals: bool,
     pub transform_only: bool,
+    /// `bun build --check` / `Bun.build({ check: true })`: stop after the scan
+    /// phase, report circular imports, and produce no output files.
+    pub check: bool,
     pub load_tsconfig_json: bool,
     pub(crate) load_package_json: bool,
 
@@ -1494,6 +1497,7 @@ impl<'a> BundleOptions<'a> {
             transform_options: std::sync::Arc::clone(&self.transform_options),
             polyfill_node_globals: self.polyfill_node_globals,
             transform_only: self.transform_only,
+            check: self.check,
             load_tsconfig_json: self.load_tsconfig_json,
             load_package_json: self.load_package_json,
             rewrite_jest_for_tests: self.rewrite_jest_for_tests,
@@ -1743,6 +1747,7 @@ impl<'a> BundleOptions<'a> {
             defines_loaded: false,
             polyfill_node_globals: false,
             transform_only: false,
+            check: false,
             load_tsconfig_json: true,
             load_package_json: true,
             rewrite_jest_for_tests: false,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1273,7 +1273,7 @@ pub struct BundleOptions<'a> {
     pub(crate) polyfill_node_globals: bool,
     pub transform_only: bool,
     /// `bun build --check` / `Bun.build({ check: true })`: stop after the scan
-    /// phase, report circular imports, and produce no output files.
+    /// phase, report circular dependencies, and produce no output files.
     pub check: bool,
     pub load_tsconfig_json: bool,
     pub(crate) load_package_json: bool,

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -199,7 +199,7 @@ pub struct BundlerOptions {
     pub code_splitting: bool,
     pub split_require: bool,
     pub transform_only: bool,
-    /// `--check`: scan the module graph, report circular imports, write nothing.
+    /// `--check`: scan the module graph, report circular dependencies, write nothing.
     pub check: bool,
     pub inline_entrypoint_import_meta_main: bool,
     pub minify_syntax: bool,

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -199,6 +199,8 @@ pub struct BundlerOptions {
     pub code_splitting: bool,
     pub split_require: bool,
     pub transform_only: bool,
+    /// `--check`: scan the module graph, report circular imports, write nothing.
+    pub check: bool,
     pub inline_entrypoint_import_meta_main: bool,
     pub minify_syntax: bool,
     pub minify_whitespace: bool,
@@ -259,6 +261,7 @@ impl Default for BundlerOptions {
             code_splitting: false,
             split_require: true,
             transform_only: false,
+            check: false,
             inline_entrypoint_import_meta_main: false,
             minify_syntax: false,
             minify_whitespace: false,

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -121,6 +121,8 @@ pub mod js_bundler {
         pub(crate) force_node_env: options::ForceNodeEnv,
         pub(crate) code_splitting: bool,
         pub(crate) split_require: bool,
+        /// `check`: see `BundleOptions::check`.
+        pub(crate) check: bool,
         pub(crate) minify: Minify,
         pub(crate) no_macros: bool,
         pub(crate) ignore_dce_annotations: bool,
@@ -189,6 +191,7 @@ pub mod js_bundler {
                 force_node_env: options::ForceNodeEnv::Unspecified,
                 code_splitting: false,
                 split_require: true,
+                check: false,
                 minify: Minify::default(),
                 no_macros: false,
                 ignore_dce_annotations: false,
@@ -1184,6 +1187,10 @@ pub mod js_bundler {
                 this.throw_on_error = flag;
             }
 
+            if let Some(check) = config.get_boolean_loose(global_this, "check")? {
+                this.check = check;
+            }
+
             // Parse metafile option: boolean | string | { json?: string, markdown?: string }
             if let Some(metafile_value) =
                 config.get_own(global_this, &BunString::static_("metafile"))?
@@ -1320,6 +1327,23 @@ pub mod js_bundler {
                 if has_all_html && this.compile.as_ref().is_some_and(|c| !c.assets.is_empty()) {
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "Cannot use compile.assets with target 'browser' for standalone HTML"
+                    )));
+                }
+            }
+
+            if this.check {
+                let conflict = if this.compile.is_some() {
+                    Some("compile")
+                } else if has_out_dir {
+                    Some("outdir")
+                } else if this.metafile {
+                    Some("metafile")
+                } else {
+                    None
+                };
+                if let Some(option) = conflict {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "check writes no files, so it cannot be used with {option}"
                     )));
                 }
             }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1014,6 +1014,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.code_splitting = config.code_splitting;
         transpiler.options.split_require = config.split_require;
         transpiler.options.check = config.check;
+        transpiler.options.scan_graph_as_written = config.check;
         transpiler.options.emit_dce_annotations = config
             .emit_dce_annotations
             .unwrap_or(!config.minify.whitespace);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1013,6 +1013,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         };
         transpiler.options.code_splitting = config.code_splitting;
         transpiler.options.split_require = config.split_require;
+        transpiler.options.check = config.check;
         transpiler.options.emit_dce_annotations = config
             .emit_dce_annotations
             .unwrap_or(!config.minify.whitespace);

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -507,6 +507,9 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
         ),
         parse_param!("--no-bundle                      Transpile file only, do not bundle"),
         parse_param!(
+            "--check                          Resolve and parse every module, report circular imports, and write no files"
+        ),
+        parse_param!(
             "--emit-dce-annotations           Re-emit DCE annotations in bundles. Enabled by default unless --minify-whitespace is passed."
         ),
         parse_param!(
@@ -2654,5 +2657,33 @@ fn parse_build_command_options(
         // happens in build_command.rs once it's known whether --compile
         // produces an executable or a standalone HTML file (browsers do read
         // the comment, so standalone HTML keeps the user's choice).
+    }
+
+    ctx.bundler_options.check = args.flag(b"--check");
+    if ctx.bundler_options.check {
+        let conflict: Option<&str> = if ctx.bundler_options.compile {
+            Some("--compile")
+        } else if ctx.bundler_options.transform_only {
+            Some("--no-bundle")
+        } else if ctx.bundler_options.bake {
+            Some("--app")
+        } else if args.option(b"--outdir").is_some() {
+            Some("--outdir")
+        } else if args.option(b"--outfile").is_some() {
+            Some("--outfile")
+        } else if args.option(b"--metafile").is_some() {
+            Some("--metafile")
+        } else if args.option(b"--metafile-md").is_some() {
+            Some("--metafile-md")
+        } else {
+            None
+        };
+        if let Some(flag) = conflict {
+            Output::err_generic(
+                "--check writes no files, so it cannot be used with {}",
+                (flag,),
+            );
+            Global::crash();
+        }
     }
 }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -507,7 +507,7 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
         ),
         parse_param!("--no-bundle                      Transpile file only, do not bundle"),
         parse_param!(
-            "--check                          Resolve and parse every module, report circular imports, and write no files"
+            "--check                          Resolve and parse every module, report circular dependencies, and write no files"
         ),
         parse_param!(
             "--emit-dce-annotations           Re-emit DCE annotations in bundles. Enabled by default unless --minify-whitespace is passed."

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -445,6 +445,7 @@ impl BuildCommand {
         this_transpiler.options.code_splitting = ctx.bundler_options.code_splitting;
         this_transpiler.options.transform_only = ctx.bundler_options.transform_only;
         this_transpiler.options.check = ctx.bundler_options.check;
+        this_transpiler.options.scan_graph_as_written = ctx.bundler_options.check;
 
         this_transpiler.options.env.behavior = ctx.bundler_options.env_behavior;
         this_transpiler

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -375,6 +375,7 @@ impl BuildCommand {
 
         if ctx.bundler_options.outdir.is_empty()
             && !ctx.bundler_options.compile
+            && !ctx.bundler_options.check
             && fetcher.is_none()
         {
             if this_transpiler.options.entry_points.len() > 1 {
@@ -443,6 +444,7 @@ impl BuildCommand {
         this_transpiler.options.root_dir = src_root_dir.into();
         this_transpiler.options.code_splitting = ctx.bundler_options.code_splitting;
         this_transpiler.options.transform_only = ctx.bundler_options.transform_only;
+        this_transpiler.options.check = ctx.bundler_options.check;
 
         this_transpiler.options.env.behavior = ctx.bundler_options.env_behavior;
         this_transpiler
@@ -687,6 +689,21 @@ impl BuildCommand {
                     exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
                 }
             };
+
+            if ctx.bundler_options.check {
+                bun_core::prettyln!(
+                    "<green>Checked {} module{} in {}ms<r>",
+                    reachable_file_count,
+                    if reachable_file_count == 1 { "" } else { "s" },
+                    (bun_core::time::nano_timestamp() - cli_start_time())
+                        / (bun_core::time::NS_PER_MS as i128)
+                );
+                Output::flush();
+                log_ref.print(std::ptr::from_mut::<bun_core::io::Writer>(
+                    Output::error_writer(),
+                ))?;
+                exit_or_watch(0, ctx.debug.hot_reload == HotReload::Watch);
+            }
 
             // Write metafile if requested
             if let Some(metafile_json) = build_result.metafile.as_deref() {

--- a/test/bundler/bundler_check.test.ts
+++ b/test/bundler/bundler_check.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { readdirSync } from "fs";
+import { mkdirSync, readdirSync, symlinkSync } from "fs";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "path";
 
@@ -152,6 +152,23 @@ describe("bun build --check", () => {
     const result = await run(String(dir), ["build", "./index.ts", "--check"]);
 
     expect(result).toEqual({ stdout: "Checked 3 modules in <time>", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("follows a workspace package that node_modules links to", async () => {
+    using dir = tempDir("build-check-workspace", {
+      "app/index.ts": `import { shared } from "shared";\nexport const app = 1;\nconsole.log(shared);\n`,
+      "shared/package.json": JSON.stringify({ name: "shared", main: "index.ts" }),
+      "shared/index.ts": `import { app } from "../app/index.ts";\nexport const shared = app;\n`,
+    });
+    mkdirSync(join(String(dir), "app", "node_modules"));
+    symlinkSync(join(String(dir), "shared"), join(String(dir), "app", "node_modules", "shared"), "junction");
+
+    const result = await run(String(dir), ["build", "./app/index.ts", "--check"]);
+
+    expect(errorLines(result.stderr)).toEqual([
+      "error: Circular import: app/index.ts -> shared/index.ts -> app/index.ts",
+    ]);
+    expect(result.exitCode).toBe(1);
   });
 
   test.concurrent("follows a re-export that a build would defer", async () => {

--- a/test/bundler/bundler_check.test.ts
+++ b/test/bundler/bundler_check.test.ts
@@ -71,8 +71,7 @@ describe("bun build --check", () => {
   });
 
   test.concurrent("reports a resolve error and a cycle in one run", async () => {
-    // A file with an import that does not resolve stops the scan of its other
-    // imports, so the cycle is in a file that the scan still reaches.
+    // An import that does not resolve stops the scan of its file, so the cycle is in other files.
     using dir = tempDir("build-check-resolve-error", {
       "index.ts": `import "./broken";\nimport "./a";\n`,
       "broken.ts": `import "./missing";\n`,
@@ -191,8 +190,7 @@ describe("bun build --check", () => {
   });
 
   test.concurrent("follows a re-export that a build would defer", async () => {
-    // With "sideEffects": false, a build does not load "./unused" because no file
-    // imports `unused` from the barrel. The program that runs unbundled loads it.
+    // With "sideEffects": false, a build never loads unused.ts. Unbundled code does.
     using dir = tempDir("build-check-barrel", {
       "package.json": JSON.stringify({ name: "app", sideEffects: false }),
       "index.ts": `import { used } from "./barrel";\nconsole.log(used);\n`,

--- a/test/bundler/bundler_check.test.ts
+++ b/test/bundler/bundler_check.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync } from "fs";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "path";
+
+async function run(cwd: string, args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return {
+    stdout: normalizeBunSnapshot(stdout, cwd).replace(/in \d+ms/, "in <time>"),
+    stderr: normalizeBunSnapshot(stderr, cwd),
+    exitCode,
+  };
+}
+
+// Each error line of `bun build --check` output.
+function errorLines(stderr: string) {
+  return stderr.split("\n").filter(line => line.startsWith("error: "));
+}
+
+describe("bun build --check", () => {
+  test.concurrent("reports a cycle with each import in it and writes no files", async () => {
+    using dir = tempDir("build-check-cycle", {
+      "index.ts": `import { a } from "./a";\nconsole.log(a());\n`,
+      "a.ts": `import { b } from "./b";\nexport const a = () => b();\n`,
+      "b.ts": `import { c } from "./c";\nexport const b = () => c();\n`,
+      "c.ts": `import { a } from "./a";\nexport const c = () => a;\n`,
+    });
+    const before = readdirSync(String(dir)).sort();
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(result.stderr).toMatchInlineSnapshot(`
+      "1 | import { b } from "./b";
+                            ^
+      error: Circular import: a.ts -> b.ts -> c.ts -> a.ts
+          at <dir>/a.ts:1:19
+
+      1 | import { c } from "./c";
+                            ^
+      note: b.ts imports c.ts here:
+         at <dir>/b.ts:1:19
+      1 | import { a } from "./a";
+                            ^
+      note: c.ts imports a.ts here:
+         at <dir>/c.ts:1:19"
+    `);
+    expect(result.stdout).toBe("");
+    expect(readdirSync(String(dir)).sort()).toEqual(before);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent("exits 0 and writes no files when there is no cycle", async () => {
+    using dir = tempDir("build-check-ok", {
+      "index.ts": `import { a } from "./a";\nconsole.log(a);\n`,
+      "a.ts": `import { b } from "./b";\nexport const a = b;\n`,
+      "b.ts": `export const b = 1;\n`,
+    });
+    const before = readdirSync(String(dir)).sort();
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(result).toEqual({ stdout: "Checked 3 modules in <time>", stderr: "", exitCode: 0 });
+    expect(readdirSync(String(dir)).sort()).toEqual(before);
+  });
+
+  test.concurrent("follows export-from, side-effect imports, and require()", async () => {
+    using dir = tempDir("build-check-kinds", {
+      "index.ts": `import "./reexport";\nimport "./bare";\nrequire("./cjs.js");\n`,
+      "reexport.ts": `export { x } from "./reexport-back";\n`,
+      "reexport-back.ts": `import "./reexport";\nexport const x = 1;\n`,
+      "bare.ts": `import "./bare-back";\n`,
+      "bare-back.ts": `import "./bare";\n`,
+      "cjs.js": `module.exports = require("./cjs-back.js");\n`,
+      "cjs-back.js": `require("./cjs.js");\nmodule.exports = 1;\n`,
+    });
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(errorLines(result.stderr)).toEqual([
+      "error: Circular import: reexport.ts -> reexport-back.ts -> reexport.ts",
+      "error: Circular import: bare.ts -> bare-back.ts -> bare.ts",
+      "error: Circular import: cjs.js -> cjs-back.js -> cjs.js",
+    ]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent("reports a file that imports itself", async () => {
+    using dir = tempDir("build-check-self", {
+      "index.ts": `import "./self";\n`,
+      "self.ts": `import "./self";\nexport const x = 1;\n`,
+    });
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(errorLines(result.stderr)).toEqual(["error: Circular import: self.ts -> self.ts"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent("skips type-only imports, import(), and import defer", async () => {
+    using dir = tempDir("build-check-skip", {
+      "index.ts": `import { a } from "./a";\nconsole.log(a);\n`,
+      "a.ts": [
+        `import type { T } from "./type-only";`,
+        `import { U } from "./used-as-type";`,
+        `export type { V } from "./export-type";`,
+        `import defer * as deferred from "./deferred";`,
+        `export const a: T | U = 1;`,
+        `export const load = () => import("./lazy");`,
+        `export const read = () => deferred.d;`,
+      ].join("\n"),
+      "type-only.ts": `import { a } from "./a";\nexport type T = typeof a;\n`,
+      "used-as-type.ts": `import { a } from "./a";\nexport type U = typeof a;\n`,
+      "export-type.ts": `import { a } from "./a";\nexport type V = typeof a;\n`,
+      "lazy.ts": `import { a } from "./a";\nexport default a;\n`,
+      "deferred.ts": `import { a } from "./a";\nexport const d = a;\n`,
+    });
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(result).toEqual({ stdout: "Checked 4 modules in <time>", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("reports a cycle once when several entry points reach it", async () => {
+    using dir = tempDir("build-check-entries", {
+      "one.ts": `import "./a";\n`,
+      "two.ts": `import "./b";\n`,
+      "a.ts": `import "./b";\n`,
+      "b.ts": `import "./a";\n`,
+    });
+
+    const result = await run(String(dir), ["build", "./one.ts", "./two.ts", "--check"]);
+
+    expect(errorLines(result.stderr)).toEqual(["error: Circular import: a.ts -> b.ts -> a.ts"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent("skips cycles inside node_modules", async () => {
+    using dir = tempDir("build-check-node-modules", {
+      "index.ts": `import { x } from "pkg";\nconsole.log(x);\n`,
+      "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "index.js" }),
+      "node_modules/pkg/index.js": `export { x } from "./other.js";\n`,
+      "node_modules/pkg/other.js": `import "./index.js";\nexport const x = 1;\n`,
+    });
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(result).toEqual({ stdout: "Checked 3 modules in <time>", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("follows a re-export that a build would defer", async () => {
+    // With "sideEffects": false, a build does not load "./unused" because no file
+    // imports `unused` from the barrel. The program that runs unbundled loads it.
+    using dir = tempDir("build-check-barrel", {
+      "package.json": JSON.stringify({ name: "app", sideEffects: false }),
+      "index.ts": `import { used } from "./barrel";\nconsole.log(used);\n`,
+      "barrel.ts": `export { used } from "./used";\nexport { unused } from "./unused";\n`,
+      "used.ts": `export const used = 1;\n`,
+      "unused.ts": `import { used } from "./barrel";\nexport const unused = used;\n`,
+    });
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(errorLines(result.stderr)).toEqual(["error: Circular import: barrel.ts -> unused.ts -> barrel.ts"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent.each(["--outdir=out", "--outfile=out.js", "--metafile=meta.json", "--compile", "--no-bundle"])(
+    "rejects %s",
+    async flag => {
+      using dir = tempDir("build-check-conflict", {
+        "index.ts": `console.log(1);\n`,
+      });
+      const name = flag.split("=")[0];
+
+      const result = await run(String(dir), ["build", "./index.ts", "--check", flag]);
+
+      expect(result).toEqual({
+        stdout: "",
+        stderr: `error: --check writes no files, so it cannot be used with ${name}`,
+        exitCode: 1,
+      });
+      expect(readdirSync(String(dir))).toEqual(["index.ts"]);
+    },
+  );
+});
+
+describe("Bun.build({ check: true })", () => {
+  const files = {
+    "index.ts": `import { a } from "./a";\nconsole.log(a());\n`,
+    "a.ts": `import { b } from "./b";\nexport const a = () => b();\n`,
+    "b.ts": `import { a } from "./a";\nexport const b = () => a;\n`,
+  };
+
+  test.concurrent("returns the cycle in logs", async () => {
+    using dir = tempDir("build-check-api", {
+      ...files,
+      "build.ts": `
+        const result = await Bun.build({ entrypoints: ["./index.ts"], check: true, throw: false });
+        console.log(JSON.stringify({
+          success: result.success,
+          outputs: result.outputs.length,
+          logs: result.logs.map(log => ({
+            level: log.level,
+            message: log.message,
+            file: log.position?.file.replaceAll("\\\\", "/").split("/").pop(),
+            line: log.position?.line,
+            column: log.position?.column,
+          })),
+        }));
+      `,
+    });
+
+    const result = await run(String(dir), ["build.ts"]);
+
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: false,
+      outputs: 0,
+      logs: [{ level: "error", message: "Circular import: a.ts -> b.ts -> a.ts", file: "a.ts", line: 1, column: 19 }],
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.concurrent("rejects when throw is not false", async () => {
+    using dir = tempDir("build-check-api-throw", {
+      ...files,
+      "build.ts": `
+        try {
+          await Bun.build({ entrypoints: ["./index.ts"], check: true });
+          console.log("resolved");
+        } catch (error) {
+          console.log(error.constructor.name, error.errors.map(e => e.message).join("|"));
+        }
+      `,
+    });
+
+    const result = await run(String(dir), ["build.ts"]);
+
+    expect(result).toEqual({
+      stdout: "AggregateError Circular import: a.ts -> b.ts -> a.ts",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("succeeds with no outputs when there is no cycle", async () => {
+    using dir = tempDir("build-check-api-ok", {
+      "index.ts": `import { a } from "./a";\nconsole.log(a);\n`,
+      "a.ts": `export const a = 1;\n`,
+    });
+
+    const result = await Bun.build({ entrypoints: [join(String(dir), "index.ts")], check: true });
+
+    expect({ success: result.success, outputs: result.outputs.length, logs: result.logs.length }).toEqual({
+      success: true,
+      outputs: 0,
+      logs: 0,
+    });
+    expect(readdirSync(String(dir)).sort()).toEqual(["a.ts", "index.ts"]);
+  });
+
+  test.each(["outdir", "metafile", "compile"])("throws with %s", async name => {
+    using dir = tempDir("build-check-api-conflict", { "index.ts": `console.log(1);\n` });
+    const out = join(String(dir), "out");
+    const extra = { outdir: { outdir: out }, metafile: { metafile: true }, compile: { compile: { outfile: out } } }[
+      name
+    ];
+
+    expect(() => Bun.build({ entrypoints: [join(String(dir), "index.ts")], check: true, ...extra })).toThrow(
+      `check writes no files, so it cannot be used with ${name}`,
+    );
+    expect(readdirSync(String(dir))).toEqual(["index.ts"]);
+  });
+});

--- a/test/bundler/bundler_check.test.ts
+++ b/test/bundler/bundler_check.test.ts
@@ -70,6 +70,25 @@ describe("bun build --check", () => {
     expect(readdirSync(String(dir)).sort()).toEqual(before);
   });
 
+  test.concurrent("reports a resolve error and a cycle in one run", async () => {
+    // A file with an import that does not resolve stops the scan of its other
+    // imports, so the cycle is in a file that the scan still reaches.
+    using dir = tempDir("build-check-resolve-error", {
+      "index.ts": `import "./broken";\nimport "./a";\n`,
+      "broken.ts": `import "./missing";\n`,
+      "a.ts": `import "./b";\n`,
+      "b.ts": `import "./a";\n`,
+    });
+
+    const result = await run(String(dir), ["build", "./index.ts", "--check"]);
+
+    expect(errorLines(result.stderr)).toEqual([
+      `error: Could not resolve: "./missing"`,
+      "error: Circular dependency: a.ts -> b.ts -> a.ts",
+    ]);
+    expect(result.exitCode).toBe(1);
+  });
+
   test.concurrent("follows export-from, side-effect imports, and require()", async () => {
     using dir = tempDir("build-check-kinds", {
       "index.ts": `import "./reexport";\nimport "./bare";\nrequire("./cjs.js");\n`,

--- a/test/bundler/bundler_check.test.ts
+++ b/test/bundler/bundler_check.test.ts
@@ -39,7 +39,7 @@ describe("bun build --check", () => {
     expect(result.stderr).toMatchInlineSnapshot(`
       "1 | import { b } from "./b";
                             ^
-      error: Circular import: a.ts -> b.ts -> c.ts -> a.ts
+      error: Circular dependency: a.ts -> b.ts -> c.ts -> a.ts
           at <dir>/a.ts:1:19
 
       1 | import { c } from "./c";
@@ -84,9 +84,9 @@ describe("bun build --check", () => {
     const result = await run(String(dir), ["build", "./index.ts", "--check"]);
 
     expect(errorLines(result.stderr)).toEqual([
-      "error: Circular import: reexport.ts -> reexport-back.ts -> reexport.ts",
-      "error: Circular import: bare.ts -> bare-back.ts -> bare.ts",
-      "error: Circular import: cjs.js -> cjs-back.js -> cjs.js",
+      "error: Circular dependency: reexport.ts -> reexport-back.ts -> reexport.ts",
+      "error: Circular dependency: bare.ts -> bare-back.ts -> bare.ts",
+      "error: Circular dependency: cjs.js -> cjs-back.js -> cjs.js",
     ]);
     expect(result.exitCode).toBe(1);
   });
@@ -99,7 +99,7 @@ describe("bun build --check", () => {
 
     const result = await run(String(dir), ["build", "./index.ts", "--check"]);
 
-    expect(errorLines(result.stderr)).toEqual(["error: Circular import: self.ts -> self.ts"]);
+    expect(errorLines(result.stderr)).toEqual(["error: Circular dependency: self.ts -> self.ts"]);
     expect(result.exitCode).toBe(1);
   });
 
@@ -137,7 +137,7 @@ describe("bun build --check", () => {
 
     const result = await run(String(dir), ["build", "./one.ts", "./two.ts", "--check"]);
 
-    expect(errorLines(result.stderr)).toEqual(["error: Circular import: a.ts -> b.ts -> a.ts"]);
+    expect(errorLines(result.stderr)).toEqual(["error: Circular dependency: a.ts -> b.ts -> a.ts"]);
     expect(result.exitCode).toBe(1);
   });
 
@@ -166,7 +166,7 @@ describe("bun build --check", () => {
     const result = await run(String(dir), ["build", "./app/index.ts", "--check"]);
 
     expect(errorLines(result.stderr)).toEqual([
-      "error: Circular import: app/index.ts -> shared/index.ts -> app/index.ts",
+      "error: Circular dependency: app/index.ts -> shared/index.ts -> app/index.ts",
     ]);
     expect(result.exitCode).toBe(1);
   });
@@ -184,7 +184,7 @@ describe("bun build --check", () => {
 
     const result = await run(String(dir), ["build", "./index.ts", "--check"]);
 
-    expect(errorLines(result.stderr)).toEqual(["error: Circular import: barrel.ts -> unused.ts -> barrel.ts"]);
+    expect(errorLines(result.stderr)).toEqual(["error: Circular dependency: barrel.ts -> unused.ts -> barrel.ts"]);
     expect(result.exitCode).toBe(1);
   });
 
@@ -240,7 +240,9 @@ describe("Bun.build({ check: true })", () => {
     expect(JSON.parse(result.stdout)).toEqual({
       success: false,
       outputs: 0,
-      logs: [{ level: "error", message: "Circular import: a.ts -> b.ts -> a.ts", file: "a.ts", line: 1, column: 19 }],
+      logs: [
+        { level: "error", message: "Circular dependency: a.ts -> b.ts -> a.ts", file: "a.ts", line: 1, column: 19 },
+      ],
     });
     expect(result.exitCode).toBe(0);
   });
@@ -261,7 +263,7 @@ describe("Bun.build({ check: true })", () => {
     const result = await run(String(dir), ["build.ts"]);
 
     expect(result).toEqual({
-      stdout: "AggregateError Circular import: a.ts -> b.ts -> a.ts",
+      stdout: "AggregateError Circular dependency: a.ts -> b.ts -> a.ts",
       stderr: "",
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem
- Bun cannot list the circular dependencies of a project. Users run dpdm or madge. Their own resolver can disagree with Bun about tsconfig `paths`, package `exports`, and plugins.
- A cycle lets a module read a binding before it is initialized. For `let`, `const`, and `class`, this throws a `ReferenceError`.

### Fix
- `bun build --check` and `Bun.build({ check: true })` stop after the scan phase. `src/bundler/circular_imports.rs` walks the import records depth-first from the entry points. It logs one error for each import back to a file on the path. Nothing is written. The CLI exits with code 1.
- The walk follows `import`, `export ... from`, and `require()`. It skips type-only imports, `import()`, `import defer`, and `node_modules`. Rolldown's `checks.circularDependency` uses the same edges and walk.
- A check sets the new `scan_graph_as_written` option. It turns off the scan-time rewrites that hide files: barrel deferral and CommonJS redirects.
- Verified: `test/bundler/bundler_check.test.ts` (21 tests, all fail on the released bun). Also `bundler_barrel`, `cli`, `bun-build-api`, and `metafile`.

### Background
- The scan phase resolves and parses each reachable file. Each import becomes a record with a kind, a source range, and a target file.
- The link and print phases produce the output files. A check skips them.
- A barrel file only re-exports. With `"sideEffects": false`, a build skips a re-export that nothing uses. Unbundled code loads it.
- A CommonJS redirect is a file that is only `module.exports = require(x)`. A build points its importers at `x`.

<details><summary>Notes</summary>

Output for a cycle of two files:

```
1 | import { b } from "./b";
                      ^
error: Circular dependency: src/a.ts -> src/b.ts -> src/a.ts
    at /project/src/a.ts:1:19

1 | import { a } from "./a";
                      ^
note: src/b.ts imports src/a.ts here:
   at /project/src/b.ts:1:19
```

- The error points at the first import of the cycle. A note points at each other import. The top-level await error prints its import chain the same way.
- The message text is the one Rollup uses (`Circular dependency: a.js -> b.js -> a.js`).
- The walk uses an explicit stack. Each file is expanded once, so the number of errors is at most the number of imports. The order follows the entry points and the import order in each file.
- The check also reports resolve and parse errors. The walk runs after them, so one run reports both. A file with an import that does not resolve stops the scan of its other imports.
- The check does not run the link step, so it does not report link errors, such as an import of a name that a module does not export. The docs say that a build can fail after the check passes. In a check, the link step would see a graph without barrel deferral, so its errors would not match the errors of a build.
- A fixture with one cycle for each import kind: Rolldown and `--check` report the same cycles in the same order. Rolldown also reports a cycle inside `node_modules`.
- A 60-file graph with millions of elementary cycles: `--check` reports 8 cycles in about 250 ms on a debug build. Rolldown reports the same 8.
- `scripts/build.ts` in this repo: `dpdm -T` and `bun build --check` report the same 3 cycles.
- A workspace package is checked. The resolver follows the link in `node_modules` to the directory of the package. This also works with a junction on Windows.
- `--check` rejects the options that name an output: `--outdir`, `--outfile`, `--metafile`, `--metafile-md`, `--compile`, `--no-bundle`, and `--app`. `Bun.build` rejects `outdir`, `metafile`, and `compile`.
- `--check --watch` checks again after each change.
- Other tools: dpdm, madge, dependency-cruiser, eslint-plugin-import (`import/no-cycle`), Biome (`noImportCycles`), and oxlint. esbuild, Turbopack, Parcel, and Deno have no module cycle check.

Not in this PR:
- A way to allow a known cycle. dpdm has `// @dpdm-ignore` for this.
- Barrel deferral for files in `node_modules`. The walk does not enter these files, so a large `"sideEffects": false` package costs parse time and gives nothing. This needs a fix in `un_defer_record` first, because it also clears `IS_UNUSED` on the imports that TypeScript removes.
- `bun test --changed` has the same barrel gap. It can set `scan_graph_as_written`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_check.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_check.test.ts:
34 |     });
35 |     const before = readdirSync(String(dir)).sort();
36 | 
37 |     const result = await run(String(dir), ["build", "./index.ts", "--check"]);
38 | 
39 |     expect(result.stderr).toMatchInlineSnapshot(`
                               ^
error: expect(received).toMatchInlineSnapshot(expected)

- 
- "1 | import { b } from "./b";
-                       ^
- error: Circular dependency: a.ts -> b.ts -> c.ts -> a.ts
-     at <dir>/a.ts:1:19
- 
- 1 | import { c } from "./c";
-                       ^
- note: b.ts imports c.ts here:
-    at <dir>/b.ts:1:19
- 1 | import { a } from "./a";
-                       ^
- note: c.ts imports a.ts here:
-    at <dir>/c.ts:1:19"
- 
+ ""

- Expected  - 15
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/bundler_check.test.ts:39:27)
(fail) bun build --check > reports a cycle with each import in it and writes no files [260.86ms]
115 |       "self.ts": `import "./self";\nexpor
... (truncated)

release without fix: 21 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/bundler/bundler_check.test.ts:
79 |       "b.ts": `import "./a";\n`,
80 |     });
81 | 
82 |     const result = await run(String(dir), ["build", "./index.ts", "--check"]);
83 | 
84 |     expect(errorLines(result.stderr)).toEqual([
                                           ^
error: expect(received).toEqual(expected)

  [
    "error: Could not resolve: "./missing"",
-   "error: Circular dependency: a.ts -> b.ts -> a.ts",
  ]

- Expected  - 1
+ Received  + 0

      at <anonymous> (/workspace/bun/test/bundler/bundler_check.test.ts:84:39)
153 |       "b.ts": `import "./a";\n`,
154 |     });
155 | 
156 |     const result = await run(String(dir), ["build", "./one.ts", "./two.ts", "--check"]);
157 | 
158 |     expect(errorLines(result.stderr)).toEqual(["error: Circular dependency: a.ts -> b.ts -> a.ts"]);
                                            ^
error: expect(received).toEqual(expected)

  [
-   "error: Circular dependency: a.ts -> b.ts -> a.ts",
+   "error: Must use --outdir when specifying more than one entry point.",
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/bundler_check.test.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_check.test.ts
bun test v1.4.1 (a6c4cc276)

test/bundler/bundler_check.test.ts:
(pass) bun build --check > reports a cycle with each import in it and writes no files [330.42ms]
(pass) bun build --check > follows export-from, side-effect imports, and require() [295.14ms]
(pass) bun build --check > exits 0 and writes no files when there is no cycle [347.34ms]
(pass) bun build --check > reports a resolve error and a cycle in one run [350.57ms]
(pass) bun build --check > reports a file that imports itself [343.47ms]
(pass) bun build --check > skips type-only imports, import(), and import defer [266.17ms]
(pass) bun build --check > skips cycles inside node_modules [207.91ms]
(pass) bun build --check > follows a re-export that a build would defer [179.34ms]
(pass) bun build --check > reports a cycle once when several entry points reach it [260.91ms]
(pass) bun build --check > follows a workspace package that node_modules links to [261.41ms]
(pass) bun build --check > rejects --metafile=meta.json [114.69ms]
(pass) bun build
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5d1a546e84
  features     baseline

23 deps, 131 codegen, 1172 objects in 646ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 25 installs across 62 packages (no changes) [11.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 1 install across 2 packages (no changes) [4.00ms]
[5/1244] gen .bind.ts → GeneratedBindings.cpp
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (a6c4cc276)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Pro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/index.mdx                       |  58 +++++
 docs/snippets/cli/build.mdx                  |   5 +
 packages/bun-types/bun.d.ts                  |  24 ++
 src/bundler/ParseTask.rs                     |   6 +-
 src/bundler/bundle_v2.rs                     |  36 ++-
 src/bundler/circular_imports.rs              | 167 ++++++++++++++
 src/bundler/lib.rs                           |   1 +
 src/bundler/options.rs                       |   8 +
 src/options_types/context.rs                 |   3 +
 src/runtime/api/JSBundler.rs                 |  24 ++
 src/runtime/api/js_bundle_completion_task.rs |   2 +
 src/runtime/cli/Arguments.rs                 |  31 +++
 src/runtime/cli/build_command.rs             |  18 ++
 test/bundler/bundler_check.test.ts           | 317 +++++++++++++++++++++++++++
 14 files changed, 693 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
docs/bundler/index.mdx                            5      6     25
docs/snippets/cli/build.mdx                       2      2     25
packages/bun-types/bun.d.ts                       4      5     26
src/bundler/ParseTask.rs                          2      3     25
src/bundler/bundle_v2.rs                         13     11     25
src/bundler/circular_imports.rs                   6     18     25
src/bundler/lib.rs                                1      2     25
src/bundler/options.rs                            4      7     25
src/options_types/context.rs                      1      2     25
src/runtime/api/JSBundler.rs                      5      4     25
src/runtime/api/js_bundle_completion_task.rs      1      3     25
src/runtime/cli/Arguments.rs                      5      3     25
src/runtime/cli/build_command.rs                  4      4     25
test/bundler/bundler_check.test.ts                2     12     25
```

</details>

<!-- robobun:evidence:end -->