### PR TITLE
test(dgram): wait for the close callback instead of eight loop turns

### DIFF
--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -28,14 +28,15 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
         }
       });
       rx.on("close", () => trace.push("closeEvent"));
+      rx.on("error", closed.reject);
       const tx = dgram.createSocket("udp4");
-      tx.on("error", () => {});
+      tx.on("error", closed.reject);
       // Queue a burst on the kernel rx buffer before the loop dispatches
       // 'message'. Each send is awaited so its syscall has completed before
       // the next one starts; on loopback this deterministically yields a
       // multi-packet recvmmsg batch.
       for (let i = 0; i < 16; i++) {
-        await new Promise(r => tx.send(String(i), port, "127.0.0.1", r));
+        await new Promise((r, j) => tx.send(String(i), port, "127.0.0.1", e => (e ? j(e) : r())));
       }
       // Loopback delivery is asynchronous on macOS, so wait for the close
       // itself, not for a number of loop turns. Then give a replay of the rest

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -56,12 +56,13 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
     .split("\n")
     .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
     .join("\n");
-  const trace = JSON.parse(stdout.trim());
   // The socket closes on the first datagram. Node ordering: 'close' event
   // first, then the close() callback (both via queueMicrotask in dgram.ts).
-  expect({ stderr, trace }).toEqual({
+  // stdout stays a string so that a child error shows up in stderr here
+  // instead of as a JSON.parse failure on empty output.
+  expect({ stderr, stdout }).toEqual({
     stderr: "",
-    trace: ["message:0", "closeEvent", "closeCallback"],
+    stdout: JSON.stringify(["message:0", "closeEvent", "closeCallback"]) + "\n",
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -14,12 +14,18 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
       `
       import dgram from "node:dgram";
       const trace = [];
+      const closed = Promise.withResolvers();
       const rx = dgram.createSocket("udp4");
       await new Promise(r => rx.bind(0, "127.0.0.1", r));
       const port = rx.address().port;
       rx.on("message", d => {
         trace.push("message:" + d.toString());
-        if (d.toString() === "0") rx.close(() => trace.push("closeCallback"));
+        if (d.toString() === "0") {
+          rx.close(() => {
+            trace.push("closeCallback");
+            closed.resolve();
+          });
+        }
       });
       rx.on("close", () => trace.push("closeEvent"));
       const tx = dgram.createSocket("udp4");
@@ -31,7 +37,10 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
       for (let i = 0; i < 16; i++) {
         await new Promise(r => tx.send(String(i), port, "127.0.0.1", r));
       }
-      // Let any queued 'message' / 'close' events drain.
+      // Loopback delivery is asynchronous on macOS, so wait for the close
+      // itself, not for a number of loop turns. Then give a replay of the rest
+      // of the batch a few turns to show up in the trace.
+      await closed.promise;
       for (let i = 0; i < 8; i++) await new Promise(r => setImmediate(r));
       tx.close();
       console.log(JSON.stringify(trace));


### PR DESCRIPTION
### Problem
- `test/js/node/dgram/node-dgram.test.js` fails on the darwin x64 lanes in the parallel batch: `close() inside 'message' handler stops remaining batch datagrams` prints `trace: []`. Main builds 109692 and 109717 and 7 PR builds (109698, 109725, 109726, 109731, 109732, 109741, 109755) in the last two days, all on `darwin-x64-pita` or `darwin-x64-crumpet`.
- Cause: the fixture sends 16 datagrams to itself, then waits 8 `setImmediate` turns and prints the trace. Those turns take under 1 ms. Loopback delivery is asynchronous on macOS, so on a loaded agent no datagram has arrived when the trace is printed.

### Fix
- The fixture waits for the `close()` callback, which fires after the first datagram. Then it gives a replay of the rest of the batch 8 turns to show up in the trace, as before.
- Correct because the assertion is about what happens after `close()`. Waiting for the close is the condition. The turn count was a timer in disguise.
- Verified: `bun bd test test/js/node/dgram/node-dgram.test.js` (the IPv6 membership test fails in the container with ENODEV before and after, unrelated). The fixture ran 30 of 30 on `darwin-x64-matzo` with the CI build of 5f4940e91a.

### Background
- #33669 added this test. Before that fix, bun replayed the rest of a recvmmsg batch into a socket whose `close` event had fired. Such a replay lands in the trace after `closeCallback`, so the new wait still catches it.
- #41270 adds this file to `test/flaky-tests.txt`. With this change that entry is not needed for this test.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/dgram/node-dgram.test.js

<!-- robobun:evidence:end -->