### PR TITLE
sql(postgres): bind an untyped sql.array without a cast

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -418,7 +418,7 @@ await sql`SELECT ${sql.array([1, 2, 3], "INT")} AS ids`;
 
 Without a type, the parameter has no cast. PostgreSQL infers the element type from the target column, the compared value, or a cast in the query. Pass the type when the query gives the server no context: a bare `SELECT ${sql.array([1])}` comes back as the literal text `{"1"}`, and a function argument such as `unnest(${sql.array([1])})` fails with `could not determine polymorphic type`. Pass `"JSON"` or `"JSONB"` for string elements that go into a `json[]` or `jsonb[]` column, so each string is JSON-encoded.
 
-<Note>`sql.array` is PostgreSQL-only. Multi-dimensional arrays and NULL elements may not be supported yet.</Note>
+<Note>`sql.array` is PostgreSQL-only. Multi-dimensional arrays may not be supported yet.</Note>
 
 ---
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -416,7 +416,7 @@ await sql`SELECT ${sql.array([1, 2, 3], "INT")} AS ids`;
 // Binds: $1::INT[] with '{1,2,3}'
 ```
 
-Without a type, the parameter has no cast. PostgreSQL infers the element type from the target column, the compared value, or a cast in the query. Pass the type when the query gives the server no context: a bare `SELECT ${sql.array([1])}` comes back as the literal text `{"1"}`, and a function argument such as `unnest(${sql.array([1])})` fails with `could not determine polymorphic type`. Pass `"JSON"` or `"JSONB"` for string elements that go into a `json[]` or `jsonb[]` column, so each string is JSON-encoded.
+Without a type, the parameter has no cast. PostgreSQL infers the element type from the target column, the compared value, or a cast in the query. Pass the type when the query gives the server no context: a bare `SELECT ${sql.array([1])}` comes back as the literal text `{"1"}`, and a function argument such as `unnest(${sql.array([1])})` fails with `function unnest(unknown) is not unique`. Pass `"JSON"` or `"JSONB"` for string elements that go into a `json[]` or `jsonb[]` column, so each string is JSON-encoded.
 
 <Note>`sql.array` is PostgreSQL-only. Multi-dimensional arrays may not be supported yet.</Note>
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -400,17 +400,23 @@ await sql`SELECT * FROM users WHERE id IN ${sql(users, "id")}`;
 
 ### `sql.array` helper
 
-The `sql.array` helper creates PostgreSQL array literals from JavaScript arrays:
+The `sql.array` helper binds a JavaScript array as one PostgreSQL array parameter:
 
 ```ts
-// Create array literals for PostgreSQL
+// The server infers text[] from the column
 await sql`INSERT INTO tags (items) VALUES (${sql.array(["red", "blue", "green"])})`;
-// Generates: INSERT INTO tags (items) VALUES (ARRAY['red', 'blue', 'green'])
+// Binds: $1 with '{"red","blue","green"}'
 
-// Works with numeric arrays too
-await sql`SELECT * FROM products WHERE ids = ANY(${sql.array([1, 2, 3])})`;
-// Generates: SELECT * FROM products WHERE ids = ANY(ARRAY[1, 2, 3])
+// The server infers the element type from the compared column
+await sql`SELECT * FROM products WHERE id = ANY(${sql.array([1, 2, 3])})`;
+// Binds: $1 with '{"1","2","3"}'
+
+// Pass the element type when the query gives the server no context
+await sql`SELECT ${sql.array([1, 2, 3], "INT")} AS ids`;
+// Binds: $1::INT[] with '{1,2,3}'
 ```
+
+Without a type, the parameter has no cast. PostgreSQL infers the element type from the target column, the compared value, or a cast in the query. Pass the type when the query gives the server no context: a bare `SELECT ${sql.array([1])}` comes back as the literal text `{"1"}`, and a function argument such as `unnest(${sql.array([1])})` fails with `could not determine polymorphic type`. Pass `"JSON"` or `"JSONB"` for string elements that go into a `json[]` or `jsonb[]` column, so each string is JSON-encoded.
 
 <Note>`sql.array` is PostgreSQL-only. Multi-dimensional arrays and NULL elements may not be supported yet.</Note>
 

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -69,9 +69,11 @@ declare module "bun" {
      */
     serializedValues: string;
     /**
-     * The element type of the array, for example `"INT"`
+     * The element type of the array, for example `"INT"`. `undefined` when
+     * no type was given: the parameter is bound without a cast and the
+     * server infers the element type from the context.
      */
-    arrayType: ArrayType;
+    arrayType: ArrayType | undefined;
   }
 
   /**
@@ -760,7 +762,12 @@ declare module "bun" {
     /**
      * Creates a SQL array parameter
      * @param values Array values to bind
-     * @param typeNameOrTypeID Element type name or type ID; defaults to JSON when omitted
+     * @param typeNameOrTypeID Element type name or type ID. When omitted, the
+     * parameter is bound without a cast and the server infers the element
+     * type from the target column, the compared value, or a cast in the
+     * query. Pass the type when the query gives the server no context: a bare
+     * `SELECT ${sql.array([1])}` comes back as the text `{"1"}`, and a
+     * function argument such as `unnest(...)` fails to resolve its type.
      * @returns The array parameter, ready to interpolate into a query
      *
      * @example
@@ -768,6 +775,10 @@ declare module "bun" {
      * const array = sql.array([1, 2, 3], "INT");
      * await sql`CREATE TABLE users_posts (user_id INT, posts_id INT[])`;
      * await sql`INSERT INTO users_posts (user_id, posts_id) VALUES (${user.id}, ${array})`;
+     *
+     * // the server infers int[] from the column and uuid[] from the key
+     * await sql`INSERT INTO users_posts (user_id, posts_id) VALUES (${user.id}, ${sql.array([1, 2, 3])})`;
+     * await sql`SELECT * FROM users WHERE id = ANY(${sql.array(uuids)})`;
      * ```
      */
     array(values: any[], typeNameOrTypeID?: number | ArrayType): SQLArrayParameter;

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -781,7 +781,7 @@ declare module "bun" {
      * await sql`SELECT * FROM users WHERE id = ANY(${sql.array(uuids)})`;
      * ```
      */
-    array(values: any[], typeNameOrTypeID?: number | ArrayType): SQLArrayParameter;
+    array(values: any[] | NodeJS.TypedArray, typeNameOrTypeID?: number | ArrayType): SQLArrayParameter;
 
     /**
      * Begins a new transaction.

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -228,8 +228,6 @@ function getArrayType(typeNameOrID: number | ArrayType | undefined): ArrayType |
     }
     return type;
   }
-  // No type: the parameter is bound without a cast and the server infers the
-  // element type from the column or from the cast the query applies to it.
   return undefined;
 }
 function serializeArray(values: any[], type: ArrayType | undefined) {

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -149,7 +149,8 @@ function arrayValueSerializer(type: ArrayType | undefined, is_numeric: boolean, 
   if ($isArray(value) || isTypedArray(value)) {
     if (!value.length) return "{}";
     const delimiter = type === "BOX" ? ";" : ",";
-    return `{${value.map(arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
+    // Array.prototype.map: a TypedArray's own map coerces each result back to a number.
+    return `{${Array.prototype.map.$call(value, arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
 
   if (value === null) return "null";
@@ -239,7 +240,18 @@ function serializeArray(values: any[], type: ArrayType | undefined) {
   // Only _box (1020) has the ';' delimiter for arrays, all other types use the ',' delimiter
   const delimiter = type === "BOX" ? ";" : ",";
 
-  return `{${values.map(arrayValueSerializer.bind(this, type, type !== undefined && isPostgresNumericType(type), type !== undefined && isPostgresJsonType(type))).join(delimiter)}}`;
+  // Array.prototype.map: a TypedArray's own map coerces each result back to a number.
+  return `{${Array.prototype.map
+    .$call(
+      values,
+      arrayValueSerializer.bind(
+        this,
+        type,
+        type !== undefined && isPostgresNumericType(type),
+        type !== undefined && isPostgresJsonType(type),
+      ),
+    )
+    .join(delimiter)}}`;
 }
 
 function wrapPostgresError(error: Error | PostgresErrorOptions) {

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -142,7 +142,7 @@ function getPostgresArrayType(typeId: number) {
   return POSTGRES_ARRAY_TYPES[typeId] || null;
 }
 
-function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boolean, value: any) {
+function arrayValueSerializer(type: ArrayType | undefined, is_numeric: boolean, is_json: boolean, value: any) {
   // we do minimal to none type validation, we just try to format nicely and let the server handle if is valid SQL
   // postgres will try to convert string -> array type
   // postgres will emit a nice error saying what value dont have the expected format outputing the value in the error
@@ -152,6 +152,7 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
     return `{${value.map(arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
 
+  if (value === null) return "null";
   switch (typeof value) {
     case "undefined":
       return "null";
@@ -192,9 +193,9 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
       }
       if (Buffer.isBuffer(value)) {
         const hexValue = value.toString("hex");
-        // bytea array
-        if (type === "BYTEA") {
-          return `"\\x${arrayEscape(hexValue)}"`;
+        // bytea array. The array parser unescapes the backslash, so byteain sees \xHEX.
+        if (type === "BYTEA" || type === undefined) {
+          return `"${arrayEscape("\\x" + hexValue)}"`;
         }
         if (is_json) {
           return `"${arrayEscape(JSON.stringify(hexValue))}"`;
@@ -205,10 +206,10 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
       return `"${arrayEscape(JSON.stringify(value))}"`;
   }
 }
-function getArrayType(typeNameOrID: number | ArrayType | undefined = undefined): ArrayType {
+function getArrayType(typeNameOrID: number | ArrayType | undefined): ArrayType | undefined {
   const typeOfType = typeof typeNameOrID;
   if (typeOfType === "number") {
-    return getPostgresArrayType(typeNameOrID as number) ?? "JSON";
+    return getPostgresArrayType(typeNameOrID as number) ?? undefined;
   }
   if (typeOfType === "string") {
     const type = (typeNameOrID as string).toUpperCase();
@@ -226,10 +227,11 @@ function getArrayType(typeNameOrID: number | ArrayType | undefined = undefined):
     }
     return type;
   }
-  // default to JSON so we accept most of the types
-  return "JSON";
+  // No type: the parameter is bound without a cast and the server infers the
+  // element type from the column or from the cast the query applies to it.
+  return undefined;
 }
-function serializeArray(values: any[], type: ArrayType) {
+function serializeArray(values: any[], type: ArrayType | undefined) {
   if (!$isArray(values) && !isTypedArray(values)) return values;
 
   if (!values.length) return "{}";
@@ -237,7 +239,7 @@ function serializeArray(values: any[], type: ArrayType) {
   // Only _box (1020) has the ';' delimiter for arrays, all other types use the ',' delimiter
   const delimiter = type === "BOX" ? ";" : ",";
 
-  return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type))).join(delimiter)}}`;
+  return `{${values.map(arrayValueSerializer.bind(this, type, type !== undefined && isPostgresNumericType(type), type !== undefined && isPostgresJsonType(type))).join(delimiter)}}`;
 }
 
 function wrapPostgresError(error: Error | PostgresErrorOptions) {
@@ -519,7 +521,11 @@ class PostgresAdapter
   bindParam(value: unknown, binding_values: unknown[], index: number): string {
     if (value instanceof SQLArrayParameter) {
       binding_values.push(value.serializedValues);
-      return `$${index}::${value.arrayType}[] `;
+      const { arrayType } = value;
+      if (arrayType === undefined) {
+        return `$${index} `;
+      }
+      return `$${index}::${arrayType}[] `;
     }
     return pushBindParam(this, value, binding_values, index);
   }

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -32,6 +32,8 @@ const cmds = ["", "INSERT", "DELETE", "UPDATE", "MERGE", "SELECT", "MOVE", "FETC
 
 const escapeBackslash = /\\/g;
 const escapeQuote = /"/g;
+// A TypedArray's own map coerces each serialized element back to a number.
+const ArrayPrototypeMap = Array.prototype.map;
 
 function arrayEscape(value: string) {
   return value.replace(escapeBackslash, "\\\\").replace(escapeQuote, '\\"');
@@ -149,8 +151,7 @@ function arrayValueSerializer(type: ArrayType | undefined, is_numeric: boolean, 
   if ($isArray(value) || isTypedArray(value)) {
     if (!value.length) return "{}";
     const delimiter = type === "BOX" ? ";" : ",";
-    // Array.prototype.map: a TypedArray's own map coerces each result back to a number.
-    return `{${Array.prototype.map.$call(value, arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
+    return `{${ArrayPrototypeMap.$call(value, arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
 
   // SQL NULL, except in a json[] where null stays the JSON value null.
@@ -239,18 +240,15 @@ function serializeArray(values: any[], type: ArrayType | undefined) {
   // Only _box (1020) has the ';' delimiter for arrays, all other types use the ',' delimiter
   const delimiter = type === "BOX" ? ";" : ",";
 
-  // Array.prototype.map: a TypedArray's own map coerces each result back to a number.
-  return `{${Array.prototype.map
-    .$call(
-      values,
-      arrayValueSerializer.bind(
-        this,
-        type,
-        type !== undefined && isPostgresNumericType(type),
-        type !== undefined && isPostgresJsonType(type),
-      ),
-    )
-    .join(delimiter)}}`;
+  return `{${ArrayPrototypeMap.$call(
+    values,
+    arrayValueSerializer.bind(
+      this,
+      type,
+      type !== undefined && isPostgresNumericType(type),
+      type !== undefined && isPostgresJsonType(type),
+    ),
+  ).join(delimiter)}}`;
 }
 
 function wrapPostgresError(error: Error | PostgresErrorOptions) {

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -153,7 +153,8 @@ function arrayValueSerializer(type: ArrayType | undefined, is_numeric: boolean, 
     return `{${Array.prototype.map.$call(value, arrayValueSerializer.bind(this, type, is_numeric, is_json)).join(delimiter)}}`;
   }
 
-  if (value === null) return "null";
+  // SQL NULL, except in a json[] where null stays the JSON value null.
+  if (value === null && !is_json) return "null";
   switch (typeof value) {
     case "undefined":
       return "null";

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -65,8 +65,8 @@ type ArrayType =
 export type { ArrayType, SQLArrayParameter, SQLResultArray };
 class SQLArrayParameter {
   serializedValues: string;
-  arrayType: ArrayType;
-  constructor(serializedValues: string, arrayType: ArrayType) {
+  arrayType: ArrayType | undefined;
+  constructor(serializedValues: string, arrayType: ArrayType | undefined) {
     this.serializedValues = serializedValues;
     this.arrayType = arrayType;
   }

--- a/test/js/sql/postgres-array-untyped.test.ts
+++ b/test/js/sql/postgres-array-untyped.test.ts
@@ -109,6 +109,19 @@ describe("untyped sql.array", () => {
     });
   });
 
+  test("typed array elements keep their values", async () => {
+    expect(await captureBind(sql => sql`SELECT ${sql.array(new Int32Array([100, 200]))}`)).toEqual({
+      query: "SELECT $1 ",
+      oids: [0],
+      params: ['{"100","200"}'],
+    });
+    expect(await captureBind(sql => sql`SELECT ${sql.array([new Float64Array([1.5, 2])], "TEXT")}`)).toEqual({
+      query: "SELECT $1::TEXT[] ",
+      oids: [0],
+      params: ['{{"1.5","2"}}'],
+    });
+  });
+
   test("an explicit type still casts", async () => {
     expect(await captureBind(sql => sql`SELECT ${sql.array(["a", 1], "TEXT")}`)).toEqual({
       query: "SELECT $1::TEXT[] ",

--- a/test/js/sql/postgres-array-untyped.test.ts
+++ b/test/js/sql/postgres-array-untyped.test.ts
@@ -115,6 +115,12 @@ describe("untyped sql.array", () => {
       oids: [0],
       params: ['{"\\\\x6869",null}'],
     });
+    // In a json[] a null element stays the JSON value null, as before.
+    expect(await captureBind(sql => sql`SELECT ${sql.array([null, undefined], "JSON")}`)).toEqual({
+      query: "SELECT $1::JSON[] ",
+      oids: [0],
+      params: ['{"null",null}'],
+    });
   });
 
   test("typed array elements keep their values", async () => {

--- a/test/js/sql/postgres-array-untyped.test.ts
+++ b/test/js/sql/postgres-array-untyped.test.ts
@@ -181,15 +181,29 @@ describeWithContainer("untyped sql.array against postgres", { image: "postgres_p
     const [row] = await sql`INSERT INTO ${sql(table)} (tags, ints, blobs) VALUES (
       ${sql.array(["a", null])},
       ${sql.array([1, null])},
-      ${sql.array([Buffer.from("hi"), null])}
+      ${sql.array([Buffer.from("hi"), Buffer.from([0, 255]), null])}
     ) RETURNING tags, ints::text[] AS ints, blobs`;
     expect(row).toEqual({
       tags: ["a", null],
       ints: ["1", null],
-      blobs: [Buffer.from("hi"), null],
+      blobs: [Buffer.from("hi"), Buffer.from([0, 255]), null],
     });
     const [typed] = await sql`SELECT ${sql.array([Buffer.from("hi")], "BYTEA")} AS blobs`;
     expect(typed).toEqual({ blobs: [Buffer.from("hi")] });
+  });
+
+  test("an explicit type binds a null element as NULL", async () => {
+    await container.ready;
+    await using sql = connect();
+    const [row] = await sql`SELECT
+      ${sql.array(["a", null, undefined, "null"], "TEXT")} AS texts,
+      ${sql.array([{ a: 1 }, null, undefined], "JSON")} AS docs,
+      ${sql.array([true, null], "BOOLEAN")} AS flags`;
+    expect(row).toEqual({
+      texts: ["a", null, null, "null"],
+      docs: [{ a: 1 }, null, null],
+      flags: [true, null],
+    });
   });
 
   test("prepare: false binds the same literal", async () => {
@@ -212,8 +226,8 @@ describeWithContainer("untyped sql.array against postgres", { image: "postgres_p
     await using sql = connect();
     const [{ x }] = await sql`SELECT ${sql.array([1, 2])}::int[] AS x`;
     expect(Array.from(x)).toEqual([1, 2]);
-    const [{ t }] = await sql`SELECT pg_typeof(${sql.array(["a"])}::text[])::text AS t`;
-    expect(t).toBe("text[]");
+    const [{ t }] = await sql`SELECT ${sql.array(["a", 'b"c'])}::text[] AS t`;
+    expect(t).toEqual(["a", 'b"c']);
   });
 
   test("ANY() infers the element type from the compared value", async () => {

--- a/test/js/sql/postgres-array-untyped.test.ts
+++ b/test/js/sql/postgres-array-untyped.test.ts
@@ -238,4 +238,33 @@ describeWithContainer("untyped sql.array against postgres", { image: "postgres_p
     const [{ u }] = await sql`SELECT ${uuid}::uuid = ANY(${sql.array([uuid])}) AS u`;
     expect(u).toBe(true);
   });
+
+  // The JSON default returned an array here. With no context the server reads
+  // the parameter as text, so these queries need the type.
+  test("a query with no context needs the type", async () => {
+    await container.ready;
+    await using sql = connect();
+    const [row] = await sql`SELECT ${sql.array([1, 2])} AS untyped, ${sql.array([1, 2], "INT")} AS typed`;
+    expect({ untyped: row.untyped, typed: Array.from(row.typed) }).toEqual({ untyped: '{"1","2"}', typed: [1, 2] });
+    const error = await sql`SELECT unnest(${sql.array([1, 2])})`.catch(e => e);
+    expect(error.message).toBe("function unnest(unknown) is not unique");
+    const rows = await sql`SELECT unnest(${sql.array([1, 2], "INT")}) AS n`;
+    expect(rows.map(r => r.n)).toEqual([1, 2]);
+  });
+
+  // The JSON default JSON-encoded each string. Untyped, a string element
+  // reaches json_in as is, so json[] and jsonb[] columns need the type.
+  test("json[] and jsonb[] columns need the type for string elements", async () => {
+    await container.ready;
+    await using sql = connect();
+    const table = "array_untyped_" + Bun.randomUUIDv7("hex");
+    await sql`CREATE TEMPORARY TABLE ${sql(table)} (docs JSONB[], notes JSON[])`;
+    const [row] = await sql`INSERT INTO ${sql(table)} (docs, notes) VALUES (
+      ${sql.array([{ a: 1 }, 2, true, null])},
+      ${sql.array(["a", 'b"c'], "JSON")}
+    ) RETURNING docs, notes`;
+    expect(row).toEqual({ docs: [{ a: 1 }, 2, true, null], notes: ["a", 'b"c'] });
+    const error = await sql`INSERT INTO ${sql(table)} (docs) VALUES (${sql.array(["a"])})`.catch(e => e);
+    expect(error.message).toBe("invalid input syntax for type json");
+  });
 });

--- a/test/js/sql/postgres-array-untyped.test.ts
+++ b/test/js/sql/postgres-array-untyped.test.ts
@@ -1,0 +1,200 @@
+// `sql.array(values)` with no type used to bind as `$N::JSON[]` with every
+// element in its JSON form. A write into a `text[]` column then stored `"a"`
+// with the quotes, `::int[]` failed with "cannot cast type json[] to
+// integer[]", and `id = ANY(...)` failed with "operator does not exist:
+// integer = json". Now the untyped parameter carries no cast and a plain array
+// literal, so the server infers the element type from the column or from the
+// cast the query applies (issue #41242).
+//
+// The wire test pins the query text and the bound literal with a scripted
+// backend. The end-to-end tests run against the docker-compose postgres.
+
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+import {
+  pgErrorResponse,
+  pgMockServer,
+  pgParameterDescription,
+  pgParseComplete,
+  pgRaw,
+  pgReadyForQuery,
+} from "./wire-frames";
+
+type Captured = { query: string; oids: number[]; params: (string | null)[] };
+
+// Records the Parse text and the Bind values of one extended-protocol query.
+// The client sends Parse + Describe + Sync and waits for the parameter types
+// before it binds, so Describe is answered as a server that resolved every
+// parameter to text[] would. Execute is answered with an error so the client
+// settles.
+async function captureBind(run: (sql: SQL) => Promise<unknown>): Promise<Captured> {
+  const captured: Captured = { query: "", oids: [], params: [] };
+  const { port, server } = await pgMockServer((type, body) => {
+    if (type === "D") {
+      return [
+        pgParseComplete(),
+        pgParameterDescription(captured.oids.map(() => 1009)),
+        pgRaw("n", Buffer.alloc(0)), // NoData
+      ];
+    }
+    if (type === "P") {
+      const nameEnd = body.indexOf(0);
+      const queryEnd = body.indexOf(0, nameEnd + 1);
+      captured.query = body.toString("utf8", nameEnd + 1, queryEnd);
+      const count = body.readInt16BE(queryEnd + 1);
+      for (let i = 0; i < count; i++) captured.oids.push(body.readInt32BE(queryEnd + 3 + i * 4));
+    } else if (type === "B") {
+      const portalEnd = body.indexOf(0);
+      const nameEnd = body.indexOf(0, portalEnd + 1);
+      let offset = nameEnd + 1;
+      const formats = body.readInt16BE(offset);
+      offset += 2 + formats * 2;
+      const count = body.readInt16BE(offset);
+      offset += 2;
+      for (let i = 0; i < count; i++) {
+        const len = body.readInt32BE(offset);
+        offset += 4;
+        if (len === -1) {
+          captured.params.push(null);
+          continue;
+        }
+        captured.params.push(body.toString("utf8", offset, offset + len));
+        offset += len;
+      }
+    } else if (type === "E") {
+      return pgErrorResponse({ S: "ERROR", C: "0A000", M: "mock" });
+    } else if (type === "S") {
+      return pgReadyForQuery();
+    }
+  });
+  try {
+    await using sql = new SQL(`postgres://u@127.0.0.1:${port}/db`, { max: 1 });
+    await run(sql).catch(() => {});
+  } finally {
+    server.close();
+  }
+  return captured;
+}
+
+describe("untyped sql.array", () => {
+  test("binds without a cast and without JSON quoting", async () => {
+    expect(
+      await captureBind(sql => sql`INSERT INTO probe (tags) VALUES (${sql.array(["a", 'He said "hi"', 1, true])})`),
+    ).toEqual({
+      query: "INSERT INTO probe (tags) VALUES ($1 )",
+      oids: [0],
+      params: ['{"a","He said \\"hi\\"","1","true"}'],
+    });
+  });
+
+  test("leaves the caller's cast as the only cast", async () => {
+    expect(await captureBind(sql => sql`SELECT ${sql.array([1, 2])}::int[]`)).toEqual({
+      query: "SELECT $1 ::int[]",
+      oids: [0],
+      params: ['{"1","2"}'],
+    });
+  });
+
+  test("null elements are NULL and buffers are hex bytea", async () => {
+    expect(await captureBind(sql => sql`SELECT ${sql.array(["a", null, undefined, Buffer.from("hi")])}`)).toEqual({
+      query: "SELECT $1 ",
+      oids: [0],
+      params: ['{"a",null,null,"\\\\x6869"}'],
+    });
+    expect(await captureBind(sql => sql`SELECT ${sql.array([Buffer.from("hi"), null], "BYTEA")}`)).toEqual({
+      query: "SELECT $1::BYTEA[] ",
+      oids: [0],
+      params: ['{"\\\\x6869",null}'],
+    });
+  });
+
+  test("an explicit type still casts", async () => {
+    expect(await captureBind(sql => sql`SELECT ${sql.array(["a", 1], "TEXT")}`)).toEqual({
+      query: "SELECT $1::TEXT[] ",
+      oids: [0],
+      params: ['{"a","1"}'],
+    });
+    expect(await captureBind(sql => sql`SELECT ${sql.array(["a", 1], "JSON")}`)).toEqual({
+      query: "SELECT $1::JSON[] ",
+      oids: [0],
+      params: ['{"\\"a\\"",1}'],
+    });
+  });
+});
+
+describeWithContainer("untyped sql.array against postgres", { image: "postgres_plain" }, container => {
+  const connect = () => new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max: 1 });
+  const uuid = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+
+  test("the server infers the column types on insert", async () => {
+    await container.ready;
+    await using sql = connect();
+    const table = "array_untyped_" + Bun.randomUUIDv7("hex");
+    await sql`CREATE TEMPORARY TABLE ${sql(table)} (tags TEXT[], ints INT[], ids UUID[], flags BOOLEAN[])`;
+    const [row] = await sql`INSERT INTO ${sql(table)} (tags, ints, ids, flags) VALUES (
+      ${sql.array(["a", 'He said "hi"', "x,y", "c:\\win"])},
+      ${sql.array([1, 2])},
+      ${sql.array([uuid])},
+      ${sql.array([true, false])}
+    ) RETURNING tags, ints::text[] AS ints, ids::text[] AS ids, flags`;
+    expect(row).toEqual({
+      tags: ["a", 'He said "hi"', "x,y", "c:\\win"],
+      ints: ["1", "2"],
+      ids: [uuid],
+      flags: [true, false],
+    });
+  });
+
+  test("null elements and buffers reach the column as NULL and bytea", async () => {
+    await container.ready;
+    await using sql = connect();
+    const table = "array_untyped_" + Bun.randomUUIDv7("hex");
+    await sql`CREATE TEMPORARY TABLE ${sql(table)} (tags TEXT[], ints INT[], blobs BYTEA[])`;
+    const [row] = await sql`INSERT INTO ${sql(table)} (tags, ints, blobs) VALUES (
+      ${sql.array(["a", null])},
+      ${sql.array([1, null])},
+      ${sql.array([Buffer.from("hi"), null])}
+    ) RETURNING tags, ints::text[] AS ints, blobs`;
+    expect(row).toEqual({
+      tags: ["a", null],
+      ints: ["1", null],
+      blobs: [Buffer.from("hi"), null],
+    });
+    const [typed] = await sql`SELECT ${sql.array([Buffer.from("hi")], "BYTEA")} AS blobs`;
+    expect(typed).toEqual({ blobs: [Buffer.from("hi")] });
+  });
+
+  test("prepare: false binds the same literal", async () => {
+    await container.ready;
+    await using sql = new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, {
+      max: 1,
+      prepare: false,
+    });
+    const table = "array_untyped_" + Bun.randomUUIDv7("hex");
+    await sql`CREATE TEMPORARY TABLE ${sql(table)} (tags TEXT[], ints INT[])`;
+    const [row] = await sql`INSERT INTO ${sql(table)} (tags, ints) VALUES (
+      ${sql.array(["x", "y"])},
+      ${sql.array([3, 4])}
+    ) RETURNING tags, ints::text[] AS ints`;
+    expect(row).toEqual({ tags: ["x", "y"], ints: ["3", "4"] });
+  });
+
+  test("the caller's cast applies", async () => {
+    await container.ready;
+    await using sql = connect();
+    const [{ x }] = await sql`SELECT ${sql.array([1, 2])}::int[] AS x`;
+    expect(Array.from(x)).toEqual([1, 2]);
+    const [{ t }] = await sql`SELECT pg_typeof(${sql.array(["a"])}::text[])::text AS t`;
+    expect(t).toBe("text[]");
+  });
+
+  test("ANY() infers the element type from the compared value", async () => {
+    await container.ready;
+    await using sql = connect();
+    const [{ m }] = await sql`SELECT 2 = ANY(${sql.array([1, 2])}) AS m`;
+    expect(m).toBe(true);
+    const [{ u }] = await sql`SELECT ${uuid}::uuid = ANY(${sql.array([uuid])}) AS u`;
+    expect(u).toBe(true);
+  });
+});

--- a/test/js/sql/postgres-array-untyped.test.ts
+++ b/test/js/sql/postgres-array-untyped.test.ts
@@ -96,6 +96,14 @@ describe("untyped sql.array", () => {
     });
   });
 
+  test("an unmapped type oid binds untyped", async () => {
+    expect(await captureBind(sql => sql`SELECT ${sql.array([1, 2], 999999)}`)).toEqual({
+      query: "SELECT $1 ",
+      oids: [0],
+      params: ['{"1","2"}'],
+    });
+  });
+
   test("null elements are NULL and buffers are hex bytea", async () => {
     expect(await captureBind(sql => sql`SELECT ${sql.array(["a", null, undefined, Buffer.from("hi")])}`)).toEqual({
       query: "SELECT $1 ",


### PR DESCRIPTION
### Problem
- `sql.array(["a", "b"])` with no type binds as `$1::JSON[]`. A `text[]` column then stores `"a"` with the quotes, and no error is raised. `::int[]` fails with `cannot cast type json[] to integer[]`.
- The cause is the JSON default in `getArrayType()` (`src/js/internal/sql/postgres.ts`), from #22946. Fixes #41242.

### Fix
- An untyped array binds as a plain `$N` with no cast. The server infers the element type from the column, the compared value, or the caller's cast. An explicit type still emits `$N::TYPE[]`. This is the node-postgres model.
- Breaking change: this reverses the JSON default. With no context, `SELECT ${sql.array([1])}` returns the text `{"1"}`, and `unnest()` needs the type. Strings for a `json[]` column need `"JSON"`. The docs say so.
- A guessed cast fails for `uuid[]`, enum, and `date[]` columns, so this PR replaces #41246 (see Notes). The serializer binds a `null` element as SQL NULL and keeps the `\x` prefix of a `Buffer`. A TypedArray no longer uses its own `map`.
- Verified: `test/js/sql/postgres-array-untyped.test.ts` (stock bun 1.4.1 fails 13 of 14). Also the `sql.array` tests in `sql.test.ts`, and `bun-types.test.ts`.

### Background
- The native side sends Parse with one type oid per parameter. Oid 0 means that the server decides. `Signature.rs` already sends oid 0 for a string, so no native change is needed.
- PostgreSQL resolves an oid-0 parameter from its context. With no context, a bare `SELECT $1` resolves to `text`.
- The server has no assignment cast from `text[]` to `uuid[]`, so no cast is safer than a guessed cast.

<details><summary>Notes</summary>

**Comparison with #41246.** Both branches merged onto main at 4661e494f0, run against Postgres 17.11:

| case | main | #41246 (guessed cast) | this PR |
| --- | --- | --- | --- |
| insert into `text[]` | stores `"a"` | ok | ok |
| `int_col = ANY(...)` | operator does not exist: integer = json | ok | ok |
| insert into `int[]`, `bigint[]`, `numeric[]` | expression is of type json[] | ok | ok |
| insert into `uuid[]`, enum `[]`, `date[]` | expression is of type json[] | expression is of type text[] | ok |
| `uuid_col = ANY(...)` | operator does not exist: uuid = json | operator does not exist: uuid = text | ok |
| bare `SELECT ${sql.array([1, 2])}` | `[1, 2]` | `Int32Array [1, 2]` | text `{"1","2"}` |
| `unnest(${sql.array([1, 2])})` | `[1, 2]` | `[1, 2]` | function unnest(unknown) is not unique |

The tests from #41246 that still apply are in this PR: a null element under an explicit `TEXT`, `JSON`, and `BOOLEAN` type, a `bytea[]` round trip with the bytes 0 and 255, and the values that `::text[]` returns. They pass on this branch. Its `pg_typeof` test and its three untyped `SELECT` tests check the guessed cast, so they do not apply.

**Behavior change for the no-context case.** The JSON default came from #22946 (`// default to JSON so we accept most of the types`). A `json[]` parameter accepts any element, but each string is JSON-encoded, and the server rejects `json[]` for every other array column.

- `SELECT ${sql.array([1, 2])} AS x` returned `json[]` and now returns the text `{"1","2"}`.
- `unnest(${sql.array(...)})` returned json elements and now fails with `function unnest(unknown) is not unique`. A function with one `anyarray` argument, such as `array_length`, fails with `could not determine polymorphic type because input has type unknown`.
- A string element for a `json[]` or `jsonb[]` column needs `"JSON"` or `"JSONB"`, so that the string is JSON-encoded. Without the type the server fails with `invalid input syntax for type json`. Objects need no type: `{"{\"a\":1}"}` parses as json.

Each of these needs an explicit type. The docs and the JSDoc say so, and two end-to-end tests pin the cases.

**Serializer rules.** #35111 and #36241 change the same function, so these are the rules that they can rebase onto:

- `null`: SQL NULL in an untyped array and in an array of any type other than `JSON` and `JSONB`. In an explicit `JSON` or `JSONB` array it is the JSON value null (the quoted `"null"`), as on main. `undefined` is SQL NULL everywhere, as on main.
- A `Buffer` element: `\x` hex for `BYTEA` and for an untyped array. The array parser consumes one backslash, so the old literal `"\x6869"` reached `byteain` as `x6869` and stored those bytes. This also affected an explicit `"BYTEA"` type.
- Any other TypedArray element: a nested dimension of its numbers, as on main. `%TypedArray%.prototype.map` stores each callback result back as a number, so an untyped `new Int32Array([100, 200])` would bind `{0,0}`. `Array.prototype.map` is captured at module load, as in `node/vm.ts`.

An unknown numeric type oid also binds untyped now. It used to fall back to `JSON`.

Probe on Postgres 17 with `sql.unsafe` and raw literals:

| case | `$1::text[]` | `$1` (untyped) |
| --- | --- | --- |
| insert into `uuid[]` | column is of type uuid[] but expression is of type text[] | ok |
| insert into enum `[]` | same error | ok |
| insert into `date[]` | same error | ok |
| insert into `int[]` | same error | ok |
| `uuid = ANY($1)` | operator does not exist: uuid = text | ok |
| `$1::int[]` | ok | ok |
| bare `SELECT $1` | ok | returns text |
| `unnest($1)` | ok | function unnest(unknown) is not unique |

**Not in this PR.**

- The raw JS array path from the end of the issue (`sql.unsafe("SELECT $1::text[]", [["a", "b"]])`) is in `PostgresRequest.rs`. #29551 tracks it, and #33579 fixes it.
- `sql({ ints: sql.array([1, 2]) })` and `sql.unsafe("SELECT $1::int[]", [sql.array([1, 2])])` fail with `insufficient data left in message`, as on main, also with an explicit `"INT"` type. These paths bind the `SQLArrayParameter` object, not its string. The server reports `int4[]`, and the native side then encodes the object in binary. A `text[]` column works through both paths with this PR.

**Tests.** The tests are in a new file. `test/js/sql/sql.test.ts` runs its PostgreSQL suite only when `isDockerEnabled()` is true (line 20), and that needs a docker daemon. `describeWithContainer` also runs against `BUN_TEST_SERVICE_postgres_plain`, and the wire tests need no server. `prepare: false` (unnamed statements, Parse and Bind in one batch) is covered and sends the same literal.

Other suites:

- All of `sql.test.ts` with the docker check bypassed, on a debug build: 835 pass, 17 fail. A release build of main fails the same 15: local server encoding, missing md5 and scram users, `max_prepared_transactions` set to 0, and the connection timeout test. The other 2 (`should not timeout in long results`, `query string memory leak test`) time out on the debug build with the JS of main too.
- `test/integration/bun-types/bun-types.test.ts`: 21 pass.

**Self-review.**

- First round: 5 concerns raised, 4 addressed (null element, Buffer `\x`, a docs claim that a bare SELECT errors, `prepare: false` coverage). Not taken: move the fix into the native Bind encoder. The element type is only known there after ParameterDescription, and a native encoder needs this same plain `$N` with a text literal for the oid-0 case.
- Second round, after the merge of the two PRs: the review asked for 5 changes, and 4 are in. They are the breaking-change note and label, end-to-end tests for the bare `SELECT` and `json[]` cases, the serializer rules above, and a review request to the owner of the JSON default. Not taken: change "Fixes #41242" to "Part of #41242". The issue reports the template path, and this PR fixes it. The `int[]` failures through `sql({...})` and `sql.unsafe` have a different cause (see "Not in this PR").

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-array-untyped.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/192] install /workspace/bun
FAILED: stamps/install__workspace_bun.stamp ../../node_modules/@lezer/common/package.json ../../node_modules/@lezer/cpp/package.json ../../node_modules/@types/bun/package.json ../../node_modules/esbuild/package.json ../../node_modules/oxlint/package.json ../../node_modules/prettier/package.json ../../node_modules/prettier-plugin-organize-imports/package.json ../../node_modules/react/package.json ../../node_modules/react-dom/package.json ../../node_modules/source-map-js/package.json ../../node_modules/typescript/package.json 
cd /workspace/bun && /workspace/bun/build/release/bun install --frozen-lockfile && touch /workspace/bun/build/debug/stamps/install__workspace_bun.stamp
bun install v1.4.1-canary.1 (e0a2b82fd)
error: the root package depends on workspace "@types/bun" (packages/@types/bun), which is listed in bun.lock but not on disk
note: a pruned checkout must keep every workspace that its remaining worksp
... (truncated)

release without fix: 13 FAILED
bun test v1.4.1-canary.1 (e0a2b82fd)

test/js/sql/postgres-array-untyped.test.ts:
79 | 
80 | describe("untyped sql.array", () => {
81 |   test("binds without a cast and without JSON quoting", async () => {
82 |     expect(
83 |       await captureBind(sql => sql`INSERT INTO probe (tags) VALUES (${sql.array(["a", 'He said "hi"', 1, true])})`),
84 |     ).toEqual({
           ^
error: expect(received).toEqual(expected)

  {
    "oids": [
      0,
    ],
    "params": [
-     "{"a","He said \"hi\"","1","true"}",
+     "{"\"a\"","\"He said \\\"hi\\\"\"",1,true}",
    ],
-   "query": "INSERT INTO probe (tags) VALUES ($1 )",
+   "query": "INSERT INTO probe (tags) VALUES ($1::JSON[] )",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/postgres-array-untyped.test.ts:84:7)
(fail) untyped sql.array > binds without a cast and without JSON quoting [10.89ms]
87 |       params: ['{"a","He said \\"hi\\"","1","true"}'],
88 |     });
89 |   });
90 | 
91 |   test("leaves the caller's cast as the only cast", async () => {
92 |     expect(await captureBind(sql => sql`SELECT ${sql.array([1, 2])}::int[]`)).toEqual({
                                  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-array-untyped.test.ts
bun test v1.4.1 (e0a2b82fd)

test/js/sql/postgres-array-untyped.test.ts:
(pass) untyped sql.array > binds without a cast and without JSON quoting [625.62ms]
(pass) untyped sql.array > leaves the caller's cast as the only cast [125.30ms]
(pass) untyped sql.array > an unmapped type oid binds untyped [42.48ms]
(pass) untyped sql.array > null elements are NULL and buffers are hex bytea [118.61ms]
(pass) untyped sql.array > typed array elements keep their values [70.13ms]
(pass) untyped sql.array > an explicit type still casts [75.98ms]
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) untyped sql.array against postgres > the server infers the column types on insert [60.80ms]
(pass) untyped sql.array against postgres > null elements and buffers reach the column as NULL and bytea [52.23ms]
(pass) untyped sql.array against postgres > an explicit type binds a null element as NULL [29.14ms]
(pass) untyped sql.array against postgres > prepare: false binds the same literal [37.82
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c839618453
  features     baseline

23 deps, 131 codegen, 1172 objects in 719ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 25 installs across 62 packages (no changes) [12.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 1 install across 2 packages (no changes) [9.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sql.mdx                       |  20 ++-
 packages/bun-types/sql.d.ts                |  19 +-
 src/js/internal/sql/postgres.ts            |  39 +++--
 src/js/internal/sql/shared.ts              |   4 +-
 test/js/sql/postgres-array-untyped.test.ts | 270 +++++++++++++++++++++++++++++
 5 files changed, 327 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
docs/runtime/sql.mdx                            1      1     25
packages/bun-types/sql.d.ts                     0      0     27
src/js/internal/sql/postgres.ts                 3      2     26
src/js/internal/sql/shared.ts                   0      0     26
test/js/sql/postgres-array-untyped.test.ts      1      1     25
```

</details>

<!-- robobun:evidence:end -->

