### PR TITLE
run --filter: compact append-only renderer, stable per-package colors

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -4409,10 +4409,10 @@
     },
     {
       "name": "elide-lines",
-      "description": "Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines.",
+      "description": "Number of lines of script output shown when using --filter (default: 0, show all lines)",
       "hasValue": true,
       "valueType": "val",
-      "defaultValue": "10)",
+      "defaultValue": "0",
       "required": false,
       "multiple": false
     },

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -871,7 +871,7 @@ bun run --silent dev
 
 ### `run.elide-lines` - truncate filtered output
 
-The number of lines of script output shown per script when using `--filter`. Default `10`. Set to `0` to show all lines. Equivalent to the `--elide-lines` flag.
+When using `--filter` in a terminal, show at most the last N lines of each finished script's output. Default `0` (show all lines). Equivalent to the `--elide-lines` flag.
 
 ```toml title="bunfig.toml" icon="settings"
 [run]

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -28,8 +28,8 @@ bun run <file or script>
 
 ### Workspace Management
 
-<ParamField path="--elide-lines" type="number" default="10">
-  Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines
+<ParamField path="--elide-lines" type="number" default="0">
+  Truncate each script's output to its last N lines when using --filter. Default 0 shows all lines
 </ParamField>
 
 <ParamField path="--filter" type="string">

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -342,7 +342,7 @@ const AUTO_ONLY_PARAMS: &[ParamType] = concat_params!(
         // parse_param!("--all"),
         parse_param!("--silent                          Don't print the script command"),
         parse_param!(
-            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines."
+            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 0, show all lines)"
         ),
         parse_param!("-v, --version                     Print version and exit"),
         parse_param!("--revision                        Print version with revision and exit"),
@@ -360,7 +360,7 @@ const RUN_ONLY_PARAMS: &[ParamType] = concat_params!(
     &[
         parse_param!("--silent                          Don't print the script command"),
         parse_param!(
-            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines."
+            "--elide-lines <NUMBER>            Number of lines of script output shown when using --filter (default: 0, show all lines)"
         ),
     ],
     AUTO_OR_RUN_PARAMS,

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -244,13 +244,19 @@ pub(crate) fn select_packages(
         graph.as_ref(),
         RootSelection::Implicit,
     );
-    workspace_selection::warn_unmatched(&patterns, &selection.unmatched_patterns);
-    let packages = discovered
+    let packages: Vec<WorkspacePackage> = discovered
         .into_iter()
         .enumerate()
         .filter(|&(i, _)| selection.selected.is_set(i))
         .map(|(_, p)| p)
         .collect();
+    if packages.is_empty() && !ctx.workspaces {
+        if ctx.if_present {
+            Global::exit(0);
+        }
+        workspace_selection::error_unmatched(&patterns);
+    }
+    workspace_selection::warn_unmatched(&patterns, &selection.unmatched_patterns);
     Ok(SelectedPackages { root_dir, packages })
 }
 

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -65,6 +65,8 @@ pub(crate) struct ProcessHandle<'a> {
     /// `remaining_scripts`, so a later pipe/exit event or the abort sweep
     /// cannot finish it twice.
     finished: bool,
+    /// Pretty mode: the final block has been written above the live region.
+    flushed: bool,
     buffer: Vec<u8>,
 
     process: Option<ProcessInfo>,
@@ -324,7 +326,8 @@ struct State<'a> {
     remaining_scripts: usize,
     // buffer for batched output
     draw_buf: Vec<u8>,
-    last_lines_written: usize,
+    /// Lines currently on screen below the flushed output, erased on each redraw.
+    live_lines: usize,
     pretty_output: bool,
     shell_bin: &'static ZStr, // intentionally leaked (process exits)
     aborted: bool,
@@ -503,6 +506,99 @@ impl<'a> State<'a> {
         }
     }
 
+    /// Upper bound on the redrawn region; everything else is append-only.
+    const MAX_LIVE_LINES: usize = 50;
+
+    fn write_header(out: &mut Vec<u8>, config: &ScriptConfig) -> crate::Result<()> {
+        config.color.label(out, &config.package_name);
+        write!(
+            out,
+            fmt!(" {s} <d>$ {s}<r>  "),
+            bstr::BStr::new(&config.script_name),
+            bstr::BStr::new(&config.script_content),
+        )?;
+        Ok(())
+    }
+
+    fn line_count(buf: &[u8]) -> usize {
+        strings::count_char(buf, b'\n') + (!buf.is_empty() && !buf.ends_with(b"\n")) as usize
+    }
+
+    fn write_lines(out: &mut Vec<u8>, color: LabelColor, mut content: &[u8]) {
+        while !content.is_empty() {
+            let (line, rest) = match strings::index_of_char(content, b'\n') {
+                Some(i) => content.split_at(i as usize + 1),
+                None => (content, &b""[..]),
+            };
+            color.gutter(out);
+            out.extend_from_slice(fmt!("│<r> ").as_bytes());
+            out.extend_from_slice(line);
+            if !line.ends_with(b"\n") {
+                out.push(b'\n');
+            }
+            content = rest;
+        }
+    }
+
+    /// A script's permanent block: header with its final status, then its output.
+    fn write_final(
+        out: &mut Vec<u8>,
+        handle: &ProcessHandle<'a>,
+        is_abort: bool,
+    ) -> crate::Result<()> {
+        Self::write_header(out, handle.config)?;
+        match handle.process.as_ref().map(|p| (&p.status, p)) {
+            None => out.extend_from_slice(fmt!("<d>[not started]<r>\n").as_bytes()),
+            Some((Status::Running, _)) => {
+                out.extend_from_slice(fmt!("<red>[interrupted]<r>\n").as_bytes())
+            }
+            Some((Status::Exited(exited), p)) if exited.code == 0 => match p.end_time {
+                Some(end) => {
+                    let ms = end.duration_since(p.start_time).as_secs_f64() * 1000.0;
+                    if ms > 1000.0 {
+                        write!(out, fmt!("<d>[{:.2} s]<r>\n"), ms / 1000.0)?;
+                    } else {
+                        write!(out, fmt!("<d>[{:.0} ms]<r>\n"), ms)?;
+                    }
+                }
+                None => out.extend_from_slice(fmt!("<d>[done]<r>\n").as_bytes()),
+            },
+            Some((Status::Exited(exited), _)) => {
+                write!(out, fmt!("<red>[exit {d}]<r>\n"), exited.code)?;
+            }
+            Some((Status::Signaled(code), _)) => {
+                if *code == bun_sys::SignalCode::SIGINT.0 {
+                    out.extend_from_slice(fmt!("<red>[interrupted]<r>\n").as_bytes());
+                } else {
+                    write!(
+                        out,
+                        fmt!("<red>[{s}]<r>\n"),
+                        bun_sys::SignalCode(*code).name().unwrap_or("UNKNOWN"),
+                    )?;
+                }
+            }
+            Some((Status::Err(_), _)) => {
+                out.extend_from_slice(fmt!("<red>[failed to start]<r>\n").as_bytes());
+            }
+        }
+        // on abort we print everything to aid debugging
+        let max = if is_abort {
+            None
+        } else {
+            handle.config.elide_count.filter(|&n| n > 0)
+        };
+        let e = Self::elide(&handle.buffer, max);
+        if e.elided_count > 0 {
+            handle.config.color.gutter(out);
+            write!(out, fmt!("│<r> <d>[{d} lines elided]<r>\n"), e.elided_count)?;
+        }
+        Self::write_lines(out, handle.config.color, e.content);
+        Ok(())
+    }
+
+    /// Finished scripts are written once, in completion order, and never
+    /// touched again; below them a bounded region (running scripts with the
+    /// tail of their output, then what is still waiting) is erased and redrawn.
     fn redraw(&mut self, is_abort: bool) -> crate::Result<()> {
         if !self.pretty_output {
             return Ok(());
@@ -510,122 +606,117 @@ impl<'a> State<'a> {
         self.draw_buf.clear();
         self.draw_buf
             .extend_from_slice(Output::SYNCHRONIZED_START.as_bytes());
-        if self.last_lines_written > 0 {
-            // move cursor to the beginning of the line and clear it
-            self.draw_buf.extend_from_slice(b"\x1b[0G\x1b[K");
-            for _ in 0..self.last_lines_written {
-                // move cursor up and clear the line
-                self.draw_buf.extend_from_slice(b"\x1b[1A\x1b[K");
-            }
+        for _ in 0..self.live_lines {
+            // cursor up one line, clear it
+            self.draw_buf.extend_from_slice(b"\x1b[1A\x1b[2K");
         }
-        // Reshaped for borrowck — iterating handles by index since draw_buf is also &mut self.
+        self.draw_buf.extend_from_slice(b"\x1b[0G");
+
         for idx in 0..self.handles.len() {
             let handle = &self.handles[idx];
-            // normally we truncate the output to 10 lines, but on abort we print everything to aid debugging
-            let elide_lines = if is_abort {
-                None
-            } else {
-                Some(handle.config.elide_count.unwrap_or(10))
-            };
-            let e = Self::elide(&handle.buffer, elide_lines);
-            let color = handle.config.color;
+            if handle.flushed || !(handle.finished || is_abort) {
+                continue;
+            }
+            if is_abort && handle.process.is_none() {
+                continue;
+            }
+            // Reshaped for borrowck: draw_buf and handles are both fields of self.
+            let mut out = core::mem::take(&mut self.draw_buf);
+            Self::write_final(&mut out, &self.handles[idx], is_abort)?;
+            self.draw_buf = out;
+            self.handles[idx].flushed = true;
+        }
 
-            color.label(&mut self.draw_buf, &handle.config.package_name);
-            write!(
-                &mut self.draw_buf,
-                fmt!(" {s} $ <d>{s}<r>\n"),
-                bstr::BStr::new(&handle.config.script_name),
-                bstr::BStr::new(&handle.config.script_content),
-            )?;
-            if e.elided_count > 0 {
-                color.gutter(&mut self.draw_buf);
-                write!(
-                    &mut self.draw_buf,
-                    fmt!("│<r> <d>[{d} lines elided]<r>\n"),
-                    e.elided_count,
-                )?;
+        let winsize = bun_core::output::File::from(bun_core::Fd::stdout()).winsize();
+        let rows = winsize.map_or(24, |w| w.row as usize);
+        let budget = Self::MAX_LIVE_LINES.min(rows.saturating_sub(1));
+        let running = self
+            .handles
+            .iter()
+            .filter(|h| !h.flushed && h.process.is_some())
+            .count();
+        let waiting = self
+            .handles
+            .iter()
+            .filter(|h| !h.flushed && h.process.is_none())
+            .count();
+        let waiting_lines = waiting
+            .min(budget.saturating_sub(running * 2))
+            .max((waiting > 0) as usize);
+        let tail_each = if running == 0 {
+            0
+        } else {
+            budget.saturating_sub(running + waiting_lines) / running
+        };
+
+        // Lines here are clipped, not wrapped, so `live_lines` is exact.
+        self.draw_buf.extend_from_slice(b"\x1b[?7l");
+        let mut live_lines = 0usize;
+        for handle in self.handles.iter() {
+            if handle.flushed || handle.process.is_none() || live_lines >= budget {
+                continue;
             }
-            let mut content = e.content;
-            while let Some(i) = strings::index_of_char(content, b'\n') {
-                let i = i as usize;
-                let line = &content[0..i + 1];
-                color.gutter(&mut self.draw_buf);
-                self.draw_buf.extend_from_slice(fmt!("│<r> ").as_bytes());
-                self.draw_buf.extend_from_slice(line);
-                content = &content[i + 1..];
-            }
-            if !content.is_empty() {
-                color.gutter(&mut self.draw_buf);
-                self.draw_buf.extend_from_slice(fmt!("│<r> ").as_bytes());
-                self.draw_buf.extend_from_slice(content);
-                self.draw_buf.push(b'\n');
-            }
-            color.gutter(&mut self.draw_buf);
-            self.draw_buf.extend_from_slice("└─ ".as_bytes());
-            if let Some(proc) = &handle.process {
-                match &proc.status {
-                    Status::Running => {
-                        self.draw_buf
-                            .extend_from_slice(fmt!("Running...<r>\n").as_bytes());
-                    }
-                    Status::Exited(exited) => {
-                        if exited.code == 0 {
-                            if let Some(end) = proc.end_time {
-                                let duration = end.duration_since(proc.start_time);
-                                let ms = duration.as_nanos() as f64 / 1_000_000.0;
-                                if ms > 1000.0 {
-                                    write!(
-                                        &mut self.draw_buf,
-                                        fmt!("Done in {:.2} s<r>\n"),
-                                        ms / 1_000.0,
-                                    )?;
-                                } else {
-                                    write!(&mut self.draw_buf, fmt!("Done in {:.0} ms<r>\n"), ms,)?;
-                                }
-                            } else {
-                                self.draw_buf
-                                    .extend_from_slice(fmt!("Done<r>\n").as_bytes());
-                            }
-                        } else {
-                            write!(
-                                &mut self.draw_buf,
-                                fmt!("<r><red>Exited with code {d}<r>\n"),
-                                exited.code,
-                            )?;
-                        }
-                    }
-                    Status::Signaled(code) => {
-                        if *code == bun_sys::SignalCode::SIGINT.0 {
-                            write!(&mut self.draw_buf, fmt!("<r><red>Interrupted<r>\n"))?;
-                        } else {
-                            write!(
-                                &mut self.draw_buf,
-                                fmt!("<r><red>Signaled with code {s}<r>\n"),
-                                bun_sys::SignalCode(*code).name().unwrap_or("UNKNOWN"),
-                            )?;
-                        }
-                    }
-                    Status::Err(_) => {
-                        self.draw_buf
-                            .extend_from_slice(fmt!("<r><red>Error<r>\n").as_bytes());
-                    }
+            Self::write_header(&mut self.draw_buf, handle.config)?;
+            handle.config.color.gutter(&mut self.draw_buf);
+            self.draw_buf.extend_from_slice("…".as_bytes());
+            let max = match handle.config.elide_count {
+                Some(n) if n > 0 => n.min(tail_each),
+                _ => tail_each,
+            };
+            let e = if max == 0 {
+                ElideResult {
+                    content: &[],
+                    elided_count: Self::line_count(&handle.buffer),
                 }
             } else {
+                Self::elide(&handle.buffer, Some(max))
+            };
+            if e.elided_count > 0 {
                 write!(
                     &mut self.draw_buf,
-                    fmt!("<d>Waiting for {d} other script(s)<r>\n"),
-                    handle.remaining_dependencies,
+                    fmt!("<r> <d>({d} lines)<r>"),
+                    e.elided_count + Self::line_count(e.content),
                 )?;
             }
+            self.draw_buf.extend_from_slice(fmt!("<r>\n").as_bytes());
+            live_lines += 1;
+            let before = self.draw_buf.len();
+            Self::write_lines(&mut self.draw_buf, handle.config.color, e.content);
+            live_lines += strings::count_char(&self.draw_buf[before..], b'\n');
         }
+        if waiting > 0 {
+            let shown = if waiting_lines < waiting {
+                waiting_lines - 1
+            } else {
+                waiting
+            };
+            let mut n = 0;
+            for handle in self.handles.iter() {
+                if handle.flushed || handle.process.is_some() {
+                    continue;
+                }
+                if n == shown {
+                    break;
+                }
+                Self::write_header(&mut self.draw_buf, handle.config)?;
+                self.draw_buf
+                    .extend_from_slice(fmt!("<d>[waiting]<r>\n").as_bytes());
+                n += 1;
+            }
+            if shown < waiting {
+                write!(
+                    &mut self.draw_buf,
+                    fmt!("<d>[{d} more waiting]<r>\n"),
+                    waiting - shown
+                )?;
+                n += 1;
+            }
+            live_lines += n;
+        }
+        self.draw_buf.extend_from_slice(b"\x1b[?7h");
+        self.live_lines = live_lines;
         self.draw_buf
             .extend_from_slice(Output::SYNCHRONIZED_END.as_bytes());
-        self.last_lines_written = 0;
-        for &c in &self.draw_buf {
-            if c == b'\n' {
-                self.last_lines_written += 1;
-            }
-        }
         self.flush_draw_buf();
         Ok(())
     }
@@ -807,10 +898,18 @@ pub(crate) fn run_scripts_with_filter(
     )?;
 
     let mut scripts: Vec<ScriptConfig> = Vec::new();
-    for package in &selected.packages {
+    for (package_idx, package) in selected.packages.iter().enumerate() {
         let path: &[u8] = &package.dir;
         let Some(pkgscripts) = &package.json.scripts else {
             continue;
+        };
+        let package_name: Box<[u8]> = if package.json.name.is_empty() {
+            Box::from(bun_paths::resolve_path::relative_platform::<
+                bun_paths::resolve_path::platform::Posix,
+                false,
+            >(&selected.root_dir, path))
+        } else {
+            Box::from(&package.json.name[..])
         };
 
         let run_in_bun = ctx.debug.run_in_bun;
@@ -877,14 +976,14 @@ pub(crate) fn run_scripts_with_filter(
 
             scripts.push(ScriptConfig {
                 package_json_path: package.package_json_path.clone(),
-                package_name: Box::<[u8]>::from(&package.json.name[..]),
+                package_name: package_name.clone(),
                 script_name: Box::<[u8]>::from(*name),
                 script_content: Box::<[u8]>::from(&interned[0..len_command_only]),
                 combined,
                 deps,
                 PATH: Box::<[u8]>::from(&path_var[..]),
                 elide_count: ctx.bundler_options.elide_lines,
-                color: LabelColor::for_label(&package.json.name, scripts.len()),
+                color: LabelColor::for_label(&package_name, package_idx),
             });
         }
     }
@@ -960,7 +1059,7 @@ pub(crate) fn run_scripts_with_filter(
         event_loop_handle: EventLoopHandle::init_mini(event_loop),
         remaining_scripts: 0,
         draw_buf: Vec::new(),
-        last_lines_written: 0,
+        live_lines: 0,
         pretty_output: {
             #[cfg(windows)]
             {
@@ -996,6 +1095,7 @@ pub(crate) fn run_scripts_with_filter(
             buffer: Vec::new(),
             remaining_fds: 0,
             finished: false,
+            flushed: false,
             process: None,
             options: SpawnOptions {
                 stdin: spawn::Stdio::Ignore,

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -8,6 +8,7 @@ use crate::api::bun::process::SpawnResultExt as _;
 use crate::api::bun::process::{self as spawn, Rusage, SpawnOptions, Status};
 use crate::cli::Command;
 use crate::cli::filter_arg as FilterArg;
+use crate::cli::label_color::LabelColor;
 use crate::cli::run_command::{ConfigureEnvOptions, RunCommand};
 use bun_collections::StringHashMap;
 use bun_core::{Global, Output};
@@ -37,6 +38,7 @@ struct ScriptConfig {
     #[allow(non_snake_case)]
     PATH: Box<[u8]>,
     elide_count: Option<usize>,
+    color: LabelColor,
 }
 
 struct ProcessInfo {
@@ -526,18 +528,20 @@ impl<'a> State<'a> {
                 Some(handle.config.elide_count.unwrap_or(10))
             };
             let e = Self::elide(&handle.buffer, elide_lines);
+            let color = handle.config.color;
 
+            color.pill(&mut self.draw_buf, &handle.config.package_name);
             write!(
                 &mut self.draw_buf,
-                fmt!("<b>{s}<r> {s} $ <d>{s}<r>\n"),
-                bstr::BStr::new(&handle.config.package_name),
+                fmt!(" {s} $ <d>{s}<r>\n"),
                 bstr::BStr::new(&handle.config.script_name),
                 bstr::BStr::new(&handle.config.script_content),
             )?;
             if e.elided_count > 0 {
+                color.gutter(&mut self.draw_buf);
                 write!(
                     &mut self.draw_buf,
-                    fmt!("<cyan>│<r> <d>[{d} lines elided]<r>\n"),
+                    fmt!("│<r> <d>[{d} lines elided]<r>\n"),
                     e.elided_count,
                 )?;
             }
@@ -545,24 +549,24 @@ impl<'a> State<'a> {
             while let Some(i) = strings::index_of_char(content, b'\n') {
                 let i = i as usize;
                 let line = &content[0..i + 1];
-                self.draw_buf
-                    .extend_from_slice(fmt!("<cyan>│<r> ").as_bytes());
+                color.gutter(&mut self.draw_buf);
+                self.draw_buf.extend_from_slice(fmt!("│<r> ").as_bytes());
                 self.draw_buf.extend_from_slice(line);
                 content = &content[i + 1..];
             }
             if !content.is_empty() {
-                self.draw_buf
-                    .extend_from_slice(fmt!("<cyan>│<r> ").as_bytes());
+                color.gutter(&mut self.draw_buf);
+                self.draw_buf.extend_from_slice(fmt!("│<r> ").as_bytes());
                 self.draw_buf.extend_from_slice(content);
                 self.draw_buf.push(b'\n');
             }
-            self.draw_buf
-                .extend_from_slice(fmt!("<cyan>└─<r> ").as_bytes());
+            color.gutter(&mut self.draw_buf);
+            self.draw_buf.extend_from_slice("└─ ".as_bytes());
             if let Some(proc) = &handle.process {
                 match &proc.status {
                     Status::Running => {
                         self.draw_buf
-                            .extend_from_slice(fmt!("<cyan>Running...<r>\n").as_bytes());
+                            .extend_from_slice(fmt!("Running...<r>\n").as_bytes());
                     }
                     Status::Exited(exited) => {
                         if exited.code == 0 {
@@ -572,48 +576,44 @@ impl<'a> State<'a> {
                                 if ms > 1000.0 {
                                     write!(
                                         &mut self.draw_buf,
-                                        fmt!("<cyan>Done in {:.2} s<r>\n"),
+                                        fmt!("Done in {:.2} s<r>\n"),
                                         ms / 1_000.0,
                                     )?;
                                 } else {
-                                    write!(
-                                        &mut self.draw_buf,
-                                        fmt!("<cyan>Done in {:.0} ms<r>\n"),
-                                        ms,
-                                    )?;
+                                    write!(&mut self.draw_buf, fmt!("Done in {:.0} ms<r>\n"), ms,)?;
                                 }
                             } else {
                                 self.draw_buf
-                                    .extend_from_slice(fmt!("<cyan>Done<r>\n").as_bytes());
+                                    .extend_from_slice(fmt!("Done<r>\n").as_bytes());
                             }
                         } else {
                             write!(
                                 &mut self.draw_buf,
-                                fmt!("<red>Exited with code {d}<r>\n"),
+                                fmt!("<r><red>Exited with code {d}<r>\n"),
                                 exited.code,
                             )?;
                         }
                     }
                     Status::Signaled(code) => {
                         if *code == bun_sys::SignalCode::SIGINT.0 {
-                            write!(&mut self.draw_buf, fmt!("<red>Interrupted<r>\n"))?;
+                            write!(&mut self.draw_buf, fmt!("<r><red>Interrupted<r>\n"))?;
                         } else {
                             write!(
                                 &mut self.draw_buf,
-                                fmt!("<red>Signaled with code {s}<r>\n"),
+                                fmt!("<r><red>Signaled with code {s}<r>\n"),
                                 bun_sys::SignalCode(*code).name().unwrap_or("UNKNOWN"),
                             )?;
                         }
                     }
                     Status::Err(_) => {
                         self.draw_buf
-                            .extend_from_slice(fmt!("<red>Error<r>\n").as_bytes());
+                            .extend_from_slice(fmt!("<r><red>Error<r>\n").as_bytes());
                     }
                 }
             } else {
                 write!(
                     &mut self.draw_buf,
-                    fmt!("<cyan><d>Waiting for {d} other script(s)<r>\n"),
+                    fmt!("<d>Waiting for {d} other script(s)<r>\n"),
                     handle.remaining_dependencies,
                 )?;
             }
@@ -884,6 +884,7 @@ pub(crate) fn run_scripts_with_filter(
                 deps,
                 PATH: Box::<[u8]>::from(&path_var[..]),
                 elide_count: ctx.bundler_options.elide_lines,
+                color: LabelColor::for_label(&package.json.name, scripts.len()),
             });
         }
     }

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -530,7 +530,7 @@ impl<'a> State<'a> {
             let e = Self::elide(&handle.buffer, elide_lines);
             let color = handle.config.color;
 
-            color.pill(&mut self.draw_buf, &handle.config.package_name);
+            color.label(&mut self.draw_buf, &handle.config.package_name);
             write!(
                 &mut self.draw_buf,
                 fmt!(" {s} $ <d>{s}<r>\n"),
@@ -902,12 +902,15 @@ pub(crate) fn run_scripts_with_filter(
         } else {
             let patterns: Vec<&[u8]> = ctx.filters.iter().map(|f| &**f).collect();
             Output::err_generic(
-                "{}",
-                (bstr::BStr::new(
-                    &bun_install::package_manager::workspace_selection::unmatched_message(
-                        &patterns,
+                "No workspace packages matching {} have script \"{}\"",
+                (
+                    bstr::BStr::new(
+                        &bun_install::package_manager::workspace_selection::quote_patterns(
+                            &patterns,
+                        ),
                     ),
-                ),),
+                    bstr::BStr::new(script_name),
+                ),
             );
         }
         Global::exit(1);

--- a/src/runtime/cli/label_color.rs
+++ b/src/runtime/cli/label_color.rs
@@ -1,0 +1,100 @@
+//! Per-package colors for `bun run --filter` / `--parallel` prefixes.
+//!
+//! On truecolor terminals the color is a pure function of the label, so a
+//! package keeps its color across runs. Hue (and a chroma tier) come from a
+//! hash; lightness/chroma are fixed in OKLCH so every hue is equally legible.
+//! The label is drawn as a pill whose foreground and background are both ours
+//! (dark shade on light tint), and the gutter uses a mid-lightness foreground,
+//! so both read on light and dark terminals. Other terminals rotate through the
+//! six basic ANSI colors by position.
+
+use std::io::Write as _;
+
+use bun_core::output::{ColorDepth, Source, ansi};
+use bun_css::values::color::{OKLCH, RGBA, SRGB};
+
+const BASIC: [&str; 6] = [
+    ansi::CYAN,
+    ansi::YELLOW,
+    ansi::MAGENTA,
+    ansi::GREEN,
+    ansi::BLUE,
+    ansi::RED,
+];
+
+#[derive(Clone, Copy)]
+pub enum LabelColor {
+    Basic(&'static str),
+    Rgb {
+        gutter: [u8; 3],
+        pill_bg: [u8; 3],
+        pill_fg: [u8; 3],
+    },
+}
+
+impl LabelColor {
+    pub fn for_label(label: &[u8], position: usize) -> LabelColor {
+        Self::for_label_at_depth(label, position, Source::color_depth())
+    }
+
+    pub fn for_label_at_depth(label: &[u8], position: usize, depth: ColorDepth) -> LabelColor {
+        if depth != ColorDepth::C16m {
+            return LabelColor::Basic(BASIC[position % BASIC.len()]);
+        }
+        let h = bun_wyhash::hash(label);
+        let hue = (h >> 32) as f32 * (360.0 / 4_294_967_296.0);
+        let chroma = if h & 1 == 0 { 0.14 } else { 0.10 };
+        LabelColor::Rgb {
+            gutter: oklch_to_srgb(0.68, chroma, hue),
+            pill_bg: oklch_to_srgb(0.86, 0.08, hue),
+            pill_fg: oklch_to_srgb(0.32, 0.09, hue),
+        }
+    }
+
+    /// SGR that colors gutter text (`│`, `|`) in the package color.
+    pub fn gutter(self, out: &mut Vec<u8>) {
+        match self {
+            LabelColor::Basic(c) => out.extend_from_slice(c.as_bytes()),
+            LabelColor::Rgb {
+                gutter: [r, g, b], ..
+            } => {
+                let _ = write!(out, "\x1b[38;2;{r};{g};{b}m");
+            }
+        }
+    }
+
+    /// Writes `label` as a colored pill (truecolor) or bold colored text.
+    pub fn pill(self, out: &mut Vec<u8>, label: &[u8]) {
+        match self {
+            LabelColor::Basic(c) => {
+                out.extend_from_slice(ansi::BOLD.as_bytes());
+                out.extend_from_slice(c.as_bytes());
+                out.extend_from_slice(label);
+                out.extend_from_slice(ansi::RESET.as_bytes());
+            }
+            LabelColor::Rgb {
+                pill_bg: [br, bg, bb],
+                pill_fg: [fr, fg, fb],
+                ..
+            } => {
+                let _ = write!(
+                    out,
+                    "\x1b[48;2;{br};{bg};{bb}m\x1b[38;2;{fr};{fg};{fb}m\x1b[1m "
+                );
+                out.extend_from_slice(label);
+                out.extend_from_slice(b" ");
+                out.extend_from_slice(ansi::RESET.as_bytes());
+            }
+        }
+    }
+}
+
+fn oklch_to_srgb(l: f32, c: f32, h: f32) -> [u8; 3] {
+    let rgb = RGBA::from(SRGB::from(OKLCH {
+        l,
+        c,
+        h,
+        alpha: 1.0,
+    }));
+    [rgb.red, rgb.green, rgb.blue]
+}

--- a/src/runtime/cli/label_color.rs
+++ b/src/runtime/cli/label_color.rs
@@ -1,12 +1,11 @@
 //! Per-package colors for `bun run --filter` / `--parallel` prefixes.
 //!
 //! On truecolor terminals the color is a pure function of the label, so a
-//! package keeps its color across runs. Hue (and a chroma tier) come from a
-//! hash; lightness/chroma are fixed in OKLCH so every hue is equally legible.
-//! The label is drawn as a pill whose foreground and background are both ours
-//! (dark shade on light tint), and the gutter uses a mid-lightness foreground,
-//! so both read on light and dark terminals. Other terminals rotate through the
-//! six basic ANSI colors by position.
+//! package keeps its color across runs: a hash picks the hue, drawn at a fixed
+//! OKLCH lightness that reads on light and dark backgrounds with as much chroma
+//! as sRGB has at that hue (CSS gamut mapping trims the excess). The
+//! mustard/olive hues are skipped. Other terminals rotate through the six basic
+//! ANSI colors by position.
 
 use std::io::Write as _;
 
@@ -22,14 +21,16 @@ const BASIC: [&str; 6] = [
     ansi::RED,
 ];
 
+const LIGHTNESS: f32 = 0.72;
+const CHROMA: f32 = 0.2;
+/// OKLCH hues in `[SKIP_FROM, SKIP_TO)` come out mustard/olive at this lightness.
+const SKIP_FROM: f32 = 70.0;
+const SKIP_TO: f32 = 128.0;
+
 #[derive(Clone, Copy)]
 pub enum LabelColor {
     Basic(&'static str),
-    Rgb {
-        gutter: [u8; 3],
-        pill_bg: [u8; 3],
-        pill_fg: [u8; 3],
-    },
+    Rgb([u8; 3]),
 }
 
 impl LabelColor {
@@ -41,60 +42,35 @@ impl LabelColor {
         if depth != ColorDepth::C16m {
             return LabelColor::Basic(BASIC[position % BASIC.len()]);
         }
-        let h = bun_wyhash::hash(label);
-        let hue = (h >> 32) as f32 * (360.0 / 4_294_967_296.0);
-        let chroma = if h & 1 == 0 { 0.14 } else { 0.10 };
-        LabelColor::Rgb {
-            gutter: oklch_to_srgb(0.68, chroma, hue),
-            pill_bg: oklch_to_srgb(0.86, 0.08, hue),
-            pill_fg: oklch_to_srgb(0.32, 0.09, hue),
+        let unit = (bun_wyhash::hash(label) >> 40) as f32 / (1u32 << 24) as f32;
+        let mut h = unit * (360.0 - (SKIP_TO - SKIP_FROM));
+        if h >= SKIP_FROM {
+            h += SKIP_TO - SKIP_FROM;
         }
+        let rgb = RGBA::from(SRGB::from(OKLCH {
+            l: LIGHTNESS,
+            c: CHROMA,
+            h,
+            alpha: 1.0,
+        }));
+        LabelColor::Rgb([rgb.red, rgb.green, rgb.blue])
     }
 
     /// SGR that colors gutter text (`│`, `|`) in the package color.
     pub fn gutter(self, out: &mut Vec<u8>) {
         match self {
             LabelColor::Basic(c) => out.extend_from_slice(c.as_bytes()),
-            LabelColor::Rgb {
-                gutter: [r, g, b], ..
-            } => {
+            LabelColor::Rgb([r, g, b]) => {
                 let _ = write!(out, "\x1b[38;2;{r};{g};{b}m");
             }
         }
     }
 
-    /// Writes `label` as a colored pill (truecolor) or bold colored text.
-    pub fn pill(self, out: &mut Vec<u8>, label: &[u8]) {
-        match self {
-            LabelColor::Basic(c) => {
-                out.extend_from_slice(ansi::BOLD.as_bytes());
-                out.extend_from_slice(c.as_bytes());
-                out.extend_from_slice(label);
-                out.extend_from_slice(ansi::RESET.as_bytes());
-            }
-            LabelColor::Rgb {
-                pill_bg: [br, bg, bb],
-                pill_fg: [fr, fg, fb],
-                ..
-            } => {
-                let _ = write!(
-                    out,
-                    "\x1b[48;2;{br};{bg};{bb}m\x1b[38;2;{fr};{fg};{fb}m\x1b[1m "
-                );
-                out.extend_from_slice(label);
-                out.extend_from_slice(b" ");
-                out.extend_from_slice(ansi::RESET.as_bytes());
-            }
-        }
+    /// Writes `label` in bold package color.
+    pub fn label(self, out: &mut Vec<u8>, label: &[u8]) {
+        out.extend_from_slice(ansi::BOLD.as_bytes());
+        self.gutter(out);
+        out.extend_from_slice(label);
+        out.extend_from_slice(ansi::RESET.as_bytes());
     }
-}
-
-fn oklch_to_srgb(l: f32, c: f32, h: f32) -> [u8; 3] {
-    let rgb = RGBA::from(SRGB::from(OKLCH {
-        l,
-        c,
-        h,
-        alpha: 1.0,
-    }));
-    [rgb.red, rgb.green, rgb.blue]
 }

--- a/src/runtime/cli/label_color.rs
+++ b/src/runtime/cli/label_color.rs
@@ -2,8 +2,8 @@
 //!
 //! On truecolor terminals the color is a pure function of the label, so a
 //! package keeps its color across runs: a hash picks the hue, drawn at a fixed
-//! OKLCH lightness that reads on light and dark backgrounds with as much chroma
-//! as sRGB has at that hue (CSS gamut mapping trims the excess). The
+//! OKLCH lightness that reads on light and dark backgrounds, asking for more
+//! chroma than sRGB has so each hue comes out as saturated as it can. The
 //! mustard/olive hues are skipped. Other terminals rotate through the six basic
 //! ANSI colors by position.
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -342,6 +342,7 @@ pub(crate) mod dedupe_command;
 pub mod filter_arg;
 #[path = "filter_run.rs"]
 pub mod filter_run;
+pub mod label_color;
 #[path = "link_command.rs"]
 pub mod link_command;
 #[path = "multi_run.rs"]

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use crate::Error;
+use crate::cli::label_color::LabelColor;
 use bun_collections::{StringArrayHashMap, VecExt};
 use bun_core::strings;
 use bun_core::{self as bun, Global, Output, UnwrapOrOom};
@@ -39,6 +40,9 @@ type OwnedScriptsMap = StringArrayHashMap<Box<[u8]>>;
 
 struct ScriptConfig {
     label: Box<[u8]>,
+    /// `label[..color_key_len]` is hashed for the color: the package name when
+    /// there is one, so a package matches its `--filter` color.
+    color_key_len: usize,
     command: Box<[u8]>,
     cwd: Box<[u8]>,
     /// PATH env var value for this script
@@ -113,7 +117,8 @@ struct ProcessSlot {
 pub(crate) struct ProcessHandle<'a> {
     config: &'a ScriptConfig,
     state: *const State<'a>,
-    color_idx: usize,
+    /// `label<pad> | `, colored once up front; written before every line.
+    prefix: Box<[u8]>,
 
     stdout_reader: PipeReader<'a>,
     stderr_reader: PipeReader<'a>,
@@ -330,16 +335,29 @@ bun_spawn::link_impl_ProcessExit! {
     }
 }
 
-use bun_core::output::ansi;
-const COLORS: [&[u8]; 6] = [
-    ansi::CYAN.as_bytes(),
-    ansi::YELLOW.as_bytes(),
-    ansi::MAGENTA.as_bytes(),
-    ansi::GREEN.as_bytes(),
-    ansi::BLUE.as_bytes(),
-    ansi::RED.as_bytes(),
-];
-const RESET: &[u8] = ansi::RESET.as_bytes();
+fn line_prefix(
+    config: &ScriptConfig,
+    max_label_len: usize,
+    position: usize,
+    use_colors: bool,
+) -> Box<[u8]> {
+    let padding = max_label_len.saturating_sub(config.label.len());
+    let mut buf: Vec<u8> = Vec::with_capacity(config.label.len() + padding + 48);
+    if use_colors {
+        let color = LabelColor::for_label(&config.label[..config.color_key_len], position);
+        color.pill(&mut buf, &config.label);
+        buf.extend(core::iter::repeat_n(b' ', padding + 1));
+        color.gutter(&mut buf);
+        buf.push(b'|');
+        buf.extend_from_slice(bun_core::output::ansi::RESET.as_bytes());
+        buf.push(b' ');
+    } else {
+        buf.extend_from_slice(&config.label);
+        buf.extend(core::iter::repeat_n(b' ', padding));
+        buf.extend_from_slice(b" | ");
+    }
+    buf.into_boxed_slice()
+}
 
 struct State<'a> {
     handles: Box<[ProcessHandle<'a>]>,
@@ -348,13 +366,11 @@ struct State<'a> {
     /// (`bun_io::EventLoopHandle` wraps `*const EventLoopHandle`).
     event_loop_handle: EventLoopHandle,
     remaining_scripts: usize,
-    max_label_len: usize,
     // NUL-terminated (last byte is 0) for argv[0].
     shell_bin: Box<[u8]>,
     aborted: bool,
     no_exit_on_error: bool,
     env: *mut DotEnvLoader,
-    use_colors: bool,
 }
 
 impl<'a> State<'a> {
@@ -396,21 +412,7 @@ impl<'a> State<'a> {
     }
 
     fn write_prefix(&self, handle: &ProcessHandle, writer: &mut OutputWriter) -> Result<(), Error> {
-        if self.use_colors {
-            writer.write_all(COLORS[handle.color_idx % COLORS.len()])?;
-        }
-
-        writer.write_all(&handle.config.label)?;
-        let padding = self.max_label_len.saturating_sub(handle.config.label.len());
-        for _ in 0..padding {
-            writer.write_all(b" ")?;
-        }
-
-        if self.use_colors {
-            writer.write_all(RESET)?;
-        }
-
-        writer.write_all(b" | ")?;
+        writer.write_all(&handle.prefix)?;
         Ok(())
     }
 
@@ -456,7 +458,7 @@ impl<'a> State<'a> {
         // raw-ptr-based throughout this file).
         let handle_ptr = std::ptr::from_mut::<ProcessHandle>(handle);
         // SAFETY: handle_ptr is live for this call; flush_pipe_buffer reads only
-        // `config`/`color_idx` from `handle` and writes only `pipe.line_buffer`.
+        // `config`/`color` from `handle` and writes only `pipe.line_buffer`.
         unsafe {
             self.flush_pipe_buffer(&*handle_ptr, &mut (*handle_ptr).stdout_reader)?;
             self.flush_pipe_buffer(&*handle_ptr, &mut (*handle_ptr).stderr_reader)?;
@@ -736,6 +738,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
     } else {
         Box::from(raw_name)
     };
+    let color_key_len = label_prefix.map_or(label.len(), |p| p.len());
 
     let script_content = scripts_map.and_then(|sm| sm.get(raw_name));
 
@@ -763,6 +766,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
             cmd_buf.push(0);
             configs.push(ScriptConfig {
                 label: label.clone(),
+                color_key_len,
                 command: cmd_buf.into_boxed_slice(),
                 cwd: Box::from(cwd),
                 path: Box::from(path),
@@ -776,6 +780,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
             cmd_buf.push(0);
             configs.push(ScriptConfig {
                 label: label.clone(),
+                color_key_len,
                 command: cmd_buf.into_boxed_slice(),
                 cwd: Box::from(cwd),
                 path: Box::from(path),
@@ -788,6 +793,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
             cmd_buf.push(0);
             configs.push(ScriptConfig {
                 label,
+                color_key_len,
                 command: cmd_buf.into_boxed_slice(),
                 cwd: Box::from(cwd),
                 path: Box::from(path),
@@ -821,6 +827,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
         };
         configs.push(ScriptConfig {
             label,
+            color_key_len,
             command: command_z,
             cwd: Box::from(cwd),
             path: Box::from(path),
@@ -1154,12 +1161,10 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         event_loop,
         event_loop_handle: EventLoopHandle::init_mini(event_loop),
         remaining_scripts: 0,
-        max_label_len,
         shell_bin,
         aborted: false,
         no_exit_on_error: ctx.no_exit_on_error,
         env: env_ptr,
-        use_colors,
     };
 
     // Initialize handles
@@ -1177,7 +1182,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         handles.push(ProcessHandle {
             state: &raw const state,
             config,
-            color_idx,
+            prefix: line_prefix(config, max_label_len, color_idx, use_colors),
             stdout_reader: PipeReader::new(false),
             stderr_reader: PipeReader::new(true),
             process: None,

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -345,7 +345,7 @@ fn line_prefix(
     let mut buf: Vec<u8> = Vec::with_capacity(config.label.len() + padding + 48);
     if use_colors {
         let color = LabelColor::for_label(&config.label[..config.color_key_len], position);
-        color.pill(&mut buf, &config.label);
+        color.label(&mut buf, &config.label);
         buf.extend(core::iter::repeat_n(b' ', padding + 1));
         color.gutter(&mut buf);
         buf.push(b'|');
@@ -1053,11 +1053,13 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 );
             } else {
                 let patterns: Vec<&[u8]> = ctx.filters.iter().map(|f| &**f).collect();
+                let names: Vec<&[u8]> = script_names.iter().map(|n| &**n).collect();
                 Output::err_generic(
-                    "{}",
-                    (bstr::BStr::new(&workspace_selection::unmatched_message(
-                        &patterns,
-                    )),),
+                    "No workspace packages matching {} have script {}",
+                    (
+                        bstr::BStr::new(&workspace_selection::quote_patterns(&patterns)),
+                        bstr::BStr::new(&workspace_selection::quote_patterns(&names)),
+                    ),
                 );
             }
             Global::exit(1);

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -458,7 +458,7 @@ impl<'a> State<'a> {
         // raw-ptr-based throughout this file).
         let handle_ptr = std::ptr::from_mut::<ProcessHandle>(handle);
         // SAFETY: handle_ptr is live for this call; flush_pipe_buffer reads only
-        // `config`/`color` from `handle` and writes only `pipe.line_buffer`.
+        // `prefix` from `handle` and writes only `pipe.line_buffer`.
         unsafe {
             self.flush_pipe_buffer(&*handle_ptr, &mut (*handle_ptr).stdout_reader)?;
             self.flush_pipe_buffer(&*handle_ptr, &mut (*handle_ptr).stderr_reader)?;

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -481,7 +481,12 @@ describe("bun", () => {
     runInCwdFailure(cwd_root, "*", "notpresent", /error: No workspace packages matching "\*" have script "notpresent"/);
   });
   test("should error when the filter matches no package", () => {
-    runInCwdFailure(cwd_root, "nosuchpkg", "present", /error: No workspace packages matched the filter "nosuchpkg"\n(?![^]*nosuchpkg)/);
+    runInCwdFailure(
+      cwd_root,
+      "nosuchpkg",
+      "present",
+      /error: No workspace packages matched the filter "nosuchpkg"\n(?![^]*nosuchpkg)/,
+    );
   });
   test("warns about a filter that matched nothing while running the others", () => {
     const { exitCode, stdout, stderr } = spawnSync({

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -540,7 +540,7 @@ describe("bun", () => {
     target_pattern,
     antipattern,
   }: {
-    elideLines: number;
+    elideLines?: number;
     target_pattern: RegExp[];
     antipattern?: RegExp[];
   }) {
@@ -574,7 +574,14 @@ describe("bun", () => {
       // code path.
       const { exitCode, stderr, stdout } = spawnSync({
         cwd: dir,
-        cmd: [bunExe(), "run", "--filter", "./packages/dep0", "--elide-lines", String(elideLines), "script"],
+        cmd: [
+          bunExe(),
+          "run",
+          "--filter",
+          "./packages/dep0",
+          ...(elideLines === undefined ? [] : ["--elide-lines", String(elideLines)]),
+          "script",
+        ],
         env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: "0" },
         stdout: "pipe",
         stderr: "pipe",
@@ -603,10 +610,10 @@ describe("bun", () => {
     });
   }
 
-  test("elides output by default when using --filter", () => {
+  test("does not elide output by default when using --filter", () => {
     runElideLinesTest({
-      elideLines: 10,
-      target_pattern: [/\[10 lines elided\]/, /(?:log_line[\s\S]*?){20}/],
+      target_pattern: [/(?:log_line[\s\S]*?){20}/],
+      antipattern: [/lines elided/],
     });
   });
 
@@ -657,6 +664,50 @@ describe("bun", () => {
   });
 
   // The terminal renderer is TTY-only on Windows (see runElideLinesTest).
+  test.skipIf(isWindows)("terminal renderer redraws a bounded region and appends finished output once", () => {
+    const lines = 200;
+    using dir = tempDir("filter-live-region", {
+      packages: {
+        chatty: {
+          "chatty.js": `for (let i = 1; i <= ${lines}; i++) console.log("chatty line " + i);`,
+          "package.json": JSON.stringify({ name: "chatty", scripts: { go: `${bunExe()} chatty.js` } }),
+        },
+        after: {
+          "package.json": JSON.stringify({
+            name: "after",
+            dependencies: { chatty: "workspace:*" },
+            scripts: { go: "echo after-ran" },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    });
+    const { exitCode, stdout } = spawnSync({
+      cwd: String(dir),
+      cmd: [bunExe(), "run", "--filter", "*", "go"],
+      env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const out = stdout.toString();
+    const frames = out.split("\x1b[?2026h").slice(1);
+    expect(frames.length).toBeGreaterThan(1);
+    // No frame ever moves the cursor up more than the live-region cap, however much output there is.
+    for (const frame of frames) {
+      expect(frame.split("\x1b[1A").length - 1).toBeLessThanOrEqual(50);
+    }
+    // `chatty` finishes first and is flushed above the live region exactly once, in full;
+    // `after` (which waited on it) is flushed later, so completion order = output order.
+    const text = Bun.stripANSI(out);
+    const finalHeader = text.lastIndexOf("chatty go $");
+    const flushed = text.slice(finalHeader);
+    for (let i = 1; i <= lines; i++) expect(flushed).toContain(`│ chatty line ${i}\n`);
+    expect(flushed.indexOf("chatty line 1\n")).toBeLessThan(flushed.indexOf("after go $"));
+    expect(flushed).toMatch(/after go \$ echo after-ran  \[\d+ ms\]\n│ after-ran/);
+    expect(text.slice(0, finalHeader)).toContain("after go $ echo after-ran  [waiting]");
+    expect(exitCode).toBe(0);
+  });
+
   test.skipIf(isWindows)("terminal output reports how long a successful script took", () => {
     using dir = tempDir("filter-done-in", {
       packages: {
@@ -675,7 +726,9 @@ describe("bun", () => {
       stderr: "pipe",
     });
 
-    expect(stdout.toString()).toMatch(/Done in (?:\d+ ms|\d+\.\d{2} s)/);
+    expect(stdout.toString()).toMatch(
+      /dep0\x1b\[0m script \x1b\[2m\$ exit 0\x1b\[0m  \x1b\[2m\[(?:\d+ ms|\d+\.\d{2} s)\]/,
+    );
     expect(exitCode).toBe(0);
   });
 
@@ -1271,21 +1324,21 @@ describe("auto-discovered bunfig.toml [run] section", () => {
 
   // Elision only happens on a terminal. On POSIX FORCE_COLOR=1 turns the
   // terminal renderer on for a pipe; on Windows it stays off (see runElideLinesTest).
-  test.skipIf(isWindows)("[run] elide-lines = 0 disables elision for --filter", () => {
-    using dir = workspace("filter-bunfig-elide", "[run]\nelide-lines = 0\n");
+  test.skipIf(isWindows)("[run] elide-lines enables elision for --filter", () => {
+    using dir = workspace("filter-bunfig-elide", "[run]\nelide-lines = 15\n");
     const r = run(String(dir), ["run", "--filter", "dep0", "lines"], { FORCE_COLOR: "1", NO_COLOR: "0" });
-    expect(r.stdout).not.toMatch(/lines elided/);
-    expect(r.stdout).toMatch(/(?:log_line[\s\S]*?){20}/);
+    expect(r.stdout).toMatch(/\[5 lines elided\]/);
     expect(r.exitCode).toBe(0);
   });
 
   test.skipIf(isWindows)("--elide-lines on the CLI wins over [run] elide-lines", () => {
-    using dir = workspace("filter-bunfig-cli-elide", "[run]\nelide-lines = 0\n");
-    const r = run(String(dir), ["run", "--elide-lines", "15", "--filter", "dep0", "lines"], {
+    using dir = workspace("filter-bunfig-cli-elide", "[run]\nelide-lines = 15\n");
+    const r = run(String(dir), ["run", "--elide-lines", "0", "--filter", "dep0", "lines"], {
       FORCE_COLOR: "1",
       NO_COLOR: "0",
     });
-    expect(r.stdout).toMatch(/\[5 lines elided\]/);
+    expect(r.stdout).not.toMatch(/lines elided/);
+    expect(r.stdout).toMatch(/(?:log_line[\s\S]*?){20}/);
     expect(r.exitCode).toBe(0);
   });
 

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -478,7 +478,10 @@ describe("bun", () => {
   });
 
   test("should error with missing script", () => {
-    runInCwdFailure(cwd_root, "*", "notpresent", /error: No workspace packages matched the filter "\*"/);
+    runInCwdFailure(cwd_root, "*", "notpresent", /error: No workspace packages matching "\*" have script "notpresent"/);
+  });
+  test("should error when the filter matches no package", () => {
+    runInCwdFailure(cwd_root, "nosuchpkg", "present", /error: No workspace packages matched the filter "nosuchpkg"\n(?![^]*nosuchpkg)/);
   });
   test("warns about a filter that matched nothing while running the others", () => {
     const { exitCode, stdout, stderr } = spawnSync({

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1751,13 +1751,67 @@ describe.concurrent("color cycling", () => {
     // All tasks should produce prefixed output (check Done lines in stderr since they're unique to multi-run)
     // ANSI color codes wrap the label, so match optionally around the label name
     for (let i = 0; i < 7; i++) {
-      expect(stderr).toMatch(new RegExp(`task${i}[^\n]*\\| Done`));
+      expect(Bun.stripANSI(stderr)).toMatch(new RegExp(`task${i}[^\n]*\\| Done`));
     }
     // Stdout should also have prefixed content
     for (let i = 0; i < 7; i++) {
-      expect(stdout).toMatch(new RegExp(`task${i}[^\n]*\\| t${i}`));
+      expect(Bun.stripANSI(stdout)).toMatch(new RegExp(`task${i}[^\n]*\\| t${i}`));
     }
+    // 16-color terminals rotate the six basic colors by position, so the 7th wraps to the 1st.
+    const colorOf = (i: number) => stdout.match(new RegExp(`(\x1b\\[3\\dm)task${i}\x1b`))?.[1];
+    expect(colorOf(0)).toBe("\x1b[36m");
+    expect(colorOf(1)).not.toBe(colorOf(0));
+    expect(colorOf(6)).toBe(colorOf(0));
     expect(exitCode).toBe(0);
+  });
+
+  /** `label` → the SGR run that paints its pill, from truecolor output. */
+  function pillOf(output: string, label: string) {
+    const m = output.match(
+      new RegExp(`(\x1b\\[48;2;[\\d;]+m\x1b\\[38;2;[\\d;]+m)\x1b\\[1m ${escapeRe(label)} \x1b\\[0m`),
+    );
+    return m?.[1];
+  }
+
+  test("truecolor terminals get a stable per-package color with its own background", async () => {
+    using dir = makeWorkspace("mr-color-24bit", {
+      "pkg-a": { build: `echo a`, lint: `echo a` },
+      "pkg-b": { build: `echo b`, lint: `echo b` },
+    });
+    const env = { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "3" };
+    const run = async (...args: string[]) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", ...args],
+        env,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      return { stdout, exitCode };
+    };
+
+    const { stdout: build, exitCode: buildExit } = await run("--parallel", "--filter", "*", "build");
+    const { stdout: lint, exitCode: lintExit } = await run("--parallel", "--filter", "*", "lint");
+    const a = pillOf(build, "pkg-a:build");
+    const b = pillOf(build, "pkg-b:build");
+    // Both foreground and background are set, so the label reads on any terminal theme.
+    expect(a).toMatch(/^\x1b\[48;2;\d+;\d+;\d+m\x1b\[38;2;\d+;\d+;\d+m$/);
+    expect(b).toMatch(/^\x1b\[48;2;\d+;\d+;\d+m\x1b\[38;2;\d+;\d+;\d+m$/);
+    expect(a).not.toBe(b);
+    // The color is a function of the package name, not the script or position.
+    expect(pillOf(lint, "pkg-a:lint")).toBe(a);
+    expect(pillOf(lint, "pkg-b:lint")).toBe(b);
+    expect(buildExit).toBe(0);
+    expect(lintExit).toBe(0);
+    // ...and `--filter` without `--parallel` paints the same package the same color.
+    // (Windows only draws the `--filter` UI on a real console; see filter-workspace.test.ts.)
+    if (!isWindows) {
+      const { stdout: filter, exitCode } = await run("--filter", "*", "build");
+      expect(pillOf(filter, "pkg-a")).toBe(a);
+      expect(pillOf(filter, "pkg-b")).toBe(b);
+      expect(exitCode).toBe(0);
+    }
   });
 });
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1785,7 +1785,7 @@ describe.concurrent("color cycling", () => {
         stderr: "pipe",
         stdout: "pipe",
       });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       return { stdout, exitCode };
     };
 
@@ -1801,16 +1801,16 @@ describe.concurrent("color cycling", () => {
     // The color is a function of the package name, not the script or position.
     expect(colorOfLabel(lint, "pkg-a:lint")).toBe(a);
     expect(colorOfLabel(lint, "pkg-b:lint")).toBe(b);
-    expect(buildExit).toBe(0);
-    expect(lintExit).toBe(0);
     // ...and `--filter` without `--parallel` paints the same package the same color.
     // (Windows only draws the `--filter` UI on a real console; see filter-workspace.test.ts.)
-    if (!isWindows) {
-      const { stdout: filter, exitCode } = await run("--filter", "*", "build");
-      expect(colorOfLabel(filter, "pkg-a")).toBe(a);
-      expect(colorOfLabel(filter, "pkg-b")).toBe(b);
-      expect(exitCode).toBe(0);
+    const filter = isWindows ? undefined : await run("--filter", "*", "build");
+    if (filter) {
+      expect(colorOfLabel(filter.stdout, "pkg-a")).toBe(a);
+      expect(colorOfLabel(filter.stdout, "pkg-b")).toBe(b);
     }
+    expect(buildExit).toBe(0);
+    expect(lintExit).toBe(0);
+    if (filter) expect(filter.exitCode).toBe(0);
   });
 });
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1765,15 +1765,13 @@ describe.concurrent("color cycling", () => {
     expect(exitCode).toBe(0);
   });
 
-  /** `label` → the SGR run that paints its pill, from truecolor output. */
-  function pillOf(output: string, label: string) {
-    const m = output.match(
-      new RegExp(`(\x1b\\[48;2;[\\d;]+m\x1b\\[38;2;[\\d;]+m)\x1b\\[1m ${escapeRe(label)} \x1b\\[0m`),
-    );
+  /** `label` → the truecolor SGR that paints it. */
+  function colorOfLabel(output: string, label: string) {
+    const m = output.match(new RegExp(`\x1b\\[1m(\x1b\\[38;2;[\\d;]+m)${escapeRe(label)}\x1b\\[0m`));
     return m?.[1];
   }
 
-  test("truecolor terminals get a stable per-package color with its own background", async () => {
+  test("truecolor terminals get a stable per-package color", async () => {
     using dir = makeWorkspace("mr-color-24bit", {
       "pkg-a": { build: `echo a`, lint: `echo a` },
       "pkg-b": { build: `echo b`, lint: `echo b` },
@@ -1793,23 +1791,24 @@ describe.concurrent("color cycling", () => {
 
     const { stdout: build, exitCode: buildExit } = await run("--parallel", "--filter", "*", "build");
     const { stdout: lint, exitCode: lintExit } = await run("--parallel", "--filter", "*", "lint");
-    const a = pillOf(build, "pkg-a:build");
-    const b = pillOf(build, "pkg-b:build");
-    // Both foreground and background are set, so the label reads on any terminal theme.
-    expect(a).toMatch(/^\x1b\[48;2;\d+;\d+;\d+m\x1b\[38;2;\d+;\d+;\d+m$/);
-    expect(b).toMatch(/^\x1b\[48;2;\d+;\d+;\d+m\x1b\[38;2;\d+;\d+;\d+m$/);
+    const a = colorOfLabel(build, "pkg-a:build");
+    const b = colorOfLabel(build, "pkg-b:build");
+    expect(a).toMatch(/^\x1b\[38;2;\d+;\d+;\d+m$/);
+    expect(b).toMatch(/^\x1b\[38;2;\d+;\d+;\d+m$/);
     expect(a).not.toBe(b);
+    // The gutter is painted the same color as its label.
+    expect(build).toContain(`${a}|\x1b[0m a`);
     // The color is a function of the package name, not the script or position.
-    expect(pillOf(lint, "pkg-a:lint")).toBe(a);
-    expect(pillOf(lint, "pkg-b:lint")).toBe(b);
+    expect(colorOfLabel(lint, "pkg-a:lint")).toBe(a);
+    expect(colorOfLabel(lint, "pkg-b:lint")).toBe(b);
     expect(buildExit).toBe(0);
     expect(lintExit).toBe(0);
     // ...and `--filter` without `--parallel` paints the same package the same color.
     // (Windows only draws the `--filter` UI on a real console; see filter-workspace.test.ts.)
     if (!isWindows) {
       const { stdout: filter, exitCode } = await run("--filter", "*", "build");
-      expect(pillOf(filter, "pkg-a")).toBe(a);
-      expect(pillOf(filter, "pkg-b")).toBe(b);
+      expect(colorOfLabel(filter, "pkg-a")).toBe(a);
+      expect(colorOfLabel(filter, "pkg-b")).toBe(b);
       expect(exitCode).toBe(0);
     }
   });
@@ -1966,6 +1965,21 @@ describe("workspace integration", () => {
     expectPrefixed(r.stdout, "pkg-b:build", "b-built");
     expectPrefixed(r.stdout, "pkg-c:build", "c-built");
     expect(r.exitCode).toBe(0);
+  });
+
+  test("--parallel --filter distinguishes an unmatched filter from a missing script", async () => {
+    using dir = makeWorkspace("mr-ws-missing", {
+      "pkg-a": { build: `echo a` },
+    });
+    const noPkg = await runMulti(["run", "--parallel", "--filter", "nope", "build"], String(dir));
+    expect(noPkg.stderr.trim()).toBe(`error: No workspace packages matched the filter "nope"`);
+    expect(noPkg.exitCode).toBe(1);
+    const negated = await runMulti(["run", "--parallel", "--filter", "*", "--filter", "!*", "build"], String(dir));
+    expect(negated.stderr.trim()).toBe(`error: No workspace packages matched the filters "*", "!*"`);
+    expect(negated.exitCode).toBe(1);
+    const noScript = await runMulti(["run", "--parallel", "--filter", "pkg-a", "lint", "test"], String(dir));
+    expect(noScript.stderr.trim()).toBe(`error: No workspace packages matching "pkg-a" have script "lint", "test"`);
+    expect(noScript.exitCode).toBe(1);
   });
 
   test("--parallel --filter='pkg-a' runs only in matching package", async () => {


### PR DESCRIPTION
### What does this PR do?

Reworks the terminal UI of `bun run --filter` (and the label colors shared with `--parallel`/`--sequential`).

**Append-only renderer with a bounded live region.** Previously every output chunk erased and re-rendered every script's block, which is why `--elide-lines` defaulted to 10 — without it the redraw grew without bound and couldn't reach lines that had scrolled off-screen. Now:

- A finished script is written **once**, in completion order, with its full output (or the last `--elide-lines N` lines) and is never touched again.
- Below that, only the **running** scripts (header + the tail of their output, budget split between them) and the **waiting** ones are erased and redrawn, capped at `min(50, terminal rows − 1)` lines, with auto-wrap disabled inside the region so the cursor math is exact.
- Status lives on the header line — `pkg script $ cmd  [12 ms]` / `[exit 1]` / `…` / `[waiting]` — instead of a `└─ Done in …` footer, so each script costs one line plus its output.
- `--elide-lines` therefore defaults to `0` (help/docs/completions updated); it now only trims the flushed block.

```
cli build $ true  [2 ms]                                  ← flushed, permanent
ui build $ … exit 3  … (19 lines)                         ← live: running, tail shown
│ ui line 17
│ ui line 18
│ ui line 19
docs build $ …; echo done docs  … (200 lines)
│ docs line 198
│ docs line 199
│ docs line 200
web prebuild $ echo pre  [waiting]
api prebuild $ echo pre  [waiting]
```

**Stable per-package colors.** On truecolor terminals (`Output`'s `ColorDepth::C16m` detection) the label/gutter color is a pure function of the package name: `wyhash(name)` → OKLCH hue (mustard/olive band skipped) at fixed lightness with chroma pushed to the sRGB edge, so every result is a vivid coral/orange/green/teal/sky/violet/pink that reads on light and dark backgrounds, and a package keeps its color across runs and between `--filter` and `--parallel`. Other terminals keep the six-color rotation (now per package, so pre/main/post share a color). `--parallel` builds each prefix once instead of per line.

**Error message.** `bun run --filter <pkg> <missing>` said `No workspace packages matched the filter "<pkg>"` even when it matched; it now says `No workspace packages matching "<pkg>" have script "<missing>"`, and a truly unmatched filter errors once instead of warn + error. Unnamed packages fall back to their relative path in `--filter` output, as `--parallel` already did.

Follow-up to #41323 (elide default); draft until that lands.

### How did you verify your code works?

- `test/cli/run/filter-workspace.test.ts`: new test drives a 200-line script plus a dependent under the terminal renderer and asserts no frame moves the cursor up more than the cap, the finished block appears once with all 200 lines, completion order = output order, and the dependent shows `[waiting]` before it runs; header/status format; elide default/override; missing-script vs unmatched-filter messages.
- `test/cli/run/multi-run.test.ts`: truecolor color is 24-bit, stable per package across scripts and between `--parallel --filter` and `--filter`, gutter matches label; 16-color rotation wraps; unmatched/negated filter vs missing script messages.
- `bun bd test test/cli/run/{filter-workspace,multi-run,workspaces,no-orphans}.test.ts` — all pass; new tests fail with `USE_SYSTEM_BUN=1`.
- Drove the debug binary in a 30×100 pty (`script` + `stty rows 30`) with a 200-line script, a failing 30-line script and dependents, replayed the byte stream through a terminal emulator: max cursor-up per frame was 29, final scrollback contained every line exactly once.
- `bun scripts/rust-check-all.ts x86_64-pc-windows-msvc` compiles.