### PR TITLE
Add bun login and bun logout

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3054,6 +3054,90 @@
       "documentationUrl": "https://bun.com/docs/cli/publish.",
       "dynamicCompletions": {}
     },
+    "login": {
+      "name": "login",
+      "description": "Log in to an npm registry in the browser and save the token to your user-level .npmrc.",
+      "flags": [
+        {
+          "name": "registry",
+          "description": "Log in to this registry instead of the configured one",
+          "hasValue": true,
+          "valueType": "val",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "scope",
+          "description": "Log in to the registry configured for this scope (e.g. @myorg)",
+          "hasValue": true,
+          "valueType": "val",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "help",
+          "shortName": "h",
+          "description": "Print this help menu",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        }
+      ],
+      "positionalArgs": [
+        {
+          "name": "flags",
+          "required": false,
+          "multiple": false,
+          "type": "string"
+        }
+      ],
+      "examples": ["bun login", "bun login --registry https://npm.pkg.github.com", "bun login --scope @myorg"],
+      "usage": "Usage: bun login [flags]",
+      "documentationUrl": "https://bun.com/docs/pm/cli/login",
+      "dynamicCompletions": {}
+    },
+    "logout": {
+      "name": "logout",
+      "description": "Revoke the saved token for an npm registry and remove it from your user-level .npmrc.",
+      "flags": [
+        {
+          "name": "registry",
+          "description": "Log out of this registry instead of the configured one",
+          "hasValue": true,
+          "valueType": "val",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "scope",
+          "description": "Log out of the registry configured for this scope (e.g. @myorg)",
+          "hasValue": true,
+          "valueType": "val",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "help",
+          "shortName": "h",
+          "description": "Print this help menu",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        }
+      ],
+      "positionalArgs": [
+        {
+          "name": "flags",
+          "required": false,
+          "multiple": false,
+          "type": "string"
+        }
+      ],
+      "examples": ["bun logout", "bun logout --scope @myorg"],
+      "usage": "Usage: bun logout [flags]",
+      "documentationUrl": "https://bun.com/docs/pm/cli/login",
+      "dynamicCompletions": {}
+    },
     "patch": {
       "name": "patch",
       "description": "Prepare a package for patching, or generate and save a patch.",

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -89,7 +89,7 @@ _bun_completions() {
     declare -A PACKAGE_OPTIONS;
     declare -A PM_OPTIONS;
 
-    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord help init pm x test repl update audit dedupe prune outdated link unlink build";
+    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord help init pm x test repl update audit dedupe prune outdated link unlink build publish login logout";
 
     GLOBAL_OPTIONS[LONG_OPTIONS]="--use --cwd --bunfile --server-bunfile --config --disable-react-fast-refresh --disable-hmr --env-file --extension-order --jsx-factory --jsx-fragment --extension-order --jsx-factory --jsx-fragment --jsx-import-source --jsx-production --jsx-runtime --main-fields --no-summary --version --platform --public-dir --tsconfig-override --define --external --help --inject --loader --origin --port --dump-environment-variables --dump-limits --disable-bun-js";
     GLOBAL_OPTIONS[SHORT_OPTIONS]="-c -v -d -e -h -i -l -u -p";
@@ -196,6 +196,9 @@ _bun_completions() {
             return;;
         upgrade)
             COMPREPLY=( $(compgen -W "--version --cwd --help -v -h") );
+            return;;
+        login|logout)
+            COMPREPLY=( $(compgen -W "--registry --scope --help -h" -- "${cur_word}") );
             return;;
         repl)
             COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") );

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -249,6 +249,12 @@ complete -c bun -n "__fish_seen_subcommand_from update" -l "no-cache" -d "Ignore
 complete -c bun -n "__fish_seen_subcommand_from update" -l "silent" -d "Don't log anything" -f
 complete -c bun -n "__fish_seen_subcommand_from update" -l "verbose" -d "Excessively verbose logging" -f
 complete -c bun -n "__fish_use_subcommand" -a "publish" -d "Publish your package from local to npm" -f
+complete -c bun -n "__fish_use_subcommand" -a "login" -d "Log in to an npm registry" -f
+complete -c bun -n "__fish_seen_subcommand_from login" -l "registry" -r -d "Log in to this registry instead of the configured one" -f
+complete -c bun -n "__fish_seen_subcommand_from login" -l "scope" -r -d "Log in to the registry configured for this scope" -f
+complete -c bun -n "__fish_use_subcommand" -a "logout" -d "Log out of an npm registry" -f
+complete -c bun -n "__fish_seen_subcommand_from logout" -l "registry" -r -d "Log out of this registry instead of the configured one" -f
+complete -c bun -n "__fish_seen_subcommand_from logout" -l "scope" -r -d "Log out of the registry configured for this scope" -f
 complete -c bun -n "__fish_use_subcommand" -a "repl" -d "Start a REPL session with Bun" -f
 complete -c bun -n "__fish_seen_subcommand_from repl" -s "e" -l "eval" -r -d "Evaluate argument as a script, then exit" -f
 complete -c bun -n "__fish_seen_subcommand_from repl" -s "p" -l "print" -r -d "Evaluate argument as a script, print the result, then exit" -f

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -749,6 +749,16 @@ _bun_prune_completion() {
         ret=0
 }
 
+_bun_login_completion() {
+    _arguments -s -C \
+        '1: :->cmd1' \
+        '--registry[Use this registry instead of the configured one]:url' \
+        '--scope[Use the registry configured for this scope (e.g. @myorg)]:scope' \
+        '-h[Print this help menu]' \
+        '--help[Print this help menu]' &&
+        ret=0
+}
+
 _bun_audit_completion() {
     _arguments -s -C \
         '1: :->cmd1' \
@@ -885,6 +895,8 @@ _bun() {
             'audit\:"Check installed packages for vulnerabilities" '
             'dedupe\:"Remove duplicate versions from the lockfile" '
             'prune\:"Remove packages that are not in the lockfile from node_modules" '
+            'login\:"Log in to an npm registry" '
+            'logout\:"Log out of an npm registry" '
             'outdated\:"Display the latest versions of outdated dependencies" '
             'link\:"Link an npm package globally" '
             'unlink\:"Globally unlink an npm package" '
@@ -976,6 +988,10 @@ _bun() {
             ;;
         prune)
             _bun_prune_completion
+
+            ;;
+        login|logout)
+            _bun_login_completion
 
             ;;
         'test')
@@ -1075,6 +1091,10 @@ _bun() {
                     ;;
                 prune)
                     _bun_prune_completion
+
+                    ;;
+                login|logout)
+                    _bun_login_completion
 
                     ;;
                 'test')

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -203,7 +203,14 @@
           {
             "group": "Publishing & Analysis",
             "icon": "upload",
-            "pages": ["/pm/cli/publish", "/pm/cli/outdated", "/pm/cli/why", "/pm/cli/audit", "/pm/cli/info"]
+            "pages": [
+              "/pm/cli/publish",
+              "/pm/cli/login",
+              "/pm/cli/outdated",
+              "/pm/cli/why",
+              "/pm/cli/audit",
+              "/pm/cli/info"
+            ]
           },
           {
             "group": "Workspace Management",

--- a/docs/pm/cli/login.mdx
+++ b/docs/pm/cli/login.mdx
@@ -1,0 +1,72 @@
+---
+title: "bun login"
+description: "Log in to an npm registry and save the token for bun install and bun publish"
+---
+
+`bun login` authenticates you against an npm registry in the browser and saves the resulting token to your user-level `.npmrc`. `bun install`, `bun publish` and `bun pm whoami` read that file, so the login works for all of them.
+
+```bash terminal icon="terminal"
+bun login
+```
+
+```
+bun login v1.4.0 (abc12345)
+Logging in to https://registry.npmjs.org/
+
+Authenticate your account at (press ENTER to open in browser):
+┌──────────────────────────────────────────────────────────────┐
+│ https://www.npmjs.com/login?next=/login/cli/3f1c...          │
+└──────────────────────────────────────────────────────────────┘
+
+Saved the token to /home/me/.npmrc
+Logged in as alice on https://registry.npmjs.org/
+```
+
+Bun asks the registry for a login URL (`POST /-/v1/login`), prints it, and polls the registry until you finish the login in the browser. Pressing ENTER opens the URL in your default browser. Without a terminal (for example in CI), the URL is still printed and polled. The wait is capped at 5 minutes.
+
+The token goes to the first of these files:
+
+1. `$XDG_CONFIG_HOME/.npmrc`, if that file already exists
+2. `$HOME/.npmrc`
+
+This is the same lookup `bun install` uses, so the saved token is the one Bun reads back. The file is written with mode `0600`. Lines that `bun login` did not write, including comments and their order, stay as they are.
+
+<Note>
+  Some registries (GitHub Packages, older Verdaccio versions) do not implement web login. `bun login` then exits with an
+  error and prints the `.npmrc` line to add by hand with a token created on the registry's website.
+</Note>
+
+### `--registry`
+
+Log in to a registry other than the configured one:
+
+```bash terminal icon="terminal"
+bun login --registry https://registry.example.com
+```
+
+This writes `//registry.example.com/:_authToken=<token>`. The default registry setting is not changed.
+
+### `--scope`
+
+Log in to the registry configured for a scope, and bind the scope to that registry:
+
+```bash terminal icon="terminal"
+bun login --scope @myorg
+bun login --scope @myorg --registry https://npm.pkg.example.com
+```
+
+This writes both the token line and `@myorg:registry=<url>`. With `--scope` and no `--registry`, Bun uses the registry your `.npmrc` or `bunfig.toml` already configures for that scope, else the default registry.
+
+## `bun logout`
+
+`bun logout` revokes the saved token on the registry (`DELETE /-/user/token/<token>`) and removes its line from the user-level `.npmrc`.
+
+```bash terminal icon="terminal"
+bun logout
+bun logout --scope @myorg
+bun logout --registry https://registry.example.com
+```
+
+`--scope` also removes the `@myorg:registry` line. If the registry answers `401` or `404`, the token is already invalid and the line is removed anyway. On any other failure the file is left unchanged.
+
+`bun logout` only touches the user-level `.npmrc`. If the registry's credentials come from `bunfig.toml`, a project `.npmrc`, or an environment variable, it exits with an error that says so.

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -292,7 +292,7 @@ With one name and no version, the left side is the version this project's `bun.l
 
 ## whoami
 
-Print your npm username. Requires you to be logged in (`bunx npm login`) with credentials in either `bunfig.toml` or `.npmrc`:
+Print your npm username. Requires you to be logged in (`bun login`) with credentials in either `bunfig.toml` or `.npmrc`:
 
 ```bash terminal icon="terminal"
 bun pm whoami

--- a/docs/pm/cli/publish.mdx
+++ b/docs/pm/cli/publish.mdx
@@ -5,7 +5,7 @@ description: Use `bun publish` to publish a package to the npm registry
 
 import Publish from "/snippets/cli/publish.mdx";
 
-`bun publish` packs your package into a tarball and strips catalog and workspace protocols from the `package.json`, resolving versions if necessary. It then publishes to the registry specified in your configuration files. Both `bunfig.toml` and `.npmrc` files are supported.
+`bun publish` packs your package into a tarball and strips catalog and workspace protocols from the `package.json`, resolving versions if necessary. It then publishes to the registry specified in your configuration files. Both `bunfig.toml` and `.npmrc` files are supported. Run [`bun login`](/pm/cli/login) first to save a token for the registry.
 
 ```sh terminal icon="terminal"
 ## Publishing the package from the current working directory

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1930,34 +1930,9 @@ pub fn init(
         let npmrc_local = ZBox::from_bytes(b".npmrc");
 
         let mut buf = PathBuffer::uninit();
-        let parts = [b"./.npmrc" as &[u8]];
 
-        // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
-        // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
-        let mut global_len: usize = 0;
-        if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
-            let p =
-                resolve_path::join_abs_string_buf_z::<platform::Auto>(xdg_dir, &mut buf, &parts);
-            if bun_sys::exists_z(p) {
-                global_len = p.len();
-            }
-        }
-        if global_len == 0 {
-            if let Some(home_dir) = bun_core::env_var::HOME.get_not_empty() {
-                global_len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
-                    home_dir, &mut buf, &parts,
-                )
-                .len();
-            }
-        }
-
-        let registry_auth = if global_len > 0 {
-            ini::load_npmrc_config(
-                &mut install,
-                env,
-                true,
-                &[ZStr::from_buf(&buf[..], global_len), &*npmrc_local],
-            )
+        let registry_auth = if let Some(user_npmrc) = crate::npmrc::user_npmrc_path(&mut buf) {
+            ini::load_npmrc_config(&mut install, env, true, &[user_npmrc, &*npmrc_local])
         } else {
             ini::load_npmrc_config(&mut install, env, true, &[&*npmrc_local])
         };

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -509,6 +509,8 @@ pub enum Subcommand {
     Why,
     Dedupe,
     Prune,
+    Login,
+    Logout,
     // bin,
     // hash,
     // @"hash-print",
@@ -1580,7 +1582,10 @@ pub fn init(
             //
             // probably wont matter as if package.json isn't writable, it's likely that
             // the underlying directory and node_modules isn't either.
-            let need_write = subcommand != Subcommand::Install || cli.positionals.len() > 1;
+            let need_write = !matches!(
+                subcommand,
+                Subcommand::Install | Subcommand::Login | Subcommand::Logout
+            ) || cli.positionals.len() > 1;
 
             loop {
                 let mut package_json_path_buf = PathBuffer::uninit();

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -412,6 +412,36 @@ static PUBLISH_PARAMS: &[ParamType] = concat_params![
     ]
 ];
 
+static LOGIN_PARAMS: &[ParamType] = concat_params![
+    SHARED_PARAMS,
+    &[
+        clap::param!(
+            "--scope <STR>                          Log in to the registry configured for this scope (e.g. @myorg)"
+        ),
+        clap::param!("<POS> ...                              "),
+    ]
+];
+
+const LOGIN_HELP_PARAMS: &[ParamType] = &[
+    clap::param!(
+        "--registry <STR>                       Log in to this registry instead of the configured one"
+    ),
+    clap::param!(
+        "--scope <STR>                          Log in to the registry configured for this scope (e.g. @myorg)"
+    ),
+    clap::param!("-h, --help                             Print this help menu"),
+];
+
+const LOGOUT_HELP_PARAMS: &[ParamType] = &[
+    clap::param!(
+        "--registry <STR>                       Log out of this registry instead of the configured one"
+    ),
+    clap::param!(
+        "--scope <STR>                          Log out of the registry configured for this scope (e.g. @myorg)"
+    ),
+    clap::param!("-h, --help                             Print this help menu"),
+];
+
 static WHY_PARAMS: &[ParamType] = concat_params![
     SHARED_PARAMS,
     &[
@@ -552,7 +582,10 @@ pub struct CommandLineArguments {
 
     pub(crate) patch: PatchOpts,
 
-    pub(crate) registry: &'static [u8],
+    pub registry: &'static [u8],
+
+    // `bun login` / `bun logout` options
+    pub scope: &'static [u8],
 
     pub(crate) publish_config: Options::PublishConfig,
 
@@ -657,6 +690,8 @@ impl Default for CommandLineArguments {
             patch: PatchOpts::Nothing,
 
             registry: b"",
+
+            scope: b"",
 
             publish_config: Options::PublishConfig::default(),
 
@@ -1225,6 +1260,59 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
                 pretty_help(outro_text);
                 Output::flush();
             }
+            Subcommand::Login => {
+                let intro_text = r"
+<b>Usage<r>: <b><green>bun login<r> <cyan>[flags]<r>
+
+  Log in to an npm registry in the browser and save the token to your user-level .npmrc.
+
+<b>Flags:<r>";
+
+                let outro_text = r"
+
+<b>Examples:<r>
+  <d>Log in to the default registry<r>
+  <b><green>bun login<r>
+
+  <d>Log in to a different registry<r>
+  <b><green>bun login<r> <cyan>--registry https://npm.pkg.github.com<r>
+
+  <d>Log in to the registry configured for a scope<r>
+  <b><green>bun login<r> <cyan>--scope @myorg<r>
+
+Full documentation is available at <magenta>https://bun.com/docs/pm/cli/login<r>.
+";
+
+                pretty_help(intro_text);
+                clap::simple_help(LOGIN_HELP_PARAMS);
+                pretty_help(outro_text);
+                Output::flush();
+            }
+            Subcommand::Logout => {
+                let intro_text = r"
+<b>Usage<r>: <b><green>bun logout<r> <cyan>[flags]<r>
+
+  Revoke the saved token for an npm registry and remove it from your user-level .npmrc.
+
+<b>Flags:<r>";
+
+                let outro_text = r"
+
+<b>Examples:<r>
+  <d>Log out of the default registry<r>
+  <b><green>bun logout<r>
+
+  <d>Log out of the registry configured for a scope<r>
+  <b><green>bun logout<r> <cyan>--scope @myorg<r>
+
+Full documentation is available at <magenta>https://bun.com/docs/pm/cli/login<r>.
+";
+
+                pretty_help(intro_text);
+                clap::simple_help(LOGOUT_HELP_PARAMS);
+                pretty_help(outro_text);
+                Output::flush();
+            }
         }
     }
 
@@ -1247,6 +1335,7 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             Subcommand::Why => WHY_PARAMS,
             Subcommand::Dedupe => DEDUPE_PARAMS,
             Subcommand::Prune => PRUNE_PARAMS,
+            Subcommand::Login | Subcommand::Logout => LOGIN_PARAMS,
 
             // TODO: we will probably want to do this for other *_params. this way extra params
             // are not included in the help text
@@ -1476,6 +1565,20 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             }
 
             cli.tolerate_republish = args.flag(b"--tolerate-republish");
+        }
+
+        if matches!(subcommand, Subcommand::Login | Subcommand::Logout) {
+            if let Some(scope) = args.option(b"--scope") {
+                if !strings::starts_with_char(scope, b'@') || scope.len() < 2 {
+                    Output::err_generic(
+                        "invalid `--scope` value: {}, expected a scope like '@myorg'",
+                        (bun_core::fmt::quote(scope),),
+                    );
+                    Global::exit(1);
+                }
+                cli.scope = scope;
+            }
+            cli.no_project_ok = true;
         }
 
         // link and unlink default to not saving, all others default to

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -68,6 +68,7 @@ pub mod error;
 pub use error::{Error, Result};
 
 pub mod npm;
+pub mod npmrc;
 #[path = "PackageManifestMap.rs"]
 pub mod package_manifest_map;
 pub mod resolution;

--- a/src/install/npmrc.rs
+++ b/src/install/npmrc.rs
@@ -1,8 +1,12 @@
-//! The user-level `.npmrc` and where it lives.
+//! The user-level `.npmrc`: its path, and line-preserving edits for `bun login` / `bun logout`.
 
-use bun_core::ZStr;
-use bun_paths::PathBuffer;
+use bun_core::{ZStr, strings};
 use bun_paths::resolve_path::{self, platform};
+use bun_paths::{PathBuffer, path_buffer_pool};
+use bun_sys::{self, Fd, File, O};
+use bun_url::URL;
+
+use crate::bun_json as JSON;
 
 /// `$XDG_CONFIG_HOME/.npmrc` when that file exists, else `$HOME/.npmrc`. Shared by the reader and `bun login`.
 pub fn user_npmrc_path(buf: &mut PathBuffer) -> Option<&ZStr> {
@@ -30,4 +34,288 @@ pub fn user_npmrc_path(buf: &mut PathBuffer) -> Option<&ZStr> {
     }
     // SAFETY: `join_abs_string_buf_z` wrote the NUL at `len`.
     Some(ZStr::from_buf(&buf[..], len))
+}
+
+/// npm's "nerf dart" for a registry: `//host[:port]/path/`, host lowercased.
+pub fn registry_key(registry_href: &[u8]) -> Vec<u8> {
+    let url = URL::parse(registry_href);
+    let mut key = Vec::with_capacity(url.host.len() + url.pathname.len() + 3);
+    key.extend_from_slice(b"//");
+    key.extend_from_slice(url.host);
+    key[2..].make_ascii_lowercase();
+    let pathname = bun_core::without_trailing_slash(url.pathname);
+    if !strings::starts_with_char(pathname, b'/') {
+        key.push(b'/');
+    }
+    key.extend_from_slice(pathname);
+    if !strings::ends_with_char(&key, b'/') {
+        key.push(b'/');
+    }
+    key
+}
+
+/// `//host/path/:_authToken`
+pub fn auth_token_key(registry_href: &[u8]) -> Vec<u8> {
+    let mut key = registry_key(registry_href);
+    key.extend_from_slice(b":_authToken");
+    key
+}
+
+/// `@scope:registry`
+pub fn scope_registry_key(scope: &[u8]) -> Vec<u8> {
+    let scope = strings::trim_leading_char(scope, b'@');
+    let mut key = Vec::with_capacity(scope.len() + b"@:registry".len());
+    key.push(b'@');
+    key.extend_from_slice(scope);
+    key.extend_from_slice(b":registry");
+    key
+}
+
+/// `key = value` on one ini line. `None` for blank lines, comments and lines without `=`.
+fn split_key_value(line: &[u8]) -> Option<(&[u8], &[u8])> {
+    let trimmed = strings::trim(line, &strings::WHITESPACE_CHARS);
+    if trimmed.is_empty() || trimmed[0] == b';' || trimmed[0] == b'#' {
+        return None;
+    }
+    let (key, value) = strings::split_once_char(trimmed, b'=')?;
+    Some((
+        strings::trim(key, &strings::WHITESPACE_CHARS),
+        strings::trim(value, &strings::WHITESPACE_CHARS),
+    ))
+}
+
+/// The ini reader JSON-parses a `"..."` / `'...'` value; do the same so escapes decode alike.
+fn unquote(value: &[u8]) -> Vec<u8> {
+    let double = strings::starts_with_char(value, b'"') && strings::ends_with_char(value, b'"');
+    let single = strings::starts_with_char(value, b'\'') && strings::ends_with_char(value, b'\'');
+    if value.len() < 2 || !(double || single) {
+        return value.to_vec();
+    }
+    if single {
+        return value[1..value.len() - 1].to_vec();
+    }
+    let mut log = bun_ast::Log::init();
+    let source = bun_ast::Source::init_path_string("???", value);
+    match JSON::ParsedJson::parse_json(&source, &mut log) {
+        Ok(parsed) => match parsed.root.as_utf8_string_literal() {
+            Some(text) => text.to_vec(),
+            None => value[1..value.len() - 1].to_vec(),
+        },
+        Err(_) => value[1..value.len() - 1].to_vec(),
+    }
+}
+
+/// npm's `ini.safe`: the reader ends an unquoted value at `;` or `#`, so such values are written as JSON strings.
+fn quote_if_needed(value: &[u8]) -> Vec<u8> {
+    let needs_quotes = value.is_empty()
+        || strings::index_of_any(value, b";#=\"\r\n").is_some()
+        || strings::starts_with_char(value, b'[')
+        || strings::trim(value, &strings::WHITESPACE_CHARS).len() != value.len();
+    if !needs_quotes {
+        return value.to_vec();
+    }
+    let mut out = Vec::with_capacity(value.len() + 2);
+    out.push(b'"');
+    for &byte in value {
+        if byte == b'"' || byte == b'\\' {
+            out.push(b'\\');
+        }
+        out.push(byte);
+    }
+    out.push(b'"');
+    out
+}
+
+/// A `.npmrc` as lines. Edits touch only the lines for their key; the ini reader keeps the last duplicate, so does `get`/`set`.
+pub struct Npmrc {
+    lines: Vec<Vec<u8>>,
+    crlf: bool,
+}
+
+impl Npmrc {
+    /// A missing file loads as empty.
+    pub fn load(path: &ZStr) -> bun_sys::Maybe<Npmrc> {
+        let bytes = match File::openat(Fd::cwd(), path.as_bytes(), O::RDONLY | O::CLOEXEC, 0) {
+            Ok(file) => file.read_to_end()?,
+            Err(err) if err.get_errno() == bun_sys::E::ENOENT => {
+                return Ok(Npmrc {
+                    lines: Vec::new(),
+                    crlf: false,
+                });
+            }
+            Err(err) => return Err(err),
+        };
+
+        let crlf = strings::contains(&bytes, b"\r\n");
+        let mut lines: Vec<Vec<u8>> = strings::split(&bytes, b"\n")
+            .map(|line| strings::trim_suffix(line, b"\r").to_vec())
+            .collect();
+        // a trailing newline yields one empty tail element
+        if lines.last().is_some_and(|l| l.is_empty()) {
+            lines.pop();
+        }
+
+        Ok(Npmrc { lines, crlf })
+    }
+
+    /// Where the first `[section]` starts; the reader only reads registry keys before it.
+    fn root_end(&self) -> usize {
+        self.lines
+            .iter()
+            .position(|line| {
+                let trimmed = strings::trim(line, &strings::WHITESPACE_CHARS);
+                strings::starts_with_char(trimmed, b'[') && strings::ends_with_char(trimmed, b']')
+            })
+            .unwrap_or(self.lines.len())
+    }
+
+    fn position(&self, key: &[u8]) -> Option<usize> {
+        self.lines[..self.root_end()]
+            .iter()
+            .rposition(|line| split_key_value(line).is_some_and(|(k, _)| k == key))
+    }
+
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        let line = &self.lines[self.position(key)?];
+        split_key_value(line).map(|(_, v)| unquote(v))
+    }
+
+    pub fn set(&mut self, key: &[u8], value: &[u8]) {
+        let value = quote_if_needed(value);
+        let mut line = Vec::with_capacity(key.len() + value.len() + 1);
+        line.extend_from_slice(key);
+        line.push(b'=');
+        line.extend_from_slice(&value);
+        match self.position(key) {
+            Some(i) => self.lines[i] = line,
+            None => {
+                let at = self.root_end();
+                self.lines.insert(at, line);
+            }
+        }
+    }
+
+    /// Returns whether any line was removed.
+    pub fn remove(&mut self, key: &[u8]) -> bool {
+        let root_end = self.root_end();
+        let before = self.lines.len();
+        let mut i = 0;
+        self.lines.retain(|line| {
+            let keep = i >= root_end || !split_key_value(line).is_some_and(|(k, _)| k == key);
+            i += 1;
+            keep
+        });
+        self.lines.len() != before
+    }
+
+    pub fn save(&self, path: &ZStr) -> bun_sys::Maybe<()> {
+        let newline: &[u8] = if self.crlf { b"\r\n" } else { b"\n" };
+        let mut bytes: Vec<u8> = Vec::new();
+        for line in &self.lines {
+            bytes.extend_from_slice(line);
+            bytes.extend_from_slice(newline);
+        }
+
+        // Write through a symlinked `.npmrc` (dotfile managers) instead of replacing the link.
+        let mut real_buf = path_buffer_pool::get();
+        let target: Vec<u8> = match bun_sys::realpath(path, &mut real_buf) {
+            Ok(real) => real.to_vec(),
+            Err(err) if err.get_errno() == bun_sys::E::ENOENT => follow_dangling_links(path)?,
+            Err(err) => return Err(err),
+        };
+        let target: &[u8] = &target;
+        let dir_path = bun_paths::dirname(target).unwrap_or(b".");
+        let dir_fd = bun_sys::open_dir_absolute(dir_path)?;
+        let _close_dir = bun_sys::CloseOnDrop::new(dir_fd);
+
+        let mut random = [0u8; 8];
+        bun_boringssl_sys::rand_bytes(&mut random);
+        let mut tmpname_buf = [0u8; 64];
+        let tmpname: &ZStr = {
+            use std::io::Write as _;
+            let mut cursor: &mut [u8] = &mut tmpname_buf[..];
+            let start_len = cursor.len();
+            write!(
+                cursor,
+                ".npmrc-{}.tmp\0",
+                bun_core::fmt::HexBytes::<true>(&random)
+            )
+            .expect("64 bytes fit the fixed-width name");
+            let written = start_len - cursor.len();
+            ZStr::from_buf(&tmpname_buf, written - 1)
+        };
+
+        // 0600: the file holds a credential.
+        let mut tmpfile = bun_sys::Tmpfile::create_with_mode(dir_fd, tmpname, 0o600)?;
+        let _close = bun_sys::CloseOnDrop::new(tmpfile.fd);
+        if let Err(err) = File::borrow(&tmpfile.fd)
+            .write_all(&bytes)
+            .and_then(|()| fsync(tmpfile.fd))
+        {
+            let _ = bun_sys::unlinkat(dir_fd, tmpname);
+            return Err(err);
+        }
+        let basename = bun_paths::basename(target);
+        let mut dest_buf = [0u8; 256];
+        let dest: &ZStr = if basename.len() < dest_buf.len() {
+            dest_buf[..basename.len()].copy_from_slice(basename);
+            ZStr::from_buf(&dest_buf, basename.len())
+        } else {
+            let _ = bun_sys::unlinkat(dir_fd, tmpname);
+            return Err(bun_sys::Error::from_code(
+                bun_sys::E::ENAMETOOLONG,
+                bun_sys::Tag::rename,
+            ));
+        };
+        if let Err(err) = tmpfile.finish(dest) {
+            let _ = bun_sys::unlinkat(dir_fd, tmpname);
+            return Err(err);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn fsync(fd: Fd) -> bun_sys::Maybe<()> {
+    bun_sys::sys_uv::fsync(fd)
+}
+
+#[cfg(not(windows))]
+fn fsync(fd: Fd) -> bun_sys::Maybe<()> {
+    bun_sys::fsync(fd)
+}
+
+/// The final path of a symlink chain whose last target does not exist yet.
+fn follow_dangling_links(path: &ZStr) -> bun_sys::Maybe<Vec<u8>> {
+    let mut current = path_buffer_pool::get();
+    let mut current_len = path.len();
+    current[..=current_len].copy_from_slice(path.as_bytes_with_nul());
+    let mut link_buf = path_buffer_pool::get();
+    let mut joined = path_buffer_pool::get();
+    for _ in 0..40 {
+        // SAFETY: `current[current_len]` is the NUL the copy or `join_abs_string_buf_z` wrote (then swapped in).
+        let current_z = ZStr::from_buf(&current[..], current_len);
+        match bun_sys::readlink(current_z, &mut link_buf[..]) {
+            Ok(len) => {
+                let parent = bun_paths::dirname(&current[..current_len]).unwrap_or(b".");
+                let link = &link_buf[..len];
+                current_len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
+                    parent,
+                    &mut joined[..],
+                    &[link],
+                )
+                .len();
+                core::mem::swap(&mut current, &mut joined);
+            }
+            // not a link, or the link's parent is gone: this is the final path
+            Err(err) if matches!(err.get_errno(), bun_sys::E::EINVAL | bun_sys::E::ENOENT) => {
+                return Ok(current[..current_len].to_vec());
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    Err(
+        bun_sys::Error::from_code(bun_sys::E::ELOOP, bun_sys::Tag::readlink)
+            .with_path(path.as_bytes()),
+    )
 }

--- a/src/install/npmrc.rs
+++ b/src/install/npmrc.rs
@@ -1,0 +1,33 @@
+//! The user-level `.npmrc` and where it lives.
+
+use bun_core::ZStr;
+use bun_paths::PathBuffer;
+use bun_paths::resolve_path::{self, platform};
+
+/// `$XDG_CONFIG_HOME/.npmrc` when that file exists, else `$HOME/.npmrc`. Shared by the reader and `bun login`.
+pub fn user_npmrc_path(buf: &mut PathBuffer) -> Option<&ZStr> {
+    let parts = [b"./.npmrc" as &[u8]];
+    let mut len: usize = 0;
+    if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
+        let p =
+            resolve_path::join_abs_string_buf_z::<platform::Auto>(xdg_dir, &mut buf[..], &parts);
+        if bun_sys::exists_z(p) {
+            len = p.len();
+        }
+    }
+    if len == 0 {
+        if let Some(home_dir) = bun_core::env_var::HOME.get_not_empty() {
+            len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
+                home_dir,
+                &mut buf[..],
+                &parts,
+            )
+            .len();
+        }
+    }
+    if len == 0 {
+        return None;
+    }
+    // SAFETY: `join_abs_string_buf_z` wrote the NUL at `len`.
+    Some(ZStr::from_buf(&buf[..], len))
+}

--- a/src/options_types/command_tag.rs
+++ b/src/options_types/command_tag.rs
@@ -44,6 +44,8 @@ pub enum Tag {
     WhyCommand,
     DedupeCommand,
     PruneCommand,
+    LoginCommand,
+    LogoutCommand,
     FuzzilliCommand,
 }
 
@@ -86,6 +88,8 @@ impl Tag {
             Tag::WhyCommand => b'W',
             Tag::DedupeCommand => b'd',
             Tag::PruneCommand => b'N',
+            Tag::LoginCommand => b'L',
+            Tag::LogoutCommand => b'O',
             Tag::FuzzilliCommand => b'F',
         }
     }
@@ -106,6 +110,8 @@ impl Tag {
                 | Tag::AuditCommand
                 | Tag::DedupeCommand
                 | Tag::PruneCommand
+                | Tag::LoginCommand
+                | Tag::LogoutCommand
         )
     }
 
@@ -127,6 +133,8 @@ impl Tag {
                 | Tag::AuditCommand
                 | Tag::DedupeCommand
                 | Tag::PruneCommand
+                | Tag::LoginCommand
+                | Tag::LogoutCommand
         )
     }
 
@@ -171,6 +179,8 @@ impl Tag {
         Self::WhyCommand,
         Self::DedupeCommand,
         Self::PruneCommand,
+        Self::LoginCommand,
+        Self::LogoutCommand,
         Self::FuzzilliCommand,
     ];
 
@@ -230,6 +240,8 @@ pub static LOADS_CONFIG: TagTable<bool> = TagTable({
     a[Tag::AuditCommand as usize] = true;
     a[Tag::DedupeCommand as usize] = true;
     a[Tag::PruneCommand as usize] = true;
+    a[Tag::LoginCommand as usize] = true;
+    a[Tag::LogoutCommand as usize] = true;
     a
 });
 
@@ -251,6 +263,8 @@ pub static ALWAYS_LOADS_CONFIG: TagTable<bool> = TagTable({
     a[Tag::AuditCommand as usize] = true;
     a[Tag::DedupeCommand as usize] = true;
     a[Tag::PruneCommand as usize] = true;
+    a[Tag::LoginCommand as usize] = true;
+    a[Tag::LogoutCommand as usize] = true;
     a
 });
 
@@ -260,6 +274,8 @@ pub static USES_GLOBAL_OPTIONS: TagTable<bool> = TagTable({
     a[Tag::AuditCommand as usize] = false;
     a[Tag::DedupeCommand as usize] = false;
     a[Tag::PruneCommand as usize] = false;
+    a[Tag::LoginCommand as usize] = false;
+    a[Tag::LogoutCommand as usize] = false;
     a[Tag::BunxCommand as usize] = false;
     a[Tag::CreateCommand as usize] = false;
     a[Tag::InfoCommand as usize] = false;

--- a/src/runtime/cli/login_command.rs
+++ b/src/runtime/cli/login_command.rs
@@ -1,0 +1,384 @@
+//! `bun login` (npm web login, token saved to the user `.npmrc`) and `bun logout` (revoke and remove it).
+
+use std::time::{Duration, Instant};
+
+use bun_core::{Global, MutableString, Output, ZStr, fmt as bun_fmt, strings};
+use bun_install::Npm;
+use bun_install::npmrc::{self, Npmrc};
+use bun_install::package_manager_real::{CommandLineArguments, PackageManager, Subcommand};
+use bun_paths::{PathBuffer, path_buffer_pool};
+use bun_url::URL;
+
+use crate::Command;
+use crate::cli::web_login::{self, WebLoginError, WebLoginStart};
+
+/// How long `bun login` waits for the browser login to finish.
+const LOGIN_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// `--registry` wins over `--scope`; `--scope` picks that scope's configured registry.
+fn select_registry<'a>(
+    manager: &'a PackageManager,
+    explicit_registry: bool,
+    scope: &[u8],
+) -> &'a Npm::Registry::Scope {
+    if !explicit_registry && !scope.is_empty() {
+        return manager.options.scope_for_package_name(scope);
+    }
+    &manager.options.scope
+}
+
+fn user_npmrc_path_or_exit(buf: &mut PathBuffer) -> &ZStr {
+    match npmrc::user_npmrc_path(buf) {
+        Some(path) => path,
+        None => {
+            Output::err_generic(
+                "could not find the user-level .npmrc: neither $XDG_CONFIG_HOME nor $HOME is set",
+                (),
+            );
+            Global::exit(1);
+        }
+    }
+}
+
+fn load_npmrc_or_exit(path: &ZStr) -> Npmrc {
+    match Npmrc::load(path) {
+        Ok(rc) => rc,
+        Err(err) => {
+            Output::err(
+                err,
+                "failed to read {s}",
+                (bstr::BStr::new(path.as_bytes()),),
+            );
+            Global::exit(1);
+        }
+    }
+}
+
+fn save_npmrc_or_exit(rc: &Npmrc, path: &ZStr) {
+    if let Err(err) = rc.save(path) {
+        Output::err(
+            err,
+            "failed to write {s}",
+            (bstr::BStr::new(path.as_bytes()),),
+        );
+        Global::exit(1);
+    }
+}
+
+fn os_hostname() -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        let mut buf = [0u8; 256];
+        if bun_sys::posix::gethostname(&mut buf[..]).is_ok() {
+            return bun_core::slice_to_nul(&buf[..]).to_vec();
+        }
+    }
+    #[cfg(windows)]
+    {
+        let mut wide = [0u16; 256];
+        // SAFETY: idempotent Winsock init (libuv defers it to first use).
+        unsafe { bun_sys::windows::libuv::uv__winsock_ensure() };
+        // SAFETY: `wide` holds 256 u16; the call writes at most 255 plus the NUL.
+        if unsafe { bun_sys::windows::GetHostNameW(wide.as_mut_ptr(), 255) } == 0 {
+            let len = wide.iter().take_while(|&&c| c != 0).count();
+            return strings::to_utf8_alloc_with_type(&wide[..len]);
+        }
+    }
+    b"unknown".to_vec()
+}
+
+/// Same grammar as the `.npmrc` reader: `${VAR}` (kept literal when unset) and `${VAR?}` (empty when unset).
+fn expand_env_vars(value: &[u8], env: &bun_dotenv::Loader) -> Vec<u8> {
+    let mut out = Vec::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(start) = strings::index_of(rest, b"${") {
+        out.extend_from_slice(&rest[..start]);
+        rest = &rest[start..];
+        let Some(end) = strings::index_of_char_usize(rest, b'}') else {
+            break;
+        };
+        let raw_name = &rest[2..end];
+        let optional = strings::ends_with_char(raw_name, b'?');
+        let name = if optional {
+            &raw_name[..raw_name.len() - 1]
+        } else {
+            raw_name
+        };
+        match env.get(name) {
+            Some(expanded) => out.extend_from_slice(expanded),
+            None if optional => {}
+            None => out.extend_from_slice(&rest[..=end]),
+        }
+        rest = &rest[end + 1..];
+    }
+    out.extend_from_slice(rest);
+    out
+}
+
+fn is_loopback_host(hostname: &[u8]) -> bool {
+    strings::eql_comptime(hostname, b"localhost")
+        || strings::eql_comptime(hostname, b"127.0.0.1")
+        || strings::eql_comptime(hostname, b"[::1]")
+        || strings::eql_comptime(hostname, b"::1")
+}
+
+/// Exit on a non-http(s) registry; warn before a token crosses plain http to a remote host.
+fn check_transport(registry: &Npm::Registry::Scope) {
+    let url = registry.url.url();
+    if !(url.is_http() || url.is_https()) {
+        Output::err_generic(
+            "registry URL must start with http:// or https://: {}",
+            (bun_fmt::redacted_npm_url(registry.url.href()),),
+        );
+        Global::exit(1);
+    }
+    if url.is_http() && !is_loopback_host(url.hostname) {
+        bun_core::warn!(
+            "{} uses plain http. The token will travel unencrypted.",
+            bun_fmt::redacted_npm_url(registry.url.href()),
+        );
+    }
+}
+
+fn print_command_name(manager: &PackageManager, name: &str) {
+    if manager.options.should_print_command_name() {
+        bun_core::prettyln!(
+            "<r><b>bun {} <r><d>v{}<r>\n",
+            name,
+            Global::package_json_version_with_sha,
+        );
+        Output::flush();
+    }
+}
+
+pub(crate) struct LoginCommand;
+
+impl LoginCommand {
+    pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
+        let cli = CommandLineArguments::parse(Subcommand::Login)?;
+
+        // positionals[0] is "login" itself
+        if cli.positionals.len() > 1 {
+            Output::err_generic("bun login does not take arguments", ());
+            bun_core::note!("run 'bun login --help' for more information");
+            Global::exit(1);
+        }
+
+        let explicit_registry = !cli.registry.is_empty();
+        let scope = cli.scope;
+        let (manager, _cwd) = PackageManager::init(&mut *ctx, cli, Subcommand::Login)?;
+        print_command_name(manager, "login");
+
+        let registry = select_registry(manager, explicit_registry, scope);
+        let registry_href: &[u8] = registry.url.href();
+        check_transport(registry);
+
+        bun_core::prettyln!(
+            "Logging in to <b>{}<r>",
+            bun_fmt::redacted_npm_url(registry_href)
+        );
+        Output::flush();
+
+        let mut response_buf =
+            MutableString::init(1024).unwrap_or_else(|_| bun_core::out_of_memory());
+
+        let hostname = os_hostname();
+
+        let (login_url, done_url) = match web_login::request_web_login(
+            registry,
+            &hostname,
+            &mut response_buf,
+        ) {
+            Ok(WebLoginStart::Challenge {
+                login_url,
+                done_url,
+            }) => (login_url, done_url),
+            Ok(WebLoginStart::Unsupported { status }) => {
+                Output::err_generic(
+                    "{} did not offer a web login (HTTP {} from /-/v1/login)",
+                    (bun_fmt::redacted_npm_url(registry_href), status),
+                );
+                let mut path_buf = path_buffer_pool::get();
+                let path = user_npmrc_path_or_exit(&mut path_buf);
+                bun_core::note!(
+                    "create a token on the registry's website and add it to {} as:\n  {}=\\<token\\>",
+                    bstr::BStr::new(path.as_bytes()),
+                    bstr::BStr::new(&npmrc::auth_token_key(registry_href)),
+                );
+                Global::exit(1);
+            }
+            Err(_) => bun_core::out_of_memory(),
+        };
+
+        web_login::print_auth_url(login_url);
+
+        let headers = web_login::registry_headers(registry, b"login", None, false)
+            .unwrap_or_else(|_| bun_core::out_of_memory());
+
+        let token = match web_login::poll_done_url(
+            &URL::parse(&done_url),
+            &headers,
+            &mut response_buf,
+            Some(Instant::now() + LOGIN_TIMEOUT),
+            None,
+        ) {
+            Ok(token) => token,
+            Err(WebLoginError::OutOfMemory) => bun_core::out_of_memory(),
+            Err(WebLoginError::TimedOut) => {
+                Output::err_generic(
+                    "timed out after {} minutes waiting for the login to complete",
+                    (LOGIN_TIMEOUT.as_secs() / 60,),
+                );
+                Global::exit(1);
+            }
+        };
+
+        if token.is_empty() || token.iter().any(|b| b.is_ascii_control()) {
+            Output::err_generic("the registry returned an invalid token", ());
+            Global::exit(1);
+        }
+
+        let mut path_buf = path_buffer_pool::get();
+        let path = user_npmrc_path_or_exit(&mut path_buf);
+        let mut rc = load_npmrc_or_exit(path);
+        rc.set(&npmrc::auth_token_key(registry_href), &token);
+        if !scope.is_empty() {
+            rc.set(&npmrc::scope_registry_key(scope), registry_href);
+        }
+        save_npmrc_or_exit(&rc, path);
+
+        bun_core::prettyln!(
+            "\n<green>Saved the token to<r> <b>{}<r>",
+            bstr::BStr::new(path.as_bytes())
+        );
+        Output::flush();
+
+        let username = web_login::whoami_best_effort(registry, &token, &mut response_buf)
+            .unwrap_or_else(|_| bun_core::out_of_memory());
+        match username {
+            Some(username) => bun_core::prettyln!(
+                "Logged in as <b>{}<r> on <b>{}<r>",
+                bstr::BStr::new(&username),
+                bun_fmt::redacted_npm_url(registry_href),
+            ),
+            None => bun_core::prettyln!(
+                "Logged in on <b>{}<r>",
+                bun_fmt::redacted_npm_url(registry_href)
+            ),
+        }
+        Output::flush();
+        Ok(())
+    }
+}
+
+pub(crate) struct LogoutCommand;
+
+impl LogoutCommand {
+    pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
+        let cli = CommandLineArguments::parse(Subcommand::Logout)?;
+
+        // positionals[0] is "logout" itself
+        if cli.positionals.len() > 1 {
+            Output::err_generic("bun logout does not take arguments", ());
+            bun_core::note!("run 'bun logout --help' for more information");
+            Global::exit(1);
+        }
+
+        let explicit_registry = !cli.registry.is_empty();
+        let scope = cli.scope;
+        let (manager, _cwd) = PackageManager::init(&mut *ctx, cli, Subcommand::Logout)?;
+        print_command_name(manager, "logout");
+
+        let registry = select_registry(manager, explicit_registry, scope);
+        let registry_href: &[u8] = registry.url.href();
+        check_transport(registry);
+
+        let mut path_buf = path_buffer_pool::get();
+        let path = user_npmrc_path_or_exit(&mut path_buf);
+        let mut rc = load_npmrc_or_exit(path);
+
+        let token_key = npmrc::auth_token_key(registry_href);
+        let Some(raw_token) = rc.get(&token_key) else {
+            Output::err_generic(
+                "not logged in to {}",
+                (bun_fmt::redacted_npm_url(registry_href),),
+            );
+            bun_core::note!(
+                "{} has no `{}` line",
+                bstr::BStr::new(path.as_bytes()),
+                bstr::BStr::new(&token_key),
+            );
+            if !registry.token.is_empty() || !registry.auth.is_empty() {
+                bun_core::note!(
+                    "the credentials for this registry come from bunfig.toml, a project .npmrc, or an environment variable. Remove them there."
+                );
+            }
+            Global::exit(1);
+        };
+
+        let expand = |value: &[u8]| match manager.env.as_deref() {
+            Some(env) => expand_env_vars(value, env),
+            None => value.to_vec(),
+        };
+        let token = expand(&raw_token);
+        if token.is_empty() {
+            Output::err_generic(
+                "the token for {} is `{}`, which expands to an empty string",
+                (
+                    bun_fmt::redacted_npm_url(registry_href),
+                    bstr::BStr::new(&raw_token),
+                ),
+            );
+            Global::exit(1);
+        }
+
+        let mut response_buf =
+            MutableString::init(1024).unwrap_or_else(|_| bun_core::out_of_memory());
+        let status = web_login::revoke_token(registry, &token, &mut response_buf)
+            .unwrap_or_else(|_| bun_core::out_of_memory());
+
+        match status {
+            200..=299 => {}
+            // the saved line is dead either way
+            401 | 404 => {
+                bun_core::note!(
+                    "{} reports the token is already invalid (HTTP {})",
+                    bun_fmt::redacted_npm_url(registry_href),
+                    status,
+                );
+            }
+            _ => {
+                Output::err_generic(
+                    "failed to revoke the token on {} (HTTP {}). {} was left unchanged.",
+                    (
+                        bun_fmt::redacted_npm_url(registry_href),
+                        status,
+                        bstr::BStr::new(path.as_bytes()),
+                    ),
+                );
+                Global::exit(1);
+            }
+        }
+
+        rc.remove(&token_key);
+        if !scope.is_empty() {
+            let scope_key = npmrc::scope_registry_key(scope);
+            let points_here = rc.get(&scope_key).is_some_and(|url| {
+                strings::without_trailing_slash(&expand(&url))
+                    == strings::without_trailing_slash(registry_href)
+            });
+            if points_here {
+                rc.remove(&scope_key);
+            }
+        }
+        save_npmrc_or_exit(&rc, path);
+
+        bun_core::prettyln!(
+            "Logged out of <b>{}<r>. Removed the token from <b>{}<r>",
+            bun_fmt::redacted_npm_url(registry_href),
+            bstr::BStr::new(path.as_bytes()),
+        );
+        Output::flush();
+        Ok(())
+    }
+}

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -344,6 +344,8 @@ pub mod filter_arg;
 pub mod filter_run;
 #[path = "link_command.rs"]
 pub mod link_command;
+#[path = "login_command.rs"]
+pub(crate) mod login_command;
 #[path = "multi_run.rs"]
 pub mod multi_run;
 #[path = "outdated_command.rs"]
@@ -375,8 +377,6 @@ pub mod pm_view_command;
 pub(crate) mod pm_why_command;
 #[path = "prune_command.rs"]
 pub(crate) mod prune_command;
-#[path = "web_login.rs"]
-pub(crate) mod web_login;
 #[path = "publish_command.rs"]
 pub mod publish_command;
 #[path = "remove_command.rs"]
@@ -389,6 +389,8 @@ pub mod unlink_command;
 pub(crate) mod update_command;
 #[path = "update_interactive_command.rs"]
 pub mod update_interactive_command;
+#[path = "web_login.rs"]
+pub(crate) mod web_login;
 #[path = "why_command.rs"]
 pub mod why_command;
 
@@ -661,6 +663,8 @@ pub mod help_command {
   <b><blue>link<r>      <d>[\\<package\\>]<r>          Register or link a local npm package
   <b><blue>unlink<r>                         Unregister a local npm package
   <b><blue>publish<r>                        Publish a package to the npm registry
+  <b><blue>login<r>                          Log in to an npm registry
+  <b><blue>logout<r>                         Log out of an npm registry
   <b><blue>patch <d>\\<pkg\\><r>                    Prepare a package for patching
   <b><blue>pm <d>\\<subcommand\\><r>                Additional package management utilities
   <b><blue>info<r>      <d>{:<16}<r>     Display package metadata from the registry
@@ -1054,14 +1058,18 @@ pub mod command {
         if x == RootCommandMatcher::case(b"prune") {
             return Tag::PruneCommand;
         }
+        if x == RootCommandMatcher::case(b"login") {
+            return Tag::LoginCommand;
+        }
+        if x == RootCommandMatcher::case(b"logout") {
+            return Tag::LogoutCommand;
+        }
         // reserved
         if x == RootCommandMatcher::case(b"deploy")
             || x == RootCommandMatcher::case(b"cloud")
             || x == RootCommandMatcher::case(b"config")
             || x == RootCommandMatcher::case(b"use")
             || x == RootCommandMatcher::case(b"auth")
-            || x == RootCommandMatcher::case(b"login")
-            || x == RootCommandMatcher::case(b"logout")
         {
             return Tag::ReservedCommand;
         }
@@ -1307,6 +1315,8 @@ pub mod command {
             Tag::AuditCommand => exec_audit(log),
             Tag::DedupeCommand => exec_dedupe(log),
             Tag::PruneCommand => exec_prune(log),
+            Tag::LoginCommand => exec_login(log),
+            Tag::LogoutCommand => exec_logout(log),
             Tag::WhyCommand => exec_why(log),
             Tag::BunxCommand => exec_bunx(log),
             Tag::ReplCommand => exec_repl(log),
@@ -1613,6 +1623,8 @@ pub mod command {
         exec_why                => (WhyCommand,            super::why_command::WhyCommand::exec),
         exec_dedupe             => (DedupeCommand,         super::dedupe_command::DedupeCommand::exec),
         exec_prune              => (PruneCommand,          super::prune_command::PruneCommand::exec),
+        exec_login              => (LoginCommand,          super::login_command::LoginCommand::exec),
+        exec_logout             => (LogoutCommand,         super::login_command::LogoutCommand::exec),
         exec_remove             => (RemoveCommand,         super::remove_command::RemoveCommand::exec),
         exec_link               => (LinkCommand,           super::link_command::LinkCommand::exec),
         exec_unlink             => (UnlinkCommand,         super::unlink_command::UnlinkCommand::exec),
@@ -2175,6 +2187,12 @@ Execute a shell script directly from Bun.
             }
             Tag::PruneCommand => {
                 pm_print_help(PmSubcommand::Prune);
+            }
+            Tag::LoginCommand => {
+                pm_print_help(PmSubcommand::Login);
+            }
+            Tag::LogoutCommand => {
+                pm_print_help(PmSubcommand::Logout);
             }
             Tag::InfoCommand => {
                 pretty!(

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -375,6 +375,8 @@ pub mod pm_view_command;
 pub(crate) mod pm_why_command;
 #[path = "prune_command.rs"]
 pub(crate) mod prune_command;
+#[path = "web_login.rs"]
+pub(crate) mod web_login;
 #[path = "publish_command.rs"]
 pub mod publish_command;
 #[path = "remove_command.rs"]

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -328,7 +328,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                         Npm::WhoamiError::OutOfMemory => bun_core::out_of_memory(),
                         Npm::WhoamiError::NeedAuth => {
                             Output::err_generic(
-                                "missing authentication (run <cyan>`bunx npm login`<r>)",
+                                "missing authentication (run <cyan>`bun login`<r>)",
                                 (),
                             );
                         }

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1868,7 +1868,7 @@ impl PublishError {
         match self {
             PublishError::OutOfMemory => bun_core::out_of_memory(),
             PublishError::NeedAuth => {
-                Output::err_generic("missing authentication (run <cyan>`bunx npm login`<r>)", ());
+                Output::err_generic("missing authentication (run <cyan>`bun login`<r>)", ());
                 Global::crash();
             }
         }

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -31,24 +31,9 @@ use bun_install::dependency;
 use bun_install::{AuthType, LogLevel};
 use bun_sys::FdExt as _;
 
-// `json_mod::parse_utf8` returns `bun_ast::Expr` (the value-shaped
-// JSON-only `Expr`), not `bun_ast::Expr`, so `Expr::get_string_cloned`
-// can't be applied. Mirror the lookup as a free fn over the JSON `Expr` using
-// its own `as_property` / `as_string_cloned` surface.
-#[inline]
-fn json_get_string_cloned<'b>(
-    expr: &bun_ast::Expr,
-    bump: &'b bun_alloc::Arena,
-    name: &[u8],
-) -> Result<Option<&'b [u8]>, AllocError> {
-    match expr.as_property(name) {
-        Some(q) => q.expr.as_string_cloned(bump),
-        None => Ok(None),
-    }
-}
-
 use crate::Command;
 use crate::cli::pack_command::{self as pack};
+use crate::cli::web_login::{self, json_get_string_cloned};
 
 pub(crate) struct ReadmeInfo {
     pub filename: Vec<u8>,
@@ -80,7 +65,6 @@ fn is_readme_os_path(name: &[OSPathChar]) -> bool {
 }
 
 use crate::cli::init_command::InitCommand;
-use crate::cli::open;
 use crate::run_command::RunCommand as Run;
 
 type SHA1Digest = [u8; sha::SHA1::DIGEST];
@@ -1074,29 +1058,6 @@ impl PublishCommand {
         Ok(())
     }
 
-    fn press_enter_to_open_in_browser(auth_url: &ZStr) {
-        // unset `ENABLE_VIRTUAL_TERMINAL_INPUT` on windows. This prevents backspace from
-        // deleting the entire line
-        #[cfg(windows)]
-        let _stdin_mode =
-            bun_sys::windows::StdinModeGuard::set(bun_sys::windows::UpdateStdioModeFlagsOpts {
-                unset: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
-                ..Default::default()
-            });
-
-        loop {
-            // SAFETY: `buffered_stdin()` returns a process-global `*mut`; this
-            // loop is the only accessor while it runs (single-threaded CLI path).
-            match unsafe { (*Output::buffered_stdin()).reader().read_byte() } {
-                Ok(b'\n') => break,
-                Ok(_) => continue,
-                Err(_) => return,
-            }
-        }
-
-        let _ = bun_core::spawn_sync_inherit(&[open::OPENER, auth_url.as_bytes()]);
-    }
-
     fn get_otp<const DIRECTORY_PUBLISH: bool>(
         ctx: &Context<'_, DIRECTORY_PUBLISH>,
         registry: &Npm::Registry::Scope,
@@ -1124,21 +1085,8 @@ impl PublishCommand {
                 let Some(auth_url_str) = json_get_string_cloned(&json, &bump, b"authUrl")? else {
                     break 'try_web;
                 };
-                // Note: bump-owned `&[u8]` — dupe into the process-lifetime
-                // CLI arena so the spawned thread (which outlives `bump`) can
-                // borrow it `'static`.
-                let auth_url_str: &'static ZStr = {
-                    let len = auth_url_str.len();
-                    let buf: &'static mut [u8] =
-                        crate::cli::cli_arena().alloc_slice_fill_default(len + 1);
-                    buf[..len].copy_from_slice(auth_url_str);
-                    // SAFETY: `buf[len] == 0`; arena-backed `'static`.
-                    ZStr::from_buf(&buf[..], len)
-                };
-                let auth_url_is_web = {
-                    let auth_url = URL::parse(auth_url_str.as_bytes());
-                    auth_url.is_http() || auth_url.is_https()
-                };
+                // bump-owned `&[u8]`; the browser thread outlives `bump`.
+                let auth_url_str: &'static ZStr = web_login::dupe_static_z(auth_url_str);
 
                 // important to clone because it belongs to `response_buf`, and `response_buf` will be
                 // reused with the following requests
@@ -1157,88 +1105,7 @@ impl PublishCommand {
                     }
                 }
 
-                if auth_url_is_web {
-                    bun_core::prettyln!(
-                        "\nAuthenticate your account at (press <b>ENTER<r> to open in browser):\n",
-                    );
-                } else {
-                    bun_core::prettyln!("\nAuthenticate your account at:\n");
-                }
-
-                const PADDING: usize = 1;
-
-                let horizontal = if Output::enable_ansi_colors_stdout() {
-                    "─"
-                } else {
-                    "-"
-                };
-                let vertical = if Output::enable_ansi_colors_stdout() {
-                    "│"
-                } else {
-                    "|"
-                };
-                let top_left = if Output::enable_ansi_colors_stdout() {
-                    "┌"
-                } else {
-                    "|"
-                };
-                let top_right = if Output::enable_ansi_colors_stdout() {
-                    "┐"
-                } else {
-                    "|"
-                };
-                let bottom_left = if Output::enable_ansi_colors_stdout() {
-                    "└"
-                } else {
-                    "|"
-                };
-                let bottom_right = if Output::enable_ansi_colors_stdout() {
-                    "┘"
-                } else {
-                    "|"
-                };
-
-                let width: usize = (PADDING * 2) + auth_url_str.len();
-
-                Output::print(format_args!("{}", top_left));
-                for _ in 0..width {
-                    Output::print(format_args!("{}", horizontal));
-                }
-                Output::print(format_args!("{}\n", top_right));
-
-                Output::print(format_args!("{}", vertical));
-                for _ in 0..PADDING {
-                    Output::print(format_args!(" "));
-                }
-                bun_core::pretty!("<b>{}<r>", bstr::BStr::new(auth_url_str.as_bytes()));
-                for _ in 0..PADDING {
-                    Output::print(format_args!(" "));
-                }
-                Output::print(format_args!("{}\n", vertical));
-
-                Output::print(format_args!("{}", bottom_left));
-                for _ in 0..width {
-                    Output::print(format_args!("{}", horizontal));
-                }
-                Output::print(format_args!("{}\n", bottom_right));
-                Output::flush();
-
-                if auth_url_is_web {
-                    // on another thread because pressing enter is not required
-                    match std::thread::Builder::new()
-                        .spawn(move || Self::press_enter_to_open_in_browser(auth_url_str))
-                    {
-                        Ok(_t) => { /* JoinHandle dropped → detached */ }
-                        Err(_e) => {
-                            Output::err(
-                                "ThreadSpawn",
-                                "failed to spawn thread for opening auth url",
-                                (),
-                            );
-                            Global::crash();
-                        }
-                    }
-                }
+                web_login::print_auth_url(auth_url_str);
 
                 let auth_headers = Self::construct_publish_headers(
                     print_buf,
@@ -1249,110 +1116,24 @@ impl PublishCommand {
                     ctx.manager.options.publish_config.auth_type,
                 )?;
 
-                loop {
-                    response_buf.reset();
-
-                    // Note: `done_url`/`auth_headers.entries` move into
-                    // `init_sync`, so re-clone per iteration.
-                    let mut req = http::AsyncHTTP::init_sync(
-                        http::Method::GET,
-                        done_url.clone(),
-                        auth_headers.entries.clone()?,
-                        auth_headers.content.written_slice(),
-                        b"",
-                        None,
-                        http::FetchRedirect::Follow,
-                    );
-
-                    let res = match req.send_sync(response_buf) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            if e == bun_http::Error::Alloc(bun_alloc::AllocError) {
-                                return Err(GetOTPError::OutOfMemory);
-                            }
-                            Output::err(e, "failed to send OTP request", ());
-                            Global::crash();
-                        }
-                    };
-
-                    match res.status_code() {
-                        202 => {
-                            // retry
-                            let nanoseconds: u64 = 'nanoseconds: {
-                                if let Some(retry) = res.header(b"retry-after") {
-                                    'default: {
-                                        let trimmed =
-                                            strings::trim(retry, &strings::WHITESPACE_CHARS);
-                                        // Header value is bytes, not UTF-8; use the byte-slice parser.
-                                        let Ok(seconds) = strings::parse_int::<u32>(trimmed, 10)
-                                        else {
-                                            break 'default;
-                                        };
-                                        break 'nanoseconds (seconds as u64) * 1_000_000_000;
-                                    }
-                                }
-
-                                break 'nanoseconds 500 * 1_000_000;
-                            };
-
-                            std::thread::sleep(std::time::Duration::from_nanos(nanoseconds));
-                            continue;
-                        }
-                        200 => {
-                            // login successful
-                            let done_bump = bun_alloc::Arena::new();
-                            let otp_done_source = bun_ast::Source::init_path_string(
-                                b"???",
-                                response_buf.list.as_slice(),
-                            );
-                            let otp_done_json = match json_mod::parse_utf8(
-                                &otp_done_source,
-                                manager_log,
-                                &done_bump,
-                            ) {
-                                Ok(j) => j,
-                                Err(e) => {
-                                    if e == bun_parsers::Error::Alloc(bun_alloc::AllocError) {
-                                        return Err(GetOTPError::OutOfMemory);
-                                    }
-                                    Output::err("WebLogin", "failed to parse response json", ());
-                                    Global::crash();
-                                }
-                            };
-
-                            let token =
-                                json_get_string_cloned(&otp_done_json, &done_bump, b"token")?
-                                    .unwrap_or_else(|| {
-                                        Output::err(
-                                            "WebLogin",
-                                            "missing `token` field in reponse json",
-                                            (),
-                                        );
-                                        Global::crash();
-                                    });
-
-                            // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/node_modules/npm-registry-fetch/lib/check-response.js#L14
-                            // ignore if x-local-cache exists
-                            if let Some(notice) =
-                                res.header_if_other_is_absent(b"npm-notice", b"x-local-cache")
-                            {
-                                Output::print_error(format_args!("\n"));
-                                bun_core::note!("{}", bstr::BStr::new(notice));
-                                Output::flush();
-                            }
-
-                            return Ok(token.into());
-                        }
-                        _ => {
-                            Npm::response_error::<false>(
-                                &req,
-                                &res,
-                                Some((&ctx.package_name, &ctx.package_version)),
-                                response_buf,
-                            )?;
-                        }
+                return match web_login::poll_done_url(
+                    &done_url,
+                    &auth_headers,
+                    response_buf,
+                    None,
+                    Some((&ctx.package_name, &ctx.package_version)),
+                ) {
+                    Ok(token) => Ok(token),
+                    Err(web_login::WebLoginError::OutOfMemory) => Err(GetOTPError::OutOfMemory),
+                    Err(web_login::WebLoginError::TimedOut) => {
+                        Output::err(
+                            "WebLogin",
+                            "timed out waiting for the login to complete",
+                            (),
+                        );
+                        Global::crash();
                     }
-                }
+                };
             }
         }
 

--- a/src/runtime/cli/web_login.rs
+++ b/src/runtime/cli/web_login.rs
@@ -1,0 +1,218 @@
+//! npm's web login handshake (show URL, offer the browser, poll `doneUrl`), lifted out of `bun publish`.
+
+use std::time::{Duration, Instant};
+
+use bun_alloc::AllocError;
+use bun_core::{Global, MutableString, Output, ZStr, strings};
+use bun_http as http;
+use bun_install::Npm;
+use bun_parsers::json as json_mod;
+use bun_url::URL;
+
+use crate::cli::open;
+
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
+pub(crate) enum WebLoginError {
+    #[error("OutOfMemory")]
+    OutOfMemory,
+    #[error("TimedOut")]
+    TimedOut,
+}
+bun_core::oom_from_alloc!(WebLoginError);
+
+#[inline]
+pub(crate) fn json_get_string_cloned<'b>(
+    expr: &bun_ast::Expr,
+    bump: &'b bun_alloc::Arena,
+    name: &[u8],
+) -> Result<Option<&'b [u8]>, AllocError> {
+    match expr.as_property(name) {
+        Some(q) => q.expr.as_string_cloned(bump),
+        None => Ok(None),
+    }
+}
+
+/// NUL-terminated copy in the process-lifetime CLI arena, for the detached browser thread.
+pub(crate) fn dupe_static_z(bytes: &[u8]) -> &'static ZStr {
+    let len = bytes.len();
+    let buf: &'static mut [u8] = crate::cli::cli_arena().alloc_slice_fill_default(len + 1);
+    buf[..len].copy_from_slice(bytes);
+    // SAFETY: `buf[len] == 0`; arena-backed `'static`.
+    ZStr::from_buf(&buf[..], len)
+}
+
+pub(crate) fn is_web_url(url: &[u8]) -> bool {
+    let url = URL::parse(url);
+    url.is_http() || url.is_https()
+}
+
+fn press_enter_to_open_in_browser(auth_url: &ZStr) {
+    // without this, backspace deletes the whole line on Windows
+    #[cfg(windows)]
+    let _stdin_mode =
+        bun_sys::windows::StdinModeGuard::set(bun_sys::windows::UpdateStdioModeFlagsOpts {
+            unset: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
+            ..Default::default()
+        });
+
+    loop {
+        // SAFETY: `buffered_stdin()` is process-global and this thread is its only reader.
+        match unsafe { (*Output::buffered_stdin()).reader().read_byte() } {
+            Ok(b'\n') => break,
+            Ok(_) => continue,
+            Err(_) => return,
+        }
+    }
+
+    let _ = bun_core::spawn_sync_inherit(&[open::OPENER, auth_url.as_bytes()]);
+}
+
+/// Print `auth_url` in a box; for http(s) also wait for ENTER on a detached thread and open the browser.
+pub(crate) fn print_auth_url(auth_url: &'static ZStr) {
+    let offer_browser = is_web_url(auth_url.as_bytes());
+
+    if offer_browser {
+        bun_core::prettyln!(
+            "\nAuthenticate your account at (press <b>ENTER<r> to open in browser):\n",
+        );
+    } else {
+        bun_core::prettyln!("\nAuthenticate your account at:\n");
+    }
+
+    const PADDING: usize = 1;
+
+    let colors = Output::enable_ansi_colors_stdout();
+    let horizontal = if colors { "─" } else { "-" };
+    let vertical = if colors { "│" } else { "|" };
+    let top_left = if colors { "┌" } else { "|" };
+    let top_right = if colors { "┐" } else { "|" };
+    let bottom_left = if colors { "└" } else { "|" };
+    let bottom_right = if colors { "┘" } else { "|" };
+
+    let width: usize = (PADDING * 2) + auth_url.len();
+
+    Output::print(format_args!("{}", top_left));
+    for _ in 0..width {
+        Output::print(format_args!("{}", horizontal));
+    }
+    Output::print(format_args!("{}\n", top_right));
+
+    Output::print(format_args!("{}", vertical));
+    for _ in 0..PADDING {
+        Output::print(format_args!(" "));
+    }
+    bun_core::pretty!("<b>{}<r>", bstr::BStr::new(auth_url.as_bytes()));
+    for _ in 0..PADDING {
+        Output::print(format_args!(" "));
+    }
+    Output::print(format_args!("{}\n", vertical));
+
+    Output::print(format_args!("{}", bottom_left));
+    for _ in 0..width {
+        Output::print(format_args!("{}", horizontal));
+    }
+    Output::print(format_args!("{}\n", bottom_right));
+    Output::flush();
+
+    if offer_browser {
+        // on another thread because pressing enter is not required
+        match std::thread::Builder::new().spawn(move || press_enter_to_open_in_browser(auth_url)) {
+            Ok(_t) => { /* JoinHandle dropped → detached */ }
+            Err(_e) => {
+                Output::err(
+                    "ThreadSpawn",
+                    "failed to spawn thread for opening auth url",
+                    (),
+                );
+                Global::crash();
+            }
+        }
+    }
+}
+
+/// `GET done_url` until 200 `{"token"}`; 202 waits `retry-after` seconds (else 500ms) up to `deadline`.
+pub(crate) fn poll_done_url(
+    done_url: &URL<'_>,
+    headers: &http::HeaderBuilder,
+    response_buf: &mut MutableString,
+    deadline: Option<Instant>,
+    pkg_id: Option<(&[u8], &[u8])>,
+) -> Result<Box<[u8]>, WebLoginError> {
+    loop {
+        let now = Instant::now();
+        if deadline.is_some_and(|d| now >= d) {
+            return Err(WebLoginError::TimedOut);
+        }
+
+        response_buf.reset();
+
+        let mut req = http::AsyncHTTP::init_sync(
+            http::Method::GET,
+            done_url.clone(),
+            headers.entries.clone()?,
+            headers.content.written_slice(),
+            b"",
+            None,
+            http::FetchRedirect::Follow,
+        );
+
+        let res = match req.send_sync(response_buf) {
+            Ok(r) => r,
+            Err(bun_http::Error::Alloc(AllocError)) => return Err(WebLoginError::OutOfMemory),
+            Err(e) => {
+                Output::err(e, "failed to poll the login status", ());
+                Global::crash();
+            }
+        };
+
+        match res.status_code() {
+            202 => {
+                let mut pause = Duration::from_millis(500);
+                if let Some(retry) = res.header(b"retry-after") {
+                    let trimmed = strings::trim(retry, &strings::WHITESPACE_CHARS);
+                    if let Ok(seconds) = strings::parse_int::<u32>(trimmed, 10) {
+                        pause = Duration::from_secs(u64::from(seconds));
+                    }
+                }
+                if let Some(d) = deadline {
+                    pause = pause.min(d.saturating_duration_since(now));
+                }
+                std::thread::sleep(pause);
+            }
+            200 => {
+                let bump = bun_alloc::Arena::new();
+                let mut log = bun_ast::Log::init();
+                let source =
+                    bun_ast::Source::init_path_string(b"???", response_buf.list.as_slice());
+                let json = match json_mod::parse_utf8(&source, &mut log, &bump) {
+                    Ok(j) => j,
+                    Err(bun_parsers::Error::Alloc(AllocError)) => {
+                        return Err(WebLoginError::OutOfMemory);
+                    }
+                    Err(_) => {
+                        Output::err("WebLogin", "failed to parse response json", ());
+                        Global::crash();
+                    }
+                };
+
+                let token = json_get_string_cloned(&json, &bump, b"token")?.unwrap_or_else(|| {
+                    Output::err("WebLogin", "missing `token` field in response json", ());
+                    Global::crash();
+                });
+
+                // npm-registry-fetch ignores npm-notice when x-local-cache is set
+                if let Some(notice) = res.header_if_other_is_absent(b"npm-notice", b"x-local-cache")
+                {
+                    Output::print_error(format_args!("\n"));
+                    bun_core::note!("{}", bstr::BStr::new(notice));
+                    Output::flush();
+                }
+
+                return Ok(token.into());
+            }
+            _ => {
+                Npm::response_error::<false>(&req, &res, pkg_id, response_buf)?;
+            }
+        }
+    }
+}

--- a/src/runtime/cli/web_login.rs
+++ b/src/runtime/cli/web_login.rs
@@ -1,5 +1,6 @@
-//! npm's web login handshake (show URL, offer the browser, poll `doneUrl`), lifted out of `bun publish`.
+//! npm's web login handshake (show URL, offer the browser, poll `doneUrl`), shared by `bun login` and `bun publish`.
 
+use std::io::Write as _;
 use std::time::{Duration, Instant};
 
 use bun_alloc::AllocError;
@@ -9,6 +10,7 @@ use bun_install::Npm;
 use bun_parsers::json as json_mod;
 use bun_url::URL;
 
+use crate::cli::ci_info as ci;
 use crate::cli::open;
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
@@ -130,6 +132,158 @@ pub(crate) fn print_auth_url(auth_url: &'static ZStr) {
     }
 }
 
+/// The headers every registry request shares; `include_auth` adds the credentials in `registry`.
+pub(crate) fn registry_headers(
+    registry: &Npm::Registry::Scope,
+    npm_command: &[u8],
+    body_len: Option<usize>,
+    include_auth: bool,
+) -> Result<http::HeaderBuilder, AllocError> {
+    let mut pairs: Vec<(&[u8], Vec<u8>)> = Vec::new();
+    pairs.push((b"accept", b"*/*".to_vec()));
+    pairs.push((b"accept-encoding", b"gzip,deflate".to_vec()));
+
+    if include_auth {
+        if !registry.token.is_empty() {
+            let mut v = b"Bearer ".to_vec();
+            v.extend_from_slice(&registry.token);
+            pairs.push((b"authorization", v));
+        } else if !registry.auth.is_empty() {
+            let mut v = b"Basic ".to_vec();
+            v.extend_from_slice(&registry.auth);
+            pairs.push((b"authorization", v));
+        }
+    }
+
+    if body_len.is_some() {
+        // verdaccio rejects anything other than exactly `application/json`
+        pairs.push((b"content-type", b"application/json".to_vec()));
+    }
+
+    pairs.push((b"npm-auth-type", b"web".to_vec()));
+    pairs.push((b"npm-command", npm_command.to_vec()));
+
+    let ci_name = ci::detect_ci_name();
+    let mut user_agent = Vec::new();
+    let _ = write!(
+        user_agent,
+        "{} {} {} workspaces/false{}{}",
+        Global::user_agent,
+        Global::os_name,
+        Global::arch_name,
+        if ci_name.is_some() { " ci/" } else { "" },
+        bstr::BStr::new(ci_name.unwrap_or(b"")),
+    );
+    pairs.push((b"user-agent", user_agent));
+
+    pairs.push((b"Connection", b"keep-alive".to_vec()));
+
+    if let Some(len) = body_len {
+        pairs.push((b"Content-Length", len.to_string().into_bytes()));
+    }
+
+    let mut headers = http::HeaderBuilder::default();
+    for (name, value) in &pairs {
+        headers.count(name, value);
+    }
+    headers.allocate()?;
+    for (name, value) in &pairs {
+        headers.append(name, value);
+    }
+    Ok(headers)
+}
+
+/// `<registry>/-/<path>`
+pub(crate) fn registry_endpoint(registry: &Npm::Registry::Scope, path: &str) -> Vec<u8> {
+    let mut url = Vec::new();
+    let _ = write!(
+        url,
+        "{}/-/{}",
+        bstr::BStr::new(strings::without_trailing_slash(registry.url.href())),
+        path,
+    );
+    url
+}
+
+pub(crate) enum WebLoginStart {
+    /// The registry accepted `POST /-/v1/login`.
+    Challenge {
+        login_url: &'static ZStr,
+        done_url: Box<[u8]>,
+    },
+    /// The registry answered `/-/v1/login` with an error or without both URLs.
+    Unsupported { status: u32 },
+}
+
+/// `POST <registry>/-/v1/login {"hostname": ...}`; non-http(s) URLs in the answer count as no web login.
+pub(crate) fn request_web_login(
+    registry: &Npm::Registry::Scope,
+    hostname: &[u8],
+    response_buf: &mut MutableString,
+) -> Result<WebLoginStart, AllocError> {
+    let mut body = Vec::new();
+    let _ = write!(
+        body,
+        "{{\"hostname\":{}}}",
+        bun_core::fmt::format_json_string_utf8(hostname, Default::default()),
+    );
+
+    let headers = registry_headers(registry, b"login", Some(body.len()), false)?;
+    let url = registry_endpoint(registry, "v1/login");
+
+    response_buf.reset();
+    let mut req = http::AsyncHTTP::init_sync(
+        http::Method::POST,
+        URL::parse(&url),
+        headers.entries.clone()?,
+        headers.content.written_slice(),
+        &body,
+        None,
+        http::FetchRedirect::Follow,
+    );
+
+    let res = match req.send_sync(response_buf) {
+        Ok(r) => r,
+        Err(bun_http::Error::Alloc(AllocError)) => return Err(AllocError),
+        Err(e) => {
+            Output::err(e, "failed to send login request", ());
+            Global::crash();
+        }
+    };
+
+    // npm-profile treats any 4xx or 500 here as "no web login" and falls back
+    let status = res.status_code();
+    if !(200..300).contains(&status) {
+        return Ok(WebLoginStart::Unsupported { status });
+    }
+
+    let bump = bun_alloc::Arena::new();
+    let mut log = bun_ast::Log::init();
+    let source = bun_ast::Source::init_path_string(b"???", response_buf.list.as_slice());
+    let json = match json_mod::parse_utf8(&source, &mut log, &bump) {
+        Ok(j) => j,
+        Err(bun_parsers::Error::Alloc(AllocError)) => return Err(AllocError),
+        Err(_) => {
+            Output::err("WebLogin", "failed to parse the login response as JSON", ());
+            Global::crash();
+        }
+    };
+
+    let login_url = json_get_string_cloned(&json, &bump, b"loginUrl")?;
+    let done_url = json_get_string_cloned(&json, &bump, b"doneUrl")?;
+    let (Some(login_url), Some(done_url)) = (login_url, done_url) else {
+        return Ok(WebLoginStart::Unsupported { status });
+    };
+    if !is_web_url(login_url) || !is_web_url(done_url) {
+        return Ok(WebLoginStart::Unsupported { status });
+    }
+
+    Ok(WebLoginStart::Challenge {
+        login_url: dupe_static_z(login_url),
+        done_url: done_url.into(),
+    })
+}
+
 /// `GET done_url` until 200 `{"token"}`; 202 waits `retry-after` seconds (else 500ms) up to `deadline`.
 pub(crate) fn poll_done_url(
     done_url: &URL<'_>,
@@ -215,4 +369,94 @@ pub(crate) fn poll_done_url(
             }
         }
     }
+}
+
+/// `GET <registry>/-/whoami` with `token`. `None` on any failure: the caller already saved the token.
+pub(crate) fn whoami_best_effort(
+    registry: &Npm::Registry::Scope,
+    token: &[u8],
+    response_buf: &mut MutableString,
+) -> Result<Option<Vec<u8>>, AllocError> {
+    let mut authed = registry.clone();
+    authed.token = token.into();
+    let headers = registry_headers(&authed, b"whoami", None, true)?;
+    let url = registry_endpoint(registry, "whoami");
+
+    response_buf.reset();
+    let mut req = http::AsyncHTTP::init_sync(
+        http::Method::GET,
+        URL::parse(&url),
+        headers.entries.clone()?,
+        headers.content.written_slice(),
+        b"",
+        None,
+        http::FetchRedirect::Follow,
+    );
+    let res = match req.send_sync(response_buf) {
+        Ok(r) => r,
+        Err(bun_http::Error::Alloc(AllocError)) => return Err(AllocError),
+        Err(_) => return Ok(None),
+    };
+    if res.status_code() != 200 {
+        return Ok(None);
+    }
+
+    let bump = bun_alloc::Arena::new();
+    let mut log = bun_ast::Log::init();
+    let source = bun_ast::Source::init_path_string(b"???", response_buf.list.as_slice());
+    let json = match json_mod::parse_utf8(&source, &mut log, &bump) {
+        Ok(j) => j,
+        Err(bun_parsers::Error::Alloc(AllocError)) => return Err(AllocError),
+        Err(_) => return Ok(None),
+    };
+    Ok(json_get_string_cloned(&json, &bump, b"username")?.map(<[u8]>::to_vec))
+}
+
+/// JavaScript's `encodeURIComponent`, so the token is one path segment.
+fn encode_uri_component(input: &[u8], out: &mut Vec<u8>) {
+    out.reserve(input.len());
+    for &byte in input {
+        if byte.is_ascii_alphanumeric() || strings::contains_char(b"-_.!~*'()", byte) {
+            out.push(byte);
+        } else {
+            let hex = bun_core::fmt::hex2_upper(byte);
+            out.extend_from_slice(&[b'%', hex[0], hex[1]]);
+        }
+    }
+}
+
+/// `DELETE <registry>/-/user/token/<token>` with that token as Bearer; the URL holds the token, never print it.
+pub(crate) fn revoke_token(
+    registry: &Npm::Registry::Scope,
+    token: &[u8],
+    response_buf: &mut MutableString,
+) -> Result<u32, AllocError> {
+    let mut authed = registry.clone();
+    authed.token = token.into();
+    let headers = registry_headers(&authed, b"logout", None, true)?;
+
+    let mut url = registry_endpoint(registry, "user/token/");
+    encode_uri_component(token, &mut url);
+
+    response_buf.reset();
+    let mut req = http::AsyncHTTP::init_sync(
+        http::Method::DELETE,
+        URL::parse(&url),
+        headers.entries.clone()?,
+        headers.content.written_slice(),
+        b"",
+        None,
+        http::FetchRedirect::Follow,
+    );
+
+    let res = match req.send_sync(response_buf) {
+        Ok(r) => r,
+        Err(bun_http::Error::Alloc(AllocError)) => return Err(AllocError),
+        Err(e) => {
+            Output::err(e, "failed to send the token revocation request", ());
+            Global::crash();
+        }
+    };
+
+    Ok(res.status_code())
 }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -524,7 +524,7 @@ describe("whoami", async () => {
     const out = await stdout.text();
     expect(out).toBeEmpty();
     const err = await stderr.text();
-    expect(err).toBe("error: missing authentication (run `bunx npm login`)\n");
+    expect(err).toBe("error: missing authentication (run `bun login`)\n");
     expect(await exited).toBe(1);
   });
   test("invalid token", async () => {

--- a/test/cli/install/bun-login.test.ts
+++ b/test/cli/install/bun-login.test.ts
@@ -1,0 +1,556 @@
+import { describe, expect, test } from "bun:test";
+import { lstatSync, readFileSync, statSync, symlinkSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// A registry that speaks npm's web login protocol:
+//   POST /-/v1/login            -> { loginUrl, doneUrl }
+//   GET  /-/v1/done/<id>        -> 202 until `pending` polls passed, then { token }
+//   GET  /-/whoami              -> { username } for the issued token
+//   DELETE /-/user/token/<tok>  -> `deleteStatus`
+function mockRegistry(
+  opts: {
+    token?: string;
+    loginStatus?: number;
+    deleteStatus?: number;
+    whoamiStatus?: number;
+    pending?: number;
+    doneOrigin?: string;
+  } = {},
+) {
+  const { token = "npm_test_token", loginStatus = 200, deleteStatus = 200, whoamiStatus = 200, pending = 2 } = opts;
+  const requests: { method: string; path: string; authorization: string | null; host: string | null; body: string }[] =
+    [];
+  let polls = 0;
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      requests.push({
+        method: req.method,
+        path: url.pathname,
+        authorization: req.headers.get("authorization"),
+        host: req.headers.get("host"),
+        body: await req.text(),
+      });
+
+      if (req.method === "POST" && url.pathname === "/-/v1/login") {
+        if (loginStatus !== 200) return new Response("", { status: loginStatus });
+        return Response.json({
+          loginUrl: `${server.url.href}login/abc`,
+          doneUrl: `${opts.doneOrigin ?? server.url.href}-/v1/done/abc`,
+        });
+      }
+      if (url.pathname === "/-/v1/done/abc") {
+        polls++;
+        if (polls <= pending) return new Response(null, { status: 202, headers: { "retry-after": "0" } });
+        return Response.json({ token });
+      }
+      if (url.pathname === "/-/whoami") {
+        if (whoamiStatus !== 200) return new Response("", { status: whoamiStatus });
+        if (req.headers.get("authorization") === `Bearer ${token}`) return Response.json({ username: "alice" });
+        return Response.json({ error: "unauthorized" }, { status: 401 });
+      }
+      if (req.method === "DELETE" && url.pathname.startsWith("/-/user/token/")) {
+        return new Response(null, { status: deleteStatus });
+      }
+      return new Response("unexpected url", { status: 500 });
+    },
+  });
+  return { server, requests, url: server.url.href };
+}
+
+// bunEnv spreads process.env. CI runners commonly export XDG_CONFIG_HOME, so it is
+// removed here and each test passes back exactly the value it is testing.
+async function runBun(dir: string, args: string[], envOverride: Record<string, string> = {}) {
+  const spawnEnv: Record<string, string | undefined> = {
+    ...bunEnv,
+    HOME: join(dir, "home"),
+    USERPROFILE: join(dir, "home"),
+  };
+  delete spawnEnv.XDG_CONFIG_HOME;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: join(dir, "pkg"),
+    env: { ...spawnEnv, ...envOverride },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+const pkg = { "pkg/package.json": JSON.stringify({ name: "login-test", version: "0.0.1" }) };
+const readNpmrc = (dir: string, rel = "home/.npmrc") => readFileSync(join(dir, rel), "utf8");
+
+describe("bun login", () => {
+  test.concurrent("web login writes the token to $HOME/.npmrc and keeps the other lines", async () => {
+    using registry = mockRegistry({ token: "tok-home" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-home", {
+      ...pkg,
+      "home/.npmrc": `# keep me\nregistry=${registry.url.href}\n\n@other:registry=https://other.example/\n`,
+    });
+
+    const result = await runBun(String(dir), ["login"]);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Authenticate your account at (press ENTER to open in browser):");
+    expect(result.stdout).toContain(`${registry.url.href}login/abc`);
+    expect(result.stdout).toContain(`Saved the token to ${join(String(dir), "home", ".npmrc")}`);
+    expect(result.stdout).toContain(`Logged in as alice on ${registry.url.href}`);
+    expect(result.stdout).not.toContain("tok-home");
+    expect(result.exitCode).toBe(0);
+
+    expect(readNpmrc(String(dir))).toBe(
+      `# keep me\nregistry=${registry.url.href}\n\n@other:registry=https://other.example/\n//${host}/:_authToken=tok-home\n`,
+    );
+    if (!isWindows) {
+      expect(statSync(join(String(dir), "home", ".npmrc")).mode & 0o777).toBe(0o600);
+    }
+
+    // the token bun login wrote is the token bun reads back
+    const whoami = await runBun(String(dir), ["pm", "whoami"]);
+    expect(whoami.stdout).toBe("alice\n");
+    expect(whoami.exitCode).toBe(0);
+  });
+
+  test.concurrent("quotes a token the ini reader would otherwise cut at ; or #", async () => {
+    using registry = mockRegistry({ token: "ab#c;d=e" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-quoted", { ...pkg, "home/.npmrc": `registry=${registry.url.href}\n` });
+
+    const result = await runBun(String(dir), ["login"]);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Logged in as alice");
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`registry=${registry.url.href}\n//${host}/:_authToken="ab#c;d=e"\n`);
+
+    // the reader gets the whole token back
+    const whoami = await runBun(String(dir), ["pm", "whoami"]);
+    expect(whoami.stdout).toBe("alice\n");
+
+    const logout = await runBun(String(dir), ["logout"]);
+    expect(logout.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`registry=${registry.url.href}\n`);
+  });
+
+  test.concurrent("inserts the token before an ini [section], where the reader looks for it", async () => {
+    using registry = mockRegistry({ token: "tok-root" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-section", {
+      ...pkg,
+      "home/.npmrc": `registry=${registry.url.href}\n[other]\n//${host}/:_authToken=not-root\n`,
+    });
+
+    const result = await runBun(String(dir), ["login"]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(
+      `registry=${registry.url.href}\n//${host}/:_authToken=tok-root\n[other]\n//${host}/:_authToken=not-root\n`,
+    );
+
+    const whoami = await runBun(String(dir), ["pm", "whoami"]);
+    expect(whoami.stdout).toBe("alice\n");
+  });
+
+  test.concurrent("replaces an existing token line for the same registry in place", async () => {
+    using registry = mockRegistry({ token: "tok-new" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-replace", {
+      ...pkg,
+      "home/.npmrc": `//${host}/:_authToken=tok-old\nregistry=${registry.url.href}\n`,
+    });
+
+    const result = await runBun(String(dir), ["login"]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`//${host}/:_authToken=tok-new\nregistry=${registry.url.href}\n`);
+  });
+
+  test.concurrent("with duplicate token lines, updates the last one (the one the reader uses)", async () => {
+    using registry = mockRegistry({ token: "tok-new" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-duplicates", {
+      ...pkg,
+      "home/.npmrc": `//${host}/:_authToken=tok-first\n//${host}/:_authToken=tok-last\n`,
+    });
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`//${host}/:_authToken=tok-first\n//${host}/:_authToken=tok-new\n`);
+  });
+
+  test.concurrent("writes to $XDG_CONFIG_HOME/.npmrc when that file exists", async () => {
+    using registry = mockRegistry({ token: "tok-xdg" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-xdg", {
+      ...pkg,
+      "home/.npmrc": "# home\n",
+      "xdg/.npmrc": "# xdg\n",
+    });
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href], {
+      XDG_CONFIG_HOME: join(String(dir), "xdg"),
+    });
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(`Saved the token to ${join(String(dir), "xdg", ".npmrc")}`);
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir), "xdg/.npmrc")).toBe(`# xdg\n//${host}/:_authToken=tok-xdg\n`);
+    expect(readNpmrc(String(dir), "home/.npmrc")).toBe("# home\n");
+  });
+
+  test.concurrent("creates $HOME/.npmrc when it does not exist", async () => {
+    using registry = mockRegistry({ token: "tok-fresh" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-fresh", { ...pkg, "home/.keep": "" });
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`//${host}/:_authToken=tok-fresh\n`);
+  });
+
+  test.concurrent("--scope also writes the @scope:registry line", async () => {
+    using registry = mockRegistry({ token: "tok-scope" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-scope", { ...pkg, "home/.npmrc": "" });
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href, "--scope", "@acme"]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`//${host}/:_authToken=tok-scope\n@acme:registry=${registry.url.href}\n`);
+  });
+
+  test.concurrent("--scope without --registry logs in to the registry configured for that scope", async () => {
+    const { server: registry } = mockRegistry({ token: "tok-scoped" });
+    using _registry = registry;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-scope-configured", {
+      ...pkg,
+      "home/.npmrc": `@acme:registry=${registry.url.href}\n`,
+    });
+
+    const result = await runBun(String(dir), ["login", "--scope", "@acme"]);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(`Logged in as alice on ${registry.url.href}`);
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`@acme:registry=${registry.url.href}\n//${host}/:_authToken=tok-scoped\n`);
+  });
+
+  test.concurrent("sends the hostname and no credentials to /-/v1/login", async () => {
+    const { server: registry, requests } = mockRegistry();
+    using _registry = registry;
+    using dir = tempDir("login-request", { ...pkg, "home/.npmrc": "" });
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.exitCode).toBe(0);
+
+    const login = requests.find(r => r.path === "/-/v1/login");
+    expect(login).toEqual({
+      method: "POST",
+      path: "/-/v1/login",
+      authorization: null,
+      host: new URL(registry.url).host,
+      body: expect.stringMatching(/^\{"hostname":".+"\}$/),
+    });
+    expect(requests.filter(r => r.path === "/-/v1/done/abc").map(r => r.authorization)).toEqual([null, null, null]);
+  });
+
+  test.concurrent("polls a doneUrl on another host with that host's Host header", async () => {
+    const done = mockRegistry({ token: "tok-cross" });
+    using _done = done.server;
+    using registry = mockRegistry({ token: "tok-cross", doneOrigin: done.url }).server;
+    using dir = tempDir("login-cross-done", { ...pkg, "home/.npmrc": "" });
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    const polls = done.requests.filter(r => r.path === "/-/v1/done/abc");
+    expect(polls.length).toBeGreaterThan(0);
+    expect(new Set(polls.map(r => r.host))).toEqual(new Set([new URL(done.url).host]));
+  });
+
+  test.concurrent("still reports success when the registry has no /-/whoami", async () => {
+    using registry = mockRegistry({ token: "tok-nowhoami", whoamiStatus: 404 }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-no-whoami", { ...pkg, "home/.npmrc": "" });
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Saved the token to");
+    expect(result.stdout).toContain(`Logged in on ${registry.url.href}`);
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe(`//${host}/:_authToken=tok-nowhoami\n`);
+  });
+
+  test.skipIf(isWindows).concurrent("follows a dangling .npmrc symlink and creates its target", async () => {
+    using registry = mockRegistry({ token: "tok-dangling" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-dangling", { ...pkg, "dotfiles/.keep": "", "home/.keep": "" });
+    symlinkSync(join(String(dir), "dotfiles", "npmrc"), join(String(dir), "home", ".npmrc"));
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(lstatSync(join(String(dir), "home", ".npmrc")).isSymbolicLink()).toBe(true);
+    expect(readNpmrc(String(dir), "dotfiles/npmrc")).toBe(`//${host}/:_authToken=tok-dangling\n`);
+  });
+
+  test.skipIf(isWindows).concurrent("follows a chain of dangling symlinks to the final target", async () => {
+    using registry = mockRegistry({ token: "tok-chain" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-chain", { ...pkg, "dotfiles/.keep": "", "home/.keep": "" });
+    symlinkSync(join(String(dir), "dotfiles", "npmrc"), join(String(dir), "home", ".npmrc"));
+    symlinkSync(join(String(dir), "dotfiles", "real-npmrc"), join(String(dir), "dotfiles", "npmrc"));
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(lstatSync(join(String(dir), "home", ".npmrc")).isSymbolicLink()).toBe(true);
+    expect(lstatSync(join(String(dir), "dotfiles", "npmrc")).isSymbolicLink()).toBe(true);
+    expect(readNpmrc(String(dir), "dotfiles/real-npmrc")).toBe(`//${host}/:_authToken=tok-chain\n`);
+  });
+
+  test.skipIf(isWindows).concurrent("refuses to write through a symlink loop", async () => {
+    using registry = mockRegistry({ token: "tok-loop" }).server;
+    using dir = tempDir("login-loop", { ...pkg, "home/.keep": "" });
+    symlinkSync(join(String(dir), "home", ".npmrc"), join(String(dir), "home", ".npmrc"));
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toContain("ELOOP");
+    expect(result.exitCode).toBe(1);
+    expect(lstatSync(join(String(dir), "home", ".npmrc")).isSymbolicLink()).toBe(true);
+  });
+
+  test.skipIf(isWindows).concurrent("writes through a symlinked .npmrc instead of replacing the link", async () => {
+    using registry = mockRegistry({ token: "tok-link" }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("login-symlink", { ...pkg, "dotfiles/npmrc": "# managed\n", "home/.keep": "" });
+    symlinkSync(join(String(dir), "dotfiles", "npmrc"), join(String(dir), "home", ".npmrc"));
+
+    const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(lstatSync(join(String(dir), "home", ".npmrc")).isSymbolicLink()).toBe(true);
+    expect(readNpmrc(String(dir), "dotfiles/npmrc")).toBe(`# managed\n//${host}/:_authToken=tok-link\n`);
+  });
+
+  test.concurrent.each([404, 401, 500])(
+    "a registry without web login (HTTP %i) fails and names the line to add by hand",
+    async status => {
+      using registry = mockRegistry({ loginStatus: status }).server;
+      const host = new URL(registry.url).host;
+      using dir = tempDir("login-unsupported", { ...pkg, "home/.npmrc": "# untouched\n" });
+
+      const result = await runBun(String(dir), ["login", "--registry", registry.url.href]);
+      expect(result.stderr).toContain(
+        `${registry.url.href} did not offer a web login (HTTP ${status} from /-/v1/login)`,
+      );
+      expect(result.stderr).toContain(`//${host}/:_authToken=<token>`);
+      expect(result.exitCode).toBe(1);
+      expect(readNpmrc(String(dir))).toBe("# untouched\n");
+    },
+  );
+
+  test.concurrent("rejects positional arguments and a scope without @", async () => {
+    using dir = tempDir("login-args", { ...pkg, "home/.npmrc": "" });
+
+    const extra = await runBun(String(dir), ["login", "somebody"]);
+    expect(extra.stderr).toContain("bun login does not take arguments");
+    expect(extra.exitCode).toBe(1);
+
+    const badScope = await runBun(String(dir), ["login", "--scope", "acme"]);
+    expect(badScope.stderr).toContain("invalid `--scope` value");
+    expect(badScope.exitCode).toBe(1);
+  });
+});
+
+describe("bun logout", () => {
+  test.concurrent("revokes the token and removes only its line", async () => {
+    const { server: registry, requests } = mockRegistry();
+    using _registry = registry;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-ok", {
+      ...pkg,
+      "home/.npmrc": `# keep me\nregistry=${registry.url.href}\n//${host}/:_authToken=tok-gone\n@other:registry=https://other.example/\n`,
+    });
+
+    const result = await runBun(String(dir), ["logout"]);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(`Logged out of ${registry.url.href}`);
+    expect(result.stdout).not.toContain("tok-gone");
+    expect(result.exitCode).toBe(0);
+
+    expect(requests).toEqual([
+      { method: "DELETE", path: "/-/user/token/tok-gone", authorization: "Bearer tok-gone", host, body: "" },
+    ]);
+    expect(readNpmrc(String(dir))).toBe(
+      `# keep me\nregistry=${registry.url.href}\n@other:registry=https://other.example/\n`,
+    );
+  });
+
+  test.concurrent("--scope also removes the @scope:registry line", async () => {
+    using registry = mockRegistry().server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-scope", {
+      ...pkg,
+      "home/.npmrc": `@acme:registry=${registry.url.href}\n//${host}/:_authToken=tok-scope\n`,
+    });
+
+    const result = await runBun(String(dir), ["logout", "--scope", "@acme"]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe("");
+  });
+
+  test.concurrent("warns before sending the token over plain http to a remote host", async () => {
+    using registry = mockRegistry().server;
+    // 0.0.0.0 reaches the mock on every platform but is not in the loopback allow-list
+    const remote = `http://0.0.0.0:${registry.port}/`;
+    using dir = tempDir("logout-http-warn", {
+      ...pkg,
+      "home/.npmrc": `//0.0.0.0:${registry.port}/:_authToken=tok\n`,
+    });
+
+    const result = await runBun(String(dir), ["logout", "--registry", remote]);
+    expect(result.stderr).toContain(`warn: ${remote} uses plain http`);
+  });
+
+  test.concurrent("fails when there is no token for the registry", async () => {
+    using registry = mockRegistry().server;
+    using dir = tempDir("logout-none", { ...pkg, "home/.npmrc": "# nothing here\n" });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href]);
+    expect(result.stderr).toContain(`not logged in to ${registry.url.href}`);
+    expect(result.exitCode).toBe(1);
+    expect(readNpmrc(String(dir))).toBe("# nothing here\n");
+  });
+
+  test.concurrent("points at the other source when the token does not come from the user .npmrc", async () => {
+    using registry = mockRegistry().server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-elsewhere", {
+      ...pkg,
+      "home/.npmrc": "",
+      "pkg/.npmrc": `registry=${registry.url.href}\n//${host}/:_authToken=project-token\n`,
+    });
+
+    const result = await runBun(String(dir), ["logout"]);
+    expect(result.stderr).toContain(`not logged in to ${registry.url.href}`);
+    expect(result.stderr).toContain("come from bunfig.toml, a project .npmrc, or an environment variable");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent("leaves the file alone when the registry refuses to revoke the token", async () => {
+    using registry = mockRegistry({ deleteStatus: 500 }).server;
+    const host = new URL(registry.url).host;
+    const npmrc = `//${host}/:_authToken=tok-stuck\n`;
+    using dir = tempDir("logout-fail", { ...pkg, "home/.npmrc": npmrc });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href]);
+    expect(result.stderr).toContain(`failed to revoke the token on ${registry.url.href} (HTTP 500)`);
+    expect(result.stderr).not.toContain("tok-stuck");
+    expect(result.exitCode).toBe(1);
+    expect(readNpmrc(String(dir))).toBe(npmrc);
+  });
+
+  test.concurrent.each([401, 404])("still removes a token the registry no longer accepts (HTTP %i)", async status => {
+    using registry = mockRegistry({ deleteStatus: status }).server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-expired", { ...pkg, "home/.npmrc": `//${host}/:_authToken=tok-expired\n` });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href]);
+    expect(result.stderr).toContain(`the token is already invalid (HTTP ${status})`);
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe("");
+  });
+
+  test.concurrent("revokes the last of duplicate token lines and removes all of them", async () => {
+    const { server: registry, requests } = mockRegistry();
+    using _registry = registry;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-duplicates", {
+      ...pkg,
+      "home/.npmrc": `//${host}/:_authToken=tok-stale\nregistry=${registry.url.href}\n//${host}/:_authToken=tok-live\n`,
+    });
+
+    const result = await runBun(String(dir), ["logout"]);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(requests.map(r => r.path)).toEqual(["/-/user/token/tok-live"]);
+    expect(readNpmrc(String(dir))).toBe(`registry=${registry.url.href}\n`);
+  });
+
+  test.concurrent.each([
+    ['"AKCp5abc=="', "AKCp5abc=="],
+    ['"a\\"b\\\\c\\u0041"', 'a"b\\cA'],
+    ["'single=quoted'", "single=quoted"],
+  ])("reads a token npm wrote in quotes (%s)", async (written, expected) => {
+    const { server: registry, requests } = mockRegistry();
+    using _registry = registry;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-quoted", { ...pkg, "home/.npmrc": `//${host}/:_authToken=${written}\n` });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href]);
+    expect(result.exitCode).toBe(0);
+    expect(requests.map(r => r.authorization)).toEqual([`Bearer ${expected}`]);
+    expect(readNpmrc(String(dir))).toBe("");
+  });
+
+  test.concurrent("sends the token as one percent-encoded path segment", async () => {
+    const { server: registry, requests } = mockRegistry();
+    using _registry = registry;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-encode", { ...pkg, "home/.npmrc": `//${host}/:_authToken=a/b?c#d%e f\n` });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href]);
+    expect(result.exitCode).toBe(0);
+    expect(requests.map(r => r.path)).toEqual(["/-/user/token/a%2Fb%3Fc%23d%25e%20f"]);
+    expect(readNpmrc(String(dir))).toBe("");
+  });
+
+  test.concurrent("expands ${VAR} in the saved token before revoking it", async () => {
+    const { server: registry, requests } = mockRegistry();
+    using _registry = registry;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-env", { ...pkg, "home/.npmrc": `//${host}/:_authToken=pre-\${LOGIN_TEST_TOKEN}\n` });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href], {
+      LOGIN_TEST_TOKEN: "from-env",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(requests.map(r => r.authorization)).toEqual(["Bearer pre-from-env"]);
+    expect(readNpmrc(String(dir))).toBe("");
+  });
+
+  test.concurrent("--scope removes a scope mapping whose ${VAR} expands to this registry", async () => {
+    using registry = mockRegistry().server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-scope-env", {
+      ...pkg,
+      "home/.npmrc": `@acme:registry=\${LOGIN_TEST_REGISTRY}\n//${host}/:_authToken=tok-scope\n`,
+    });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href, "--scope", "@acme"], {
+      LOGIN_TEST_REGISTRY: registry.url.href,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe("");
+  });
+
+  test.concurrent("--scope keeps a scope mapping that points at another registry", async () => {
+    using registry = mockRegistry().server;
+    const host = new URL(registry.url).host;
+    using dir = tempDir("logout-scope-other", {
+      ...pkg,
+      "home/.npmrc": `@acme:registry=https://other.example/\n//${host}/:_authToken=tok-scope\n`,
+    });
+
+    const result = await runBun(String(dir), ["logout", "--registry", registry.url.href, "--scope", "@acme"]);
+    expect(result.exitCode).toBe(0);
+    expect(readNpmrc(String(dir))).toBe("@acme:registry=https://other.example/\n");
+  });
+});

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -900,7 +900,7 @@ describe.concurrent("credentials in the registry url", () => {
     const packageDir = await packageDirFor("no-credentials-pkg");
 
     const { err, exitCode } = await publish(env, packageDir, "--registry", `http://localhost:${mock.port}/`);
-    expect(err).toBe("error: missing authentication (run `bunx npm login`)\n");
+    expect(err).toBe("error: missing authentication (run `bun login`)\n");
     expect(mock.requests).toEqual([]);
     expect(exitCode).toBe(1);
   });
@@ -917,7 +917,7 @@ describe.concurrent("credentials in the registry url", () => {
       "--registry",
       `http://localhost:${mock.port}/`,
     );
-    expect(err).toBe("error: missing authentication (run `bunx npm login`)\n");
+    expect(err).toBe("error: missing authentication (run `bun login`)\n");
     expect(mock.requests).toEqual([]);
     expect(exitCode).toBe(1);
   });

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -98,11 +98,11 @@
   "src/runtime/cli/open.rs": {
     "thread spawn": 1
   },
-  "src/runtime/cli/publish_command.rs": {
-    "thread spawn": 1
-  },
   "src/runtime/cli/run_command.rs": {
     "HTTPThread::schedule": 1
+  },
+  "src/runtime/cli/web_login.rs": {
+    "thread spawn": 1
   },
   "src/runtime/dns_jsc/dns.rs": {
     "WorkPool::schedule*": 1,


### PR DESCRIPTION
Fixes #41289

### Problem
- `bun login` prints `Uh-oh. bun login is a subcommand reserved for future use by Bun.` (`src/runtime/cli/mod.rs`, the `Tag::ReservedCommand` arm). Bun's own auth error hints at `bunx npm login`.
- That hint fails for XDG users: npm writes `~/.npmrc`, Bun reads `$XDG_CONFIG_HOME/.npmrc` first when it exists (`src/install/PackageManager.rs`). It also needs npm reachable without auth.

### Fix
- Add `bun login [--registry <url>] [--scope @org]`: npm's web login (`POST /-/v1/login`, print `loginUrl`, ENTER opens the browser, poll `doneUrl`, 5 minute cap). The token goes to the user `.npmrc` as `//<host>/<path>/:_authToken=<token>` (plus `@org:registry=<url>` with `--scope`), mode 0600, via temp file and rename. Other lines keep their text and order.
- Add `bun logout [--registry] [--scope]`: `DELETE /-/user/token/<token>`, then remove the line. No saved token is exit 1. A failed DELETE leaves the file alone, except 401 and 404 (token already dead).
- One function, `bun_install::npmrc::user_npmrc_path`, serves reader and writer. The `Npmrc` editor follows the reader: last duplicate wins, quotes stripped, `${VAR}` expanded, symlinks written through. The browser prompt and `doneUrl` poll move from `publish_command.rs` to `cli/web_login.rs`; `bun publish` keeps its behaviour.
- Verified: `test/cli/install/bun-login.test.ts` (36 tests, all fail on stock bun). Also `bun-publish.test.ts`, `npmrc.test.ts`, `bun-install-registry.test.ts`, source lints, `cargo check` for Windows and macOS.

### Background
- npm's web login (npm-profile `webAuth`) is the handshake `bun publish` runs for an OTP challenge. The login poll carries no credentials because there is no token yet.
- `//host/path/:_authToken` is npm's per-registry key. Bun's reader (`src/ini/lib.rs`, `RegistryAuth::matches`) compares host and pathname, so the writer builds the key from the same parts.
- `login` and `logout` were reserved in #4465 for this. `publish`, `whoami`, `info`, and `prune` graduated from the same arm.

<details><summary>Notes</summary>

- Two commits, in landing order. The first is a behaviour-free refactor (the `.npmrc` lookup lift and the publish web-login move), proven by `bun-publish.test.ts` and `npmrc.test.ts`. The second is the feature. They can land as one PR or be split.
- Self-reviewed: 5 concerns raised, 3 addressed (any 4xx or 5xx from `/-/v1/login` is "no web login" instead of a crash, the refactor is its own commit, the notes state the deferrals). Not done: rebasing on #40423 (`bun_ini::RegistryKey`, `Scope::authorization`), which is still open with changes requested. `npmrc::registry_key` produces the same `host/path/` key (with the `//` prefix) and `web_login::registry_headers` the same `Authorization` value, so both collapse into #40423's helpers once it lands. Also not done: moving the `.npmrc` editor into `bun_ini`. It stays next to the reader's consumer in `bun_install` and matches the reader on last-wins duplicates, quoting, and `${VAR}` expansion.

- Legacy (username/password) login is not included. npm-profile falls back to it on any 4xx/500 from `/-/v1/login`, and the couchdb `PUT /-/user/org.couchdb.user:<name>` also registers a user on registries with open registration. Bun exits 1 on 404/405 and prints the `.npmrc` line to add by hand. Other non-2xx statuses print the registry's error. This can be a follow-up.
- `NPM_CONFIG_USERCONFIG` is not read. Open PR #38047 adds it. After this PR, that change lands in one place, `user_npmrc_path`.
- PR #36556 changes the same-origin check in `get_otp`. This PR leaves that check where it was, so the conflict is only the move of the poll loop.
- The reserved-command path still covers `deploy`, `cloud`, `config`, `use`, `auth`.
- `Tag::LoginCommand` is `'L'` and `Tag::LogoutCommand` is `'O'` in `Tag::char()`. bun.report's remap table needs the same two entries.
- Completions (bash, zsh, fish, `bun-cli.json`), `bun --help`, and `docs/pm/cli/login.mdx` are updated. The `bunx npm login` hints in `publish_command.rs`, `package_manager_command.rs`, and `docs/pm/cli/pm.mdx` now say `bun login`.
- `bun login` does not need a `package.json`. It uses the `no_project_ok` path that `bun pm diff` already uses.
- Manual run against a local mock registry: login wrote the token next to existing comments and a scoped registry line, `bun pm whoami` read it back, logout revoked it and removed only that line.
- Review rounds: last-match semantics for duplicate keys, fsync before rename, percent-encoded token in the revoke URL, `${VAR}` expansion on logout, `@scope:registry` removed only when it points at the registry being logged out of, ini quotes stripped on read, realpath before the atomic write, best-effort `/-/whoami` after the save (a failure prints `Logged in on <registry>`), no hard-coded `Host` header so a `doneUrl` on another host is polled with its own `Host`, a dangling symlink chain is followed with `readlink` and a loop is an error, values that hold `;` `#` `=` or quotes are written as JSON strings (npm's `ini.safe`) and quoted values are decoded with the JSON parser, the commands return normally so buffers drop under LeakSanitizer, logout runs the same http(s) check and plain-http warning as login, per-command shell completions. Not changed: the login poll does not require `doneUrl` to share the registry origin, because it carries no credentials and npm mirrors hand back a `doneUrl` on another host.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts, test/cli/install/bun-login.test.ts, test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->