### PR TITLE
bundler: let a nested binding keep its name unless it would capture a reference

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -63,7 +63,8 @@ pub struct Ast<'a> {
     // This list may be mutated later, so we should store the capacity
     pub symbols: SymbolList<'a>,
     pub module_scope: Scope,
-    pub char_freq: Option<CharFreq>,
+    pub char_freq: Option<bun_alloc::AstBox<CharFreq>>,
+    pub scope_uses: ScopeUseList,
     pub exports_ref: Ref,
     pub module_ref: Ref,
     /// When using format .bake_internal_dev, this is the HMR variable instead
@@ -129,6 +130,7 @@ impl<'a> Ast<'a> {
             symbols: SymbolList::new_in(arena),
             module_scope: Scope::default(),
             char_freq: None,
+            scope_uses: ScopeUseList::default(),
             exports_ref: Ref::NONE,
             module_ref: Ref::NONE,
             wrapper_ref: Ref::NONE,
@@ -179,6 +181,60 @@ pub enum CommonJSExportValue {
 pub type CommonJSNamedExports = StringArrayHashMap<CommonJSNamedExport, StringContext, AstAlloc>;
 
 pub type NamedImports = ArrayHashMap<Ref, NamedImport, AutoContext, AstAlloc>;
+/// This file's symbol `symbol` (inner index) is referenced directly in the
+/// scope whose `Scope::visit_span` starts at `scope`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ScopeUse {
+    pub scope: u32,
+    pub symbol: u32,
+}
+
+/// The symbol may be referenced from any scope in `first..=last`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ScopeUseSpan {
+    pub symbol: u32,
+    pub first: u32,
+    pub last: u32,
+}
+
+impl ScopeUseSpan {
+    pub const fn whole_file(symbol: u32) -> ScopeUseSpan {
+        ScopeUseSpan {
+            symbol,
+            first: 0,
+            last: u32::MAX,
+        }
+    }
+}
+
+/// Where the file references each symbol, for the bundler's number renamer:
+/// a nested binding may keep a name an enclosing binding also has when the
+/// enclosing one is never referenced beneath it. Filled only when bundling
+/// without identifier minification. References to unbound globals are left
+/// out (every scope avoids their names anyway).
+pub struct ScopeUseList {
+    /// `false`: nothing was recorded; every symbol must count as referenced
+    /// everywhere.
+    pub tracked: bool,
+    /// In visit order, adjacent repeats dropped.
+    pub points: AstVec<ScopeUse>,
+    /// Sorted, no repeats. Class field initializers (may be printed inside
+    /// the constructor: the span is the class body), the parser's generated
+    /// temporaries and helpers (may be printed deeper than recorded) and
+    /// `module`/`exports` (printed for one another): the span is the file.
+    pub spans: AstVec<ScopeUseSpan>,
+}
+
+impl Default for ScopeUseList {
+    fn default() -> Self {
+        ScopeUseList {
+            tracked: false,
+            points: AstAlloc::vec(),
+            spans: AstAlloc::vec(),
+        }
+    }
+}
+
 /// One `import()` / `require()` whose every use the parser accounted for.
 #[derive(Clone, Copy, Default)]
 pub struct DynamicImportUse {

--- a/src/ast/char_freq.rs
+++ b/src/ast/char_freq.rs
@@ -26,7 +26,8 @@ impl Default for CharFreq {
     }
 }
 
-const SCAN_BIG_CHUNK_SIZE: usize = 32;
+// Below this, zeroing `scan_big`'s count tables costs more than the scan.
+const SCAN_BIG_CHUNK_SIZE: usize = 1024;
 
 impl CharFreq {
     pub fn scan(&mut self, text: &[u8], delta: i32) {
@@ -109,41 +110,38 @@ impl CharFreq {
 }
 
 fn scan_big(out: &mut Buffer, text: &[u8], delta: i32) {
-    // The field is naturally aligned, so operate on `out` directly.
-    let mut deltas: [i32; 256] = [0; 256];
-
-    debug_assert!(text.len() >= SCAN_BIG_CHUNK_SIZE);
-
-    let unrolled = text.len() - (text.len() % SCAN_BIG_CHUNK_SIZE);
-    let (chunks, remain) = text.split_at(unrolled);
-
-    for chunk in chunks.as_chunks::<SCAN_BIG_CHUNK_SIZE>().0 {
-        // PERF: candidate for unrolling — profile
-        for i in 0..SCAN_BIG_CHUNK_SIZE {
-            deltas[chunk[i] as usize] += delta;
-        }
+    // Four count tables fed round-robin so a run of the same byte does not
+    // serialize on one counter's store-to-load latency; summed at the end.
+    let mut counts = [[0u32; 256]; 4];
+    let (words, tail) = text.as_chunks::<8>();
+    for word in words {
+        counts[0][word[0] as usize] += 1;
+        counts[1][word[1] as usize] += 1;
+        counts[2][word[2] as usize] += 1;
+        counts[3][word[3] as usize] += 1;
+        counts[0][word[4] as usize] += 1;
+        counts[1][word[5] as usize] += 1;
+        counts[2][word[6] as usize] += 1;
+        counts[3][word[7] as usize] += 1;
     }
+    for &c in tail {
+        counts[0][c as usize] += 1;
+    }
+    let total = |c: u8| -> i32 {
+        let c = c as usize;
+        (counts[0][c] + counts[1][c] + counts[2][c] + counts[3][c]) as i32 * delta
+    };
 
-    for &c in remain {
-        deltas[c as usize] += delta;
+    // Accumulate (`+=`): `scan` is called once per text with mixed deltas.
+    for i in 0..26u8 {
+        out[i as usize] += total(b'a' + i);
+        out[26 + i as usize] += total(b'A' + i);
     }
-
-    // Accumulate (`+=`) — overwriting the accumulator instead would make
-    // every ≥32-byte scan discard all prior counts (last-big-scan-wins), and
-    // since `scope.members` is a RandomState-seeded map the result would be
-    // nondeterministic (an observed `OV`/`OU` flap on three.js). Accumulating
-    // keeps the freq table both correct and run-to-run stable.
-    for i in 0..26 {
-        out[i] += deltas[b'a' as usize + i];
+    for i in 0..10u8 {
+        out[52 + i as usize] += total(b'0' + i);
     }
-    for i in 0..26 {
-        out[26 + i] += deltas[b'A' as usize + i];
-    }
-    for i in 0..10 {
-        out[52 + i] += deltas[b'0' as usize + i];
-    }
-    out[62] += deltas[b'_' as usize];
-    out[63] += deltas[b'$' as usize];
+    out[62] += total(b'_');
+    out[63] += total(b'$');
 }
 
 fn scan_small(out: &mut Buffer, text: &[u8], delta: i32) {

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -1,5 +1,5 @@
 use bun_alloc::{AstAlloc, AstVec};
-use bun_collections::{StringHashMap, VecExt};
+use bun_collections::VecExt;
 
 use crate::StrictModeKind;
 use crate::base::Ref;
@@ -7,12 +7,290 @@ use crate::nodes::StoreRef;
 use crate::symbol::{self, Symbol};
 use crate::ts::TSNamespaceScope;
 
-/// Backed by `AstAlloc` so the table allocation *and* the per-key boxes land
-/// in the thread-local AST `mi_heap` and are reclaimed by the same
-/// `mi_heap_destroy` that frees the arena-allocated `Scope` holding the map.
-/// `Scope` itself sits in an arena slot whose `Drop` never runs, so a
-/// global-heap-backed map here would leak.
-pub(crate) type MemberHashMap = StringHashMap<Member, AstAlloc>;
+/// One binding of a scope in a `Members::Table`: its name (a slice of the
+/// source text or the lexer's string table, which outlive the arena holding
+/// the scope), the name's `Members::hash`, and the symbol.
+#[derive(Clone, Copy)]
+pub struct MemberEntry {
+    pub name: crate::StoreStr,
+    hash: u32,
+    pub member: Member,
+}
+
+/// Up to `INLINE_MAX` bindings, hashes first so that a lookup that misses
+/// (the common case while resolving an identifier up the scope chain) reads
+/// one cache line.
+pub struct InlineMembers {
+    hashes: [u32; Members::INLINE_MAX],
+    len: u32,
+    names: [crate::StoreStr; Members::INLINE_MAX],
+    members: [Member; Members::INLINE_MAX],
+}
+
+impl InlineMembers {
+    /// Bit `i` set: entry `i` has this hash.
+    #[inline]
+    fn matches(&self, hash: u32) -> u32 {
+        let mut mask = 0u32;
+        for (i, h) in self.hashes.iter().enumerate() {
+            mask |= u32::from(*h == hash) << i;
+        }
+        mask & ((1u32 << self.len) - 1)
+    }
+
+    #[inline]
+    fn find(&self, hash: u32, name: &[u8]) -> Option<usize> {
+        let mut mask = self.matches(hash);
+        while mask != 0 {
+            let i = mask.trailing_zeros() as usize;
+            if self.names[i].slice() == name {
+                return Some(i);
+            }
+            mask &= mask - 1;
+        }
+        None
+    }
+}
+
+/// A scope's bindings by name. Most scopes bind a handful of names, so they
+/// start as a short inline array and only become a hash table past
+/// `INLINE_MAX`. Both live in `AstAlloc` (freed with the arena holding the
+/// `Scope`; a `Scope`'s `Drop` never runs).
+#[derive(Default)]
+pub enum Members {
+    #[default]
+    Empty,
+    /// In declaration order.
+    Inline(bun_alloc::AstBox<InlineMembers>),
+    Table(bun_collections::hashbrown::HashTable<MemberEntry, AstAlloc>),
+}
+
+pub struct MembersGetOrPut<'a> {
+    pub found_existing: bool,
+    pub value_ptr: &'a mut Member,
+}
+
+pub enum MembersIter<'a> {
+    Empty,
+    Inline(&'a InlineMembers, usize),
+    Table(bun_collections::hashbrown::hash_table::Iter<'a, MemberEntry>),
+}
+
+impl<'a> Iterator for MembersIter<'a> {
+    type Item = (&'a [u8], &'a Member);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            MembersIter::Empty => None,
+            MembersIter::Inline(inline, i) => {
+                if *i >= inline.len as usize {
+                    return None;
+                }
+                let item = (inline.names[*i].slice(), &inline.members[*i]);
+                *i += 1;
+                Some(item)
+            }
+            MembersIter::Table(it) => it.next().map(|e| (e.name.slice(), &e.member)),
+        }
+    }
+}
+
+impl Members {
+    pub const EMPTY: Members = Members::Empty;
+    pub const INLINE_MAX: usize = 8;
+
+    /// The low 32 bits of wyhash; `hashbrown` takes its tag from the top 7
+    /// bits of what it is given, so `Table` feeds it the `u32` widened.
+    #[inline]
+    pub fn hash(name: &[u8]) -> u32 {
+        bun_wyhash::hash(name) as u32
+    }
+
+    #[inline]
+    fn table_hash(hash: u32) -> u64 {
+        (u64::from(hash) << 32) | u64::from(hash)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Members::Empty => 0,
+            Members::Inline(inline) => inline.len as usize,
+            Members::Table(table) => table.len(),
+        }
+    }
+
+    #[inline]
+    pub fn count(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn iter(&self) -> MembersIter<'_> {
+        match self {
+            Members::Empty => MembersIter::Empty,
+            Members::Inline(inline) => MembersIter::Inline(inline, 0),
+            Members::Table(table) => MembersIter::Table(table.iter()),
+        }
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &Member> + '_ {
+        self.iter().map(|(_, member)| member)
+    }
+
+    #[inline]
+    pub fn get(&self, name: &[u8]) -> Option<&Member> {
+        self.get_hashed(Self::hash(name), name)
+    }
+
+    #[inline]
+    pub fn contains_key(&self, name: &[u8]) -> bool {
+        self.get(name).is_some()
+    }
+
+    #[inline]
+    pub fn get_hashed(&self, hash: u32, name: &[u8]) -> Option<&Member> {
+        match self {
+            Members::Empty => None,
+            Members::Inline(inline) => inline.find(hash, name).map(|i| &inline.members[i]),
+            Members::Table(table) => table
+                .find(Self::table_hash(hash), |e| {
+                    e.hash == hash && e.name.slice() == name
+                })
+                .map(|e| &e.member),
+        }
+    }
+
+    /// Room for about `n` members (the module scope, sized from the source).
+    pub fn reserve(&mut self, n: usize) {
+        if n > Self::INLINE_MAX {
+            self.to_table(n);
+        }
+    }
+
+    fn to_table(&mut self, capacity: usize) {
+        let mut table = match core::mem::take(self) {
+            Members::Table(mut table) => {
+                table.reserve(capacity, |e| Self::table_hash(e.hash));
+                table
+            }
+            Members::Empty => {
+                bun_collections::hashbrown::HashTable::with_capacity_in(capacity, AstAlloc)
+            }
+            Members::Inline(inline) => {
+                let mut table = bun_collections::hashbrown::HashTable::with_capacity_in(
+                    capacity.max(Self::INLINE_MAX * 2),
+                    AstAlloc,
+                );
+                for i in 0..inline.len as usize {
+                    let entry = MemberEntry {
+                        name: inline.names[i],
+                        hash: inline.hashes[i],
+                        member: inline.members[i],
+                    };
+                    table.insert_unique(Self::table_hash(entry.hash), entry, |e| {
+                        Self::table_hash(e.hash)
+                    });
+                }
+                table
+            }
+        };
+        let _ = core::mem::replace(
+            self,
+            Members::Table(core::mem::replace(
+                &mut table,
+                bun_collections::hashbrown::HashTable::new_in(AstAlloc),
+            )),
+        );
+    }
+
+    /// The entry for `name`, inserted with `Member::default()` if absent.
+    ///
+    /// # Safety
+    /// `name` is stored by reference: it must outlive this scope (source
+    /// text, the lexer's string table, or the AST arena all do).
+    pub unsafe fn get_or_put_hashed(&mut self, hash: u32, name: &[u8]) -> MembersGetOrPut<'_> {
+        loop {
+            match self {
+                Members::Empty => {
+                    *self = Members::Inline(bun_alloc::ast_box(InlineMembers {
+                        hashes: [0; Self::INLINE_MAX],
+                        len: 0,
+                        names: [crate::StoreStr::EMPTY; Self::INLINE_MAX],
+                        members: [Member::EMPTY; Self::INLINE_MAX],
+                    }));
+                }
+                Members::Inline(inline) => {
+                    if let Some(i) = inline.find(hash, name) {
+                        let Members::Inline(inline) = self else {
+                            unreachable!()
+                        };
+                        return MembersGetOrPut {
+                            found_existing: true,
+                            value_ptr: &mut inline.members[i],
+                        };
+                    }
+                    let i = inline.len as usize;
+                    if i < Self::INLINE_MAX {
+                        let Members::Inline(inline) = self else {
+                            unreachable!()
+                        };
+                        inline.hashes[i] = hash;
+                        inline.names[i] = crate::StoreStr::new(name);
+                        inline.members[i] = Member::default();
+                        inline.len += 1;
+                        return MembersGetOrPut {
+                            found_existing: false,
+                            value_ptr: &mut inline.members[i],
+                        };
+                    }
+                    self.to_table(Self::INLINE_MAX * 2);
+                }
+                Members::Table(table) => {
+                    return match table.entry(
+                        Self::table_hash(hash),
+                        |e| e.hash == hash && e.name.slice() == name,
+                        |e| Self::table_hash(e.hash),
+                    ) {
+                        bun_collections::hashbrown::hash_table::Entry::Occupied(o) => {
+                            MembersGetOrPut {
+                                found_existing: true,
+                                value_ptr: &mut o.into_mut().member,
+                            }
+                        }
+                        bun_collections::hashbrown::hash_table::Entry::Vacant(v) => {
+                            MembersGetOrPut {
+                                found_existing: false,
+                                value_ptr: &mut v
+                                    .insert(MemberEntry {
+                                        name: crate::StoreStr::new(name),
+                                        hash,
+                                        member: Member::default(),
+                                    })
+                                    .into_mut()
+                                    .member,
+                            }
+                        }
+                    };
+                }
+            }
+        }
+    }
+
+    /// Insert or overwrite.
+    ///
+    /// # Safety
+    /// As for `get_or_put_hashed`.
+    pub unsafe fn put(&mut self, name: &[u8], member: Member) {
+        // SAFETY: forwarded contract.
+        *unsafe { self.get_or_put_hashed(Self::hash(name), name) }.value_ptr = member;
+    }
+}
 
 // `Scope` is a value type — `Ast.module_scope` / `BundledAst.module_scope`
 // hold it by value and `toAST` / `init` bitwise-copy it (`this.module_scope`). Vec no
@@ -27,7 +305,7 @@ pub struct Scope {
     /// `AstVec` for the same reason as `members` above. Elements are `StoreRef`
     /// so iteration yields safe `Deref` instead of `unsafe { child.as_ref() }`.
     pub children: AstVec<StoreRef<Scope>>,
-    pub members: MemberHashMap,
+    pub members: Members,
     /// `AstVec`: arena-backed.
     pub generated: AstVec<Ref>,
     /// This scope's index in the visit pass's pre-order walk and the index of
@@ -70,7 +348,7 @@ impl Scope {
         kind: Kind::Block,
         parent: None,
         children: AstAlloc::vec(),
-        members: MemberHashMap::new_in(AstAlloc),
+        members: Members::EMPTY,
         generated: AstAlloc::vec(),
         visit_span: [u32::MAX, u32::MAX],
         label_ref: Ref::NONE,
@@ -98,39 +376,28 @@ impl Scope {
         (first != u32::MAX && first <= last).then_some((first, last))
     }
 
-    // Must agree with `StringHashMap`'s `BuildHasher` (`bun_wyhash::BuildHasher`,
-    // i.e. `BuildHasherDefault<OneShotHasher>`) so the precomputed hash can be
-    // fed to `get_hashed` without a rehash per scope level. If the map's hasher
-    // ever changes, this must change with it (the debug_assert below catches it).
-    pub fn get_member_hash(name: &[u8]) -> u64 {
-        bun_wyhash::auto_hash::<[u8]>(name)
+    #[inline]
+    pub fn get_member_hash(name: &[u8]) -> u32 {
+        Members::hash(name)
     }
-    pub fn get_member_with_hash(&self, name: &[u8], hash_value: u64) -> Option<Member> {
-        debug_assert_eq!(
-            self.members.hash_key(name),
-            hash_value,
-            "Scope::get_member_hash diverged from StringHashMap's BuildHasher"
-        );
+
+    #[inline]
+    pub fn get_member_with_hash(&self, name: &[u8], hash_value: u32) -> Option<Member> {
         self.members.get_hashed(hash_value, name).copied()
     }
-    pub fn get_or_put_member_with_hash(
+
+    /// # Safety
+    /// `name` must outlive the scope: see `Members::get_or_put_hashed`. The
+    /// parser's names are slices of the source or of the lexer's string
+    /// table, which outlive the AST arena.
+    #[inline]
+    pub unsafe fn get_or_put_member_with_hash(
         &mut self,
         name: &[u8],
-        hash_value: u64,
-    ) -> bun_collections::array_hash_map::StringHashMapGetOrPut<'_, Member> {
-        // PERF: `get_or_put_borrowed` doesn't accept a precomputed hash;
-        // this path is once-per-declared-symbol (not per-scope-per-identifier),
-        // so the redundant rehash is left as-is.
-        let _ = hash_value;
-        // SAFETY: `name` is always a slice into either the source-file contents
-        // or the lexer string-table (the only producers of identifier text in
-        // the parser). Both outlive the `AstAlloc` arena that owns this
-        // `Scope`, so storing the slice by reference is sound — the map is
-        // freed by the same arena reset that would invalidate the
-        // source/string-table.
-        // This avoids one `mi_heap_malloc` per declared identifier per scope,
-        // which profiling showed as the parser's hottest slow-path allocation.
-        unsafe { self.members.get_or_put_borrowed(name) }
+        hash_value: u32,
+    ) -> MembersGetOrPut<'_> {
+        // SAFETY: forwarded contract.
+        unsafe { self.members.get_or_put_hashed(hash_value, name) }
     }
 
     /// Associated-fn form of [`can_merge_symbols`] taking the scope's [`Kind`]
@@ -248,6 +515,13 @@ impl Scope {
 pub struct Member {
     pub ref_: Ref,
     pub loc: crate::Loc,
+}
+
+impl Member {
+    pub const EMPTY: Member = Member {
+        ref_: Ref::NONE,
+        loc: crate::Loc::EMPTY,
+    };
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -17,17 +17,27 @@ pub struct MemberEntry {
     pub member: Member,
 }
 
-/// Up to `INLINE_MAX` bindings, hashes first so that a lookup that misses
-/// (the common case while resolving an identifier up the scope chain) reads
-/// one cache line.
-pub struct InlineMembers {
-    hashes: [u32; Members::INLINE_MAX],
+/// Up to `N` bindings, hashes first so that a lookup that misses (the common
+/// case while resolving an identifier up the scope chain) reads one cache
+/// line. Scopes start with `N = 4` (most have no more) and move to `N = 8`
+/// before becoming a table.
+pub struct InlineMembers<const N: usize> {
+    hashes: [u32; N],
     len: u32,
-    names: [crate::StoreStr; Members::INLINE_MAX],
-    members: [Member; Members::INLINE_MAX],
+    members: [Member; N],
+    names: [crate::StoreStr; N],
 }
 
-impl InlineMembers {
+impl<const N: usize> InlineMembers<N> {
+    fn new() -> Self {
+        InlineMembers {
+            hashes: [0; N],
+            len: 0,
+            members: [Member::EMPTY; N],
+            names: [crate::StoreStr::EMPTY; N],
+        }
+    }
+
     /// Bit `i` set: entry `i` has this hash.
     #[inline]
     fn matches(&self, hash: u32) -> u32 {
@@ -50,6 +60,27 @@ impl InlineMembers {
         }
         None
     }
+
+    /// Caller checks `len < N`.
+    #[inline]
+    fn push(&mut self, hash: u32, name: &[u8]) -> usize {
+        let i = self.len as usize;
+        self.hashes[i] = hash;
+        self.names[i] = crate::StoreStr::new(name);
+        self.members[i] = Member::default();
+        self.len += 1;
+        i
+    }
+
+    fn grow<const M: usize>(&self) -> InlineMembers<M> {
+        let mut out = InlineMembers::<M>::new();
+        let n = self.len as usize;
+        out.hashes[..n].copy_from_slice(&self.hashes[..n]);
+        out.members[..n].copy_from_slice(&self.members[..n]);
+        out.names[..n].copy_from_slice(&self.names[..n]);
+        out.len = self.len;
+        out
+    }
 }
 
 /// A scope's bindings by name. Most scopes bind a handful of names, so they
@@ -61,7 +92,8 @@ pub enum Members {
     #[default]
     Empty,
     /// In declaration order.
-    Inline(bun_alloc::AstBox<InlineMembers>),
+    Small(bun_alloc::AstBox<InlineMembers<4>>),
+    Inline(bun_alloc::AstBox<InlineMembers<8>>),
     Table(bun_collections::hashbrown::HashTable<MemberEntry, AstAlloc>),
 }
 
@@ -71,8 +103,7 @@ pub struct MembersGetOrPut<'a> {
 }
 
 pub enum MembersIter<'a> {
-    Empty,
-    Inline(&'a InlineMembers, usize),
+    Inline(&'a [crate::StoreStr], &'a [Member], usize),
     Table(bun_collections::hashbrown::hash_table::Iter<'a, MemberEntry>),
 }
 
@@ -82,12 +113,8 @@ impl<'a> Iterator for MembersIter<'a> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            MembersIter::Empty => None,
-            MembersIter::Inline(inline, i) => {
-                if *i >= inline.len as usize {
-                    return None;
-                }
-                let item = (inline.names[*i].slice(), &inline.members[*i]);
+            MembersIter::Inline(names, members, i) => {
+                let item = (names.get(*i)?.slice(), &members[*i]);
                 *i += 1;
                 Some(item)
             }
@@ -100,8 +127,9 @@ impl Members {
     pub const EMPTY: Members = Members::Empty;
     pub const INLINE_MAX: usize = 8;
 
-    /// The low 32 bits of wyhash; `hashbrown` takes its tag from the top 7
-    /// bits of what it is given, so `Table` feeds it the `u32` widened.
+    /// The low 32 bits of wyhash. A match is always confirmed by comparing
+    /// the names. `Table` feeds `hashbrown` the value widened, since it takes
+    /// its tag from the top bits.
     #[inline]
     pub fn hash(name: &[u8]) -> u32 {
         bun_wyhash::hash(name) as u32
@@ -116,6 +144,7 @@ impl Members {
     pub fn len(&self) -> usize {
         match self {
             Members::Empty => 0,
+            Members::Small(inline) => inline.len as usize,
             Members::Inline(inline) => inline.len as usize,
             Members::Table(table) => table.len(),
         }
@@ -133,8 +162,13 @@ impl Members {
 
     pub fn iter(&self) -> MembersIter<'_> {
         match self {
-            Members::Empty => MembersIter::Empty,
-            Members::Inline(inline) => MembersIter::Inline(inline, 0),
+            Members::Empty => MembersIter::Inline(&[], &[], 0),
+            Members::Small(m) => {
+                MembersIter::Inline(&m.names[..m.len as usize], &m.members[..m.len as usize], 0)
+            }
+            Members::Inline(m) => {
+                MembersIter::Inline(&m.names[..m.len as usize], &m.members[..m.len as usize], 0)
+            }
             Members::Table(table) => MembersIter::Table(table.iter()),
         }
     }
@@ -157,6 +191,7 @@ impl Members {
     pub fn get_hashed(&self, hash: u32, name: &[u8]) -> Option<&Member> {
         match self {
             Members::Empty => None,
+            Members::Small(inline) => inline.find(hash, name).map(|i| &inline.members[i]),
             Members::Inline(inline) => inline.find(hash, name).map(|i| &inline.members[i]),
             Members::Table(table) => table
                 .find(Self::table_hash(hash), |e| {
@@ -174,7 +209,27 @@ impl Members {
     }
 
     fn to_table(&mut self, capacity: usize) {
-        let mut table = match core::mem::take(self) {
+        fn fill<const N: usize>(
+            inline: &InlineMembers<N>,
+            capacity: usize,
+        ) -> bun_collections::hashbrown::HashTable<MemberEntry, AstAlloc> {
+            let mut table = bun_collections::hashbrown::HashTable::with_capacity_in(
+                capacity.max(Members::INLINE_MAX * 2),
+                AstAlloc,
+            );
+            for i in 0..inline.len as usize {
+                let entry = MemberEntry {
+                    name: inline.names[i],
+                    hash: inline.hashes[i],
+                    member: inline.members[i],
+                };
+                table.insert_unique(Members::table_hash(entry.hash), entry, |e| {
+                    Members::table_hash(e.hash)
+                });
+            }
+            table
+        }
+        let table = match core::mem::take(self) {
             Members::Table(mut table) => {
                 table.reserve(capacity, |e| Self::table_hash(e.hash));
                 table
@@ -182,31 +237,10 @@ impl Members {
             Members::Empty => {
                 bun_collections::hashbrown::HashTable::with_capacity_in(capacity, AstAlloc)
             }
-            Members::Inline(inline) => {
-                let mut table = bun_collections::hashbrown::HashTable::with_capacity_in(
-                    capacity.max(Self::INLINE_MAX * 2),
-                    AstAlloc,
-                );
-                for i in 0..inline.len as usize {
-                    let entry = MemberEntry {
-                        name: inline.names[i],
-                        hash: inline.hashes[i],
-                        member: inline.members[i],
-                    };
-                    table.insert_unique(Self::table_hash(entry.hash), entry, |e| {
-                        Self::table_hash(e.hash)
-                    });
-                }
-                table
-            }
+            Members::Small(inline) => fill(&inline, capacity),
+            Members::Inline(inline) => fill(&inline, capacity),
         };
-        let _ = core::mem::replace(
-            self,
-            Members::Table(core::mem::replace(
-                &mut table,
-                bun_collections::hashbrown::HashTable::new_in(AstAlloc),
-            )),
-        );
+        *self = Members::Table(table);
     }
 
     /// The entry for `name`, inserted with `Member::default()` if absent.
@@ -218,34 +252,38 @@ impl Members {
         loop {
             match self {
                 Members::Empty => {
-                    *self = Members::Inline(bun_alloc::ast_box(InlineMembers {
-                        hashes: [0; Self::INLINE_MAX],
-                        len: 0,
-                        names: [crate::StoreStr::EMPTY; Self::INLINE_MAX],
-                        members: [Member::EMPTY; Self::INLINE_MAX],
-                    }));
+                    *self = Members::Small(bun_alloc::ast_box(InlineMembers::new()));
                 }
-                Members::Inline(inline) => {
-                    if let Some(i) = inline.find(hash, name) {
-                        let Members::Inline(inline) = self else {
+                Members::Small(inline) => {
+                    let found = inline.find(hash, name);
+                    if found.is_some() || (inline.len as usize) < 4 {
+                        let Members::Small(inline) = self else {
                             unreachable!()
                         };
+                        let i = match found {
+                            Some(i) => i,
+                            None => inline.push(hash, name),
+                        };
                         return MembersGetOrPut {
-                            found_existing: true,
+                            found_existing: found.is_some(),
                             value_ptr: &mut inline.members[i],
                         };
                     }
-                    let i = inline.len as usize;
-                    if i < Self::INLINE_MAX {
+                    let grown = inline.grow::<8>();
+                    *self = Members::Inline(bun_alloc::ast_box(grown));
+                }
+                Members::Inline(inline) => {
+                    let found = inline.find(hash, name);
+                    if found.is_some() || (inline.len as usize) < Self::INLINE_MAX {
                         let Members::Inline(inline) = self else {
                             unreachable!()
                         };
-                        inline.hashes[i] = hash;
-                        inline.names[i] = crate::StoreStr::new(name);
-                        inline.members[i] = Member::default();
-                        inline.len += 1;
+                        let i = match found {
+                            Some(i) => i,
+                            None => inline.push(hash, name),
+                        };
                         return MembersGetOrPut {
-                            found_existing: false,
+                            found_existing: found.is_some(),
                             value_ptr: &mut inline.members[i],
                         };
                     }

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -19,7 +19,6 @@ pub(crate) type MemberHashMap = StringHashMap<Member, AstAlloc>;
 // longer derives `Clone` (private `origin` field); callers that need a shallow copy must
 // `core::mem::take` or `core::ptr::read` instead.
 pub struct Scope {
-    pub id: usize,
     pub kind: Kind,
     // BACKREF: parent owns this scope via `children`. `StoreRef` (arena
     // back-pointer with safe `Deref`/`DerefMut`) so callers don't open-code
@@ -31,6 +30,10 @@ pub struct Scope {
     pub members: MemberHashMap,
     /// `AstVec`: arena-backed.
     pub generated: AstVec<Ref>,
+    /// This scope's index in the visit pass's pre-order walk and the index of
+    /// the last scope inside it, which `Ast::scope_uses` refers to.
+    /// `u32::MAX` for a scope the visit pass never entered.
+    pub visit_span: [u32; 2],
 
     // This is used to store the ref of the label symbol for ScopeLabel scopes.
     pub label_ref: Ref,
@@ -64,12 +67,12 @@ impl Scope {
     /// const-folded zero header rather than three out-of-line `default()`
     /// calls. `AstAlloc::vec` and `StringHashMap::new_in` are both `const fn`.
     pub const EMPTY: Self = Self {
-        id: 0,
         kind: Kind::Block,
         parent: None,
         children: AstAlloc::vec(),
         members: MemberHashMap::new_in(AstAlloc),
         generated: AstAlloc::vec(),
+        visit_span: [u32::MAX, u32::MAX],
         label_ref: Ref::NONE,
         label_stmt_is_loop: false,
         contains_direct_eval: false,
@@ -88,6 +91,13 @@ impl Default for Scope {
 }
 
 impl Scope {
+    /// `(first, last)`: this scope and everything inside it, as visit-pass
+    /// pre-order indices. `None` if the visit pass did not enter and leave it.
+    pub fn visit_span(&self) -> Option<(u32, u32)> {
+        let [first, last] = self.visit_span;
+        (first != u32::MAX && first <= last).then_some((first, last))
+    }
+
     // Must agree with `StringHashMap`'s `BuildHasher` (`bun_wyhash::BuildHasher`,
     // i.e. `BuildHasherDefault<OneShotHasher>`) so the precomputed hash can be
     // fed to `get_hashed` without a rehash per scope level. If the map's hasher

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -358,9 +358,52 @@ impl Kind {
     }
 }
 
+/// A part's uses of one symbol: an estimated count, plus whether any of them
+/// was added without its scope being recorded in `Ast::scope_uses` (by the
+/// linker or a transform), in which case the renamer must assume the symbol
+/// may be printed in any scope of the part. Packed into one word because
+/// every part holds one per referenced symbol.
 #[derive(Default, Clone, Copy)]
-pub struct Use {
-    pub count_estimate: u32,
+pub struct Use(u32);
+
+impl Use {
+    const UNSCOPED: u32 = 1 << 31;
+
+    /// `count` uses whose scope is not on record.
+    pub const fn unscoped(count: u32) -> Use {
+        Use(if count >= Self::UNSCOPED {
+            u32::MAX
+        } else {
+            count | Self::UNSCOPED
+        })
+    }
+
+    #[inline]
+    pub const fn count_estimate(self) -> u32 {
+        self.0 & !Self::UNSCOPED
+    }
+
+    #[inline]
+    pub const fn has_unscoped(self) -> bool {
+        self.0 & Self::UNSCOPED != 0
+    }
+
+    /// The parser's `record_usage`: the use's scope is on record.
+    #[inline]
+    pub fn add_scoped(&mut self, count: u32) {
+        debug_assert!(self.count_estimate() + count < Self::UNSCOPED);
+        self.0 += count;
+    }
+
+    #[inline]
+    pub fn subtract(&mut self, count: u32) {
+        self.0 = self.count_estimate().saturating_sub(count) | (self.0 & Self::UNSCOPED);
+    }
+
+    pub fn merge(&mut self, other: Use) {
+        let count = self.count_estimate().saturating_add(other.count_estimate());
+        self.0 = count.min(Self::UNSCOPED - 1) | ((self.0 | other.0) & Self::UNSCOPED);
+    }
 }
 
 pub type List<'a> = bun_alloc::ArenaVec<'a, Symbol>;
@@ -612,6 +655,21 @@ impl Map {
     /// An iterative two-phase walk so the per-hop work is just two raw
     /// pointer adds and a load — no call frame, no `Option` unwrap, no
     /// repeated tag/null guards. Every node on the path from `ref_` to the
+    /// The symbol whose name the printer writes for a reference to `ref_`:
+    /// `follow`, then through `namespace_alias` (an import that prints as a
+    /// property of its namespace object prints that object's symbol).
+    pub fn follow_printed(&self, ref_: Ref) -> Ref {
+        let mut ref_ = self.follow(ref_);
+        while let Some(alias) = &self.get_const(ref_).unwrap().namespace_alias {
+            let next = self.follow(alias.namespace_ref);
+            if next == ref_ {
+                break;
+            }
+            ref_ = next;
+        }
+        ref_
+    }
+
     /// union-find root has its `link` rewritten to the root (full path
     /// compression).
     pub fn follow(&self, ref_: Ref) -> Ref {

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -650,11 +650,6 @@ impl Map {
         }
     }
 
-    /// Equivalent to followSymbols in esbuild.
-    ///
-    /// An iterative two-phase walk so the per-hop work is just two raw
-    /// pointer adds and a load — no call frame, no `Option` unwrap, no
-    /// repeated tag/null guards. Every node on the path from `ref_` to the
     /// The symbol whose name the printer writes for a reference to `ref_`:
     /// `follow`, then through `namespace_alias` (an import that prints as a
     /// property of its namespace object prints that object's symbol).
@@ -670,6 +665,11 @@ impl Map {
         ref_
     }
 
+    /// Equivalent to followSymbols in esbuild.
+    ///
+    /// An iterative two-phase walk so the per-hop work is just two raw
+    /// pointer adds and a load — no call frame, no `Option` unwrap, no
+    /// repeated tag/null guards. Every node on the path from `ref_` to the
     /// union-find root has its `link` rewritten to the root (full path
     /// compression).
     pub fn follow(&self, ref_: Ref) -> Ref {

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -275,7 +275,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                             self.source_index,
                             RefTag::Symbol,
                         ),
-                        symbol::Use { count_estimate: 1 },
+                        symbol::Use::unscoped(1),
                     );
                 }
                 break 'uses map;
@@ -399,7 +399,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                         })?;
                         parts[1]
                             .symbol_uses
-                            .put(temp_id, symbol::Use { count_estimate: 1 })?;
+                            .put(temp_id, symbol::Use::unscoped(1))?;
                         VecExt::append(&mut self.current_scope_mut().generated, temp_id);
                         export_props.push(G::Property {
                             key: Some(Expr::init(E::String::init(b"default"), stmt.loc)),
@@ -456,7 +456,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                 // mark a dependency on module_ref so it is renamed
                 parts[1]
                     .symbol_uses
-                    .put(self.module_ref, symbol::Use { count_estimate: 1 })?;
+                    .put(self.module_ref, symbol::Use::unscoped(1))?;
                 parts[1].declared_symbols.append(DeclaredSymbol {
                     ref_: self.module_ref,
                     is_top_level: true,
@@ -550,7 +550,8 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             named_exports: core::mem::take(&mut self.named_exports),
             dynamic_import_aliases: Default::default(),
             top_level_symbols_to_parts,
-            char_freq: bun_ast::CharFreq { freqs: [0; 64] },
+            scope_uses: Default::default(),
+            char_freq: None,
             flags: Default::default(),
             target,
             top_level_await_keyword: Range::NONE,

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -82,6 +82,10 @@ pub struct Chunk {
     // borrows from the symbol table and so can't live in this owning struct.
     // `ChunkRenamer` is the owning equivalent (see `crate::bun_renamer`).
     pub(crate) renamer: bun_renamer::ChunkRenamer,
+    /// The nested scopes still to name after `rename_symbols_in_chunk`
+    /// (number renamer only), `(source_index, module-scope child)` grouped by
+    /// file; each file becomes a `NestedRenamer` task.
+    pub(crate) nested_scopes_to_rename: Vec<(u32, *const bun_ast::Scope)>,
 
     pub compile_results_for_chunk: CompileResultSlots,
 
@@ -213,6 +217,7 @@ impl Default for Chunk {
             intermediate_output: IntermediateOutput::default(),
             isolated_hash: u64::MAX,
             renamer: bun_renamer::ChunkRenamer::default(),
+            nested_scopes_to_rename: Vec::new(),
             compile_results_for_chunk: CompileResultSlots::default(),
             metafile_chunk_json: Box::default(),
             flags: Flags::default(),

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -3439,7 +3439,7 @@ impl<'a> LinkerContext<'a> {
                     };
                 let mut symbol_uses = PartSymbolUseMap::default();
                 symbol_uses
-                    .put(wrapper_ref, SymbolUse { count_estimate: 1 })
+                    .put(wrapper_ref, SymbolUse::unscoped(1))
                     .expect("OOM");
                 let exports_ref = self.graph.ast.items_exports_ref()[source_index as usize];
                 let module_ref = self.graph.ast.items_module_ref()[source_index as usize];
@@ -3557,7 +3557,7 @@ impl<'a> LinkerContext<'a> {
 
                 let mut symbol_uses = PartSymbolUseMap::default();
                 symbol_uses
-                    .put(wrapper_ref, SymbolUse { count_estimate: 1 })
+                    .put(wrapper_ref, SymbolUse::unscoped(1))
                     .expect("OOM");
                 let part_index = self
                     .graph
@@ -4635,11 +4635,11 @@ impl<'a> LinkerContext<'a> {
                     .iter()
                     .zip(part.symbol_uses.values())
                 {
-                    if item_use.count_estimate == 0 {
+                    if item_use.count_estimate() == 0 {
                         continue;
                     }
                     if let Some(&namespace_ref) = method_call_items.get(item) {
-                        namespace_uses.push((namespace_ref, item_use.count_estimate));
+                        namespace_uses.push((namespace_ref, item_use.count_estimate()));
                     }
                 }
                 for &(namespace_ref, count) in &namespace_uses {
@@ -4647,7 +4647,7 @@ impl<'a> LinkerContext<'a> {
                         .get_or_put_value(namespace_ref, Default::default())
                         .expect("OOM")
                         .value_ptr
-                        .count_estimate += count;
+                        .merge(SymbolUse::unscoped(count));
                 }
             }
         }
@@ -4838,7 +4838,7 @@ impl<'a> LinkerContext<'a> {
                         .get_or_put_value(resolved.r#ref, Default::default())
                         .expect("OOM")
                         .value_ptr
-                        .count_estimate += count;
+                        .merge(SymbolUse::unscoped(count));
                 }
                 if resolved.source_index != source_index
                     && !imports_to_bind.contains(&resolved.r#ref)

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -460,11 +460,9 @@ pub(crate) fn generate_symbol_import_and_use(
         let part: &mut Part = &mut parts[source_index as usize].as_mut_slice()[part_index as usize];
         let uses_entry = part.symbol_uses.get_or_put(ref_)?;
         if !uses_entry.found_existing {
-            *uses_entry.value_ptr = symbol::Use {
-                count_estimate: use_count,
-            };
+            *uses_entry.value_ptr = symbol::Use::unscoped(use_count);
         } else {
-            uses_entry.value_ptr.count_estimate += use_count;
+            uses_entry.value_ptr.merge(symbol::Use::unscoped(use_count));
         }
     }
 

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -690,11 +690,10 @@ impl Worker {
         let arena_ref: &'static ThreadLocalArena =
             unsafe { bun_ptr::detach_lifetime_ref(self.arena.get()) };
 
-        // The
-        // ASTMemoryAllocator owns its bump arena internally and ignores the
-        // passed fallback (see ASTMemoryAllocator::new doc).
-        *self.ast_memory_store = bun_ast::ASTMemoryAllocator::new(arena_ref);
-        self.ast_memory_store.reset();
+        // One mi_heap for the AST stores, `AstAlloc` spills and the parser's
+        // arena: allocations alternate between them per node, and mimalloc
+        // caches only the last heap a thread touched.
+        *self.ast_memory_store = bun_ast::ASTMemoryAllocator::borrowing(arena_ref);
 
         let log: *mut bun_ast::Log = arena_ref.alloc(bun_ast::Log::init());
         self.ctx = bun_ptr::BackRef::from(NonNull::from(ctx).cast::<BundleV2<'static>>());

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -71,8 +71,7 @@ pub struct BundledAst<'arena> {
     pub(crate) url_for_css: &'arena [u8],
     pub(crate) symbols: symbol::List<'arena>,
     pub(crate) module_scope: Scope,
-    // Only meaningful when flags.HAS_CHAR_FREQ is set; zero-initialized otherwise.
-    pub(crate) char_freq: CharFreq,
+    pub(crate) char_freq: Option<bun_alloc::AstBox<CharFreq>>,
     pub(crate) exports_ref: Ref,
     pub(crate) module_ref: Ref,
     pub(crate) wrapper_ref: Ref,
@@ -89,6 +88,7 @@ pub struct BundledAst<'arena> {
     pub(crate) dynamic_import_aliases: bun_ast::ast_result::DynamicImportAliases,
 
     pub(crate) top_level_symbols_to_parts: TopLevelSymbolToParts,
+    pub(crate) scope_uses: bun_ast::ast_result::ScopeUseList,
 
     pub(crate) commonjs_named_exports: CommonJSNamedExports,
 
@@ -119,7 +119,7 @@ bun_collections::multi_array_columns! {
         url_for_css: &'arena [u8],
         symbols: symbol::List<'arena>,
         module_scope: Scope,
-        char_freq: CharFreq,
+        char_freq: Option<bun_alloc::AstBox<CharFreq>>,
         exports_ref: Ref,
         module_ref: Ref,
         wrapper_ref: Ref,
@@ -131,6 +131,7 @@ bun_collections::multi_array_columns! {
         export_star_import_records: bun_alloc::AstVec<u32>,
         dynamic_import_aliases: bun_ast::ast_result::DynamicImportAliases,
         top_level_symbols_to_parts: TopLevelSymbolToParts,
+        scope_uses: bun_ast::ast_result::ScopeUseList,
         commonjs_named_exports: CommonJSNamedExports,
         redirect_import_record_index: u32,
         target: bun_ast::Target,
@@ -149,7 +150,6 @@ bitflags::bitflags! {
         const USES_MODULE_REF = 1 << 1;
         // const USES_REQUIRE_REF = 1 << 2;
         const USES_EXPORT_KEYWORD = 1 << 2;
-        const HAS_CHAR_FREQ = 1 << 3;
         const FORCE_CJS_TO_ESM = 1 << 4;
         const HAS_LAZY_EXPORT = 1 << 5;
         const COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED = 1 << 6;
@@ -179,7 +179,7 @@ impl<'arena> BundledAst<'arena> {
             url_for_css: b"",
             symbols: symbol::List::new_in(arena),
             module_scope: Scope::default(),
-            char_freq: CharFreq::default(),
+            char_freq: None,
             exports_ref: Ref::NONE,
             module_ref: Ref::NONE,
             wrapper_ref: Ref::NONE,
@@ -191,6 +191,7 @@ impl<'arena> BundledAst<'arena> {
             export_star_import_records: bun_alloc::AstAlloc::vec(),
             dynamic_import_aliases: Default::default(),
             top_level_symbols_to_parts: TopLevelSymbolToParts::default(),
+            scope_uses: Default::default(),
             commonjs_named_exports: CommonJSNamedExports::default(),
             redirect_import_record_index: u32::MAX,
             target: bun_ast::Target::Browser,
@@ -217,11 +218,7 @@ impl<'arena> BundledAst<'arena> {
             // This list may be mutated later, so we should store the capacity
             symbols: self.symbols,
             module_scope: self.module_scope,
-            char_freq: if self.flags.contains(Flags::HAS_CHAR_FREQ) {
-                Some(self.char_freq)
-            } else {
-                None
-            },
+            char_freq: self.char_freq,
             exports_ref: self.exports_ref,
             module_ref: self.module_ref,
             wrapper_ref: self.wrapper_ref,
@@ -237,6 +234,7 @@ impl<'arena> BundledAst<'arena> {
             dynamic_import_aliases: self.dynamic_import_aliases,
 
             top_level_symbols_to_parts: self.top_level_symbols_to_parts,
+            scope_uses: self.scope_uses,
 
             commonjs_named_exports: self.commonjs_named_exports,
 
@@ -287,7 +285,6 @@ impl<'arena> BundledAst<'arena> {
         flags.set(Flags::USES_MODULE_REF, ast.uses_module_ref);
         // flags.set(Flags::USES_REQUIRE_REF, ast.uses_require_ref);
         flags.set(Flags::USES_EXPORT_KEYWORD, ast.export_keyword.len > 0);
-        flags.set(Flags::HAS_CHAR_FREQ, ast.char_freq.is_some());
         flags.set(Flags::FORCE_CJS_TO_ESM, ast.force_cjs_to_esm);
         flags.set(Flags::COMMONJS_LIFTED_TO_ESM, ast.commonjs_lifted_to_esm);
         flags.set(Flags::HAS_LAZY_EXPORT, ast.has_lazy_export);
@@ -319,8 +316,7 @@ impl<'arena> BundledAst<'arena> {
             // This list may be mutated later, so we should store the capacity
             symbols: ast.symbols,
             module_scope: ast.module_scope,
-            // Only read when flags.HAS_CHAR_FREQ is set.
-            char_freq: ast.char_freq.unwrap_or_default(),
+            char_freq: ast.char_freq,
             exports_ref: ast.exports_ref,
             module_ref: ast.module_ref,
             wrapper_ref: ast.wrapper_ref,
@@ -337,6 +333,7 @@ impl<'arena> BundledAst<'arena> {
 
             // arena: ast.arena,
             top_level_symbols_to_parts: ast.top_level_symbols_to_parts,
+            scope_uses: ast.scope_uses,
 
             commonjs_named_exports: ast.commonjs_named_exports,
 

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -140,6 +140,7 @@ impl DefineExt for Define {
     ) -> Result<(), bun_alloc::AllocError> {
         let key = global[global.len() - 1];
         let parts: Vec<Box<[u8]>> = global.iter().map(|p| Box::<[u8]>::from(*p)).collect();
+        self.dots_filter.insert(key);
         if let Some(existing) = self.dots.get_mut(key) {
             existing.push(DotDefine {
                 parts,
@@ -166,6 +167,7 @@ impl DefineExt for Define {
         let mut define = Box::new(Define {
             identifiers: StringHashMap::default(),
             dots: StringHashMap::default(),
+            dots_filter: Default::default(),
             drop_debugger,
             user_hash: None,
         });

--- a/src/bundler/linker_context/crossChunkNames.rs
+++ b/src/bundler/linker_context/crossChunkNames.rs
@@ -180,12 +180,12 @@ pub(crate) fn assign_minified(
 
     // One name sequence for the bundle, tuned to its overall character mix.
     let mut freq = bun_ast::CharFreq { freqs: [0i32; 64] };
-    let (flags, char_freqs) = (c.graph.ast.items_flags(), c.graph.ast.items_char_freq());
+    let char_freqs = c.graph.ast.items_char_freq();
     for chunk in chunks.iter() {
         if let Content::Javascript(js) = &chunk.content {
             for &source_index in js.files_in_chunk_order.iter() {
-                if flags[source_index as usize].contains(crate::bundled_ast::Flags::HAS_CHAR_FREQ) {
-                    freq.include(&char_freqs[source_index as usize]);
+                if let Some(char_freq) = &char_freqs[source_index as usize] {
+                    freq.include(char_freq);
                 }
             }
         }

--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -328,12 +328,12 @@ impl LinkerContext<'_> {
                                 for (name, prop_use) in properties.iter() {
                                     if enum_data.get(name).is_none() {
                                         found_non_inlined_enum = true;
-                                        use_.count_estimate += prop_use.count_estimate;
+                                        use_.merge(SymbolUse::unscoped(prop_use.count_estimate));
                                     }
                                 }
 
                                 if !found_non_inlined_enum {
-                                    if use_.count_estimate == 0 {
+                                    if use_.count_estimate() == 0 {
                                         let _ = symbol_uses.swap_remove(ref_);
                                     }
                                     continue;
@@ -345,11 +345,11 @@ impl LinkerContext<'_> {
 
                 // Common path: this import isn't a TypeScript enum
                 for prop_use in properties.values() {
-                    use_.count_estimate += prop_use.count_estimate;
+                    use_.merge(SymbolUse::unscoped(prop_use.count_estimate));
                 }
                 // Every property read was bound straight to the namespace's
                 // export by `bind_import_property_accesses`.
-                if use_.count_estimate == 0 {
+                if use_.count_estimate() == 0 {
                     let _ = symbol_uses.swap_remove(ref_);
                 }
             }
@@ -371,7 +371,7 @@ impl LinkerContext<'_> {
                         .iter()
                         .position(|k| *k == ref_)
                         .unwrap();
-                    part.symbol_uses.values()[j].count_estimate > 0
+                    part.symbol_uses.values()[j].count_estimate() > 0
                 });
 
                 // Inlined `c.top_level_symbols_to_parts(id, ref_)` against the
@@ -621,8 +621,7 @@ impl LinkerContext<'_> {
                     ..Default::default()
                 });
             }
-            ns_export_symbol_uses
-                .put_assume_capacity(exp_data.import_ref, SymbolUse { count_estimate: 1 });
+            ns_export_symbol_uses.put_assume_capacity(exp_data.import_ref, SymbolUse::unscoped(1));
 
             // Make sure the part that declares the export is included
             let parts =

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -147,6 +147,15 @@ pub(crate) fn find_imported_parts_in_js_order(
             parts: this.graph.ast.items_parts(),
             import_records: this.graph.ast.items_import_records(),
             entry_bits: chunk.entry_bits(),
+            largest_source_len: this
+                .parse_graph()
+                .input_files
+                .items_source()
+                .iter()
+                .map(|source| source.contents.len())
+                .max()
+                .unwrap_or(0)
+                .min(i32::MAX as usize) as i32,
             c: this,
             chunk_index,
             entry_point_chunk_indices,
@@ -203,6 +212,8 @@ fn run_visits<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
 
 pub(crate) struct FindImportedPartsVisitor<'a, 'ctx> {
     pub(crate) entry_bits: &'a AutoBitSet,
+    /// Of the JavaScript files in the bundle.
+    pub(crate) largest_source_len: i32,
     pub(crate) flags: &'a [crate::js_meta::Flags],
     pub(crate) parts: &'a [bun_ast::PartList<'ctx>],
     pub(crate) import_records: &'a [bun_ast::import_record::List<'ctx>],
@@ -242,14 +253,38 @@ enum PartsFrame {
 }
 
 impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
+    /// Each range is printed as one task, so a range stops growing once it
+    /// spans this many source bytes: enough ranges for a large file to occupy
+    /// the thread pool, few enough that small files stay whole.
+    fn range_source_bytes_max(&self) -> i32 {
+        const MIN: i32 = 128 * 1024;
+        let threads = self.c.worker_pool().max_threads().max(1) as i32;
+        (self.largest_source_len / (2 * threads)).max(MIN)
+    }
+
     fn append_or_extend_range(
-        ranges: &mut Vec<PartRange>,
+        &mut self,
+        in_prefix: bool,
         source_index: IndexInt,
         part_index: IndexInt,
     ) {
+        let parts = self.parts[source_index as usize].as_slice();
+        let part_start = |part_index: IndexInt| -> i32 {
+            match parts[part_index as usize].stmts.slice().first() {
+                Some(stmt) => stmt.loc.start,
+                None => 0,
+            }
+        };
+        let max = self.range_source_bytes_max();
+        let ranges = if in_prefix {
+            &mut self.parts_prefix
+        } else {
+            &mut self.part_ranges
+        };
         if let Some(last_range) = ranges.last_mut() {
             if last_range.source_index.get() == source_index
                 && last_range.part_index_end == part_index
+                && part_start(part_index) - part_start(last_range.part_index_begin) < max
             {
                 last_range.part_index_end += 1;
                 return;
@@ -289,12 +324,11 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                         && part_index != bun_ast::NAMESPACE_EXPORT_PART_INDEX
                         && self.c.should_include_part(source_index, part)
                     {
-                        let js_parts = if source_index == Index::RUNTIME.value() {
-                            &mut self.parts_prefix
-                        } else {
-                            &mut self.part_ranges
-                        };
-                        Self::append_or_extend_range(js_parts, source_index, part_index);
+                        self.append_or_extend_range(
+                            source_index == Index::RUNTIME.value(),
+                            source_index,
+                            part_index,
+                        );
                     }
                     continue;
                 }
@@ -386,8 +420,8 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                         && is_file_in_chunk
                         && parts_live.is_set(bun_ast::NAMESPACE_EXPORT_PART_INDEX as usize)
                     {
-                        Self::append_or_extend_range(
-                            &mut self.part_ranges,
+                        self.append_or_extend_range(
+                            false,
                             source_index,
                             bun_ast::NAMESPACE_EXPORT_PART_INDEX,
                         );

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -39,7 +39,10 @@ pub(crate) fn find_all_imported_parts_in_js_order(
     struct Ctx<'a, 'f> {
         inner: crate::linker_context_mod::GenerateChunkCtx<'a>,
         chunk_of_file: &'f [u32],
+        range_source_bytes_max: i32,
     }
+
+    let range_source_bytes_max = range_source_bytes_max(this);
 
     // One chunk per task. Each task writes only its own `Chunk` and, for
     // server-component files, that file's `entry_point_chunk_index` slot (a
@@ -54,6 +57,7 @@ pub(crate) fn find_all_imported_parts_in_js_order(
             chunks: bun_ptr::BackRef::new(&*chunks),
         },
         chunk_of_file: &chunk_of_file,
+        range_source_bytes_max,
     };
     let chunks_len = chunks.len();
     this.worker_pool().each_ptr(
@@ -74,11 +78,32 @@ pub(crate) fn find_all_imported_parts_in_js_order(
                 u32::try_from(index).expect("int cast"),
                 ctx.chunk_of_file,
                 chunks_len,
+                ctx.range_source_bytes_max,
             ));
         },
         chunks,
     );
     Ok(())
+}
+
+/// Each part range is printed as one task, so a range stops growing once it
+/// spans this many source bytes: enough ranges for a large file to occupy
+/// the thread pool, few enough that small files stay whole.
+pub(crate) fn range_source_bytes_max(this: &LinkerContext) -> i32 {
+    const MIN: usize = 128 * 1024;
+    let loaders = this.parse_graph().input_files.items_loader();
+    let largest = this
+        .parse_graph()
+        .input_files
+        .items_source()
+        .iter()
+        .zip(loaders)
+        .filter(|(_, loader)| loader.is_javascript_like_or_json())
+        .map(|(source, _)| source.contents.len())
+        .max()
+        .unwrap_or(0);
+    let threads = this.worker_pool().max_threads().max(1) as usize;
+    (largest / (2 * threads)).max(MIN).min(i32::MAX as usize) as i32
 }
 
 pub(crate) fn find_imported_parts_in_js_order(
@@ -89,6 +114,7 @@ pub(crate) fn find_imported_parts_in_js_order(
     chunk_index: u32,
     chunk_of_file: &[u32],
     chunks_len: usize,
+    range_source_bytes_max: i32,
 ) -> Result<(), bun_alloc::AllocError> {
     let mut chunk_order_array: Vec<Order> =
         Vec::with_capacity(chunk.files_with_parts_in_chunk.count());
@@ -147,15 +173,7 @@ pub(crate) fn find_imported_parts_in_js_order(
             parts: this.graph.ast.items_parts(),
             import_records: this.graph.ast.items_import_records(),
             entry_bits: chunk.entry_bits(),
-            largest_source_len: this
-                .parse_graph()
-                .input_files
-                .items_source()
-                .iter()
-                .map(|source| source.contents.len())
-                .max()
-                .unwrap_or(0)
-                .min(i32::MAX as usize) as i32,
+            range_source_bytes_max,
             c: this,
             chunk_index,
             entry_point_chunk_indices,
@@ -212,8 +230,7 @@ fn run_visits<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
 
 pub(crate) struct FindImportedPartsVisitor<'a, 'ctx> {
     pub(crate) entry_bits: &'a AutoBitSet,
-    /// Of the JavaScript files in the bundle.
-    pub(crate) largest_source_len: i32,
+    pub(crate) range_source_bytes_max: i32,
     pub(crate) flags: &'a [crate::js_meta::Flags],
     pub(crate) parts: &'a [bun_ast::PartList<'ctx>],
     pub(crate) import_records: &'a [bun_ast::import_record::List<'ctx>],
@@ -253,15 +270,6 @@ enum PartsFrame {
 }
 
 impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
-    /// Each range is printed as one task, so a range stops growing once it
-    /// spans this many source bytes: enough ranges for a large file to occupy
-    /// the thread pool, few enough that small files stay whole.
-    fn range_source_bytes_max(&self) -> i32 {
-        const MIN: i32 = 128 * 1024;
-        let threads = self.c.worker_pool().max_threads().max(1) as i32;
-        (self.largest_source_len / (2 * threads)).max(MIN)
-    }
-
     fn append_or_extend_range(
         &mut self,
         in_prefix: bool,
@@ -275,7 +283,7 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                 None => 0,
             }
         };
-        let max = self.range_source_bytes_max();
+        let max = self.range_source_bytes_max;
         let ranges = if in_prefix {
             &mut self.parts_prefix
         } else {

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -39,10 +39,7 @@ pub(crate) fn find_all_imported_parts_in_js_order(
     struct Ctx<'a, 'f> {
         inner: crate::linker_context_mod::GenerateChunkCtx<'a>,
         chunk_of_file: &'f [u32],
-        range_source_bytes_max: i32,
     }
-
-    let range_source_bytes_max = range_source_bytes_max(this);
 
     // One chunk per task. Each task writes only its own `Chunk` and, for
     // server-component files, that file's `entry_point_chunk_index` slot (a
@@ -57,7 +54,6 @@ pub(crate) fn find_all_imported_parts_in_js_order(
             chunks: bun_ptr::BackRef::new(&*chunks),
         },
         chunk_of_file: &chunk_of_file,
-        range_source_bytes_max,
     };
     let chunks_len = chunks.len();
     this.worker_pool().each_ptr(
@@ -78,7 +74,6 @@ pub(crate) fn find_all_imported_parts_in_js_order(
                 u32::try_from(index).expect("int cast"),
                 ctx.chunk_of_file,
                 chunks_len,
-                ctx.range_source_bytes_max,
             ));
         },
         chunks,
@@ -87,24 +82,10 @@ pub(crate) fn find_all_imported_parts_in_js_order(
 }
 
 /// Each part range is printed as one task, so a range stops growing once it
-/// spans this many source bytes: enough ranges for a large file to occupy
-/// the thread pool, few enough that small files stay whole.
-pub(crate) fn range_source_bytes_max(this: &LinkerContext) -> i32 {
-    const MIN: usize = 128 * 1024;
-    let loaders = this.parse_graph().input_files.items_loader();
-    let largest = this
-        .parse_graph()
-        .input_files
-        .items_source()
-        .iter()
-        .zip(loaders)
-        .filter(|(_, loader)| loader.is_javascript_like_or_json())
-        .map(|(source, _)| source.contents.len())
-        .max()
-        .unwrap_or(0);
-    let threads = this.worker_pool().max_threads().max(1) as usize;
-    (largest / (2 * threads)).max(MIN).min(i32::MAX as usize) as i32
-}
+/// spans this many source bytes and a large unwrapped file prints on several
+/// threads. A constant, not derived from the thread count: range boundaries
+/// reach the output (blank lines between ranges) and the chunk hash.
+const RANGE_SOURCE_BYTES_MAX: i32 = 128 * 1024;
 
 pub(crate) fn find_imported_parts_in_js_order(
     this: &LinkerContext,
@@ -114,7 +95,6 @@ pub(crate) fn find_imported_parts_in_js_order(
     chunk_index: u32,
     chunk_of_file: &[u32],
     chunks_len: usize,
-    range_source_bytes_max: i32,
 ) -> Result<(), bun_alloc::AllocError> {
     let mut chunk_order_array: Vec<Order> =
         Vec::with_capacity(chunk.files_with_parts_in_chunk.count());
@@ -173,7 +153,6 @@ pub(crate) fn find_imported_parts_in_js_order(
             parts: this.graph.ast.items_parts(),
             import_records: this.graph.ast.items_import_records(),
             entry_bits: chunk.entry_bits(),
-            range_source_bytes_max,
             c: this,
             chunk_index,
             entry_point_chunk_indices,
@@ -230,7 +209,6 @@ fn run_visits<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
 
 pub(crate) struct FindImportedPartsVisitor<'a, 'ctx> {
     pub(crate) entry_bits: &'a AutoBitSet,
-    pub(crate) range_source_bytes_max: i32,
     pub(crate) flags: &'a [crate::js_meta::Flags],
     pub(crate) parts: &'a [bun_ast::PartList<'ctx>],
     pub(crate) import_records: &'a [bun_ast::import_record::List<'ctx>],
@@ -283,7 +261,7 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                 None => 0,
             }
         };
-        let max = self.range_source_bytes_max;
+        let max = RANGE_SOURCE_BYTES_MAX;
         let ranges = if in_prefix {
             &mut self.parts_prefix
         } else {

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -73,6 +73,27 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         // link step); `pool` is the arena-allocated bundler ThreadPool.
         c.worker_pool()
             .each_ptr(ctx, LinkerContext::generate_js_renamer, chunks);
+        if !c.options.minify_identifiers {
+            // Top-level names are final; name each file's nested scopes in
+            // parallel.
+            let mut tasks =
+                crate::linker_context::rename_symbols_in_chunk::nested_rename_tasks(chunks);
+            c.worker_pool().each_ptr(
+                ctx,
+                crate::linker_context::rename_symbols_in_chunk::run_nested_rename_task,
+                &mut tasks,
+            );
+            for task in tasks {
+                if let (crate::bun_renamer::ChunkRenamer::Number(r), Some(names)) =
+                    (&mut chunks[task.chunk_index as usize].renamer, task.names)
+                {
+                    r.absorb(names);
+                }
+            }
+            for chunk in chunks.iter_mut() {
+                chunk.nested_scopes_to_rename = Vec::new();
+            }
+        }
         if c.graph.code_splitting {
             if c.options.minify_identifiers {
                 // Counts are in; name the cross-chunk bindings, pin them, then

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -495,15 +495,16 @@ pub(crate) fn run_nested_rename_task(
     task: *mut NestedRenameTask,
     _task_index: usize,
 ) {
-    // SAFETY: `each_ptr` hands us a unique `*mut NestedRenameTask`.
-    let task = unsafe { &mut *task };
+    // SAFETY: `each_ptr` hands us a unique `*mut NestedRenameTask`; nothing
+    // below re-enters it.
+    let (chunk_index, scope_range) = unsafe { ((*task).chunk_index, (*task).scopes.clone()) };
     let c: &LinkerContext<'_> = &ctx.c;
-    let chunk = &ctx.chunks[task.chunk_index as usize];
+    let chunk = &ctx.chunks[chunk_index as usize];
     let ChunkRenamer::Number(root) = &chunk.renamer else {
         unreachable!()
     };
     let scopes =
-        &chunk.nested_scopes_to_rename[task.scopes.start as usize..task.scopes.end as usize];
+        &chunk.nested_scopes_to_rename[scope_range.start as usize..scope_range.end as usize];
     let source_index = scopes[0].0;
     let ast = c.graph.ast.split_raw();
     // SAFETY: read-only column views; see `rename_symbols_in_chunk`.
@@ -526,5 +527,6 @@ pub(crate) fn run_nested_rename_task(
         // SAFETY: live arena-allocated scope (see `rename_symbols_in_chunk`).
         nested.assign_names_recursive(unsafe { &*scope }, &mut sorted);
     }
-    task.names = Some(nested.into_names());
+    // SAFETY: as above.
+    unsafe { (*task).names = Some(nested.into_names()) };
 }

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -9,7 +9,7 @@ use bun_ast::{Part, Ref, SlotCounts};
 
 use crate::bun_renamer as renamer;
 use crate::bun_renamer::{
-    ChunkRenamer, MinifyRenamer, NumberRenamer, ScopeUses, StableSymbolCount,
+    ChunkRenamer, MinifyRenamer, NestedRenamer, NumberRenamer, ScopeUses, StableSymbolCount,
 };
 use crate::chunk::Content;
 use crate::js_meta;
@@ -88,8 +88,7 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         module_ref_col,
         nested_slot_counts_col,
         cjs_export_copies_col,
-        scope_uses_col,
-    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _, _, _) = unsafe {
+    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _, _) = unsafe {
         (
             &mut *ast.module_scope,
             &*meta.flags,
@@ -102,7 +101,6 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             &*ast.module_ref,
             &*ast.nested_scope_slot_counts,
             &*meta.cjs_export_copies,
-            &*ast.scope_uses,
         )
     };
 
@@ -322,8 +320,6 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         r.add_top_level_symbol(stable_ref.r#ref);
     }
 
-    let mut sorted: Vec<u32> = Vec::new();
-
     // Renamed in a second pass, once every top-level symbol in the chunk is
     // in the root scope. Interleaving the passes let a nested local shadow a
     // later part's top-level symbol (#41054).
@@ -442,9 +438,14 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             }
 
             r.add_top_level_declared_symbols(&mut part.declared_symbols);
-            // `Part.scopes: StoreSlice<*mut Scope>` — safe `Deref` to `&[*mut Scope]`.
-            for scope in part.scopes.iter() {
-                nested_scopes.push((source_index, (*scope).cast_const()));
+            // `part.scopes` lists every scope visited for the part; the walk
+            // below recurses, so only the module scope's children go in.
+            for &scope in part.scopes.iter() {
+                // SAFETY: live arena-allocated scope (see below).
+                let parent = unsafe { (*scope).parent };
+                if parent.is_some_and(|parent| parent.parent.is_none()) {
+                    nested_scopes.push((source_index, scope.cast_const()));
+                }
             }
         }
     }
@@ -455,33 +456,75 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         r.add_top_level_symbol(copy);
     }
 
-    // `nested_scopes` is grouped by file.
-    for group in nested_scopes.chunk_by(|a, b| a.0 == b.0) {
-        let source_index = group[0].0;
-        let uses = ScopeUses::new(
-            source_index,
-            &scope_uses_col[source_index as usize],
-            all_parts[source_index as usize].as_slice(),
-            &c.graph.parts_live[source_index as usize],
-            // SAFETY: `symbols` points to the live `c.graph.symbols`; read-only here.
-            unsafe { &*symbols },
-        );
-        for &(_, scope) in group {
-            // Raw pointer for borrowck: `assign_names_*` takes `&mut r` plus
-            // `r.root`, and never reaches `self.root` through `self`.
-            let root: *mut renamer::NumberScope = core::ptr::addr_of_mut!(r.root);
-            // SAFETY: each `scope` is a live arena-allocated scope collected
-            // above; nothing mutates those scopes in between.
-            r.assign_names_recursive_with_number_scope(
-                root,
-                unsafe { &*scope },
-                source_index,
-                &mut sorted,
-                &uses,
-            );
-            r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
+    chunk.nested_scopes_to_rename = nested_scopes;
+    Ok(ChunkRenamer::Number(r))
+}
+
+/// One `NestedRenamer` task: the nested scopes of one file of one chunk.
+pub(crate) struct NestedRenameTask {
+    pub chunk_index: u32,
+    /// Range into `chunk.nested_scopes_to_rename`.
+    pub scopes: core::ops::Range<u32>,
+    pub names: Option<renamer::NestedNames>,
+}
+
+pub(crate) fn nested_rename_tasks(chunks: &[Chunk]) -> Vec<NestedRenameTask> {
+    let mut tasks = Vec::new();
+    for (chunk_index, chunk) in chunks.iter().enumerate() {
+        let scopes = &chunk.nested_scopes_to_rename;
+        let mut start = 0;
+        for group in scopes.chunk_by(|a, b| a.0 == b.0) {
+            let end = start + group.len();
+            tasks.push(NestedRenameTask {
+                chunk_index: chunk_index as u32,
+                scopes: start as u32..end as u32,
+                names: None,
+            });
+            start = end;
         }
     }
+    tasks
+}
 
-    Ok(ChunkRenamer::Number(r))
+// CONCURRENCY: `each_ptr` callback, one task per (chunk, file). Reads the
+// chunk's `NumberRenamer` (complete for top-level symbols; not written until
+// every task has finished) and `graph.{ast,symbols,parts_live}`; writes only
+// `task.names`.
+pub(crate) fn run_nested_rename_task(
+    ctx: &crate::linker_context_mod::GenerateChunkCtx,
+    task: *mut NestedRenameTask,
+    _task_index: usize,
+) {
+    // SAFETY: `each_ptr` hands us a unique `*mut NestedRenameTask`.
+    let task = unsafe { &mut *task };
+    let c: &LinkerContext<'_> = &ctx.c;
+    let chunk = &ctx.chunks[task.chunk_index as usize];
+    let ChunkRenamer::Number(root) = &chunk.renamer else {
+        unreachable!()
+    };
+    let scopes =
+        &chunk.nested_scopes_to_rename[task.scopes.start as usize..task.scopes.end as usize];
+    let source_index = scopes[0].0;
+    let ast = c.graph.ast.split_raw();
+    // SAFETY: read-only column views; see `rename_symbols_in_chunk`.
+    let (parts, scope_uses) = unsafe {
+        (
+            &(&(*ast.parts))[source_index as usize],
+            &(&(*ast.scope_uses))[source_index as usize],
+        )
+    };
+    let uses = ScopeUses::new(
+        source_index,
+        scope_uses,
+        parts.as_slice(),
+        &c.graph.parts_live[source_index as usize],
+        &c.graph.symbols,
+    );
+    let mut nested = NestedRenamer::new(root, &uses, source_index);
+    let mut sorted: Vec<u32> = Vec::new();
+    for &(_, scope) in scopes {
+        // SAFETY: live arena-allocated scope (see `rename_symbols_in_chunk`).
+        nested.assign_names_recursive(unsafe { &*scope }, &mut sorted);
+    }
+    task.names = Some(nested.into_names());
 }

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -8,7 +8,9 @@ use bun_ast::symbol;
 use bun_ast::{Part, Ref, SlotCounts};
 
 use crate::bun_renamer as renamer;
-use crate::bun_renamer::{ChunkRenamer, MinifyRenamer, NumberRenamer, StableSymbolCount};
+use crate::bun_renamer::{
+    ChunkRenamer, MinifyRenamer, NumberRenamer, ScopeUses, StableSymbolCount,
+};
 use crate::chunk::Content;
 use crate::js_meta;
 use crate::{Chunk, LinkerContext, StableRef, WrapKind};
@@ -72,7 +74,7 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
     // elements; the lists do not reallocate during this function. Read-only
     // columns are deref'd to `&[T]`; the two written columns
     // (`module_scope`, `parts`) are deref'd to `&mut [T]` — see CONCURRENCY
-    // note above re: code-splitting overlap. All eleven derefs share the same
+    // note above re: code-splitting overlap. All derefs share the same
     // invariant, so they are grouped under one `unsafe` block.
     let (
         all_module_scopes,
@@ -86,7 +88,8 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         module_ref_col,
         nested_slot_counts_col,
         cjs_export_copies_col,
-    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _, _) = unsafe {
+        scope_uses_col,
+    ): (_, &[js_meta::Flags], _, _, _, _, _, _, _, _, _, _) = unsafe {
         (
             &mut *ast.module_scope,
             &*meta.flags,
@@ -99,6 +102,7 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             &*ast.module_ref,
             &*ast.nested_scope_slot_counts,
             &*meta.cjs_export_copies,
+            &*ast.scope_uses,
         )
     };
 
@@ -207,8 +211,8 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         let mut freq = bun_ast::CharFreq { freqs: [0i32; 64] };
 
         for &source_index in files_in_order {
-            if ast_flags_col[source_index as usize].contains(AstFlags::HAS_CHAR_FREQ) {
-                freq.include(&char_freq_col[source_index as usize]);
+            if let Some(char_freq) = &char_freq_col[source_index as usize] {
+                freq.include(char_freq);
             }
         }
 
@@ -451,19 +455,32 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         r.add_top_level_symbol(copy);
     }
 
-    for &(source_index, scope) in &nested_scopes {
-        // Raw pointer for borrowck: `assign_names_*` takes `&mut r` plus
-        // `r.root`, and never reaches `self.root` through `self`.
-        let root: *mut renamer::NumberScope = core::ptr::addr_of_mut!(r.root);
-        // SAFETY: each `scope` is a live arena-allocated scope collected
-        // above; nothing mutates those scopes in between.
-        r.assign_names_recursive_with_number_scope(
-            root,
-            unsafe { &*scope },
+    // `nested_scopes` is grouped by file.
+    for group in nested_scopes.chunk_by(|a, b| a.0 == b.0) {
+        let source_index = group[0].0;
+        let uses = ScopeUses::new(
             source_index,
-            &mut sorted,
+            &scope_uses_col[source_index as usize],
+            all_parts[source_index as usize].as_slice(),
+            &c.graph.parts_live[source_index as usize],
+            // SAFETY: `symbols` points to the live `c.graph.symbols`; read-only here.
+            unsafe { &*symbols },
         );
-        r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
+        for &(_, scope) in group {
+            // Raw pointer for borrowck: `assign_names_*` takes `&mut r` plus
+            // `r.root`, and never reaches `self.root` through `self`.
+            let root: *mut renamer::NumberScope = core::ptr::addr_of_mut!(r.root);
+            // SAFETY: each `scope` is a live arena-allocated scope collected
+            // above; nothing mutates those scopes in between.
+            r.assign_names_recursive_with_number_scope(
+                root,
+                unsafe { &*scope },
+                source_index,
+                &mut sorted,
+                &uses,
+            );
+            r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
+        }
     }
 
     Ok(ChunkRenamer::Number(r))

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -13,7 +13,7 @@ use crate::bun_renamer::{
 };
 use crate::chunk::Content;
 use crate::js_meta;
-use crate::{Chunk, LinkerContext, StableRef, WrapKind};
+use crate::{BundleV2, Chunk, LinkerContext, StableRef, ThreadPool, WrapKind};
 
 /// TODO: investigate if we need to parallelize this function
 /// esbuild does parallelize it.
@@ -521,12 +521,19 @@ pub(crate) fn run_nested_rename_task(
         &c.graph.parts_live[source_index as usize],
         &c.graph.symbols,
     );
-    let mut nested = NestedRenamer::new(root, &uses, source_index);
+    // SAFETY: `c` is `BundleV2.linker`; `Worker::get` only needs `&BundleV2`.
+    let bundle_v2: &BundleV2<'_> = unsafe { &*LinkerContext::bundle_v2_ptr(ctx.c.as_mut_ptr()) };
+    let worker = scopeguard::guard(ThreadPool::Worker::get(bundle_v2), |w| w.unget());
+    // Made-up names go in this thread's worker arena, which lives until the
+    // bundle is done.
+    let mut nested = NestedRenamer::new(root, &uses, source_index, &worker.arena);
     let mut sorted: Vec<u32> = Vec::new();
     for &(_, scope) in scopes {
         // SAFETY: live arena-allocated scope (see `rename_symbols_in_chunk`).
         nested.assign_names_recursive(unsafe { &*scope }, &mut sorted);
     }
+    let names = nested.into_names();
+    drop(worker);
     // SAFETY: as above.
-    unsafe { (*task).names = Some(nested.into_names()) };
+    unsafe { (*task).names = Some(names) };
 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1441,6 +1441,7 @@ impl<'a> BundleOptions<'a> {
             define: Box::new(defines::Define {
                 identifiers: self.define.identifiers.clone(),
                 dots: self.define.dots.clone(),
+                dots_filter: self.define.dots_filter.clone(),
                 drop_debugger: self.define.drop_debugger,
                 user_hash: self.define.user_hash,
             }),

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -492,12 +492,58 @@ pub mod defines {
     pub struct Define {
         pub identifiers: StringHashMap<IdentifierDefine>,
         pub dots: StringHashMap<Vec<DotDefine>>,
+        /// Which `DotFilter::bit`s the keys of `dots` set. The visitor asks
+        /// about every property access; nearly all miss, and this says so
+        /// without hashing the name.
+        pub dots_filter: DotFilter,
         pub drop_debugger: bool,
         /// `hash_user_inputs` of this table's inputs, for the runtime transpiler cache key.
         pub user_hash: Option<u64>,
     }
 
+    #[derive(Clone)]
+    pub struct DotFilter([u64; 64]);
+
+    impl Default for DotFilter {
+        fn default() -> Self {
+            DotFilter([0; 64])
+        }
+    }
+
+    impl DotFilter {
+        #[inline]
+        fn bit(name: &[u8]) -> usize {
+            let (first, last) = match name {
+                [] => (0, 0),
+                [first, .., last] | [first @ last] => (*first as usize, *last as usize),
+            };
+            (name.len().wrapping_mul(131) ^ first.wrapping_mul(31) ^ last.wrapping_mul(7)) & 4095
+        }
+
+        #[inline]
+        pub fn insert(&mut self, name: &[u8]) {
+            let bit = Self::bit(name);
+            self.0[bit / 64] |= 1 << (bit % 64);
+        }
+
+        #[inline]
+        pub fn may_contain(&self, name: &[u8]) -> bool {
+            let bit = Self::bit(name);
+            self.0[bit / 64] & (1 << (bit % 64)) != 0
+        }
+    }
+
     impl Define {
+        /// The dot defines whose last part is `name` (`NODE_ENV` for
+        /// `process.env.NODE_ENV`).
+        #[inline]
+        pub fn dots_for(&self, name: &[u8]) -> Option<&Vec<DotDefine>> {
+            if !self.dots_filter.may_contain(name) {
+                return None;
+            }
+            self.dots.get(name)
+        }
+
         /// Order-independent, length-prefixed hash of the three inputs. `None` when all are empty.
         pub fn hash_user_inputs<'i>(
             defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
@@ -568,6 +614,7 @@ pub mod defines {
                 }
                 parts.push(Box::from(tail));
 
+                self.dots_filter.insert(tail);
                 if let Some(existing) = self.dots.get_mut(tail) {
                     for part in existing.iter_mut() {
                         if are_parts_equal(&part.parts, &parts) {

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -195,7 +195,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                             })?;
                         self.last_part
                             .symbol_uses
-                            .put_no_clobber(temp_id, js_ast::symbol::Use { count_estimate: 1 })?;
+                            .put_no_clobber(temp_id, js_ast::symbol::Use::unscoped(1))?;
                         // SAFETY: `current_scope` is a live arena ptr for the parser lifetime.
                         VecExt::append(&mut p.current_scope_mut().generated, temp_id);
 
@@ -593,7 +593,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 })?;
             self.last_part
                 .symbol_uses
-                .put_no_clobber(arg1, js_ast::symbol::Use { count_estimate: 1 })?;
+                .put_no_clobber(arg1, js_ast::symbol::Use::unscoped(1))?;
             // SAFETY: `current_scope` is a live arena ptr for the parser lifetime.
             VecExt::append(&mut p.current_scope_mut().generated, arg1);
 
@@ -684,7 +684,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
             // mark a dependency on module_ref so it is renamed
             self.last_part
                 .symbol_uses
-                .put(p.module_ref, js_ast::symbol::Use { count_estimate: 1 })?;
+                .put(p.module_ref, js_ast::symbol::Use::unscoped(1))?;
             self.last_part
                 .declared_symbols
                 .append(js_ast::DeclaredSymbol {
@@ -739,7 +739,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 if !gop.found_existing {
                     *gop.value_ptr = v;
                 } else {
-                    gop.value_ptr.count_estimate += v.count_estimate;
+                    gop.value_ptr.merge(v);
                 }
             }
             part.stmts = bun_ast::StoreSlice::EMPTY;

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -471,7 +471,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                     // Note: the concrete `P` always carries `symbol_uses`;
                     // once a `ParserLike` trait is introduced for
                     // AstBuilder, that variant should override this to a no-op.
-                    p.symbol_uses.swap_remove(&namespace_ref);
+                    p.forget_part_use(namespace_ref);
                 }
             }
             if stmt.star_name_loc.is_empty() {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9591,7 +9591,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // the vast majority of real files in a single allocation.
         let estimated_symbol_count = source.contents.len() / 16;
 
-        let mut scope_order = ScopeOrderList::with_capacity_in(1, arena);
+        // ~one scope per 64 source bytes covers most files without regrowth.
+        let mut scope_order =
+            ScopeOrderList::with_capacity_in((source.contents.len() / 64).max(1), arena);
         let scope_obj = arena.alloc(Scope {
             members: Default::default(),
             children: bun_alloc::AstAlloc::vec(),
@@ -9725,7 +9727,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             latest_arrow_arg_loc: bun_ast::Loc::EMPTY,
             forbid_suffix_after_as_loc: bun_ast::Loc::EMPTY,
             scopes_for_current_part: BumpVec::new_in(arena),
-            symbols: BumpVec::new_in(arena),
+            symbols: BumpVec::with_capacity_in(estimated_symbol_count, arena),
             ts_use_counts: BumpVec::new_in(arena),
             exports_ref: Ref::NONE,
             require_ref: Ref::NONE,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5552,6 +5552,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         parts: &mut ListManaged<'a, js_ast::Part>,
         stmts: &'a mut [Stmt],
     ) -> Result<(), crate::Error> {
+        // Uses recorded outside a part's visit (the parse pass resolving
+        // decorator-metadata types) belong to no part.
+        self.part_uses.clear();
+        self.part_generation += 1;
         self.declared_symbols.clear_retaining_capacity();
         self.scopes_for_current_part.clear();
         self.import_records_for_current_part.clear();

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -311,7 +311,17 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     pub(crate) has_called_runtime: bool,
 
+    /// The current part's symbol uses, built from `part_uses` when the part
+    /// is done (`take_symbol_uses`); empty while visiting.
     pub(crate) symbol_uses: SymbolUseMap,
+    /// The current part's uses in first-use order. By symbol inner index,
+    /// `part_use_generation[i] == part_generation` says symbol `i` has a live
+    /// entry at `part_uses[part_use_index[i]]`. One dense lookup per reference
+    /// instead of one hash-map probe.
+    pub(crate) part_uses: Vec<(Ref, js_ast::symbol::Use)>,
+    pub(crate) part_use_generation: Vec<u32>,
+    pub(crate) part_use_index: Vec<u32>,
+    pub(crate) part_generation: u32,
     pub(crate) declared_symbols: bun_ast::DeclaredSymbolList,
     pub(crate) runtime_imports: RuntimeImports,
 
@@ -2031,6 +2041,58 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// The current part's use entry for `ref_`, created if absent.
+    fn part_use(&mut self, ref_: Ref) -> &mut js_ast::symbol::Use {
+        let i = ref_.inner_index() as usize;
+        if i >= self.part_use_generation.len() {
+            let len = self.symbols.len();
+            self.part_use_generation.resize(len, 0);
+            self.part_use_index.resize(len, 0);
+        }
+        if self.part_use_generation[i] != self.part_generation {
+            self.part_use_generation[i] = self.part_generation;
+            self.part_use_index[i] = self.part_uses.len() as u32;
+            self.part_uses.push((ref_, js_ast::symbol::Use::default()));
+        }
+        &mut self.part_uses[self.part_use_index[i] as usize].1
+    }
+
+    fn existing_part_use(&mut self, ref_: Ref) -> Option<&mut js_ast::symbol::Use> {
+        let i = ref_.inner_index() as usize;
+        if self.part_use_generation.get(i).copied() != Some(self.part_generation) {
+            return None;
+        }
+        Some(&mut self.part_uses[self.part_use_index[i] as usize].1)
+    }
+
+    /// Drop the current part's uses of `ref_`.
+    pub(crate) fn forget_part_use(&mut self, ref_: Ref) {
+        if let Some(generation) = self
+            .part_use_generation
+            .get_mut(ref_.inner_index() as usize)
+        {
+            *generation = 0;
+        }
+    }
+
+    /// The current part's uses as a map; starts the next part.
+    pub(crate) fn take_symbol_uses(&mut self) -> Result<SymbolUseMap, bun_alloc::AllocError> {
+        let mut map = core::mem::take(&mut self.symbol_uses);
+        map.clear_retaining_capacity();
+        map.ensure_total_capacity(self.part_uses.len())?;
+        for (at, &(ref_, use_)) in self.part_uses.iter().enumerate() {
+            let i = ref_.inner_index() as usize;
+            if self.part_use_generation[i] == self.part_generation
+                && self.part_use_index[i] as usize == at
+            {
+                map.put_assume_capacity(ref_, use_);
+            }
+        }
+        self.part_uses.clear();
+        self.part_generation += 1;
+        Ok(map)
+    }
+
     /// `scope_use = false`: the reference can never be captured by renaming
     /// another binding (an unbound global, whose name every scope already
     /// avoids), so `scope_uses` skips it.
@@ -2044,12 +2106,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !self.is_control_flow_dead {
             debug_assert!(self.symbols.len() > ref_.inner_index() as usize);
             self.symbols[ref_.inner_index() as usize].use_count_estimate += 1;
-            // `get_or_put` zero-initializes the slot on insert (`Use::default()`).
-            self.symbol_uses
-                .get_or_put(ref_)
-                .expect("unreachable")
-                .value_ptr
-                .add_scoped(1);
+            self.part_use(ref_).add_scoped(1);
             if scope_use {
                 self.record_scope_use(ref_);
             }
@@ -5489,9 +5546,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         parts: &mut ListManaged<'a, js_ast::Part>,
         stmts: &'a mut [Stmt],
     ) -> Result<(), crate::Error> {
-        // Reuse the memory if possible
-        // This is reusable if the last part turned out to be dead
-        self.symbol_uses.clear_retaining_capacity();
         self.declared_symbols.clear_retaining_capacity();
         self.scopes_for_current_part.clear();
         self.import_records_for_current_part.clear();
@@ -5558,9 +5612,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let final_stmts = bun_ast::StoreSlice::from_bump(part_stmts);
             let can_be_removed_if_unused = self.stmts_can_be_removed_if_unused(final_stmts.slice());
 
+            let symbol_uses = self.take_symbol_uses()?;
             parts.push(js_ast::Part {
                 stmts: final_stmts,
-                symbol_uses: core::mem::take(&mut self.symbol_uses),
+                symbol_uses,
                 import_symbol_property_uses: {
                     let m = core::mem::take(&mut self.import_symbol_property_uses);
                     if m.is_empty() {
@@ -5596,11 +5651,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // `symbol_uses` / `import_symbol_property_uses` were already reset
             // to empty by `core::mem::take` above; no second assignment needed.
             self.had_commonjs_named_exports_this_visit = false;
-        } else if self.declared_symbols.len() > 0 || self.symbol_uses.count() > 0 {
+        } else if self.declared_symbols.len() > 0 || !self.part_uses.is_empty() {
             // if the part is dead, invalidate all the usage counts
+            let symbol_uses = self.take_symbol_uses()?;
             self.clear_symbol_usages_from_dead_part(&js_ast::Part {
                 declared_symbols: self.declared_symbols.clone()?,
-                symbol_uses: self.symbol_uses.clone()?,
+                symbol_uses,
                 ..Default::default()
             });
             self.declared_symbols.clear_retaining_capacity();
@@ -6604,7 +6660,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if self.is_revisit_for_substitution {
             return true;
         }
-        let Some(use_) = self.symbol_uses.get_mut(&base) else {
+        let Some(use_) = self.existing_part_use(base) else {
             return false;
         };
         use_.subtract(1);
@@ -6630,14 +6686,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 [r#ref.inner_index() as usize]
                 .use_count_estimate
                 .saturating_sub(1);
-            let Some(mut use_) = self.symbol_uses.get(&r#ref).copied() else {
-                return;
-            };
-            use_.subtract(1);
-            if use_.count_estimate() == 0 {
-                let _ = self.symbol_uses.swap_remove(&r#ref);
-            } else {
-                self.symbol_uses.put_assume_capacity(r#ref, use_);
+            if let Some(use_) = self.existing_part_use(r#ref) {
+                use_.subtract(1);
+                if use_.count_estimate() == 0 {
+                    self.forget_part_use(r#ref);
+                }
             }
         }
 
@@ -9689,6 +9742,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,
             symbol_uses,
+            part_uses: Vec::new(),
+            part_use_generation: Vec::new(),
+            part_use_index: Vec::new(),
+            part_generation: 1,
             declared_symbols: Default::default(),
             runtime_imports: RuntimeImports::default(),
             imports_to_convert_from_require: BumpVec::new_in(arena),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -315,12 +315,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// is done (`take_symbol_uses`); empty while visiting.
     pub(crate) symbol_uses: SymbolUseMap,
     /// The current part's uses in first-use order. By symbol inner index,
-    /// `part_use_generation[i] == part_generation` says symbol `i` has a live
-    /// entry at `part_uses[part_use_index[i]]`. One dense lookup per reference
-    /// instead of one hash-map probe.
+    /// `part_use_slot[i]` says whether symbol `i` has a live entry in
+    /// `part_uses` this part and where: one dense lookup per reference
+    /// instead of a hash-map probe.
     pub(crate) part_uses: Vec<(Ref, js_ast::symbol::Use)>,
-    pub(crate) part_use_generation: Vec<u32>,
-    pub(crate) part_use_index: Vec<u32>,
+    /// `generation << 32 | index`.
+    pub(crate) part_use_slot: Vec<u64>,
     pub(crate) part_generation: u32,
     pub(crate) declared_symbols: bun_ast::DeclaredSymbolList,
     pub(crate) runtime_imports: RuntimeImports,
@@ -2044,34 +2044,33 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// The current part's use entry for `ref_`, created if absent.
     fn part_use(&mut self, ref_: Ref) -> &mut js_ast::symbol::Use {
         let i = ref_.inner_index() as usize;
-        if i >= self.part_use_generation.len() {
-            let len = self.symbols.len();
-            self.part_use_generation.resize(len, 0);
-            self.part_use_index.resize(len, 0);
+        if i >= self.part_use_slot.len() {
+            self.part_use_slot.resize(self.symbols.len(), 0);
         }
-        if self.part_use_generation[i] != self.part_generation {
-            self.part_use_generation[i] = self.part_generation;
-            self.part_use_index[i] = self.part_uses.len() as u32;
+        let slot = self.part_use_slot[i];
+        let index = if (slot >> 32) as u32 == self.part_generation {
+            slot as u32 as usize
+        } else {
+            let index = self.part_uses.len();
+            self.part_use_slot[i] = (u64::from(self.part_generation) << 32) | index as u64;
             self.part_uses.push((ref_, js_ast::symbol::Use::default()));
-        }
-        &mut self.part_uses[self.part_use_index[i] as usize].1
+            index
+        };
+        &mut self.part_uses[index].1
     }
 
     fn existing_part_use(&mut self, ref_: Ref) -> Option<&mut js_ast::symbol::Use> {
-        let i = ref_.inner_index() as usize;
-        if self.part_use_generation.get(i).copied() != Some(self.part_generation) {
+        let slot = *self.part_use_slot.get(ref_.inner_index() as usize)?;
+        if (slot >> 32) as u32 != self.part_generation {
             return None;
         }
-        Some(&mut self.part_uses[self.part_use_index[i] as usize].1)
+        Some(&mut self.part_uses[slot as u32 as usize].1)
     }
 
     /// Drop the current part's uses of `ref_`.
     pub(crate) fn forget_part_use(&mut self, ref_: Ref) {
-        if let Some(generation) = self
-            .part_use_generation
-            .get_mut(ref_.inner_index() as usize)
-        {
-            *generation = 0;
+        if let Some(slot) = self.part_use_slot.get_mut(ref_.inner_index() as usize) {
+            *slot = 0;
         }
     }
 
@@ -2080,11 +2079,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut map = core::mem::take(&mut self.symbol_uses);
         map.clear_retaining_capacity();
         map.ensure_total_capacity(self.part_uses.len())?;
+        let generation = u64::from(self.part_generation) << 32;
         for (at, &(ref_, use_)) in self.part_uses.iter().enumerate() {
-            let i = ref_.inner_index() as usize;
-            if self.part_use_generation[i] == self.part_generation
-                && self.part_use_index[i] as usize == at
-            {
+            if self.part_use_slot[ref_.inner_index() as usize] == generation | at as u64 {
                 map.put_assume_capacity(ref_, use_);
             }
         }
@@ -3546,7 +3543,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let members = &scope_ref.members;
                     let mut v = BumpVec::with_capacity_in(members.count(), arena);
                     for (k, m) in members.iter() {
-                        v.push((js_ast::StoreStr::new(k.as_ref()), *m));
+                        v.push((js_ast::StoreStr::new(k), *m));
                     }
                     v
                 };
@@ -3560,7 +3557,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // `Symbol.original_name` is an arena-owned `StoreStr` valid for 'a.
                     let name: &'a [u8] = self.symbols[symbol_idx].original_name.slice();
-                    let mut hash: Option<u64> = None;
+                    let mut hash: Option<u32> = None;
 
                     if scope_parent.kind == js_ast::scope::Kind::CatchBinding
                         && self.symbols[symbol_idx].kind != js_ast::symbol::Kind::Hoisted
@@ -3679,9 +3676,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 // `StringHashMap` get_or_put already stores the key on insert and
                                 // cannot hand out `&mut K` (see StringHashMapGetOrPut docs), so
                                 // no key write is needed here.
-                                *_scope
-                                    .get_or_put_member_with_hash(name, hash.unwrap())
-                                    .value_ptr = member_in_scope;
+                                // SAFETY: `name` is a symbol's `original_name`.
+                                *unsafe {
+                                    _scope.get_or_put_member_with_hash(name, hash.unwrap())
+                                }
+                                .value_ptr = member_in_scope;
 
                                 // "function foo() {} { var foo; }"
                                 if _scope_ptr == self.module_scope
@@ -3745,14 +3744,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // If this is a catch identifier, silently merge the existing symbol
                             // into this symbol but continue hoisting past this catch scope
                             self.symbols[existing_idx].link.set(value.ref_);
-                            *_scope
-                                .get_or_put_member_with_hash(name, hash.unwrap())
+                            // SAFETY: `name` is a symbol's `original_name`.
+                            *unsafe { _scope.get_or_put_member_with_hash(name, hash.unwrap()) }
                                 .value_ptr = value;
                         }
 
                         if _scope.kind_stops_hoisting() {
-                            *_scope
-                                .get_or_put_member_with_hash(name, hash.unwrap())
+                            // SAFETY: `name` is a symbol's `original_name`.
+                            *unsafe { _scope.get_or_put_member_with_hash(name, hash.unwrap()) }
                                 .value_ptr = value;
                             break;
                         }
@@ -3926,7 +3925,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // lexer string-table (see `get_or_put_member_with_hash`),
                     // both of which outlive every arena-backed `Scope`. Avoids
                     // a per-argument `mi_heap_malloc` on every function body.
-                    unsafe { scope.members.put_borrowed(key, value)? };
+                    unsafe { scope.members.put(key, value) };
                 }
             }
         }
@@ -5048,13 +5047,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let ref_ = self.new_symbol(kind, name);
 
         if member.is_none() {
-            self.module_scope_mut().members.put(
-                name,
-                js_ast::scope::Member {
-                    ref_,
-                    loc: bun_ast::Loc::EMPTY,
-                },
-            )?;
+            // SAFETY: `name` is `'static`.
+            unsafe {
+                self.module_scope_mut().members.put(
+                    name,
+                    js_ast::scope::Member {
+                        ref_,
+                        loc: bun_ast::Loc::EMPTY,
+                    },
+                )
+            };
             return Ok(ref_);
         }
 
@@ -5156,7 +5158,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let scope_kind = scope.kind;
         // SAFETY: see key-lifetime note above — `name: &'a [u8]` outlives the
         // arena-owned `Scope` map.
-        let entry = unsafe { scope.members.get_or_put_borrowed(name) };
+        let entry = unsafe {
+            scope
+                .members
+                .get_or_put_hashed(js_ast::scope::Members::hash(name), name)
+        };
         if entry.found_existing {
             let existing: js_ast::scope::Member = *entry.value_ptr;
             let symbol_idx = existing.ref_.inner_index() as usize;
@@ -5987,7 +5993,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .get_or_put_value(self.exports_ref, Default::default())
                     .expect("OOM")
                     .value_ptr
-                    .count_estimate += count;
+                    .merge(js_ast::symbol::Use::unscoped(count));
             }
         }
     }
@@ -9595,9 +9601,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             parent: None,
             ..Default::default()
         });
-        let _ = scope_obj
-            .members
-            .ensure_total_capacity(estimated_symbol_count);
+        scope_obj.members.reserve(estimated_symbol_count);
         let scope = js_ast::StoreRef::from_bump(scope_obj);
 
         scope_order.push(Some(ScopeOrder::new(loc_module_scope, scope.as_ptr())));
@@ -9743,8 +9747,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_called_runtime: false,
             symbol_uses,
             part_uses: Vec::new(),
-            part_use_generation: Vec::new(),
-            part_use_index: Vec::new(),
+            part_use_slot: Vec::new(),
             part_generation: 1,
             declared_symbols: Default::default(),
             runtime_imports: RuntimeImports::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -531,6 +531,19 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) module_scope: js_ast::StoreRef<js_ast::Scope>,
     pub(crate) module_scope_directive_loc: bun_ast::Loc,
     pub(crate) is_control_flow_dead: bool,
+    /// Fill `scope_uses` (bundling with the number renamer).
+    pub(crate) track_scope_uses: bool,
+    /// Next `Scope::visit_span` pre-order index. The module scope is 0.
+    pub(crate) visit_scope_count: u32,
+    /// Class body scopes whose field initializer is being visited. Lowering
+    /// may move the initializer into the constructor, so its uses count as
+    /// uses anywhere in the class body.
+    pub(crate) field_init_class_bodies: Vec<js_ast::StoreRef<Scope>>,
+    /// Becomes `Ast::scope_uses`.
+    pub(crate) scope_uses: Vec<js_ast::ast_result::ScopeUse>,
+    /// `(class body scope, symbol)`; becomes `Ast::scope_uses.spans` once the
+    /// visit pass has numbered every scope. A `None` scope is the whole file.
+    pub(crate) span_uses: Vec<(Option<js_ast::StoreRef<Scope>>, u32)>,
 
     /// True while `visit_single_stmt` is visiting a non-block body. `if`,
     /// `else`, `while`, and `do` reach it without pushing a scope, so inside
@@ -1778,7 +1791,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             symbols[r#ref.inner_index() as usize].use_count_estimate = symbols
                 [r#ref.inner_index() as usize]
                 .use_count_estimate
-                .saturating_sub(prev.count_estimate);
+                .saturating_sub(prev.count_estimate());
         }
         let declared_refs = part.declared_symbols.refs();
         for declared in declared_refs {
@@ -1787,6 +1800,54 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     // s() lives in the impl block above (deduped).
+
+    fn take_scope_uses(&mut self) -> js_ast::ast_result::ScopeUseList {
+        use js_ast::ast_result::{ScopeUseList, ScopeUseSpan};
+        if !self.track_scope_uses {
+            return ScopeUseList::default();
+        }
+        // Pushed first in the visit pass and never popped.
+        self.module_scope_mut().visit_span[1] = self.visit_scope_count.saturating_sub(1);
+        let file = ScopeUseSpan::whole_file;
+        let mut spans: Vec<ScopeUseSpan> = Vec::with_capacity(self.span_uses.len() + 2);
+        for &(scope, symbol) in &self.span_uses {
+            spans.push(match scope.and_then(|scope| scope.visit_span()) {
+                Some((first, last)) => ScopeUseSpan {
+                    symbol,
+                    first,
+                    last,
+                },
+                None => file(symbol),
+            });
+        }
+        // `module.exports` prints as `exports`, `exports` may print as
+        // `module.exports`.
+        spans.push(file(self.exports_ref.inner_index()));
+        spans.push(file(self.module_ref.inner_index()));
+        // The parser may print a temporary or helper it generated in a deeper
+        // scope than it referenced it in; not so its generated import items.
+        fn generated(symbols: &[Symbol], scope: &Scope, spans: &mut Vec<ScopeUseSpan>) {
+            for ref_ in scope.generated.slice() {
+                if symbols[ref_.inner_index() as usize].kind != js_ast::symbol::Kind::Import {
+                    spans.push(ScopeUseSpan::whole_file(ref_.inner_index()));
+                }
+            }
+            for child in scope.children.slice() {
+                generated(symbols, child, spans);
+            }
+        }
+        generated(self.symbols.as_slice(), self.module_scope(), &mut spans);
+        spans.sort_unstable();
+        spans.dedup();
+
+        let list = ScopeUseList {
+            tracked: true,
+            points: bun_alloc::AstAlloc::vec_from_slice(&self.scope_uses),
+            spans: bun_alloc::AstAlloc::vec_from_slice(&spans),
+        };
+        self.scope_uses = Vec::new();
+        list
+    }
 
     fn compute_character_frequency(&mut self) -> Option<js_ast::CharFreq> {
         if !self.options.features.minify_identifiers || self.is_source_runtime() {
@@ -1935,6 +1996,45 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub(crate) fn record_usage(&mut self, ref_: Ref) {
+        self.record_usage_impl(ref_, true);
+    }
+
+    fn record_scope_use(&mut self, ref_: Ref) {
+        if !self.track_scope_uses {
+            return;
+        }
+        let symbol = ref_.inner_index();
+        let scope = self.current_scope;
+        if scope.visit_span[0] == u32::MAX {
+            // The parse pass (TypeScript decorator metadata resolves type
+            // names then): no scope numbering yet.
+            self.span_uses.push((None, symbol));
+        } else if scope.kind == js_ast::scope::Kind::ClassBody {
+            // A field initializer is visited in the class body scope but may
+            // be printed inside the constructor.
+            if self.span_uses.last().copied() != Some((Some(scope), symbol)) {
+                self.span_uses.push((Some(scope), symbol));
+            }
+        } else {
+            let point = js_ast::ast_result::ScopeUse {
+                scope: scope.visit_span[0],
+                symbol,
+            };
+            if self.scope_uses.last().copied() != Some(point) {
+                self.scope_uses.push(point);
+            }
+        }
+        for &class_body in &self.field_init_class_bodies {
+            if self.span_uses.last().copied() != Some((Some(class_body), symbol)) {
+                self.span_uses.push((Some(class_body), symbol));
+            }
+        }
+    }
+
+    /// `scope_use = false`: the reference can never be captured by renaming
+    /// another binding (an unbound global, whose name every scope already
+    /// avoids), so `scope_uses` skips it.
+    pub(crate) fn record_usage_impl(&mut self, ref_: Ref, scope_use: bool) {
         if self.is_revisit_for_substitution {
             return;
         }
@@ -1949,7 +2049,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .get_or_put(ref_)
                 .expect("unreachable")
                 .value_ptr
-                .count_estimate += 1;
+                .add_scoped(1);
+            if scope_use {
+                self.record_scope_use(ref_);
+            }
         }
 
         // The correctness of TypeScript-to-JavaScript conversion relies on accurate
@@ -3661,7 +3764,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.panic("Scope mismatch while visiting", format_args!(""));
         }
 
-        self.current_scope = order.scope_ref();
+        let mut scope = order.scope_ref();
+        scope.visit_span[0] = self.visit_scope_count;
+        self.visit_scope_count += 1;
+        self.current_scope = scope;
         self.scopes_for_current_part.push(order.scope);
         Ok(())
     }
@@ -5252,6 +5358,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // The parse pass pops scopes before the visit pass numbers them.
+        let mut scope = current_scope;
+        if scope.visit_span[0] != u32::MAX {
+            scope.visit_span[1] = self.visit_scope_count - 1;
+        }
         self.current_scope = current_scope.parent.unwrap_or_else(|| {
             self.panic(
                 "Internal error: attempted to call popScope() on the topmost scope",
@@ -6496,7 +6607,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let Some(use_) = self.symbol_uses.get_mut(&base) else {
             return false;
         };
-        use_.count_estimate = use_.count_estimate.saturating_sub(1);
+        use_.subtract(1);
         // note: this use is not removed as we assume it exists later
 
         let gop = self
@@ -6522,8 +6633,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let Some(mut use_) = self.symbol_uses.get(&r#ref).copied() else {
                 return;
             };
-            use_.count_estimate = use_.count_estimate.saturating_sub(1);
-            if use_.count_estimate == 0 {
+            use_.subtract(1);
+            if use_.count_estimate() == 0 {
                 let _ = self.symbol_uses.swap_remove(&r#ref);
             } else {
                 self.symbol_uses.put_assume_capacity(r#ref, use_);
@@ -9145,7 +9256,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let ts_enums = self.compute_ts_enums_map(arena)?;
 
-        let char_freq: Option<js_ast::CharFreq> = self.compute_character_frequency();
+        let char_freq = self.compute_character_frequency().map(bun_alloc::ast_box);
+        let scope_uses = self.take_scope_uses();
 
         let module_scope_strict = self.module_scope().strict_mode;
         // Scope is not `Clone` (Vec/HashMap members), so move it out and leave
@@ -9216,6 +9328,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             export_keyword: self.esm_export_keyword,
             top_level_symbols_to_parts,
             char_freq,
+            scope_uses,
             directive: if module_scope_strict == js_ast::StrictModeKind::ExplicitStrictMode {
                 Some(bun_ast::StoreStr::new(b"use strict"))
             } else {
@@ -9447,6 +9560,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // literal in the by-value-return shape; now precomputed so the
         // literal below is the *only* write to `*out`). ───
         lexer.track_comments = opts.features.minify_identifiers;
+        let track_scope_uses = opts.bundle && !opts.features.minify_identifiers;
         lexer.track_react_suppressions = opts.features.react_compiler.is_enabled();
 
         if !TYPESCRIPT {
@@ -9622,6 +9736,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             scope_order_to_visit: &[],
             module_scope_directive_loc: bun_ast::Loc::default(),
             is_control_flow_dead: false,
+            track_scope_uses,
+            visit_scope_count: 0,
+            field_init_class_bodies: Vec::new(),
+            scope_uses: Vec::new(),
+            span_uses: Vec::new(),
             is_inside_single_stmt_body: false,
             is_revisit_for_substitution: false,
             method_call_must_be_replaced_with_undefined: false,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1717,7 +1717,7 @@ impl<'a> Parser<'a> {
                 p.symbols.as_mut_slice()[p.module_ref.inner_index() as usize].use_count_estimate =
                     0;
                 match part.symbol_uses.get_mut(&found.namespace_ref) {
-                    Some(uses) if uses.count_estimate > 1 => uses.count_estimate -= 1,
+                    Some(uses) if uses.count_estimate() > 1 => uses.subtract(1),
                     _ => {
                         let _ = part.symbol_uses.swap_remove(&found.namespace_ref);
                     }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -900,7 +900,7 @@ impl<'a> Parser<'a> {
 
         let mut before = BumpVec::<js_ast::Part>::new_in(p.arena);
         let mut after = BumpVec::<js_ast::Part>::new_in(p.arena);
-        let mut parts = BumpVec::<js_ast::Part>::new_in(p.arena);
+        let mut parts = BumpVec::<js_ast::Part>::with_capacity_in(stmts.len() + 2, p.arena);
         // (Element ownership is transferred into `parts` below via bitwise copy + set_len(0).)
 
         if p.options.bundle {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -605,7 +605,7 @@ impl<'a> Parser<'a> {
         });
         let part = js_ast::Part {
             stmts: stmts.into(),
-            symbol_uses: core::mem::take(&mut p.symbol_uses),
+            symbol_uses: p.take_symbol_uses()?,
             ..Default::default()
         };
         let mut parts = BumpVec::with_capacity_in(2, p.arena);

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -449,11 +449,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     underscores += 1;
                 };
                 arg_ref = p.new_symbol(SymbolKind::Hoisted, prefixed);
-                // SAFETY: see above.
-                VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             } else {
+                // Not a member: a reference to the name inside the namespace
+                // resolves to a merged sibling's export of that name first.
                 arg_ref = p.new_symbol(SymbolKind::Hoisted, name_text);
             }
+            // Named in this scope so that no binding inside shadows it.
+            VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             ts_namespace.arg_ref = arg_ref;
         }
         p.pop_scope();

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -112,9 +112,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 });
             }
 
-            let gpe = self
-                .module_scope_mut()
-                .get_or_put_member_with_hash(name, hash);
+            // SAFETY: `name` is a slice of the source or the lexer's string table.
+            let gpe = unsafe {
+                self.module_scope_mut()
+                    .get_or_put_member_with_hash(name, hash)
+            };
 
             // I don't think this happens?
             if gpe.found_existing {
@@ -127,10 +129,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Drop gpe, allocate, then re-insert.
             let new_ref = self.new_symbol(js_ast::symbol::Kind::Unbound, name);
 
-            *self
-                .module_scope_mut()
-                .get_or_put_member_with_hash(name, hash)
-                .value_ptr = js_ast::scope::Member { ref_: new_ref, loc };
+            // SAFETY: as above.
+            *unsafe {
+                self.module_scope_mut()
+                    .get_or_put_member_with_hash(name, hash)
+            }
+            .value_ptr = js_ast::scope::Member { ref_: new_ref, loc };
 
             declare_loc = loc;
             scope_use = false;

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -22,6 +22,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // early-`return` builds its own `FindSymbolResult` without reading it.
         let declare_loc: bun_ast::Loc;
         let mut is_inside_with_scope = false;
+        let mut scope_use = true;
         // This function can show up in profiling.
         // That's part of why we do this.
         // Instead of rehashing `name` for every scope, we do it just once.
@@ -54,6 +55,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // Is the symbol a member of this scope?
                 if let Some(member) = scope.get_member_with_hash(name, hash) {
                     declare_loc = member.loc;
+                    // Unbound globals live in the module scope.
+                    scope_use = self.track_scope_uses
+                        && (scope.parent.is_some()
+                            || self.symbols[member.ref_.inner_index() as usize].kind
+                                != js_ast::symbol::Kind::Unbound);
                     break 'brk member.ref_;
                 }
 
@@ -127,6 +133,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .value_ptr = js_ast::scope::Member { ref_: new_ref, loc };
 
             declare_loc = loc;
+            scope_use = false;
 
             break 'brk new_ref;
         };
@@ -141,7 +148,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Track how many times we've referenced this symbol
         if RECORD_USAGE {
-            self.record_usage(ref_);
+            self.record_usage_impl(ref_, scope_use);
         }
 
         Ok(FindSymbolResult {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1005,16 +1005,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let original_name: &'a [u8] = self.symbols[name_ref.inner_index() as usize]
                 .original_name
                 .slice();
-            self.vis_scope()
-                .members
-                .put(
+            // SAFETY: `original_name` is an AST-arena slice.
+            unsafe {
+                self.vis_scope().members.put(
                     original_name,
                     ScopeMember {
                         ref_: name.ref_,
                         loc: name.loc,
                     },
                 )
-                .expect("oom");
+            };
             name_ref
         } else {
             let name_str: &'a [u8] = if default_name_ref.is_empty() {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -62,16 +62,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub(crate) fn record_declared_symbol(&mut self, r#ref: Ref) {
+        self.record_declared_symbol_in(r#ref, false);
+    }
+
+    /// `own_scope`: the name of a function or class expression, bound in the
+    /// expression's own scope rather than the one being visited.
+    pub(crate) fn record_declared_symbol_in(&mut self, r#ref: Ref, own_scope: bool) {
         debug_assert!(r#ref.is_symbol());
         self.declared_symbols
             .append(bun_ast::DeclaredSymbol {
                 ref_: r#ref,
-                is_top_level: self.current_scope == self.module_scope,
+                is_top_level: !own_scope && self.current_scope == self.module_scope,
             })
             .expect("oom");
     }
 
-    pub(crate) fn visit_func(&mut self, mut func: G::Fn, open_parens_loc: bun_ast::Loc) -> G::Fn {
+    pub(crate) fn visit_func(
+        &mut self,
+        mut func: G::Fn,
+        open_parens_loc: bun_ast::Loc,
+        is_expr: bool,
+    ) -> G::Fn {
         debug_assert!(
             !SCAN_ONLY,
             "only_scan_imports_and_do_not_visit must not run this."
@@ -89,7 +100,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if let Some(name) = func.name {
             if let Some(name_ref) = name.ref_.to_nullable() {
-                self.record_declared_symbol(name_ref);
+                self.record_declared_symbol_in(name_ref, is_expr);
                 let symbol_name = self.load_name_from_ref(name_ref);
                 if is_eval_or_arguments(symbol_name) {
                     self.mark_strict_mode_feature(
@@ -962,6 +973,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name_scope_loc: bun_ast::Loc,
         class: &mut G::Class,
         default_name_ref: Ref,
+        is_expr: bool,
     ) -> Ref {
         debug_assert!(
             !SCAN_ONLY,
@@ -971,7 +983,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.visit_ts_decorators(&mut class.ts_decorators);
 
         if let Some(name) = class.class_name {
-            self.record_declared_symbol(name.ref_);
+            self.record_declared_symbol_in(name.ref_, is_expr);
         }
 
         self.push_scope_for_visit_pass(ScopeKind::ClassName, name_scope_loc)
@@ -1072,7 +1084,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     };
                     self.record_declared_symbol(priv_ref);
                 } else if let Some(key) = property.key.as_mut() {
+                    // Lowering may move a field's computed key into the
+                    // constructor along with its initializer.
+                    let is_field = !property.flags.contains(flags::Property::IsMethod);
+                    if is_field {
+                        let class_body = self.current_scope;
+                        self.field_init_class_bodies.push(class_body);
+                    }
                     self.visit_expr(key);
+                    if is_field {
+                        self.field_init_class_bodies.pop();
+                    }
                 }
 
                 // Make it an error to use "arguments" in a class body
@@ -1151,7 +1173,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if let Some(val) = property.initializer {
-                    // if (property.flags.is_static and )
+                    let class_body = self.current_scope;
+                    self.field_init_class_bodies.push(class_body);
                     if let Some(name) = name_to_keep {
                         let was_anon = val.is_anonymous_named();
                         let prev_dcn2 = self.decorator_class_name;
@@ -1170,6 +1193,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     } else {
                         self.visit_expr(property.initializer.as_mut().unwrap());
                     }
+                    self.field_init_class_bodies.pop();
                 }
 
                 // manual restore for the two `defer`s above

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2723,7 +2723,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // For function *expressions* the .function_args scope is pushed at the
         // `function` keyword loc, not at open_parens_loc. (s_function correctly
         // uses open_parens_loc.)
-        e_.func = p.visit_func(core::mem::take(&mut e_.func), expr.loc);
+        e_.func = p.visit_func(core::mem::take(&mut e_.func), expr.loc, true);
 
         // Restore now so the stack-local pointer never escapes this frame.
         p.react_refresh.hook_ctx_storage = prev_hook_ctx;
@@ -2789,7 +2789,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let decorator_name_from_context = p.decorator_class_name;
         p.decorator_class_name = None;
 
-        let _ = p.visit_class(expr.loc, &mut e_, Ref::NONE);
+        let _ = p.visit_class(expr.loc, &mut e_, Ref::NONE, true);
 
         // Lower standard decorators for class expressions
         if e_.should_lower_standard_decorators {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1353,7 +1353,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // tied to `'a`, not `&*p`, and `&mut self` helpers below can be called
         // while iterating without laundering.
         let defines = p.define;
-        if let Some(parts) = defines.dots.get(e_.name.slice()) {
+        if let Some(parts) = defines.dots_for(e_.name.slice()) {
             for define in parts.as_slice() {
                 if p.is_dot_define_match(expr, &define.parts) {
                     if in_.assign_target == js_ast::AssignTarget::None {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -604,7 +604,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             );
                         }
                         let open_parens_loc = func.func.open_parens_loc;
-                        func.func = p.visit_func(core::mem::take(&mut func.func), open_parens_loc);
+                        func.func =
+                            p.visit_func(core::mem::take(&mut func.func), open_parens_loc, false);
                         p.react_compiler_candidate_name = None;
 
                         if p.is_control_flow_dead {
@@ -774,7 +775,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     StmtData::SClass(mut class_ref) => {
                         let class: &mut S::Class = &mut *class_ref;
-                        let _ = p.visit_class(s2_loc, &mut class.class, data.default_name.ref_);
+                        let _ =
+                            p.visit_class(s2_loc, &mut class.class, data.default_name.ref_, false);
 
                         if p.is_control_flow_dead {
                             restore_dead!();
@@ -907,7 +909,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         let open_parens_loc = data.func.open_parens_loc;
         let this_expr_count_before = p.this_expr_count;
-        data.func = p.visit_func(core::mem::take(&mut data.func), open_parens_loc);
+        data.func = p.visit_func(core::mem::take(&mut data.func), open_parens_loc, false);
         p.react_compiler_candidate_name = None;
 
         let name_ref = data.func.name.expect("infallible: name checked").ref_;
@@ -1058,7 +1060,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.is_control_flow_dead = true;
         }
 
-        let _ = p.visit_class(stmt.loc, &mut data.class, Ref::NONE);
+        let _ = p.visit_class(stmt.loc, &mut data.class, Ref::NONE, false);
 
         // Remove the export flag inside a namespace
         let was_export_inside_namespace = data.is_export && p.enclosing_namespace_arg_ref.is_some();

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -551,9 +551,8 @@ pub struct NumberRenamer {
     // See `NoOpRenamer.symbols` — non-owning view.
     pub(crate) symbols: ManuallyDrop<symbol::Map>,
     pub(crate) names: Box<[Vec<NameStr>]>,
-    /// Backs renamed-name slices written into `names` and interned keys;
-    /// plus the arenas of absorbed `NestedRenamer`s.
-    pub(crate) arenas: Vec<Bump>,
+    /// Backs top-level renamed-name slices in `names` and interned keys.
+    pub(crate) arena: Bump,
     /// Every name seen in the chunk's root scope → index into `slots`.
     ids: NameIds,
     /// By name id: who holds that name in the root scope.
@@ -618,7 +617,8 @@ enum NameUse {
 /// The name table a binding is checked against: the chunk's root scope
 /// (`NumberRenamer`) or one file's nested scopes over it (`NestedRenamer`).
 trait NameScopes {
-    fn arena(&self) -> &Bump;
+    /// Copies a made-up name (`foo2`) somewhere that outlives printing.
+    fn keep_name(&self, name: &[u8]) -> NameStr;
     /// Serial number of the scope being named.
     fn scope(&self) -> u32;
     fn id_of(&self, name: &[u8]) -> Option<u32>;
@@ -664,7 +664,7 @@ trait NameScopes {
             let name = if unchanged {
                 input_name
             } else {
-                NameStr::new(self.arena().alloc_slice_copy(name))
+                self.keep_name(name)
             };
             let id = match id {
                 Some(id) => id,
@@ -711,7 +711,7 @@ trait NameScopes {
                         },
                     },
                 );
-                let renamed = NameStr::new(self.arena().alloc_slice_copy(candidate.slice()));
+                let renamed = self.keep_name(candidate.slice());
                 let candidate_id = match candidate_id {
                     Some(id) => id,
                     None => self.intern(renamed),
@@ -783,8 +783,8 @@ fn store_name(names: &mut Vec<NameStr>, inner_index: u32, name: NameStr) {
 }
 
 impl NameScopes for NumberRenamer {
-    fn arena(&self) -> &Bump {
-        &self.arenas[0]
+    fn keep_name(&self, name: &[u8]) -> NameStr {
+        NameStr::new(self.arena.alloc_slice_copy(name))
     }
     fn scope(&self) -> u32 {
         ROOT_SCOPE
@@ -825,7 +825,7 @@ impl NumberRenamer {
         let mut r = Box::new(NumberRenamer {
             symbols: ManuallyDrop::new(symbols),
             names,
-            arenas: vec![Bump::new()],
+            arena: Bump::new(),
             ids: NameIds::with_capacity_and_hasher(
                 root_names.len() + symbol_count / 4,
                 Default::default(),
@@ -834,7 +834,7 @@ impl NumberRenamer {
         });
         // `root_names` owns its keys and is dropped by the caller; copy them.
         for (key, &count) in root_names.iter() {
-            let duped = NameStr::new(r.arenas[0].alloc_slice_copy(&**key));
+            let duped = NameStr::new(r.arena.alloc_slice_copy(&**key));
             let id = r.intern(duped);
             r.slots[id as usize] = NameSlot {
                 scope: ROOT_SCOPE,
@@ -887,7 +887,7 @@ impl NumberRenamer {
         if self.symbols.get_const(ref_).unwrap().slot_namespace() != SlotNamespace::Default {
             return;
         }
-        let name = NameStr::new(self.arenas[0].alloc_slice_copy(name));
+        let name = NameStr::new(self.arena.alloc_slice_copy(name));
         let id = self.intern(name);
         self.slots[id as usize] = NameSlot {
             scope: ROOT_SCOPE,
@@ -913,7 +913,6 @@ impl NumberRenamer {
     /// Takes the names a `NestedRenamer` over this renamer assigned.
     pub fn absorb(&mut self, nested: NestedNames) {
         self.names[nested.source_index as usize] = nested.names;
-        self.arenas.push(nested.arena);
     }
 
     pub fn name_for_symbol(&self, ref_: Ref) -> &[u8] {
@@ -932,7 +931,7 @@ impl NumberRenamer {
             let renamed: NameStr = renamed_list[inner_index as usize];
             if renamed.raw_len() > 0 {
                 // `StoreStr::slice` centralises the deref; allocated from
-                // `self.arenas` or borrows an AST-arena `original_name`, both
+                // `self.arena` (or a bundler worker arena) or borrows an AST-arena `original_name`, both
                 // of which outlive `self`.
                 return renamed.slice();
             }
@@ -971,18 +970,17 @@ pub struct NestedRenamer<'r> {
     scope: u32,
     next_scope: u32,
     ast_scope: *const js_ast::Scope,
-    arena: Bump,
+    arena: &'r bun_alloc::Arena,
 }
 
 pub struct NestedNames {
     source_index: u32,
     names: Vec<NameStr>,
-    arena: Bump,
 }
 
 impl<'r> NameScopes for NestedRenamer<'r> {
-    fn arena(&self) -> &Bump {
-        &self.arena
+    fn keep_name(&self, name: &[u8]) -> NameStr {
+        NameStr::new(self.arena.alloc_slice_copy(name))
     }
     fn scope(&self) -> u32 {
         self.scope
@@ -1041,7 +1039,14 @@ impl<'r> NameScopes for NestedRenamer<'r> {
 }
 
 impl<'r> NestedRenamer<'r> {
-    pub fn new(root: &'r NumberRenamer, uses: &'r ScopeUses<'r>, source_index: u32) -> Self {
+    /// `arena`: where made-up names go; must outlive printing (the bundler
+    /// passes the worker thread's arena).
+    pub fn new(
+        root: &'r NumberRenamer,
+        uses: &'r ScopeUses<'r>,
+        source_index: u32,
+        arena: &'r bun_alloc::Arena,
+    ) -> Self {
         let symbol_count = root.symbols.symbols_for_source[source_index as usize].len();
         let mut names = Vec::with_capacity(symbol_count);
         names.extend_from_slice(&root.names[source_index as usize]);
@@ -1059,7 +1064,7 @@ impl<'r> NestedRenamer<'r> {
             scope: ROOT_SCOPE,
             next_scope: ROOT_SCOPE + 1,
             ast_scope: core::ptr::null(),
-            arena: Bump::new(),
+            arena,
         }
     }
 
@@ -1067,7 +1072,6 @@ impl<'r> NestedRenamer<'r> {
         NestedNames {
             source_index: self.source_index,
             names: self.names,
-            arena: self.arena,
         }
     }
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -561,6 +561,30 @@ pub struct NumberRenamer {
 }
 
 type NameIds = bun_collections::hashbrown::HashMap<NameKey, u32, bun_wyhash::BuildHasher>;
+/// Name id -> index into `NestedRenamer::slots`, for the names the file's
+/// nested scopes bind or renumber; every other id reads the root's slot.
+type OverlayMap =
+    bun_collections::hashbrown::HashMap<u32, u32, core::hash::BuildHasherDefault<IdHasher>>;
+
+/// Name ids are dense small integers; multiply-shift spreads them for
+/// hashbrown's top-bit tag.
+#[derive(Default)]
+struct IdHasher(u64);
+
+impl core::hash::Hasher for IdHasher {
+    #[inline]
+    fn write(&mut self, _: &[u8]) {
+        unreachable!()
+    }
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.0 = u64::from(n).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    }
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
 
 #[derive(Clone, Copy)]
 struct NameSlot {
@@ -934,11 +958,14 @@ pub struct NestedRenamer<'r> {
     /// `slots` of the innermost enclosing scope's slot for that name. Slots of
     /// scopes already left are dropped, so a present slot is always an
     /// enclosing one.
-    overlay: Vec<u32>,
+    overlay: OverlayMap,
+    /// Ids `root.slots.len()..next_local_id` are this file's `local_ids`.
+    next_local_id: u32,
     slots: Vec<NameSlot>,
     /// Names first seen in this file's nested scopes.
     local_ids: NameIds,
-    /// `(id, previous overlay value)`, to restore on scope exit.
+    /// `(id, 0)` for an id the scope added to `overlay`, else `(id, 1 + the
+    /// index it mapped to)`; restored on scope exit.
     undo: Vec<(u32, u32)>,
     /// The AST scope being named and its serial number (from `ROOT_SCOPE + 1`).
     scope: u32,
@@ -969,32 +996,41 @@ impl<'r> NameScopes for NestedRenamer<'r> {
     }
     fn intern(&mut self, name: NameStr) -> u32 {
         debug_assert!(self.root.ids.get(name.slice()).is_none());
-        let (id, new) = intern_into(&mut self.local_ids, self.overlay.len() as u32, name);
+        let (id, new) = intern_into(&mut self.local_ids, self.next_local_id, name);
         if new {
-            self.overlay.push(0);
+            self.next_local_id += 1;
         }
         id
     }
     fn slot(&self, id: u32) -> NameSlot {
-        match self.overlay[id as usize] {
-            0 => self
+        match self.overlay.get(&id) {
+            None => self
                 .root
                 .slots
                 .get(id as usize)
                 .copied()
                 .unwrap_or(NameSlot::EMPTY),
-            local => self.slots[local as usize - 1],
+            Some(&local) => self.slots[local as usize],
         }
     }
     fn set_slot(&mut self, id: u32, slot: NameSlot) {
         debug_assert_eq!(slot.scope, self.scope);
-        let local = self.overlay[id as usize];
-        if local != 0 && self.slots[local as usize - 1].scope == self.scope {
-            self.slots[local as usize - 1] = slot;
-        } else {
-            self.slots.push(slot);
-            self.undo.push((id, local));
-            self.overlay[id as usize] = self.slots.len() as u32;
+        match self.overlay.entry(id) {
+            bun_collections::hashbrown::hash_map::Entry::Occupied(mut entry) => {
+                let local = *entry.get();
+                if self.slots[local as usize].scope == self.scope {
+                    self.slots[local as usize] = slot;
+                } else {
+                    self.undo.push((id, local + 1));
+                    *entry.get_mut() = self.slots.len() as u32;
+                    self.slots.push(slot);
+                }
+            }
+            bun_collections::hashbrown::hash_map::Entry::Vacant(entry) => {
+                self.undo.push((id, 0));
+                entry.insert(self.slots.len() as u32);
+                self.slots.push(slot);
+            }
         }
     }
     fn sees(&self, owner: Ref) -> bool {
@@ -1015,7 +1051,8 @@ impl<'r> NestedRenamer<'r> {
             uses,
             source_index,
             names,
-            overlay: vec![0u32; root.slots.len()],
+            overlay: OverlayMap::default(),
+            next_local_id: root.slots.len() as u32,
             slots: Vec::new(),
             local_ids: NameIds::default(),
             undo: Vec::new(),
@@ -1090,7 +1127,14 @@ impl<'r> NestedRenamer<'r> {
         }
 
         for &(id, prev) in self.undo[undo_mark..].iter().rev() {
-            self.overlay[id as usize] = prev;
+            match prev {
+                0 => {
+                    self.overlay.remove(&id);
+                }
+                local => {
+                    self.overlay.insert(id, local - 1);
+                }
+            }
         }
         self.undo.truncate(undo_mark);
         self.slots.truncate(slots_mark);

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -11,7 +11,6 @@ use bun_ast::lexer_tables::{
 use bun_ast::symbol;
 use bun_ast::symbol::SlotNamespace;
 use bun_ast::{Ref, Symbol};
-use bun_collections::hive_array::Fallback as HiveArrayFallback;
 use bun_collections::{HashMap, StringHashMap, VecExt};
 use bun_core::Output;
 use bun_core::{MutableString, strings};
@@ -38,23 +37,11 @@ const SLOT_NAMESPACES: [SlotNamespace; 4] = [
     SlotNamespace::MangledProp,
 ];
 
-/// Lifetime-erased name slice used as the key in `NumberScope::name_counts`.
-///
-/// `NumberScope` lives in a `HiveArrayFallback` pool inside `NumberRenamer`,
-/// alongside the renamer's `arena: Bump`. A `&'a [u8]` key would make
-/// `NumberScope<'a>` self-referential to its own owner, so the renamer (like
-/// the rest of the AST layer) carries name slices as the lifetime-erased
-/// [`bun_ast::StoreStr`] and re-borrows on read. Every key inserted here points
-/// either at `Symbol::original_name` (an AST-arena slice that strictly outlives
-/// the renamer) or at bytes bump-allocated from the renamer's own `arena: Bump`,
-/// which is only reset on `NumberRenamer::Drop` after every `NumberScope` is
-/// returned to the pool — so the borrow contract documented on `StoreStr::slice`
-/// is always satisfied.
-///
-/// Replaces the previous `StringHashMap<u32>` (whose `put_no_clobber` heap-boxed
-/// a `Box<[u8]>` copy of the key) with a `Copy` 16-byte key that needs no
-/// allocation on insert and no free on the per-scope drop in the renamer's
-/// pool walkback.
+/// Lifetime-erased name slice used as the `NumberRenamer` interner key. Every
+/// key points either at `Symbol::original_name` (an AST-arena slice that
+/// strictly outlives the renamer) or at bytes bump-allocated from the
+/// renamer's own `arena`, so the borrow contract documented on
+/// `StoreStr::slice` is always satisfied.
 #[derive(Clone, Copy)]
 pub struct NameKey(NameStr);
 
@@ -87,22 +74,6 @@ impl core::borrow::Borrow<[u8]> for NameKey {
         self.as_bytes()
     }
 }
-
-/// `count`: next collision counter for the name. `owner`: the symbol that
-/// holds the name in this scope, or `Ref::NONE` for reserved names and
-/// counter-only entries, which every inner scope must avoid.
-#[derive(Clone, Copy)]
-pub(crate) struct NameEntry {
-    count: u32,
-    owner: Ref,
-}
-
-/// Per-`NumberScope` map of assigned names → next collision counter.
-/// `bun_wyhash::BuildHasher` matches `StringHashMap` so the renamer keeps its
-/// existing hash quality; `NameKey` is a `Copy` lifetime-erased slice so insert
-/// never heap-allocates a key copy and drop never frees one.
-pub(crate) type NameCountMap =
-    bun_collections::hashbrown::HashMap<NameKey, NameEntry, bun_wyhash::BuildHasher>;
 
 pub struct NoOpRenamer<'a> {
     // `symbol::Map` is `Vec<Vec<Symbol>>` (owning). Unlike `MinifyRenamer`/`NumberRenamer` (which the bundler builds over a
@@ -580,23 +551,272 @@ pub struct NumberRenamer {
     // See `NoOpRenamer.symbols` — non-owning view.
     pub(crate) symbols: ManuallyDrop<symbol::Map>,
     pub(crate) names: Box<[Vec<NameStr>]>,
-    pub number_scope_pool: HiveArrayFallback<NumberScope, 128>,
-    pub root: NumberScope,
-    /// Backs renamed-name slices written into `names`.
-    pub(crate) arena: Bump,
+    /// Backs renamed-name slices written into `names` and interned keys;
+    /// plus the arenas of absorbed `NestedRenamer`s.
+    pub(crate) arenas: Vec<Bump>,
+    /// Every name seen in the chunk's root scope → index into `slots`.
+    ids: NameIds,
+    /// By name id: who holds that name in the root scope.
+    slots: Vec<NameSlot>,
+}
+
+type NameIds = bun_collections::hashbrown::HashMap<NameKey, u32, bun_wyhash::BuildHasher>;
+
+#[derive(Clone, Copy)]
+struct NameSlot {
+    /// The scope holding this name (`ROOT_SCOPE`, or a `NestedRenamer`
+    /// scope serial), or `NO_SCOPE`.
+    scope: u32,
+    /// Next collision counter for the name in that scope.
+    count: u32,
+    /// The symbol holding the name, or `Ref::NONE` for reserved names and
+    /// counter-only entries, which every inner scope must avoid.
+    owner: Ref,
+}
+
+const NO_SCOPE: u32 = 0;
+const ROOT_SCOPE: u32 = 1;
+
+impl NameSlot {
+    const EMPTY: NameSlot = NameSlot {
+        scope: NO_SCOPE,
+        count: 0,
+        owner: Ref::NONE,
+    };
+}
+
+enum NameUse {
+    Unused,
+    SameScope(u32),
+    Used,
+}
+
+/// The name table a binding is checked against: the chunk's root scope
+/// (`NumberRenamer`) or one file's nested scopes over it (`NestedRenamer`).
+trait NameScopes {
+    fn arena(&self) -> &Bump;
+    /// Serial number of the scope being named.
+    fn scope(&self) -> u32;
+    fn id_of(&self, name: &[u8]) -> Option<u32>;
+    /// `name` must outlive the renamer (an AST `original_name` or a slice of
+    /// `arena()`).
+    fn intern(&mut self, name: NameStr) -> u32;
+    fn slot(&self, id: u32) -> NameSlot;
+    /// Give `id` to the current scope.
+    fn set_slot(&mut self, id: u32, slot: NameSlot);
+    /// Whether the scope being named references `owner`, the symbol holding
+    /// a name in an enclosing scope. When it does not, the binding may shadow
+    /// it: `owner` only took that name because whatever held it further out
+    /// is not referenced beneath `owner`'s scope either.
+    fn sees(&self, owner: Ref) -> bool;
+
+    fn find(&self, id: Option<u32>) -> NameUse {
+        let Some(id) = id else {
+            return NameUse::Unused;
+        };
+        let slot = self.slot(id);
+        if slot.scope == NO_SCOPE {
+            NameUse::Unused
+        } else if slot.scope == self.scope() {
+            NameUse::SameScope(slot.count)
+        } else if slot.owner.is_empty() || self.sees(slot.owner) {
+            NameUse::Used
+        } else {
+            NameUse::Unused
+        }
+    }
+
+    /// Takes `name` for `owner` in the current scope if free, else the first
+    /// free `name2`, `name3`, …. `None`: `name` itself was free.
+    fn find_unused_name(&mut self, input_name: NameStr, owner: Ref) -> Option<NameStr> {
+        // `MutableString::ensure_valid_identifier` always heap-allocates, even
+        // when the input is already a valid ASCII identifier; the strict-mode
+        // reserved-word remap (`let` → `_let`, ...) is the only transform that
+        // fires for an otherwise-valid ASCII name.
+        let owned_name;
+        let (name, normalized): (&[u8], bool) = if is_simple_ascii_identifier(input_name.slice())
+            && !bun_ast::lexer_tables::is_strict_mode_reserved_word(input_name.slice())
+        {
+            (input_name.slice(), false)
+        } else {
+            owned_name =
+                MutableString::ensure_valid_identifier(input_name.slice()).expect("unreachable");
+            (&owned_name, true)
+        };
+        debug_assert!(js_lexer::is_identifier(name));
+
+        let id = self.id_of(name);
+        let use_ = self.find(id);
+        if let NameUse::Unused = use_ {
+            let unchanged = !normalized || strings::eql_long(name, input_name.slice(), true);
+            let name = if unchanged {
+                input_name
+            } else {
+                NameStr::new(self.arena().alloc_slice_copy(name))
+            };
+            let id = match id {
+                Some(id) => id,
+                None => self.intern(name),
+            };
+            let scope = self.scope();
+            self.set_slot(
+                id,
+                NameSlot {
+                    scope,
+                    count: 1,
+                    owner,
+                },
+            );
+            return if unchanged { None } else { Some(name) };
+        }
+
+        // To avoid O(n^2) behavior, the number must start off being the number
+        // used last time there was a collision with this name in this scope;
+        // sibling scopes can reuse the same numbers.
+        let prefix_id = id.unwrap();
+        let mut tries: u32 = match use_ {
+            NameUse::SameScope(count) => count,
+            _ => 1,
+        };
+        let mut candidate = MutableString::init_empty();
+        candidate
+            .grow_if_needed(name.len() + 4)
+            .expect("unreachable");
+        candidate.append_slice(name).expect("unreachable");
+        loop {
+            tries += 1;
+            candidate.reset_to(name.len());
+            candidate.append_int(tries as u64).expect("unreachable");
+            let candidate_id = self.id_of(candidate.slice());
+            if let NameUse::Unused = self.find(candidate_id) {
+                let scope = self.scope();
+                // Where to resume for the next collision in this scope.
+                let prefix_slot = self.slot(prefix_id);
+                self.set_slot(
+                    prefix_id,
+                    NameSlot {
+                        scope,
+                        count: tries,
+                        owner: if prefix_slot.scope == scope {
+                            prefix_slot.owner
+                        } else {
+                            Ref::NONE
+                        },
+                    },
+                );
+                let renamed = NameStr::new(self.arena().alloc_slice_copy(candidate.slice()));
+                let candidate_id = match candidate_id {
+                    Some(id) => id,
+                    None => self.intern(renamed),
+                };
+                self.set_slot(
+                    candidate_id,
+                    NameSlot {
+                        scope,
+                        count: 1,
+                        owner,
+                    },
+                );
+                return Some(renamed);
+            }
+        }
+    }
+}
+
+fn intern_into(ids: &mut NameIds, next_id: u32, name: NameStr) -> (u32, bool) {
+    use bun_collections::hashbrown::hash_map::RawEntryMut;
+    match ids.raw_entry_mut().from_key(name.slice()) {
+        RawEntryMut::Occupied(o) => (*o.get(), false),
+        RawEntryMut::Vacant(v) => {
+            v.insert(NameKey(name), next_id);
+            (next_id, true)
+        }
+    }
+}
+
+fn store_name(names: &mut Vec<NameStr>, inner_index: u32, name: NameStr) {
+    let new_len = names.len().max(inner_index as usize + 1);
+    if names.len() < new_len {
+        names.resize(new_len, name_str_empty());
+    }
+    names[inner_index as usize] = name;
+}
+
+impl NameScopes for NumberRenamer {
+    fn arena(&self) -> &Bump {
+        &self.arenas[0]
+    }
+    fn scope(&self) -> u32 {
+        ROOT_SCOPE
+    }
+    fn id_of(&self, name: &[u8]) -> Option<u32> {
+        self.ids.get(name).copied()
+    }
+    fn intern(&mut self, name: NameStr) -> u32 {
+        let (id, new) = intern_into(&mut self.ids, self.slots.len() as u32, name);
+        if new {
+            self.slots.push(NameSlot::EMPTY);
+        }
+        id
+    }
+    fn slot(&self, id: u32) -> NameSlot {
+        self.slots[id as usize]
+    }
+    fn set_slot(&mut self, id: u32, slot: NameSlot) {
+        self.slots[id as usize] = slot;
+    }
+    fn sees(&self, _owner: Ref) -> bool {
+        // Top-level symbols of the whole chunk share one scope.
+        true
+    }
 }
 
 impl NumberRenamer {
-    pub(crate) fn assign_name(
-        &mut self,
-        scope: &mut NumberScope,
-        input_ref: Ref,
-        sees: &impl Fn(Ref) -> bool,
-    ) {
+    pub fn init(
+        symbols: symbol::Map,
+        root_names: &StringHashMap<u32>,
+    ) -> Result<Box<NumberRenamer>, bun_alloc::AllocError> {
+        let len = symbols.symbols_for_source.len();
+        let names: Box<[Vec<NameStr>]> = core::iter::repeat_with(Vec::<NameStr>::default)
+            .take(len)
+            .collect();
+        let symbol_count: usize = symbols.symbols_for_source.iter().map(|s| s.len()).sum();
+
+        let mut r = Box::new(NumberRenamer {
+            symbols: ManuallyDrop::new(symbols),
+            names,
+            arenas: vec![Bump::new()],
+            ids: NameIds::with_capacity_and_hasher(
+                root_names.len() + symbol_count / 4,
+                Default::default(),
+            ),
+            slots: Vec::with_capacity(root_names.len() + symbol_count / 4),
+        });
+        // `root_names` owns its keys and is dropped by the caller; copy them.
+        for (key, &count) in root_names.iter() {
+            let duped = NameStr::new(r.arenas[0].alloc_slice_copy(&**key));
+            let id = r.intern(duped);
+            r.slots[id as usize] = NameSlot {
+                scope: ROOT_SCOPE,
+                count,
+                owner: Ref::NONE,
+            };
+        }
+
+        // Debug-only, presence-checked symbol dump.
+        #[cfg(debug_assertions)]
+        if bun_core::env_var::BUN_DUMP_SYMBOLS.get().is_some() {
+            r.symbols.dump();
+        }
+
+        Ok(r)
+    }
+
+    pub fn add_top_level_symbol(&mut self, input_ref: Ref) {
         let ref_ = self.symbols.follow(input_ref);
 
         // Don't rename the same symbol more than once
-        let inner: &mut Vec<NameStr> = &mut self.names[ref_.source_index() as usize];
+        let inner: &Vec<NameStr> = &self.names[ref_.source_index() as usize];
         if inner.len() > ref_.inner_index() as usize && inner[ref_.inner_index() as usize].len() > 0
         {
             return;
@@ -608,181 +828,15 @@ impl NumberRenamer {
             return;
         }
 
-        // SAFETY: `original_name` is an AST-arena slice that outlives the renamer.
-        let original_name: &[u8] = symbol.original_name.slice();
-        let name: NameStr = match scope.find_unused_name(&self.arena, original_name, ref_, sees) {
-            UnusedName::Renamed(name) => name,
-            UnusedName::NoCollision => symbol.original_name,
-        };
-        let new_len = inner.len().max(ref_.inner_index() as usize + 1);
-        if inner.len() < new_len {
-            inner.resize(new_len, name_str_empty());
-        }
-        inner[ref_.inner_index() as usize] = name;
-    }
-
-    pub fn init(
-        symbols: symbol::Map,
-        root_names: &StringHashMap<u32>,
-    ) -> Result<Box<NumberRenamer>, bun_alloc::AllocError> {
-        let len = symbols.symbols_for_source.len();
-        let names: Box<[Vec<NameStr>]> = core::iter::repeat_with(Vec::<NameStr>::default)
-            .take(len)
-            .collect();
-
-        let number_scope_pool = HiveArrayFallback::<NumberScope, 128>::init();
-
-        // The arena is created here (before `root.name_counts`) so the
-        // reserved-name keys can be duped into it: `root_names` owns its keys
-        // as `Box<[u8]>` and is dropped at the end of this function, while
-        // `NameKey` is a lifetime-erased borrow that must outlive `root`.
-        // The set is bounded by the unique unbound/must-not-be-renamed globals
-        // across the chunk (typically a few hundred names), and this copy
-        // happens once per chunk vs. the millions of per-symbol ops below.
-        let arena = Bump::new();
-        let mut root = NumberScope::default();
-        root.name_counts.reserve(root_names.len());
-        for (key, &value) in root_names.iter() {
-            let duped = arena.alloc_slice_copy(&**key);
-            root.name_counts.insert(
-                NameKey(NameStr::new(duped)),
-                NameEntry {
-                    count: value,
-                    owner: Ref::NONE,
-                },
-            );
-        }
-
-        // Debug-only, presence-checked symbol dump.
-        #[cfg(debug_assertions)]
-        if bun_core::env_var::BUN_DUMP_SYMBOLS.get().is_some() {
-            symbols.dump();
-        }
-
-        Ok(Box::new(NumberRenamer {
-            symbols: ManuallyDrop::new(symbols),
-            names,
-            number_scope_pool,
-            root,
-            arena,
-        }))
-    }
-
-    fn assign_names_in_scope(
-        &mut self,
-        s: &mut NumberScope,
-        scope: &js_ast::Scope,
-        source_index: u32,
-        sorted: &mut Vec<u32>,
-        sees: &impl Fn(Ref) -> bool,
-    ) {
-        {
-            sorted.clear();
-            sorted.extend(scope.members.values().map(|value_ref| {
-                debug_assert!(!value_ref.ref_.is_source_contents_slice());
-                value_ref.ref_.inner_index()
-            }));
-            debug_assert_eq!(sorted.len(), scope.members.count());
-            sorted.sort_unstable();
-
-            for &inner_index in sorted.iter() {
-                self.assign_name(
-                    s,
-                    Ref::new(inner_index, source_index, bun_ast::RefTag::Symbol),
-                    sees,
-                );
-            }
-        }
-
-        for ref_ in scope.generated.slice() {
-            self.assign_name(s, *ref_, sees);
-        }
-    }
-
-    pub fn assign_names_recursive_with_number_scope(
-        &mut self,
-        initial_scope: *mut NumberScope,
-        scope_: &js_ast::Scope,
-        source_index: u32,
-        sorted: &mut Vec<u32>,
-        uses: &ScopeUses<'_>,
-    ) {
-        let mut s: *mut NumberScope = initial_scope;
-        let mut scope = scope_;
-
-        loop {
-            let symbol_count = scope.members.count() + scope.generated.len_u32() as usize;
-            if symbol_count > 0 {
-                let new_child_scope: *mut NumberScope = self
-                    .number_scope_pool
-                    .get_init(NumberScope {
-                        // `s` is non-null (either `initial_scope` or a fresh
-                        // pool slot from a prior iteration); the new child
-                        // outlives this `ParentRef` only until `put()` below.
-                        // SAFETY: `s` is the live pool slot / initial scope (write provenance).
-                        parent: Some(unsafe {
-                            bun_ptr::ParentRef::from_raw_mut(
-                                core::ptr::NonNull::new(s)
-                                    .expect("number_scope non-null")
-                                    .as_ptr(),
-                            )
-                        }),
-                        // Pre-size to the AST scope's symbol count so the
-                        // per-name insert path doesn't realloc the table
-                        // 0→4→8→… as names are assigned. Most scopes assign
-                        // every member exactly once, so this is the exact
-                        // final size; symbols skipped by `assign_name`
-                        // (already renamed, non-default namespace) just leave
-                        // a little slack.
-                        name_counts: NameCountMap::with_capacity_and_hasher(
-                            symbol_count,
-                            Default::default(),
-                        ),
-                    })
-                    .as_ptr();
-                s = new_child_scope;
-
-                // SAFETY: s is a valid pool slot just initialized above
-                self.assign_names_in_scope(
-                    unsafe { &mut *s },
-                    scope,
-                    source_index,
-                    sorted,
-                    &|symbol| uses.sees(symbol, scope),
-                );
-            }
-
-            if scope.children.len_u32() == 1 {
-                // `StoreRef<Scope>: Deref<Target = Scope>` — safe arena-backed deref.
-                scope = scope.children.at(0).get();
-            } else {
-                break;
-            }
-        }
-
-        // Symbols in child scopes may also have to be renamed to avoid conflicts
-        for child in scope.children.slice() {
-            // `StoreRef<Scope>: Deref<Target = Scope>` — safe arena-backed deref.
-            self.assign_names_recursive_with_number_scope(s, child, source_index, sorted, uses);
-        }
-
-        // The pool fallback and `name_counts` data live on the global heap
-        // (HiveArrayFallback::init() uses Box, StringHashMap uses global alloc),
-        // so we must walk the parent chain and `put` every intermediate scope
-        // we allocated in the loop above — not just the deepest one.
-        while s != initial_scope {
-            // SAFETY: `s` is a pool slot we allocated and initialized in the
-            // loop above; every such slot has `parent: Some(...)`. Read parent
-            // before `put` (which drops/frees the slot).
-            let parent = unsafe { (*s).parent }
-                .map(|p| p.as_mut_ptr())
-                .unwrap_or(initial_scope);
-            // SAFETY: `s` came from `number_scope_pool.get()` in the loop above
-            // and was fully initialized; `put` drops `name_counts` in place
-            // before recycling/freeing the slot.
-            unsafe { self.number_scope_pool.put(s) };
-            s = parent;
-        }
+        let original_name = symbol.original_name;
+        let name = self
+            .find_unused_name(original_name, ref_)
+            .unwrap_or(original_name);
+        store_name(
+            &mut self.names[ref_.source_index() as usize],
+            ref_.inner_index(),
+            name,
+        );
     }
 
     /// Gives top-level symbol `ref_` the name `name` (taken to be free in the
@@ -793,31 +847,18 @@ impl NumberRenamer {
         if self.symbols.get_const(ref_).unwrap().slot_namespace() != SlotNamespace::Default {
             return;
         }
-        let duped: &[u8] = self.arena.alloc_slice_copy(name);
-        let name = NameStr::new(duped);
-        self.root.name_counts.insert(
-            NameKey(name),
-            NameEntry {
-                count: 1,
-                owner: ref_,
-            },
+        let name = NameStr::new(self.arenas[0].alloc_slice_copy(name));
+        let id = self.intern(name);
+        self.slots[id as usize] = NameSlot {
+            scope: ROOT_SCOPE,
+            count: 1,
+            owner: ref_,
+        };
+        store_name(
+            &mut self.names[ref_.source_index() as usize],
+            ref_.inner_index(),
+            name,
         );
-        let inner: &mut Vec<NameStr> = &mut self.names[ref_.source_index() as usize];
-        let new_len = inner.len().max(ref_.inner_index() as usize + 1);
-        if inner.len() < new_len {
-            inner.resize(new_len, name_str_empty());
-        }
-        inner[ref_.inner_index() as usize] = name;
-    }
-
-    pub fn add_top_level_symbol(&mut self, ref_: Ref) {
-        // Reshaped for borrowck — root is a field of self, but `assign_name`
-        // needs `&mut self` AND `&mut self.root` simultaneously. Sound only
-        // while `assign_name` never reaches `self.root` through `self`; keep
-        // that invariant if `assign_name` changes.
-        let root: *mut NumberScope = &raw mut self.root;
-        // SAFETY: assign_name does not touch self.root through `self`
-        self.assign_name(unsafe { &mut *root }, ref_, &|_| true);
     }
 
     pub fn add_top_level_declared_symbols(
@@ -827,6 +868,12 @@ impl NumberRenamer {
         js_ast::DeclaredSymbol::for_each_top_level_symbol(declared_symbols, self, |r, ref_| {
             r.add_top_level_symbol(ref_)
         });
+    }
+
+    /// Takes the names a `NestedRenamer` over this renamer assigned.
+    pub fn absorb(&mut self, nested: NestedNames) {
+        self.names[nested.source_index as usize] = nested.names;
+        self.arenas.push(nested.arena);
     }
 
     pub fn name_for_symbol(&self, ref_: Ref) -> &[u8] {
@@ -845,7 +892,7 @@ impl NumberRenamer {
             let renamed: NameStr = renamed_list[inner_index as usize];
             if renamed.raw_len() > 0 {
                 // `StoreStr::slice` centralises the deref; allocated from
-                // `self.arena` or borrows an AST-arena `original_name`, both
+                // `self.arenas` or borrows an AST-arena `original_name`, both
                 // of which outlive `self`.
                 return renamed.slice();
             }
@@ -858,83 +905,187 @@ impl NumberRenamer {
     }
 }
 
-#[derive(Default)]
-pub struct NumberScope {
-    /// Backreference to the enclosing `NumberScope`. The parent is either
-    /// `NumberRenamer::root` or a pool slot allocated earlier in the same
-    /// `assign_names_recursive_with_number_scope` call, both of which strictly
-    /// outlive this child (children are `put()` back before their parent), so
-    /// `ParentRef::get()` is sound without per-site `unsafe`.
-    pub(crate) parent: Option<bun_ptr::ParentRef<NumberScope, bun_ptr::Mut>>,
-    pub(crate) name_counts: NameCountMap,
+/// Names the nested scopes of one file once every top-level symbol of the
+/// chunk is named (`NumberRenamer`), which it only reads; files can run in
+/// parallel. `into_names` hands the result back for `NumberRenamer::absorb`.
+pub struct NestedRenamer<'r> {
+    root: &'r NumberRenamer,
+    uses: &'r ScopeUses<'r>,
+    source_index: u32,
+    /// This file's names; starts as the top-level ones.
+    names: Vec<NameStr>,
+    /// By name id (the root's ids, then `local_ids`): 0, or 1 + the index in
+    /// `slots` of the innermost enclosing scope's slot for that name. Slots of
+    /// scopes already left are dropped, so a present slot is always an
+    /// enclosing one.
+    overlay: Vec<u32>,
+    slots: Vec<NameSlot>,
+    /// Names first seen in this file's nested scopes.
+    local_ids: NameIds,
+    /// `(id, previous overlay value)`, to restore on scope exit.
+    undo: Vec<(u32, u32)>,
+    /// The AST scope being named and its serial number (from `ROOT_SCOPE + 1`).
+    scope: u32,
+    next_scope: u32,
+    ast_scope: *const js_ast::Scope,
+    arena: Bump,
 }
 
-enum NameUse {
-    Unused,
-    SameScope(u32),
-    Used,
+pub struct NestedNames {
+    source_index: u32,
+    names: Vec<NameStr>,
+    arena: Bump,
 }
 
-impl NameUse {
-    /// `sees(owner)`: whether the scope being named references `owner`, the
-    /// symbol holding `name` in an enclosing scope. When it does not, the
-    /// binding may shadow it.
-    fn find(this: &NumberScope, name: &[u8], sees: &impl Fn(Ref) -> bool) -> NameUse {
-        // This version doesn't allocate
-        debug_assert!(js_lexer::is_identifier(name));
-
-        // Hash `name` once and probe each scope in the parent chain with the
-        // same precomputed hash via hashbrown's raw-entry API; the previous
-        // `get_adapted`/`contains_adapted` calls re-hashed `name` per scope.
-        let hash = {
-            use core::hash::BuildHasher;
-
-            <bun_wyhash::BuildHasher as Default>::default().hash_one(name)
-        };
-
-        if let Some((_, entry)) = this
-            .name_counts
-            .raw_entry()
-            .from_hash(hash, |k| k.as_bytes() == name)
-        {
-            return NameUse::SameScope(entry.count);
+impl<'r> NameScopes for NestedRenamer<'r> {
+    fn arena(&self) -> &Bump {
+        &self.arena
+    }
+    fn scope(&self) -> u32 {
+        self.scope
+    }
+    fn id_of(&self, name: &[u8]) -> Option<u32> {
+        self.root
+            .ids
+            .get(name)
+            .or_else(|| self.local_ids.get(name))
+            .copied()
+    }
+    fn intern(&mut self, name: NameStr) -> u32 {
+        debug_assert!(self.root.ids.get(name.slice()).is_none());
+        let (id, new) = intern_into(&mut self.local_ids, self.overlay.len() as u32, name);
+        if new {
+            self.overlay.push(0);
         }
-
-        let mut s: Option<bun_ptr::ParentRef<NumberScope, bun_ptr::Mut>> = this.parent;
-
-        while let Some(scope) = s {
-            // `ParentRef<NumberScope>: Deref` — safe backref deref under the
-            // parent-outlives-child invariant documented on the field.
-            if let Some((_, entry)) = scope
-                .name_counts
-                .raw_entry()
-                .from_hash(hash, |k| k.as_bytes() == name)
-            {
-                if entry.owner.is_empty() || sees(entry.owner) {
-                    return NameUse::Used;
-                }
-            }
-            s = scope.parent;
+        id
+    }
+    fn slot(&self, id: u32) -> NameSlot {
+        match self.overlay[id as usize] {
+            0 => self
+                .root
+                .slots
+                .get(id as usize)
+                .copied()
+                .unwrap_or(NameSlot::EMPTY),
+            local => self.slots[local as usize - 1],
         }
-
-        NameUse::Unused
+    }
+    fn set_slot(&mut self, id: u32, slot: NameSlot) {
+        debug_assert_eq!(slot.scope, self.scope);
+        let local = self.overlay[id as usize];
+        if local != 0 && self.slots[local as usize - 1].scope == self.scope {
+            self.slots[local as usize - 1] = slot;
+        } else {
+            self.slots.push(slot);
+            self.undo.push((id, local));
+            self.overlay[id as usize] = self.slots.len() as u32;
+        }
+    }
+    fn sees(&self, owner: Ref) -> bool {
+        // SAFETY: `ast_scope` is the live scope `assign_names_recursive` is
+        // visiting.
+        self.uses.sees(owner, unsafe { &*self.ast_scope })
     }
 }
 
-pub(crate) enum UnusedName {
-    NoCollision,
-    Renamed(NameStr),
+impl<'r> NestedRenamer<'r> {
+    pub fn new(root: &'r NumberRenamer, uses: &'r ScopeUses<'r>, source_index: u32) -> Self {
+        let symbol_count = root.symbols.symbols_for_source[source_index as usize].len();
+        let mut names = Vec::with_capacity(symbol_count);
+        names.extend_from_slice(&root.names[source_index as usize]);
+        names.resize(symbol_count, name_str_empty());
+        NestedRenamer {
+            root,
+            uses,
+            source_index,
+            names,
+            overlay: vec![0u32; root.slots.len()],
+            slots: Vec::new(),
+            local_ids: NameIds::default(),
+            undo: Vec::new(),
+            scope: ROOT_SCOPE,
+            next_scope: ROOT_SCOPE + 1,
+            ast_scope: core::ptr::null(),
+            arena: Bump::new(),
+        }
+    }
+
+    pub fn into_names(self) -> NestedNames {
+        NestedNames {
+            source_index: self.source_index,
+            names: self.names,
+            arena: self.arena,
+        }
+    }
+
+    fn assign_name(&mut self, input_ref: Ref) {
+        let symbols = &self.root.symbols;
+        let ref_ = symbols.follow(input_ref);
+        // A link out of the file leads to a top-level symbol, already named.
+        if ref_.source_index() != self.source_index {
+            debug_assert!(!self.root.name_for_symbol(ref_).is_empty());
+            return;
+        }
+        // Don't rename the same symbol more than once
+        if self.names[ref_.inner_index() as usize].len() > 0 {
+            return;
+        }
+        // Don't rename unbound symbols, symbols marked as reserved names, labels, or private names
+        let symbol: &Symbol = symbols.get_const(ref_).unwrap();
+        if symbol.slot_namespace() != SlotNamespace::Default {
+            return;
+        }
+        let original_name = symbol.original_name;
+        let name = self
+            .find_unused_name(original_name, ref_)
+            .unwrap_or(original_name);
+        self.names[ref_.inner_index() as usize] = name;
+    }
+
+    /// Names `scope` and everything below it.
+    pub fn assign_names_recursive(&mut self, scope: &js_ast::Scope, sorted: &mut Vec<u32>) {
+        let parent = (self.scope, self.ast_scope);
+        let undo_mark = self.undo.len();
+        let slots_mark = self.slots.len();
+        self.scope = self.next_scope;
+        self.next_scope += 1;
+        self.ast_scope = scope;
+
+        sorted.clear();
+        sorted.extend(scope.members.values().map(|value_ref| {
+            debug_assert!(!value_ref.ref_.is_source_contents_slice());
+            value_ref.ref_.inner_index()
+        }));
+        debug_assert_eq!(sorted.len(), scope.members.count());
+        sorted.sort_unstable();
+        for i in 0..sorted.len() {
+            self.assign_name(Ref::new(
+                sorted[i],
+                self.source_index,
+                bun_ast::RefTag::Symbol,
+            ));
+        }
+        for ref_ in scope.generated.slice() {
+            self.assign_name(*ref_);
+        }
+
+        for child in scope.children.slice() {
+            self.assign_names_recursive(child, sorted);
+        }
+
+        for &(id, prev) in self.undo[undo_mark..].iter().rev() {
+            self.overlay[id as usize] = prev;
+        }
+        self.undo.truncate(undo_mark);
+        self.slots.truncate(slots_mark);
+        (self.scope, self.ast_scope) = parent;
+    }
 }
 
 /// Fast-path for `MutableString::ensure_valid_identifier`: returns `true` iff
-/// `s` is a non-empty ASCII identifier (`[A-Za-z_$][A-Za-z0-9_$]*`). This is
-/// a sufficient condition for `MutableString::ensure_valid_identifier` to
-/// return the input unchanged (modulo the strict-mode-reserved-word remap,
-/// handled by the caller). That function currently always allocates
-/// a `Box<[u8]>` even on the borrow path, so hoisting
-/// this check into the renamer keeps zero-alloc behaviour for the
-/// overwhelmingly common case (`symbol.original_name` is parser-produced and
-/// almost always satisfies this).
+/// `s` is a non-empty ASCII identifier (`[A-Za-z_$][A-Za-z0-9_$]*`), for which
+/// that function returns the input unchanged (modulo the strict-mode reserved
+/// word remap, handled by the caller) but still allocates.
 #[inline]
 fn is_simple_ascii_identifier(s: &[u8]) -> bool {
     let Some((&first, rest)) = s.split_first() else {
@@ -949,162 +1100,6 @@ fn is_simple_ascii_identifier(s: &[u8]) -> bool {
         }
     }
     true
-}
-
-impl NumberScope {
-    /// Caller must use an arena allocator
-    pub(crate) fn find_unused_name(
-        &mut self,
-        arena: &Bump,
-        input_name: &[u8],
-        owner: Ref,
-        sees: &impl Fn(Ref) -> bool,
-    ) -> UnusedName {
-        // `MutableString::ensure_valid_identifier` always heap-allocates
-        // (Box<[u8]>), even when the input is already a valid ASCII
-        // identifier. Skip the call entirely for the common case so this
-        // stays alloc-free.
-        // The strict-mode-reserved-word remap (`let` → `_let`, etc.) is the
-        // only transform that fires for an otherwise-valid ASCII name, so
-        // gate on that too and fall through to the full normalizer when it
-        // would apply.
-        let owned_name;
-        let normalized;
-        let mut name: &[u8] = if is_simple_ascii_identifier(input_name)
-            && !bun_ast::lexer_tables::is_strict_mode_reserved_word(input_name)
-        {
-            normalized = false;
-            input_name
-        } else {
-            normalized = true;
-            owned_name = MutableString::ensure_valid_identifier(input_name).expect("unreachable");
-            &owned_name
-        };
-        // Hoisted from inside the match arm so `name` (which may borrow
-        // it) stays valid through the trailing dupe.
-        let mut mutable_name = MutableString::init_empty();
-        // True iff a "name2"/"name3" suffix was appended below (i.e. `name` was
-        // reassigned to `mutable_name.slice()`). On the hot ASCII path
-        // `!collided && !normalized` implies `name == input_name` so the tail
-        // check skips the byte compare; the rare `normalized` path still
-        // compares (see the comment at the tail).
-        let mut collided = false;
-
-        match NameUse::find(self, name, sees) {
-            NameUse::Unused => {}
-            use_ => {
-                collided = true;
-                let mut tries: u32 = if matches!(use_, NameUse::Used) {
-                    1
-                } else {
-                    // To avoid O(n^2) behavior, the number must start off being the number
-                    // that we used last time there was a collision with this name. Otherwise
-                    // if there are many collisions with the same name, each name collision
-                    // would have to increment the counter past all previous name collisions
-                    // which is a O(n^2) time algorithm. Only do this if this symbol comes
-                    // from the same scope as the previous one since sibling scopes can reuse
-                    // the same name without problems.
-                    match use_ {
-                        NameUse::SameScope(n) => n,
-                        _ => unreachable!(),
-                    }
-                };
-
-                let prefix = name;
-
-                tries += 1;
-
-                mutable_name
-                    .grow_if_needed(prefix.len() + 4)
-                    .expect("unreachable");
-                mutable_name.append_slice(prefix).expect("unreachable");
-                mutable_name.append_int(tries as u64).expect("unreachable");
-
-                match NameUse::find(self, mutable_name.slice(), sees) {
-                    NameUse::Unused => {
-                        if matches!(use_, NameUse::SameScope(_)) {
-                            // `prefix` may borrow the local `owned_name`; if a
-                            // new entry is needed, dupe into the renamer arena
-                            // so the `NameKey` outlives this function.
-                            self.entry_or_arena_dup(prefix, arena).count = tries;
-                        }
-                        name = mutable_name.slice();
-                    }
-                    cur_use => loop {
-                        mutable_name.reset_to(prefix.len());
-                        mutable_name.append_int(tries as u64).expect("unreachable");
-
-                        tries += 1;
-
-                        match NameUse::find(self, mutable_name.slice(), sees) {
-                            NameUse::Unused => {
-                                if matches!(cur_use, NameUse::SameScope(_)) {
-                                    self.entry_or_arena_dup(prefix, arena).count = tries;
-                                }
-
-                                name = mutable_name.slice();
-                                break;
-                            }
-                            _ => {}
-                        }
-                    },
-                }
-            }
-        }
-
-        // Each name starts off with a count of 1 so that the first collision with
-        // "name" is called "name2".
-        //
-        // `name` may still equal `input_name` bytewise even when `normalized`
-        // is true: `ensure_valid_identifier` returns the input bytes unchanged
-        // for any already-valid identifier (e.g. `Café`, `π`), since only
-        // `is_simple_ascii_identifier` is ASCII-restricted. The hot ASCII path
-        // skips the byte compare via `!normalized`; the rare non-ASCII path
-        // falls back to it.
-        if !collided && (!normalized || strings::eql_long(name, input_name, true)) {
-            // `input_name` is `Symbol::original_name.slice()` — an AST-arena
-            // slice that outlives the renamer (see [`NameKey`] doc). No copy.
-            let prev = self.name_counts.insert(
-                NameKey(NameStr::new(input_name)),
-                NameEntry { count: 1, owner },
-            );
-            debug_assert!(prev.is_none(), "put_no_clobber: key already present");
-            return UnusedName::NoCollision;
-        }
-
-        let duped: &[u8] = arena.alloc_slice_copy(name);
-        let name: NameStr = bun_ast::StoreStr::new(duped);
-
-        // `duped` is bump-allocated from the renamer's `arena: Bump`, which
-        // outlives every `NumberScope` (see [`NameKey`] doc). No copy.
-        let prev = self
-            .name_counts
-            .insert(NameKey(name), NameEntry { count: 1, owner });
-        debug_assert!(prev.is_none(), "put_no_clobber: key already present");
-        UnusedName::Renamed(name)
-    }
-
-    /// `name_counts.entry(prefix).or_insert(0)` with a vacant-only arena dup:
-    /// when the key is already present we mutate it in place; when it is not,
-    /// the bytes are bump-allocated into `arena` so the resulting [`NameKey`]
-    /// outlives the renamer.
-    fn entry_or_arena_dup(&mut self, prefix: &[u8], arena: &Bump) -> &mut NameEntry {
-        use bun_collections::hashbrown::hash_map::RawEntryMut;
-        match self.name_counts.raw_entry_mut().from_key(prefix) {
-            RawEntryMut::Occupied(o) => o.into_mut(),
-            RawEntryMut::Vacant(v) => {
-                let duped = arena.alloc_slice_copy(prefix);
-                v.insert(
-                    NameKey(NameStr::new(duped)),
-                    NameEntry {
-                        count: 0,
-                        owner: Ref::NONE,
-                    },
-                )
-                .1
-            }
-        }
-    }
 }
 
 /// One file's `Ast::scope_uses`, indexed on first use so the number renamer

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -629,21 +629,9 @@ trait NameScopes {
     /// Takes `name` for `owner` in the current scope if free, else the first
     /// free `name2`, `name3`, …. `None`: `name` itself was free.
     fn find_unused_name(&mut self, input_name: NameStr, owner: Ref) -> Option<NameStr> {
-        // `MutableString::ensure_valid_identifier` always heap-allocates, even
-        // when the input is already a valid ASCII identifier; the strict-mode
-        // reserved-word remap (`let` → `_let`, ...) is the only transform that
-        // fires for an otherwise-valid ASCII name.
-        let owned_name;
-        let (name, normalized): (&[u8], bool) = if is_simple_ascii_identifier(input_name.slice())
-            && !bun_ast::lexer_tables::is_strict_mode_reserved_word(input_name.slice())
-        {
-            (input_name.slice(), false)
-        } else {
-            owned_name =
-                MutableString::ensure_valid_identifier(input_name.slice()).expect("unreachable");
-            (&owned_name, true)
-        };
-        debug_assert!(js_lexer::is_identifier(name));
+        let owned_name = valid_identifier_for(input_name.slice());
+        let normalized = owned_name.is_some();
+        let name: &[u8] = owned_name.as_deref().unwrap_or_else(|| input_name.slice());
 
         let id = self.id_of(name);
         let use_ = self.find(id);
@@ -678,15 +666,10 @@ trait NameScopes {
             NameUse::SameScope(count) => count,
             _ => 1,
         };
-        let mut candidate = MutableString::init_empty();
-        candidate
-            .grow_if_needed(name.len() + 4)
-            .expect("unreachable");
-        candidate.append_slice(name).expect("unreachable");
+        let mut candidate = numbered_name_buffer(name);
         loop {
             tries += 1;
-            candidate.reset_to(name.len());
-            candidate.append_int(tries as u64).expect("unreachable");
+            write_numbered_name(&mut candidate, name.len(), tries);
             let candidate_id = self.id_of(candidate.slice());
             if let NameUse::Unused = self.find(candidate_id) {
                 let scope = self.scope();
@@ -721,6 +704,39 @@ trait NameScopes {
             }
         }
     }
+}
+
+/// `name` made a valid identifier (`let` → `_let`, non-ASCII escapes), or
+/// `None` when it already is one.
+fn valid_identifier_for(name: &[u8]) -> Option<Box<[u8]>> {
+    // `MutableString::ensure_valid_identifier` always heap-allocates, even
+    // when the input is already a valid ASCII identifier; the strict-mode
+    // reserved-word remap is the only transform that fires for an
+    // otherwise-valid ASCII name.
+    if is_simple_ascii_identifier(name)
+        && !bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
+    {
+        debug_assert!(js_lexer::is_identifier(name));
+        return None;
+    }
+    let valid = MutableString::ensure_valid_identifier(name).expect("unreachable");
+    debug_assert!(js_lexer::is_identifier(&valid));
+    Some(valid)
+}
+
+fn numbered_name_buffer(name: &[u8]) -> MutableString {
+    let mut candidate = MutableString::init_empty();
+    candidate
+        .grow_if_needed(name.len() + 4)
+        .expect("unreachable");
+    candidate.append_slice(name).expect("unreachable");
+    candidate
+}
+
+/// `candidate[..prefix_len]` followed by `n`.
+fn write_numbered_name(candidate: &mut MutableString, prefix_len: usize, n: u32) {
+    candidate.reset_to(prefix_len);
+    candidate.append_int(u64::from(n)).expect("unreachable");
 }
 
 fn intern_into(ids: &mut NameIds, next_id: u32, name: NameStr) -> (u32, bool) {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -953,10 +953,10 @@ pub struct NestedRenamer<'r> {
     source_index: u32,
     /// This file's names; starts as the top-level ones.
     names: Vec<NameStr>,
-    /// By name id (the root's ids, then `local_ids`): 0, or 1 + the index in
-    /// `slots` of the innermost enclosing scope's slot for that name. Slots of
-    /// scopes already left are dropped, so a present slot is always an
-    /// enclosing one.
+    /// Name id (the root's ids, then `local_ids`) -> index in `slots` of the
+    /// innermost enclosing scope's slot for that name; ids not present read
+    /// the root's slot. Slots of scopes already left are dropped, so a present
+    /// slot is always an enclosing one.
     overlay: OverlayMap,
     /// Ids `root.slots.len()..next_local_id` are this file's `local_ids`.
     next_local_id: u32,

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -88,12 +88,21 @@ impl core::borrow::Borrow<[u8]> for NameKey {
     }
 }
 
+/// `count`: next collision counter for the name. `owner`: the symbol that
+/// holds the name in this scope, or `Ref::NONE` for reserved names and
+/// counter-only entries, which every inner scope must avoid.
+#[derive(Clone, Copy)]
+pub(crate) struct NameEntry {
+    count: u32,
+    owner: Ref,
+}
+
 /// Per-`NumberScope` map of assigned names → next collision counter.
 /// `bun_wyhash::BuildHasher` matches `StringHashMap` so the renamer keeps its
 /// existing hash quality; `NameKey` is a `Copy` lifetime-erased slice so insert
 /// never heap-allocates a key copy and drop never frees one.
 pub(crate) type NameCountMap =
-    bun_collections::hashbrown::HashMap<NameKey, u32, bun_wyhash::BuildHasher>;
+    bun_collections::hashbrown::HashMap<NameKey, NameEntry, bun_wyhash::BuildHasher>;
 
 pub struct NoOpRenamer<'a> {
     // `symbol::Map` is `Vec<Vec<Symbol>>` (owning). Unlike `MinifyRenamer`/`NumberRenamer` (which the bundler builds over a
@@ -341,7 +350,7 @@ impl MinifyRenamer {
             self.accumulate_symbol_use_count(
                 top_level_symbols,
                 *key,
-                value.count_estimate,
+                value.count_estimate(),
                 stable_source_indices,
             )?;
         }
@@ -355,17 +364,8 @@ impl MinifyRenamer {
         count: u32,
         stable_source_indices: &[u32],
     ) -> Result<(), bun_alloc::AllocError> {
-        let mut ref_ = self.symbols.follow(ref_);
-        let mut symbol: &Symbol = self.symbols.get_const(ref_).unwrap();
-
-        while let Some(alias) = &symbol.namespace_alias {
-            let new_ref = self.symbols.follow(alias.namespace_ref);
-            if new_ref.eql(ref_) {
-                break;
-            }
-            ref_ = new_ref;
-            symbol = self.symbols.get_const(new_ref).unwrap();
-        }
+        let ref_ = self.symbols.follow_printed(ref_);
+        let symbol: &Symbol = self.symbols.get_const(ref_).unwrap();
 
         let ns = symbol.slot_namespace();
         if ns == SlotNamespace::MustNotBeRenamed {
@@ -587,7 +587,12 @@ pub struct NumberRenamer {
 }
 
 impl NumberRenamer {
-    pub(crate) fn assign_name(&mut self, scope: &mut NumberScope, input_ref: Ref) {
+    pub(crate) fn assign_name(
+        &mut self,
+        scope: &mut NumberScope,
+        input_ref: Ref,
+        sees: &impl Fn(Ref) -> bool,
+    ) {
         let ref_ = self.symbols.follow(input_ref);
 
         // Don't rename the same symbol more than once
@@ -605,7 +610,7 @@ impl NumberRenamer {
 
         // SAFETY: `original_name` is an AST-arena slice that outlives the renamer.
         let original_name: &[u8] = symbol.original_name.slice();
-        let name: NameStr = match scope.find_unused_name(&self.arena, original_name) {
+        let name: NameStr = match scope.find_unused_name(&self.arena, original_name, ref_, sees) {
             UnusedName::Renamed(name) => name,
             UnusedName::NoCollision => symbol.original_name,
         };
@@ -639,7 +644,13 @@ impl NumberRenamer {
         root.name_counts.reserve(root_names.len());
         for (key, &value) in root_names.iter() {
             let duped = arena.alloc_slice_copy(&**key);
-            root.name_counts.insert(NameKey(NameStr::new(duped)), value);
+            root.name_counts.insert(
+                NameKey(NameStr::new(duped)),
+                NameEntry {
+                    count: value,
+                    owner: Ref::NONE,
+                },
+            );
         }
 
         // Debug-only, presence-checked symbol dump.
@@ -663,6 +674,7 @@ impl NumberRenamer {
         scope: &js_ast::Scope,
         source_index: u32,
         sorted: &mut Vec<u32>,
+        sees: &impl Fn(Ref) -> bool,
     ) {
         {
             sorted.clear();
@@ -674,12 +686,16 @@ impl NumberRenamer {
             sorted.sort_unstable();
 
             for &inner_index in sorted.iter() {
-                self.assign_name(s, Ref::init(inner_index, source_index, false));
+                self.assign_name(
+                    s,
+                    Ref::new(inner_index, source_index, bun_ast::RefTag::Symbol),
+                    sees,
+                );
             }
         }
 
         for ref_ in scope.generated.slice() {
-            self.assign_name(s, *ref_);
+            self.assign_name(s, *ref_, sees);
         }
     }
 
@@ -689,6 +705,7 @@ impl NumberRenamer {
         scope_: &js_ast::Scope,
         source_index: u32,
         sorted: &mut Vec<u32>,
+        uses: &ScopeUses<'_>,
     ) {
         let mut s: *mut NumberScope = initial_scope;
         let mut scope = scope_;
@@ -726,7 +743,13 @@ impl NumberRenamer {
                 s = new_child_scope;
 
                 // SAFETY: s is a valid pool slot just initialized above
-                self.assign_names_in_scope(unsafe { &mut *s }, scope, source_index, sorted);
+                self.assign_names_in_scope(
+                    unsafe { &mut *s },
+                    scope,
+                    source_index,
+                    sorted,
+                    &|symbol| uses.sees(symbol, scope),
+                );
             }
 
             if scope.children.len_u32() == 1 {
@@ -740,7 +763,7 @@ impl NumberRenamer {
         // Symbols in child scopes may also have to be renamed to avoid conflicts
         for child in scope.children.slice() {
             // `StoreRef<Scope>: Deref<Target = Scope>` — safe arena-backed deref.
-            self.assign_names_recursive_with_number_scope(s, child, source_index, sorted);
+            self.assign_names_recursive_with_number_scope(s, child, source_index, sorted, uses);
         }
 
         // The pool fallback and `name_counts` data live on the global heap
@@ -772,7 +795,13 @@ impl NumberRenamer {
         }
         let duped: &[u8] = self.arena.alloc_slice_copy(name);
         let name = NameStr::new(duped);
-        self.root.name_counts.insert(NameKey(name), 1);
+        self.root.name_counts.insert(
+            NameKey(name),
+            NameEntry {
+                count: 1,
+                owner: ref_,
+            },
+        );
         let inner: &mut Vec<NameStr> = &mut self.names[ref_.source_index() as usize];
         let new_len = inner.len().max(ref_.inner_index() as usize + 1);
         if inner.len() < new_len {
@@ -788,7 +817,7 @@ impl NumberRenamer {
         // that invariant if `assign_name` changes.
         let root: *mut NumberScope = &raw mut self.root;
         // SAFETY: assign_name does not touch self.root through `self`
-        self.assign_name(unsafe { &mut *root }, ref_);
+        self.assign_name(unsafe { &mut *root }, ref_, &|_| true);
     }
 
     pub fn add_top_level_declared_symbols(
@@ -847,7 +876,10 @@ enum NameUse {
 }
 
 impl NameUse {
-    fn find(this: &NumberScope, name: &[u8]) -> NameUse {
+    /// `sees(owner)`: whether the scope being named references `owner`, the
+    /// symbol holding `name` in an enclosing scope. When it does not, the
+    /// binding may shadow it.
+    fn find(this: &NumberScope, name: &[u8], sees: &impl Fn(Ref) -> bool) -> NameUse {
         // This version doesn't allocate
         debug_assert!(js_lexer::is_identifier(name));
 
@@ -860,12 +892,12 @@ impl NameUse {
             <bun_wyhash::BuildHasher as Default>::default().hash_one(name)
         };
 
-        if let Some((_, &count)) = this
+        if let Some((_, entry)) = this
             .name_counts
             .raw_entry()
             .from_hash(hash, |k| k.as_bytes() == name)
         {
-            return NameUse::SameScope(count);
+            return NameUse::SameScope(entry.count);
         }
 
         let mut s: Option<bun_ptr::ParentRef<NumberScope, bun_ptr::Mut>> = this.parent;
@@ -873,13 +905,14 @@ impl NameUse {
         while let Some(scope) = s {
             // `ParentRef<NumberScope>: Deref` — safe backref deref under the
             // parent-outlives-child invariant documented on the field.
-            if scope
+            if let Some((_, entry)) = scope
                 .name_counts
                 .raw_entry()
                 .from_hash(hash, |k| k.as_bytes() == name)
-                .is_some()
             {
-                return NameUse::Used;
+                if entry.owner.is_empty() || sees(entry.owner) {
+                    return NameUse::Used;
+                }
             }
             s = scope.parent;
         }
@@ -920,7 +953,13 @@ fn is_simple_ascii_identifier(s: &[u8]) -> bool {
 
 impl NumberScope {
     /// Caller must use an arena allocator
-    pub(crate) fn find_unused_name(&mut self, arena: &Bump, input_name: &[u8]) -> UnusedName {
+    pub(crate) fn find_unused_name(
+        &mut self,
+        arena: &Bump,
+        input_name: &[u8],
+        owner: Ref,
+        sees: &impl Fn(Ref) -> bool,
+    ) -> UnusedName {
         // `MutableString::ensure_valid_identifier` always heap-allocates
         // (Box<[u8]>), even when the input is already a valid ASCII
         // identifier. Skip the call entirely for the common case so this
@@ -951,7 +990,7 @@ impl NumberScope {
         // compares (see the comment at the tail).
         let mut collided = false;
 
-        match NameUse::find(self, name) {
+        match NameUse::find(self, name, sees) {
             NameUse::Unused => {}
             use_ => {
                 collided = true;
@@ -981,13 +1020,13 @@ impl NumberScope {
                 mutable_name.append_slice(prefix).expect("unreachable");
                 mutable_name.append_int(tries as u64).expect("unreachable");
 
-                match NameUse::find(self, mutable_name.slice()) {
+                match NameUse::find(self, mutable_name.slice(), sees) {
                     NameUse::Unused => {
                         if matches!(use_, NameUse::SameScope(_)) {
                             // `prefix` may borrow the local `owned_name`; if a
                             // new entry is needed, dupe into the renamer arena
                             // so the `NameKey` outlives this function.
-                            *self.entry_or_arena_dup(prefix, arena) = tries;
+                            self.entry_or_arena_dup(prefix, arena).count = tries;
                         }
                         name = mutable_name.slice();
                     }
@@ -997,10 +1036,10 @@ impl NumberScope {
 
                         tries += 1;
 
-                        match NameUse::find(self, mutable_name.slice()) {
+                        match NameUse::find(self, mutable_name.slice(), sees) {
                             NameUse::Unused => {
                                 if matches!(cur_use, NameUse::SameScope(_)) {
-                                    *self.entry_or_arena_dup(prefix, arena) = tries;
+                                    self.entry_or_arena_dup(prefix, arena).count = tries;
                                 }
 
                                 name = mutable_name.slice();
@@ -1025,9 +1064,10 @@ impl NumberScope {
         if !collided && (!normalized || strings::eql_long(name, input_name, true)) {
             // `input_name` is `Symbol::original_name.slice()` — an AST-arena
             // slice that outlives the renamer (see [`NameKey`] doc). No copy.
-            let prev = self
-                .name_counts
-                .insert(NameKey(NameStr::new(input_name)), 1);
+            let prev = self.name_counts.insert(
+                NameKey(NameStr::new(input_name)),
+                NameEntry { count: 1, owner },
+            );
             debug_assert!(prev.is_none(), "put_no_clobber: key already present");
             return UnusedName::NoCollision;
         }
@@ -1037,7 +1077,9 @@ impl NumberScope {
 
         // `duped` is bump-allocated from the renamer's `arena: Bump`, which
         // outlives every `NumberScope` (see [`NameKey`] doc). No copy.
-        let prev = self.name_counts.insert(NameKey(name), 1);
+        let prev = self
+            .name_counts
+            .insert(NameKey(name), NameEntry { count: 1, owner });
         debug_assert!(prev.is_none(), "put_no_clobber: key already present");
         UnusedName::Renamed(name)
     }
@@ -1046,15 +1088,177 @@ impl NumberScope {
     /// when the key is already present we mutate it in place; when it is not,
     /// the bytes are bump-allocated into `arena` so the resulting [`NameKey`]
     /// outlives the renamer.
-    fn entry_or_arena_dup(&mut self, prefix: &[u8], arena: &Bump) -> &mut u32 {
+    fn entry_or_arena_dup(&mut self, prefix: &[u8], arena: &Bump) -> &mut NameEntry {
         use bun_collections::hashbrown::hash_map::RawEntryMut;
         match self.name_counts.raw_entry_mut().from_key(prefix) {
             RawEntryMut::Occupied(o) => o.into_mut(),
             RawEntryMut::Vacant(v) => {
                 let duped = arena.alloc_slice_copy(prefix);
-                v.insert(NameKey(NameStr::new(duped)), 0).1
+                v.insert(
+                    NameKey(NameStr::new(duped)),
+                    NameEntry {
+                        count: 0,
+                        owner: Ref::NONE,
+                    },
+                )
+                .1
             }
         }
+    }
+}
+
+/// One file's `Ast::scope_uses`, indexed on first use so the number renamer
+/// can ask whether a nested binding would capture a reference to an enclosing
+/// binding of the same name.
+pub struct ScopeUses<'a> {
+    source_index: u32,
+    list: &'a js_ast::ast_result::ScopeUseList,
+    parts: &'a [js_ast::Part],
+    parts_live: &'a bun_collections::AutoBitSet,
+    symbols: &'a symbol::Map,
+    index: core::cell::OnceCell<ScopeUseIndex>,
+}
+
+/// Scopes are numbered in pre-order (`Scope::visit_span`), so a scope
+/// together with everything inside it is the span `[first, last]`.
+#[derive(Default)]
+struct ScopeUseIndex {
+    /// `scope_indices[offsets[i]..offsets[i + 1]]`: the scopes that reference
+    /// this file's symbol `i`, ascending.
+    offsets: Vec<u32>,
+    scope_indices: Vec<u32>,
+    /// Printed symbols the linker added uses of: no scope on record, so they
+    /// may be printed anywhere in the file.
+    everywhere: HashMap<Ref, ()>,
+    /// `(printed symbol, this file's symbol that prints as it)` where the two
+    /// differ (linked import items, hoisted duplicates, namespace members).
+    /// Sorted.
+    aliases: Vec<(u64, u32)>,
+}
+
+impl<'a> ScopeUses<'a> {
+    pub fn new(
+        source_index: u32,
+        list: &'a js_ast::ast_result::ScopeUseList,
+        parts: &'a [js_ast::Part],
+        parts_live: &'a bun_collections::AutoBitSet,
+        symbols: &'a symbol::Map,
+    ) -> Self {
+        ScopeUses {
+            source_index,
+            list,
+            parts,
+            parts_live,
+            symbols,
+            index: core::cell::OnceCell::new(),
+        }
+    }
+
+    /// Whether a binding in `scope` would capture a reference to `symbol`,
+    /// i.e. whether `symbol` is referenced in `scope` or anywhere inside it.
+    pub fn sees(&self, symbol: Ref, scope: &js_ast::Scope) -> bool {
+        let Some(span) = scope.visit_span() else {
+            return true;
+        };
+        if !self.list.tracked {
+            return true;
+        }
+        let index = self.index.get_or_init(|| ScopeUseIndex::build(self));
+        if index.everywhere.contains_key(&symbol) {
+            return true;
+        }
+        if symbol.source_index() == self.source_index
+            && self.sees_own(index, symbol.inner_index(), span)
+        {
+            return true;
+        }
+        let key = symbol.to_raw_bits();
+        let i = index.aliases.partition_point(|&(printed, _)| printed < key);
+        index.aliases[i..]
+            .iter()
+            .take_while(|&&(printed, _)| printed == key)
+            .any(|&(_, own)| self.sees_own(index, own, span))
+    }
+
+    /// For a symbol of this file, by inner index.
+    fn sees_own(&self, index: &ScopeUseIndex, symbol: u32, (first, last): (u32, u32)) -> bool {
+        let (lo, hi) = (
+            index.offsets[symbol as usize],
+            index.offsets[symbol as usize + 1],
+        );
+        let scopes = &index.scope_indices[lo as usize..hi as usize];
+        let i = scopes.partition_point(|&at| at < first);
+        if scopes.get(i).is_some_and(|&at| at <= last) {
+            return true;
+        }
+        let spans = self.list.spans.as_slice();
+        let i = spans.partition_point(|s| s.symbol < symbol);
+        spans[i..]
+            .iter()
+            .take_while(|s| s.symbol == symbol)
+            .any(|s| s.first <= last && first <= s.last)
+    }
+}
+
+impl ScopeUseIndex {
+    fn build(file: &ScopeUses<'_>) -> ScopeUseIndex {
+        let mut index = ScopeUseIndex::default();
+
+        for (part_index, part) in file.parts.iter().enumerate() {
+            if !file.parts_live.is_set(part_index) {
+                continue;
+            }
+            for (ref_, use_) in part
+                .symbol_uses
+                .keys()
+                .iter()
+                .zip(part.symbol_uses.values())
+            {
+                if use_.has_unscoped() {
+                    index
+                        .everywhere
+                        .insert(file.symbols.follow_printed(*ref_), ());
+                }
+            }
+        }
+
+        let file_symbols = &file.symbols.symbols_for_source[file.source_index as usize];
+        for (inner, symbol) in file_symbols.iter().enumerate() {
+            if !symbol.has_link() && symbol.namespace_alias.is_none() {
+                continue;
+            }
+            let own = Ref::new(inner as u32, file.source_index, bun_ast::RefTag::Symbol);
+            let printed = file.symbols.follow_printed(own);
+            if printed != own {
+                index.aliases.push((printed.to_raw_bits(), inner as u32));
+            }
+        }
+        index.aliases.sort_unstable();
+
+        // Bucket the points by symbol (counting sort), then order each
+        // symbol's scopes.
+        let points = file.list.points.as_slice();
+        // `offsets[i]` = end of bucket `i`; filling each bucket from its end
+        // turns it into the start.
+        let mut offsets = vec![0u32; file_symbols.len() + 1];
+        for point in points {
+            offsets[point.symbol as usize] += 1;
+        }
+        for i in 1..offsets.len() {
+            offsets[i] += offsets[i - 1];
+        }
+        let mut scope_indices = vec![0u32; points.len()];
+        for point in points.iter().rev() {
+            let slot = &mut offsets[point.symbol as usize];
+            *slot -= 1;
+            scope_indices[*slot as usize] = point.scope;
+        }
+        for symbol in 0..file_symbols.len() {
+            scope_indices[offsets[symbol] as usize..offsets[symbol + 1] as usize].sort_unstable();
+        }
+        index.offsets = offsets;
+        index.scope_indices = scope_indices;
+        index
     }
 }
 

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -220,12 +220,6 @@ impl Default for Config {
 }
 
 impl ThreadPool {
-    pub fn max_threads(&self) -> u32 {
-        self.max_threads
-    }
-}
-
-impl ThreadPool {
     /// Statically initialize the thread pool using the configuration.
     pub fn init(config: Config) -> ThreadPool {
         ThreadPool {

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -220,6 +220,12 @@ impl Default for Config {
 }
 
 impl ThreadPool {
+    pub fn max_threads(&self) -> u32 {
+        self.max_threads
+    }
+}
+
+impl ThreadPool {
     /// Statically initialize the thread pool using the configuration.
     pub fn init(config: Config) -> ThreadPool {
         ThreadPool {

--- a/test/bundler/__snapshots__/bun-build-api.test.ts.snap
+++ b/test/bundler/__snapshots__/bun-build-api.test.ts.snap
@@ -27,8 +27,8 @@ function fn(a) {
 
 // test/bundler/fixtures/trivial/index.js
 var NS = Promise.resolve().then(() => exports_fn);
-NS.then(({ fn: fn2 }) => {
-  console.log(fn2(42));
+NS.then(({ fn }) => {
+  console.log(fn(42));
 });
 "
 `;
@@ -60,17 +60,17 @@ function fn(a) {
 
 // test/bundler/fixtures/trivial/index.js
 var NS = Promise.resolve().then(() => exports_fn);
-NS.then(({ fn: fn2 }) => {
-  console.log(fn2(42));
+NS.then(({ fn }) => {
+  console.log(fn(42));
 });
 "
 `;
 
-exports[`Bun.build BuildArtifact properties: hash 1`] = `"g9c33042"`;
+exports[`Bun.build BuildArtifact properties: hash 1`] = `"xccrrspv"`;
 
-exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"2ksyc1td"`;
+exports[`Bun.build BuildArtifact properties + entry.naming: hash 1`] = `"jvbamvbx"`;
 
-exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"g9c33042"`;
+exports[`Bun.build BuildArtifact properties sourcemap: hash index.js 1`] = `"xccrrspv"`;
 
 exports[`Bun.build BuildArtifact properties sourcemap: hash index.js.map 1`] = `"00000000"`;
 
@@ -101,8 +101,8 @@ function fn(a) {
 
 // test/bundler/fixtures/trivial/index.js
 var NS = Promise.resolve().then(() => exports_fn);
-NS.then(({ fn: fn2 }) => {
-  console.log(fn2(42));
+NS.then(({ fn }) => {
+  console.log(fn(42));
 });
 "
 `;

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -451,17 +451,17 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "5d2ce9ace50d60d07530d33bea5f58669ae9c3b8c8ded447c09dda11364bc73f",
+          "js": "50b3e5192dd86a205c73583d585884c1b414467b14db54d03c77d3026bf236ff",
           "jsc": {
             "bytes": 1997464,
-            "sha256": "1fc3a766354fb508a3e45d9dcd0459869d9577fc8cf7b557837df128b31fdb1f",
+            "sha256": "cf47f5e069b3f20c112160c430a3b18c5ce2d501f1c52525d34dfbd054273cfb",
           },
         },
         "bun build --bytecode --minify features.js": {
-          "js": "d49da0aa39824bf9eba2af5d3a010525ad14ca5c1cedc0d8adcfdd5f4984a0d0",
+          "js": "d30a5febed53e316cc2dd2b076502079e809bb0c201ef1671e9a190ecdcf093d",
           "jsc": {
             "bytes": 46152,
-            "sha256": "db36543ec2430a8cbdce13a6a980148f502e2c6b135cf95f62b6743c3fa30968",
+            "sha256": "7dc5fe8fbfaed3c41d424d2f172efb0efa1be60524ecefcc9d77dfc8088b32af",
           },
         },
         "bun build --bytecode --minify records.js": {

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -472,17 +472,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode acorn/dist/acorn.mjs": {
-          "js": "9750b95678aa2ad19085761db9ff451e592cd0ce4e04dd156c64a0c42bb32461",
+          "js": "aa22cb20382fa5d66ff2ddd90817c0899f82b346bdd1da87dc9e193d203a0ce9",
           "jsc": {
-            "bytes": 266176,
-            "sha256": "d71089597ed075372781d7f66db2ce07fbbe612ae2efc22c11194d5d3fa27735",
+            "bytes": 266016,
+            "sha256": "869fd863c0ae1c797c0ccc9540b37f73167aca0139ce807eaef6e108b8eb6e76",
           },
         },
         "bun build --bytecode all.js": {
-          "js": "b694a11873c7b3755c194d8ed04030e40c95afc33f0f1cc4ab834bc8f0df7bf2",
+          "js": "ce4cf9db35e0aa3257f982fb756363a5686fb52a3b7cc63ac0c66bdcaf13a849",
           "jsc": {
-            "bytes": 2176816,
-            "sha256": "0ed7dd7caefbbdc3f7fdc9ed616d0d1bf3b712cbd8882f4c67d058b76f725ccd",
+            "bytes": 2175416,
+            "sha256": "7c6591c879c6eb529297d5c0d03802e5b8c5b619cbbc26a50b9da652e2457653",
           },
         },
         "bun build --bytecode big.js": {
@@ -500,38 +500,38 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode happy-dom/lib/index.js": {
-          "js": "ad001095310e6ac9cf264d5736950500bdef1928710489df4ee286c6c94b9d46",
+          "js": "75d2ad2bc252c916f90f8ca85f53f0883ca46049c2700e3c1fe2337ec42d1142",
           "jsc": {
-            "bytes": 2529040,
-            "sha256": "be79a30e0074fff783765e637684696fc650cc4459b4256be9769b36a8f24065",
+            "bytes": 2528112,
+            "sha256": "a05ebff1f6fe479cb7bbbedf983114231cd634d5088554d137f4ff160f628620",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
-          "js": "82ad84644b8be6b98cac3186bb04d17307d8d43fadd9b84b0f4067e6b29c9de4",
+          "js": "d011b6c5105dad96f17aaf541c848b8d2be1b2e65a1de050112380352979bb6b",
           "jsc": {
-            "bytes": 280384,
-            "sha256": "02548420a1064d59943269c7148768cdb43ede4ae88cc86d52ae5fd3d4e8db73",
+            "bytes": 278104,
+            "sha256": "9d1d36f64bd567397cc17eba6ddd4a7803b4ef4651cdcd07aeb7b7a2007c11f2",
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "1f68e441cd2fca858d1d4d4591dadaa2e79e181fe54252cdc4cc3fb148ff6960",
+          "js": "493bab674ff49b287f26be3f356a3ad6681afb0c7eeffaa590f10cdcd8b58724",
           "jsc": {
-            "bytes": 23789856,
-            "sha256": "70afd133ad4b7006f51bd42fa9eb858dd4a7de3cbb781519f606c14fa3bb4e0c",
+            "bytes": 23772944,
+            "sha256": "c0bb1ca0664a9c7146fadb951e4f6f801811918489f5777fdbbda101a6ffd6c6",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
-          "js": "e372f1aec6b2bba20581abfce3b7273aae0ec4f593ed2aa4aa5c60c66836856d",
+          "js": "54d4179e9e85d931490846667d2101e01d42f31c70d455c42f2e59b6fc77bf6a",
           "jsc": {
-            "bytes": 347488,
-            "sha256": "531d6bb544c53641289a44e72ac096560b19d360c2ee19b77483987c367b9b5e",
+            "bytes": 347200,
+            "sha256": "a1b09047322d27494939aa6bf2bd58cad3716d45daeb32072b6ddd18c8b5f2e8",
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {
-          "js": "e2cf34c8eb6f5952a33ca91e3949b28786349cf97ea3fbf0b3b8500dbccd4860",
+          "js": "3392a38ccef2f1bb7b1c8c8cbfc8111b45f6cf6f8dec3c72a99f13a6568fd5a1",
           "jsc": {
-            "bytes": 980080,
-            "sha256": "32fa8492ad9fdf3ea31395756898d556df9dc6bdfbac9bba07bcafa748ab38ca",
+            "bytes": 979752,
+            "sha256": "9ebd11bf33d2eb06395c4031937e545e0220eb555fe056475b663ec497c68a45",
           },
         },
         "bun build --bytecode records.js": {
@@ -549,17 +549,17 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode svelte/compiler/index.js": {
-          "js": "5ced9487e680d82a45548d0f509ecc5c931f06485a2d17bac56ddd60e3ede785",
+          "js": "17e7431a6f28a4b6b5d356fc815b0876ebd9613ae6c25a98dc4c5560004341ce",
           "jsc": {
-            "bytes": 1996728,
-            "sha256": "1e224f518c1be57eb53460723b34128ca4c310bbe75a7a1ea93a900e24c3db74",
+            "bytes": 2021744,
+            "sha256": "3065c774fd5520ab7bf0543a8a3408d67ab3e4e2254bf1045b10f99c70702c8d",
           },
         },
         "bun build --bytecode undici/index.js": {
-          "js": "69bf9c543e66889d9ed35bcc99ffd8f4bc3315437f0f0aaf7c264fadd660eb03",
+          "js": "e1c4f1494711ecaae57a6d63dfb8ac6096629582f55cc42530ff5a156b70c9de",
           "jsc": {
-            "bytes": 937000,
-            "sha256": "a7df79cea1f01223e4160c68c2a9faf75f159e8e549aa273ac2f85c545dc1106",
+            "bytes": 936728,
+            "sha256": "4558df385945651dd4940927c840deb45ee8fd63daaa408b23e4ef54e8f710df",
           },
         },
         "vm.Script big.js": {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2963,6 +2963,170 @@ describe("bundler", () => {
     minifyIdentifiers: false,
     run: { stdout: "43" },
   });
+  // A binding in a nested scope keeps its name when the enclosing bindings of
+  // that name (top-level ones included, from any file in the chunk) are never
+  // referenced inside its scope, so `Function#name` / `constructor.name`
+  // survive bundling. Class and function expression names are bound in their
+  // own scope, not at top level.
+  itBundled("identifiers/NestedBindingKeepsNameWhenOuterIsNotReferencedInside", {
+    files: {
+      "/entry.js": /* js */ `
+        import { make } from "./dep.js";
+        const factory = () => { class Model {} return Model; };
+        const Model = factory();
+        var Foo = class Foo { static self() { return Foo; } };
+        var fn = function fn() { return fn; };
+        let User = class User { me() { return User; } };
+        User = ((c) => c)(User);
+        class Bar { static { Bar.tag = "bar"; } }
+        function outer() { const make = () => "local"; return make(); }
+        console.log(JSON.stringify([
+          Model.name, Foo.name, Foo.self() === Foo, fn.name, fn() === fn, User.name,
+          new User().me() === User, Bar.name, Bar.tag, make().name, outer(),
+        ]));
+      `,
+      "/dep.js": /* js */ `
+        export function make() { class Model {} return Model; }
+      `,
+    },
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toMatch(/\b(Model|Foo|fn|User|Bar|make)[0-9]\b/);
+    },
+    run: { stdout: `["Model","Foo",true,"fn",true,"User",true,"Bar","bar","Model","local"]` },
+  });
+  // The other direction: when the scope does reference the outer binding (as
+  // the printer will write it: a linked import, a namespace member, a CommonJS
+  // namespace object, a runtime helper, a class field moved into the
+  // constructor), the nested binding is renamed out of the way.
+  itBundled("identifiers/NestedBindingRenamedWhenOuterIsReferencedInside", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { T as U, value } from "./dep.ts";
+        import * as ns from "./ns.ts";
+        import cjs from "./cjs.cjs";
+        const lazy = () => require("./ns.ts");
+        var C = class T { m() { return U; } };
+        function a() { const parse = "local"; return [parse, ns.parse()]; }
+        function b() { let x = value; { let value = "inner"; return [value, x]; } }
+        function c() { { let value = "inner"; return [value, U.name]; } }
+        function d() { const import_cjs = "local"; return [import_cjs, cjs.kind]; }
+        function e() { const __toCommonJS = "local"; return [__toCommonJS, lazy().parse()]; }
+        function dec(target: unknown, key?: unknown) {}
+        class F {
+          @dec prop = value;
+          @dec lazy = () => value;
+          constructor(value: string) { this.arg = value; }
+          arg: string;
+        }
+        const f = new F("arg");
+        console.log(JSON.stringify([C.name, new C().m().name, a(), b(), c(), d(), e(), f.prop, f.lazy(), f.arg]));
+      `,
+      "/tsconfig.json": /* json */ `
+        { "compilerOptions": { "experimentalDecorators": true } }
+      `,
+      "/dep.ts": /* ts */ `
+        export class T {}
+        export const value = "dep";
+      `,
+      "/ns.ts": /* ts */ `
+        export function parse() { return "parsed"; }
+      `,
+      "/cjs.cjs": /* js */ `
+        module.exports = { kind: "cjs" };
+      `,
+    },
+    minifyIdentifiers: false,
+    run: {
+      stdout: `["T2","T",["local","parsed"],["inner","dep"],["inner","T"],["local","cjs"],["local","parsed"],"dep","dep","arg"]`,
+    },
+  });
+  // References that print under a name owned by an enclosing scope even
+  // though the symbol is declared beside the reference: imports inside a
+  // CommonJS-wrapped module (linked to another file's top-level symbol, or
+  // hoisted out of the closure when external), `import()` destructuring bound
+  // to the target's export, Annex B block functions hoisted to the function
+  // scope, and the TypeScript namespace closure parameter.
+  itBundled("identifiers/NestedBindingRenamedAroundLinkedAndHoistedNames", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { fn as viaStatic } from "./fn.ts";
+        import { join } from "node:path";
+        const { foo, p } = require("./a.js");
+        const block = require("./c.cjs");
+        async function g() {
+          const fn2 = 1;
+          const { fn } = await import("./fn.ts");
+          return [fn(), fn2, viaStatic()];
+        }
+        namespace NS {
+          export let a = 1;
+          a++;
+          export function f() { const NS = "local"; return [NS, a]; }
+        }
+        namespace M { export const M = "selfname"; export const other = 1; }
+        namespace M { export function f() { return [M, other]; } }
+        namespace V { export const y = 1; if (globalThis) { var V = 6 as any; } export const seen = [y, typeof V]; }
+        console.log(JSON.stringify([foo, p, block, await g(), NS.f(), typeof join, M.f(), V.seen]));
+      `,
+      "/a.js": /* js */ `
+        import make from "./b.js";
+        import { join } from "node:path";
+        var foo = make();
+        var join2 = "local";
+        module.exports = { foo, p: [join("x", "y").length, join2] };
+      `,
+      "/c.cjs": /* js */ `
+        function outer() {
+          if (true) { function make() { return "block"; } }
+          return make();
+        }
+        module.exports = outer();
+      `,
+      "/b.js": /* js */ `
+        export default function foo() { return "from b"; }
+      `,
+      "/fn.ts": /* ts */ `
+        export function fn() { return "fn"; }
+      `,
+    },
+    target: "node",
+    minifyIdentifiers: false,
+    run: { stdout: `["from b",[3,"local"],"block",["fn",1,"fn"],["local",2],"function",["selfname",1],[1,"number"]]` },
+  });
+  // The enclosing reference may come after the nested scope (a smaller scope
+  // index recorded later), through `module.exports` (printed as `exports`), or
+  // from a TypeScript type position resolved during the parse pass.
+  itBundled("identifiers/NestedBindingRenamedWhenOuterIsReferencedLater", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./a.js";
+        import { calc, v, f } from "./b.js";
+        import m from "./c.cjs";
+        console.log(JSON.stringify([calc("-arg"), f(), v, m.run()]));
+      `,
+      "/a.js": /* js */ `
+        export var value = "a";
+        export let v = "a";
+        console.log(value, v);
+      `,
+      "/b.js": /* js */ `
+        export var value = "b";
+        export function calc(value2) { return value + value2; }
+        export let v = "outer";
+        export function f() { const v2 = "local"; return [v2, v].join(); }
+        console.log(value, v);
+      `,
+      "/c.cjs": /* js */ `
+        module.exports.foo = "F";
+        module.exports.run = function () { return g(); };
+        function g() { const exports = { foo: "L" }; return [exports.foo, module.exports.foo].join(); }
+      `,
+    },
+    minifyIdentifiers: false,
+    run: { stdout: `a a\nb outer\n["b-arg","local,outer","outer","L,F"]` },
+  });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {
     files: {
       "/entry.ts": /* js */ `

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -95,7 +95,7 @@ describe.concurrent("bundler", () => {
         `,
     },
     run: {
-      error: "TypeError: bar2 is not a function. (In 'bar2()', 'bar2' is undefined)",
+      error: "TypeError: bar is not a function. (In 'bar()', 'bar' is undefined)",
       errorLineMatch: /console\.log/,
     },
   });


### PR DESCRIPTION
### What

**1. Nested bindings keep their names.** Non-minified bundles no longer number a binding in a nested scope just because a top-level symbol in the chunk (or another enclosing binding) has the same name. A nested binding keeps its name unless the symbol that owns that name in an enclosing scope is actually referenced inside the binding's scope — so `Function#name` / `constructor.name` match unbundled code, Node and Rollup.

```js
const factory = () => { class Model {} return Model; };
const Model = factory();
console.log(Model.name); // "Model2" before, "Model" now
```

| | before | after |
|---|---|---|
| nested `class Model` + top-level `Model` | `Model2` | `Model` |
| chalk@5 default export `.name` | `chalk2` | `chalk` |
| `var Foo = class Foo {}`, tsc's `let User = class User {}` | `Foo2`, `User2` | `Foo`, `User` |
| `var fn = function fn() {}` | `fn2` | `fn` |
| nested binding that would capture an outer reference (`import { T as U }` + `class T { m() { return U } }`, a local `parse` next to `ns.parse()`, a local `import_x` next to a CommonJS default import) | renamed | still renamed |

Follow-up to #41062 (that fix stands; #41054 stays fixed).

**2. `bun build` is faster**, mostly on large / many-module ESM inputs. Linux x64, LTO release builds of 1.4.0, `main` (14ab660) and this branch, hyperfine on 8 pinned cores, non-minified unless noted:

| | 1.4.0 | main | this PR |
|---|---|---|---|
| `bench/bundle` three.js ×100 (`index.ts`) | 1.83 s | 1.51 s | **1.12 s** |
| `bench/bundle` three.js ×10 (`index10.ts`) | 253 ms | 258 ms | **221 ms** |
| three.js `src/` tree ×100 (~70k modules) | 2.34 s | 2.48 s | **2.03 s** |
| three.js `src/` tree ×10 | 220 ms | 221 ms | **196 ms** |
| vite dep chunk + rollup (3 MB ESM, `--packages=external`) | 95 ms | 97 ms | **86 ms** |
| `typescript.js` as entry, `--format=cjs` | 291 ms | 304 ms | **278 ms** |
| typescript+svelte+react-dom+lodash (CJS-wrapped deps) | 298 ms | 312 ms | 300 ms |
| hono+mongodb+fastify+axios+express | 55 ms | 55 ms | 52 ms |
| three.js ×10 `--minify` (n=30) | 134 ms | 133 ms | 127 ms |
| rolldown-benchmarks `apps/10000` (10k tiny JSX files), `--production --sourcemap` | 571 ms | 584 ms | 580 ms |
| same, non-minified | 619 ms | 665 ms | 635 ms |

macOS arm64 (`bunx bun-pr 41286` vs 1.4 release): `bench/bundle` three.js ×100 382 → 257 ms (`--minify` 265 → 256 ms); three.js `src/` tree ×100 999 → 845 ms (`--minify` 801 → 807 ms). `--minify` builds see only the parser-side share (the minifier has its own renamer); CJS-wrapped dependencies print as one closure and see mostly parity; bundles of thousands of tiny modules are dominated by per-module resolve/link cost and see little change.

### How

Renamer:
- The parser records `(scope, symbol)` for each identifier reference into a flat per-file list (`Ast::scope_uses`), with scopes numbered in visit pre-order so a subtree is a range. Only when bundling without `--minify-identifiers`; references to unbound globals are skipped.
- `NumberRenamer` keeps the chunk's top-level names as interned ids with one slot each (scope, count, owner). Each file's nested scopes are named by a `NestedRenamer` overlaying that table (sparse, undo-logged per scope) and run as parallel per-file tasks once top-level names are final. A nested binding may take a name held further out when the holder is not referenced in its scope subtree.
- Conservative cases: uses the linker adds (`symbol::Use` carries an "unscoped" bit), parser-generated temporaries/helpers, `module`/`exports`, TypeScript decorator-metadata type references, and class field initializers/keys count as referenced across the whole file / class body. Class and function *expression* names are declared in their own scope. The TS namespace closure parameter is now visible to the renamer.

Parser / linker:
- Scope member tables start as a 4-slot inline block (hashes first, compared as a group; names compared only on a hash match), then 8, then a hash table — most scopes never allocate a table, and resolving an identifier up the scope chain touches one cache line per scope.
- Per-part symbol-use counts are tracked in a dense side table and turned into the part's map once, instead of a hash probe per identifier reference.
- Property accesses check a small bit filter before hashing the name against dot defines.
- `symbols`, `scopes_in_order` and the part list are sized from the source up front; the bundler's parse workers use one mimalloc heap for AST nodes, `AstAlloc` spills and the parser arena.
- A file's part range stops growing at `max(largest_source / (2 × threads), 128 KB)` of source, so a large unwrapped file prints on several threads (ranges already join the way files do).
- `CharFreq::scan` (minifier) counts into four interleaved tables.

Minified output can differ from main in which equally-short name a nested slot gets (scope members now iterate in declaration order, which changes the creation order of hoisted symbols); sizes move by ±0.001%. The bytecode-portability snapshot is updated for that and for the non-minified naming change.

### Tests

`test/bundler/bundler_edgecase.test.ts`: `identifiers/NestedBindingKeepsNameWhenOuterIsNotReferencedInside` (fails on main), `identifiers/NestedBindingRenamedWhenOuterIsReferencedInside`, `identifiers/NestedBindingRenamedAroundLinkedAndHoistedNames`, `identifiers/NestedBindingRenamedWhenOuterIsReferencedLater` (capture cases that must still rename). Two existing expectations updated (`bar2` → `bar` in an expected runtime error, `fn2` → `fn` in a snapshot); `bundler_bytecode_portable` snapshot updated.
