### PR TITLE
console: do not call inspect.custom on a prototype object

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2132,10 +2132,7 @@ pub mod formatter {
                         // Like util.inspect, skip the hook on a prototype object. The
                         // hook expects an instance, and a native hook throws
                         // ERR_INVALID_THIS for the prototype.
-                        let is_prototype = jsc::from_js_host_call_generic(global_this, || {
-                            JSC__JSValue__isPrototypeObject(global_this, value)
-                        })?;
-                        if !is_prototype {
+                        if !crate::cpp::JSC__JSValue__isPrototypeObject(global_this, value)? {
                             return Ok(TagResult {
                                 tag: TagPayload::CustomFormattedObject(CustomFormattedObject {
                                     function: callback_value,
@@ -3197,9 +3194,6 @@ pub mod formatter {
             max_depth: u32,
             colors: bool,
         ) -> JSValue;
-        /// C++ helper (`UtilInspect.cpp`). True when `value` is the `prototype`
-        /// of its own `constructor` data property. Can throw.
-        safe fn JSC__JSValue__isPrototypeObject(global: &JSGlobalObject, value: JSValue) -> bool;
     }
 
     // ───────────────────────────────────────────────────────────────────────

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2129,10 +2129,8 @@ pub mod formatter {
                         });
                     }
                     Ok(Some(callback_value)) if callback_value.is_callable() => {
-                        // Like util.inspect, skip the hook on a prototype object. The
-                        // hook expects an instance, and a native hook throws
-                        // ERR_INVALID_THIS for the prototype.
-                        if !crate::cpp::JSC__JSValue__isPrototypeObject(global_this, value)? {
+                        // Like util.inspect: a hook expects an instance, not the prototype.
+                        if !crate::cpp::JSC__JSValue__isConstructorPrototype(global_this, value)? {
                             return Ok(TagResult {
                                 tag: TagPayload::CustomFormattedObject(CustomFormattedObject {
                                     function: callback_value,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2129,13 +2129,21 @@ pub mod formatter {
                         });
                     }
                     Ok(Some(callback_value)) if callback_value.is_callable() => {
-                        return Ok(TagResult {
-                            tag: TagPayload::CustomFormattedObject(CustomFormattedObject {
-                                function: callback_value,
-                                this: value,
-                            }),
-                            cell: js_type,
-                        });
+                        // Like util.inspect, skip the hook on a prototype object. The
+                        // hook expects an instance, and a native hook throws
+                        // ERR_INVALID_THIS for the prototype.
+                        let is_prototype = jsc::from_js_host_call_generic(global_this, || {
+                            JSC__JSValue__isPrototypeObject(global_this, value)
+                        })?;
+                        if !is_prototype {
+                            return Ok(TagResult {
+                                tag: TagPayload::CustomFormattedObject(CustomFormattedObject {
+                                    function: callback_value,
+                                    this: value,
+                                }),
+                                cell: js_type,
+                            });
+                        }
                     }
                     _ => {}
                 }
@@ -3189,6 +3197,9 @@ pub mod formatter {
             max_depth: u32,
             colors: bool,
         ) -> JSValue;
+        /// C++ helper (`UtilInspect.cpp`). True when `value` is the `prototype`
+        /// of its own `constructor` data property. Can throw.
+        safe fn JSC__JSValue__isPrototypeObject(global: &JSGlobalObject, value: JSValue) -> bool;
     }
 
     // ───────────────────────────────────────────────────────────────────────

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -70,7 +70,7 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
 
 // util.inspect does not call a custom inspect function on a prototype object. It finds one with
 // `Object.getOwnPropertyDescriptor(value, "constructor")?.value?.prototype === value`.
-extern "C" bool JSC__JSValue__isPrototypeObject(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
+extern "C" [[ZIG_EXPORT(check_slow)]] bool JSC__JSValue__isPrototypeObject(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
 {
     JSValue value = JSValue::decode(encodedValue);
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -68,6 +68,33 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
     RELEASE_AND_RETURN(scope, JSValue::encode(inspectRet));
 }
 
+// util.inspect does not call a custom inspect function on a prototype object. It finds one with
+// `Object.getOwnPropertyDescriptor(value, "constructor")?.value?.prototype === value`.
+extern "C" bool JSC__JSValue__isPrototypeObject(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
+{
+    JSValue value = JSValue::decode(encodedValue);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* object = value.getObject();
+    if (!object)
+        return false;
+
+    PropertyDescriptor descriptor;
+    bool hasConstructor = object->getOwnPropertyDescriptor(globalObject, vm.propertyNames->constructor, descriptor);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!hasConstructor)
+        return false;
+
+    JSValue constructor = descriptor.value();
+    if (!constructor || constructor.isUndefinedOrNull())
+        return false;
+
+    JSValue prototype = constructor.get(globalObject, vm.propertyNames->prototype);
+    RETURN_IF_EXCEPTION(scope, false);
+    return prototype == value;
+}
+
 // Port of V8's `internalBinding('util').getOwnNonIndexProperties(object, filter)` used by
 // util.inspect and the REPL completer: own keys minus array indices, without materializing
 // a name (or descriptor) per element the way Object.getOwnPropertyNames() on an array would.

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -68,9 +68,8 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
     RELEASE_AND_RETURN(scope, JSValue::encode(inspectRet));
 }
 
-// util.inspect does not call a custom inspect function on a prototype object. It finds one with
-// `Object.getOwnPropertyDescriptor(value, "constructor")?.value?.prototype === value`.
-extern "C" [[ZIG_EXPORT(check_slow)]] bool JSC__JSValue__isPrototypeObject(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
+// Node's check, from formatValue: `Object.getOwnPropertyDescriptor(value, "constructor")?.value?.prototype === value`.
+extern "C" [[ZIG_EXPORT(check_slow)]] bool JSC__JSValue__isConstructorPrototype(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
 {
     JSValue value = JSValue::decode(encodedValue);
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
@@ -267,17 +267,10 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformanceEntryPrototypeFunction_inspectCustom, (JSG
     if (depth < 0 || !entry)
         return JSValue::encode(thisValue);
 
-    // util.inspect skips the hook on a prototype object (`obj.constructor.prototype === obj`),
-    // but console.log / Bun.inspect call it, and toJSON below is brand-checked. On the WebCore
-    // prototypes `constructor` is a custom getter, so this has to be a [[Get]], not an own-value check.
     JSValue constructor = entry->get(lexicalGlobalObject, vm.propertyNames->constructor);
     RETURN_IF_EXCEPTION(throwScope, {});
     JSValue constructorName = jsUndefined();
     if (constructor.isObject()) {
-        JSValue prototype = constructor.get(lexicalGlobalObject, vm.propertyNames->prototype);
-        RETURN_IF_EXCEPTION(throwScope, {});
-        if (prototype == thisValue)
-            return JSValue::encode(thisValue);
         constructorName = constructor.get(lexicalGlobalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(throwScope, {});
     }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -33,6 +33,32 @@ it("prototype", () => {
   Bun.gc(true);
 });
 
+// The inspect.custom of CompressionStream throws ERR_INVALID_THIS for its prototype. Like
+// util.inspect, console.log and the reportError printer must not call it for a prototype.
+it("console.log and reportError format a prototype whose class has a native inspect.custom", async () => {
+  const code = `
+    console.log(CompressionStream.prototype);
+    try {
+      reportError({ prototype: CompressionStream.prototype });
+      console.log("reportError returned");
+    } catch (error) {
+      console.log("reportError threw " + error.code);
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toStartWith("CompressionStream {\n");
+  expect(stdout).toEndWith("}\nreportError returned\n");
+  expect(stderr).toContain("prototype: CompressionStream {\n");
+  // reportError reports the value as an uncaught error, and that sets the exit code.
+  expect(exitCode).toBe(1);
+});
+
 it("getters", () => {
   const obj = {
     get foo() {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -33,9 +33,8 @@ it("prototype", () => {
   Bun.gc(true);
 });
 
-// The inspect.custom of CompressionStream throws ERR_INVALID_THIS for its prototype. Like
-// util.inspect, console.log and the reportError printer must not call it for a prototype.
-it("console.log and reportError format a prototype whose class has a native inspect.custom", async () => {
+// The inspect.custom of CompressionStream throws ERR_INVALID_THIS when `this` is the prototype.
+it.concurrent("console.log and reportError format a prototype whose class has an inspect.custom", async () => {
   const code = `
     console.log(CompressionStream.prototype);
     try {
@@ -52,11 +51,18 @@ it("console.log and reportError format a prototype whose class has a native insp
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toStartWith("CompressionStream {\n");
-  expect(stdout).toEndWith("}\nreportError returned\n");
-  expect(stderr).toContain("prototype: CompressionStream {\n");
-  // reportError reports the value as an uncaught error, and that sets the exit code.
-  expect(exitCode).toBe(1);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout:
+      "CompressionStream {\n" +
+      "  readable: undefined,\n" +
+      "  writable: undefined,\n" +
+      "  [Symbol(nodejs.util.inspect.custom)]: [Function: anonymous],\n" +
+      "}\n" +
+      "reportError returned\n",
+    stderr: expect.stringContaining("\n  prototype: CompressionStream {\n"),
+    // reportError reports the value as an uncaught error, and that sets the exit code.
+    exitCode: 1,
+  });
 });
 
 it("getters", () => {

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -222,9 +222,8 @@ test("mark/measure toJSON and inspection include detail without perf_hooks being
          json,
          inspected: [inspect(mark), inspect(measure, { depth: 0 }), inspect(mark, { depth: -1 })],
          nativeInspected: Bun.inspect(mark),
-         // util.inspect never calls the hook on a prototype object. Bun.inspect / console.log do,
-         // and the hook has to fall back to the default formatting there instead of throwing
-         // from the brand-checked toJSON.
+         // util.inspect, Bun.inspect and console.log never call the hook on a prototype object,
+         // so a prototype gets the default formatting and not a throw from the brand-checked toJSON.
          protos: [
            inspect(PerformanceMark.prototype),
            Bun.inspect(PerformanceEntry.prototype).split("\\n")[0],

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -1,6 +1,7 @@
 // this file is compatible with jest to test node.js' util.inspect as well as bun's
 
 const util = require("util");
+const vm = require("vm");
 
 test("util.inspect.custom exists", () => {
   expect(util.inspect.custom).toEqual(Symbol.for("nodejs.util.inspect.custom"));
@@ -370,8 +371,8 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
   });
 });
 
-// The native inspect.custom of these classes throws ERR_INVALID_THIS when `this` is not an
-// instance. Bun.inspect and console.log must not call it with the prototype as `this`.
+// The inspect.custom of these classes throws ERR_INVALID_THIS when `this` is not an instance.
+// Bun.inspect and console.log must not call it with the prototype as `this`.
 test.each([
   "CompressionStream",
   "DecompressionStream",
@@ -379,8 +380,12 @@ test.each([
   "TextDecoderStream",
   "BroadcastChannel",
   "Buffer",
-])("Bun.inspect formats %s.prototype without its inspect.custom", className => {
-  const prototype = globalThis[className].prototype;
+  "vm.Module",
+  "vm.SourceTextModule",
+  "vm.SyntheticModule",
+])("Bun.inspect formats %s.prototype without its inspect.custom", path => {
+  const className = path.replace("vm.", "");
+  const { prototype } = path.startsWith("vm.") ? vm[className] : globalThis[className];
   expect(prototype[customSymbol]).toBeFunction();
   expect(() => prototype[customSymbol].call(prototype, 2, {})).toThrow(
     expect.objectContaining({ code: "ERR_INVALID_THIS" }),

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -146,6 +146,44 @@ for (const [name, inspect] of process.versions.bun
     expect(inspect(obj, { depth: 3 }).replace(/\s/g, "")).toBe(expected);
   });
 
+  test(name + " does not call inspect.custom on a prototype object", () => {
+    const receivers = [];
+    class Foo {
+      [customSymbol]() {
+        receivers.push(this === Foo.prototype ? "prototype" : "instance");
+        return "custom";
+      }
+    }
+
+    expect(inspect(new Foo())).toBe("custom");
+    inspect(Foo.prototype);
+    inspect({ nested: Foo.prototype });
+    expect(receivers).toEqual(["instance"]);
+  });
+
+  test(name + " finds a prototype object only through an own constructor data property", () => {
+    const receivers = [];
+    function custom() {
+      receivers.push(this.name);
+      return "custom";
+    }
+    const primitiveConstructor = { name: "primitive", constructor: 1, [customSymbol]: custom };
+    const accessorConstructor = {
+      name: "accessor",
+      get constructor() {
+        throw new Error("the constructor getter must not run");
+      },
+      [customSymbol]: custom,
+    };
+    const prototypeObject = { name: "prototype", [customSymbol]: custom };
+    prototypeObject.constructor = { prototype: prototypeObject };
+
+    expect(inspect(primitiveConstructor)).toBe("custom");
+    expect(inspect(accessorConstructor)).toBe("custom");
+    inspect(prototypeObject);
+    expect(receivers).toEqual(["primitive", "accessor"]);
+  });
+
   const exceptions = [new Error("don't crash!"), 42];
 
   test.each(exceptions)(name + " handles exceptions %s", err => {
@@ -330,4 +368,23 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
     // formats as a plain object instead of throwing.
     expect(inspect(globalThis[className].prototype)).toContain("encoding: [Getter]");
   });
+});
+
+// The native inspect.custom of these classes throws ERR_INVALID_THIS when `this` is not an
+// instance. Bun.inspect and console.log must not call it with the prototype as `this`.
+test.each([
+  "CompressionStream",
+  "DecompressionStream",
+  "TextEncoderStream",
+  "TextDecoderStream",
+  "BroadcastChannel",
+  "Buffer",
+])("Bun.inspect formats %s.prototype without its inspect.custom", className => {
+  const prototype = globalThis[className].prototype;
+  expect(prototype[customSymbol]).toBeFunction();
+  expect(() => prototype[customSymbol].call(prototype, 2, {})).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_THIS" }),
+  );
+  expect(Bun.inspect(prototype)).toStartWith(`${className} {\n`);
+  expect(Bun.inspect({ nested: prototype })).toStartWith(`{\n  nested: ${className} {\n`);
 });

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -168,6 +168,7 @@ for (const [name, inspect] of process.versions.bun
       receivers.push(this.name);
       return "custom";
     }
+    const nullConstructor = { name: "null", constructor: null, [customSymbol]: custom };
     const primitiveConstructor = { name: "primitive", constructor: 1, [customSymbol]: custom };
     const accessorConstructor = {
       name: "accessor",
@@ -176,13 +177,37 @@ for (const [name, inspect] of process.versions.bun
       },
       [customSymbol]: custom,
     };
+    // The inherited constructor points back at the object, but it is not an own property.
+    const parent = { name: "parent", [customSymbol]: custom };
+    const inheritedConstructor = Object.create(parent, { name: { value: "inherited" } });
+    parent.constructor = { prototype: inheritedConstructor };
     const prototypeObject = { name: "prototype", [customSymbol]: custom };
     prototypeObject.constructor = { prototype: prototypeObject };
 
+    expect(inspect(nullConstructor)).toBe("custom");
     expect(inspect(primitiveConstructor)).toBe("custom");
     expect(inspect(accessorConstructor)).toBe("custom");
+    expect(inspect(inheritedConstructor)).toBe("custom");
     inspect(prototypeObject);
-    expect(receivers).toEqual(["primitive", "accessor"]);
+    expect(receivers).toEqual(["null", "primitive", "accessor", "inherited"]);
+  });
+
+  test(name + " propagates an exception thrown while it reads constructor.prototype", () => {
+    let hookCalls = 0;
+    const obj = {
+      constructor: {
+        get prototype() {
+          throw new Error("prototype getter");
+        },
+      },
+      [customSymbol]() {
+        hookCalls++;
+        return "custom";
+      },
+    };
+
+    expect(() => inspect(obj)).toThrow(new Error("prototype getter"));
+    expect(hookCalls).toBe(0);
   });
 
   const exceptions = [new Error("don't crash!"), 42];
@@ -348,8 +373,12 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
   test("wrong receiver returns the receiver (no infinite recursion)", () => {
     const o = {};
     expect(ReadableStream.prototype[customSymbol].call(o, 2, {})).toBe(o);
-    // util.inspect and Bun.inspect must both fall through to default formatting
-    // rather than recursing on a custom function that returned its own `this`.
+    // The hook returns a receiver that is not a stream as is. util.inspect and Bun.inspect
+    // must then use the default formatting, and not call the hook again.
+    const foreign = Object.create(ReadableStream.prototype);
+    expect(inspect(foreign)).toBe("ReadableStream {}");
+    expect(Bun.inspect(foreign)).toStartWith("ReadableStream {\n");
+    // Neither of them calls the hook for a prototype.
     expect(inspect(ReadableStream.prototype)).toContain("[ReadableStream]");
     expect(Bun.inspect(ReadableStream.prototype).length > 0).toBeTrue();
     expect(Bun.inspect(TransformStream.prototype).length > 0).toBeTrue();
@@ -371,8 +400,6 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
   });
 });
 
-// The inspect.custom of these classes throws ERR_INVALID_THIS when `this` is not an instance.
-// Bun.inspect and console.log must not call it with the prototype as `this`.
 test.each([
   "CompressionStream",
   "DecompressionStream",
@@ -380,6 +407,10 @@ test.each([
   "TextDecoderStream",
   "BroadcastChannel",
   "Buffer",
+  "PerformanceEntry",
+  "PerformanceMark",
+  "PerformanceMeasure",
+  "PerformanceResourceTiming",
   "vm.Module",
   "vm.SourceTextModule",
   "vm.SyntheticModule",


### PR DESCRIPTION
### Problem
- `console.log(CompressionStream.prototype)` and `Bun.inspect(CompressionStream.prototype)` throw `TypeError: Value of "this" must be of type CompressionStream` (`ERR_INVALID_THIS`). Node and `util.inspect` print the object. At least nine built-in prototypes fail this way (list in Notes). A fuzzer found this. No issue is open.
- `Tag::get_advanced` (`src/jsc/ConsoleObject.rs:2119`) calls any callable `[util.inspect.custom]`. For a prototype, the hook of the class runs with the prototype as `this`. Its brand check then throws.

### Fix
- Skip the hook when the value is a prototype object. Node's `formatValue` and Bun's JS port (`src/js/internal/util/inspect.js:1237`) use this check: `Object.getOwnPropertyDescriptor(value, "constructor")?.value?.prototype === value`. Open PR #35292 has a copy of this check (`Tag::is_constructor_prototype`) that it can drop.
- The new C++ function `JSC__JSValue__isConstructorPrototype` (`UtilInspect.cpp`) does the check. It reads the property descriptor, so a `constructor` getter does not run. An exception from `constructor.prototype` propagates, as in `util.inspect`.
- Delete the prototype guard in the `PerformanceEntry` hook (#39921). The new check makes it redundant.
- Verified: `test/js/node/util/custom-inspect.test.js` and `test/js/bun/util/inspect.test.js`. Stock bun fails 17 of the new tests. Also ran `perf_hooks.test.ts` and the console suites. Self-review: 11 concerns raised, 11 addressed.

### Background
- `console.log`, `Bun.inspect` and the error printer share one native formatter (`ConsoleObject.rs`). `util.inspect` is a separate JS port of Node's code.
- `Tag::get_advanced` decides how the formatter prints a value. A callable `[util.inspect.custom]` on the value makes the formatter call that hook.
- A class installs its hook on its prototype. Most hooks check that `this` is an instance, so the prototype itself fails the check.

<details><summary>Notes</summary>

- The nine prototypes: `CompressionStream`, `DecompressionStream`, `TextEncoderStream`, `TextDecoderStream`, `BroadcastChannel`, `Buffer`, `vm.Module`, `vm.SourceTextModule` and `vm.SyntheticModule`. `MessagePort` fails the same way after `node:worker_threads` loads. A user class whose hook needs an instance also fails.
- After the fix, a prototype prints with the default object output of the formatter, for example `CompressionStream { readable: undefined, ... }`. `ReadableStream.prototype` already prints that way. This text is not the same as the text from Node.
- The error printer and `reportError` use the same formatter. So `reportError({ p: CompressionStream.prototype })` no longer throws.
- A direct call of the `PerformanceEntry` hook with the prototype as `this` now throws `ERR_INVALID_THIS` from the brand-checked `toJSON`. Node does the same.
- The check runs only for an object that has a callable hook. An instance has no own `constructor` property, so the check is one own-property lookup.
- The tests pin Node's result for these edge cases: a `null`, primitive, accessor, or inherited `constructor` does not make a prototype object. An object whose own `constructor.prototype` is the object itself is one.
- Not changed: when a script sets `globalThis.constructor = { prototype: globalThis }`, the check does not match, because the formatter unwraps the global proxy first. This case is contrived.
- Three tests in `test/js/node/util/` and `test/js/node/vm/` hit the 5 s timeout under the local debug build: `parseArgs ... 100 mixed several times`, "no assertion failures 2" in `util-inspect.test.js`, and `vm.Script > shouldn't leak memory`. None of them uses the native formatter.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->