### PR TITLE
bundler: resolve Bun.build files imports without the extension, like on disk

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -250,7 +250,7 @@ console.log(output);
 
 When all entrypoints are in the `files` map, Bun uses the current working directory as the root.
 
-An import resolves against the keys of `files` the same way it resolves against files on disk. In the example above, `./greet` and `./greet.js` also find `/app/greet.ts`, and `./lib` would find `/app/lib/index.ts`. An entrypoint must match a key exactly.
+An import of a relative or absolute path resolves against the keys of `files` the same way it resolves against files on disk. In the example above, `./greet` and `./greet.js` also find `/app/greet.ts`, and `./lib` would find `/app/lib/index.ts`. A bare specifier such as `greet` does not find `/app/greet.ts`. An entrypoint must match a key exactly.
 
 #### Override files on disk
 

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -250,6 +250,8 @@ console.log(output);
 
 When all entrypoints are in the `files` map, Bun uses the current working directory as the root.
 
+An import resolves against the keys of `files` the same way it resolves against files on disk. In the example above, `./greet` and `./greet.js` also find `/app/greet.ts`, and `./lib` would find `/app/lib/index.ts`. An entrypoint must match a key exactly.
+
 #### Override files on disk
 
 In-memory files take priority over files on disk, so you can override specific files while keeping the rest of your codebase unchanged:

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3537,8 +3537,9 @@ declare module "bun" {
      * A map of file paths to their contents for in-memory bundling.
      *
      * Use this to bundle virtual files that don't exist on disk, or override
-     * the contents of files that do exist on disk. The keys are file paths (which should
-     * match how they're imported) and the values are the file contents.
+     * the contents of files that do exist on disk. The keys are file paths and the values
+     * are the file contents. An import resolves against the keys the same way it resolves
+     * against files on disk, so `./helper` finds `/app/helper.ts`.
      *
      * File contents can be provided as:
      * - `string` - The source code as a string

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3538,8 +3538,10 @@ declare module "bun" {
      *
      * Use this to bundle virtual files that don't exist on disk, or override
      * the contents of files that do exist on disk. The keys are file paths and the values
-     * are the file contents. An import resolves against the keys the same way it resolves
-     * against files on disk, so `./helper` finds `/app/helper.ts`.
+     * are the file contents. An import of a relative or absolute path resolves against the
+     * keys the same way it resolves against files on disk, so `./helper` finds
+     * `/app/helper.ts`. A bare specifier such as `helper` does not. An entry point in
+     * {@link entrypoints} must match a key exactly.
      *
      * File contents can be provided as:
      * - `string` - The source code as a string

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -931,9 +931,6 @@ pub mod bv2_impl {
                 /// not found. Handles direct key matches and relative specifiers
                 /// joined against `dirname(source_file)` (with Windows
                 /// drive-letter / separator normalization).
-                ///
-                /// `arena` is the build's bump arena (`BundleV2::arena()`), see
-                /// [`Self::result_for_key`].
                 pub(crate) fn resolve(
                     &self,
                     arena: &bun_alloc::Arena,
@@ -944,15 +941,7 @@ pub mod bv2_impl {
                     Some(Self::result_for_key(arena, key))
                 }
 
-                /// [`Self::resolve`] for an import. A relative or absolute
-                /// specifier that names no key also matches the keys that the
-                /// disk resolver tries for it, see [`Self::probe`].
-                ///
-                /// A probed key that names a file on disk returns `None`, so the
-                /// import takes the disk route as it did before the probe. The
-                /// disk resolver then picks the file, the file gets its
-                /// directory's `tsconfig.json` and `package.json`, and the parse
-                /// task reads the contents from the map (`Self::get`).
+                /// [`Self::resolve`] for an import, which also tries the names in [`Self::probe`].
                 pub(crate) fn resolve_import(
                     &self,
                     arena: &bun_alloc::Arena,
@@ -964,12 +953,12 @@ pub mod bv2_impl {
                 ) -> Option<bun_resolver::Result> {
                     let (key, probed) =
                         self.find(source_file, specifier, Some((&resolver.opts, kind)))?;
+                    // A probed key for a file on disk keeps the disk route and its tsconfig.json.
                     if probed {
-                        // The key names a file on disk when the disk resolver finds
-                        // the key itself. Through a symlink it finds another path.
+                        // The disk resolver resolves such a key to the key itself.
                         if let Ok(disk) = resolver.resolve(source_dir, key, kind) {
-                            // Compare in the spelling of the keys (`file_map_from_js`).
                             let mut disk_path = disk.path_pair.primary.text.to_vec();
+                            // Compare in the spelling of the keys (`file_map_from_js`).
                             bun_paths::resolve_path::dangerously_convert_path_to_posix_in_place::<u8>(
                                 &mut disk_path,
                             );
@@ -981,9 +970,7 @@ pub mod bv2_impl {
                     Some(Self::result_for_key(arena, key))
                 }
 
-                /// The key that `specifier` names from `source_file`, and whether
-                /// [`Self::probe`] found it. `import` holds the resolver options
-                /// and the import kind. Without it, only an exact key matches.
+                /// The key for `specifier`, and whether it came from [`Self::probe`], which needs `import`.
                 fn find(
                     &self,
                     source_file: &[u8],
@@ -1008,15 +995,13 @@ pub mod bv2_impl {
                         return Some((&**key, false));
                     }
 
-                    // `path` is the file the specifier names.
+                    // Also try joining a relative specifier against the importer's
+                    // directory. Relative = not posix-absolute and not Windows
+                    // drive-absolute (e.g. `C:/`).
                     let mut buf = bun_paths::path_buffer_pool::get();
                     let path: &[u8] = if bun_paths::is_absolute_loose(specifier) {
                         posix_specifier
                     } else if !specifier.is_empty() {
-                        // Also try joining a relative specifier against the importer's
-                        // directory. Relative = not posix-absolute and not Windows
-                        // drive-absolute (e.g. `C:/`).
-                        //
                         // `source_file` may itself be relative (e.g. on Windows
                         // when the bundler stores paths relative to cwd).
                         let mut abs_source_buf = bun_paths::path_buffer_pool::get();
@@ -1089,13 +1074,7 @@ pub mod bv2_impl {
                     Some((key, true))
                 }
 
-                /// The key the disk resolver finds for `specifier` when no key
-                /// equals `path`, the file that `specifier` names.
-                /// `Resolver::check_relative_path` tries the same names in the
-                /// same order: `path` with each extension, the TypeScript rewrite
-                /// of its extension (`a.js` to `a.ts`), then `path/index` with
-                /// each extension. A specifier that names a directory (`./lib/`)
-                /// tries only the index names.
+                /// The first key among the names that `Resolver::check_relative_path` tries for `path`.
                 fn probe(
                     &self,
                     path: &[u8],
@@ -1107,6 +1086,7 @@ pub mod bv2_impl {
                     let extension_order = options.path_extension_order(kind, in_node_modules);
                     let mut candidate: Vec<u8> = Vec::with_capacity(path.len() + 16);
 
+                    // A specifier that names a directory (`./lib/`) tries only the index names.
                     if !bun_resolver::Resolver::import_path_names_directory(specifier) {
                         for ext in extension_order {
                             if let Some(key) = self.key_for(&mut candidate, &[path, &ext[..]]) {
@@ -1141,8 +1121,7 @@ pub mod bv2_impl {
                     None
                 }
 
-                /// The map's copy of the key that `parts` spell when joined.
-                /// `candidate` is scratch space.
+                /// The map's copy of the key that `parts` spell, joined in `candidate`.
                 fn key_for(&self, candidate: &mut Vec<u8>, parts: &[&[u8]]) -> Option<&[u8]> {
                     candidate.clear();
                     for part in parts {
@@ -1153,10 +1132,7 @@ pub mod bv2_impl {
                         .map(|(key, _)| &**key)
                 }
 
-                /// Build a `bun_resolver::Result` for a matched key. The key is
-                /// copied into `arena`, the build's bump arena, so the returned
-                /// `Path<'static>` borrows arena memory (lives for the entire
-                /// build pass) instead of the map's key storage.
+                /// A `bun_resolver::Result` for `key`, with a copy of `key` in the build's `arena`.
                 #[inline]
                 fn result_for_key(arena: &bun_alloc::Arena, key: &[u8]) -> bun_resolver::Result {
                     // SAFETY: ARENA — `arena` is the build-pass bump arena

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -932,51 +932,91 @@ pub mod bv2_impl {
                 /// joined against `dirname(source_file)` (with Windows
                 /// drive-letter / separator normalization).
                 ///
-                /// `arena` is the build's bump arena (`BundleV2::arena()`);
-                /// the matched key is copied into it so the returned
-                /// `bun_resolver::Result`'s `Path<'static>` borrows arena memory
-                /// (lives for the entire build pass) instead of the map's key
-                /// storage.
+                /// `arena` is the build's bump arena (`BundleV2::arena()`), see
+                /// [`Self::result_for_key`].
                 pub(crate) fn resolve(
                     &self,
                     arena: &bun_alloc::Arena,
                     source_file: &[u8],
                     specifier: &[u8],
                 ) -> Option<bun_resolver::Result> {
+                    let (key, _) = self.find(source_file, specifier, None)?;
+                    Some(Self::result_for_key(arena, key))
+                }
+
+                /// [`Self::resolve`] for an import. A relative or absolute
+                /// specifier that names no key also matches the keys that the
+                /// disk resolver tries for it, see [`Self::probe`].
+                ///
+                /// A probed key that names a file on disk returns `None`, so the
+                /// import takes the disk route as it did before the probe. The
+                /// disk resolver then picks the file, the file gets its
+                /// directory's `tsconfig.json` and `package.json`, and the parse
+                /// task reads the contents from the map (`Self::get`).
+                pub(crate) fn resolve_import(
+                    &self,
+                    arena: &bun_alloc::Arena,
+                    resolver: &mut bun_resolver::Resolver<'_>,
+                    source_dir: &[u8],
+                    source_file: &[u8],
+                    specifier: &[u8],
+                    kind: ImportKind,
+                ) -> Option<bun_resolver::Result> {
+                    let (key, probed) =
+                        self.find(source_file, specifier, Some((&resolver.opts, kind)))?;
+                    if probed {
+                        // The key names a file on disk when the disk resolver finds
+                        // the key itself. Through a symlink it finds another path.
+                        if let Ok(disk) = resolver.resolve(source_dir, key, kind) {
+                            // Compare in the spelling of the keys (`file_map_from_js`).
+                            let mut disk_path = disk.path_pair.primary.text.to_vec();
+                            bun_paths::resolve_path::dangerously_convert_path_to_posix_in_place::<u8>(
+                                &mut disk_path,
+                            );
+                            if disk_path == key {
+                                return None;
+                            }
+                        }
+                    }
+                    Some(Self::result_for_key(arena, key))
+                }
+
+                /// The key that `specifier` names from `source_file`, and whether
+                /// [`Self::probe`] found it. `import` holds the resolver options
+                /// and the import kind. Without it, only an exact key matches.
+                fn find(
+                    &self,
+                    source_file: &[u8],
+                    specifier: &[u8],
+                    import: Option<(&bun_resolver::options::BundleOptions, ImportKind)>,
+                ) -> Option<(&[u8], bool)> {
                     if self.map.is_empty() {
                         return None;
                     }
 
-                    // SAFETY: ARENA — `arena` is the build-pass bump arena
-                    // (never freed before the `Result` is consumed); detaching the
-                    // borrow lifetime matches the established `Path<'static>`
-                    // convention used throughout `bun_resolver` (PORTING.md
-                    // §Lifetimes: ARENA → `&'bump T`).
-                    let dupe = |key: &[u8]| -> &'static [u8] {
-                        // SAFETY: see ARENA note above — bytes live in the build-pass arena.
-                        unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(key)) }
+                    // The keys use `/` separators (`file_map_from_js`).
+                    let mut specifier_buf = bun_paths::path_buffer_pool::get();
+                    let posix_specifier: &[u8] = if cfg!(windows) {
+                        bun_paths::resolve_path::path_to_posix_buf(specifier, &mut **specifier_buf)
+                    } else {
+                        specifier
                     };
 
                     // Direct key match (must use `getKey` to return the map-owned
                     // key, not the parameter).
-                    #[cfg(not(windows))]
-                    if let Some((key, _)) = self.map.get_key_value(specifier) {
-                        return Some(Self::result_for_key(dupe(key.as_ref())));
-                    }
-                    #[cfg(windows)]
-                    {
-                        let mut buf = bun_paths::path_buffer_pool::get();
-                        let normalized =
-                            bun_paths::resolve_path::path_to_posix_buf(specifier, &mut **buf);
-                        if let Some((key, _)) = self.map.get_key_value(normalized) {
-                            return Some(Self::result_for_key(dupe(key.as_ref())));
-                        }
+                    if let Some((key, _)) = self.map.get_key_value(posix_specifier) {
+                        return Some((&**key, false));
                     }
 
-                    // Also try joining a relative specifier against the importer's
-                    // directory. Relative = not posix-absolute and not Windows
-                    // drive-absolute (e.g. `C:/`).
-                    if !specifier.is_empty() && !bun_paths::is_absolute_loose(specifier) {
+                    // `path` is the file the specifier names.
+                    let mut buf = bun_paths::path_buffer_pool::get();
+                    let path: &[u8] = if bun_paths::is_absolute_loose(specifier) {
+                        posix_specifier
+                    } else if !specifier.is_empty() {
+                        // Also try joining a relative specifier against the importer's
+                        // directory. Relative = not posix-absolute and not Windows
+                        // drive-absolute (e.g. `C:/`).
+                        //
                         // `source_file` may itself be relative (e.g. on Windows
                         // when the bundler stores paths relative to cwd).
                         let mut abs_source_buf = bun_paths::path_buffer_pool::get();
@@ -995,7 +1035,6 @@ pub mod bv2_impl {
                             &mut **source_file_buf,
                         );
 
-                        let mut buf = bun_paths::path_buffer_pool::get();
                         let source_dir = bun_paths::resolve_path::dirname::<
                             bun_paths::platform::Posix,
                         >(normalized_source_file);
@@ -1032,20 +1071,101 @@ pub mod bv2_impl {
                         }
                         let joined = &buf[0..joined_len];
                         if let Some((key, _)) = self.map.get_key_value(joined) {
-                            return Some(Self::result_for_key(dupe(key.as_ref())));
+                            return Some((&**key, false));
+                        }
+                        joined
+                    } else {
+                        return None;
+                    };
+
+                    let (options, kind) = import?;
+                    // A bare specifier names a package, not a file.
+                    if !bun_paths::is_absolute_loose(specifier)
+                        && bun_paths::is_package_path_not_absolute(specifier)
+                    {
+                        return None;
+                    }
+                    let key = self.probe(path, specifier, options, kind)?;
+                    Some((key, true))
+                }
+
+                /// The key the disk resolver finds for `specifier` when no key
+                /// equals `path`, the file that `specifier` names.
+                /// `Resolver::check_relative_path` tries the same names in the
+                /// same order: `path` with each extension, the TypeScript rewrite
+                /// of its extension (`a.js` to `a.ts`), then `path/index` with
+                /// each extension. A specifier that names a directory (`./lib/`)
+                /// tries only the index names.
+                fn probe(
+                    &self,
+                    path: &[u8],
+                    specifier: &[u8],
+                    options: &bun_resolver::options::BundleOptions,
+                    kind: ImportKind,
+                ) -> Option<&[u8]> {
+                    let in_node_modules = bun_core::strings::contains(path, b"/node_modules/");
+                    let extension_order = options.path_extension_order(kind, in_node_modules);
+                    let mut candidate: Vec<u8> = Vec::with_capacity(path.len() + 16);
+
+                    if !bun_resolver::Resolver::import_path_names_directory(specifier) {
+                        for ext in extension_order {
+                            if let Some(key) = self.key_for(&mut candidate, &[path, &ext[..]]) {
+                                return Some(key);
+                            }
+                        }
+
+                        let name_start =
+                            bun_core::strings::last_index_of_char(path, b'/').map_or(0, |i| i + 1);
+                        if let Some(dot) =
+                            bun_core::strings::last_index_of_char(&path[name_start..], b'.')
+                        {
+                            let (stem, ext) = path.split_at(name_start + dot);
+                            for &new_ext in
+                                bun_resolver::rewritten_file_extensions(ext, || in_node_modules)
+                            {
+                                if let Some(key) = self.key_for(&mut candidate, &[stem, new_ext]) {
+                                    return Some(key);
+                                }
+                            }
                         }
                     }
 
+                    let dir = path.strip_suffix(b"/").unwrap_or(path);
+                    for ext in extension_order {
+                        if let Some(key) =
+                            self.key_for(&mut candidate, &[dir, &b"/index"[..], &ext[..]])
+                        {
+                            return Some(key);
+                        }
+                    }
                     None
                 }
 
-                /// Build a `bun_resolver::Result` for a matched key. `key` must
-                /// already satisfy `'static` — see [`resolve`], which copies the
-                /// map-owned key into the build's bump arena before calling here so
-                /// the resulting `Path<'static>` borrows arena memory rather than
-                /// forging a `'static` from a map borrow.
+                /// The map's copy of the key that `parts` spell when joined.
+                /// `candidate` is scratch space.
+                fn key_for(&self, candidate: &mut Vec<u8>, parts: &[&[u8]]) -> Option<&[u8]> {
+                    candidate.clear();
+                    for part in parts {
+                        candidate.extend_from_slice(part);
+                    }
+                    self.map
+                        .get_key_value(candidate.as_slice())
+                        .map(|(key, _)| &**key)
+                }
+
+                /// Build a `bun_resolver::Result` for a matched key. The key is
+                /// copied into `arena`, the build's bump arena, so the returned
+                /// `Path<'static>` borrows arena memory (lives for the entire
+                /// build pass) instead of the map's key storage.
                 #[inline]
-                fn result_for_key(key: &'static [u8]) -> bun_resolver::Result {
+                fn result_for_key(arena: &bun_alloc::Arena, key: &[u8]) -> bun_resolver::Result {
+                    // SAFETY: ARENA — `arena` is the build-pass bump arena
+                    // (never freed before the `Result` is consumed); detaching the
+                    // borrow lifetime matches the established `Path<'static>`
+                    // convention used throughout `bun_resolver` (PORTING.md
+                    // §Lifetimes: ARENA → `&'bump T`).
+                    let key: &'static [u8] =
+                        unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(key)) };
                     bun_resolver::Result {
                         path_pair: bun_resolver::PathPair {
                             primary: crate::bun_fs::Path::init_with_namespace(key, b"file"),
@@ -2352,10 +2472,14 @@ pub mod bv2_impl {
 
             // Check the FileMap first for in-memory files
             if let Some(file_map) = self.file_map {
-                if let Some(_file_map_result) = file_map.resolve(
+                if let Some(_file_map_result) = file_map.resolve_import(
                     self.arena(),
+                    // SAFETY: see `transpiler` note above.
+                    unsafe { &mut (*transpiler).resolver },
+                    source_dir,
                     &import_record.source_file,
                     &import_record.specifier,
+                    import_record.kind,
                 ) {
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
@@ -6382,9 +6506,14 @@ pub mod bv2_impl {
 
                 // Check the FileMap first for in-memory files
                 if let Some(file_map) = self.file_map {
-                    if let Some(_file_map_result) =
-                        file_map.resolve(self.arena(), source.path.text, import_record.path.text)
-                    {
+                    if let Some(_file_map_result) = file_map.resolve_import(
+                        self.arena(),
+                        &mut transpiler.resolver,
+                        source_dir,
+                        source.path.text,
+                        import_record.path.text,
+                        import_record.kind,
+                    ) {
                         let mut file_map_result = _file_map_result;
                         let mut path_primary = file_map_result.path_pair.primary;
                         let import_record_loader = import_record.loader.unwrap_or_else(|| {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -52,6 +52,7 @@ pub use tsconfig_json::TSConfigJSON;
 pub use ::bun_install_types::resolver_hooks as install_types;
 pub use resolver::{
     AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver, module_type_from_ext,
+    rewritten_file_extensions,
 };
 pub use result::{
     DebugLogs, DirEntryResolveQueueItem, ExternalKind, FlushMode, LoadResult, MatchResult,

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -139,8 +139,7 @@ impl BundleOptions {
         }
     }
 
-    /// The extensions `Resolver::check_relative_path` tries, in order, on a
-    /// path imported with `kind`. A path inside `node_modules` has its own order.
+    /// The extension order of `Resolver::check_relative_path` for a path imported with `kind`.
     pub fn path_extension_order(
         &self,
         kind: bun_ast::ImportKind,

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -138,6 +138,16 @@ impl BundleOptions {
             ExtOrder::MainField => &self.main_field_extension_order,
         }
     }
+
+    /// The extensions `Resolver::check_relative_path` tries, in order, on a
+    /// path imported with `kind`. A path inside `node_modules` has its own order.
+    pub fn path_extension_order(
+        &self,
+        kind: bun_ast::ImportKind,
+        in_node_modules: bool,
+    ) -> &[Box<[u8]>] {
+        self.ext_order_slice(self.extension_order.kind(kind, in_node_modules))
+    }
 }
 
 pub mod bundle_options {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1999,7 +1999,7 @@ impl<'a> Resolver<'a> {
 
     /// Whether an import specifier explicitly names a directory: a trailing
     /// separator, `.`, `..`, or a path ending in `/.` or `/..`.
-    fn import_path_names_directory(import_path: &[u8]) -> bool {
+    pub fn import_path_names_directory(import_path: &[u8]) -> bool {
         let Some(&last) = import_path.last() else {
             return false;
         };
@@ -6745,7 +6745,7 @@ pub fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
 /// is esbuild's `rewrittenFileExtensions` table plus Bun's `.js` → `.mts`
 /// (oven-sh/bun#12580). `inside_node_modules` gates only `.mjs` and `.cjs`:
 /// `DISABLE_AUTO_JS_TO_TS_IN_NODE_MODULES` never applied to `.js`/`.jsx`.
-fn rewritten_file_extensions(
+pub fn rewritten_file_extensions(
     ext: &[u8],
     inside_node_modules: impl Fn() -> bool,
 ) -> &'static [&'static [u8]] {

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -601,4 +601,138 @@ describe("bundler files option", () => {
     const output = await result.outputs[0].text();
     expect(output).toContain("injected by plugin");
   });
+
+  describe("an import resolves against the keys like a path on disk", () => {
+    // Bundles the config and returns the `from <file>` strings in the output, or the build errors.
+    async function picked(config: Bun.BuildConfig) {
+      const result = await Bun.build({ ...config, throw: false });
+      if (!result.success) return result.logs.map(log => log.message);
+      return (await result.outputs[0].text()).match(/from [\w./]+/g);
+    }
+
+    test.each([
+      ["./greet", "/app/greet.ts"],
+      ["./greet", "/app/greet.json"],
+      ["/app/greet", "/app/greet.tsx"],
+      ["../app/greet", "/app/greet.js"],
+      ["./lib", "/app/lib/index.ts"],
+      ["./lib/", "/app/lib/index.js"],
+      [".", "/app/index.js"],
+      ["./greet.js", "/app/greet.ts"],
+      ["./greet.mjs", "/app/greet.mts"],
+    ])("import %p finds %p", async (specifier, key) => {
+      const files = {
+        "/app/main.ts": `import greet from ${JSON.stringify(specifier)}; console.log(greet);`,
+        [key]: key.endsWith(".json") ? `"from ${key}"` : `export default "from ${key}";`,
+      };
+      expect(await picked({ entrypoints: ["/app/main.ts"], files })).toEqual([`from ${key}`]);
+    });
+
+    // The extension order depends on the import kind, and it is different inside node_modules.
+    test.each([
+      ["main.ts", `import { a } from "./a";`, ["a.ts", "a.mts", "a.js", "a.jsx"], "a.jsx"],
+      ["main.ts", `const { a } = require("./a");`, ["a.ts", "a.mts", "a.js", "a.jsx"], "a.ts"],
+      [
+        "node_modules/lib/main.js",
+        `const { a } = require("./a");`,
+        ["node_modules/lib/a.ts", "node_modules/lib/a.js"],
+        "node_modules/lib/a.js",
+      ],
+      ["main.ts", `import { a } from "./a";`, ["a.js", "a/index.ts"], "a.js"],
+      ["main.ts", `import { a } from "./a/";`, ["a.js", "a/index.ts"], "a/index.ts"],
+      ["main.ts", `import { a } from "./a.js";`, ["a.ts", "a.js.ts"], "a.js.ts"],
+      ["main.ts", `import { a } from "./a.js";`, ["a.mts", "a.tsx", "a.ts"], "a.ts"],
+    ])("%s: %s with %j picks %p, like the disk resolver", async (entry, statement, names, expected) => {
+      const sources = Object.fromEntries([
+        [entry, `${statement} console.log(a);`],
+        ...names.map(name => [name, `export const a = "from ${name}";`]),
+      ]);
+      using dir = tempDir("bundler-files-order", sources);
+      const disk = await picked({ entrypoints: [`${dir}/${entry}`] });
+      const memory = await picked({
+        entrypoints: [`/app/${entry}`],
+        files: Object.fromEntries(Object.entries(sources).map(([name, code]) => [`/app/${name}`, code])),
+      });
+      expect({ disk, memory }).toEqual({ disk: [`from ${expected}`], memory: [`from ${expected}`] });
+    });
+
+    test("a file on disk that a key overrides keeps its tsconfig.json when the import has no extension", async () => {
+      using dir = tempDir("bundler-files-override-tsconfig", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react", jsxFactory: "h" } }),
+        "main.ts": `import App from "./App"; console.log(App);`,
+        "App.tsx": `export default <div>from disk</div>;`,
+      });
+      const files = { [`${dir}/App.tsx`]: `export default <div>from memory</div>;` };
+      const result = await Bun.build({ entrypoints: [`${dir}/main.ts`], files, external: ["react/*"], throw: false });
+      expect(result.logs).toEqual([]);
+      expect(await result.outputs[0].text()).toContain(`h("div", null, "from memory")`);
+    });
+
+    test("a key that overrides a file on disk does not change which file an import picks", async () => {
+      using dir = tempDir("bundler-files-override-order", {
+        "main.ts": `import { a } from "./a"; console.log(a);`,
+        "a.jsx": `export const a = "from disk/a.jsx";`,
+        "a.ts": `export const a = "from disk/a.ts";`,
+      });
+      const files = { [`${dir}/a.ts`]: `export const a = "from memory/a.ts";` };
+      expect(await picked({ entrypoints: [`${dir}/main.ts`], files })).toEqual(["from disk/a.jsx"]);
+    });
+
+    test("a key wins over another file on disk that the import names", async () => {
+      using dir = tempDir("bundler-files-key-wins", {
+        "main.ts": `import { a } from "./a"; console.log(a);`,
+        "a.ts": `export const a = "from disk/a.ts";`,
+      });
+      const files = { [`${dir}/a.js`]: `export const a = "from memory/a.js";` };
+      expect(await picked({ entrypoints: [`${dir}/main.ts`], files })).toEqual(["from memory/a.js"]);
+    });
+
+    test("an exact key wins over the .js rewrite", async () => {
+      const files = {
+        "/app/main.ts": `import greet from "./greet.js"; console.log(greet);`,
+        "/app/greet.js": `export default "from greet.js";`,
+        "/app/greet.ts": `export default "from greet.ts";`,
+      };
+      expect(await picked({ entrypoints: ["/app/main.ts"], files })).toEqual(["from greet.js"]);
+    });
+
+    test("a bare import does not find a key", async () => {
+      const files = {
+        "/app/main.ts": `import greet from "greet"; console.log(greet);`,
+        "/app/greet.ts": `export default "from greet.ts";`,
+      };
+      expect(await picked({ entrypoints: ["/app/main.ts"], files })).toEqual([
+        expect.stringContaining('Could not resolve: "greet"'),
+      ]);
+    });
+
+    test("a file on disk imports an in-memory file without the extension", async () => {
+      using dir = tempDir("bundler-files-disk-importer", {
+        "main.ts": `import generated from "./generated"; console.log(generated);`,
+      });
+      const files = { [`${dir}/generated.ts`]: `export default "from generated.ts";` };
+      expect(await picked({ entrypoints: [`${dir}/main.ts`], files })).toEqual(["from generated.ts"]);
+    });
+
+    test("an import that an onResolve plugin declines finds the in-memory file", async () => {
+      let declined = 0;
+      const files = {
+        "/app/main.ts": `import greet from "./greet"; console.log(greet);`,
+        "/app/greet.ts": `export default "from greet.ts";`,
+      };
+      const plugins: Bun.BunPlugin[] = [
+        {
+          name: "decline",
+          setup(build) {
+            build.onResolve({ filter: /^\.\/greet$/ }, () => {
+              declined++;
+              return undefined;
+            });
+          },
+        },
+      ];
+      expect(await picked({ entrypoints: ["/app/main.ts"], files, plugins })).toEqual(["from greet.ts"]);
+      expect(declined).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
### Problem

- With `Bun.build({ files })`, an import between in-memory files needs the full file name. `import "./greet"` with the key `/app/greet.ts` fails with `Could not resolve: "./greet"`. So do `./lib` (for `/app/lib/index.ts`) and `./greet.js` (for `/app/greet.ts`).
- `FileMap::resolve` (`src/bundler/bundle_v2.rs:940`) looks up only the specifier and the specifier joined to the importer's directory.

### Fix

- The two import call sites use the new `FileMap::resolve_import`. When no key equals the path, it tries the names that the disk resolver tries, in the same order: each extension, the `.js` to `.ts` rewrite, then `index` files.
- A probed key that names a file on disk keeps the disk route, as before. That route applies the directory's `tsconfig.json` and `package.json`. Only a key with no file behind it takes the in-memory route.
- Bare specifiers and entry points still match a key exactly. A build without `files` does not reach this code.
- Verified: `test/bundler/bundler_files.test.ts` (23 new tests, 19 fail on 1.4.1, 4 guard current behavior). Also `test/js/bun/css/doesnt_crash.test.ts`.

### Background

- `files` maps paths to contents. For each import, the bundler looks in this map before it resolves the import on disk.
- An override is a key for a file that also exists on disk. The parse task reads its contents from the map (`FileMap::get`), whichever route resolved it.
- The disk resolver's extension order depends on the import kind and on `node_modules`. For example, `import` tries `.jsx` before `.ts`, and `require` tries `.ts` first.

<details><summary>Notes</summary>

- Imports that resolve today and change:
  - A key with no file on disk wins over another disk file that the import also names. With the key `a.js` and the disk file `a.ts`, `import "./a"` now gives the key. The docs say that in-memory files take priority over files on disk.
  - A key in a symlinked directory takes the in-memory route, because the disk resolver returns the real path. Before, `./App` used the disk contents while `./App.ts` used the key. Now both use the key.
- The disk check resolves the key, not the specifier. With the disk files `a.jsx` and `a.ts` and a key for `a.ts`, `import "./a"` still gives the disk `a.jsx`, as before.
- The extension order comes from the resolver options (`path_extension_order`), so a user order and the `.node` extension apply. A specifier that names a directory (`./lib/`, `.`) tries only `index` files, as `Resolver::check_relative_path` does.
- Entry points are out of scope. `Bun.build` picks the root directory with an exact `files.contains` check (`src/runtime/api/JSBundler.rs:921`), so an extensionless in-memory entry point fails there first. The docs say that an entrypoint must match a key exactly.
- Relative keys such as `./src/a.ts` do not match an import on main. #38650 fixes that. #38650 and #40345 also change `FileMap::resolve`, so the second PR to merge needs a rebase.
- `cargo check --target x86_64-pc-windows-msvc` passes. CI runs the tests on Windows.

</details>
