### PR TITLE
lexer: only treat __PURE__ as an annotation when it starts a // comment

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2068,8 +2068,7 @@ impl<'a> Lexer<'a> {
     fn scan_single_line_comment(&mut self) {
         // PERF: keep the source slice register-resident — see `next_codepoint_with`.
         let contents: &[u8] = self.contents;
-        // `__PURE__` must be the first word of a `//` comment. Only the first
-        // `#` / `@` can qualify.
+        // Only the first `#` / `@` of a `//` comment can start a `__PURE__` annotation.
         let mut first_marker = true;
         loop {
             // Find index of newline (ASCII/Unicode), non-ASCII, '#', or '@'.

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -1963,8 +1963,8 @@ impl<'a> Lexer<'a> {
                     let offset = self.scan_pragma(
                         self.start + i + (text.len() - rest.len()),
                         chunk,
-                        false,
-                        true,
+                        CommentKind::MultiLine,
+                        PureAnnotation::Allow,
                     );
 
                     rest = &rest[
@@ -2092,14 +2092,22 @@ impl<'a> Lexer<'a> {
 
                     0x23 | 0x40 => {
                         let pragma_trigger_pos = self.end;
-                        let allow_pure = first_marker
+                        let pure = if first_marker
                             && strings::is_all_whitespace(
                                 &contents[self.start + 2..pragma_trigger_pos],
-                            );
+                            ) {
+                            PureAnnotation::Allow
+                        } else {
+                            PureAnnotation::Ignore
+                        };
                         first_marker = false;
                         let chunk = js_ast::StoreStr::new(self.remaining());
-                        self.current +=
-                            self.scan_pragma(pragma_trigger_pos, chunk.slice(), true, allow_pure);
+                        self.current += self.scan_pragma(
+                            pragma_trigger_pos,
+                            chunk.slice(),
+                            CommentKind::SingleLine,
+                            pure,
+                        );
                         continue;
                     }
                     _ => {
@@ -2127,10 +2135,12 @@ impl<'a> Lexer<'a> {
         &mut self,
         offset_for_errors: usize,
         chunk: &[u8],
-        allow_newline: bool,
-        allow_pure: bool,
+        comment: CommentKind,
+        pure: PureAnnotation,
     ) -> usize {
-        if allow_pure && !self.has_pure_comment_before {
+        // A `//` comment ends at the line break, so a pragma argument stops there.
+        let allow_newline = comment == CommentKind::SingleLine;
+        if pure == PureAnnotation::Allow && !self.has_pure_comment_before {
             if strings::has_prefix_with_word_boundary(chunk, b"__PURE__") {
                 self.has_pure_comment_before = true;
                 return "__PURE__".len();
@@ -3429,6 +3439,19 @@ pub(crate) fn latin1_identifier_continue_length_scalar(name: &[u8]) -> usize {
     }
 
     name.len()
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CommentKind {
+    SingleLine,
+    MultiLine,
+}
+
+/// Whether a `__PURE__` match at this position marks the next call.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PureAnnotation {
+    Allow,
+    Ignore,
 }
 
 pub struct PragmaArg;

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2068,6 +2068,9 @@ impl<'a> Lexer<'a> {
     fn scan_single_line_comment(&mut self) {
         // PERF: keep the source slice register-resident — see `next_codepoint_with`.
         let contents: &[u8] = self.contents;
+        // `__PURE__` must be the first word of a `//` comment. Only the first
+        // `#` / `@` can qualify.
+        let mut first_marker = true;
         loop {
             // Find index of newline (ASCII/Unicode), non-ASCII, '#', or '@'.
             if let Some(relative_index) =
@@ -2090,10 +2093,11 @@ impl<'a> Lexer<'a> {
 
                     0x23 | 0x40 => {
                         let pragma_trigger_pos = self.end;
-                        // `__PURE__` must be the first word of a `//` comment.
-                        let allow_pure = strings::is_all_whitespace(
-                            &contents[self.start + 2..pragma_trigger_pos],
-                        );
+                        let allow_pure = first_marker
+                            && strings::is_all_whitespace(
+                                &contents[self.start + 2..pragma_trigger_pos],
+                            );
+                        first_marker = false;
                         let chunk = js_ast::StoreStr::new(self.remaining());
                         self.current +=
                             self.scan_pragma(pragma_trigger_pos, chunk.slice(), true, allow_pure);

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2090,14 +2090,8 @@ impl<'a> Lexer<'a> {
 
                     0x23 | 0x40 => {
                         let pragma_trigger_pos = self.end;
-                        // `@__PURE__` / `#__PURE__` only count as an annotation when
-                        // they are the first word of a `//` comment. Later in the
-                        // line the marker is prose, such as a `/*#__PURE__*/` that
-                        // a comment quotes. esbuild matches the marker anywhere but
-                        // only acts on it under --minify-syntax. Bun removes an
-                        // unused pure call even without minification, so a false
-                        // match deletes code. Block comments keep the esbuild rule:
-                        // they cannot quote a `/*#__PURE__*/`.
+                        // `__PURE__` is an annotation only as the first word of a
+                        // `//` comment. Anywhere else it is prose.
                         let allow_pure = strings::is_all_whitespace(
                             &contents[self.start + 2..pragma_trigger_pos],
                         );
@@ -2126,8 +2120,6 @@ impl<'a> Lexer<'a> {
 
     /// Scans the string for a pragma.
     /// offset is used when there's an issue with the JSX pragma later on.
-    /// `allow_pure` is false when a `__PURE__` match at this position is prose
-    /// and not an annotation.
     /// Returns the byte length to advance by if found, otherwise 0.
     fn scan_pragma(
         &mut self,

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2090,8 +2090,7 @@ impl<'a> Lexer<'a> {
 
                     0x23 | 0x40 => {
                         let pragma_trigger_pos = self.end;
-                        // `__PURE__` is an annotation only as the first word of a
-                        // `//` comment. Anywhere else it is prose.
+                        // `__PURE__` must be the first word of a `//` comment.
                         let allow_pure = strings::is_all_whitespace(
                             &contents[self.start + 2..pragma_trigger_pos],
                         );

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -1960,8 +1960,12 @@ impl<'a> Lexer<'a> {
             match c {
                 b'@' | b'#' => {
                     let chunk = rest;
-                    let offset =
-                        self.scan_pragma(self.start + i + (text.len() - rest.len()), chunk, false);
+                    let offset = self.scan_pragma(
+                        self.start + i + (text.len() - rest.len()),
+                        chunk,
+                        false,
+                        true,
+                    );
 
                     rest = &rest[
                         // The min is necessary because the file could end
@@ -2086,8 +2090,20 @@ impl<'a> Lexer<'a> {
 
                     0x23 | 0x40 => {
                         let pragma_trigger_pos = self.end;
+                        // `@__PURE__` / `#__PURE__` only count as an annotation when
+                        // they are the first word of a `//` comment. Later in the
+                        // line the marker is prose, such as a `/*#__PURE__*/` that
+                        // a comment quotes. esbuild matches the marker anywhere but
+                        // only acts on it under --minify-syntax. Bun removes an
+                        // unused pure call even without minification, so a false
+                        // match deletes code. Block comments keep the esbuild rule:
+                        // they cannot quote a `/*#__PURE__*/`.
+                        let allow_pure = strings::is_all_whitespace(
+                            &contents[self.start + 2..pragma_trigger_pos],
+                        );
                         let chunk = js_ast::StoreStr::new(self.remaining());
-                        self.current += self.scan_pragma(pragma_trigger_pos, chunk.slice(), true);
+                        self.current +=
+                            self.scan_pragma(pragma_trigger_pos, chunk.slice(), true, allow_pure);
                         continue;
                     }
                     _ => {
@@ -2110,14 +2126,17 @@ impl<'a> Lexer<'a> {
 
     /// Scans the string for a pragma.
     /// offset is used when there's an issue with the JSX pragma later on.
+    /// `allow_pure` is false when a `__PURE__` match at this position is prose
+    /// and not an annotation.
     /// Returns the byte length to advance by if found, otherwise 0.
     fn scan_pragma(
         &mut self,
         offset_for_errors: usize,
         chunk: &[u8],
         allow_newline: bool,
+        allow_pure: bool,
     ) -> usize {
-        if !self.has_pure_comment_before {
+        if allow_pure && !self.has_pure_comment_before {
             if strings::has_prefix_with_word_boundary(chunk, b"__PURE__") {
                 self.has_pure_comment_before = true;
                 return "__PURE__".len();

--- a/test/bundler/bundler_comments.test.ts
+++ b/test/bundler/bundler_comments.test.ts
@@ -298,6 +298,15 @@ describe("single-line comments", () => {
     },
   });
 
+  itBundled("many markers after leading whitespace in a single-line comment", {
+    files: {
+      "/entry.js": `//${Buffer.alloc(4096, " ").toString()}${Buffer.alloc(4096, "@").toString()}__PURE__\nconsole.log("hello");`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("hello");
+    },
+  });
+
   itBundled("__PURE__ comment in single-line comment with text after", {
     files: {
       "/entry.js": `// #__PURE__ some text\nconsole.log("hello");`,

--- a/test/bundler/bundler_comments.test.ts
+++ b/test/bundler/bundler_comments.test.ts
@@ -259,12 +259,42 @@ describe("single-line comments", () => {
     },
   });
 
+  // A marker that is not the first word of a `//` comment is prose, not an
+  // annotation. An unused pure call is removed even without minification, so a
+  // false match deletes code.
   itBundled("__PURE__ comment in single-line comment with text before", {
     files: {
       "/entry.js": `// some text #__PURE__\nconsole.log("hello");`,
     },
     onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("hello");
+    },
+  });
+
+  itBundled("__PURE__ comment in single-line comment with tab before", {
+    files: {
+      "/entry.js": `//\t@__PURE__\nconsole.log("hello");`,
+    },
+    onAfterBundle(api) {
       api.expectFile("/out.js").not.toContain("hello");
+    },
+  });
+
+  itBundled("quoted /*#__PURE__*/ inside a single-line comment", {
+    files: {
+      "/entry.js": `function repro() {\n  // \`/*#__PURE__*/\`\n  console.log("hello");\n}\nrepro();`,
+    },
+    run: {
+      stdout: "hello",
+    },
+  });
+
+  itBundled("quoted /*#__PURE__*/ after text inside a single-line comment", {
+    files: {
+      "/entry.js": `// Wrap class inside init: \`/*#__PURE__*/ (() => { let C = class C {}; return C; })()\`\nconsole.log("hello");`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("hello");
     },
   });
 
@@ -282,6 +312,15 @@ describe("single-line comments", () => {
       "/entry.js": `// 你好 #__PURE__ 世界\nconsole.log("hello");`,
     },
     onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("hello");
+    },
+  });
+
+  itBundled("__PURE__ comment in single-line comment with unicode characters after", {
+    files: {
+      "/entry.js": `// #__PURE__ 世界\nconsole.log("hello");`,
+    },
+    onAfterBundle(api) {
       api.expectFile("/out.js").not.toContain("hello");
     },
   });
@@ -291,7 +330,7 @@ describe("single-line comments", () => {
       "/entry.js": `// 🚀 #__PURE__ 🔥\nconsole.log("hello");`,
     },
     onAfterBundle(api) {
-      api.expectFile("/out.js").not.toContain("hello");
+      api.expectFile("/out.js").toContain("hello");
     },
   });
 
@@ -300,7 +339,7 @@ describe("single-line comments", () => {
       "/entry.js": `// \uD800 #__PURE__ \uDC00\nconsole.log("hello");`,
     },
     onAfterBundle(api) {
-      api.expectFile("/out.js").not.toContain("hello");
+      api.expectFile("/out.js").toContain("hello");
     },
   });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1586,7 +1586,10 @@ function foo() {}
       //   jsxErrorArrow +
       //     'Unexpected end of file before a closing "const" tag\n<stdin>: NOTE: The opening "const" tag is here:\n',
       // );
-      err("async <const T>() => {}", "Unexpected const");
+      // `async <const T>() => {}` is valid in the `ts` loader. The
+      // "Unexpected const" error for it is TSX-only.
+      exp("x = async <const T>() => {}", "x = async () => {};\n");
+      exp("x = async <const const T>() => {}", "x = async () => {};\n");
       err("async <const const>() => {}", "Unexpected const");
 
       // TODO: why doesn't this one fail?

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -401,6 +401,37 @@ describe.concurrent("bun run", () => {
     expect(exitCode).toBe(0);
   });
 
+  // https://github.com/oven-sh/bun/issues/41275
+  it("a __PURE__ marker that is not the first word of a // comment is not a DCE annotation", async () => {
+    using dir = tempDir("test", {
+      "index.ts": `
+      function repro() {
+        // \`/*#__PURE__*/\`
+        console.log("Hello, world!");
+      }
+      repro();
+      // Wrap class inside init: \`/*#__PURE__*/ (() => { let C = class C {}; return C; })()\`
+      console.log("second");
+      // @__PURE__
+      console.log("removed");
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "index.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("Hello, world!\nsecond\n");
+    expect(exitCode).toBe(0);
+  });
+
   it("--ignore-dce-annotations ignores DCE annotations", async () => {
     using dir = tempDir("test", {
       "index.ts": `

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -403,8 +403,7 @@ describe.concurrent("bun run", () => {
 
   // https://github.com/oven-sh/bun/issues/41275
   it("a __PURE__ marker that is not the first word of a // comment is not a DCE annotation", async () => {
-    using dir = tempDir("test", {
-      "index.ts": `
+    const source = `
       function repro() {
         // \`/*#__PURE__*/\`
         console.log("Hello, world!");
@@ -414,12 +413,10 @@ describe.concurrent("bun run", () => {
       console.log("second");
       // @__PURE__
       console.log("removed");
-    `,
-    });
+    `;
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "index.ts"],
-      cwd: String(dir),
+      cmd: [bunExe(), "-e", source],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
### Problem
- A `//` comment that mentions `/*#__PURE__*/` as text marks the next call as pure. Bun removes an unused pure call at runtime and in `bun build`, without minification. So `` // `/*#__PURE__*/` `` followed by `console.log(...)` deletes the `console.log`. In `@angular/build` this deleted `source.appendRight(...)` and corrupted the Angular build output (angular/angular-cli#33973).
- The cause is `scan_single_line_comment` in `src/js_parser/lexer.rs:2087`. On any `#` or `@` in a `//` comment it calls `scan_pragma`, which sets `has_pure_comment_before` when `__PURE__` follows. The position in the comment does not matter.

Fixes #41275. Fixes #19355.

### Fix
- In a `//` comment, `@__PURE__` or `#__PURE__` is an annotation only when it is the first word: only whitespace may sit between `//` and the marker. Text after the marker is still allowed. Block comments are unchanged.
- This deviates from esbuild, terser and rollup, which match the marker anywhere in a comment. Those tools only act on it when minifying or tree shaking. Bun acts on it always, so a false match deletes user code. Line directives such as `// @ts-ignore`, `//# sourceMappingURL=` and `// eslint-disable-next-line` use the same first-word rule. Block comments keep the esbuild rule because a `/* */` comment cannot quote a `/*#__PURE__*/`, and `/** @__PURE__ */` must keep working.
- Four existing tests in `test/bundler/bundler_comments.test.ts` put text before the marker and asserted removal. They came in with the SIMD lexer change (#19134) to exercise the scanner, and now assert that the call is kept. `test/bundler/transpiler/transpiler.test.js:1589` was a victim of this bug: the `@__PURE__` text in the commented-out lines above it deleted the first `err(...)` call, which asserted a TSX-only error for the `ts` loader. It now asserts the `ts` behavior, as in esbuild's `ts_parser_test.go`.
- Verified: `test/bundler/bundler_comments.test.ts` (4 new cases) and `test/cli/install/bun-run.test.ts` (1 new runtime case). Both fail on the release binary. Also ran `test/bundler/esbuild/dce.test.ts`, `default.test.ts`, `tsconfig.test.ts`, `bundler_minify.test.ts`, `bundler_jsx.test.ts`, `transpiler/transpiler.test.js`, `transpiler/react-compiler.test.ts`.

### Background
- A pure annotation (`/* @__PURE__ */ f()`) tells a bundler that the call has no side effects. If the result is unused, the call can be removed.
- Bun's `dead_code_elimination` parser feature is on by default, also for `bun run`. The SExpr visitor (`src/js_parser/visit/visit_stmt.rs:1430`) calls `SideEffects::simplify_unused_expr` with no minify gate, and `scan_side_effects.rs` drops a call marked `IfUnused` whose arguments have no side effects. The docs describe pure annotation support as "Always active".
- `has_pure_comment_before` is reset at the start of `Lexer::next()` and read in `parse_expr_common` (`src/js_parser/parse/mod.rs:75`), which marks the next `ECall` or `ENew` as `CanBeUnwrapped::IfUnused`.

<details><summary>Notes</summary>

Repro under bun 1.4.1:

```
$ bun -e 'function repro() {
    // `/*#__PURE__*/`
    console.log("This should not be deleted");
}
console.log(repro.toString());'
function repro() {}
```

esbuild 0.21.5 attaches the annotation to the same input but keeps the call unless `--minify-syntax` is passed.

Alternative considered: gate the removal of a pure-marked expression statement on `minify_syntax`, as esbuild does. That changes documented runtime behavior and unminified `bun build` output for every correctly annotated call, so this PR narrows what counts as an annotation instead.

A `/* see @__PURE__ for details */` block comment before a call still marks it pure. That is the esbuild rule and is not changed here. A quoted `/*#__PURE__*/` cannot occur inside a block comment, so the real-world reports all come from `//` comments.

Self-reviewed: the review found the dead `transpiler.test.js` assertion and asked for the esbuild deviation to be stated. Both are addressed above. It also suggested gating `bun test` on `ignore_dce_annotations`. That is a separate change and is not in this PR.

Unrelated failures seen locally with the debug build: two `bun-build-api.test.ts` bytecode tests that time out at 5s under the debug build.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-run.test.ts

<!-- robobun:evidence:end -->