### PR TITLE
node:vm: name SourceTextModule stack frames after the identifier

### DIFF
--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -90,8 +90,7 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
 
     RefPtr fetcher(NodeVMScriptFetcher::create(vm, dynamicImportCallback, moduleWrapper));
 
-    // The origin URL stays empty: SourceCodeKey compares it, so a URL here would
-    // make cachedData acceptance depend on the identifier.
+    // No origin URL: SourceCodeKey compares it, and cachedData must not depend on the identifier.
     SourceOrigin sourceOrigin { {}, *fetcher };
 
     WTF::String identifier = identifierValue.toWTFString(globalObject);
@@ -105,8 +104,6 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
         clampOffsetForSource(OrdinalNumber::fromZeroBasedInt(columnOffset), sourceText.length()),
     };
 
-    // The identifier is the provider's source URL, so stack frames name the module
-    // the same way vm.Script frames name the filename.
     Ref<StringSourceProvider> sourceProvider = StringSourceProvider::create(WTF::move(sourceText), sourceOrigin, identifier, SourceTaintedOrigin::Untainted, startPosition, SourceProviderSourceType::Module);
 
     SourceCode sourceCode(WTF::move(sourceProvider), startPosition.m_line.zeroBasedInt(), startPosition.m_column.zeroBasedInt());

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -90,7 +90,12 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
 
     RefPtr fetcher(NodeVMScriptFetcher::create(vm, dynamicImportCallback, moduleWrapper));
 
+    // The origin URL stays empty: SourceCodeKey compares it, so a URL here would
+    // make cachedData acceptance depend on the identifier.
     SourceOrigin sourceOrigin { {}, *fetcher };
+
+    WTF::String identifier = identifierValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     WTF::String sourceText = sourceTextValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -100,13 +105,13 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
         clampOffsetForSource(OrdinalNumber::fromZeroBasedInt(columnOffset), sourceText.length()),
     };
 
-    Ref<StringSourceProvider> sourceProvider = StringSourceProvider::create(WTF::move(sourceText), sourceOrigin, String {}, SourceTaintedOrigin::Untainted, startPosition, SourceProviderSourceType::Module);
+    // The identifier is the provider's source URL, so stack frames name the module
+    // the same way vm.Script frames name the filename.
+    Ref<StringSourceProvider> sourceProvider = StringSourceProvider::create(WTF::move(sourceText), sourceOrigin, identifier, SourceTaintedOrigin::Untainted, startPosition, SourceProviderSourceType::Module);
 
     SourceCode sourceCode(WTF::move(sourceProvider), startPosition.m_line.zeroBasedInt(), startPosition.m_column.zeroBasedInt());
 
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    WTF::String identifier = identifierValue.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, nullptr);
     NodeVMSourceTextModule* ptr = new (NotNull, allocateCell<NodeVMSourceTextModule>(vm)) NodeVMSourceTextModule(
         vm, zigGlobalObject->NodeVMSourceTextModuleStructure(), WTF::move(identifier), contextValue,
         WTF::move(sourceCode), moduleWrapper, initializeImportMeta);

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -591,12 +591,12 @@ describe("bytecode cache portability", () => {
           "sha256": "953551a49ed6db7b5fce11b21382f11f3a0d0d4945507f5e38bf6a14ca724e8a",
         },
         "vm.SourceTextModule acorn.mjs": {
-          "bytes": 264176,
-          "sha256": "b39984469ff175c7b37e0255c217c8464fe9d564aa8f8da429e02ef0f05d7781",
+          "bytes": 264200,
+          "sha256": "f7cd66bcb69335fa15b378b394cc82701536d0a137aa8a3e3164ff47f7cf9226",
         },
         "vm.SourceTextModule module.js": {
-          "bytes": 9712,
-          "sha256": "b864ddcfde36d03c8ddba5728ae2f3dde05e08e640dea1599b8915a515429517",
+          "bytes": 9736,
+          "sha256": "30d1a1eb04b246f8c91767afa7516cb16ce532b3d8200f9435f8e31881cb6278",
         },
       }
     `);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1894,6 +1894,48 @@ test.concurrent("timeout during a nested event-loop wait beneath the script", as
   expect(exitCode).toBe(0);
 });
 
+// Node names module frames after the identifier (the V8 resource name). JSC prints the
+// source provider's URL, so the identifier has to reach the provider.
+describe.concurrent("node:vm SourceTextModule frames name the identifier", () => {
+  async function stackOf(identifierOption: string) {
+    const code = `
+      const vm = require("node:vm");
+      const ctx = vm.createContext({});
+      const src = "export const a = 1;\\nfunction boom() { throw new Error('from module'); }\\nboom();";
+      const mod = new vm.SourceTextModule(src, { ${identifierOption} context: ctx });
+      await mod.link(() => { throw new Error("no imports"); });
+      try {
+        await mod.evaluate();
+      } catch (e) {
+        console.log(e.stack);
+      }
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  test("an explicit identifier", async () => {
+    const stack = await stackOf('identifier: "file:///virtual/probe-module.mjs",');
+    expect(stack.split("\n").slice(0, 3)).toEqual([
+      "Error: from module",
+      expect.stringMatching(/^ {4}at boom \(file:\/\/\/virtual\/probe-module\.mjs:2:\d+\)$/),
+      expect.stringMatching(/^ {4}at file:\/\/\/virtual\/probe-module\.mjs:3:\d+$/),
+    ]);
+  });
+
+  test("the generated vm:module(N) identifier", async () => {
+    const stack = await stackOf("");
+    expect(stack.split("\n").slice(0, 3)).toEqual([
+      "Error: from module",
+      expect.stringMatching(/^ {4}at boom \(vm:module\(\d+\):2:\d+\)$/),
+      expect.stringMatching(/^ {4}at vm:module\(\d+\):3:\d+$/),
+    ]);
+  });
+});
+
 describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
   // Node's validator accepts any int32 here. JSC stores positions as ints,
   // converts the offset to one-based and counts the source's own lines on top

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1912,27 +1912,29 @@ describe.concurrent("node:vm SourceTextModule frames name the identifier", () =>
     `;
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-    return stdout;
+    return { stack: stdout.split("\n").slice(0, 3), stderr, exitCode };
   }
 
   test("an explicit identifier", async () => {
-    const stack = await stackOf('identifier: "file:///virtual/probe-module.mjs",');
-    expect(stack.split("\n").slice(0, 3)).toEqual([
+    const { stack, stderr, exitCode } = await stackOf('identifier: "file:///virtual/probe-module.mjs",');
+    expect(stack).toEqual([
       "Error: from module",
       expect.stringMatching(/^ {4}at boom \(file:\/\/\/virtual\/probe-module\.mjs:2:\d+\)$/),
       expect.stringMatching(/^ {4}at file:\/\/\/virtual\/probe-module\.mjs:3:\d+$/),
     ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 
   test("the generated vm:module(N) identifier", async () => {
-    const stack = await stackOf("");
-    expect(stack.split("\n").slice(0, 3)).toEqual([
+    const { stack, stderr, exitCode } = await stackOf("");
+    expect(stack).toEqual([
       "Error: from module",
       expect.stringMatching(/^ {4}at boom \(vm:module\(\d+\):2:\d+\)$/),
       expect.stringMatching(/^ {4}at vm:module\(\d+\):3:\d+$/),
     ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem
- Stack frames from code inside a `vm.SourceTextModule` print `unknown` as the file name: `at boom (unknown:3:34)`. Node prints the module's `identifier`. `vm.Script` with `filename` is fine.
- The cause is `NodeVMSourceTextModule::create` (`src/jsc/bindings/NodeVMSourceTextModule.cpp:103`). It builds the `StringSourceProvider` with an empty source URL. The identifier is read after that and only stored on the module object. JSC's stack trace builder prints the provider's URL, so every frame in that source says `unknown`.

### Fix
- Read the identifier before the provider is built and pass it as the provider's source URL. This is the role `filename` plays for `vm.Script` in `NodeVMScript.cpp:139`.
- Node uses the identifier verbatim as the resource name, so the string is passed as is, not through `fileURLWithFileSystemPath`. The generated `vm:module(N)` name now shows up too.
- The `SourceOrigin` URL stays empty on purpose. `SourceCodeKey` compares the origin host, so a URL there would make `cachedData` acceptance depend on the identifier. Checked: cachedData created under one identifier is still accepted under another.
- The cached bytecode now embeds the identifier as the source URL, as `vm.Script` cachedData embeds the filename. The two `SourceTextModule` entries in `test/bundler/bundler_bytecode_portable.test.ts` grow by 24 bytes each. The new hashes match between linux x64 and linux aarch64.
- Verified: `test/js/node/vm/vm.test.ts` (two new tests, both fail on main). Also ran all of `test/js/node/vm/` and the bytecode portability snapshot test.

### Background
- A JSC `SourceProvider` holds the source text and a source URL. The URL is what stack frames and `error.sourceURL` print. `vm.Script` sets it from `filename`. `SourceTextModule` never set it.
- The native `at evaluate (unknown)` frame below the module frames is unchanged. `vm.Script` prints `at runInThisContext (unknown)` the same way. That is how Bun prints these host functions and is separate from this issue.
- #38235 also names the frames after the identifier as part of a larger offset rework. That PR is three weeks old and conflicts with main. This PR is the minimal fix for the reported bug.

Fixes #41316

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts, test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->
