### PR TITLE
test: probe process liveness with signal 0 in common.isAlive()

### DIFF
--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -834,9 +834,13 @@ function nodeProcessAborted(exitCode, signal) {
   return expectedExitCodes.includes(exitCode);
 }
 
+// Node probes with SIGCONT. Signal 0 checks the pid and sends nothing.
+// LeakSanitizer stops every thread at exit with PTRACE_ATTACH, which queues
+// a SIGSTOP. A SIGCONT that arrives before a thread takes that SIGSTOP
+// discards it, and the exiting process then never finishes.
 function isAlive(pid) {
   try {
-    process.kill(pid, 'SIGCONT');
+    process.kill(pid, 0);
     return true;
   } catch {
     return false;

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -152,7 +152,6 @@ test/js/node/test/parallel/test-http-blank-header.js
 test/js/node/test/parallel/test-http-server-keepalive-req-gc.js
 
 # Timeouts
-test/js/node/test/parallel/test-cluster-primary-kill.js
 test/cli/test/parallel.test.ts
 test/cli/test/parallel-startup-failure.test.ts
 


### PR DESCRIPTION
### Problem
- `test/js/node/test/parallel/test-cluster-primary-error.js` times out on `debian 13 x64-asan` (builds 109742, 109850, 109916). The annotation says `timeout` and `main process killed by undefined but no core file found`.
- `common.isAlive()` (`test/js/node/test/common/index.js:837`) probes a pid with SIGCONT. The test polls two cluster workers with it every 50 ms while they exit. On this lane, LeakSanitizer runs at exit. A SIGCONT at the wrong moment leaves a worker stuck, so the poll never ends.
- The race is old. #41204 made a failure final unless `test/flaky-tests.txt` lists the file, so the retry that hid it is gone.

### Fix
- `isAlive()` calls `process.kill(pid, 0)`. Signal 0 checks that the pid exists and sends nothing.
- `test-cluster-primary-kill.js` polls the same way. It left LeakSanitizer in April for "LSAN causing test timeouts". This PR removes it from `test/no-validate-leaksan.txt`.
- Verified with the CI ASAN environment, 7 runs at once: `test-cluster-primary-error.js` passes 140 of 140, `test-cluster-primary-kill.js` 42 of 42. All six `isAlive()` users pass on Linux and Windows x64.

### Background
- Before LeakSanitizer scans memory, it stops every thread with `PTRACE_ATTACH`. That call queues a SIGSTOP for the thread. Then the tracer waits for the thread to stop.
- When a SIGCONT arrives, the kernel discards every pending stop signal. A thread that has not taken its SIGSTOP yet never stops, and the tracer waits forever.
- On Windows, `process.kill(pid, 'SIGCONT')` throws `ERR_UNKNOWN_SIGNAL`, so `isAlive()` always returned false there. Signal 0 works on Windows, so these tests now check the pid there.

<details><summary>Notes</summary>

- Live capture of a hang (debug ASAN build, CI environment). The test process still polls worker 32508. The worker is an orphan in state `t`. Nine of its threads sleep in `ptrace_stop`. Thread 32704 has the tracer attached, but it sleeps in `futex_do_wait`. The tracer, a child of the worker, sleeps in `do_wait`. The worker stays stuck after the poller is killed.
- A `tgkill(32508, 32704, SIGSTOP)` by hand sent the lost signal. LeakSanitizer finished, and the worker exited at once.
- Deterministic repro: start a process with `detect_leaks=1`, then call `isAlive()` on it in a tight loop while it exits. SIGCONT: 3 of 3 hang in state `t`. Signal 0: 0 of 10. A plain C program built with `-fsanitize=address` hangs the same way (3 of 3), so the cause is not in bun.
- The same test with a 1 ms poll interval: SIGCONT hangs 5 times in 84 runs, each with the signature above. Signal 0: no hang in 140 runs.
- The unmodified test with SIGCONT: 2 hangs in about 200 runs.
- The flake is in PR builds from 2026-08-26 on (the oldest I checked). Builds on a base before #41204 show "(1 retry)". Builds on a later base have no retry and fail. Main does not run the ASAN lane, so the list that #41204 seeded from main builds does not name this file.
- Upstream Node still probes with SIGCONT. This copy of `common/index.js` already differs from upstream, and the comment says why this line does.
- Windows x64 (canary build): the six `isAlive()` tests pass 5 of 5 rounds. `process.kill(pid, 0)` returns true for a live child and throws `ESRCH` after it exits.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->