### PR TITLE
Test cyclic Array#join in the interpreter and the optimizing JIT tiers

### DIFF
--- a/test/regression/issue/41198.test.ts
+++ b/test/regression/issue/41198.test.ts
@@ -2,8 +2,7 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // https://github.com/oven-sh/bun/issues/41198
-// A cyclic array converted to a string renders the nested reference as the
-// empty string, like V8 and SpiderMonkey, instead of overflowing the stack.
+// A cyclic array converts to a string with "" for the cycle, like V8, and does not throw RangeError.
 
 async function run(source: string, env: Record<string, string> = {}) {
   await using proc = Bun.spawn({
@@ -65,7 +64,7 @@ test.concurrent("optimized code joins a cyclic array the same way as the interpr
   // baseline tier before ArrayJoin runs on the cyclic array.
   const { stdout, stderr, exitCode } = await run(
     `
-    const { numberOfDFGCompiles } = require("bun:jsc");
+    import { numberOfDFGCompiles } from "bun:jsc";
     const a = [];
     a.push(1, a, 2);
     const join = x => x.join("-");

--- a/test/regression/issue/41198.test.ts
+++ b/test/regression/issue/41198.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/41198
+// A cyclic array converted to a string renders the nested reference as the
+// empty string, like V8 and SpiderMonkey, instead of overflowing the stack.
+
+async function run(source: string, env: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: { ...bunEnv, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("a cyclic array converts to a string the way Node does", async () => {
+  const { stdout, stderr, exitCode } = await run(`
+    const a = [];
+    a.push(1, a, 2);
+    const b = [0];
+    b.push([b]);
+    const cases = {
+      xor: 0 ^ a,
+      string: String(a),
+      join: a.join("-"),
+      joinDefault: a.join(),
+      toLocaleString: a.toLocaleString(),
+      template: \`\${b}\`,
+      equals: a == "1,,2",
+      selfOnly: String([(x => (x[0] = x, x))([])]),
+      shared: (s => [s, s].join("|"))([1, 2]),
+    };
+    console.log(JSON.stringify(cases));
+    let threw;
+    try { JSON.stringify(a); } catch (e) { threw = e.constructor.name; }
+    console.log(threw);
+  `);
+  expect(stderr).toBe("");
+  expect(stdout.split("\n")).toEqual([
+    JSON.stringify({
+      xor: 0,
+      string: "1,,2",
+      join: "1--2",
+      joinDefault: "1,,2",
+      toLocaleString: "1,,2",
+      template: "0,",
+      equals: true,
+      selfOnly: "",
+      shared: "1,2|1,2",
+    }),
+    "TypeError",
+    "",
+  ]);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("optimized code joins a cyclic array the same way as the interpreter", async () => {
+  // The DFG and the FTL compile x.join(sep) to an ArrayJoin node. That node
+  // calls its own operation, not Array.prototype.join, so it needs its own
+  // cycle guard. The warmup must use the cyclic array itself. A warmup on an
+  // Int32 array compiles code for that shape, and the code exits to the
+  // baseline tier before ArrayJoin runs on the cyclic array.
+  const { stdout, stderr, exitCode } = await run(
+    `
+    const { numberOfDFGCompiles } = require("bun:jsc");
+    const a = [];
+    a.push(1, a, 2);
+    const join = x => x.join("-");
+    const convert = x => \`\${x}\`;
+    for (let i = 0; i < 2000; i++) {
+      const joined = join(a);
+      const converted = convert(a);
+      if (joined !== "1--2" || converted !== "1,,2") throw new Error(\`iteration \${i}: \${joined} \${converted}\`);
+    }
+    console.log(JSON.stringify([join(a), convert(a), numberOfDFGCompiles(join) >= 1]));
+    `,
+    {
+      BUN_JSC_useConcurrentJIT: "0",
+      BUN_JSC_thresholdForJITAfterWarmUp: "10",
+      BUN_JSC_thresholdForOptimizeAfterWarmUp: "100",
+      BUN_JSC_thresholdForFTLOptimizeAfterWarmUp: "1000",
+    },
+  );
+  expect(stderr).toBe("");
+  expect(stdout).toBe(JSON.stringify(["1--2", "1,,2", true]) + "\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- In #41198, a string conversion of a cyclic array threw `RangeError: Maximum call stack size exceeded`. #41324 fixed it on main with WebKit `6119947592b6` (oven-sh/WebKit#559). Its test covers the interpreter only.
- The optimizing JIT tiers (the DFG and the FTL) compile `x.join(sep)` to an `ArrayJoin` node. The node calls `operationArrayJoin` in `DFGOperations.cpp`. oven-sh/WebKit#559 adds a separate guard there, and no test runs that path.

### Fix
- This PR no longer changes the WebKit pin, because main has the merged commit. It adds only `test/regression/issue/41198.test.ts`.
- The first test checks the conversions from the issue. It also checks a cycle through two arrays, and an acyclic array that occurs twice.
- The second test warms up `x.join("-")` on the cyclic array. Then the optimized code calls `operationArrayJoin` on it. Without that guard, the result is `"1-1,,2-2"` and not `"1--2"`.
- Verified: both tests pass on a debug build of main and on canary `b1f7b8e36`. Both fail on `e0a2b82fd` with the `RangeError`.

### Background
- `StringRecursionChecker` records an array for the duration of one conversion. A nested conversion of the same array gives the empty string. V8 does the same.
- JSC runs code in four tiers: the interpreter, the baseline JIT, the DFG, and the FTL. The DFG and the FTL compile code for the array shapes that the profile saw.
- An OSR exit is a jump from optimized code back to the baseline tier. It occurs when a check fails.

<details><summary>Notes</summary>

- The previous version of the test warmed up on `[1, 2, 3]`, which has the Int32 shape. The cyclic array has the Contiguous shape. With `BUN_JSC_printEachOSRExit=1`, the call on the cyclic array exits at `bc#0` (`BadCache`). A gdb breakpoint on `operationArrayJoin` for Contiguous arrays counted 0 calls.
- With the warmup on the cyclic array, the same breakpoint counts 1993 calls in 2000 iterations. No exit occurs in `join`.
- With `BUN_JSC_reportCompileTimes=1`, `join` reaches the DFG before iteration 10 and the FTL before iteration 100. The loop takes about 0.5 s on a debug ASAN build.
- No prebuilt WebKit has the interpreter guard without the DFG guard. The `"1-1,,2-2"` result comes from the code: `fastArrayJoin` converts a nested array with `JSArray::fastToString`, and that function has its own guard.
- Also ran `test/js/bun/jsc/webkit-upgrade-3722912f.test.ts` on the debug build.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 5 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/41198.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/41198.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/regression/issue/41198.test.ts:
(pass) a cyclic array converts to a string the way Node does [401.17ms]
(pass) optimized code joins a cyclic array the same way as the interpreter [678.03ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [2.80s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/41198.test.ts | 89 +++++++++++++++++++++++++++++++++++++
 1 file changed, 89 insertions(+)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/regression/issue/41198.test.ts      2      4     13
```

</details>

<!-- robobun:evidence:end -->
