### PR TITLE
bun:test: spyOn on a non-function value at an index installs a getter/setter

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1592,9 +1592,6 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             if (JSModuleNamespaceObject* moduleNamespaceObject = tryJSDynamicCast<JSModuleNamespaceObject*>(object)) {
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
-            } else if (auto index = parseIndex(propertyKey)) {
-                // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1174,27 +1174,34 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
-    test("spyOn works with indexed properties that hold a non-function value", () => {
-      const arr = [];
-      arr[0] = 42;
+    test.each([
+      [
+        "an array",
+        () => {
+          const arr = [];
+          arr[0] = 42;
+          return arr;
+        },
+      ],
+      ["an array literal", () => [42]],
+      ["an object", () => ({ 0: 42 })],
+    ])("spyOn works with an indexed property that holds a non-function value on %s", (_, makeTarget) => {
+      const target = makeTarget();
+      const fn = spyOn(target, 0);
+      expect(fn).not.toHaveBeenCalled();
+      expect(target[0]).toBe(42);
+      expect(fn).toHaveBeenCalledTimes(1);
 
-      for (const target of [arr, [42], { 0: 42 }]) {
-        const fn = spyOn(target, 0);
-        expect(fn).not.toHaveBeenCalled();
-        expect(target[0]).toBe(42);
-        expect(fn).toHaveBeenCalledTimes(1);
+      target[0] = 1;
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls[1]).toEqual([1]);
+      expect(target[0]).toBe(42);
 
-        target[0] = 1;
-        expect(fn).toHaveBeenCalledTimes(2);
-        expect(fn.mock.calls[1]).toEqual([1]);
-        expect(target[0]).toBe(42);
-
-        fn.mockRestore();
-        expect(fn).not.toHaveBeenCalled();
-        expect(target[0]).toBe(42);
-        target[0] = 1;
-        expect(target[0]).toBe(1);
-      }
+      fn.mockRestore();
+      expect(fn).not.toHaveBeenCalled();
+      expect(target[0]).toBe(42);
+      target[0] = 1;
+      expect(target[0]).toBe(1);
     });
 
     test("spyOn twice on a missing indexed property throws instead of crashing", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1174,6 +1174,42 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    test("spyOn works with indexed properties that hold a non-function value", () => {
+      const arr = [];
+      arr[0] = 42;
+
+      for (const target of [arr, [42], { 0: 42 }]) {
+        const fn = spyOn(target, 0);
+        expect(fn).not.toHaveBeenCalled();
+        expect(target[0]).toBe(42);
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        target[0] = 1;
+        expect(fn).toHaveBeenCalledTimes(2);
+        expect(fn.mock.calls[1]).toEqual([1]);
+        expect(target[0]).toBe(42);
+
+        fn.mockRestore();
+        expect(fn).not.toHaveBeenCalled();
+        expect(target[0]).toBe(42);
+        target[0] = 1;
+        expect(target[0]).toBe(1);
+      }
+    });
+
+    test("spyOn twice on a missing indexed property throws instead of crashing", () => {
+      const arr = [];
+      const fn = spyOn(arr, 4);
+      expect(arr[4]).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(() => spyOn(arr, 4)).toThrow("spyOn(target, prop) does not support accessor properties yet");
+
+      fn.mockRestore();
+      expect(Object.hasOwn(arr, 4)).toBe(true);
+      expect(arr[4]).toBeUndefined();
+      expect(fn).not.toHaveBeenCalled();
+    });
+
     // The engine serves a function's `prototype` property specially, so it cannot be
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {


### PR DESCRIPTION
### What does this PR do?

For a named key, `spyOn(target, key)` on a non-function value wraps the mock in a `GetterSetter`. For an index key, it stored the bare mock and kept the `Accessor` attribute. JSC reads that attribute and expects a `GetterSetter` value. The result depends on the access:

- A write to the index casts the mock to `GetterSetter`. The release build segfaults at address `0x38`.
- A read hits a debug assertion in `PropertySlot::setValue`. The fuzzer found this case.
- In a release build, a read returns the mock function, not the value. The spy records no call.

Repro. The release build segfaults on the last line:

```js
import { spyOn } from "bun:test";

const arr = [];
arr[0] = 42;
spyOn(arr, 0);
arr[0] = 1;
```

`JSObject::putDirectAccessor` already sends an index key to `putDirectIndex`. This PR removes the index branch in `JSMock__jsSpyOn`. An index key now gets the same getter/setter spy as a named key:

- A read returns the original value and records a call.
- A write calls the mock.
- A second `spyOn` on the same index throws `spyOn(target, prop) does not support accessor properties yet`. A named key does the same.

Some targets reject an accessor at an index, for example a typed array element or a non-configurable index. On those targets the property stays unchanged, and the spy records nothing. The old code did not spy on these targets either. On a typed array it wrote the mock into the element, and the element became 0.

### How did you verify your code works?

- I added two tests to `test/js/bun/test/mock-fn.test.js`. They fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`.
- The first test uses an array, a copy-on-write array literal, and a plain object. The array literal takes the `defineOwnProperty` path in JSC.
- The second test is the fuzzer case: two `spyOn` calls on a missing index.
- `mock-fn.test.js`, `mock-disposable.test.ts`, and `mock/mock-module.test.ts` pass on the debug build.
- The fuzzer script runs to the end on the debug build. The second `spyOn` throws a JS error.
