### PR TITLE
test: make the chunk boundaries in async-iterator-stream.test.ts deterministic

### DIFF
--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -4,13 +4,17 @@ import { bunEnv, bunExe } from "harness";
 
 describe.concurrent("Streaming body via", () => {
   test("async generator function", async () => {
+    // The generator writes its second chunk only after the client has read the first. A timer
+    // between the two writes does not keep them apart: if the event loop is busy for longer
+    // than the timer, fetch delivers both writes as one chunk.
+    const { promise: firstChunkRead, resolve: onChunkRead } = Promise.withResolvers<void>();
     using server = Bun.serve({
       port: 0,
 
       async fetch(req) {
         return new Response(async function* yo() {
           yield "Hello, ";
-          await Bun.sleep(30);
+          await firstChunkRead;
           yield Buffer.from("world!");
           return "not a chunk";
         });
@@ -18,13 +22,13 @@ describe.concurrent("Streaming body via", () => {
     });
 
     const res = await fetch(`${server.url}/`);
-    const chunks = [];
+    const chunks: string[] = [];
     for await (const chunk of res.body) {
-      chunks.push(chunk);
+      chunks.push(Buffer.from(chunk).toString());
+      onChunkRead();
     }
 
-    expect(Buffer.concat(chunks).toString()).toBe("Hello, world!");
-    expect(chunks).toHaveLength(2);
+    expect(chunks).toEqual(["Hello, ", "world!"]);
   });
 
   test("a hand-written async iterator without return() completes", async () => {
@@ -173,6 +177,8 @@ describe.concurrent("Streaming body via", () => {
   });
 
   test("[Symbol.asyncIterator]", async () => {
+    // As in "async generator function", the last write waits for the client to read the first chunk.
+    const { promise: firstChunkRead, resolve: onChunkRead } = Promise.withResolvers<void>();
     using server = Bun.serve({
       port: 0,
 
@@ -181,7 +187,7 @@ describe.concurrent("Streaming body via", () => {
           async *[Symbol.asyncIterator]() {
             var controller = yield "my string goes here\n";
             var controller2 = yield Buffer.from("my buffer goes here\n");
-            await Bun.sleep(30);
+            await firstChunkRead;
             yield Buffer.from("end!\n");
             if (controller !== controller2 || typeof controller.sinkId !== "number") {
               throw new Error("Controller mismatch");
@@ -193,13 +199,14 @@ describe.concurrent("Streaming body via", () => {
     });
 
     const res = await fetch(`${server.url}/`);
-    const chunks = [];
+    const chunks: string[] = [];
     for await (const chunk of res.body) {
-      chunks.push(chunk);
+      chunks.push(Buffer.from(chunk).toString());
+      onChunkRead();
     }
 
-    expect(Buffer.concat(chunks).toString()).toBe("my string goes here\nmy buffer goes here\nend!\n");
-    expect(chunks).toHaveLength(2);
+    // The two writes before the await are sent in one flush.
+    expect(chunks).toEqual(["my string goes here\nmy buffer goes here\n", "end!\n"]);
   });
 
   test("[Symbol.asyncIterator] with a custom iterator", async () => {


### PR DESCRIPTION
### Problem
- `async-iterator-stream.test.ts` fails in the Linux parallel batch: `async generator function`, `Expected length: 2`, `Received length: 1`. Build 109725 failed on debian 13 x64 and aarch64.
- The server writes `"Hello, "`, waits `Bun.sleep(30)`, then writes `"world!"`. If the loop does not run the queued body callback in those 30 ms, the HTTP thread adds `"world!"` to it (`src/runtime/webcore/fetch/FetchTasklet.rs:2447`). So the client reads one chunk.
- No runtime change caused this. The 30 ms gap dates from #8941. #22823 made the file `describe.concurrent`, so its other 94 tests run on the same loop at once. Since #41204, CI does not retry it, so the flake fails the build.

### Fix
- Each generator waits for a promise that the client resolves on each read. The last write cannot join the first chunk. `[Symbol.asyncIterator]` has the same flaw and the same change.
- The assertions check the exact chunks. They still check the boundaries and that the return value is not sent.
- Verified: with the CI environment under CPU contention, the old file failed 4 of 36 runs, the new one 0 of 60. `bun bd test` passes.

### Background
- `FetchTasklet` is the JS-thread state of one `fetch()`. The HTTP thread posts body bytes to it. Bytes that arrive while a post waits join that post.
- CI sets `BUN_GARBAGE_COLLECTOR_LEVEL=1` (`scripts/runner.node.mjs:1912`). Then each matcher requests a garbage collection (`src/runtime/test_runner/expect.rs:1683`).
- One loop turn runs all due timers before the queued callbacks. Tests that complete in that turn collect there.

<details><summary>Notes</summary>

**Trace of one failing run** (ms from the start of the file, 1 CPU shared with three busy loops, `BUN_GARBAGE_COLLECTOR_LEVEL=1`):

- 443: the server writes `"Hello, "`. The HTTP thread reads it at once. The TCP receive queue of the client socket is empty in every sample of `/proc/net/tcp`.
- 473: the timers of this test and of seven `Bun.sleep(30)` body tests expire.
- 478 to 652: one timer pass runs them. Each body test completes, calls `expect`, and runs a collection (about 25 ms each on this CPU). This test's timer runs at 643 and writes `"world!"` at 652.
- 1276: the loop runs the queued body callback, which now holds `"Hello, world!"`, after the next group of tests.

**Reproduction:** run the file with `taskset` on one CPU, with three busy loops on the same CPU, and with `BUN_GARBAGE_COLLECTOR_LEVEL=1`. It fails in about 1 of 8 runs, on a build from 2026-08-30 (a6c4cc276) and on canary 8f9aece15. Without `BUN_GARBAGE_COLLECTOR_LEVEL=1` it does not fail.

**Onset in CI:** the annotations of the last 2000 builds (since build 107726, 2026-08-28) show this failure first in build 109135 (2026-09-02). It shows in 19 of 372 builds whose base contains 683d304e92 (#40412), and in none of about 980 builds with an older base. The runtime changes in the range 4057f64cd1..683d304e92 do not touch this path: #41130 moves code on the abort path, #40412 changes the TLS close, and #41132 is macOS DNS. The range adds two test files, and the shard packing uses the file list. So the batch of this file's shard (debian 13 x64, shard 15 of 20) has 25 other files in build 109135 than in build 109112. I did not find which neighbor adds the load. In the failing CI runs, this test took 180 to 870 ms. Alone it takes about 35 ms.

**Other tests:** the `Bun.sleep(30)` calls in the body tests and in `[Symbol.asyncIterator] with a custom iterator` stay. Those tests check only the body text, so a merged chunk does not change their result.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/async-iterator-stream.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/async-iterator-stream.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/http/async-iterator-stream.test.ts:
(pass) Streaming body via > a hand-written async iterator without return() completes [55.81ms]
(pass) Streaming body via > an iterator returning thenables (non-native promises) streams [13.42ms]
(pass) Streaming body via > async generator function [217.61ms]
(pass) Streaming body via > async generator aborted doesn't crash [38.57ms]
(pass) Streaming body via > [Symbol.asyncIterator] [36.13ms]
(pass) Streaming body via > [Symbol.asyncIterator] with a custom iterator [122.80ms]
(pass) Streaming body via > yield [8.67ms]
(pass) Streaming body via > the value of a done result is not part of the body > async generator return value [13.19ms]
(pass) Streaming body via > the value of a done result is not part of the body > hand-written async iterator [7.80ms]
(pass) Streaming body via > the value of a done result is not part of the body > sync generator under Symbol.asyncIterator [14.22ms]
(pass) Streaming body via > an iterator whose next() rejects and has no throw() rejects the body [396.12ms]
(pass) Streaming body via > "Hello, world! #1" > Response(arrayBuffer) [18.03ms]
(pass) Streaming body via > "Hello, world! #1" > Response(bytes) [3.34ms]
(pass) Streaming body via > "Hello, world! #1" > Response(text) [3.18ms]
(pass) Streaming body via > "Hello, world! #1" > Response(json) [8.47ms]
(pass) Streaming body via > "Hello, world! #1" > Response(blob) [11.52ms]
(pass) Streaming body via > "Hello, world! #1" > Request(arrayBuffer) [4.58ms]
(pass) Streaming body via > "Hello, world! #1" > Request(bytes) [3.34ms]
(pass) Streaming body via > "Hello, world! #1" > Request(text) [3.14ms]
(pass) Streaming body via > "Hello, world! #1" > Request(json) [3.48ms]
(pass) Streaming body via > "Hello, world! #1" > Request(blob) [4.13ms]
(pass) Streaming body via > "Hello, wor
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/async-iterator-stream.test.ts | 27 ++++++++++++++++----------
 1 file changed, 17 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
test/js/bun/http/async-iterator-stream.test.ts      3      3     16
```

</details>

<!-- robobun:evidence:end -->