### PR TITLE
Let idle FTL code age out once the heap goes quiet (WebKit#557/#558)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "72e75e4ec1f9a8571874328c1502f4d8226bc2bf";
+export const WEBKIT_VERSION = "autobuild-preview-pr-557-7bac2317";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e0532b1b83aebec2695e0ff945ef076998df9df";
+export const WEBKIT_VERSION = "40e43a82a755af3cc9eb4a4e025e4e020a7a3cfd";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-557-7bac2317";
+export const WEBKIT_VERSION = "2e0532b1b83aebec2695e0ff945ef076998df9df";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -189,12 +189,16 @@ impl GarbageCollectionController {
         );
     }
 
-    pub(crate) fn perform_gc(&self, full: bool) {
+    pub(crate) fn perform_gc(&self, idle_full: bool) {
         if self.disabled.get() {
             return;
         }
         let vm = VirtualMachine::get().jsc_vm();
-        vm.collect_async(full);
+        if idle_full {
+            vm.collect_async_idle();
+        } else {
+            vm.collect_async(false);
+        }
         self.gc_last_heap_size.set(vm.block_bytes_allocated());
     }
 

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -29,6 +29,7 @@ unsafe extern "C" {
     safe fn JSC__VM__runGC(vm: &VM, sync: bool) -> usize;
     safe fn JSC__VM__heapSize(vm: &VM) -> usize;
     safe fn JSC__VM__collectAsync(vm: &VM, full: bool);
+    safe fn JSC__VM__collectAsyncIdle(vm: &VM);
     safe fn JSC__VM__executionForbidden(vm: &VM) -> bool;
     safe fn JSC__VM__notifyNeedTermination(vm: &VM);
     safe fn JSC__VM__isEntered(vm: &VM) -> bool;
@@ -97,6 +98,11 @@ impl VM {
     /// Request a concurrent collection; JSC picks the scope unless `full`.
     pub(crate) fn collect_async(&self, full: bool) {
         JSC__VM__collectAsync(self, full)
+    }
+
+    /// A full collection tagged as the embedder's idle collection, in which JSC may also let idle optimized code go.
+    pub(crate) fn collect_async_idle(&self) {
+        JSC__VM__collectAsyncIdle(self)
     }
 
     pub fn execution_forbidden(&self) -> bool {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3171,6 +3171,16 @@ void JSC__VM__collectAsync(JSC::VM* vm, bool full)
         vm->heap.collectAsync();
 }
 
+// The full collection GarbageCollectionController requests because the heap has gone quiet: tagged so JSC may let idle
+// optimized code age out in it (GCRequest::isIdle), which it never does in a collection the program forces or allocation paces.
+void JSC__VM__collectAsyncIdle(JSC::VM* vm)
+{
+    JSC::JSLockHolder lock(*vm);
+    JSC::GCRequest request(JSC::CollectionScope::Full);
+    request.isIdle = true;
+    vm->heap.collectAsync(request);
+}
+
 size_t JSC__VM__heapSize(JSC::VM* arg0)
 {
     return arg0->heap.size();

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -264,6 +264,7 @@ CPP_DECL void JSC__JSValue__toZigException(JSC::EncodedJSValue JSValue0, JSC::JS
 
 CPP_DECL size_t JSC__VM__blockBytesAllocated(JSC::VM* arg0);
 CPP_DECL void JSC__VM__collectAsync(JSC::VM* arg0, bool full);
+CPP_DECL void JSC__VM__collectAsyncIdle(JSC::VM* arg0);
 CPP_DECL JSC::VM* JSC__VM__create(unsigned char HeapType0);
 CPP_DECL void JSC__VM__deleteAllCode(JSC::VM* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void JSC__VM__drainMicrotasks(JSC::VM* arg0);

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -240,19 +240,24 @@ describe("idle release lets FTL code age out", () => {
       stderr: "inherit",
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    return JSON.parse(stdout.trim()) as { before: number; after: number };
+    const counts = (stdout.trim().startsWith("{") ? JSON.parse(stdout.trim()) : {}) as {
+      before?: number;
+      after?: number;
+    };
+    return { ...counts, stdout, exitCode };
   }
 
   test.concurrent("the idle collections drop the warmed-up code", async () => {
-    const { before, after } = await run({ BUN_IDLE_GC_SECONDS: "1,1,1" });
-    expect(before).toBeGreaterThan(40);
-    expect(after).toBeLessThan(before / 4);
+    const { before, after, stdout, exitCode } = await run({ BUN_IDLE_GC_SECONDS: "1,1,1" });
+    expect(before, stdout).toBeGreaterThan(40);
+    expect(after, stdout).toBeLessThan(before! / 4);
+    expect(exitCode).toBe(0);
   });
 
   test.concurrent("collections the program forces itself do not", async () => {
-    const { before, after } = await run({ BUN_IDLE_GC_SECONDS: "0", MODE: "forced" });
-    expect(before).toBeGreaterThan(40);
-    expect(after).toBeGreaterThan(before / 2);
+    const { before, after, stdout, exitCode } = await run({ BUN_IDLE_GC_SECONDS: "0", MODE: "forced" });
+    expect(before, stdout).toBeGreaterThan(40);
+    expect(after, stdout).toBeGreaterThan(before! / 2);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -194,3 +194,65 @@ describe("idle release", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Those idle full collections are tagged (GCRequest::isIdle) so JSC may also let idle FTL code — which has no execution
+// counter of its own and pins every baseline CodeBlock it inlined — age out in them, and only in them: a program that
+// forces collections itself while running hot code must not lose that code. Eager JIT TTLs make it observable in seconds.
+describe("idle release lets FTL code age out", () => {
+  const script = /* js */ `
+    const { heapStats, noInline } = require("bun:jsc");
+    const fns = [];
+    for (let i = 0; i < 40; i++) {
+      const f = new Function("o", "h", "let s = 0; for (let k = 0; k < 40; k++) s += h(o, k) + " + i + "; return s;");
+      noInline(f);
+      fns.push(f);
+    }
+    const helper = (o, k) => o.a * k + o.b;
+    const o = { a: 1, b: 2 };
+    globalThis.keep = [helper, o, fns];
+    for (let r = 0; r < 100000; r++) for (let j = 0; j < fns.length; j++) fns[j](o, helper);
+    const count = () => heapStats().objectTypeCounts.FunctionCodeBlock ?? 0;
+    Bun.gc(true);
+    const before = count();
+    if (process.env.MODE === "forced") {
+      let n = 0;
+      const id = setInterval(() => {
+        Bun.gc(true);
+        if (++n >= 6) { clearInterval(id); console.log(JSON.stringify({ before, after: count() })); }
+      }, 700);
+    } else {
+      setTimeout(() => { Bun.gc(true); console.log(JSON.stringify({ before, after: count() })); }, 4500);
+    }
+  `;
+
+  async function run(env: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        BUN_GC_TIMER_DISABLE: undefined,
+        BUN_GC_TIMER_INTERVAL: undefined,
+        BUN_JSC_useEagerCodeBlockJettisonTiming: "1",
+        BUN_JSC_optimizedCodeAgingQuietSeconds: "0.5",
+        ...env,
+      },
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout.trim()) as { before: number; after: number };
+  }
+
+  test.concurrent("the idle collections drop the warmed-up code", async () => {
+    const { before, after } = await run({ BUN_IDLE_GC_SECONDS: "1,1,1" });
+    expect(before).toBeGreaterThan(40);
+    expect(after).toBeLessThan(before / 4);
+  });
+
+  test.concurrent("collections the program forces itself do not", async () => {
+    const { before, after } = await run({ BUN_IDLE_GC_SECONDS: "0", MODE: "forced" });
+    expect(before).toBeGreaterThan(40);
+    expect(after).toBeGreaterThan(before / 2);
+  });
+});


### PR DESCRIPTION
### What

WebKit → `40e43a82a755` (oven-sh/WebKit#557 + #558).

That change lets JSC age out FTL code (and DFG code compiled without tier-up checks) once the mutator has gone quiet. Such code has no execution counter, so since #41083 / WebKit#542 it never aged, and each block pinned its baseline alternative plus every baseline CodeBlock it inlined. Now a full collection lets it go once ≤ 1 MB has been allocated since the previous full collection looked at it for ≥ 30 s — which is exactly what the idle collections `GarbageCollectionController` already schedules (`BUN_IDLE_GC_SECONDS=10,65,65`) produce. Busy processes are unaffected: their full collections are allocation-driven and always renew the lease.

Bun side: `GarbageCollectionController` now issues those idle full collections through `JSC__VM__collectAsyncIdle`, which tags the request (`GCRequest::isIdle`, WebKit#558). JSC lets such code go **only** in a tagged collection, so a program that forces `Bun.gc()` on a timer while running hot, non-allocating code keeps its optimized code; allocation-paced and memory-pressure collections never drop it either.

### Numbers

express / hono with a library-heavy handler (ajv, zod, markdown-it+highlight.js, js-yaml, protobufjs, graphql, handlebars, sucrase, …), 5,000-request burst at c=50, then idle. Same Bun commit, WebKit#557 option off vs on, 3 runs each:

| idle +120 s | off | on |
|---|---|---|
| express anon RSS | 148 MB | **127 MB** |
| hono anon RSS | 137 MB | **117 MB** |
| surviving `FunctionCodeBlock`s (express) | ~2,400 | ~200 |

Nothing changes at +45 s (before the second idle collection) or under load; a 2-minute sustained-load run compiled the same number of FTL functions with the option on and off.

For context, idle +240 s RSS across versions on the same apps (5 runs, medians): express 1.3.14 245 / 1.4.0 224 / canary 192 → ~171 with this; hono 228 / 207 / 173 → ~152; elysia 230 / 203 / 170 → ~149; next 339 / 296 / 244 → ~223.

### Tests

`test/js/bun/gc/gc-controller-cadence.test.ts` gains two cases (eager JIT TTLs so it runs in seconds): the idle collections take a 40-function FTL workload from ~90 `FunctionCodeBlock`s to a handful; `BUN_IDLE_GC_SECONDS=0` plus `Bun.gc(true)` every 0.7 s leaves them in place. Both fail on current bun. The engine side is `JSTests/stress/codeblock-aging-ftl-idle*.js` in WebKit#557/#558.
