### PR TITLE
bundler: keep the default export of a lifted module.exports = require()

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1544,9 +1544,8 @@ impl<'a> ExportStarContext<'a> {
         self.source_index_stack.push(source_index);
         let stack_end_pos = self.source_index_stack.len();
 
-        // The export star of a lifted CommonJS file was `module.exports = ns`:
-        // it re-exports the whole namespace, `default` included. A real
-        // `export *` anywhere on the chain from the target drops it again.
+        // A lifted file's export star was `module.exports = ns`, which hands over
+        // `default` too. A real `export *` on the chain from the target drops it.
         let reexports_default = self.source_index_stack[..stack_end_pos].iter().all(|i| {
             col_ref!(self.ast_flags)[*i as usize].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
         });

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1545,9 +1545,11 @@ impl<'a> ExportStarContext<'a> {
         let stack_end_pos = self.source_index_stack.len();
 
         // The export star of a lifted CommonJS file was `module.exports = ns`:
-        // it re-exports the whole namespace, `default` included.
-        let reexports_default = col_ref!(self.ast_flags)[source_index as usize]
-            .contains(AstFlags::COMMONJS_LIFTED_TO_ESM);
+        // it re-exports the whole namespace, `default` included. A real
+        // `export *` anywhere on the chain from the target drops it again.
+        let reexports_default = self.source_index_stack[..stack_end_pos].iter().all(|i| {
+            col_ref!(self.ast_flags)[*i as usize].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
+        });
 
         for import_id in col_ref!(self.export_star_records)[source_index as usize].iter() {
             let other_source_index = col_ref!(self.import_records_list)[source_index as usize]

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1544,8 +1544,7 @@ impl<'a> ExportStarContext<'a> {
         self.source_index_stack.push(source_index);
         let stack_end_pos = self.source_index_stack.len();
 
-        // A lifted file's export star was `module.exports = ns`, which hands over
-        // `default` too. A real `export *` on the chain from the target drops it.
+        // A lifted file's export star was `module.exports = ns`: it hands over `default` too.
         let reexports_default = self.source_index_stack[..stack_end_pos].iter().all(|i| {
             col_ref!(self.ast_flags)[*i as usize].contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
         });

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -505,6 +505,7 @@ pub(crate) fn scan_imports_and_exports(
                             source_index_stack: Vec::with_capacity(32),
                             exports_kind,
                             named_exports,
+                            ast_flags: ast_flags_list,
                         });
                     }
                     export_star_ctx.as_mut().unwrap().add_exports(
@@ -1522,6 +1523,7 @@ struct ExportStarContext<'a> {
     named_exports: *mut [NamedExports],
     imports_to_bind: *mut [RefImportData],
     export_star_records: *mut [bun_alloc::AstVec<u32>],
+    ast_flags: *mut [AstFlags],
 }
 
 impl<'a> ExportStarContext<'a> {
@@ -1541,6 +1543,11 @@ impl<'a> ExportStarContext<'a> {
         }
         self.source_index_stack.push(source_index);
         let stack_end_pos = self.source_index_stack.len();
+
+        // The export star of a lifted CommonJS file was `module.exports = ns`:
+        // it re-exports the whole namespace, `default` included.
+        let reexports_default = col_ref!(self.ast_flags)[source_index as usize]
+            .contains(AstFlags::COMMONJS_LIFTED_TO_ESM);
 
         for import_id in col_ref!(self.export_star_records)[source_index as usize].iter() {
             let other_source_index = col_ref!(self.import_records_list)[source_index as usize]
@@ -1579,7 +1586,7 @@ impl<'a> ExportStarContext<'a> {
 
                 // ES6 export star statements ignore exports named "default"
                 let alias_slice: &[u8] = &alias;
-                if alias_slice == b"default" {
+                if alias_slice == b"default" && !reexports_default {
                     continue;
                 }
 

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -529,6 +529,52 @@ describe("bundler", () => {
       stdout: "side effect\nrendered render,version object",
     },
   });
+  // `module.exports = ns` re-exports the whole namespace, so `default` of an
+  // ES module target comes through too (a plain `export *` would drop it).
+  itBundled("cjs2esm/ReactSpecificUnwrappingSideEffectTargetHasDefault", {
+    files: {
+      "/entry.js": /* js */ `
+        import ReactDOM, { version } from "react-dom";
+        import * as ns from "react-dom";
+        const m = require("react-dom");
+        console.log(version, typeof ReactDOM.default, ReactDOM.default(), typeof ns.default, ns.default(), m.default(), Object.keys(ns).sort().join(","));
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        export default function render() { return "rendered"; }
+        export const version = "19.0.0";
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    run: {
+      stdout: "side effect\n19.0.0 function rendered function rendered rendered default,version",
+    },
+  });
+  itBundled("cjs2esm/ReactSpecificUnwrappingSideEffectTargetHasDefaultRequireOnly", {
+    files: {
+      "/entry.js": /* js */ `
+        const m = require("react-dom");
+        console.log(Object.keys(m).sort().join(","), typeof m.default, m.default(), m.version);
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        export default function render() { return "rendered"; }
+        export const version = "19.0.0";
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    run: {
+      stdout: "side effect\ndefault,version function rendered 19.0.0",
+    },
+  });
   // The namespace the require() became stays imported when the file also
   // reads from it before the `module.exports =` assignment.
   itBundled("cjs2esm/ReactSpecificUnwrappingNamespaceStillUsed", {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -575,6 +575,33 @@ describe("bundler", () => {
       stdout: "side effect\ndefault,version function rendered 19.0.0",
     },
   });
+  // A real `export *` of the lifted file keeps ES module semantics: `default`
+  // of the lifted namespace does not pass through it.
+  itBundled("cjs2esm/ReactSpecificUnwrappingSideEffectTargetHasDefaultBehindExportStar", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./reexport";
+        import ReactDOM from "react-dom";
+        console.log(Object.keys(ns).sort().join(","), typeof ns.default, typeof ReactDOM.default);
+      `,
+      "/reexport.js": /* js */ `
+        export * from "react-dom";
+      `,
+      "/node_modules/react-dom/index.js": /* js */ `
+        console.log('side effect');
+        module.exports = require('./impl');
+      `,
+      "/node_modules/react-dom/impl.js": /* js */ `
+        export default function render() { return "rendered"; }
+        export const version = "19.0.0";
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    run: {
+      stdout: "side effect\nversion undefined function",
+    },
+  });
   // The namespace the require() became stays imported when the file also
   // reads from it before the `module.exports =` assignment.
   itBundled("cjs2esm/ReactSpecificUnwrappingNamespaceStillUsed", {


### PR DESCRIPTION
### Problem
- In an unwrapped package (`react-dom`, `react`, `scheduler`, ...), a CommonJS entry of the shape `sideEffect(); module.exports = require('./impl')` loses the `default` export of `impl` when `impl` is an ES module with `export default`. `Object.keys(require("react-dom"))` is `["version"]` and `m.default` is `undefined`. The bundle does not contain the default export at all.
- #41188 lifts that assignment to `export * from './impl'`. The linker expands every export star in `ExportStarContext::add_exports` (`src/bundler/linker_context/scanImportsAndExports.rs:1582`) and skips `default`, which is correct for a real `export *` but not for `module.exports = ns`, which hands over the whole namespace. Bun 1.4.0 does not have the lift and is not affected.

### Fix
- `add_exports` keeps `default` when the file that owns the export star is `COMMONJS_LIFTED_TO_ESM`. A lifted file never had ES module syntax, so its only export star is the lifted assignment.
- Nested export stars keep ES module semantics. `default` passes only when every file on the chain from the target to the current hop is lifted. An `export * from './x'` inside `impl`, or a real `export * from 'react-dom'` above the lifted file, still drops it.
- Verified: `test/bundler/bundler_cjs2esm.test.ts`, three new cases (`ReactSpecificUnwrappingSideEffectTargetHasDefault*`) that fail on the released bun. Also the other bundler suites in the notes.

### Background
- The bundler converts CommonJS files of an allowlist of packages to ESM. Such files carry `COMMONJS_LIFTED_TO_ESM`. Their `module.exports = ns` (where `ns` is the `import * as ns` that the `require()` became) is replaced by an export star on the same import record.
- Step 3 of `scan_imports_and_exports` resolves export stars at link time by copying the target's named exports into the owner's `resolved_exports`. Per the ES module spec, `export *` never forwards `default`, so the loop skips it.
- A default import, `ns.default`, and `require("react-dom").default` all look up `default` in `resolved_exports` of the lifted file first, so adding it there fixes all three consumers.

<details><summary>Notes</summary>

Repro, the same layout as the report. Before: `["version"] undefined 19` and `["version"]`. After, the same as unbundled: `["default","version"] function 19` and `["default","version"]`.

```
mkdir -p node_modules/react-dom
printf '{"name":"react-dom","version":"19.0.0","main":"index.js"}' > node_modules/react-dom/package.json
printf "console.log('side effect');\nmodule.exports = require('./impl');\n" > node_modules/react-dom/index.js
printf 'export default function render(){return "r"}; export const version="19";\n' > node_modules/react-dom/impl.js
printf 'let m; try { m = require("react-dom") } catch {}\nconsole.log(JSON.stringify(Object.keys(m)), typeof m.default, m.version);\n' > a1.js
printf 'import * as ns from "react-dom"; console.log(JSON.stringify(Object.keys(ns)));\n' > a6.js
bun build ./a1.js --target=bun --outdir=o && bun o/a1.js
bun build ./a6.js --target=bun --outdir=o && bun o/a6.js
```

Also checked by hand, all the same as unbundled after the fix: `import def from "react-dom"` (`def.default()` works), `import * as ns` with `ns.default()`, `require("react-dom").default()`. One pre-existing difference stays: unbundled, `ns.default` of `import * as ns` is `module.exports` itself (an object whose `default` is the function), bundled it is the function. That is the known interop of the lift and not part of this change.

A CommonJS `impl` (the shape of #41236) is unaffected by this PR: `add_exports` skips CommonJS targets before the `default` check.

Suites run with the debug build, all green: `bundler_cjs2esm`, `bundler_cjs`, `bundler_edgecase`, `bundler_splitting`, `bundler_regressions`, `bundler_npm`, `bundler_minify`, `bundler_browser`, `bundler_bun`, `esbuild/default`, `esbuild/importstar`, `esbuild/dce`, `esbuild/packagejson`, `esbuild/splitting`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [797.61ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [346.70ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [422.46ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [325.78ms]
(pass) bundler > cjs2esm/ExportsFunction [328.73ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [351.79ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [331.31ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [375.14ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [464.08ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [394.01ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [412.89ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [527.24ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [506
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (e0a2b82fd)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [16.87ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [7.30ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [6.72ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [6.25ms]
(pass) bundler > cjs2esm/ExportsFunction [6.85ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [6.61ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [6.64ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [7.49ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [8.22ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [9.60ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [8.16ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [8.96ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [8.61ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [7.72ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [7.67ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [737.04ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [353.21ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [339.96ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [328.21ms]
(pass) bundler > cjs2esm/ExportsFunction [401.43ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [384.21ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [330.41ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [577.76ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [470.72ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [388.60ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [423.73ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [457.07ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [532
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 577ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/7] gen cpp.rs (cppbind)
[3/7] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/scanImportsAndExports.rs        |  9 ++-
 test/bundler/bundler_cjs2esm.test.ts               | 73 ++++++++++++++++++++++
 2 files changed, 81 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/linker_context/scanImportsAndExports.rs      7      8      8
test/bundler/bundler_cjs2esm.test.ts                     1      2      8
```

</details>

**root cause** · written by the author bot

Commit 696ce5a4 lifted the `module.exports = require('./impl')` pattern in unwrapped CommonJS packages into an `export * from './impl'`, but standard `export *` semantics never forward the `default` binding, so when `impl` was an ES module with a default export that binding was dropped from the bundle entirely and `require()`/`import default` callers received the namespace without it. The fix passes per-file AST flags into `ExportStarContext` so the export-star traversal can recognize chains that originate from a lifted CommonJS module and preserve `default` only for those chains, while ord…

<!-- robobun:evidence:end -->