### PR TITLE
node:http2: saturate numeric session options instead of wrapping to the minimum

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4425,12 +4425,13 @@ uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue val)
         }
     }
 
+    // Saturating: NaN and negatives read as 0, values at or above 2^64 as UINT64_MAX.
     if (value.isInt32()) {
-        return static_cast<uint64_t>(value.asInt32());
+        int32_t i = value.asInt32();
+        return i < 0 ? 0 : static_cast<uint64_t>(i);
     }
     ASSERT(value.isDouble());
 
-    // Saturating: NaN and negatives read as 0, values at or above 2^64 as UINT64_MAX.
     double number = value.asDouble();
     if (!(number >= 0.0))
         return 0;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4430,9 +4430,7 @@ uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue val)
     }
     ASSERT(value.isDouble());
 
-    // Saturate: NaN and negatives read as 0, values at or above 2^64 read as
-    // UINT64_MAX. Callers pass Number.MAX_SAFE_INTEGER (or Infinity) to mean
-    // "no limit", so a huge double must not collapse to 0.
+    // Saturating: NaN and negatives read as 0, values at or above 2^64 as UINT64_MAX.
     double number = value.asDouble();
     if (!(number >= 0.0))
         return 0;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4430,14 +4430,15 @@ uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue val)
     }
     ASSERT(value.isDouble());
 
-    int64_t result = JSC::tryConvertToInt52(value.asDouble());
-    if (result != JSC::JSValue::notInt52) {
-        if (result < 0)
-            return 0;
-
-        return static_cast<uint64_t>(result);
-    }
-    return 0;
+    // Saturate: NaN and negatives read as 0, values at or above 2^64 read as
+    // UINT64_MAX. Callers pass Number.MAX_SAFE_INTEGER (or Infinity) to mean
+    // "no limit", so a huge double must not collapse to 0.
+    double number = value.asDouble();
+    if (!(number >= 0.0))
+        return 0;
+    if (number >= 18446744073709551616.0)
+        return std::numeric_limits<uint64_t>::max();
+    return static_cast<uint64_t>(number);
 }
 
 JSC::EncodedJSValue JSC__JSValue__createObject2(JSC::JSGlobalObject* globalObject, const EncodedSlice* arg1,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -75,6 +75,7 @@
 #include "JavaScriptCore/MicrotaskQueue.h"
 #include "JavaScriptCore/ArrayConstructor.h"
 #include "JavaScriptCore/BigIntConstructor.h"
+#include "JavaScriptCore/MathCommon.h"
 #include "JavaScriptCore/BooleanConstructor.h"
 #include "JavaScriptCore/DateConstructor.h"
 #include "JavaScriptCore/ErrorConstructor.h"
@@ -4425,19 +4426,16 @@ uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue val)
         }
     }
 
-    // Saturating: NaN and negatives read as 0, values at or above 2^64 as UINT64_MAX.
     if (value.isInt32()) {
-        int32_t i = value.asInt32();
-        return i < 0 ? 0 : static_cast<uint64_t>(i);
+        return static_cast<uint64_t>(static_cast<int64_t>(value.asInt32()));
     }
     ASSERT(value.isDouble());
 
+    // >= 2^64 (and +Infinity) saturates; below that JSC::toUInt64 is exact, NaN -> 0, negatives wrap like the int32 path.
     double number = value.asDouble();
-    if (!(number >= 0.0))
-        return 0;
     if (number >= 18446744073709551616.0)
         return std::numeric_limits<uint64_t>::max();
-    return static_cast<uint64_t>(number);
+    return JSC::toUInt64(number);
 }
 
 JSC::EncodedJSValue JSC__JSValue__createObject2(JSC::JSGlobalObject* globalObject, const EncodedSlice* arg1,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7521,8 +7521,7 @@ impl H2FrameParser {
         self.native_socket.detach();
     }
 
-    /// Session limits are u32 fields. Saturate so a huge value (grpc-js passes
-    /// `Number.MAX_SAFE_INTEGER` to mean "no limit") does not wrap to 0.
+    /// Saturating read of a numeric session limit into its u32 field.
     fn session_option_u32(value: JSValue) -> u32 {
         u32::try_from(value.to_uint64_no_truncate()).unwrap_or(u32::MAX)
     }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7521,10 +7521,10 @@ impl H2FrameParser {
         self.native_socket.detach();
     }
 
-    /// node keeps these session limits as doubles, so callers such as grpc-js pass
-    /// `Number.MAX_SAFE_INTEGER` to mean "no limit". Saturate instead of wrapping.
+    /// Session limits are u32 fields. Saturate so a huge value (grpc-js passes
+    /// `Number.MAX_SAFE_INTEGER` to mean "no limit") does not wrap to 0.
     fn session_option_u32(value: JSValue) -> u32 {
-        value.as_number() as u32
+        u32::try_from(value.to_uint64_no_truncate()).unwrap_or(u32::MAX)
     }
 
     pub(crate) fn constructor(
@@ -7678,7 +7678,7 @@ impl H2FrameParser {
                     if max_pings.is_number() {
                         this_ref
                             .max_outstanding_pings
-                            .set(max_pings.as_number() as u64);
+                            .set(max_pings.to_uint64_no_truncate());
                     }
                 }
                 if let Some(max_memory) = settings_js.get(global_object, "maxSessionMemory")? {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7521,6 +7521,12 @@ impl H2FrameParser {
         self.native_socket.detach();
     }
 
+    /// node keeps these session limits as doubles, so callers such as grpc-js pass
+    /// `Number.MAX_SAFE_INTEGER` to mean "no limit". Saturate instead of wrapping.
+    fn session_option_u32(value: JSValue) -> u32 {
+        value.as_number() as u32
+    }
+
     pub(crate) fn constructor(
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
@@ -7672,14 +7678,14 @@ impl H2FrameParser {
                     if max_pings.is_number() {
                         this_ref
                             .max_outstanding_pings
-                            .set(max_pings.to_uint64_no_truncate());
+                            .set(max_pings.as_number() as u64);
                     }
                 }
                 if let Some(max_memory) = settings_js.get(global_object, "maxSessionMemory")? {
                     if max_memory.is_number() {
                         this_ref
                             .max_session_memory
-                            .set((max_memory.to_uint64_no_truncate() as u32).max(1));
+                            .set(Self::session_option_u32(max_memory).max(1));
                     }
                 }
                 if let Some(max_header_list_pairs) =
@@ -7688,14 +7694,14 @@ impl H2FrameParser {
                     if max_header_list_pairs.is_number() {
                         this_ref
                             .max_header_list_pairs
-                            .set((max_header_list_pairs.to_uint64_no_truncate() as u32).max(4));
+                            .set(Self::session_option_u32(max_header_list_pairs).max(4));
                     }
                 }
                 if let Some(max_settings) = settings_js.get(global_object, "maxSettings")? {
                     if max_settings.is_number() {
                         this_ref
                             .max_settings
-                            .set((max_settings.to_uint64_no_truncate() as u32).max(1));
+                            .set(Self::session_option_u32(max_settings).max(1));
                     }
                 }
                 if let Some(max_rejected_streams) =
@@ -7704,7 +7710,7 @@ impl H2FrameParser {
                     if max_rejected_streams.is_number() {
                         this_ref
                             .max_rejected_streams
-                            .set(max_rejected_streams.to_uint64_no_truncate() as u32);
+                            .set(Self::session_option_u32(max_rejected_streams));
                     }
                 }
                 if let Some(max_session_invalid_frames) =
@@ -7713,7 +7719,7 @@ impl H2FrameParser {
                     if max_session_invalid_frames.is_number() {
                         this_ref
                             .max_session_invalid_frames
-                            .set(max_session_invalid_frames.to_uint64_no_truncate() as u32);
+                            .set(Self::session_option_u32(max_session_invalid_frames));
                     }
                 }
                 if let Some(max_outstanding_settings) =
@@ -7722,7 +7728,7 @@ impl H2FrameParser {
                     if max_outstanding_settings.is_number() {
                         this_ref
                             .max_outstanding_settings
-                            .set((max_outstanding_settings.to_uint64_no_truncate() as u32).max(1));
+                            .set(Self::session_option_u32(max_outstanding_settings).max(1));
                     }
                 }
                 if let Some(max_send_header_block_length) =

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -63,7 +63,9 @@ it("Bun.hash.xxHash64() reads a large Number seed exactly", () => {
     Bun.hash.xxHash64(input, 2n ** 64n - 1n),
     Bun.hash.xxHash64(input, 2n ** 64n - 1n),
   ]);
-  expect([-1.5, NaN].map(seed => Bun.hash.xxHash64(input, seed))).toEqual([
+  // -1 is an int32, -1.5 is a double. Both negative paths read as 0.
+  expect([-1, -1.5, NaN].map(seed => Bun.hash.xxHash64(input, seed))).toEqual([
+    Bun.hash.xxHash64(input, 0),
     Bun.hash.xxHash64(input, 0),
     Bun.hash.xxHash64(input, 0),
   ]);

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -49,6 +49,25 @@ it(`Bun.hash.xxHash64()`, () => {
   expect(Bun.hash.xxHash64("", 16269921104521594740n)).toBe(3224619365169652240n);
   gcTick();
 });
+// A Number seed is read through the same u64 conversion as node:http2 session limits.
+// Doubles at or above 2^51 used to read as 0 (#41294); now they read exactly, and values
+// at or above 2^64 saturate to 2^64 - 1.
+it("Bun.hash.xxHash64() reads a large Number seed exactly", () => {
+  const input = "hello world";
+  const seeds = [2 ** 51 - 1, 2 ** 51, Number.MAX_SAFE_INTEGER, 2 ** 60, 2 ** 63];
+  expect(seeds.map(seed => Bun.hash.xxHash64(input, seed))).toEqual(
+    seeds.map(seed => Bun.hash.xxHash64(input, BigInt(seed))),
+  );
+  expect(Bun.hash.xxHash64(input, 2 ** 51)).not.toBe(Bun.hash.xxHash64(input, 0));
+  expect([2 ** 64, Infinity].map(seed => Bun.hash.xxHash64(input, seed))).toEqual([
+    Bun.hash.xxHash64(input, 2n ** 64n - 1n),
+    Bun.hash.xxHash64(input, 2n ** 64n - 1n),
+  ]);
+  expect([-1.5, NaN].map(seed => Bun.hash.xxHash64(input, seed))).toEqual([
+    Bun.hash.xxHash64(input, 0),
+    Bun.hash.xxHash64(input, 0),
+  ]);
+});
 it(`Bun.hash.xxHash3()`, () => {
   expect(Bun.hash.xxHash3("hello world")).toBe(0xd447b1ea40e6988bn);
   gcTick();

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -49,26 +49,20 @@ it(`Bun.hash.xxHash64()`, () => {
   expect(Bun.hash.xxHash64("", 16269921104521594740n)).toBe(3224619365169652240n);
   gcTick();
 });
-// A Number seed is read through the same u64 conversion as node:http2 session limits.
-// Doubles at or above 2^51 used to read as 0 (#41294); now they read exactly, and values
-// at or above 2^64 saturate to 2^64 - 1.
+// Number seeds >= 2^51 used to read as 0 (#41294).
 it("Bun.hash.xxHash64() reads a large Number seed exactly", () => {
   const input = "hello world";
   const seeds = [2 ** 51 - 1, 2 ** 51, Number.MAX_SAFE_INTEGER, 2 ** 60, 2 ** 63];
-  expect(seeds.map(seed => Bun.hash.xxHash64(input, seed))).toEqual(
+  expect(seeds.map(seed => Bun.hash.xxHash64(input, seed))).toStrictEqual(
     seeds.map(seed => Bun.hash.xxHash64(input, BigInt(seed))),
   );
   expect(Bun.hash.xxHash64(input, 2 ** 51)).not.toBe(Bun.hash.xxHash64(input, 0));
-  expect([2 ** 64, Infinity].map(seed => Bun.hash.xxHash64(input, seed))).toEqual([
-    Bun.hash.xxHash64(input, 2n ** 64n - 1n),
-    Bun.hash.xxHash64(input, 2n ** 64n - 1n),
-  ]);
-  // -1 is an int32, -1.5 is a double. Both negative paths read as 0.
-  expect([-1, -1.5, NaN].map(seed => Bun.hash.xxHash64(input, seed))).toEqual([
-    Bun.hash.xxHash64(input, 0),
-    Bun.hash.xxHash64(input, 0),
-    Bun.hash.xxHash64(input, 0),
-  ]);
+  const max = Bun.hash.xxHash64(input, 2n ** 64n - 1n);
+  // >= 2^64 and +Infinity saturate; negatives wrap (int32 -1 and double -1.5 agree); NaN and -Infinity are 0.
+  expect([2 ** 64, Infinity, -1, -1.5].map(seed => Bun.hash.xxHash64(input, seed))).toStrictEqual([max, max, max, max]);
+  expect(Bun.hash.xxHash64(input, -2)).toBe(Bun.hash.xxHash64(input, 2n ** 64n - 2n));
+  const zero = Bun.hash.xxHash64(input, 0);
+  expect([NaN, -Infinity].map(seed => Bun.hash.xxHash64(input, seed))).toStrictEqual([zero, zero]);
 });
 it(`Bun.hash.xxHash3()`, () => {
   expect(Bun.hash.xxHash3("hello world")).toBe(0xd447b1ea40e6988bn);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1561,6 +1561,42 @@ describe("inbound stream lifecycle", () => {
     }
   });
 
+  // grpc-js passes maxSessionMemory: Number.MAX_SAFE_INTEGER to disable the limit. node keeps the
+  // option as a double, so any huge value means "no limit"; it must saturate, not wrap to the
+  // 1MB minimum (#41294).
+  test.each([
+    ["Number.MAX_SAFE_INTEGER", Number.MAX_SAFE_INTEGER],
+    ["2**51", 2 ** 51],
+    ["2**32", 2 ** 32],
+  ])(
+    "serves a new request stream with queued response data when maxSessionMemory is %s",
+    async (_, maxSessionMemory) => {
+      const server = http2.createServer({ maxSessionMemory });
+      server.on("stream", (stream: any) => {
+        stream.on("error", () => {});
+        stream.respond({ ":status": 200 });
+        stream.write(Buffer.alloc(1 << 22, "a"));
+      });
+      server.listen(0);
+      await once(server, "listening");
+      const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+      try {
+        c.sendPreface();
+        c.sendEmptySettings();
+        c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+        await c.waitFor(f => f.type === FrameType.DATA && f.streamId === 1);
+        c.sendFrame(FrameType.HEADERS, 0x5, 3, requestHeaderBlock("GET"));
+        const reply = await c.waitFor(
+          f => (f.type === FrameType.HEADERS || f.type === FrameType.RST_STREAM) && f.streamId === 3,
+        );
+        expect(reply.type).toBe(FrameType.HEADERS);
+      } finally {
+        c.destroy();
+        server.close();
+      }
+    },
+  );
+
   /** A maxSessionMemory:1 server whose first stream queues enough response data that the
    *  next inbound HEADERS is refused. Streams that do reach JS are recorded in `seen`. */
   async function exhaustedSession() {


### PR DESCRIPTION
### Problem
- `http2.createServer({ maxSessionMemory: Number.MAX_SAFE_INTEGER })` refuses the second request stream with `ENHANCE_YOUR_CALM` (rstCode 11) once about 1MB of response data is queued. Node serves it. Any value at or above 2^51, and exactly 2^32, fails the same way. `@grpc/grpc-js` 1.14 passes `Number.MAX_SAFE_INTEGER` to disable the limit, so Pulumi programs under Bun fail with `RESOURCE_EXHAUSTED`.
- Two truncations stack. `JSC__JSValue__toUInt64NoTruncate` (`src/jsc/bindings/bindings.cpp`) routed doubles through `tryConvertToInt52` and returned 0 for a double at or above 2^51. `src/runtime/api/bun/h2_frame_parser.rs` then cast with `as u32`, which wraps 2^32 to 0. Both paths land on the `.max(1)` floor: a 1MB budget.

### Fix
- `toUInt64NoTruncate` now uses `JSC::toUInt64` for doubles, with one clamp in front: values at or above 2^64, including `+Infinity`, give `UINT64_MAX`. Below that the conversion is exact for `[0, 2^64)`, `NaN` and `-Infinity` give 0, and negatives wrap the same way the int32 path always has (`-1` and `-1.5` both give `UINT64_MAX`). No UB from `static_cast<uint64_t>(double)`.
- This is the function behind every Rust `to_uint64_no_truncate()` caller, so `Bun.hash` seeds and the other call sites get the same fix.
- The http2 parser narrows the u64 into its u32 limit fields with `u32::try_from(..).unwrap_or(u32::MAX)` instead of `as u32`. This covers `maxSessionMemory` and the five sibling options read in the same block.

### Tests
- `test/js/node/http2/h2-conformance.test.ts`: three new cases (`Number.MAX_SAFE_INTEGER`, `2**51`, `2**32`) serve the second stream.
- `test/js/bun/util/hash.test.js`: Number seeds in `[2^51, 2^64)` match their BigInt equivalents; `2**64`, `Infinity`, `-1`, `-1.5` equal seed `2^64-1`; `NaN`, `-Infinity` equal seed 0.

Fixes #41294
