### PR TITLE
Bump WebKit to 6119947592b6

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "40e43a82a755af3cc9eb4a4e025e4e020a7a3cfd";
+export const WEBKIT_VERSION = "6119947592b6e1c1faef02a4c2e03174cf05d062";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
@@ -18,12 +18,16 @@ describe.concurrent("WebKit 3722912ff800 upgrade", () => {
     expect(g().includes(5)).toBe(false);
   });
 
-  test("cyclic Array.prototype.join throws RangeError (f2f2c2ddf637)", () => {
-    // StringRecursionChecker was removed; cyclic join now recurses until the
-    // stack check throws instead of short-circuiting to the empty string.
-    const a: unknown[] = [];
-    a.push(a);
-    expect(() => a.join()).toThrow(RangeError);
+  test("cyclic Array.prototype.join returns the empty string for the cycle (oven-sh/WebKit#559)", () => {
+    // Upstream removed StringRecursionChecker in f2f2c2ddf637; oven-sh/WebKit#559
+    // restores it for the array conversions so a self-containing array matches
+    // V8 instead of throwing RangeError (oven-sh/bun#41198).
+    const a: unknown[] = [1, null, 2];
+    a[1] = a;
+    expect(a.join()).toBe("1,,2");
+    expect(a.toString()).toBe("1,,2");
+    expect(a.toLocaleString()).toBe("1,,2");
+    expect(`${a}`).toBe("1,,2");
   });
 
   test("WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d)", () => {


### PR DESCRIPTION
Updates `WEBKIT_VERSION` from `40e43a82a755` to `6119947592b6`.

Picks up:
- oven-sh/WebKit#554 — [JSC] Startup: size the atom table for a bun VM, read cgroup limits once, hand the structure arena over as zeroed
- oven-sh/WebKit#559 — Keep the cycle guard on Array#join, Array#toString and Array#toLocaleString