### PR TITLE
repl: draw the inline suggestion in gray instead of dim

### DIFF
--- a/src/bun_output_tags/lib.rs
+++ b/src/bun_output_tags/lib.rs
@@ -26,6 +26,10 @@ pub mod ansi {
     pub const MAGENTA: &str = "\x1b[35m";
     pub const CYAN: &str = "\x1b[36m";
     pub(crate) const WHITE: &str = "\x1b[37m";
+    /// SGR 90 (bright black). Prefer it over [`DIM`] for text that must read
+    /// as muted on the legacy Windows console: conhost and winpty do not
+    /// implement SGR 2 and render it as the default foreground.
+    pub const GRAY: &str = "\x1b[90m";
     pub const BRIGHT_WHITE: &str = "\x1b[97m";
     pub(crate) const BG_RED: &str = "\x1b[41m";
     pub(crate) const BG_GREEN: &str = "\x1b[42m";

--- a/src/bun_output_tags/lib.rs
+++ b/src/bun_output_tags/lib.rs
@@ -26,9 +26,7 @@ pub mod ansi {
     pub const MAGENTA: &str = "\x1b[35m";
     pub const CYAN: &str = "\x1b[36m";
     pub(crate) const WHITE: &str = "\x1b[37m";
-    /// SGR 90 (bright black). Prefer it over [`DIM`] for text that must read
-    /// as muted on the legacy Windows console: conhost and winpty do not
-    /// implement SGR 2 and render it as the default foreground.
+    /// SGR 90. Unlike [`DIM`], conhost and winpty render it.
     pub const GRAY: &str = "\x1b[90m";
     pub const BRIGHT_WHITE: &str = "\x1b[97m";
     pub(crate) const BG_RED: &str = "\x1b[41m";

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1305,14 +1305,14 @@ impl<'a> Repl<'a> {
     fn get_prompt(&self) -> &'static [u8] {
         if self.input_mode != InputMode::Normal {
             if self.use_colors {
-                return concat!("\x1b[2m", "... ", "\x1b[0m").as_bytes();
+                return concat!("\x1b[90m", "... ", "\x1b[0m").as_bytes();
             } else {
                 return b"... ";
             }
         }
 
         if self.use_colors {
-            concat!("\x1b[2m", "\u{276f}", "\x1b[0m", " ").as_bytes()
+            concat!("\x1b[90m", "\u{276f}", "\x1b[0m", " ").as_bytes()
         } else {
             b"> "
         }
@@ -1376,7 +1376,7 @@ impl<'a> Repl<'a> {
 
         let ghost = self.drawn_suggestion();
         if !ghost.is_empty() {
-            self.write(Color::DIM.as_bytes());
+            self.write(Color::GRAY.as_bytes());
             self.write(ghost);
             self.write(Color::RESET.as_bytes());
         }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -742,7 +742,7 @@ fn cmd_load(repl: &mut Repl, args: &[u8]) -> ReplResult {
 
     repl.print(format_args!(
         "{}Loading {}...{}\n",
-        Color::DIM,
+        Color::GRAY,
         BStr::new(filename),
         Color::RESET
     ));
@@ -798,7 +798,7 @@ fn cmd_editor(repl: &mut Repl, _: &[u8]) -> ReplResult {
     }
     repl.print(format_args!(
         "{}// Entering editor mode (Ctrl+D to finish, Ctrl+C to cancel){}\n",
-        Color::DIM,
+        Color::GRAY,
         Color::RESET
     ));
     repl.input_mode = InputMode::Editor;
@@ -829,7 +829,7 @@ fn cmd_history(repl: &mut Repl, _: &[u8]) -> ReplResult {
         let i = i + start;
         repl.print(format_args!(
             "  {}{:>4}{}  {}\n",
-            Color::DIM,
+            Color::GRAY,
             i + 1,
             Color::RESET,
             BStr::new(entry)
@@ -1728,7 +1728,7 @@ impl<'a> Repl<'a> {
 
         if actual_result.is_undefined() {
             if self.use_colors {
-                self.print(format_args!("{}undefined{}\n", Color::DIM, Color::RESET));
+                self.print(format_args!("{}undefined{}\n", Color::GRAY, Color::RESET));
             } else {
                 self.print(format_args!("undefined\n"));
             }
@@ -1762,7 +1762,7 @@ impl<'a> Repl<'a> {
         if strings::trim(code, b" \t\n\r").is_empty() {
             if print_result {
                 if self.use_colors {
-                    self.print(format_args!("{}undefined{}\n", Color::DIM, Color::RESET));
+                    self.print(format_args!("{}undefined{}\n", Color::GRAY, Color::RESET));
                 } else {
                     self.print(format_args!("undefined\n"));
                 }
@@ -1863,7 +1863,7 @@ impl<'a> Repl<'a> {
         if print_result {
             if actual_result.is_undefined() {
                 if self.use_colors {
-                    self.print(format_args!("{}undefined{}\n", Color::DIM, Color::RESET));
+                    self.print(format_args!("{}undefined{}\n", Color::GRAY, Color::RESET));
                 } else {
                     self.print(format_args!("undefined\n"));
                 }
@@ -1907,7 +1907,7 @@ impl<'a> Repl<'a> {
         if !result.is_undefined() {
             self.print_formatted_value(result);
         } else if self.use_colors {
-            self.print(format_args!("{}undefined{}\n", Color::DIM, Color::RESET));
+            self.print(format_args!("{}undefined{}\n", Color::GRAY, Color::RESET));
         } else {
             self.print(format_args!("undefined\n"));
         }
@@ -2070,7 +2070,7 @@ impl<'a> Repl<'a> {
         if self.use_colors {
             self.print(format_args!(
                 "{}Copied {} characters to clipboard{}\n",
-                Color::DIM,
+                Color::GRAY,
                 text.len(),
                 Color::RESET
             ));
@@ -2625,7 +2625,7 @@ impl<'a> Repl<'a> {
             InputMode::Editor => {
                 self.print(format_args!(
                     "{}// Editor mode cancelled{}\n",
-                    Color::DIM,
+                    Color::GRAY,
                     Color::RESET
                 ));
                 self.input_mode = InputMode::Normal;
@@ -2647,7 +2647,7 @@ impl<'a> Repl<'a> {
                 self.ctrl_c_pressed = true;
                 self.print(format_args!(
                     "{}(press Ctrl+C again to exit, or Ctrl+D){}\n",
-                    Color::DIM,
+                    Color::GRAY,
                     Color::RESET
                 ));
             }
@@ -2827,7 +2827,7 @@ impl<'a> Repl<'a> {
             self.leave_input(b"");
             self.print(format_args!(
                 "{}{} completions{}\n",
-                Color::DIM,
+                Color::GRAY,
                 len,
                 Color::RESET
             ));

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1158,8 +1158,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           // like `constructor` on the prototype chain, but the REPL picks the
           // shortest match.
           send("cons");
-          const output = await waitFor(`${GRAY}ole`);
-          expect(output).not.toContain("\x1b[2mole");
+          await waitFor(`${GRAY}ole`);
         },
         { env: colorEnv },
       );

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1143,9 +1143,12 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
   });
 
   describe("inline suggestions", () => {
-    // Ghost text is rendered as: ESC[2m<remainder>ESC[0m after the typed text.
+    // Ghost text is rendered as: ESC[90m<remainder>ESC[0m after the typed text.
+    // SGR 90 (gray) rather than SGR 2 (dim): the legacy Windows console
+    // (conhost, winpty) does not implement SGR 2, so dim text renders in the
+    // default foreground there. Node uses SGR 90 for its preview too (#41287).
     // The feature requires colors, so override bunEnv's NO_COLOR for these.
-    const DIM = "\x1b[2m";
+    const GRAY = "\x1b[90m";
     const colorEnv = { NO_COLOR: undefined, FORCE_COLOR: "1" };
 
     test("suggests global completion while typing", async () => {
@@ -1155,7 +1158,8 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           // like `constructor` on the prototype chain, but the REPL picks the
           // shortest match.
           send("cons");
-          await waitFor(`${DIM}ole`);
+          const output = await waitFor(`${GRAY}ole`);
+          expect(output).not.toContain("\x1b[2mole");
         },
         { env: colorEnv },
       );
@@ -1165,7 +1169,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {
           send("JSO");
-          await waitFor(`${DIM}N`);
+          await waitFor(`${GRAY}N`);
           send("\x1b[C"); // Right arrow accepts the ghost text
           // After acceptance the input is `JSON`; extend it and evaluate.
           // The result "81" never appears in the echoed input, so this only
@@ -1183,11 +1187,11 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
         async ({ send, waitFor }) => {
           // Build up `console.` by accepting the global suggestion first.
           send("cons");
-          await waitFor(`${DIM}ole`);
+          await waitFor(`${GRAY}ole`);
           send("\x1b[C"); // accept -> "console"
           send(".l");
           // console.l -> "log" is the shortest property starting with "l"
-          await waitFor(`${DIM}og`);
+          await waitFor(`${GRAY}og`);
         },
         { env: colorEnv },
       );
@@ -1197,7 +1201,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {
           send("JSON.str");
-          await waitFor(`${DIM}ingify`, 10000);
+          await waitFor(`${GRAY}ingify`, 10000);
           send("\t"); // Tab accepts the ghost suggestion -> `JSON.stringify`
           // Result "81" cannot occur in the echoed input, so it only matches
           // if Tab really completed to `stringify` and the call succeeded.
@@ -1212,7 +1216,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {
           send("Mat");
-          await waitFor(`${DIM}h`);
+          await waitFor(`${GRAY}h`);
           send("\x1b[F"); // End accepts the suggestion -> "Math"
           // Result 63 cannot occur in the echoed input; if End didn't accept,
           // `Mat.max(...)` would throw instead of producing it.
@@ -1231,7 +1235,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           send("globalThis.__sgObj = Object.create(null); __sgObj.onlyProp = 1\n");
           await waitFor("1");
           send("__sgObj.");
-          await waitFor(`${DIM}onlyProp`);
+          await waitFor(`${GRAY}onlyProp`);
         },
         { env: colorEnv },
       );
@@ -1242,7 +1246,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
         async ({ send, waitFor }) => {
           // No global starts with "instan", but the keyword `instanceof` does.
           send("x instan");
-          await waitFor(`${DIM}ceof`);
+          await waitFor(`${GRAY}ceof`);
         },
         { env: colorEnv },
       );
@@ -1274,14 +1278,14 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           );
           await waitFor("uReady");
           send("__u.caf");
-          await waitFor(`${DIM}és`);
+          await waitFor(`${GRAY}és`);
           // The typed prefix itself may contain non-ASCII characters.
           send("é");
-          await waitFor(`${DIM}s`);
+          await waitFor(`${GRAY}s`);
           // So may the object being completed: the chain segment is looked up as
           // UTF-8, not byte-per-character.
           send("\x15café.");
-          await waitFor(`${DIM}latte`);
+          await waitFor(`${GRAY}latte`);
         },
         { env: colorEnv },
       );
@@ -1295,7 +1299,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           send('globalThis.__plain = {}; "plain" + "Ready"\n');
           await waitFor("plainReady");
           send("__plain.constructor.getOwnPropertyNa");
-          await waitFor(`${DIM}mes`);
+          await waitFor(`${GRAY}mes`);
         },
         { env: colorEnv },
       );
@@ -1307,7 +1311,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           // `process.version` is a string and `.length` a number; both get boxed
           // the way a real property access would, ending on Number.prototype.
           send("process.version.length.toF");
-          await waitFor(`${DIM}ixed`);
+          await waitFor(`${GRAY}ixed`);
         },
         { env: colorEnv },
       );
@@ -1317,10 +1321,10 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {
           send("[...cons");
-          await waitFor(`${DIM}ole`);
+          await waitFor(`${GRAY}ole`);
           // Nor do they swallow the chain that follows them.
           send("\x15[...console.l");
-          await waitFor(`${DIM}og`);
+          await waitFor(`${GRAY}og`);
         },
         { env: colorEnv },
       );
@@ -1330,7 +1334,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {
           send("this.cons");
-          await waitFor(`${DIM}ole`);
+          await waitFor(`${GRAY}ole`);
         },
         { env: colorEnv },
       );
@@ -1361,7 +1365,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
       await withTerminalRepl(
         async ({ send, waitFor }) => {
           send("`${JSO");
-          await waitFor(`${DIM}N`);
+          await waitFor(`${GRAY}N`);
           // Back in template text after the `}`: "st" must get no ghost, or the
           // right arrow would accept it. `${JSON}` stringifies to the 13-char
           // "[object JSON]", plus " st", so the length is 16.
@@ -1428,7 +1432,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           // Typing the `.` computes completions for `__big` with an empty
           // prefix; the named properties must still complete afterwards.
           send("__big.byteLen");
-          await waitFor(`${DIM}gth`);
+          await waitFor(`${GRAY}gth`);
           send("\t\n");
           await waitFor("67108864");
         },
@@ -1459,7 +1463,7 @@ describe.todoIf(isWindows).concurrent("Bun REPL (Terminal)", () => {
           await waitFor("1");
           // Type a prefix that triggers a suggestion but don't accept it.
           send("zz");
-          await waitFor(`${DIM}GhostMarker`);
+          await waitFor(`${GRAY}GhostMarker`);
           // Hit Enter without accepting: the ghost text must not be part of
           // the evaluated input, so `zz` alone is a ReferenceError.
           send("\n");


### PR DESCRIPTION
### Problem
- In `bun repl` on the legacy Windows console (cmd.exe under conhost) and in Git Bash (mintty via winpty), the inline suggestion has the same color as the typed text. Windows Terminal renders it dimmed.
- The repl wraps the ghost text in SGR 2 (`\x1b[2m`, dim) at `src/runtime/cli/repl.rs:1379`. Conhost and winpty do not implement SGR 2 and draw the text in the default foreground. Microsoft's console VT sequence table lists 0, 1, 22, 4, 24, 7, 27, 30-37, 38, 39, 40-47, 48, 49, 90-97, and 100-107, but not 2.

### Fix
- Wrap the ghost text in SGR 90 (`\x1b[90m`, bright black) instead. Node's repl preview uses the same sequence (`lib/internal/repl/utils.js`), so it reads as gray in every terminal that Node supports.
- The `❯` and `... ` prompts used SGR 2 too. They now use SGR 90 for the same reason.
- Add `ansi::GRAY` to `src/bun_output_tags/lib.rs` for the constant.
- Verified: `test/js/bun/repl/repl.test.ts` (the "inline suggestions" block asserts the new sequence and that SGR 2 is not used, 15 tests fail on the released bun). The whole file passes with the debug build (127 tests).

### Background
- The repl draws the rest of the best completion after the cursor as "ghost text". The user accepts it with the right arrow or tab. Only the color separates it from the input.
- SGR (Select Graphic Rendition) is the `ESC [ n m` family of escape sequences. SGR 2 sets the faint attribute. SGR 90 sets the foreground to bright black, which most palettes draw as gray.
- `use_colors` in `repl.rs` gates all of this. With `NO_COLOR` set, the repl draws no ghost text at all, so the non-color path does not change.

Fixes #41287

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->