### PR TITLE
fix(pack): Now dedups paths in package.json bin field

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -405,9 +405,16 @@ impl PartialEq for PackQueueItem {
 #[derive(Default)]
 pub(crate) struct PackQueue {
     heap: std::collections::BinaryHeap<PackQueueItem>,
+    /// An invariant to make [`PackQueue::add`] idempotent per path
+    /// and ensure tarballs don't have duplicate files.
+    seen: StringHashMap<()>,
 }
 impl PackQueue {
     fn add(&mut self, item: PackQueueItem) -> Result<(), AllocError> {
+        let entry = self.seen.get_or_put(item.path.as_bytes())?;
+        if entry.found_existing {
+            return Ok(());
+        }
         self.heap.push(item);
         Ok(())
     }

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2062,42 +2062,36 @@ describe.concurrent("bins", () => {
   });
 
   test("deduplicates when multiple bin names point at the same file", async () => {
-    await Promise.all([
-      write(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "pack-bins-dedupe",
-          version: "1.2.3",
-          type: "module",
-          files: ["dist/minified/index.mjs", "dist/other.js"],
-          bin: {
-            pbd: "dist/minified/index.mjs",
-            "pack-bins-dedupe": "dist/minified/index.mjs",
-          },
-        }),
-      ),
-      write(join(packageDir, "dist", "minified", "index.mjs"), "#!/usr/bin/env bun\n"),
-      write(join(packageDir, "dist", "other.js"), "console.log('other')"),
-    ]);
+    using dir = tempDir("pack-bins-dedupe", {
+      "package.json": JSON.stringify({
+        name: "pack-bins-dedupe",
+        version: "1.2.3",
+        type: "module",
+        files: ["dist/minified/index.mjs", "dist/other.js"],
+        bin: {
+          pbd: "dist/minified/index.mjs",
+          "pack-bins-dedupe": "dist/minified/index.mjs",
+        },
+      }),
+      "dist/minified/index.mjs": "#!/usr/bin/env bun\n",
+      "dist/other.js": "console.log('other')",
+    });
 
-    const { out } = await pack(packageDir, bunEnv, "--dry-run");
+    const dryRun = await runPack(dir, ["--dry-run"]);
+    expect(dryRun.err).toBe("");
+    expect(dryRun.out.match(/dist\/minified\/index\.mjs/g)).toHaveLength(1);
+    expect(dryRun.out).toContain("Total files: 3");
+    expect(dryRun.exitCode).toBe(0);
 
-    expect(out.match(/dist\/minified\/index\.mjs/g)).toHaveLength(1);
-    expect(out).toContain("files: 3");
+    const { err, exitCode } = await runPack(dir);
+    expect(err).toBe("");
+    expect(exitCode).toBe(0);
 
-    await pack(packageDir, bunEnv);
-
-    const tarball = readTarball(join(packageDir, "pack-bins-dedupe-1.2.3.tgz"));
-    expect(tarball.entries).toMatchObject([
-      {
-        pathname: "package/package.json",
-      },
-      {
-        pathname: "package/dist/minified/index.mjs",
-      },
-      {
-        pathname: "package/dist/other.js",
-      },
+    const tarball = readTarball(join(dir, "pack-bins-dedupe-1.2.3.tgz"));
+    expect(entryNames(tarball)).toEqual([
+      "package/package.json",
+      "package/dist/minified/index.mjs",
+      "package/dist/other.js",
     ]);
     // the bin entry keeps its executable bit
     expect(tarball.entries[1].perm & 0o111).toBe(0o111);

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2060,6 +2060,48 @@ describe.concurrent("bins", () => {
       "package/dist/hi.js",
     ]);
   });
+
+  test("deduplicates when multiple bin names point at the same file", async () => {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "pack-bins-dedupe",
+          version: "1.2.3",
+          type: "module",
+          files: ["dist/minified/index.mjs", "dist/other.js"],
+          bin: {
+            pbd: "dist/minified/index.mjs",
+            "pack-bins-dedupe": "dist/minified/index.mjs",
+          },
+        }),
+      ),
+      write(join(packageDir, "dist", "minified", "index.mjs"), "#!/usr/bin/env bun\n"),
+      write(join(packageDir, "dist", "other.js"), "console.log('other')"),
+    ]);
+
+    const { out } = await pack(packageDir, bunEnv, "--dry-run");
+
+    expect(out.match(/dist\/minified\/index\.mjs/g)).toHaveLength(1);
+    expect(out).toContain("files: 3");
+
+    await pack(packageDir, bunEnv);
+
+    const tarball = readTarball(join(packageDir, "pack-bins-dedupe-1.2.3.tgz"));
+    expect(tarball.entries).toMatchObject([
+      {
+        pathname: "package/package.json",
+      },
+      {
+        pathname: "package/dist/minified/index.mjs",
+      },
+      {
+        pathname: "package/dist/other.js",
+      },
+    ]);
+    // the bin entry keeps its executable bit
+    expect(tarball.entries[1].perm & 0o111).toBe(0o111);
+  });
 });
 
 test.concurrent("unicode", async () => {


### PR DESCRIPTION
### What does this PR do?

It dedups files during the pack operation.

The use case that wasn't handled before is when the same binary file can have many links pointing to it. Like one binary alias is full and human-readable, and the other is a short alias to access the same binary.

### How did you verify your code works?

- built local version
- wrote and ran tests
- packaged my `ali-token-summary` with the newly built bun and confirmed npm reports a smaller size

<details>
<summary><strong>Before</strong>: <code>bun pm pack --dry-run</code></summary>

```
bun pack v1.3.14 (0d9b296a)

packed 1.0KB package.json
packed 8.19KB README.md
packed 247.73KB dist/minified/index.mjs
packed 247.73KB dist/minified/index.mjs

ali-token-summary-0.1.4.tgz

Total files: 4
Shasum: f7166e56b063baf954f085e7594a96318b24f060
Integrity: sha512-PddeIzG52zmML[...]fiPrQerJa5djg==
Unpacked size: 0.50MB
Packed size: 164.59KB
```

</details>

<details>
<summary><strong>After</strong>: <code>/home/evadev/projects/bun/build/debug/bun-debug pm pack --dry-run</code></summary>


```
bun pack v1.3.14 (b3679c6af)
[loop] inc 2 + 1 = 3
[cachefs] openat(16[/home/evadev/projects/ali-token-summary], /home/evadev/projects/ali-token-summary/package.json) = 17[/home/evadev/projects/ali-token-summary/package.json]
[sys] close(17[/home/evadev/projects/ali-token-summary/package.json])
[cachefs] openat(16[/home/evadev/projects/ali-token-summary], /home/evadev/projects/ali-token-summary/tsconfig.json) = 17[/home/evadev/projects/ali-token-summary/tsconfig.json]
[sys] close(17[/home/evadev/projects/ali-token-summary/tsconfig.json])

packed 1.0KB package.json
packed 8.19KB README.md
packed 247.73KB dist/minified/index.mjs

ali-token-summary-0.1.4.tgz

Total files: 3
Shasum: b366115f9024a9f686f6b28830bc023fc93590ee
Integrity: sha512-CaytQG2xYs1g3[...]DdbGdtgYhMXdw==
Unpacked size: 256.94KB
Packed size: 84.28KB
```

</details>

```
$ curl -s https://registry.npmjs.org/ali-token-summary | fx 'Object.fromEntries(Object.entries(this.versions).map(([v, d]) => [v, d.dist.unpackedSize]))'
{
  "0.1.0": 507082,
  "0.1.1": 507058,
  "0.1.2": 507008,
  "0.1.3": 504675,
  "0.1.4": 256944
}
```
