### PR TITLE
ci: dump the process tree when a parallel batch idles out

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1567,6 +1567,67 @@ async function runTests() {
  */
 
 /**
+ * A batch that idled out is still alive. Print where every process under it
+ * sits (kernel wait channel, each thread's state, a gdb backtrace when ptrace
+ * is allowed) and ask each worker for a core, before the SIGTERM that ends it.
+ * @param {number} rootPid
+ */
+function dumpStalledProcessTree(rootPid) {
+  if (!isLinux) return;
+  const log = text => process.stdout.write(`${text}\n`);
+  const read = path => {
+    try {
+      return readFileSync(path, "utf-8").trim();
+    } catch (error) {
+      return `(${error?.code ?? error})`;
+    }
+  };
+  try {
+    const procs = [];
+    for (const entry of readdirSync("/proc")) {
+      if (!/^\d+$/.test(entry)) continue;
+      const match = /^(\d+) \((.*)\) (\S) (\d+)/.exec(read(`/proc/${entry}/stat`));
+      if (match) procs.push({ pid: Number(match[1]), comm: match[2], state: match[3], ppid: Number(match[4]) });
+    }
+    const tree = [procs.find(p => p.pid === rootPid) ?? { pid: rootPid, comm: "?", state: "?" }];
+    for (let i = 0; i < tree.length; i++) {
+      for (const p of procs) if (p.ppid === tree[i].pid) tree.push(p);
+    }
+    log(`--- stalled batch: process tree under pid ${rootPid} (${tree.length} processes)`);
+    for (const { pid, comm, state } of tree) {
+      log(`--- pid ${pid} (${comm}) state=${state} cmdline: ${read(`/proc/${pid}/cmdline`).replaceAll("\0", " ")}`);
+      let tasks = [];
+      try {
+        tasks = readdirSync(`/proc/${pid}/task`);
+      } catch {}
+      for (const tid of tasks) {
+        const stat = /^\d+ \((.*)\) (\S)/.exec(read(`/proc/${pid}/task/${tid}/stat`));
+        log(
+          `    tid ${tid} (${stat?.[1] ?? "?"}) state=${stat?.[2] ?? "?"} wchan=${read(`/proc/${pid}/task/${tid}/wchan`)} stack: ${read(`/proc/${pid}/task/${tid}/stack`).replaceAll("\n", " | ")}`,
+        );
+      }
+      const gdb = spawnSync("gdb", ["-p", String(pid), "-batch", "-ex", "thread apply all bt"], {
+        encoding: "utf-8",
+        timeout: 120_000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const lines = `${gdb.stdout ?? ""}\n${gdb.stderr ?? ""}`
+        .split("\n")
+        .filter(line => /^(#|Thread |ptrace|warning: |Could not attach|Operation not permitted)/.test(line));
+      log(lines.length ? lines.join("\n") : `    gdb: ${gdb.error ?? `exit ${gdb.status} signal ${gdb.signal}`}`);
+    }
+    // A core per worker, so the core handler below prints every thread.
+    for (const { pid } of tree.slice(1)) {
+      try {
+        process.kill(pid, "SIGQUIT");
+      } catch {}
+    }
+  } catch (error) {
+    log(`--- stalled batch: diagnostics failed: ${error}`);
+  }
+}
+
+/**
  * @param {SpawnOptions} options
  * @returns {Promise<SpawnResult>}
  */
@@ -1650,6 +1711,7 @@ async function spawnSafe(options) {
           timedOut = true;
           clearTimeout(idleTimer);
           if (options.gracefulTimeout && !isWindows) {
+            if (idledOut) dumpStalledProcessTree(subprocess.pid);
             subprocess.kill("SIGTERM");
             timer = setTimeout(() => {
               subprocess.kill(9);
@@ -1970,7 +2032,7 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
         let out = "";
         const gdb = await spawnSafe({
           command: "gdb",
-          args: ["-batch", `--eval-command=bt`, "--core", corePath, execPath],
+          args: ["-batch", `--eval-command=thread apply all bt`, "--core", corePath, execPath],
           timeout: 240_000,
           stderr: () => {},
           stdout(text) {
@@ -1986,6 +2048,7 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
             if (
               line.startsWith("Program terminated") ||
               line.startsWith("#") || // gdb backtrace lines start with #0, #1, etc.
+              line.startsWith("Thread ") ||
               line.startsWith("[Current thread is")
             ) {
               crashes += line + "\n";


### PR DESCRIPTION
### Problem
- `test/js/bun/resolve/import-meta.test.js` stalls in the 3-wide parallel batch on the Linux glibc lanes. The batch prints nothing for 240 s and the runner kills it: "Interrupted while still running: test/js/bun/resolve/import-meta.test.js (243s)". Seen in builds 109795, 109798, 109804 (all after #41273) and 109457.
- The file passes alone and the batch passes locally (40+ runs with the same bucket, env and 4 CPUs). The hang is not a per-test timeout: a test that blocks in `spawnSync` or in a pending promise is killed at the 90 s test timeout, which was verified.

### Diagnostic
- This draft makes the runner print, when a batch idles out, the state and kernel wait channel of every thread under the coordinator, a gdb backtrace when ptrace is permitted, and a SIGQUIT to each worker so the existing core handler prints every thread's stack.
- The gdb call for a core now prints all threads.

The goal is one stalled CI run with stacks. The fix follows from that.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->