### PR TITLE
publish: add --recursive and --filter for workspace packages

### DIFF
--- a/docs/pm/cli/publish.mdx
+++ b/docs/pm/cli/publish.mdx
@@ -99,7 +99,7 @@ bun publish --tolerate-republish
 
 ### `--recursive`
 
-In a workspace, `--recursive` (`-r`) publishes every workspace package. Packages are published in dependency order: a package comes after the workspace packages it depends on. `workspace:` and `catalog:` versions are rewritten in each published `package.json`, as with a single `bun publish`.
+In a workspace, `--recursive` (`-r`) publishes every workspace package. The run has two phases. First every package is packed, with its `prepublishOnly`, `prepack` and `prepare` scripts. If one pack fails, nothing is published. Then the tarballs are published in dependency order: a package comes after the workspace packages it depends on. `workspace:` and `catalog:` versions are rewritten in each published `package.json`, as with a single `bun publish`.
 
 ```sh terminal icon="terminal"
 bun publish --recursive
@@ -110,7 +110,7 @@ Some packages are skipped:
 - A package with `"private": true` in its `package.json`.
 - A package whose `name@version` is already on the registry. This makes a re-run after a partial failure safe.
 
-If the registry rejects a package, `bun publish` reports the error, continues with the next package, and exits with code 1 at the end. `--dry-run`, `--tag`, `--access` and `--otp` apply to every package in the run. A `publishConfig` in a package's `package.json` applies to that package only. `--recursive` reads the workspace from `bun.lock`, so run `bun install` first.
+If the registry rejects a package, or its `publish` or `postpublish` script fails, `bun publish` reports the error, continues with the next package, and exits with code 1 at the end. `--dry-run`, `--tag`, `--access` and `--otp` apply to every package in the run. A `publishConfig` in a package's `package.json` applies to that package only. `--recursive` reads the workspace from `bun.lock`, so run `bun install` first.
 
 ### `--filter`
 

--- a/docs/pm/cli/publish.mdx
+++ b/docs/pm/cli/publish.mdx
@@ -97,6 +97,30 @@ Exit with code 0 instead of 1 if the package version already exists. Useful in C
 bun publish --tolerate-republish
 ```
 
+### `--recursive`
+
+In a workspace, `--recursive` (`-r`) publishes every workspace package. Packages are published in dependency order: a package comes after the workspace packages it depends on. `workspace:` and `catalog:` versions are rewritten in each published `package.json`, as with a single `bun publish`.
+
+```sh terminal icon="terminal"
+bun publish --recursive
+```
+
+Some packages are skipped:
+
+- A package with `"private": true` in its `package.json`.
+- A package whose `name@version` is already on the registry. This makes a re-run after a partial failure safe.
+
+If the registry rejects a package, `bun publish` reports the error, continues with the next package, and exits with code 1 at the end. `--dry-run`, `--tag`, `--access` and `--otp` apply to every package in the run. A `publishConfig` in a package's `package.json` applies to that package only. `--recursive` reads the workspace from `bun.lock`, so run `bun install` first.
+
+### `--filter`
+
+Publish only the workspace packages that match a pattern. `--filter` accepts the same patterns as `bun install --filter`: a package name glob, a path glob starting with `./`, or a negation starting with `!`. It can be repeated. Packages are published in dependency order, and the skip rules of `--recursive` apply.
+
+```sh terminal icon="terminal"
+bun publish --filter '@scope/*'
+bun publish --filter ./packages/core --filter ./packages/cli
+```
+
 ### `--gzip-level`
 
 Set the gzip compression level used when packing the package, from `0` to `9` (default `9`). Only applies to `bun publish` without a tarball path argument.

--- a/docs/snippets/cli/publish.mdx
+++ b/docs/snippets/cli/publish.mdx
@@ -58,9 +58,9 @@ bun publish --dry-run
 </ParamField>
 
 <ParamField path="-r, --recursive" type="boolean">
-  Publish every workspace package, dependencies first. A private package and a version that is already on the registry
-  are skipped. A rejected package is reported and the run continues, then `bun publish` exits with code 1. Needs a
-  `bun.lock`.
+  Pack every workspace package, then publish them dependencies first. A private package and a version that is already
+  on the registry are skipped. If one pack fails, nothing is published. A rejected package is reported and the run
+  continues, then `bun publish` exits with code 1. Needs a `bun.lock`.
 
 ```sh terminal icon="terminal"
 bun publish --recursive

--- a/docs/snippets/cli/publish.mdx
+++ b/docs/snippets/cli/publish.mdx
@@ -57,6 +57,27 @@ bun publish --dry-run
   `bun publish` exits with code 0 instead of 1 when the version being published already exists in the registry.
 </ParamField>
 
+<ParamField path="-r, --recursive" type="boolean">
+  Publish every workspace package, dependencies first. A private package and a version that is already on the registry
+  are skipped. A rejected package is reported and the run continues, then `bun publish` exits with code 1. Needs a
+  `bun.lock`.
+
+```sh terminal icon="terminal"
+bun publish --recursive
+```
+
+</ParamField>
+
+<ParamField path="-F, --filter" type="string">
+  Publish only the workspace packages that match the pattern (a name glob, a `./path` glob, or a `!` negation). Can be
+  repeated. Uses the same order and skip rules as `--recursive`.
+
+```sh terminal icon="terminal"
+bun publish --filter '@scope/*'
+```
+
+</ParamField>
+
 <ParamField path="--gzip-level" type="string" default="9">
   Specify the level of gzip compression to use when packing the package. Only applies to `bun publish` without a tarball
   path argument. Values range from `0` to `9` (default is `9`).

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -536,6 +536,7 @@ impl Subcommand {
                 | Self::Remove
                 | Self::Prune
                 | Self::Pm
+                | Self::Publish
         )
     }
 

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -409,6 +409,12 @@ static PUBLISH_PARAMS: &[ParamType] = concat_params![
         clap::param!(
             "--tolerate-republish                   Don't exit with code 1 when republishing over an existing version number"
         ),
+        clap::param!(
+            "-F, --filter <STR>...                  Publish each matching workspace package"
+        ),
+        clap::param!(
+            "-r, --recursive                        Publish every workspace package whose version is not on the registry"
+        ),
     ]
 ];
 
@@ -1069,6 +1075,12 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/pm#pack<r>.
   <d>Publish without failing when republishing over an existing version.<r>
   <b><green>bun publish<r> <cyan>--tolerate-republish<r>
 
+  <d>Publish every workspace package that is not on the registry yet, dependencies first.<r>
+  <b><green>bun publish<r> <cyan>--recursive<r>
+
+  <d>Publish only the matching workspace packages.<r>
+  <b><green>bun publish<r> <cyan>--filter '@scope/*'<r>
+
 Full documentation is available at <magenta>https://bun.com/docs/cli/publish<r>.
 ";
 
@@ -1415,6 +1427,10 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.dry_run = true;
             cli.recursive = args.flag(b"--recursive");
             // cli.json_output = args.flag(b"--json");
+        }
+
+        if subcommand == Subcommand::Publish {
+            cli.recursive = args.flag(b"--recursive");
         }
 
         if subcommand == Subcommand::Dedupe && args.flag(b"--check") {

--- a/src/install/PackageManager/workspace_selection.rs
+++ b/src/install/PackageManager/workspace_selection.rs
@@ -351,9 +351,7 @@ impl WorkspaceGraph {
         graph
     }
 
-    /// Candidate indices with every candidate after the candidates it depends on. A dependency
-    /// cycle is broken at one of its members. A candidate that depends on the cycle still comes
-    /// after every member of it.
+    /// Candidate indices, each after the candidates it depends on. A cycle is broken at one of its members.
     pub fn dependency_order(&self) -> Vec<u32> {
         let n = self.dependencies.len();
         let mut remaining: Vec<usize> = self.dependencies.iter().map(Vec::len).collect();
@@ -384,9 +382,7 @@ impl WorkspaceGraph {
             if order.len() == n {
                 return order;
             }
-            // Every candidate left waits on another one that is left. Follow those edges from
-            // the first of them: the walk has to revisit a candidate, and that one is on a cycle.
-            // Release it. A candidate that only depends on the cycle stays behind it.
+            // Stalled on a cycle. Follow unmet edges until one repeats: that candidate is on it.
             let mut on_walk = bitset(n);
             let mut cur = (0..n)
                 .find(|&i| !queued.is_set(i))

--- a/src/install/PackageManager/workspace_selection.rs
+++ b/src/install/PackageManager/workspace_selection.rs
@@ -351,8 +351,9 @@ impl WorkspaceGraph {
         graph
     }
 
-    /// Candidate indices with every candidate after the candidates it depends on. Members of a
-    /// dependency cycle keep their input order, after everything they depend on outside the cycle.
+    /// Candidate indices with every candidate after the candidates it depends on. A dependency
+    /// cycle is broken at one of its members. A candidate that depends on the cycle still comes
+    /// after every member of it.
     pub fn dependency_order(&self) -> Vec<u32> {
         let n = self.dependencies.len();
         let mut remaining: Vec<usize> = self.dependencies.iter().map(Vec::len).collect();
@@ -383,12 +384,23 @@ impl WorkspaceGraph {
             if order.len() == n {
                 return order;
             }
-            // Every candidate left is in a cycle. Release the first one and keep going.
-            let stuck = (0..n)
+            // Every candidate left waits on another one that is left. Follow those edges from
+            // the first of them: the walk has to revisit a candidate, and that one is on a cycle.
+            // Release it. A candidate that only depends on the cycle stays behind it.
+            let mut on_walk = bitset(n);
+            let mut cur = (0..n)
                 .find(|&i| !queued.is_set(i))
                 .expect("order.len() < n");
-            queued.set(stuck);
-            queue.push_back(stuck as u32);
+            while !on_walk.is_set(cur) {
+                on_walk.set(cur);
+                cur = self.dependencies[cur]
+                    .iter()
+                    .map(|&d| d as usize)
+                    .find(|&d| !queued.is_set(d))
+                    .expect("remaining[cur] > 0");
+            }
+            queued.set(cur);
+            queue.push_back(cur as u32);
         }
     }
 

--- a/src/install/PackageManager/workspace_selection.rs
+++ b/src/install/PackageManager/workspace_selection.rs
@@ -351,6 +351,47 @@ impl WorkspaceGraph {
         graph
     }
 
+    /// Candidate indices with every candidate after the candidates it depends on. Members of a
+    /// dependency cycle keep their input order, after everything they depend on outside the cycle.
+    pub fn dependency_order(&self) -> Vec<u32> {
+        let n = self.dependencies.len();
+        let mut remaining: Vec<usize> = self.dependencies.iter().map(Vec::len).collect();
+        let mut order: Vec<u32> = Vec::with_capacity(n);
+        let mut queued = bitset(n);
+        let mut queue: VecDeque<u32> = VecDeque::new();
+        for i in 0..n {
+            if remaining[i] == 0 {
+                queued.set(i);
+                queue.push_back(i as u32);
+            }
+        }
+
+        loop {
+            while let Some(u) = queue.pop_front() {
+                order.push(u);
+                for &v in &self.dependents[u as usize] {
+                    if queued.is_set(v as usize) {
+                        continue;
+                    }
+                    remaining[v as usize] -= 1;
+                    if remaining[v as usize] == 0 {
+                        queued.set(v as usize);
+                        queue.push_back(v);
+                    }
+                }
+            }
+            if order.len() == n {
+                return order;
+            }
+            // Every candidate left is in a cycle. Release the first one and keep going.
+            let stuck = (0..n)
+                .find(|&i| !queued.is_set(i))
+                .expect("order.len() < n");
+            queued.set(stuck);
+            queue.push_back(stuck as u32);
+        }
+    }
+
     pub fn from_dependency_names<D, I>(names: &[&[u8]], mut dependency_names: D) -> WorkspaceGraph
     where
         D: FnMut(usize) -> I,
@@ -463,6 +504,24 @@ pub fn select_lockfile_workspaces(
         ids,
         unmatched_patterns,
     }
+}
+
+/// `ids` (root and workspace packages) reordered so each one comes after the selected workspaces it depends on.
+pub fn order_lockfile_workspaces(lockfile: &Lockfile, ids: &[PackageID]) -> Vec<PackageID> {
+    let pkg_resolutions = lockfile.packages.items_resolution();
+    let name_hashes = lockfile.packages.items_name_hash();
+    let hashes: Vec<Option<PackageNameHash>> = ids
+        .iter()
+        .map(|&pkg_id| {
+            (pkg_resolutions[pkg_id as usize].tag != ResolutionTag::Root)
+                .then(|| name_hashes[pkg_id as usize])
+        })
+        .collect();
+    WorkspaceGraph::from_lockfile(lockfile, &hashes)
+        .dependency_order()
+        .into_iter()
+        .map(|i| ids[i as usize])
+        .collect()
 }
 
 pub fn quote_patterns(patterns: &[&[u8]]) -> Vec<u8> {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -273,16 +273,15 @@ pub fn print_response_error<const OTP_RESPONSE: bool>(
             bstr::BStr::new(package_version),
         );
     } else if let Some(msg) = &message {
-        if OTP_RESPONSE {
-            if res.status_code() == 401
-                && strings::contains(
-                    msg,
-                    b"You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.",
-                )
-            {
-                bun_core::pretty_errorln!("\n - Received invalid OTP");
-                Global::crash();
-            }
+        if OTP_RESPONSE
+            && res.status_code() == 401
+            && strings::contains(
+                msg,
+                b"You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.",
+            )
+        {
+            bun_core::pretty_errorln!("\n - Received invalid OTP");
+            return Ok(());
         }
         bun_core::pretty_errorln!("\n - {}", bstr::BStr::new(msg));
     }

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -222,6 +222,18 @@ pub fn response_error<const OTP_RESPONSE: bool>(
     pkg_id: Option<(&[u8], &[u8])>,
     response_body: &mut MutableString,
 ) -> Result<core::convert::Infallible, AllocError> {
+    print_response_error::<OTP_RESPONSE>(req, res, pkg_id, response_body)?;
+    Global::crash();
+}
+
+/// The error report of `response_error` without the exit, for a caller that has more work to do.
+pub fn print_response_error<const OTP_RESPONSE: bool>(
+    req: &AsyncHTTP,
+    res: &bun_http::HTTPResponseMetadata,
+    // `<name>@<version>`
+    pkg_id: Option<(&[u8], &[u8])>,
+    response_body: &mut MutableString,
+) -> Result<(), AllocError> {
     let message: Option<Vec<u8>> = 'message: {
         let mut log = bun_ast::Log::init();
         let source = bun_ast::Source::init_path_string("???", response_body.list.as_slice());
@@ -275,7 +287,7 @@ pub fn response_error<const OTP_RESPONSE: bool>(
         bun_core::pretty_errorln!("\n - {}", bstr::BStr::new(msg));
     }
 
-    Global::crash();
+    Ok(())
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2042,6 +2042,14 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     };
 
     if FOR_PUBLISH {
+        if let Some(private) = json.root.get(b"private") {
+            if let Some(is_private) = private.as_bool() {
+                if is_private {
+                    return Err(PackError::PrivatePackage);
+                }
+            }
+        }
+
         if let Some(config) = json.root.get(b"publishConfig") {
             if ctx.manager.options.publish_config.tag.is_empty() {
                 if let Some(tag) = config.get_string_cloned(bump, b"tag")? {
@@ -2097,16 +2105,6 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         .ok_or(PackError::InvalidPackageVersion)?;
     if package_version.is_empty() || has_unsafe_tarball_filename_part(package_version) {
         return Err(PackError::InvalidPackageVersion);
-    }
-
-    if FOR_PUBLISH {
-        if let Some(private) = json.root.get(b"private") {
-            if let Some(is_private) = private.as_bool() {
-                if is_private {
-                    return Err(PackError::PrivatePackage);
-                }
-            }
-        }
     }
 
     // Note: `Transpiler` has no `Default`;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2976,8 +2976,10 @@ fn run_lifecycle_script<const FOR_PUBLISH: bool>(
         use_system_shell,
         None,
     ) {
-        Ok(0) => Ok(()),
-        Ok(code) => Err(PackError::ScriptFailed(code)),
+        Ok(status) => match status.exit_code() {
+            0 => Ok(()),
+            code => Err(PackError::ScriptFailed(code)),
+        },
         Err(err) => {
             if matches!(err, crate::Error::MissingShell) {
                 Output::err_generic(

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2875,6 +2875,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         let mut root_full = json.root;
         Some(Publish::PublishCommand::normalized_package(
             ctx.manager,
+            abs_workspace_path,
             package_name,
             package_version,
             &mut root_full,

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -295,6 +295,7 @@ impl PackCommand {
                     );
                     Global::crash();
                 }
+                PackError::ScriptFailed(code) => Global::exit(code),
                 // for_publish-only variants — unreachable when FOR_PUBLISH=false.
                 PackError::RestrictedUnscopedPackage | PackError::PrivatePackage => unreachable!(),
             }
@@ -326,6 +327,9 @@ pub enum PackError<const FOR_PUBLISH: bool> {
     RestrictedUnscopedPackage,
     #[error("PrivatePackage")]
     PrivatePackage,
+    /// A lifecycle script exited with this non-zero code. The error line is already printed.
+    #[error("ScriptFailed")]
+    ScriptFailed(u32),
 }
 
 impl<const FOR_PUBLISH: bool> From<AllocError> for PackError<FOR_PUBLISH> {
@@ -2961,7 +2965,7 @@ fn run_lifecycle_script<const FOR_PUBLISH: bool>(
     silent: bool,
 ) -> Result<(), PackError<FOR_PUBLISH>> {
     let use_system_shell = command_ctx.debug.use_system_shell;
-    match RunCommand::run_package_script_foreground(
+    match RunCommand::run_package_script_foreground_status(
         command_ctx,
         script,
         name,
@@ -2970,8 +2974,10 @@ fn run_lifecycle_script<const FOR_PUBLISH: bool>(
         &[],
         silent,
         use_system_shell,
+        None,
     ) {
-        Ok(_) => Ok(()),
+        Ok(0) => Ok(()),
+        Ok(code) => Err(PackError::ScriptFailed(code)),
         Err(err) => {
             if matches!(err, crate::Error::MissingShell) {
                 Output::err_generic(

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -552,6 +552,13 @@ impl PublishCommand {
         let manager_ptr: *mut PackageManager = manager;
 
         if cli.positionals.len() > 1 {
+            if Self::is_workspace_publish(manager) {
+                Output::err_generic(
+                    "--recursive and --filter cannot be used with a tarball path",
+                    (),
+                );
+                Global::crash();
+            }
             let context = match Context::<false>::from_tarball_path(
                 ctx,
                 manager,
@@ -631,10 +638,7 @@ impl PublishCommand {
         let context =
             match Context::<true>::from_workspace(ctx, manager, lockfile.as_ref(), &abs_pkg_json) {
                 Ok(c) => c,
-                Err(err) => {
-                    Self::report_pack_error(err);
-                    Global::crash();
-                }
+                Err(err) => Global::exit(Self::report_pack_error(err)),
             };
 
         // TODO: read this into memory
@@ -646,7 +650,10 @@ impl PublishCommand {
             Err(err) => err.report_and_crash(),
         }
 
-        Self::finish_directory_publish(context, &abs_pkg_json)
+        if let Err(err) = Self::finish_directory_publish(context, &abs_pkg_json) {
+            err.report_and_crash();
+        }
+        Ok(())
     }
 
     /// `-r` or `--filter`: the run covers workspace packages, not only the current one.
@@ -654,7 +661,8 @@ impl PublishCommand {
         manager.options.do_.recursive() || !manager.options.filter_patterns.is_empty()
     }
 
-    fn report_pack_error(err: FromWorkspaceError) {
+    /// Prints the error. Returns the exit code a single-package publish ends with.
+    fn report_pack_error(err: FromWorkspaceError) -> u32 {
         use pack::PackError;
         match err {
             PackError::OutOfMemory => bun_core::out_of_memory(),
@@ -676,7 +684,9 @@ impl PublishCommand {
             PackError::PrivatePackage => {
                 Output::err_generic("attempted to publish a private package", ());
             }
+            PackError::ScriptFailed(code) => return code,
         }
+        1
     }
 
     /// `-r` / `--filter`: publish each selected workspace package, dependencies first. Exits 1 at the end if any failed.
@@ -741,6 +751,24 @@ impl PublishCommand {
 
             bun_core::prettyln!("\n<b><magenta>{}<r>", bstr::BStr::new(&member.name));
 
+            // Decide the skips before `pack` runs the pre-publish scripts. An unreadable
+            // package.json falls through: `pack` reports it.
+            if let Some(manifest) = Self::read_manifest(manager, &member.abs_pkg_json) {
+                if manifest.private {
+                    bun_core::prettyln!("<d>skipping private package<r>");
+                    continue;
+                }
+                let version = dependency::without_build_tag(&manifest.version);
+                let registry = manager.scope_for_package_name(&manifest.name);
+                if Self::check_package_version_exists(&manifest.name, version, registry) {
+                    bun_core::warn!(
+                        "Registry already knows about version {}; skipping.",
+                        bstr::BStr::new(version),
+                    );
+                    continue;
+                }
+            }
+
             let context = match Context::<true>::from_workspace(
                 &mut *ctx,
                 &mut *manager,
@@ -770,13 +798,21 @@ impl PublishCommand {
                 Err(err @ (PublishError::OutOfMemory | PublishError::NeedAuth)) => {
                     err.report_and_crash();
                 }
-                Err(PublishError::RequestFailed | PublishError::Rejected) => {
+                Err(
+                    PublishError::RequestFailed
+                    | PublishError::Rejected
+                    | PublishError::ScriptFailed(_),
+                ) => {
                     failed.push(member.name.clone());
                     continue;
                 }
             }
 
-            Self::finish_directory_publish(context, &member.abs_pkg_json)?;
+            match Self::finish_directory_publish(context, &member.abs_pkg_json) {
+                Ok(()) => {}
+                Err(PublishError::ScriptFailed(_)) => failed.push(member.name.clone()),
+                Err(err) => err.report_and_crash(),
+            }
         }
 
         if !failed.is_empty() {
@@ -798,11 +834,44 @@ impl PublishCommand {
         Ok(())
     }
 
+    /// `private`, `name` and `version` of a package.json. `None` when the file cannot be read or
+    /// parsed, or lacks a string `name` or `version`.
+    fn read_manifest(manager: &mut PackageManager, abs_pkg_json: &ZStr) -> Option<Manifest> {
+        // SAFETY: `manager.log` is set once at init. `workspace_package_json_cache` is a
+        // different field, so the two `&mut` do not overlap.
+        let log: &mut bun_ast::Log = unsafe { &mut *manager.log };
+        let install::GetJsonResult::Entry(entry) =
+            manager.workspace_package_json_cache.get_with_path(
+                log,
+                abs_pkg_json.as_bytes(),
+                install::GetJsonOptions {
+                    guess_indentation: true,
+                    ..Default::default()
+                },
+            )
+        else {
+            return None;
+        };
+        let bump = bun_alloc::Arena::new();
+        let private = entry
+            .root
+            .get(b"private")
+            .and_then(|p| p.as_bool())
+            .unwrap_or(false);
+        let name = entry.root.get(b"name")?.as_string(&bump)?;
+        let version = entry.root.get(b"version")?.as_string(&bump)?;
+        Some(Manifest {
+            private,
+            name: name.into(),
+            version: version.into(),
+        })
+    }
+
     /// The `+ name@version` line, then the `publish` and `postpublish` scripts of the package at `abs_pkg_json`.
     fn finish_directory_publish(
         context: Context<'static, true>,
         abs_pkg_json: &ZStr,
-    ) -> Result<(), Error> {
+    ) -> Result<(), PublishError> {
         bun_core::prettyln!(
             "\n<green> +<r> {}@{}{}",
             bstr::BStr::new(&context.package_name),
@@ -829,58 +898,42 @@ impl PublishCommand {
             script_env
                 .map
                 .put(b"npm_command", b"publish")
-                .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
+                .map_err(|_| PublishError::OutOfMemory)?;
 
             // Note: reshaped for borrowck — `command_ctx: &mut ContextData`
             // is held by `context`; `run_package_script_foreground` needs
             // `&mut ContextData` too. Re-derive from the raw pointer.
             let cmd_ctx_ptr: *mut crate::cli::command::ContextData = context.command_ctx;
 
-            if let Some(publish_script) = &context.publish_script {
-                if let Err(e) = Run::run_package_script_foreground(
+            let scripts: [(&[u8], &Option<Box<[u8]>>); 2] = [
+                (b"publish", &context.publish_script),
+                (b"postpublish", &context.postpublish_script),
+            ];
+            for (name, script) in scripts {
+                let Some(script) = script else { continue };
+                match Run::run_package_script_foreground_status(
                     // SAFETY: see above.
                     unsafe { &mut *cmd_ctx_ptr },
-                    publish_script,
-                    b"publish",
+                    script,
+                    name,
                     &abs_workspace_path,
                     script_env,
                     &[],
                     context.manager.options.log_level == LogLevel::Silent,
                     // SAFETY: see above.
                     unsafe { &*cmd_ctx_ptr }.debug.use_system_shell,
+                    None,
                 ) {
-                    if matches!(e, crate::Error::MissingShell) {
+                    Ok(0) => {}
+                    Ok(code) => return Err(PublishError::ScriptFailed(code)),
+                    Err(crate::Error::MissingShell) => {
                         Output::err_generic(
-                            "failed to find shell executable to run publish script",
-                            (),
+                            "failed to find shell executable to run {} script",
+                            (bstr::BStr::new(name),),
                         );
                         Global::crash();
                     }
-                    return Err(e);
-                }
-            }
-
-            if let Some(postpublish_script) = &context.postpublish_script {
-                if let Err(e) = Run::run_package_script_foreground(
-                    // SAFETY: see above.
-                    unsafe { &mut *cmd_ctx_ptr },
-                    postpublish_script,
-                    b"postpublish",
-                    &abs_workspace_path,
-                    script_env,
-                    &[],
-                    context.manager.options.log_level == LogLevel::Silent,
-                    // SAFETY: see above.
-                    unsafe { &*cmd_ctx_ptr }.debug.use_system_shell,
-                ) {
-                    if matches!(e, crate::Error::MissingShell) {
-                        Output::err_generic(
-                            "failed to find shell executable to run postpublish script",
-                            (),
-                        );
-                        Global::crash();
-                    }
-                    return Err(e);
+                    Err(_) => return Err(PublishError::OutOfMemory),
                 }
             }
         }
@@ -1916,16 +1969,13 @@ impl PublishCommand {
                     }
                 };
 
-                let mut dirs: Vec<(Fd, Box<[u8]>, bool)> = Vec::new();
+                let mut dirs: Vec<(Fd, Box<[u8]>)> = Vec::new();
 
-                dirs.push((bin_dir, normalized_bin_dir.as_bytes().into(), false));
+                dirs.push((bin_dir, normalized_bin_dir.as_bytes().into()));
 
-                while let Some(dir_info) = dirs.pop() {
-                    let (dir, dir_subpath, close_dir) = dir_info;
-                    let _close = scopeguard::guard(dir, move |d| {
-                        if close_dir {
-                            let _ = d.close();
-                        }
+                while let Some((dir, dir_subpath)) = dirs.pop() {
+                    let _close = scopeguard::guard(dir, |d| {
+                        let _ = d.close();
                     });
 
                     let mut iter = DirIterator::iterate(dir);
@@ -1985,7 +2035,7 @@ impl PublishCommand {
                             else {
                                 continue;
                             };
-                            dirs.push((subdir, subpath.as_bytes().into(), true));
+                            dirs.push((subdir, subpath.as_bytes().into()));
                         }
                     }
                 }
@@ -2213,6 +2263,12 @@ impl PublishCommand {
     }
 }
 
+struct Manifest {
+    private: bool,
+    name: Box<[u8]>,
+    version: Box<[u8]>,
+}
+
 pub(crate) enum Published {
     Yes,
     /// The registry already had this `name@version`, so nothing was sent.
@@ -2231,6 +2287,9 @@ pub(crate) enum PublishError {
     /// The registry answered with an error status. Already reported.
     #[error("Rejected")]
     Rejected,
+    /// The `publish` or `postpublish` script exited with this code. Already reported.
+    #[error("ScriptFailed")]
+    ScriptFailed(u32),
 }
 bun_core::oom_from_alloc!(PublishError);
 
@@ -2243,6 +2302,7 @@ impl PublishError {
                 Global::crash();
             }
             PublishError::RequestFailed | PublishError::Rejected => Global::crash(),
+            PublishError::ScriptFailed(code) => Global::exit(code),
         }
     }
 }

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -764,7 +764,9 @@ impl PublishCommand {
             let _ = bun_sys::unlink(&context.abs_tarball_path);
 
             match Self::publish::<true>(&context) {
-                Ok(()) => {}
+                Ok(Published::Yes) => {}
+                // Nothing was published: no `+` line, no `publish`/`postpublish` scripts.
+                Ok(Published::AlreadyOnRegistry) => continue,
                 Err(err @ (PublishError::OutOfMemory | PublishError::NeedAuth)) => {
                     err.report_and_crash();
                 }
@@ -989,7 +991,7 @@ impl PublishCommand {
 
     fn publish<const DIRECTORY_PUBLISH: bool>(
         ctx: &Context<'_, DIRECTORY_PUBLISH>,
-    ) -> Result<(), PublishError> {
+    ) -> Result<Published, PublishError> {
         let registry = ctx.manager.scope_for_package_name(&ctx.package_name);
         let registry_url = registry.url.url();
 
@@ -1017,7 +1019,7 @@ impl PublishCommand {
                     "Registry already knows about version {}; skipping.",
                     bstr::BStr::new(version_without_build_tag),
                 );
-                return Ok(());
+                return Ok(Published::AlreadyOnRegistry);
             }
         }
 
@@ -1040,16 +1042,14 @@ impl PublishCommand {
 
         // dry-run stops here
         if ctx.manager.options.dry_run {
-            return Ok(());
+            return Ok(Published::Yes);
         }
 
-        // Note: `AsyncHTTP::init_sync` requires `&'static [u8]` for the
-        // request body. Single-shot CLI path — adopt the
-        // already-owned `Box<[u8]>` (base64-encoded tarball; can be multi-MB)
-        // into the process-lifetime side-table. Zero-copy.
-        let publish_req_body: &'static [u8] = crate::cli::cli_adopt(
-            Self::construct_publish_request_body::<DIRECTORY_PUBLISH>(ctx)?,
-        );
+        // base64-encoded tarball; can be multi-MB. Freed when this call returns, so a workspace
+        // run holds one body at a time.
+        let publish_req_body: Box<[u8]> =
+            Self::construct_publish_request_body::<DIRECTORY_PUBLISH>(ctx)?;
+        let publish_req_body: &[u8] = &publish_req_body;
 
         let mut print_buf: Vec<u8> = Vec::new();
 
@@ -1117,7 +1117,7 @@ impl PublishCommand {
                                     "login is not allowed from your IP address",
                                     (),
                                 );
-                                Global::crash();
+                                return Err(PublishError::Rejected);
                             } else if strings::eql_case_insensitive_ascii(trimmed, b"otp", true) {
                                 break 'prompt_for_otp true;
                             }
@@ -1127,7 +1127,7 @@ impl PublishCommand {
                             "unable to authenticate, need: {}",
                             (bstr::BStr::new(www_authenticate),),
                         );
-                        Global::crash();
+                        return Err(PublishError::Rejected);
                     } else if strings::contains(&response_buf.list, b"one-time pass") {
                         // missing www-authenicate header but one-time pass is still included
                         break 'prompt_for_otp true;
@@ -1221,7 +1221,7 @@ impl PublishCommand {
             _ => {}
         }
 
-        Ok(())
+        Ok(Published::Yes)
     }
 
     fn press_enter_to_open_in_browser(auth_url: &ZStr) {
@@ -2221,6 +2221,12 @@ impl PublishCommand {
 
         Ok(buf.into_boxed_slice())
     }
+}
+
+pub(crate) enum Published {
+    Yes,
+    /// The registry already had this `name@version`, so nothing was sent.
+    AlreadyOnRegistry,
 }
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -11,8 +11,12 @@ use bun_core::{Environment, Global, Output};
 use bun_core::{ZStr, strings};
 use bun_dotenv as dotenv;
 use bun_http as http;
+use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::lockfile::{LoadResult, LoadStep};
-use bun_install::{self as install, Lockfile, Npm, PackageManager, Subcommand};
+use bun_install::package_manager::workspace_selection;
+use bun_install::{
+    self as install, Lockfile, Npm, PackageManager, ResolutionTag, Subcommand, WorkspaceFilter,
+};
 use bun_libarchive::lib::{Archive, ArchiveIterator, IteratorResult as ArchiveIterResult};
 use bun_parsers::json as json_mod;
 use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf, normalize_buf_z};
@@ -448,33 +452,25 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         })
     }
 
-    /// `bun publish` without a tarball path. Automatically pack the current workspace and get
-    /// information required for publishing
-    // Note: the return type is pinned to `Context<'static, true>`, the only
-    // valid shape. `'static` matches `pack::pack`'s return —
-    // the embedded `&mut PackageManager` / `Command::Context` are process-
-    // lifetime singletons reborrowed through raw pointers there.
-    pub(crate) fn from_workspace(
-        ctx: Command::Context<'a>,
-        manager: &'a mut PackageManager,
-    ) -> Result<Context<'static, true>, FromWorkspaceError> {
+    /// The lockfile of the workspace root. `None` when there is none.
+    pub(crate) fn load_lockfile(manager: &mut PackageManager) -> Option<Lockfile> {
         let mut lockfile = Lockfile::default();
         let manager_ptr: *mut PackageManager = manager;
         let log: &mut bun_ast::Log = manager.log_mut();
-        // SAFETY: `manager_ptr` was just derived from `manager: &'a mut PackageManager`;
+        // SAFETY: `manager_ptr` was just derived from `manager: &mut PackageManager`;
         // `log` borrows the disjoint `.log` field, so the re-derived `&mut`
         // never touches memory the live `log` borrow covers.
         let load_from_disk_result =
             lockfile.load_from_cwd::<false>(Some(unsafe { &mut *manager_ptr }), log);
 
-        let lockfile_ref: Option<&Lockfile> = match load_from_disk_result {
-            LoadResult::Ok(ok) => Some(&*ok.lockfile),
-            LoadResult::NotFound => None,
+        let found = match load_from_disk_result {
+            LoadResult::Ok(_) => true,
+            LoadResult::NotFound => false,
             LoadResult::Err(cause) => 'err: {
                 match cause.step {
                     LoadStep::OpenFile => {
                         if cause.value == bun_install::Error::Sys(bun_errno::SystemErrno::ENOENT) {
-                            break 'err None;
+                            break 'err false;
                         }
                         Output::err_generic("failed to open lockfile: {}", (cause.value.name(),));
                     }
@@ -500,28 +496,31 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
             }
         };
 
-        // Note: capture the package.json path before constructing
-        // `pack::Context` so the `&mut PackageManager` borrow doesn't conflict.
-        // SAFETY: `manager_ptr` came from `&'a mut PackageManager`.
-        let abs_pkg_json = bun_core::ZBox::from_bytes(
-            unsafe { &*manager_ptr }
-                .original_package_json_path
-                .as_bytes(),
-        );
+        found.then_some(lockfile)
+    }
 
+    /// `bun publish` without a tarball path. Pack the package at `abs_pkg_json` and get
+    /// information required for publishing
+    // Note: the return type is pinned to `Context<'static, true>`, the only
+    // valid shape. `'static` matches `pack::pack`'s return —
+    // the embedded `&mut PackageManager` / `Command::Context` are process-
+    // lifetime singletons reborrowed through raw pointers there.
+    pub(crate) fn from_workspace(
+        ctx: Command::Context<'a>,
+        manager: &'a mut PackageManager,
+        lockfile: Option<&Lockfile>,
+        abs_pkg_json: &ZStr,
+    ) -> Result<Context<'static, true>, FromWorkspaceError> {
         let mut pack_ctx = pack::Context {
-            // SAFETY: `manager_ptr` came from `&'a mut PackageManager`;
-            // `lockfile_ref` borrows the local `lockfile`, not the manager,
-            // so the re-derived `&mut` is the only live manager borrow.
-            manager: unsafe { &mut *manager_ptr },
+            manager,
             command_ctx: ctx,
-            lockfile: lockfile_ref,
+            lockfile,
             bundled_deps: Vec::new(),
             stats: pack::Stats::default(),
         };
 
         // `pack::<true>` returns `Some(Context<true>)` on success.
-        Ok(pack::pack::<true>(&mut pack_ctx, &abs_pkg_json)?
+        Ok(pack::pack::<true>(&mut pack_ctx, abs_pkg_json)?
             .expect("pack::<true> always yields a publish context"))
     }
 }
@@ -549,7 +548,6 @@ impl PublishCommand {
                     Global::crash();
                 }
             };
-        drop(original_cwd);
         let manager_ptr: *mut PackageManager = manager;
 
         if cli.positionals.len() > 1 {
@@ -619,34 +617,22 @@ impl PublishCommand {
             return Ok(());
         }
 
-        let context = match Context::<true>::from_workspace(ctx, manager) {
-            Ok(c) => c,
-            Err(err) => {
-                use pack::PackError;
-                match err {
-                    PackError::OutOfMemory => bun_core::out_of_memory(),
-                    PackError::MissingPackageName => {
-                        Output::err_generic("missing `name` string in package.json", ());
-                    }
-                    PackError::MissingPackageVersion => {
-                        Output::err_generic("missing `version` string in package.json", ());
-                    }
-                    PackError::InvalidPackageName | PackError::InvalidPackageVersion => {
-                        Output::err_generic(
-                            "package.json `name` and `version` fields must be non-empty strings",
-                            (),
-                        );
-                    }
-                    PackError::RestrictedUnscopedPackage => {
-                        Output::err_generic("unable to restrict access to unscoped package", ());
-                    }
-                    PackError::PrivatePackage => {
-                        Output::err_generic("attempted to publish a private package", ());
-                    }
+        if Self::is_workspace_publish(manager) {
+            return Self::exec_workspaces(ctx, manager, &original_cwd);
+        }
+        drop(original_cwd);
+
+        let lockfile = Context::<true>::load_lockfile(manager);
+        let abs_pkg_json =
+            bun_core::ZBox::from_bytes(manager.original_package_json_path.as_bytes());
+        let context =
+            match Context::<true>::from_workspace(ctx, manager, lockfile.as_ref(), &abs_pkg_json) {
+                Ok(c) => c,
+                Err(err) => {
+                    Self::report_pack_error(err);
+                    Global::crash();
                 }
-                Global::crash();
-            }
-        };
+            };
 
         // TODO: read this into memory
         let _ = bun_sys::unlink(&context.abs_tarball_path);
@@ -655,6 +641,167 @@ impl PublishCommand {
             err.report_and_crash();
         }
 
+        Self::finish_directory_publish(context, &abs_pkg_json)
+    }
+
+    /// `-r` or `--filter`: the run covers workspace packages, not only the current one.
+    fn is_workspace_publish(manager: &PackageManager) -> bool {
+        manager.options.do_.recursive() || !manager.options.filter_patterns.is_empty()
+    }
+
+    fn report_pack_error(err: FromWorkspaceError) {
+        use pack::PackError;
+        match err {
+            PackError::OutOfMemory => bun_core::out_of_memory(),
+            PackError::MissingPackageName => {
+                Output::err_generic("missing `name` string in package.json", ());
+            }
+            PackError::MissingPackageVersion => {
+                Output::err_generic("missing `version` string in package.json", ());
+            }
+            PackError::InvalidPackageName | PackError::InvalidPackageVersion => {
+                Output::err_generic(
+                    "package.json `name` and `version` fields must be non-empty strings",
+                    (),
+                );
+            }
+            PackError::RestrictedUnscopedPackage => {
+                Output::err_generic("unable to restrict access to unscoped package", ());
+            }
+            PackError::PrivatePackage => {
+                Output::err_generic("attempted to publish a private package", ());
+            }
+        }
+    }
+
+    /// `bun publish -r` / `bun publish --filter <pattern>`: pack and publish each selected
+    /// workspace package, dependencies before dependents. A version the registry already has is
+    /// skipped. A package the registry rejects is reported and the run continues with the next
+    /// one, then the process exits with 1.
+    fn exec_workspaces(
+        ctx: Command::Context,
+        manager: &mut PackageManager,
+        original_cwd: &[u8],
+    ) -> Result<(), Error> {
+        let Some(lockfile) = Context::<true>::load_lockfile(manager) else {
+            Output::err_generic("missing lockfile, nothing to publish", ());
+            bun_core::note!("run 'bun install' first");
+            Global::crash();
+        };
+
+        let filter_patterns = manager.options.filter_patterns;
+        let ids = WorkspaceFilter::select_workspaces(&lockfile, filter_patterns, original_cwd);
+        if ids.is_empty() {
+            workspace_selection::error_unmatched(filter_patterns);
+        }
+        let ids = workspace_selection::order_lockfile_workspaces(&lockfile, &ids);
+
+        struct Member {
+            name: Box<[u8]>,
+            abs_pkg_json: bun_core::ZBox,
+        }
+
+        let members: Vec<Member> = {
+            let pkg_resolutions = lockfile.packages.items_resolution();
+            let pkg_names = lockfile.packages.items_name();
+            let string_buf = lockfile.buffers.string_bytes.as_slice();
+            let top_level_dir = FileSystem::instance().top_level_dir;
+            let mut path_buf = PathBuffer::uninit();
+            ids.iter()
+                .map(|&pkg_id| {
+                    let res = &pkg_resolutions[pkg_id as usize];
+                    let rel_dir: &[u8] = match res.tag {
+                        ResolutionTag::Workspace => res.workspace().slice(string_buf),
+                        _ => b".",
+                    };
+                    let abs_pkg_json = join_abs_string_buf_z::<path::platform::Auto>(
+                        top_level_dir,
+                        &mut path_buf,
+                        &[rel_dir, b"package.json"],
+                    );
+                    Member {
+                        name: pkg_names[pkg_id as usize].slice(string_buf).into(),
+                        abs_pkg_json: bun_core::ZBox::from_bytes(abs_pkg_json.as_bytes()),
+                    }
+                })
+                .collect()
+        };
+
+        // `pack` copies `publishConfig` from each package.json into these when the flag was not
+        // given. Restore the flag values before every package so one package.json does not
+        // configure the next.
+        let cli_tag = manager.options.publish_config.tag;
+        let cli_access = manager.options.publish_config.access;
+
+        let mut attempted: usize = 0;
+        let mut failed: Vec<Box<[u8]>> = Vec::new();
+        for member in &members {
+            manager.options.publish_config.tag = cli_tag;
+            manager.options.publish_config.access = cli_access;
+
+            bun_core::prettyln!("\n<b><magenta>{}<r>", bstr::BStr::new(&member.name));
+
+            let context = match Context::<true>::from_workspace(
+                &mut *ctx,
+                &mut *manager,
+                Some(&lockfile),
+                &member.abs_pkg_json,
+            ) {
+                Ok(c) => c,
+                Err(pack::PackError::PrivatePackage) => {
+                    bun_core::prettyln!("<d>skipping private package<r>");
+                    continue;
+                }
+                Err(err) => {
+                    Self::report_pack_error(err);
+                    attempted += 1;
+                    failed.push(member.name.clone());
+                    continue;
+                }
+            };
+            attempted += 1;
+
+            let _ = bun_sys::unlink(&context.abs_tarball_path);
+
+            match Self::publish::<true>(&context) {
+                Ok(()) => {}
+                Err(err @ (PublishError::OutOfMemory | PublishError::NeedAuth)) => {
+                    err.report_and_crash();
+                }
+                Err(PublishError::RequestFailed | PublishError::Rejected) => {
+                    failed.push(member.name.clone());
+                    continue;
+                }
+            }
+
+            Self::finish_directory_publish(context, &member.abs_pkg_json)?;
+        }
+
+        if !failed.is_empty() {
+            Output::flush();
+            let mut names: Vec<u8> = Vec::new();
+            for (i, name) in failed.iter().enumerate() {
+                if i > 0 {
+                    names.extend_from_slice(b", ");
+                }
+                names.extend_from_slice(name);
+            }
+            Output::err_generic(
+                "failed to publish {} of {} packages: {}",
+                (failed.len(), attempted, bstr::BStr::new(&names)),
+            );
+            Global::crash();
+        }
+
+        Ok(())
+    }
+
+    /// Prints the `+ name@version` line and runs the `publish` and `postpublish` scripts of the
+    /// package at `abs_pkg_json`.
+    fn finish_directory_publish(
+        context: Context<'static, true>,
+        abs_pkg_json: &ZStr,
+    ) -> Result<(), Error> {
         bun_core::prettyln!(
             "\n<green> +<r> {}@{}{}",
             bstr::BStr::new(&context.package_name),
@@ -671,12 +818,10 @@ impl PublishCommand {
             .do_
             .contains(install::PackageManagerDoStub::RUN_SCRIPTS)
         {
-            let abs_workspace_path: Box<[u8]> =
-                strings::without_trailing_slash(strings::without_suffix_comptime(
-                    PackageManager::get().original_package_json_path.as_bytes(),
-                    b"package.json",
-                ))
-                .into();
+            let abs_workspace_path: Box<[u8]> = strings::without_trailing_slash(
+                strings::without_suffix_comptime(abs_pkg_json.as_bytes(), b"package.json"),
+            )
+            .into();
             let script_env = context
                 .script_env
                 .expect("DIRECTORY_PUBLISH=true sets script_env");
@@ -855,8 +1000,11 @@ impl PublishCommand {
             return Err(PublishError::NeedAuth);
         }
 
-        let tolerate_republish = ctx.manager.options.publish_config.tolerate_republish;
-        if tolerate_republish {
+        // A workspace run re-publishes what a previous run already pushed, so an existing
+        // version is a skip there too.
+        let skip_existing_version = ctx.manager.options.publish_config.tolerate_republish
+            || Self::is_workspace_publish(ctx.manager);
+        if skip_existing_version {
             let version_without_build_tag = dependency::without_build_tag(&ctx.package_version);
             let package_exists = Self::check_package_version_exists(
                 &ctx.package_name,
@@ -949,7 +1097,7 @@ impl PublishCommand {
                     return Err(PublishError::OutOfMemory);
                 }
                 Output::err(e, "failed to publish package", ());
-                Global::crash();
+                return Err(PublishError::RequestFailed);
             }
         };
 
@@ -990,12 +1138,13 @@ impl PublishCommand {
 
                 if !prompt_for_otp {
                     // general error
-                    Npm::response_error::<false>(
+                    Npm::print_response_error::<false>(
                         &req,
                         &res,
                         Some((&ctx.package_name, &ctx.package_version)),
                         &mut response_buf,
                     )?;
+                    return Err(PublishError::Rejected);
                 }
 
                 // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
@@ -1042,18 +1191,19 @@ impl PublishCommand {
                             return Err(PublishError::OutOfMemory);
                         }
                         Output::err(e, "failed to publish package", ());
-                        Global::crash();
+                        return Err(PublishError::RequestFailed);
                     }
                 };
 
                 match otp_res.status_code() {
                     400..=u32::MAX => {
-                        Npm::response_error::<true>(
+                        Npm::print_response_error::<true>(
                             &otp_req,
                             &otp_res,
                             Some((&ctx.package_name, &ctx.package_version)),
                             &mut response_buf,
                         )?;
+                        return Err(PublishError::Rejected);
                     }
                     _ => {
                         // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
@@ -2079,6 +2229,12 @@ pub(crate) enum PublishError {
     OutOfMemory,
     #[error("NeedAuth")]
     NeedAuth,
+    /// The request never got a response. Already reported.
+    #[error("RequestFailed")]
+    RequestFailed,
+    /// The registry answered with an error status. Already reported.
+    #[error("Rejected")]
+    Rejected,
 }
 bun_core::oom_from_alloc!(PublishError);
 
@@ -2090,6 +2246,7 @@ impl PublishError {
                 Output::err_generic("missing authentication (run <cyan>`bunx npm login`<r>)", ());
                 Global::crash();
             }
+            PublishError::RequestFailed | PublishError::Rejected => Global::crash(),
         }
     }
 }

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -743,8 +743,7 @@ impl PublishCommand {
         let cli_tag = manager.options.publish_config.tag;
         let cli_access = manager.options.publish_config.access;
 
-        // What a pack leaves behind. No borrow of the manager or the CLI context is kept between
-        // the phases: a `Context` is rebuilt with fresh borrows for each publish.
+        // Owned output of one pack. Phase 2 rebuilds a `Context` around it with fresh borrows.
         struct Packed<'m> {
             member: &'m Member,
             package_name: Box<[u8]>,
@@ -863,8 +862,7 @@ impl PublishCommand {
                 normalized_pkg_info,
                 publish_script,
                 postpublish_script,
-                // SAFETY: the loader is its own allocation, set once at init and never freed
-                // before exit. `manager` is reborrowed above and does not overlap it.
+                // SAFETY: the loader is a separate allocation that lives until exit.
                 script_env: Some(unsafe { &mut *script_env }),
             };
 

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -600,8 +600,10 @@ impl PublishCommand {
                 }
             };
 
-            if let Err(err) = Self::publish::<false>(&context) {
-                err.report_and_crash();
+            match Self::publish::<false>(&context) {
+                Ok(Published::Yes) => {}
+                Ok(Published::AlreadyOnRegistry) => return Ok(()),
+                Err(err) => err.report_and_crash(),
             }
 
             bun_core::prettyln!(
@@ -638,8 +640,10 @@ impl PublishCommand {
         // TODO: read this into memory
         let _ = bun_sys::unlink(&context.abs_tarball_path);
 
-        if let Err(err) = Self::publish::<true>(&context) {
-            err.report_and_crash();
+        match Self::publish::<true>(&context) {
+            Ok(Published::Yes) => {}
+            Ok(Published::AlreadyOnRegistry) => return Ok(()),
+            Err(err) => err.report_and_crash(),
         }
 
         Self::finish_directory_publish(context, &abs_pkg_json)

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -794,14 +794,9 @@ impl PublishCommand {
                 Ok(Published::Yes) => {}
                 // Nothing was published: no `+` line, no `publish`/`postpublish` scripts.
                 Ok(Published::AlreadyOnRegistry) => continue,
-                Err(err @ (PublishError::OutOfMemory | PublishError::NeedAuth)) => {
-                    err.report_and_crash();
-                }
-                Err(
-                    PublishError::RequestFailed
-                    | PublishError::Rejected
-                    | PublishError::ScriptFailed(_),
-                ) => {
+                Err(PublishError::OutOfMemory) => bun_core::out_of_memory(),
+                Err(err) => {
+                    err.report();
                     failed.push(member.name.clone());
                     continue;
                 }
@@ -921,8 +916,10 @@ impl PublishCommand {
                     unsafe { &*cmd_ctx_ptr }.debug.use_system_shell,
                     None,
                 ) {
-                    Ok(0) => {}
-                    Ok(code) => return Err(PublishError::ScriptFailed(code)),
+                    Ok(status) => match status.exit_code() {
+                        0 => {}
+                        code => return Err(PublishError::ScriptFailed(code)),
+                    },
                     Err(crate::Error::MissingShell) => {
                         Output::err_generic(
                             "failed to find shell executable to run {} script",
@@ -2291,15 +2288,21 @@ pub(crate) enum PublishError {
 bun_core::oom_from_alloc!(PublishError);
 
 impl PublishError {
+    /// Prints what is not printed yet. Every variant but `NeedAuth` is reported where it arises.
+    fn report(&self) {
+        if let PublishError::NeedAuth = self {
+            Output::err_generic("missing authentication (run <cyan>`bunx npm login`<r>)", ());
+        }
+    }
+
     fn report_and_crash(self) -> ! {
+        self.report();
         match self {
             PublishError::OutOfMemory => bun_core::out_of_memory(),
-            PublishError::NeedAuth => {
-                Output::err_generic("missing authentication (run <cyan>`bunx npm login`<r>)", ());
-                Global::crash();
-            }
-            PublishError::RequestFailed | PublishError::Rejected => Global::crash(),
             PublishError::ScriptFailed(code) => Global::exit(code),
+            PublishError::NeedAuth | PublishError::RequestFailed | PublishError::Rejected => {
+                Global::crash()
+            }
         }
     }
 }

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -689,7 +689,7 @@ impl PublishCommand {
         1
     }
 
-    /// `-r` / `--filter`: publish each selected workspace package, dependencies first. Exits 1 at the end if any failed.
+    /// `-r` / `--filter`: pack every selected workspace package, then publish them dependencies first.
     fn exec_workspaces(
         ctx: Command::Context,
         manager: &mut PackageManager,
@@ -739,12 +739,20 @@ impl PublishCommand {
                 .collect()
         };
 
-        // `pack` writes each package's `publishConfig` into these; restored before every package.
+        // `pack` writes each package's `publishConfig` into these. Each package packs and
+        // publishes with the flag values plus its own `publishConfig`.
         let cli_tag = manager.options.publish_config.tag;
         let cli_access = manager.options.publish_config.access;
 
-        let mut attempted: usize = 0;
-        let mut failed: Vec<Box<[u8]>> = Vec::new();
+        struct Packed<'m> {
+            member: &'m Member,
+            context: Context<'static, true>,
+            tag: &'static [u8],
+            access: Option<Access>,
+        }
+
+        // Phase 1: pack every eligible package. A pack failure ends the run before any publish.
+        let mut packed: Vec<Packed<'_>> = Vec::new();
         for member in &members {
             manager.options.publish_config.tag = cli_tag;
             manager.options.publish_config.access = cli_access;
@@ -780,15 +788,37 @@ impl PublishCommand {
                     continue;
                 }
                 Err(err) => {
-                    Self::report_pack_error(err);
-                    attempted += 1;
-                    failed.push(member.name.clone());
-                    continue;
+                    let code = Self::report_pack_error(err);
+                    Output::err_generic(
+                        "failed to pack {}, nothing was published",
+                        (bstr::BStr::new(&member.name),),
+                    );
+                    Global::exit(code);
                 }
             };
-            attempted += 1;
-
             let _ = bun_sys::unlink(&context.abs_tarball_path);
+            packed.push(Packed {
+                member,
+                context,
+                tag: manager.options.publish_config.tag,
+                access: manager.options.publish_config.access,
+            });
+        }
+
+        // Phase 2: publish in the same order, dependencies first.
+        let attempted = packed.len();
+        let mut failed: Vec<Box<[u8]>> = Vec::new();
+        for Packed {
+            member,
+            context,
+            tag,
+            access,
+        } in packed
+        {
+            manager.options.publish_config.tag = tag;
+            manager.options.publish_config.access = access;
+
+            bun_core::prettyln!("\n<b><magenta>{}<r>", bstr::BStr::new(&member.name));
 
             match Self::publish::<true>(&context) {
                 Ok(Published::Yes) => {}

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -751,8 +751,7 @@ impl PublishCommand {
 
             bun_core::prettyln!("\n<b><magenta>{}<r>", bstr::BStr::new(&member.name));
 
-            // Decide the skips before `pack` runs the pre-publish scripts. An unreadable
-            // package.json falls through: `pack` reports it.
+            // Skip before `pack` runs the pre-publish scripts. `pack` reports an unreadable file.
             if let Some(manifest) = Self::read_manifest(manager, &member.abs_pkg_json) {
                 if manifest.private {
                     bun_core::prettyln!("<d>skipping private package<r>");
@@ -834,11 +833,9 @@ impl PublishCommand {
         Ok(())
     }
 
-    /// `private`, `name` and `version` of a package.json. `None` when the file cannot be read or
-    /// parsed, or lacks a string `name` or `version`.
+    /// `None` when the package.json cannot be read, or lacks a string `name` or `version`.
     fn read_manifest(manager: &mut PackageManager, abs_pkg_json: &ZStr) -> Option<Manifest> {
-        // SAFETY: `manager.log` is set once at init. `workspace_package_json_cache` is a
-        // different field, so the two `&mut` do not overlap.
+        // SAFETY: `manager.log` is set once at init and is not `workspace_package_json_cache`.
         let log: &mut bun_ast::Log = unsafe { &mut *manager.log };
         let install::GetJsonResult::Entry(entry) =
             manager.workspace_package_json_cache.get_with_path(

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -739,8 +739,7 @@ impl PublishCommand {
                 .collect()
         };
 
-        // `pack` writes each package's `publishConfig` into these. Each package packs and
-        // publishes with the flag values plus its own `publishConfig`.
+        // `pack` writes each package's `publishConfig` into these; restored before every package.
         let cli_tag = manager.options.publish_config.tag;
         let cli_access = manager.options.publish_config.access;
 

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -499,12 +499,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         found.then_some(lockfile)
     }
 
-    /// `bun publish` without a tarball path. Pack the package at `abs_pkg_json` and get
-    /// information required for publishing
-    // Note: the return type is pinned to `Context<'static, true>`, the only
-    // valid shape. `'static` matches `pack::pack`'s return —
-    // the embedded `&mut PackageManager` / `Command::Context` are process-
-    // lifetime singletons reborrowed through raw pointers there.
+    /// `bun publish` without a tarball path: pack the package at `abs_pkg_json`. `'static` matches `pack::pack`'s return.
     pub(crate) fn from_workspace(
         ctx: Command::Context<'a>,
         manager: &'a mut PackageManager,
@@ -674,10 +669,7 @@ impl PublishCommand {
         }
     }
 
-    /// `bun publish -r` / `bun publish --filter <pattern>`: pack and publish each selected
-    /// workspace package, dependencies before dependents. A version the registry already has is
-    /// skipped. A package the registry rejects is reported and the run continues with the next
-    /// one, then the process exits with 1.
+    /// `-r` / `--filter`: publish each selected workspace package, dependencies first. Exits 1 at the end if any failed.
     fn exec_workspaces(
         ctx: Command::Context,
         manager: &mut PackageManager,
@@ -727,9 +719,7 @@ impl PublishCommand {
                 .collect()
         };
 
-        // `pack` copies `publishConfig` from each package.json into these when the flag was not
-        // given. Restore the flag values before every package so one package.json does not
-        // configure the next.
+        // `pack` writes each package's `publishConfig` into these; restored before every package.
         let cli_tag = manager.options.publish_config.tag;
         let cli_access = manager.options.publish_config.access;
 
@@ -798,8 +788,7 @@ impl PublishCommand {
         Ok(())
     }
 
-    /// Prints the `+ name@version` line and runs the `publish` and `postpublish` scripts of the
-    /// package at `abs_pkg_json`.
+    /// The `+ name@version` line, then the `publish` and `postpublish` scripts of the package at `abs_pkg_json`.
     fn finish_directory_publish(
         context: Context<'static, true>,
         abs_pkg_json: &ZStr,
@@ -1002,8 +991,6 @@ impl PublishCommand {
             return Err(PublishError::NeedAuth);
         }
 
-        // A workspace run re-publishes what a previous run already pushed, so an existing
-        // version is a skip there too.
         let skip_existing_version = ctx.manager.options.publish_config.tolerate_republish
             || Self::is_workspace_publish(ctx.manager);
         if skip_existing_version {
@@ -1045,8 +1032,6 @@ impl PublishCommand {
             return Ok(Published::Yes);
         }
 
-        // base64-encoded tarball; can be multi-MB. Freed when this call returns, so a workspace
-        // run holds one body at a time.
         let publish_req_body: Box<[u8]> =
             Self::construct_publish_request_body::<DIRECTORY_PUBLISH>(ctx)?;
         let publish_req_body: &[u8] = &publish_req_body;

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -414,8 +414,14 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         drop(sha512);
 
         let mut json = json;
+        let cwd_package_dir: Box<[u8]> = strings::without_suffix_comptime(
+            manager.original_package_json_path.as_bytes(),
+            b"package.json",
+        )
+        .into();
         let normalized_pkg_info = PublishCommand::normalized_package(
             manager,
+            &cwd_package_dir,
             &package_name,
             &package_version,
             &mut json,
@@ -1507,8 +1513,10 @@ impl PublishCommand {
         }
     }
 
+    /// `package_dir` is where `directories.bin` is resolved.
     pub(crate) fn normalized_package(
         manager: &mut PackageManager,
+        package_dir: &[u8],
         package_name: &[u8],
         package_version: &[u8],
         json: &mut Expr,
@@ -1644,14 +1652,7 @@ impl PublishCommand {
         )?;
 
         {
-            let workspace_root = match bun_sys::open_a(
-                strings::without_suffix_comptime(
-                    manager.original_package_json_path.as_bytes(),
-                    b"package.json",
-                ),
-                bun_sys::O::DIRECTORY,
-                0,
-            ) {
+            let workspace_root = match bun_sys::open_a(package_dir, bun_sys::O::DIRECTORY, 0) {
                 Ok(fd) => fd,
                 Err(e) => {
                     Output::err(e, "failed to open workspace directory", ());

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -743,9 +743,17 @@ impl PublishCommand {
         let cli_tag = manager.options.publish_config.tag;
         let cli_access = manager.options.publish_config.access;
 
+        // What a pack leaves behind. No borrow of the manager or the CLI context is kept between
+        // the phases: a `Context` is rebuilt with fresh borrows for each publish.
         struct Packed<'m> {
             member: &'m Member,
-            context: Context<'static, true>,
+            package_name: Box<[u8]>,
+            package_version: Box<[u8]>,
+            abs_tarball_path: Box<ZStr>,
+            tarball_bytes: Box<[u8]>,
+            normalized_pkg_info: Box<[u8]>,
+            publish_script: Option<Box<[u8]>>,
+            postpublish_script: Option<Box<[u8]>>,
             tag: &'static [u8],
             access: Option<Access>,
         }
@@ -775,7 +783,16 @@ impl PublishCommand {
                 }
             }
 
-            let context = match Context::<true>::from_workspace(
+            let Context {
+                package_name,
+                package_version,
+                abs_tarball_path,
+                tarball_bytes,
+                normalized_pkg_info,
+                publish_script,
+                postpublish_script,
+                ..
+            } = match Context::<true>::from_workspace(
                 &mut *ctx,
                 &mut *manager,
                 Some(&lockfile),
@@ -795,10 +812,16 @@ impl PublishCommand {
                     Global::exit(code);
                 }
             };
-            let _ = bun_sys::unlink(&context.abs_tarball_path);
+            let _ = bun_sys::unlink(&abs_tarball_path);
             packed.push(Packed {
                 member,
-                context,
+                package_name,
+                package_version,
+                abs_tarball_path,
+                tarball_bytes,
+                normalized_pkg_info,
+                publish_script,
+                postpublish_script,
                 tag: manager.options.publish_config.tag,
                 access: manager.options.publish_config.access,
             });
@@ -807,9 +830,19 @@ impl PublishCommand {
         // Phase 2: publish in the same order, dependencies first.
         let attempted = packed.len();
         let mut failed: Vec<Box<[u8]>> = Vec::new();
+        let script_env: *mut dotenv::Loader = manager
+            .env
+            .map(|p| p.as_ptr())
+            .expect("env set by PackageManager::init");
         for Packed {
             member,
-            context,
+            package_name,
+            package_version,
+            abs_tarball_path,
+            tarball_bytes,
+            normalized_pkg_info,
+            publish_script,
+            postpublish_script,
             tag,
             access,
         } in packed
@@ -818,6 +851,22 @@ impl PublishCommand {
             manager.options.publish_config.access = access;
 
             bun_core::prettyln!("\n<b><magenta>{}<r>", bstr::BStr::new(&member.name));
+
+            let context = Context::<true> {
+                manager: &mut *manager,
+                command_ctx: &mut *ctx,
+                package_name,
+                package_version,
+                abs_tarball_path,
+                tarball_bytes,
+                uses_workspaces: false,
+                normalized_pkg_info,
+                publish_script,
+                postpublish_script,
+                // SAFETY: the loader is its own allocation, set once at init and never freed
+                // before exit. `manager` is reborrowed above and does not overlap it.
+                script_env: Some(unsafe { &mut *script_env }),
+            };
 
             match Self::publish::<true>(&context) {
                 Ok(Published::Yes) => {}
@@ -890,7 +939,7 @@ impl PublishCommand {
 
     /// The `+ name@version` line, then the `publish` and `postpublish` scripts of the package at `abs_pkg_json`.
     fn finish_directory_publish(
-        context: Context<'static, true>,
+        context: Context<'_, true>,
         abs_pkg_json: &ZStr,
     ) -> Result<(), PublishError> {
         bun_core::prettyln!(

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -455,7 +455,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                 }
                 Output::flush();
-                return Ok(0);
+                return Ok(1);
             }
             Ok(Err(err)) => {
                 if !silent {
@@ -466,7 +466,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                 }
                 Output::flush();
-                return Ok(0);
+                return Ok(1);
             }
             Ok(Ok(result)) => result,
         };
@@ -557,7 +557,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
 
                 Output::flush();
-                return Ok(0);
+                return Ok(1);
             }
 
             _ => {}

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -272,6 +272,36 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         use_system_shell: bool,
         shell_path: Option<&[u8]>,
     ) -> crate::Result<()> {
+        let code = Self::run_package_script_foreground_status(
+            ctx,
+            original_script,
+            name,
+            cwd,
+            env,
+            passthrough,
+            silent,
+            use_system_shell,
+            shell_path,
+        )?;
+        if code != 0 {
+            Global::exit(code);
+        }
+        Ok(())
+    }
+
+    /// Like [`Self::run_package_script_foreground_with_shell_path`], but returns the script's
+    /// exit code instead of exiting on a non-zero one. The error line is still printed.
+    pub(crate) fn run_package_script_foreground_status(
+        ctx: &mut ContextData,
+        original_script: &[u8],
+        name: &[u8],
+        cwd: &[u8],
+        env: &mut DotEnv::Loader,
+        passthrough: &[Box<[u8]>],
+        silent: bool,
+        use_system_shell: bool,
+        shell_path: Option<&[u8]>,
+    ) -> crate::Result<u32> {
         let shell_search_path = shell_path.unwrap_or_else(|| env.get(b"PATH").unwrap_or(b""));
         let shell_bin =
             Self::find_shell(shell_search_path, cwd).ok_or(crate::Error::MissingShell)?;
@@ -361,9 +391,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                     Output::flush();
                 }
-                Global::exit(code as u32);
+                return Ok(code as u32);
             }
-            return Ok(());
+            return Ok(0);
         }
 
         use crate::api::bun_process::{Status as SpawnStatus, sync};
@@ -426,7 +456,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                 }
                 Output::flush();
-                return Ok(());
+                return Ok(0);
             }
             Ok(Err(err)) => {
                 if !silent {
@@ -437,7 +467,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                 }
                 Output::flush();
-                return Ok(());
+                return Ok(0);
             }
             Ok(Ok(result)) => result,
         };
@@ -484,7 +514,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                         Output::flush();
                     }
 
-                    Global::exit(exit_code.code as u32);
+                    return Ok(exit_code.code as u32);
                 }
             }
 
@@ -528,13 +558,13 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
 
                 Output::flush();
-                return Ok(());
+                return Ok(0);
             }
 
             _ => {}
         }
 
-        Ok(())
+        Ok(0)
     }
 
     /// Allocates a

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -94,6 +94,23 @@ pub(crate) struct ConfigureEnvOptions {
     pub(crate) store_root_fd: bool,
 }
 
+/// How a package script ended. A signal means the wrapper re-raises it in bun.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ScriptStatus {
+    Exited(u32),
+    Signaled(Option<bun_core::SignalCode>),
+}
+
+impl ScriptStatus {
+    pub(crate) fn exit_code(self) -> u32 {
+        match self {
+            ScriptStatus::Exited(code) => code,
+            ScriptStatus::Signaled(Some(sig)) => 128 + sig as u8 as u32,
+            ScriptStatus::Signaled(None) => 1,
+        }
+    }
+}
+
 pub(crate) struct RunCommand;
 
 impl RunCommand {
@@ -272,7 +289,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         use_system_shell: bool,
         shell_path: Option<&[u8]>,
     ) -> crate::Result<()> {
-        let code = Self::run_package_script_foreground_status(
+        match Self::run_package_script_foreground_status(
             ctx,
             original_script,
             name,
@@ -282,14 +299,24 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             silent,
             use_system_shell,
             shell_path,
-        )?;
-        if code != 0 {
-            Global::exit(code);
+        )? {
+            ScriptStatus::Exited(0) => Ok(()),
+            ScriptStatus::Exited(code) => Global::exit(code),
+            ScriptStatus::Signaled(sig) => {
+                if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN.get()
+                    == Some(true)
+                {
+                    bun_crash_handler::suppress_reporting();
+                }
+                if let Some(sig) = sig {
+                    Global::raise_ignoring_panic_handler(sig);
+                }
+                Global::exit(1)
+            }
         }
-        Ok(())
     }
 
-    /// Returns the script's exit code (already reported) instead of exiting on it.
+    /// Returns how the script ended (already reported) instead of exiting on it.
     pub(crate) fn run_package_script_foreground_status(
         ctx: &mut ContextData,
         original_script: &[u8],
@@ -300,7 +327,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         silent: bool,
         use_system_shell: bool,
         shell_path: Option<&[u8]>,
-    ) -> crate::Result<u32> {
+    ) -> crate::Result<ScriptStatus> {
         let shell_search_path = shell_path.unwrap_or_else(|| env.get(b"PATH").unwrap_or(b""));
         let shell_bin =
             Self::find_shell(shell_search_path, cwd).ok_or(crate::Error::MissingShell)?;
@@ -390,9 +417,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                     Output::flush();
                 }
-                return Ok(code as u32);
+                return Ok(ScriptStatus::Exited(code as u32));
             }
-            return Ok(0);
+            return Ok(ScriptStatus::Exited(0));
         }
 
         use crate::api::bun_process::{Status as SpawnStatus, sync};
@@ -455,7 +482,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                 }
                 Output::flush();
-                return Ok(1);
+                return Ok(ScriptStatus::Exited(1));
             }
             Ok(Err(err)) => {
                 if !silent {
@@ -466,7 +493,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     );
                 }
                 Output::flush();
-                return Ok(1);
+                return Ok(ScriptStatus::Exited(1));
             }
             Ok(Ok(result)) => result,
         };
@@ -483,15 +510,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                             bun_sys::SignalCode(sig as u8).fmt(Output::enable_ansi_colors_stderr()),
                         );
                         Output::flush();
-
-                        if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN
-                            .get()
-                            == Some(true)
-                        {
-                            bun_crash_handler::suppress_reporting();
-                        }
-
-                        Global::raise_ignoring_panic_handler(sig);
+                        return Ok(ScriptStatus::Signaled(Some(sig)));
                     }
                 }
 
@@ -513,7 +532,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                         Output::flush();
                     }
 
-                    return Ok(exit_code.code as u32);
+                    return Ok(ScriptStatus::Exited(exit_code.code as u32));
                 }
             }
 
@@ -533,18 +552,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                     }
                 }
 
-                if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN.get()
-                    == Some(true)
-                {
-                    bun_crash_handler::suppress_reporting();
-                }
-
-                if let Some(sig) = signal_code {
-                    Global::raise_ignoring_panic_handler(sig);
-                }
-                // `.signaled` always carries 1..=31 in practice; fallback only
-                // for type-totality.
-                Global::exit(1);
+                return Ok(ScriptStatus::Signaled(signal_code));
             }
 
             SpawnStatus::Err(ref err) => {
@@ -557,13 +565,13 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
 
                 Output::flush();
-                return Ok(1);
+                return Ok(ScriptStatus::Exited(1));
             }
 
             _ => {}
         }
 
-        Ok(0)
+        Ok(ScriptStatus::Exited(0))
     }
 
     /// Allocates a

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -102,8 +102,7 @@ pub(crate) enum ScriptStatus {
 }
 
 impl ScriptStatus {
-    /// The exit code of a failed script. A signal that asks bun to stop (Ctrl+C, SIGTERM, ...)
-    /// is re-raised here instead, so a batch does not carry on past it.
+    /// The exit code to report. A signal that asks bun to stop (Ctrl+C, SIGTERM) is re-raised instead.
     pub(crate) fn exit_code(self) -> u32 {
         use bun_core::SignalCode;
         match self {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -102,12 +102,30 @@ pub(crate) enum ScriptStatus {
 }
 
 impl ScriptStatus {
+    /// The exit code of a failed script. A signal that asks bun to stop (Ctrl+C, SIGTERM, ...)
+    /// is re-raised here instead, so a batch does not carry on past it.
     pub(crate) fn exit_code(self) -> u32 {
+        use bun_core::SignalCode;
         match self {
             ScriptStatus::Exited(code) => code,
+            ScriptStatus::Signaled(Some(
+                sig @ (SignalCode::SIGINT
+                | SignalCode::SIGTERM
+                | SignalCode::SIGHUP
+                | SignalCode::SIGQUIT),
+            )) => Self::raise(sig),
             ScriptStatus::Signaled(Some(sig)) => 128 + sig as u8 as u32,
             ScriptStatus::Signaled(None) => 1,
         }
+    }
+
+    fn raise(sig: bun_core::SignalCode) -> ! {
+        if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN.get()
+            == Some(true)
+        {
+            bun_crash_handler::suppress_reporting();
+        }
+        Global::raise_ignoring_panic_handler(sig)
     }
 }
 
@@ -302,14 +320,12 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         )? {
             ScriptStatus::Exited(0) => Ok(()),
             ScriptStatus::Exited(code) => Global::exit(code),
-            ScriptStatus::Signaled(sig) => {
+            ScriptStatus::Signaled(Some(sig)) => ScriptStatus::raise(sig),
+            ScriptStatus::Signaled(None) => {
                 if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN.get()
                     == Some(true)
                 {
                     bun_crash_handler::suppress_reporting();
-                }
-                if let Some(sig) = sig {
-                    Global::raise_ignoring_panic_handler(sig);
                 }
                 Global::exit(1)
             }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -289,8 +289,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         Ok(())
     }
 
-    /// Like [`Self::run_package_script_foreground_with_shell_path`], but returns the script's
-    /// exit code instead of exiting on a non-zero one. The error line is still printed.
+    /// Returns the script's exit code (already reported) instead of exiting on it.
     pub(crate) fn run_package_script_foreground_status(
         ctx: &mut ContextData,
         original_script: &[u8],

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1652,6 +1652,38 @@ describe("--recursive", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("bin entries resolve against the member directory", async () => {
+    const bins: Record<string, unknown> = {};
+    using binRegistry = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (req.method === "GET") return new Response("not found", { status: 404 });
+        const body = await req.json();
+        bins[body.name] = body.versions["1.0.0"].bin;
+        return new Response("OK");
+      },
+    });
+    const packageDir = await workspace("rec-bin", `http://localhost:${binRegistry.port}/`, {
+      "packages/tool": { name: "rec-bin-tool", version: "1.0.0", directories: { bin: "bins" } },
+      "packages/cli": { name: "rec-bin-cli", version: "1.0.0", bin: "cli.js" },
+    });
+    // The root has a `bins` directory too. It must not leak into the member's manifest.
+    await Promise.all([
+      write(join(packageDir, "bins", "root.js"), "#!/usr/bin/env bun\n"),
+      write(join(packageDir, "packages", "tool", "bins", "tool.js"), "#!/usr/bin/env bun\n"),
+      write(join(packageDir, "packages", "cli", "cli.js"), "#!/usr/bin/env bun\n"),
+    ]);
+
+    const { err, exitCode } = await publish(env, packageDir, "--filter", "rec-bin-tool", "--filter", "rec-bin-cli");
+    expect(err).not.toContain("error:");
+    expect(err).not.toContain("does not exist");
+    expect(bins).toEqual({
+      "rec-bin-tool": { "tool.js": "bins/tool.js" },
+      "rec-bin-cli": { "rec-bin-cli": "cli.js" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("without a lockfile asks for bun install", async () => {
     using mock = mockRegistry();
     using dir = tempDir("rec-nolock", {

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1433,3 +1433,227 @@ describe("--tolerate-republish", async () => {
     expect(err).not.toContain("error:");
   });
 });
+
+describe("--recursive", () => {
+  // A registry that records every PUT. `known` lists name@version pairs it already has,
+  // `reject` lists names it answers with 403.
+  function mockRegistry(opts: { known?: string[]; reject?: string[] } = {}) {
+    const puts: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const name = decodeURIComponent(new URL(req.url).pathname.slice(1));
+        if (req.method === "GET") {
+          const versions: Record<string, object> = {};
+          for (const known of opts.known ?? []) {
+            const [knownName, version] = known.split("@");
+            if (knownName === name) versions[version] = {};
+          }
+          if (Object.keys(versions).length === 0) return new Response("not found", { status: 404 });
+          return Response.json({ name, versions });
+        }
+        if (req.method === "PUT") {
+          const body = await req.json();
+          const version = Object.keys(body.versions)[0];
+          puts.push(`${name}@${version}`);
+          if (opts.reject?.includes(name)) {
+            return Response.json({ error: `${name} is not yours` }, { status: 403 });
+          }
+          return new Response("OK");
+        }
+        return new Response("unexpected", { status: 500 });
+      },
+    });
+    return {
+      server,
+      puts,
+      [Symbol.dispose]() {
+        server.stop(true);
+      },
+    };
+  }
+
+  // Root plus three members: `b` depends on `a`, `c` depends on `b`, `hidden` is private.
+  async function workspace(prefix: string, registryUrl: string, extra: Record<string, object> = {}) {
+    const { packageDir } = await registry.createTestDir();
+    const pkg = (name: string, dependencies?: Record<string, string>) =>
+      JSON.stringify({ name: `${prefix}-${name}`, version: "1.0.0", dependencies });
+    await Promise.all([
+      write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({ install: { cache: false, registry: { url: registryUrl, token: "token" } } }),
+      ),
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+      ),
+      write(join(packageDir, "packages", "a", "package.json"), pkg("a")),
+      write(join(packageDir, "packages", "b", "package.json"), pkg("b", { [`${prefix}-a`]: "workspace:*" })),
+      write(join(packageDir, "packages", "c", "package.json"), pkg("c", { [`${prefix}-b`]: "workspace:^" })),
+      write(
+        join(packageDir, "packages", "hidden", "package.json"),
+        JSON.stringify({ name: `${prefix}-hidden`, version: "1.0.0", private: true }),
+      ),
+      ...Object.entries(extra).map(([dir, json]) => write(join(packageDir, dir, "package.json"), JSON.stringify(json))),
+    ]);
+    await runBunInstall(env, packageDir);
+    return packageDir;
+  }
+
+  test("publishes dependencies before dependents and skips private packages", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace("rec-order", `http://localhost:${mock.server.port}/`);
+
+    const { out, err, exitCode } = await publish(env, packageDir, "--recursive");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("skipping private package");
+    expect(mock.puts).toEqual(["rec-order-a@1.0.0", "rec-order-b@1.0.0", "rec-order-c@1.0.0"]);
+    expect(out.match(/ \+ rec-order-\w+@1\.0\.0/g)).toEqual([
+      " + rec-order-a@1.0.0",
+      " + rec-order-b@1.0.0",
+      " + rec-order-c@1.0.0",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("skips versions the registry already has", async () => {
+    using mock = mockRegistry({ known: ["rec-skip-a@1.0.0", "rec-skip-c@1.0.0"] });
+    const packageDir = await workspace("rec-skip", `http://localhost:${mock.server.port}/`);
+
+    const { out, err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n".repeat(2));
+    expect(mock.puts).toEqual(["rec-skip-b@1.0.0"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("--filter publishes only the matching packages", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace("rec-filter", `http://localhost:${mock.server.port}/`);
+
+    const { err, exitCode } = await publish(env, packageDir, "--filter", "rec-filter-b", "--filter", "./packages/a");
+    expect(err).not.toContain("error:");
+    expect(mock.puts).toEqual(["rec-filter-a@1.0.0", "rec-filter-b@1.0.0"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("--filter that matches nothing exits 1", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace("rec-nomatch", `http://localhost:${mock.server.port}/`);
+
+    const { err, exitCode } = await publish(env, packageDir, "--filter", "does-not-exist");
+    expect(err).toContain('No workspace packages matched the filter "does-not-exist"');
+    expect(mock.puts).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("--dry-run publishes nothing", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace("rec-dry", `http://localhost:${mock.server.port}/`);
+
+    const { out, err, exitCode } = await publish(env, packageDir, "-r", "--dry-run");
+    expect(err).not.toContain("error:");
+    expect(out.match(/ \+ rec-dry-\w+@1\.0\.0 \(dry-run\)/g)).toHaveLength(3);
+    expect(mock.puts).toEqual([]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("continues after a rejected package and exits 1", async () => {
+    using mock = mockRegistry({ reject: ["rec-fail-b"] });
+    const packageDir = await workspace("rec-fail", `http://localhost:${mock.server.port}/`);
+
+    const { out, err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).toContain("rec-fail-b is not yours");
+    expect(err).toContain("error: failed to publish 1 of 3 packages: rec-fail-b");
+    expect(out).toContain(" + rec-fail-a@1.0.0");
+    expect(out).toContain(" + rec-fail-c@1.0.0");
+    expect(out).not.toContain(" + rec-fail-b@1.0.0");
+    expect(mock.puts).toEqual(["rec-fail-a@1.0.0", "rec-fail-b@1.0.0", "rec-fail-c@1.0.0"]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("each package uses its own publishConfig", async () => {
+    const tags: Record<string, string> = {};
+    using tagRegistry = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (req.method === "GET") return new Response("not found", { status: 404 });
+        const body = await req.json();
+        tags[body.name] = Object.keys(body["dist-tags"])[0];
+        return new Response("OK");
+      },
+    });
+    const packageDir = await workspace("rec-tag", `http://localhost:${tagRegistry.port}/`, {
+      "packages/next": { name: "rec-tag-next", version: "1.0.0", publishConfig: { tag: "next" } },
+    });
+
+    const { err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).not.toContain("error:");
+    expect(tags).toEqual({
+      "rec-tag-a": "latest",
+      "rec-tag-b": "latest",
+      "rec-tag-c": "latest",
+      "rec-tag-next": "next",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("without a lockfile asks for bun install", async () => {
+    using mock = mockRegistry();
+    using dir = tempDir("rec-nolock", {
+      "bunfig.toml": Bun.TOML.stringify({
+        install: { cache: false, registry: { url: `http://localhost:${mock.server.port}/`, token: "token" } },
+      }),
+      "package.json": JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+      "packages/a/package.json": JSON.stringify({ name: "rec-nolock-a", version: "1.0.0" }),
+    });
+
+    const { err, exitCode } = await publish(env, String(dir), "-r");
+    expect(err).toContain("error: missing lockfile, nothing to publish");
+    expect(mock.puts).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("published workspace dependencies resolve after install", async () => {
+    const { packageDir } = await registry.createTestDir();
+    const bunfig = await registry.authBunfig("recursive");
+    await Promise.all([
+      rm(join(registry.packagesPath, "recursive-pub-a"), { recursive: true, force: true }),
+      rm(join(registry.packagesPath, "recursive-pub-b"), { recursive: true, force: true }),
+      write(join(packageDir, "bunfig.toml"), bunfig),
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+      ),
+      write(
+        join(packageDir, "packages", "a", "package.json"),
+        JSON.stringify({ name: "recursive-pub-a", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "b", "package.json"),
+        JSON.stringify({
+          name: "recursive-pub-b",
+          version: "1.0.0",
+          dependencies: { "recursive-pub-a": "workspace:*" },
+        }),
+      ),
+    ]);
+    await runBunInstall(env, packageDir);
+
+    const { err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    using consumer = tempDir("recursive-consumer", {
+      "bunfig.toml": bunfig,
+      "package.json": JSON.stringify({ name: "consumer", dependencies: { "recursive-pub-b": "1.0.0" } }),
+    });
+    const consumerDir = String(consumer);
+    await runBunInstall(env, consumerDir);
+    expect(await file(join(consumerDir, "node_modules", "recursive-pub-b", "package.json")).json()).toEqual({
+      name: "recursive-pub-b",
+      version: "1.0.0",
+      dependencies: { "recursive-pub-a": "1.0.0" },
+    });
+    expect(await exists(join(consumerDir, "node_modules", "recursive-pub-a", "package.json"))).toBeTrue();
+  });
+});

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1602,6 +1602,46 @@ describe("--recursive", () => {
     expect(exitCode).toBe(1);
   });
 
+  test.skipIf(isWindows)("continues after a lifecycle script killed by a signal", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace(
+      "rec-signal",
+      `http://localhost:${mock.server.port}/`,
+      {},
+      { a: { prepack: "kill -TERM $$" } },
+    );
+
+    const { out, err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).toContain('script "prepack" was terminated by signal');
+    expect(err).toContain("error: failed to publish 1 of 3 packages: rec-signal-a");
+    expect(mock.puts).toEqual(["rec-signal-b@1.0.0", "rec-signal-c@1.0.0"]);
+    expect(out.match(/ \+ rec-signal-\w+@1\.0\.0/g)).toEqual([" + rec-signal-b@1.0.0", " + rec-signal-c@1.0.0"]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("continues after a package whose scope has no credentials", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace("rec-noauth", `http://localhost:${mock.server.port}/`, {
+      "packages/scoped": { name: "@rec-noauth/scoped", version: "1.0.0" },
+    });
+    await write(
+      join(packageDir, "bunfig.toml"),
+      Bun.TOML.stringify({
+        install: {
+          cache: false,
+          registry: { url: `http://localhost:${mock.server.port}/`, token: "token" },
+          scopes: { "@rec-noauth": { url: `http://localhost:${mock.server.port}/` } },
+        },
+      }),
+    );
+
+    const { err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).toContain("error: missing authentication");
+    expect(err).toContain("error: failed to publish 1 of 4 packages: @rec-noauth/scoped");
+    expect(mock.puts).toEqual(["rec-noauth-a@1.0.0", "rec-noauth-b@1.0.0", "rec-noauth-c@1.0.0"]);
+    expect(exitCode).toBe(1);
+  });
+
   test("rejects a tarball path", async () => {
     using mock = mockRegistry();
     const packageDir = await workspace("rec-tarball", `http://localhost:${mock.server.port}/`);

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1484,15 +1484,25 @@ describe("--recursive", () => {
   }
 
   // Root plus three members: `b` depends on `a`, `c` depends on `b`, `hidden` is private.
-  // Every member has a `postpublish` script that prints `postpublish <name>`.
-  async function workspace(prefix: string, registryUrl: string, extra: Record<string, object> = {}) {
+  // Every member has `prepublishOnly` and `postpublish` scripts that print `<script> <name>`.
+  // `scripts` overrides them per member.
+  async function workspace(
+    prefix: string,
+    registryUrl: string,
+    extra: Record<string, object> = {},
+    scripts: Record<string, Record<string, string>> = {},
+  ) {
     const { packageDir } = await registry.createTestDir();
     const pkg = (name: string, dependencies?: Record<string, string>) =>
       JSON.stringify({
         name: `${prefix}-${name}`,
         version: "1.0.0",
         dependencies,
-        scripts: { postpublish: `echo postpublish ${prefix}-${name}` },
+        scripts: {
+          prepublishOnly: `echo prepublishOnly ${prefix}-${name}`,
+          postpublish: `echo postpublish ${prefix}-${name}`,
+          ...scripts[name],
+        },
       });
     await Promise.all([
       write(
@@ -1542,6 +1552,7 @@ describe("--recursive", () => {
     expect(mock.puts).toEqual(["rec-skip-b@1.0.0"]);
     // A skipped package gets no success line and runs no publish scripts.
     expect(out.match(/ \+ rec-skip-\w+@1\.0\.0/g)).toEqual([" + rec-skip-b@1.0.0"]);
+    expect(err.match(/\$ echo prepublishOnly rec-skip-\w+/g)).toEqual(["$ echo prepublishOnly rec-skip-b"]);
     expect(err.match(/\$ echo postpublish rec-skip-\w+/g)).toEqual(["$ echo postpublish rec-skip-b"]);
     expect(exitCode).toBe(0);
   });
@@ -1570,6 +1581,35 @@ describe("--recursive", () => {
     expect(mock.puts).toHaveLength(3);
     expect(mock.puts.indexOf("rec-cycle-after@1.0.0")).toBeGreaterThan(mock.puts.indexOf("rec-cycle-x@1.0.0"));
     expect(exitCode).toBe(0);
+  });
+
+  test("continues after a failing lifecycle script", async () => {
+    using mock = mockRegistry();
+    // `a` fails before the publish, `b` fails after it.
+    const packageDir = await workspace(
+      "rec-script",
+      `http://localhost:${mock.server.port}/`,
+      {},
+      { a: { prepublishOnly: "exit 3" }, b: { postpublish: "exit 4" } },
+    );
+
+    const { out, err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).toContain('script "prepublishOnly" exited with code 3');
+    expect(err).toContain('script "postpublish" exited with code 4');
+    expect(err).toContain("error: failed to publish 2 of 3 packages: rec-script-a, rec-script-b");
+    expect(mock.puts).toEqual(["rec-script-b@1.0.0", "rec-script-c@1.0.0"]);
+    expect(out.match(/ \+ rec-script-\w+@1\.0\.0/g)).toEqual([" + rec-script-b@1.0.0", " + rec-script-c@1.0.0"]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("rejects a tarball path", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace("rec-tarball", `http://localhost:${mock.server.port}/`);
+
+    const { err, exitCode } = await publish(env, packageDir, "-r", "./some.tgz");
+    expect(err).toContain("error: --recursive and --filter cannot be used with a tarball path");
+    expect(mock.puts).toEqual([]);
+    expect(exitCode).toBe(1);
   });
 
   test("continues after a 401 that does not ask for an OTP", async () => {

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1583,26 +1583,47 @@ describe("--recursive", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("continues after a failing lifecycle script", async () => {
+  test("packs everything before it publishes anything", async () => {
     using mock = mockRegistry();
-    // `a` fails before the publish, `b` fails after it.
+    // `c` is packed last. Its failing prepublishOnly must keep `a` and `b` off the registry.
     const packageDir = await workspace(
-      "rec-script",
+      "rec-packfail",
       `http://localhost:${mock.server.port}/`,
       {},
-      { a: { prepublishOnly: "exit 3" }, b: { postpublish: "exit 4" } },
+      { c: { prepublishOnly: "exit 3" } },
     );
 
     const { out, err, exitCode } = await publish(env, packageDir, "-r");
     expect(err).toContain('script "prepublishOnly" exited with code 3');
+    expect(err).toContain("error: failed to pack rec-packfail-c, nothing was published");
+    expect(err).toMatch(/\$ echo prepublishOnly rec-packfail-a[\s\S]*\$ echo prepublishOnly rec-packfail-b/);
+    expect(mock.puts).toEqual([]);
+    expect(out).not.toContain(" + rec-packfail-");
+    expect(exitCode).toBe(3);
+  });
+
+  test("continues after a failing postpublish script", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace(
+      "rec-script",
+      `http://localhost:${mock.server.port}/`,
+      {},
+      { b: { postpublish: "exit 4" } },
+    );
+
+    const { out, err, exitCode } = await publish(env, packageDir, "-r");
     expect(err).toContain('script "postpublish" exited with code 4');
-    expect(err).toContain("error: failed to publish 2 of 3 packages: rec-script-a, rec-script-b");
-    expect(mock.puts).toEqual(["rec-script-b@1.0.0", "rec-script-c@1.0.0"]);
-    expect(out.match(/ \+ rec-script-\w+@1\.0\.0/g)).toEqual([" + rec-script-b@1.0.0", " + rec-script-c@1.0.0"]);
+    expect(err).toContain("error: failed to publish 1 of 3 packages: rec-script-b");
+    expect(mock.puts).toEqual(["rec-script-a@1.0.0", "rec-script-b@1.0.0", "rec-script-c@1.0.0"]);
+    expect(out.match(/ \+ rec-script-\w+@1\.0\.0/g)).toEqual([
+      " + rec-script-a@1.0.0",
+      " + rec-script-b@1.0.0",
+      " + rec-script-c@1.0.0",
+    ]);
     expect(exitCode).toBe(1);
   });
 
-  test.skipIf(isWindows)("continues after a lifecycle script that was killed", async () => {
+  test.skipIf(isWindows)("a lifecycle script that was killed publishes nothing", async () => {
     using mock = mockRegistry();
     // SIGKILL, not SIGSEGV: a core file from the shell would fail the CI job.
     const packageDir = await workspace(
@@ -1614,10 +1635,10 @@ describe("--recursive", () => {
 
     const { out, err, exitCode } = await publish(env, packageDir, "-r");
     expect(err).toContain('script "prepack" was terminated by signal');
-    expect(err).toContain("error: failed to publish 1 of 3 packages: rec-signal-a");
-    expect(mock.puts).toEqual(["rec-signal-b@1.0.0", "rec-signal-c@1.0.0"]);
-    expect(out.match(/ \+ rec-signal-\w+@1\.0\.0/g)).toEqual([" + rec-signal-b@1.0.0", " + rec-signal-c@1.0.0"]);
-    expect(exitCode).toBe(1);
+    expect(err).toContain("error: failed to pack rec-signal-a, nothing was published");
+    expect(mock.puts).toEqual([]);
+    expect(out).not.toContain(" + rec-signal-");
+    expect(exitCode).toBe(137);
   });
 
   test.skipIf(isWindows)("stops the run when a lifecycle script is told to stop", async () => {

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1436,8 +1436,9 @@ describe("--tolerate-republish", async () => {
 
 describe("--recursive", () => {
   // A registry that records every PUT. `known` lists name@version pairs it already has,
-  // `reject` lists names it answers with 403.
-  function mockRegistry(opts: { known?: string[]; reject?: string[] } = {}) {
+  // `reject` lists names it answers with 403, `unauthorized` lists names it answers with a
+  // 401 that asks for a bearer token (not an OTP).
+  function mockRegistry(opts: { known?: string[]; reject?: string[]; unauthorized?: string[] } = {}) {
     const puts: string[] = [];
     const server = Bun.serve({
       port: 0,
@@ -1459,6 +1460,12 @@ describe("--recursive", () => {
           if (opts.reject?.includes(name)) {
             return Response.json({ error: `${name} is not yours` }, { status: 403 });
           }
+          if (opts.unauthorized?.includes(name)) {
+            return new Response("unauthorized", {
+              status: 401,
+              headers: { "www-authenticate": 'Bearer realm="mock"' },
+            });
+          }
           return new Response("OK");
         }
         return new Response("unexpected", { status: 500 });
@@ -1474,10 +1481,16 @@ describe("--recursive", () => {
   }
 
   // Root plus three members: `b` depends on `a`, `c` depends on `b`, `hidden` is private.
+  // Every member has a `postpublish` script that prints `postpublish <name>`.
   async function workspace(prefix: string, registryUrl: string, extra: Record<string, object> = {}) {
     const { packageDir } = await registry.createTestDir();
     const pkg = (name: string, dependencies?: Record<string, string>) =>
-      JSON.stringify({ name: `${prefix}-${name}`, version: "1.0.0", dependencies });
+      JSON.stringify({
+        name: `${prefix}-${name}`,
+        version: "1.0.0",
+        dependencies,
+        scripts: { postpublish: `echo postpublish ${prefix}-${name}` },
+      });
     await Promise.all([
       write(
         join(packageDir, "bunfig.toml"),
@@ -1521,9 +1534,51 @@ describe("--recursive", () => {
     const packageDir = await workspace("rec-skip", `http://localhost:${mock.server.port}/`);
 
     const { out, err, exitCode } = await publish(env, packageDir, "-r");
-    expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n".repeat(2));
+    expect(err).not.toContain("error:");
+    expect(err.match(/warn: Registry already knows about version 1\.0\.0; skipping\./g)).toHaveLength(2);
     expect(mock.puts).toEqual(["rec-skip-b@1.0.0"]);
+    // A skipped package gets no success line and runs no publish scripts.
+    expect(out.match(/ \+ rec-skip-\w+@1\.0\.0/g)).toEqual([" + rec-skip-b@1.0.0"]);
+    expect(err.match(/\$ echo postpublish rec-skip-\w+/g)).toEqual(["$ echo postpublish rec-skip-b"]);
     expect(exitCode).toBe(0);
+  });
+
+  test("a dependent of a dependency cycle comes after the cycle", async () => {
+    using mock = mockRegistry();
+    // `x` and `y` depend on each other, `after` depends on `x`. Lockfile ids follow name
+    // order, so `after` has the lowest id of the three.
+    const packageDir = await workspace("rec-cycle", `http://localhost:${mock.server.port}/`, {
+      "packages/x": { name: "rec-cycle-x", version: "1.0.0", dependencies: { "rec-cycle-y": "workspace:*" } },
+      "packages/y": { name: "rec-cycle-y", version: "1.0.0", dependencies: { "rec-cycle-x": "workspace:*" } },
+      "packages/after": { name: "rec-cycle-after", version: "1.0.0", dependencies: { "rec-cycle-x": "workspace:*" } },
+    });
+
+    const { err, exitCode } = await publish(
+      env,
+      packageDir,
+      "--filter",
+      "rec-cycle-x",
+      "--filter",
+      "rec-cycle-y",
+      "--filter",
+      "rec-cycle-after",
+    );
+    expect(err).not.toContain("error:");
+    expect(mock.puts).toHaveLength(3);
+    expect(mock.puts.indexOf("rec-cycle-after@1.0.0")).toBeGreaterThan(mock.puts.indexOf("rec-cycle-x@1.0.0"));
+    expect(exitCode).toBe(0);
+  });
+
+  test("continues after a 401 that does not ask for an OTP", async () => {
+    using mock = mockRegistry({ unauthorized: ["rec-auth-a"] });
+    const packageDir = await workspace("rec-auth", `http://localhost:${mock.server.port}/`);
+
+    const { out, err, exitCode } = await publish(env, packageDir, "-r");
+    expect(err).toContain('error: unable to authenticate, need: Bearer realm="mock"');
+    expect(err).toContain("error: failed to publish 1 of 3 packages: rec-auth-a");
+    expect(out.match(/ \+ rec-auth-\w+@1\.0\.0/g)).toEqual([" + rec-auth-b@1.0.0", " + rec-auth-c@1.0.0"]);
+    expect(mock.puts).toEqual(["rec-auth-a@1.0.0", "rec-auth-b@1.0.0", "rec-auth-c@1.0.0"]);
+    expect(exitCode).toBe(1);
   });
 
   test("--filter publishes only the matching packages", async () => {
@@ -1617,8 +1672,8 @@ describe("--recursive", () => {
     const { packageDir } = await registry.createTestDir();
     const bunfig = await registry.authBunfig("recursive");
     await Promise.all([
-      rm(join(registry.packagesPath, "recursive-pub-a"), { recursive: true, force: true }),
-      rm(join(registry.packagesPath, "recursive-pub-b"), { recursive: true, force: true }),
+      rm(join(registry.packagesPath, "publish-pkg-recursive-a"), { recursive: true, force: true }),
+      rm(join(registry.packagesPath, "publish-pkg-recursive-b"), { recursive: true, force: true }),
       write(join(packageDir, "bunfig.toml"), bunfig),
       write(
         join(packageDir, "package.json"),
@@ -1626,14 +1681,14 @@ describe("--recursive", () => {
       ),
       write(
         join(packageDir, "packages", "a", "package.json"),
-        JSON.stringify({ name: "recursive-pub-a", version: "1.0.0" }),
+        JSON.stringify({ name: "publish-pkg-recursive-a", version: "1.0.0" }),
       ),
       write(
         join(packageDir, "packages", "b", "package.json"),
         JSON.stringify({
-          name: "recursive-pub-b",
+          name: "publish-pkg-recursive-b",
           version: "1.0.0",
-          dependencies: { "recursive-pub-a": "workspace:*" },
+          dependencies: { "publish-pkg-recursive-a": "workspace:*" },
         }),
       ),
     ]);
@@ -1645,15 +1700,15 @@ describe("--recursive", () => {
 
     using consumer = tempDir("recursive-consumer", {
       "bunfig.toml": bunfig,
-      "package.json": JSON.stringify({ name: "consumer", dependencies: { "recursive-pub-b": "1.0.0" } }),
+      "package.json": JSON.stringify({ name: "consumer", dependencies: { "publish-pkg-recursive-b": "1.0.0" } }),
     });
     const consumerDir = String(consumer);
     await runBunInstall(env, consumerDir);
-    expect(await file(join(consumerDir, "node_modules", "recursive-pub-b", "package.json")).json()).toEqual({
-      name: "recursive-pub-b",
+    expect(await file(join(consumerDir, "node_modules", "publish-pkg-recursive-b", "package.json")).json()).toEqual({
+      name: "publish-pkg-recursive-b",
       version: "1.0.0",
-      dependencies: { "recursive-pub-a": "1.0.0" },
+      dependencies: { "publish-pkg-recursive-a": "1.0.0" },
     });
-    expect(await exists(join(consumerDir, "node_modules", "recursive-pub-a", "package.json"))).toBeTrue();
+    expect(await exists(join(consumerDir, "node_modules", "publish-pkg-recursive-a", "package.json"))).toBeTrue();
   });
 });

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1602,13 +1602,13 @@ describe("--recursive", () => {
     expect(exitCode).toBe(1);
   });
 
-  test.skipIf(isWindows)("continues after a lifecycle script killed by a signal", async () => {
+  test.skipIf(isWindows)("continues after a lifecycle script that crashed", async () => {
     using mock = mockRegistry();
     const packageDir = await workspace(
       "rec-signal",
       `http://localhost:${mock.server.port}/`,
       {},
-      { a: { prepack: "kill -TERM $$" } },
+      { a: { prepack: "kill -SEGV $$" } },
     );
 
     const { out, err, exitCode } = await publish(env, packageDir, "-r");
@@ -1617,6 +1617,29 @@ describe("--recursive", () => {
     expect(mock.puts).toEqual(["rec-signal-b@1.0.0", "rec-signal-c@1.0.0"]);
     expect(out.match(/ \+ rec-signal-\w+@1\.0\.0/g)).toEqual([" + rec-signal-b@1.0.0", " + rec-signal-c@1.0.0"]);
     expect(exitCode).toBe(1);
+  });
+
+  test.skipIf(isWindows)("stops the run when a lifecycle script is told to stop", async () => {
+    using mock = mockRegistry();
+    const packageDir = await workspace(
+      "rec-term",
+      `http://localhost:${mock.server.port}/`,
+      {},
+      { a: { prepack: "kill -TERM $$" } },
+    );
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "publish", "-r"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [err] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).toContain('script "prepack" was terminated by signal SIGTERM');
+    expect(err).not.toContain("failed to publish");
+    expect(mock.puts).toEqual([]);
+    expect(proc.signalCode).toBe("SIGTERM");
   });
 
   test("continues after a package whose scope has no credentials", async () => {

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1602,13 +1602,14 @@ describe("--recursive", () => {
     expect(exitCode).toBe(1);
   });
 
-  test.skipIf(isWindows)("continues after a lifecycle script that crashed", async () => {
+  test.skipIf(isWindows)("continues after a lifecycle script that was killed", async () => {
     using mock = mockRegistry();
+    // SIGKILL, not SIGSEGV: a core file from the shell would fail the CI job.
     const packageDir = await workspace(
       "rec-signal",
       `http://localhost:${mock.server.port}/`,
       {},
-      { a: { prepack: "kill -SEGV $$" } },
+      { a: { prepack: "kill -KILL $$" } },
     );
 
     const { out, err, exitCode } = await publish(env, packageDir, "-r");

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1636,7 +1636,7 @@ describe("--recursive", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [err] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, err] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(err).toContain('script "prepack" was terminated by signal SIGTERM');
     expect(err).not.toContain("failed to publish");
     expect(mock.puts).toEqual([]);

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1384,6 +1384,7 @@ describe("--tolerate-republish", async () => {
     const pkgJson = {
       name: "republish-test-2",
       version: "1.0.0",
+      scripts: { postpublish: "echo postpublish ran" },
     };
 
     await Promise.all([
@@ -1396,12 +1397,14 @@ describe("--tolerate-republish", async () => {
     let { out, err, exitCode } = await publish(env, packageDir);
     expect(exitCode).toBe(0);
     expect(out).toContain("+ republish-test-2@1.0.0");
+    expect(out).toContain("postpublish ran");
 
-    // Second publish with --tolerate-republish should skip
+    // Second publish with --tolerate-republish should skip: no success line, no publish scripts
     ({ out, err, exitCode } = await publish(env, packageDir, "--tolerate-republish"));
     expect(exitCode).toBe(0);
     expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n");
-    expect(err).not.toContain("error:");
+    expect(out).not.toContain("+ republish-test-2@1.0.0");
+    expect(out).not.toContain("postpublish ran");
   });
 
   test("republishing tarball with --tolerate-republish skips when version exists", async () => {
@@ -1430,7 +1433,7 @@ describe("--tolerate-republish", async () => {
     ({ out, err, exitCode } = await publish(env, packageDir, "./republish-test-3-1.0.0.tgz", "--tolerate-republish"));
     expect(exitCode).toBe(0);
     expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n");
-    expect(err).not.toContain("error:");
+    expect(out).not.toContain("+ republish-test-3@1.0.0");
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun publish` publishes one package. A workspace with N packages needs N invocations, by hand, in dependency order, with a manual check for what is already on the registry. #40789 asks for `bun publish --recursive`. #41290 asks for a full release flow and names this as its first stage.
- `Subcommand::Publish` is absent from `supports_workspace_filtering()` (`src/install/PackageManager.rs:529`), so `--filter` is not parsed for it, and `exec` in `src/runtime/cli/publish_command.rs` packs only `manager.original_package_json_path`.

### Fix
- `bun publish -r, --recursive` and `bun publish -F, --filter <pattern>`. The run selects root and workspace packages from `bun.lock` with the existing `WorkspaceFilter::select_workspaces` and orders them with a new `WorkspaceGraph::dependency_order`, leaves first. It runs in two phases with the existing single-package code: phase 1 packs every eligible package (`prepublishOnly`, `prepack`, `prepare` run here). If one pack fails, the command exits with that error and nothing is published. Phase 2 publishes the tarballs in order. `--otp`, `--tag`, `--access`, `--dry-run` apply to every package. A `publishConfig` in a member `package.json` applies to that member only. `-r` with a tarball path is an error.
- Skips, decided before `pack` runs any lifecycle script: a `private` package, and a `name@version` the registry already has (the same check as `--tolerate-republish`, so a re-run after a partial failure is safe). A skipped package gets no `+` line and runs no `publish` or `postpublish` script. That now holds for single-package `--tolerate-republish` too.
- In phase 2, a registry rejection, a missing credential for the package's scope, or a failing `publish` or `postpublish` script is reported and the run continues. At the end the command exits 1 with the failed names. For that, `publish()` returns `PublishError::{Rejected, RequestFailed, NeedAuth, ScriptFailed}` instead of exiting, `Npm::response_error` is split so its report can be printed without the exit, and `run_package_script_foreground_status` returns a `ScriptStatus` (the existing wrapper still exits with the code or re-raises the signal). The single-package path still exits with the same codes as before.
- Two fixes the workspace loop exposed: `normalized_package` resolved `bin` and `directories.bin` against the invocation directory, not the package being packed, and the `directories.bin` descriptor was never closed.
- Verified: `test/cli/install/bun-publish.test.ts` (16 new tests under `--recursive`, plus two strengthened `--tolerate-republish` tests). Also all of `bun-publish.test.ts`, `bun-pack.test.ts`, and `test/cli/run/run-exit-code.test.ts`. Reviewed: the two review bots raised 14 findings, 13 are fixed in later commits, one is declined (the remaining exits inside `pack` are lockfile and configuration errors that end the whole run).

### Background
- `bun publish` without a tarball path runs `pack::pack::<true>`, which reads the `package.json`, runs `prepublishOnly`, `prepack` and `prepare`, rewrites `workspace:` and `catalog:` versions from `bun.lock`, and returns a `Context` with the tarball bytes. `publish()` PUTs that to the registry, then `publish` and `postpublish` run.
- `WorkspaceFilter::select_workspaces` is what `bun outdated -r` and `bun update -r` use: it lists the root and workspace package ids in `bun.lock` and applies `--filter` patterns to them. `WorkspaceGraph::from_lockfile` builds the workspace dependency edges from the same lockfile. `dependency_order` is Kahn's algorithm over those edges. A stall means a cycle, and the stall breaker releases a node that is on the cycle, so a package that only depends on the cycle still comes after it.
- `publishConfig.tag` and `publishConfig.access` are copied into `manager.options` by `pack` when the flag was not given. The recursive loop saves the flag values and restores them before each package.

<details><summary>Notes</summary>

- Staged publishing (npm's `stage` flow) is not in this PR. It can follow once this shape is settled.
- The issue asks for three stages. This PR is stage 1 only. `bun pm version --recursive` and `bun pm change` wait for a maintainer decision on #41290.
- `--recursive` needs `bun.lock` because the workspace list, the dependency order, and the `workspace:` version rewrite all come from it. Without one the command prints `missing lockfile, nothing to publish` and the `run 'bun install' first` note, like `bun outdated`.
- A `--filter` run that matches nothing exits 1 with the shared `No workspace packages matched the filter` message.
- The registry check before `pack` reads `name` and `version` from the `package.json` on disk. The check inside `publish()` stays, for a `prepublishOnly` that changes the version.
- When `--otp` is not given and the registry asks for one, each package prompts. The prompted value is not reused across packages.
- The request body used to be parked in a process-lifetime side table (`cli_adopt`). It is a local now, so a workspace run holds one body at a time.
- A script the system shell could not start used to report success (`Ok(())` after the error line). It returns 1 now, for `bun run` too.
- Docs: `docs/pm/cli/publish.mdx` and `docs/snippets/cli/publish.mdx`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->