### PR TITLE
build: bundle the node fallbacks with esbuild

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -534,19 +534,19 @@ function emitNodeFallbacks({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   // The script (build-fallbacks.ts) reads its args as [outdir, ...sources]
   // but actually ignores the sources — it does readdirSync(".") to discover
-  // files. We pass them anyway so ninja tracks them as inputs.
+  // files. We pass them anyway so ninja tracks them as inputs. It bundles
+  // with the esbuild package from the root install.
   const script = resolve(sourceDir, "build-fallbacks.ts");
   n.build({
     outputs,
-    rule: "codegen_bun",
+    rule: "codegen",
     inputs: [script, ...sources.nodeFallbacks],
-    implicitInputs: [installStamp],
+    implicitInputs: [installStamp, o.rootInstall],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: sourceDir,
       desc: "node-fallbacks/*.js",
-      // `bun run build-fallbacks` resolves to `./build-fallbacks.ts` in cwd
-      args: shJoin(cfg, ["run", "build-fallbacks", outDir, ...sources.nodeFallbacks]),
+      args: shJoin(cfg, [script, outDir, ...sources.nodeFallbacks]),
     },
   });
 
@@ -558,18 +558,18 @@ function emitNodeFallbacks({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const rrOut = resolve(outDir, "react-refresh.js");
   n.build({
     outputs: [rrOut],
-    rule: "codegen_bun",
+    rule: "esbuild",
     inputs: [resolve(sourceDir, "package.json"), resolve(sourceDir, "bun.lock")],
-    implicitInputs: [installStamp],
+    implicitInputs: [installStamp, o.rootInstall],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: sourceDir,
       desc: "node-fallbacks/react-refresh.js",
       args: shJoin(cfg, [
-        "build",
         rrSrc,
         `--outfile=${rrOut}`,
-        "--target=browser",
+        "--bundle",
+        "--platform=browser",
         "--format=cjs",
         "--minify",
         `--define:process.env.NODE_ENV="development"`,

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -1,11 +1,10 @@
+import * as esbuild from "esbuild";
 import * as fs from "fs";
-import * as Module from "module";
 import { basename, extname } from "path";
 import * as zlib from "zlib";
 
 const allFiles = fs.readdirSync(".").filter(f => f.endsWith(".js"));
 const outdir = process.argv[2];
-const builtins = Module.builtinModules;
 let commands: Promise<void>[] = [];
 
 let moduleFiles: string[] = [];
@@ -17,26 +16,33 @@ for (const name of allFiles) {
 
 for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
   const name = allFiles[fileIndex];
-  const mod = basename(name, extname(name)).replaceAll(".", "/");
-  const file = allFiles.find(f => f.startsWith(mod));
-  const externals = [...builtins];
-  const i = externals.indexOf(name);
-  if (i !== -1) {
-    externals.splice(i, 1);
-  }
 
-  // Build all files at once with specific options
-  const externalModules = builtins
-    .concat(moduleFiles.filter(f => f !== name))
-    .flatMap(b => [`--external:node:${b}`, `--external:${b}`])
-    .join(" ");
+  // Only the sibling fallback files go in `external`. `platform: "node"`
+  // already leaves the builtin modules external, and it matches their names
+  // exactly. An `external` entry also matches subpaths, so "util" would leave
+  // the `require("util/")` of the npm polyfill unbundled.
+  const externalModules = moduleFiles.filter(f => f !== name).flatMap(b => [`node:${b}`, b]);
 
-  // Create the build command with all the specified options
-  const buildCommand =
-    Bun.$`bun build --define=process.env.NODE_DEBUG:"false" --define=process.env.READABLE_STREAM="'enable'" --define=global:globalThis --outdir=${outdir} ${name} --minify-syntax --minify-whitespace --format=${name.includes("stream") ? "cjs" : "esm"} --target=node ${{ raw: externalModules }}`.text();
+  const buildCommand = esbuild.build({
+    entryPoints: [name],
+    outdir,
+    bundle: true,
+    platform: "node",
+    target: "esnext",
+    format: name.includes("stream") ? "cjs" : "esm",
+    minifySyntax: true,
+    minifyWhitespace: true,
+    external: externalModules,
+    define: {
+      "process.env.NODE_DEBUG": "false",
+      "process.env.READABLE_STREAM": "'enable'",
+      "global": "globalThis",
+    },
+    logLevel: "warning",
+  });
 
   commands.push(
-    buildCommand.then(async text => {
+    buildCommand.then(async () => {
       // This is very brittle. But that should be okay for our usecase
       let outfile = fs
         .readFileSync(`${outdir}/${name}`, "utf8")


### PR DESCRIPTION
Stacked on #41314. The diff is against that branch.

### Problem
- `build-fallbacks.ts` runs `bun build` through `Bun.$` for each file in `src/node-fallbacks`. The `react-refresh.js` edge runs `bun build` too. So both need bun.

### Fix
- `build-fallbacks.ts` calls `esbuild.build()` with the same options, and runs with `cfg.jsRuntime`. The text fix-ups after the build do not change.
- Only the sibling fallback files go in `external`. `platform: "node"` keeps the builtin modules external by exact name. An `external` entry also matches subpaths, so `"util"` would leave the `require("util/")` of the npm polyfill unbundled.
- `react-refresh.js` moves to the existing `esbuild` rule.
- Verified: each output file keeps the same `require` and `import` specifiers as the bun output. Node and bun write the same files, on Linux and on Windows.

### Background
- These files are the polyfills that `bun build --target=browser` puts in place of node builtins. Release builds embed them, zstd-compressed.
- A debug build reads them from the codegen directory at run time. So the new files can be tested with a debug binary that was built before this change.

<details><summary>Notes</summary>

- With the new files in a debug build: `bundler_browser.test.ts` (23 pass), `bundler_regressions.test.ts` (9 pass), and `bundler_loader.test.ts` (59 pass). These are the same results as with the old files.
- A browser bundle that imports all 23 polyfills exports the same names with the old and the new files. One difference: the `name`, `length`, and `prototype` keys of the `assert` default export are not enumerable now. That matches the npm package.
- esbuild keeps license comments at the end of a file. Bun dropped most of them.
- Size: `net.js` is smaller (bun folded the regex template strings). `timers.js` and `string_decoder.js` are larger (esbuild's CommonJS helpers).

</details>
