### PR TITLE
run --filter: show all output by default, clearer missing-script errors

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -4409,10 +4409,10 @@
     },
     {
       "name": "elide-lines",
-      "description": "Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines.",
+      "description": "Number of lines of script output shown when using --filter (default: 0, show all lines)",
       "hasValue": true,
       "valueType": "val",
-      "defaultValue": "10)",
+      "defaultValue": "0",
       "required": false,
       "multiple": false
     },

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -871,7 +871,7 @@ bun run --silent dev
 
 ### `run.elide-lines` - truncate filtered output
 
-The number of lines of script output shown per script when using `--filter`. Default `10`. Set to `0` to show all lines. Equivalent to the `--elide-lines` flag.
+Truncate each script's output to its last N lines when using `--filter` in a terminal. Default `0` (show all lines). Equivalent to the `--elide-lines` flag.
 
 ```toml title="bunfig.toml" icon="settings"
 [run]

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -28,8 +28,8 @@ bun run <file or script>
 
 ### Workspace Management
 
-<ParamField path="--elide-lines" type="number" default="10">
-  Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines
+<ParamField path="--elide-lines" type="number" default="0">
+  Truncate each script's output to its last N lines when using --filter. Default 0 shows all lines
 </ParamField>
 
 <ParamField path="--filter" type="string">

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -342,7 +342,7 @@ const AUTO_ONLY_PARAMS: &[ParamType] = concat_params!(
         // parse_param!("--all"),
         parse_param!("--silent                          Don't print the script command"),
         parse_param!(
-            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines."
+            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 0, show all lines)"
         ),
         parse_param!("-v, --version                     Print version and exit"),
         parse_param!("--revision                        Print version with revision and exit"),
@@ -360,7 +360,7 @@ const RUN_ONLY_PARAMS: &[ParamType] = concat_params!(
     &[
         parse_param!("--silent                          Don't print the script command"),
         parse_param!(
-            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines."
+            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 0, show all lines)"
         ),
     ],
     AUTO_OR_RUN_PARAMS,

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -1,7 +1,9 @@
 use core::ptr::NonNull;
 
+use bstr::BStr;
 use bun_ast::{self, ExprData, Log};
 use bun_core::Global;
+use bun_core::Output;
 use bun_core::{ZStr, strings};
 use bun_glob as glob;
 use bun_install::package_manager::workspace_selection::{
@@ -244,14 +246,70 @@ pub(crate) fn select_packages(
         graph.as_ref(),
         RootSelection::Implicit,
     );
-    workspace_selection::warn_unmatched(&patterns, &selection.unmatched_patterns);
-    let packages = discovered
+    let packages: Vec<WorkspacePackage> = discovered
         .into_iter()
         .enumerate()
         .filter(|&(i, _)| selection.selected.is_set(i))
         .map(|(_, p)| p)
         .collect();
+    if packages.is_empty() {
+        if ctx.if_present {
+            Global::exit(0);
+        }
+        if ctx.workspaces {
+            Output::err_generic("No workspace packages found", ());
+            Global::exit(1);
+        }
+        workspace_selection::error_unmatched(&patterns);
+    }
+    workspace_selection::warn_unmatched(&patterns, &selection.unmatched_patterns);
     Ok(SelectedPackages { root_dir, packages })
+}
+
+impl WorkspacePackage {
+    /// `package.json` name, or the directory relative to the workspace root for unnamed packages.
+    pub(crate) fn display_name(&self, root_dir: &[u8]) -> Box<[u8]> {
+        if self.json.name.is_empty() {
+            Box::from(resolve_path::relative_platform::<platform::Posix, false>(
+                root_dir, &self.dir,
+            ))
+        } else {
+            Box::from(&self.json.name[..])
+        }
+    }
+}
+
+impl SelectedPackages {
+    /// `error: Script "x" not found in package "a"` / `... in 3 packages matching "a*"` /
+    /// `... in 3 workspace packages`, then exit 1. `scripts` is already quoted.
+    pub(crate) fn error_script_not_found(&self, ctx: &Command::ContextData, scripts: &[u8]) -> ! {
+        let n = self.packages.len();
+        if n == 1 {
+            Output::err_generic(
+                "Script {} not found in package \"{}\"",
+                (
+                    BStr::new(scripts),
+                    BStr::new(&self.packages[0].display_name(&self.root_dir)),
+                ),
+            );
+        } else if ctx.workspaces {
+            Output::err_generic(
+                "Script {} not found in {} workspace packages",
+                (BStr::new(scripts), n),
+            );
+        } else {
+            let patterns: Vec<&[u8]> = ctx.filters.iter().map(|f| &**f).collect();
+            Output::err_generic(
+                "Script {} not found in {} packages matching {}",
+                (
+                    BStr::new(scripts),
+                    n,
+                    BStr::new(&workspace_selection::quote_patterns(&patterns)),
+                ),
+            );
+        }
+        Global::exit(1);
+    }
 }
 
 // Heap-allocated so the walker keeps its address while the `PackageFilterIterator` moves. Held as

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -519,11 +519,11 @@ impl<'a> State<'a> {
         // Reshaped for borrowck — iterating handles by index since draw_buf is also &mut self.
         for idx in 0..self.handles.len() {
             let handle = &self.handles[idx];
-            // normally we truncate the output to 10 lines, but on abort we print everything to aid debugging
+            // on abort we print everything to aid debugging
             let elide_lines = if is_abort {
                 None
             } else {
-                Some(handle.config.elide_count.unwrap_or(10))
+                Some(handle.config.elide_count.unwrap_or(0))
             };
             let e = Self::elide(&handle.buffer, elide_lines);
 

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -413,7 +413,11 @@ impl<'a> State<'a> {
             }
         }
         if self.pretty_output {
-            let _ = self.redraw(false);
+            // On abort `finalize` draws the last frame; drawing it here too
+            // would print everything twice once it no longer fits the screen.
+            if !self.aborted {
+                let _ = self.redraw(false);
+            }
         } else {
             self.draw_buf.clear();
             // flush any remaining buffer
@@ -516,14 +520,28 @@ impl<'a> State<'a> {
                 self.draw_buf.extend_from_slice(b"\x1b[1A\x1b[K");
             }
         }
+        // While scripts are running every chunk redraws the whole frame, so cap
+        // it to the terminal: each script shows the tail of its output. The
+        // final frame (and abort, to aid debugging) prints everything unless
+        // --elide-lines says otherwise.
+        let final_frame = is_abort || self.is_done();
+        let rows = bun_core::output::File::from(bun_core::Fd::stdout())
+            .winsize()
+            .filter(|w| w.row > 0)
+            .map_or(24, |w| w.row as usize);
+        let per_script_cap = (rows.saturating_sub(1) / self.handles.len().max(1))
+            .saturating_sub(3)
+            .max(1);
         // Reshaped for borrowck — iterating handles by index since draw_buf is also &mut self.
         for idx in 0..self.handles.len() {
             let handle = &self.handles[idx];
-            // on abort we print everything to aid debugging
+            let user_cap = handle.config.elide_count.filter(|&n| n > 0);
             let elide_lines = if is_abort {
                 None
+            } else if final_frame {
+                user_cap
             } else {
-                Some(handle.config.elide_count.unwrap_or(0))
+                Some(user_cap.map_or(per_script_cap, |n| n.min(per_script_cap)))
             };
             let e = Self::elide(&handle.buffer, elide_lines);
 
@@ -893,23 +911,9 @@ pub(crate) fn run_scripts_with_filter(
             // Exit silently with success when --if-present is set
             Global::exit(0);
         }
-        if ctx.workspaces {
-            Output::err_generic(
-                "No workspace packages have script \"{s}\"",
-                (bstr::BStr::new(script_name),),
-            );
-        } else {
-            let patterns: Vec<&[u8]> = ctx.filters.iter().map(|f| &**f).collect();
-            Output::err_generic(
-                "{}",
-                (bstr::BStr::new(
-                    &bun_install::package_manager::workspace_selection::unmatched_message(
-                        &patterns,
-                    ),
-                ),),
-            );
-        }
-        Global::exit(1);
+        let quoted =
+            bun_install::package_manager::workspace_selection::quote_patterns(&[script_name]);
+        selected.error_script_not_found(&*ctx, &quoted);
     }
 
     // SAFETY: Transpiler::init always sets `env` to the process-lifetime singleton.

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -963,15 +963,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 &package.dir,
                 run_in_bun,
             )?;
-            let pkg_name: Box<[u8]> = if !package.json.name.is_empty() {
-                Box::<[u8]>::from(&package.json.name[..])
-            } else {
-                // Fallback: use relative path from workspace root
-                Box::from(bun_paths::resolve_path::relative_platform::<
-                    bun_paths::resolve_path::platform::Posix,
-                    false,
-                >(resolve_root, &package.dir))
-            };
+            let pkg_name = package.display_name(resolve_root);
 
             matched_packages.push(MatchedPackage {
                 name: pkg_name,
@@ -1040,20 +1032,8 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             if ctx.if_present {
                 Global::exit(0);
             }
-            if ctx.workspaces {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: No workspace packages have matching scripts"
-                );
-            } else {
-                let patterns: Vec<&[u8]> = ctx.filters.iter().map(|f| &**f).collect();
-                Output::err_generic(
-                    "{}",
-                    (bstr::BStr::new(&workspace_selection::unmatched_message(
-                        &patterns,
-                    )),),
-                );
-            }
-            Global::exit(1);
+            let names: Vec<&[u8]> = script_names.iter().map(|n| &**n).collect();
+            selected.error_script_not_found(ctx, &workspace_selection::quote_patterns(&names));
         }
     } else {
         // Single-package mode: use the root package.json

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -478,7 +478,22 @@ describe("bun", () => {
   });
 
   test("should error with missing script", () => {
-    runInCwdFailure(cwd_root, "*", "notpresent", /error: No workspace packages matched the filter "\*"/);
+    runInCwdFailure(cwd_root, "*", "notpresent", /error: Script "notpresent" not found in \d+ packages matching "\*"/);
+    runInCwdFailure(cwd_root, "pkga", "notpresent", /error: Script "notpresent" not found in package "pkga"/);
+  });
+  test("should error once when the filter matches no package", () => {
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: cwd_root,
+      cmd: [bunExe(), "run", "--filter", "nosuchpkg", "present"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    // Said once, as an error — not as a warning and then again as an error.
+    expect(stderr.toString().match(/No workspace packages matched/g)).toEqual(["No workspace packages matched"]);
+    expect(stderr.toString()).toContain(`error: No workspace packages matched the filter "nosuchpkg"`);
+    expect(exitCode).toBe(1);
   });
   test("warns about a filter that matched nothing while running the others", () => {
     const { exitCode, stdout, stderr } = spawnSync({

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -532,7 +532,7 @@ describe("bun", () => {
     target_pattern,
     antipattern,
   }: {
-    elideLines: number;
+    elideLines?: number;
     target_pattern: RegExp[];
     antipattern?: RegExp[];
   }) {
@@ -566,7 +566,14 @@ describe("bun", () => {
       // code path.
       const { exitCode, stderr, stdout } = spawnSync({
         cwd: dir,
-        cmd: [bunExe(), "run", "--filter", "./packages/dep0", "--elide-lines", String(elideLines), "script"],
+        cmd: [
+          bunExe(),
+          "run",
+          "--filter",
+          "./packages/dep0",
+          ...(elideLines === undefined ? [] : ["--elide-lines", String(elideLines)]),
+          "script",
+        ],
         env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: "0" },
         stdout: "pipe",
         stderr: "pipe",
@@ -595,10 +602,10 @@ describe("bun", () => {
     });
   }
 
-  test("elides output by default when using --filter", () => {
+  test("does not elide output by default when using --filter", () => {
     runElideLinesTest({
-      elideLines: 10,
-      target_pattern: [/\[10 lines elided\]/, /(?:log_line[\s\S]*?){20}/],
+      target_pattern: [/(?:log_line[\s\S]*?){20}/],
+      antipattern: [/lines elided/],
     });
   });
 
@@ -1263,21 +1270,21 @@ describe("auto-discovered bunfig.toml [run] section", () => {
 
   // Elision only happens on a terminal. On POSIX FORCE_COLOR=1 turns the
   // terminal renderer on for a pipe; on Windows it stays off (see runElideLinesTest).
-  test.skipIf(isWindows)("[run] elide-lines = 0 disables elision for --filter", () => {
-    using dir = workspace("filter-bunfig-elide", "[run]\nelide-lines = 0\n");
+  test.skipIf(isWindows)("[run] elide-lines enables elision for --filter", () => {
+    using dir = workspace("filter-bunfig-elide", "[run]\nelide-lines = 15\n");
     const r = run(String(dir), ["run", "--filter", "dep0", "lines"], { FORCE_COLOR: "1", NO_COLOR: "0" });
-    expect(r.stdout).not.toMatch(/lines elided/);
-    expect(r.stdout).toMatch(/(?:log_line[\s\S]*?){20}/);
+    expect(r.stdout).toMatch(/\[5 lines elided\]/);
     expect(r.exitCode).toBe(0);
   });
 
   test.skipIf(isWindows)("--elide-lines on the CLI wins over [run] elide-lines", () => {
-    using dir = workspace("filter-bunfig-cli-elide", "[run]\nelide-lines = 0\n");
-    const r = run(String(dir), ["run", "--elide-lines", "15", "--filter", "dep0", "lines"], {
+    using dir = workspace("filter-bunfig-cli-elide", "[run]\nelide-lines = 15\n");
+    const r = run(String(dir), ["run", "--elide-lines", "0", "--filter", "dep0", "lines"], {
       FORCE_COLOR: "1",
       NO_COLOR: "0",
     });
-    expect(r.stdout).toMatch(/\[5 lines elided\]/);
+    expect(r.stdout).not.toMatch(/lines elided/);
+    expect(r.stdout).toMatch(/(?:log_line[\s\S]*?){20}/);
     expect(r.exitCode).toBe(0);
   });
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1914,6 +1914,22 @@ describe("workspace integration", () => {
     expect(r.exitCode).toBe(0);
   });
 
+  test("--parallel --filter distinguishes an unmatched filter from a missing script", async () => {
+    using dir = makeWorkspace("mr-ws-missing", {
+      "pkg-a": { build: `echo a` },
+      "pkg-b": { build: `echo b` },
+    });
+    const noPkg = await runMulti(["run", "--parallel", "--filter", "nope", "build"], String(dir));
+    expect(noPkg.stderr.trim()).toBe(`error: No workspace packages matched the filter "nope"`);
+    const negated = await runMulti(["run", "--parallel", "--filter", "*", "--filter", "!*", "build"], String(dir));
+    expect(negated.stderr.trim()).toBe(`error: No workspace packages matched the filters "*", "!*"`);
+    const noScript = await runMulti(["run", "--parallel", "--filter", "pkg-*", "lint", "test"], String(dir));
+    expect(noScript.stderr.trim()).toBe(`error: Script "lint", "test" not found in 2 packages matching "pkg-*"`);
+    expect(noPkg.exitCode).toBe(1);
+    expect(negated.exitCode).toBe(1);
+    expect(noScript.exitCode).toBe(1);
+  });
+
   test("--parallel --filter='pkg-a' runs only in matching package", async () => {
     using dir = makeWorkspace("mr-ws-single", {
       "pkg-a": { build: `echo a-only` },

--- a/test/cli/run/workspaces.test.ts
+++ b/test/cli/run/workspaces.test.ts
@@ -107,7 +107,26 @@ describe.concurrent("bun run --workspaces", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("");
-    expect(stderr).toContain('No workspace packages have script "nonexistent"');
+    expect(stderr.trim()).toMatch(/^error: Script "nonexistent" not found in \d+ workspace packages$/);
     expect(exitCode).toBe(1);
+  });
+
+  test("errors once when there are no workspace packages", async () => {
+    using dir = tempDir("ws-none", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"], scripts: { test: "echo root" } }),
+    });
+    for (const args of [["--workspaces"], ["--parallel", "--workspaces"]]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", ...args, "test"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(stderr.trim()).toBe("error: No workspace packages found");
+      expect(exitCode).toBe(1);
+    }
   });
 });


### PR DESCRIPTION
### What does this PR do?

**`--elide-lines` defaults to off.** `bun run --filter` previously truncated each script's terminal output to its last 10 lines unless `--elide-lines 0` was passed. Now all output is shown, and `--elide-lines N` / `[run] elide-lines = N` opts into truncation. Because the terminal renderer redraws every script's block on each output chunk, running frames are capped to what fits the terminal (each running script shows the tail of its output, `[N lines elided]` above it); the final frame — and Ctrl+C — prints everything. Abort no longer draws that last frame twice.

**Missing-script errors.** `bun run --filter docs nope` used to print `error: No workspace packages matched the filter "docs"` even though it matched. Now:

```
error: Script "nope" not found in package "docs"
error: Script "nope" not found in 12 packages matching "*"
error: Script "lint", "test" not found in 3 workspace packages      # --workspaces / --parallel
error: No workspace packages matched the filter "zzz"               # once, not warn + error
error: No workspace packages found                                  # --workspaces with none
```

Same for `--parallel/--sequential --filter`. Unnamed packages are referred to by their path relative to the workspace root.

### How did you verify your code works?

- `test/cli/run/filter-workspace.test.ts`: default shows all lines / `--elide-lines 15` elides 5 / bunfig + CLI precedence; missing script (many / single package) and unmatched-filter-said-once messages.
- `test/cli/run/multi-run.test.ts`: unmatched filter, all-negated filter, and missing scripts across N packages.
- `test/cli/run/workspaces.test.ts`: `--workspaces` missing script and no-packages messages (sequential and `--parallel`).
- `bun bd test test/cli/run/{filter-workspace,multi-run,workspaces,no-orphans}.test.ts` — 237 pass; new tests fail with `USE_SYSTEM_BUN=1`.
- Drove the debug build in a 20-row pty with a 300-line script: no frame moved the cursor up more than 19 lines, the final frame contained all 300 lines; SIGINT mid-run under a 24-row pty produced a single full frame.