### PR TITLE
test: keep JSC's MarkedBlock warm-up out of the structuredClone RSS test

### DIFF
--- a/test/js/web/structured-clone-fastpath.test.ts
+++ b/test/js/web/structured-clone-fastpath.test.ts
@@ -92,17 +92,27 @@ describe("Structured Clone Fast Path", () => {
   test("structuredClone should use a constant amount of memory for simple object inputs", () => {
     // Create a 512KB string to test fast path
     const largeValue = { property: Buffer.alloc(512 * 1024, "a").toString() };
+    const cloneMany = (count: number) => {
+      for (let i = 0; i < count; i++) {
+        structuredClone(largeValue);
+      }
+    };
+    // Keep one clone in 101 alive through the GC. The 10000 measured clones then fit in the cells
+    // of the 10000 that died, so the heap takes no new MarkedBlocks. A new block can start a refill
+    // of JSC's warm-up supply (useWarmUpMarkedBlocks), which makes up to 32 blocks resident: 2 MiB
+    // on Linux arm64, where a MarkedBlock is 64 KiB. The warm-up also gets cloneMany compiled.
+    const kept: object[] = [];
     for (let i = 0; i < 100; i++) {
-      structuredClone(largeValue);
+      kept.push(structuredClone(largeValue));
+      cloneMany(100);
     }
     Bun.gc(true);
     const rss1 = rss();
-    for (let i = 0; i < 10000; i++) {
-      structuredClone(largeValue);
-    }
+    cloneMany(10000);
     Bun.gc(true);
     const rss2 = rss();
     const delta = rss2 - rss1;
+    expect(kept).toHaveLength(100);
     // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
     // retention inflate RSS even when nothing is leaking.
     expect(delta).toBeLessThan(isASAN ? 1024 * 1024 * 400 : 1024 * 1024);


### PR DESCRIPTION
### Problem
- `test/js/web/structured-clone-fastpath.test.ts` fails on Linux aarch64 in the parallel batch: "structuredClone should use a constant amount of memory for simple object inputs", `Expected: < 1048576`, `Received: 1572864` (build 109723).
- The WebKit upgrade in #41083 added a warm-up supply of MarkedBlocks. A helper thread keeps up to 32 blocks resident and refills it when fewer than 8 are left. A MarkedBlock is 64 KiB on Linux arm64 (`max(16 KB, CeilingOnPageSize)`), so one refill makes up to 2 MiB resident. A refill in the measured loop adds 1 to 1.5 MiB.

### Fix
- The test keeps one clone in 101 of a first batch alive through the GC. The 10000 measured clones fit in the cells of the 10000 that died. So the loop takes no new blocks and cannot start a refill.
- The loop runs in a helper that JSC compiles during the first batch. The clone count and the bound do not change.
- Verified on x64 with a 2 MiB supply (`BUN_JSC_warmUpMarkedBlockCount=128`). Run alone, the old test fails 8 of 8 (+1.7 to 2.0 MiB). The new test passes 10 of 10 (+0 to 100 KiB). A retained 100-byte array per clone still fails it. `bun bd test` passes.

### Background
- A MarkedBlock is a fixed-size chunk of the JSC heap that holds cells of one size.
- `Bun.gc(true)` frees only blocks with no live cells. New cells go into the free cells of the other blocks first.
- The supply (`useWarmUpMarkedBlocks`, from upstream WebKit) moves the page faults of new blocks to a helper thread.

<details><summary>Notes</summary>

**Sightings.** I scanned the annotations of builds 108400 to 109731. The test failed in the batch 46 times in 44 builds, from build 109059 (2026-09-01 14:48 UTC) to 109723. All runs were on Linux aarch64: 27 on debian 13, 18 on ubuntu 25.04, 1 on alpine 3.23. The received values are 1048576 to 1572864. The 659 builds before 109059 have no failure. #41083 merged at 10:01 UTC on 2026-09-01, and all 44 builds have it in their base. Until #41204 the runner ran the file again alone, where it passed, so the earlier runs show as flaky.

**Why only in the batch.** The supply level at the start of the test depends on what ran before it in the same worker. On x64 with a 2 MiB supply, a run of the whole file puts the refill in the string test, which has an 8 MiB bound, and the simple-object test passes. Run alone, the simple-object test fails.

**Why only arm64.** On x64 and darwin a MarkedBlock is 16 KiB, so a refill is at most 512 KiB. The measured loop takes about 30 blocks there, about as many as a refill adds, so the supply changes the old delta very little.

**Not the cause.** e7e8fe0f12 (#36545) changes only objects with no properties. This test clones an object with one property.

**Precise RSS delta of the measured loop, x64 release (KiB, 4 to 10 runs each).** From `/proc/<pid>/smaps`. `/proc/self/stat` (what `process.memoryUsage.rss()` reads) moves in steps of `max(32, 2 * CPUs)` pages: 1 MiB on the 128-CPU machine I used, 128 KiB on the 4-vCPU CI hosts.

| test | supply | whole file | this test alone |
| --- | --- | --- | --- |
| old | 32 x 16 KiB (x64 default) | 250 to 530 | 400 to 840 |
| old | 128 x 16 KiB (2 MiB) | 4 to 52 | 1690 to 1990 |
| new | 32 x 16 KiB | 0 to 44 | 28 to 88 |
| new | 128 x 16 KiB | 0 to 36 | 36 to 96 |

With `BUN_JSC_useWarmUpMarkedBlocks=0` the old test alone is 610 to 670 KiB: most of the old delta on x64 is new blocks, which the new test does not take.

**Other checks.**
- In a serial run with `--isolate` after 10 or 57 files from the same batch, the new delta is -12 to 36 KiB.
- The new test with the aarch64 release binary under qemu-user: -32 to 40 KiB.
- Cost: 10000 more clones, about 3 ms in a release build and 0.7 s in a debug ASAN build.
- The string-input test is unchanged. A refill fits in its 8 MiB bound.
- The patch applies on top of #41276, which edits other tests in this file.

**For the WebKit fork.** `warmUpMarkedBlockCount` counts blocks. oven-sh/WebKit#553 describes the supply as 512 KiB, which holds where a MarkedBlock is 16 KiB. On Linux arm64 it is 2 MiB.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/structured-clone-fastpath.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/structured-clone-fastpath.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/web/structured-clone-fastpath.test.ts:
(pass) Structured Clone Fast Path > structuredClone should work with empty object [15.70ms]
(pass) Structured Clone Fast Path > structuredClone({}) result is spreadable after adding a property [4.83ms]
(pass) Structured Clone Fast Path > structuredClone should work with empty string [1.23ms]
(pass) Structured Clone Fast Path > structuredCloneDeOptimization [1.91ms]
(pass) Structured Clone Fast Path > structuredCloneDeOptimization [0.22ms]
(pass) Structured Clone Fast Path > structuredCloneDeOptimization [0.56ms]
(pass) Structured Clone Fast Path > structuredCloneDeOptimization [0.20ms]
(pass) Structured Clone Fast Path > structuredCloneDeOptimization [0.34ms]
(pass) Structured Clone Fast Path > structuredClone should use a constant amount of memory for string inputs [267.13ms]
(pass) Structured Clone Fast Path > structuredClone should use a constant amount of memory for simple object inputs [1391.90ms]
(pass) Structured Clone Fast Path > structuredClone should work with empty array [2.42ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of numbers [1.74ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of strings [1.59ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of mixed primitives [1.84ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of special numbers [2.85ms]
(pass) Structured Clone Fast Path > structuredClone should work with large array of numbers [27.14ms]
(pass) Structured Clone Fast Path > structuredClone should work with array of simple objects [2.14ms]
(pass) Structured Clone Fast Path > structuredClone should work with large array of same-shape objects [18.46ms]
(pass) Structured Clone Fast Path > structuredClone should work wit
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/structured-clone-fastpath.test.ts | 18 ++++++++++++++----
 1 file changed, 14 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/web/structured-clone-fastpath.test.ts      5      7     19
```

</details>

<!-- robobun:evidence:end -->