### PR TITLE
test: pin iat in the jsonwebtoken async vs sync sign comparison

### DIFF
--- a/test/js/third_party/jsonwebtoken/async_sign.test.js
+++ b/test/js/third_party/jsonwebtoken/async_sign.test.js
@@ -9,12 +9,22 @@ describe("signing a token asynchronously", function () {
     var secret = "shhhhhh";
 
     it("should return the same result as singing synchronously", function (done) {
-      jwt.sign({ foo: "bar" }, secret, { algorithm: "HS256" }, function (err, asyncToken) {
+      // Pin `iat`. Without it each sign() reads Date.now(), and the two tokens
+      // differ when a second boundary falls between the async and the sync call.
+      var payload = { foo: "bar", iat: 1700000000 };
+      jwt.sign(payload, secret, { algorithm: "HS256" }, function (err, asyncToken) {
         if (err) return done(err);
-        var syncToken = jwt.sign({ foo: "bar" }, secret, { algorithm: "HS256" });
-        expect(typeof asyncToken).toBe("string");
-        expect(asyncToken.split(".")).toHaveLength(3);
-        expect(asyncToken).toEqual(syncToken);
+        // jws runs this callback inside a try/catch and routes a throw to the
+        // 'error' listener, which jsonwebtoken wrapped in once(). A failed
+        // expect() here is swallowed and the test only times out. Report it.
+        try {
+          var syncToken = jwt.sign(payload, secret, { algorithm: "HS256" });
+          expect(typeof asyncToken).toBe("string");
+          expect(asyncToken.split(".")).toHaveLength(3);
+          expect(asyncToken).toEqual(syncToken);
+        } catch (e) {
+          return done(e);
+        }
         done();
       });
     });

--- a/test/js/third_party/jsonwebtoken/async_sign.test.js
+++ b/test/js/third_party/jsonwebtoken/async_sign.test.js
@@ -1,24 +1,33 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { generateKeyPairSync } from "crypto";
 import jwt from "jsonwebtoken";
 import jws from "jws";
+import sinon from "sinon";
 var PS_SUPPORTED = true;
 
 describe("signing a token asynchronously", function () {
   describe("when signing a token", function () {
     var secret = "shhhhhh";
 
+    // Each sign() reads Date.now() for `iat`. Freeze the clock so the async
+    // and the sync token cannot differ when a second boundary falls between them.
+    var fakeClock;
+    beforeEach(function () {
+      fakeClock = sinon.useFakeTimers({ now: 60000 });
+    });
+
+    afterEach(function () {
+      fakeClock.uninstall();
+    });
+
     it("should return the same result as singing synchronously", function (done) {
-      // Pin `iat`. Without it each sign() reads Date.now(), and the two tokens
-      // differ when a second boundary falls between the async and the sync call.
-      var payload = { foo: "bar", iat: 1700000000 };
-      jwt.sign(payload, secret, { algorithm: "HS256" }, function (err, asyncToken) {
+      jwt.sign({ foo: "bar" }, secret, { algorithm: "HS256" }, function (err, asyncToken) {
         if (err) return done(err);
         // jws runs this callback inside a try/catch and routes a throw to the
         // 'error' listener, which jsonwebtoken wrapped in once(). A failed
         // expect() here is swallowed and the test only times out. Report it.
         try {
-          var syncToken = jwt.sign(payload, secret, { algorithm: "HS256" });
+          var syncToken = jwt.sign({ foo: "bar" }, secret, { algorithm: "HS256" });
           expect(typeof asyncToken).toBe("string");
           expect(asyncToken.split(".")).toHaveLength(3);
           expect(asyncToken).toEqual(syncToken);

--- a/test/js/third_party/jsonwebtoken/async_sign.test.js
+++ b/test/js/third_party/jsonwebtoken/async_sign.test.js
@@ -1,8 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, setSystemTime } from "bun:test";
 import { generateKeyPairSync } from "crypto";
 import jwt from "jsonwebtoken";
 import jws from "jws";
-import sinon from "sinon";
 var PS_SUPPORTED = true;
 
 describe("signing a token asynchronously", function () {
@@ -11,13 +10,12 @@ describe("signing a token asynchronously", function () {
 
     // Each sign() reads Date.now() for `iat`. Freeze the clock so the async
     // and the sync token cannot differ when a second boundary falls between them.
-    var fakeClock;
     beforeEach(function () {
-      fakeClock = sinon.useFakeTimers({ now: 60000 });
+      setSystemTime(60000);
     });
 
     afterEach(function () {
-      fakeClock.uninstall();
+      setSystemTime();
     });
 
     it("should return the same result as singing synchronously", function (done) {


### PR DESCRIPTION
### Problem
- `test/js/third_party/jsonwebtoken/async_sign.test.js` fails on main with `this test timed out after 90000ms, before its done callback was called` in "should return the same result as singing synchronously". Seen in builds 108836, 109097, 109276, 109807 and 109861, on five different lanes.
- The test signs `{ foo: "bar" }` once asynchronously and once synchronously and compares the tokens. Each `jwt.sign()` reads `Date.now()` for the `iat` claim (`jsonwebtoken/sign.js:185`). When a second boundary falls between the two calls, the tokens differ and `expect()` throws.
- The throw is lost. The callback runs inside `SignStream.prototype.sign` (`jws/lib/sign-stream.js`), whose `try/catch` emits `'error'`. jsonwebtoken attached the same `once()`-wrapped callback as the error listener, and it already ran. So `done()` never runs and the test waits out its ceiling.

### Fix
- Freeze the clock with `setSystemTime(60000)` from `bun:test` in `beforeEach` and reset it with `setSystemTime()` in `afterEach`. It only fixes `Date.now()` and `new Date()`, so `process.nextTick` and the jws async path run as before. The payload stays the upstream `{ foo: "bar" }`.
- Wrap the assertions in `try/catch` and pass a failure to `done(err)`. A future mismatch reports the diff at once instead of a silent 90 s timeout.
- Verified: with `Date.now` patched to cross a second boundary, the old test reproduces the exact timeout with the release binary. With `setSystemTime(60000)`, `Date.now()` reads 60000 before and after a `nextTick`, and the signed `iat` is 60. A forced `expect` failure now reports `Expected/Received` in 3 ms. `bun bd test test/js/third_party/jsonwebtoken/async_sign.test.js` passes, as does all of `test/js/third_party/jsonwebtoken/`.

### Background
- The window between the two `Date.now()` reads is about 1.5 ms on a release build and about 107 ms on a debug build (most of it is the first `util.format` call). That gives roughly a 0.15% to 10% chance per run, depending on the build and the load on the runner.
- No bun code is at fault. The test itself is racy and has been since it was added in 2024. The recent sightings are this race, not a stream or nextTick regression.

<details><summary>Notes</summary>

The first version of this PR pinned `iat: 1700000000` in the payload instead. Review asked for fake timers like the upstream tests, then for the `bun:test` ones. The later commits switch to `setSystemTime` and restore the upstream payload.

Repro used to confirm the mechanism (release bun, `USE_SYSTEM_BUN=1`):

```js
const realNow = Date.now; let calls = 0;
Date.now = () => { calls++; const b = Math.floor(realNow() / 1000) * 1000; return calls === 1 ? b + 999 : b + 1000; };
```

With the original test body this prints two tokens that differ only in `iat` and then times out.

Window measurement (time between the two `Date.now()` calls, first test in a fresh process): debug build 106 to 107 ms over 3 runs, release 1.56 to 1.57 ms. Of the debug cost, `util.format` first call was 149 ms in a separate probe, `process.nextTick` 32 ms, first HMAC 6 ms.

CI on the first revision (build 109876): one red lane, `pnpm-migration.test.ts` on debian 13 x64-asan, where Verdaccio exited with code 2 before the test ran. Reported separately. Two other lanes passed on retry.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/third_party/jsonwebtoken/async_sign.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/third_party/jsonwebtoken/async_sign.test.js
bun test v1.4.1 (e0a2b82fd)

test/js/third_party/jsonwebtoken/async_sign.test.js:
(pass) signing a token asynchronously > when signing a token > should return the same result as singing synchronously [187.25ms]
(pass) signing a token asynchronously > when signing a token > should work with empty options [10.42ms]
(pass) signing a token asynchronously > when signing a token > should work without options object at all [9.25ms]
(pass) signing a token asynchronously > when signing a token > should work with none algorithm where secret is set [11.10ms]
(skip) signing a token asynchronously > when signing a token > should work with none algorithm where secret is falsy
(pass) signing a token asynchronously > when signing a token > should return error when secret is not a cert for RS256 [4.75ms]
(pass) signing a token asynchronously > when signing a token > should not work for RS algorithms when modulus length is less than 2048 when allowInsecureKeySizes is false or not set [52.90ms]
(pass) signing a token asynchronously > when signing a token > should work for RS algorithms when modulus length is less than 2048 when allowInsecureKeySizes is true [49.62ms]
(pass) signing a token asynchronously > when signing a token > should return error when secret is not a cert for PS256 [4.90ms]
(pass) signing a token asynchronously > when signing a token > should return error on wrong arguments [9.48ms]
(pass) signing a token asynchronously > when signing a token > should return error on wrong arguments (2) [5.43ms]
(pass) signing a token asynchronously > when signing a token > should not stringify the payload [20.13ms]
(pass) signing a token asynchronously > when signing a token > when mutatePayload is not set > should not apply claims to the original payload object (mutatePayload defaults to false) [17.52ms]
(pass) signing a token asynchronousl
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../js/third_party/jsonwebtoken/async_sign.test.js | 27 ++++++++++++++++++----
 1 file changed, 22 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
test/js/third_party/jsonwebtoken/async_sign.test.js      1      3      7
```

</details>

<!-- robobun:evidence:end -->