### PR TITLE
build: run the first two codegen scripts with cfg.jsRuntime

### DIFF
--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -125,7 +125,7 @@ Tables: `cpuTargetFlags` (`-march`/`-mcpu`/`-mtune` — also forwarded to local 
 
 **Iterate on a dependency from a local checkout** — `bun bd --local-deps=mimalloc=~/code/mimalloc …` builds that dep from the clone instead of the pinned tarball (no fetch, no patches; edits rebuild incrementally). Any `github-archive` dep the graph compiles (not lolhtml or rust-argon2 — cargo reads those via `Cargo.toml`); details in `deps/README.md`.
 
-**Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitCppBind` (needs file-list input). Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppAll` if it's a header).
+**Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitCppBind` (needs file-list input). Use the `codegen` rule: it runs the script with `cfg.jsRuntime`, so the script must run under node and bun. Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppAll` if it's a header).
 
 **Add a Config field** — add to `Config` interface and `PartialConfig` in `config.ts`, resolve in `resolveConfig()`. If it needs a CLI flag, `build.ts`'s arg parser already handles `--anyfield=value` generically.
 
@@ -247,12 +247,12 @@ Why not auto-register in emit functions? Some rules are shared (`dep_configure` 
 
 The build system runs under Node 24+ with `--experimental-strip-types` (or Node 25+ without the flag). CI invokes it this way via `process.execPath` in `.buildkite/ci.mjs`.
 
-`cfg.jsRuntime` holds the shell-ready command prefix for running `.ts` subprocesses (stream.ts, fetch-cli.ts, the regen rule) — it's `process.execPath` when bun runs configure, or `node --experimental-strip-types` when node does. The subprocesses inherit whichever runtime started the build.
+`cfg.jsRuntime` holds the shell-ready command prefix for running `.ts` subprocesses (stream.ts, fetch-cli.ts, the regen rule, the `codegen` rule) — it's `process.execPath` when bun runs configure, or `node --experimental-strip-types` when node does. The subprocesses inherit whichever runtime started the build.
 
-**TODO — remaining `cfg.bun` usage (codegen only):** For a fully bun-optional build:
+**Remaining `cfg.bun` usage (codegen only):** For a fully bun-optional build:
 
-- `cfg.packageManager` — `bun install` or `npm install` for the one codegen install step.
-- Codegen `.ts` scripts (~20 ninja rules) — either verify they're node-compatible and switch to `cfg.jsRuntime`, or bundle them via esbuild first and run the output with plain node.
+- `cfg.packageManager` — `--package-manager=npm` runs the codegen installs with npm (`npm-ci.ts`). The default is bun.
+- Codegen scripts on the `codegen_bun` rule still need bun. Move a script to the `codegen` rule once it runs under node, and check that both runtimes write the same output.
 - `cfg.esbuild` — already separate.
 
 With those done, `cfg.bun` disappears.

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -125,7 +125,7 @@ Tables: `cpuTargetFlags` (`-march`/`-mcpu`/`-mtune` — also forwarded to local 
 
 **Iterate on a dependency from a local checkout** — `bun bd --local-deps=mimalloc=~/code/mimalloc …` builds that dep from the clone instead of the pinned tarball (no fetch, no patches; edits rebuild incrementally). Any `github-archive` dep the graph compiles (not lolhtml or rust-argon2 — cargo reads those via `Cargo.toml`); details in `deps/README.md`.
 
-**Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitCppBind` (needs file-list input). Use the `codegen` rule: it runs the script with `cfg.jsRuntime`, so the script must run under node and bun. Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppAll` if it's a header).
+**Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitCppBind` (needs file-list input). Use the `codegen` rule: it runs the script with `cfg.jsRuntime`, so the script must run under node and bun. Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppHeaders` if it's a header. `emitCodegen()` builds `cppAll` from those groups at the end, so do not push to it).
 
 **Add a Config field** — add to `Config` interface and `PartialConfig` in `config.ts`, resolve in `resolveConfig()`. If it needs a CLI flag, `build.ts`'s arg parser already handles `--anyfield=value` generically.
 

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -245,7 +245,7 @@ Why not auto-register in emit functions? Some rules are shared (`dep_configure` 
 
 ## Node compatibility
 
-The build system runs under Node 24.2+ with `--experimental-strip-types` (or Node 25+ without the flag). CI invokes it this way via `process.execPath` in `.buildkite/ci.mjs`.
+The build system runs under Node 25+ (configure checks the version). CI installs Node 26 and invokes it via `process.execPath` in `.buildkite/ci.mjs`.
 
 `cfg.jsRuntime` holds the shell-ready command prefix for running `.ts` subprocesses (stream.ts, fetch-cli.ts, the regen rule, the `codegen` rule) — it's `process.execPath` when bun runs configure, or `node --experimental-strip-types` when node does. The subprocesses inherit whichever runtime started the build.
 

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -245,7 +245,7 @@ Why not auto-register in emit functions? Some rules are shared (`dep_configure` 
 
 ## Node compatibility
 
-The build system runs under Node 24+ with `--experimental-strip-types` (or Node 25+ without the flag). CI invokes it this way via `process.execPath` in `.buildkite/ci.mjs`.
+The build system runs under Node 24.2+ with `--experimental-strip-types` (or Node 25+ without the flag). CI invokes it this way via `process.execPath` in `.buildkite/ci.mjs`.
 
 `cfg.jsRuntime` holds the shell-ready command prefix for running `.ts` subprocesses (stream.ts, fetch-cli.ts, the regen rule, the `codegen` rule) — it's `process.execPath` when bun runs configure, or `node --experimental-strip-types` when node does. The subprocesses inherit whichever runtime started the build.
 

--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -105,9 +105,12 @@ export function registerCodegenRules(n: Ninja, cfg: Config): void {
   const esbuild = q(cfg.esbuild);
   const { platform, arch } = codegenTarget(cfg);
 
-  // Generic codegen: `cd <repo-root> && [env VARS] bun <args>`.
-  // Both `bun run script.ts` and `bun script.ts` go through this — the
-  // caller puts the `run` subcommand in $args when needed.
+  // Generic codegen: `cd <cwd> && [env VARS] <runtime> <args>`.
+  //
+  // `codegen` runs the script with cfg.jsRuntime, the runtime that runs
+  // configure (node in CI, bun for `bun bd`). So its scripts must run
+  // under both. `codegen_bun` is for the scripts that still need bun.
+  // Its $args can start with a bun subcommand (`run`, `build`).
   //
   // TARGET_PLATFORM/ARCH: scripts that inline process.platform into the
   // bundled JS modules (replacements.ts, bundle-modules.ts,
@@ -120,8 +123,15 @@ export function registerCodegenRules(n: Ninja, cfg: Config): void {
   const env = hostWin
     ? `set TARGET_PLATFORM=${platform}&& set TARGET_ARCH=${arch}&& `
     : `TARGET_PLATFORM=${platform} TARGET_ARCH=${arch} `;
+  const codegenCommand = (runtime: string) =>
+    hostWin ? `cmd /c "cd /d $cwd && ${env}${runtime} $args"` : `cd $cwd && ${env}${runtime} $args`;
   n.rule("codegen", {
-    command: hostWin ? `cmd /c "cd /d $cwd && ${env}${bun} $args"` : `cd $cwd && ${env}${bun} $args`,
+    command: codegenCommand(cfg.jsRuntime),
+    description: "gen $desc",
+    restat: true,
+  });
+  n.rule("codegen_bun", {
+    command: codegenCommand(bun),
     description: "gen $desc",
     restat: true,
   });
@@ -468,7 +478,7 @@ function emitCompressedEmbeds({ n, cfg, o, dirStamp }: Ctx): void {
     const out = resolve(cfg.codegenDir, "compressed", `${name}.zst`);
     n.build({
       outputs: [out],
-      rule: "codegen",
+      rule: "codegen_bun",
       inputs: [script, input],
       orderOnlyInputs: [dirStamp],
       vars: { cwd: cfg.cwd, desc: `compressed/${name}.zst`, args: shJoin(cfg, ["run", script, input, out]) },
@@ -528,7 +538,7 @@ function emitNodeFallbacks({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(sourceDir, "build-fallbacks.ts");
   n.build({
     outputs,
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script, ...sources.nodeFallbacks],
     implicitInputs: [installStamp],
     orderOnlyInputs: [dirStamp],
@@ -548,7 +558,7 @@ function emitNodeFallbacks({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const rrOut = resolve(outDir, "react-refresh.js");
   n.build({
     outputs: [rrOut],
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [resolve(sourceDir, "package.json"), resolve(sourceDir, "bun.lock")],
     implicitInputs: [installStamp],
     orderOnlyInputs: [dirStamp],
@@ -597,7 +607,7 @@ function emitStringMaps({ n, cfg, sources, o, dirStamp }: Ctx): void {
       vars: {
         cwd: cfg.cwd,
         desc: `string-map ${stem}`,
-        args: shJoin(cfg, ["run", script, src, out]),
+        args: shJoin(cfg, [script, src, out]),
       },
     });
     o.all.push(out);
@@ -630,7 +640,7 @@ function emitErrorCode({ n, cfg, o, dirStamp }: Ctx): void {
     vars: {
       cwd: cfg.cwd,
       desc: "ErrorCode+*.h",
-      args: shJoin(cfg, ["run", script, cfg.codegenDir]),
+      args: shJoin(cfg, [script, cfg.codegenDir]),
     },
   });
 
@@ -658,7 +668,7 @@ function emitGeneratedClasses({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   n.build({
     outputs,
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script, ...sources.zigGeneratedClasses],
     orderOnlyInputs: [dirStamp],
     vars: {
@@ -696,7 +706,7 @@ function emitHostExports({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   n.build({
     outputs: [output],
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script],
     implicitInputs: rsInputs,
     orderOnlyInputs: [dirStamp],
@@ -735,7 +745,7 @@ function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   n.build({
     outputs: [outputRs],
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script],
     // cppbind scans ALL .cpp files for [[ZIG_EXPORT]] annotations. Every
     // .cpp is an implicit input so changing an annotation retriggers.
@@ -803,7 +813,7 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   n.build({
     outputs,
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script, ...sources.js, ...sources.jsCodegen, extraInput, errorCodeInput],
     orderOnlyInputs: [dirStamp],
     vars: {
@@ -842,7 +852,7 @@ function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   n.build({
     outputs,
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script, ...sources.bakeRuntime],
     orderOnlyInputs: [dirStamp],
     vars: {
@@ -901,7 +911,7 @@ export function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   n.build({
     outputs: allOutputs,
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script, ...sources.bindgenV2, ...sources.bindgenV2Internal],
     orderOnlyInputs: [dirStamp],
     vars: {
@@ -937,7 +947,7 @@ export function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   // reconfigure to be picked up (next glob gets them).
   n.build({
     outputs: [cppOut, ...headers],
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script, ...sources.bindgen],
     orderOnlyInputs: [dirStamp],
     vars: {
@@ -976,7 +986,7 @@ function emitJsSink({ n, cfg, o, dirStamp }: Ctx): void {
 
   n.build({
     outputs,
-    rule: "codegen",
+    rule: "codegen_bun",
     inputs: [script, hashTableScript, perlScript],
     orderOnlyInputs: [dirStamp],
     vars: {
@@ -1042,7 +1052,7 @@ function emitObjectLuts({ n, cfg, o, dirStamp }: Ctx): void {
   for (const [src, out] of pairs) {
     n.build({
       outputs: [out],
-      rule: "codegen",
+      rule: "codegen_bun",
       inputs: [src],
       implicitInputs: [script, perlScript],
       orderOnlyInputs: [dirStamp],

--- a/scripts/build/configure.ts
+++ b/scripts/build/configure.ts
@@ -86,12 +86,13 @@ export function resolveToolchain(targetOs?: OS, packageManager: PackageManager =
   //
   // A codegen script that a module can also import runs its command line
   // only when import.meta.main is true. Node 24.2 added import.meta.main.
-  // Before that it is undefined, and the script would write nothing.
+  // Before that it is undefined, and the script would write nothing. CI
+  // installs Node 26 (scripts/bootstrap.sh), so the minimum is 25.
   if (process.versions.bun === undefined) {
-    const [major = 0, minor = 0] = process.versions.node.split(".").map(Number);
-    if (major < 24 || (major === 24 && minor < 2)) {
+    const major = Number(process.versions.node.split(".")[0]);
+    if (major < 25) {
       throw new BuildError(`Node ${process.versions.node} cannot run the codegen scripts`, {
-        hint: "Install Node 24.2 or later, or run the build with bun.",
+        hint: "Install Node 25 or later, or run the build with bun.",
       });
     }
   }

--- a/scripts/build/configure.ts
+++ b/scripts/build/configure.ts
@@ -83,6 +83,18 @@ export function resolveToolchain(targetOs?: OS, packageManager: PackageManager =
   // The codegen scripts are ES modules under the root package.json, which
   // has no "type" field. Node detects the module syntax and prints
   // MODULE_TYPELESS_PACKAGE_JSON once per process, so the flag hides it.
+  //
+  // A codegen script that a module can also import runs its command line
+  // only when import.meta.main is true. Node 24.2 added import.meta.main.
+  // Before that it is undefined, and the script would write nothing.
+  if (process.versions.bun === undefined) {
+    const [major = 0, minor = 0] = process.versions.node.split(".").map(Number);
+    if (major < 24 || (major === 24 && minor < 2)) {
+      throw new BuildError(`Node ${process.versions.node} cannot run the codegen scripts`, {
+        hint: "Install Node 24.2 or later, or run the build with bun.",
+      });
+    }
+  }
   const q = (p: string) => quote(p, host.os === "windows");
   const jsRuntime =
     process.versions.bun !== undefined

--- a/scripts/build/configure.ts
+++ b/scripts/build/configure.ts
@@ -79,9 +79,15 @@ export function resolveToolchain(targetOs?: OS, packageManager: PackageManager =
   // whatever's running us — if node, the strip-types flag comes along; if
   // bun, it's just the path. process.versions.bun distinguishes (undefined
   // in node). Pre-quoted so rule commands can splice it directly.
+  //
+  // The codegen scripts are ES modules under the root package.json, which
+  // has no "type" field. Node detects the module syntax and prints
+  // MODULE_TYPELESS_PACKAGE_JSON once per process, so the flag hides it.
   const q = (p: string) => quote(p, host.os === "windows");
   const jsRuntime =
-    process.versions.bun !== undefined ? q(process.execPath) : `${q(process.execPath)} --experimental-strip-types`;
+    process.versions.bun !== undefined
+      ? q(process.execPath)
+      : `${q(process.execPath)} --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON`;
 
   return {
     ...llvm,

--- a/src/codegen/generate-node-errors.ts
+++ b/src/codegen/generate-node-errors.ts
@@ -118,7 +118,7 @@ static CODE_STR: [&str; ErrorCode::COUNT as usize] = [
 ${rustCodeStr}];
 `;
 
-let builtindtsPath = path.join(import.meta.dir, "..", "..", "src", "js", "builtins.d.ts");
+let builtindtsPath = path.join(import.meta.dirname, "..", "..", "src", "js", "builtins.d.ts");
 let builtindts = readFileSync(builtindtsPath, "utf8");
 
 let dts = `

--- a/src/codegen/generate-string-map.ts
+++ b/src/codegen/generate-string-map.ts
@@ -20,6 +20,7 @@
 //   bun src/codegen/generate-string-map.ts <input.ts> <out.rs>
 
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { writeIfNotChanged } from "./helpers.ts";
 
 export interface StringMapSpec<V = unknown> {
@@ -288,7 +289,8 @@ if (import.meta.main) {
   if (!input || !output) {
     throw new Error("usage: bun src/codegen/generate-string-map.ts <input.string-map.ts> <out.rs>");
   }
-  const mod = await import(path.resolve(input));
+  // Node reads an absolute Windows path as a URL with a drive-letter scheme.
+  const mod = await import(pathToFileURL(path.resolve(input)).href);
   const specs = mod.default as StringMapSpec<unknown> | StringMapSpec<unknown>[];
   if (!specs) throw new Error(`${input}: missing default export`);
   writeIfNotChanged(output, generateStringMaps(specs, input));


### PR DESCRIPTION
### Problem
- Every codegen step runs under bun, so a build that node configures still needs bun. `scripts/build/codegen.ts` has one `codegen` rule, and it runs `cfg.bun`.
- Under node, `generate-node-errors.ts` reads `import.meta.dir`, which node does not have. On Windows, `generate-string-map.ts` fails with `ERR_UNSUPPORTED_ESM_URL_SCHEME`, because node reads an absolute path in `import()` as a URL.

### Fix
- The `codegen` rule runs `cfg.jsRuntime`, the runtime that runs configure. A new `codegen_bun` rule keeps bun for the scripts that still need it.
- `generate-string-map.ts` and `generate-node-errors.ts` move to `codegen`. They now use `import.meta.dirname` and a file URL, which both runtimes support.
- The node command adds `--disable-warning=MODULE_TYPELESS_PACKAGE_JSON`. Without it, node prints that warning once for each codegen process.
- Verified: configure with node, then with bun, then run `ninja codegen`. Both write the same 141 files as main, on Linux (debug and release) and on Windows. `test/internal/build-codegen-declared-outputs.test.ts` passes.

### Background
- `cfg.jsRuntime` is `node --experimental-strip-types` when node runs configure, as CI does. It is the bun path for `bun bd`. So CI runs the moved scripts under node, and local builds run them under bun.
- This is the first step of the split of #34876. The other scripts move to `codegen` one at a time, in later PRs.

<details><summary>Notes</summary>

- The root package.json has no `"type"` field. Node detects the module syntax and warns once per process, for the first typeless module it loads. A nested `src/codegen/package.json` does not help: the warning then names `src/jsc/bindings/ErrorCode.ts`. A root `"type": "module"` changes how node and the bundlers read every `.js` file in the repo.
- On Windows the rule puts the node path inside `cmd /c "..."`. A node path with a space works. I tested `C:\node dir\node.exe`.
- Between the runs, `build_options.rs` differs only in `SHA` and `CODEGEN_PATH`. Both come from configure, not from codegen.
- Timing on Linux: node starts in about 23 ms, bun in about 9 ms. A full `generate-string-map.ts` run takes 89 ms under node and 30 ms under bun. A no-op build runs neither.

</details>
