### PR TITLE
build: bundle the bake runtimes with esbuild

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -238,10 +238,9 @@ export interface CodegenOutputs {
    * ALL cpp-relevant codegen outputs — the union of cppHeaders, cppSources,
    * bindgenV2Cpp. cxx compilation order-depends on THIS (not `all`): cxx
    * doesn't need bake.*.js, runtime.out.js, or any other rust-side embedded
-   * outputs. Using `all` would pull bake-codegen in cpp-only CI mode, which
-   * fails on old CI bun versions (bake-codegen shells out to `bun build`
-   * whose CSS url() handling changed between versions). cmake only wired
-   * bake outputs into BUN_ZIG_GENERATED_SOURCES, never C++ deps — same here.
+   * outputs. Using `all` would pull bake-codegen into cpp-only CI mode for
+   * no reason. cmake only wired bake outputs into BUN_ZIG_GENERATED_SOURCES,
+   * never C++ deps — same here.
    *
    * The "undeclared .h files" issue (some scripts emit .h alongside their
    * declared outputs): those steps also emit a .cpp or .h that IS declared
@@ -848,15 +847,17 @@ function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
     resolve(cfg.codegenDir, "bake.error.js"),
   ];
 
+  // The script bundles with the esbuild package from the root install.
   n.build({
     outputs,
-    rule: "codegen_bun",
+    rule: "codegen",
     inputs: [script, ...sources.bakeRuntime],
+    implicitInputs: [o.rootInstall],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,
       desc: "bake.{client,server,error}.js",
-      args: shJoin(cfg, ["run", script, debugFlag(cfg), `--codegen-root=${cfg.codegenDir}`]),
+      args: shJoin(cfg, [script, debugFlag(cfg), `--codegen-root=${cfg.codegenDir}`]),
     },
   });
 

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -1,7 +1,8 @@
+import * as esbuild from "esbuild";
 import assert from "node:assert";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
-import { argParse, writeIfNotChanged } from "./helpers";
+import { argParse, writeIfNotChanged } from "./helpers.ts";
 
 // arg parsing
 let { "codegen-root": codegenRoot, debug, ...rest } = argParse(["codegen-root", "debug"]);
@@ -34,13 +35,17 @@ function convertRustEnum(rust: string, names: string[]) {
 }
 
 function css(file: string, is_development: boolean): string {
-  const { success, stdout, stderr } = Bun.spawnSync({
-    cmd: [process.execPath, "build", file, "--minify"],
-    cwd: import.meta.dir,
-    stdio: ["ignore", "pipe", "pipe"],
+  const result = esbuild.buildSync({
+    entryPoints: [file],
+    bundle: true,
+    minify: true,
+    write: false,
+    loader: { ".css": "css", ".svg": "dataurl" },
+    logLevel: "warning",
+    absWorkingDir: import.meta.dirname,
   });
-  if (!success) throw new Error(stderr.toString("utf-8"));
-  return stdout.toString("utf-8");
+  if (result.errors.length) throw new AggregateError(result.errors);
+  return result.outputFiles[0].text;
 }
 
 async function run() {
@@ -50,25 +55,39 @@ async function run() {
   const results = await Promise.allSettled(
     ["client", "server", "error"].map(async file => {
       const side = file === "error" ? "client" : file;
-      let result = await Bun.build({
-        entrypoints: [join(base_dir, `hmr-runtime-${file}.ts`)],
+      let result = await esbuild.build({
+        entryPoints: [join(base_dir, `hmr-runtime-${file}.ts`)],
+        bundle: true,
+        format: "esm",
+        target: "esnext",
+        write: false,
         define: {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
-        minify: {
-          syntax: !debug,
-        },
-        target: side === "server" ? "bun" : "browser",
-        drop: debug ? [] : ["ASSERT", "DEBUG"],
+        // Bun.build removed the branches that `side` makes dead, also in debug
+        // builds. esbuild removes them only with minifySyntax. A server-only
+        // branch uses import.meta, which a classic script cannot parse.
+        minifySyntax: true,
+        platform: side === "server" ? "node" : "browser",
+        // esbuild's `drop` only accepts console/debugger; bun's accepted
+        // arbitrary names. `pure` + minifySyntax removes the call (arguments
+        // that have side effects survive, which is fine for assertions).
+        pure: debug ? [] : ["DEBUG.ASSERT", "DEBUG", "ASSERT"],
         conditions: [side],
+        supported: { "using": false },
+        // Server runtime runs via executeProgram (no ambient `require`): pin it
+        // to import.meta.require so esbuild's shim delegates there; the
+        // postprocessing below rewrites `import.meta` to `$importMeta`.
+        banner: side === "server" ? { js: "var require=import.meta.require;" } : undefined,
+        external: side === "server" ? ["node:*"] : undefined,
+        logLevel: "warning",
       });
-      if (!result.success) throw new AggregateError(result.logs);
-      assert(result.outputs.length === 1, "must bundle to a single file");
-      // @ts-ignore
-      let code = await result.outputs[0].text();
+      if (result.errors.length) throw new AggregateError(result.errors);
+      assert(result.outputFiles.length === 1, "must bundle to a single file");
+      let code = result.outputFiles[0].text;
 
       // A second pass is used to convert global variables into parameters, while
       // allowing for renaming to properly function when minification is enabled.
@@ -92,15 +111,21 @@ async function run() {
 
       writeIfNotChanged(generated_entrypoint, combined_source);
 
-      result = await Bun.build({
-        entrypoints: [generated_entrypoint],
+      result = await esbuild.build({
+        entryPoints: [generated_entrypoint],
+        bundle: true,
+        format: "esm",
+        target: "esnext",
+        write: false,
         minify: !debug,
-        drop: debug ? [] : ["DEBUG"],
-        target: side === "server" ? "bun" : "browser",
+        pure: debug ? [] : ["DEBUG.ASSERT", "DEBUG"],
+        platform: side === "server" ? "node" : "browser",
+        supported: { "using": false },
+        logLevel: "warning",
       });
-      if (!result.success) throw new AggregateError(result.logs);
-      assert(result.outputs.length === 1, "must bundle to a single file");
-      code = (await result.outputs[0].text()).replace(`// ${basename(generated_entrypoint)}`, "").trim();
+      if (result.errors.length) throw new AggregateError(result.errors);
+      assert(result.outputFiles.length === 1, "must bundle to a single file");
+      code = result.outputFiles[0].text.replace(`// ${basename(generated_entrypoint)}`, "").trim();
 
       rmSync(generated_entrypoint);
 

--- a/src/runtime/bake/package.json
+++ b/src/runtime/bake/package.json
@@ -1,5 +1,7 @@
 {
-  "sideEffects": false,
+  "sideEffects": [
+    "./debug.ts"
+  ],
   "type": "module",
   "imports": {
     "#stack-trace": {


### PR DESCRIPTION
Stacked on #41315. The diff is against that branch.

### Problem
- `bake-codegen.ts` bundles the dev server runtimes (`bake.client.js`, `bake.server.js`, `bake.error.js`) with `Bun.build`. It minifies the overlay CSS with `bun build`. So the step needs bun.

### Fix
- The script calls `esbuild.build()` for the runtimes and `esbuild.buildSync()` for the CSS, and runs with `cfg.jsRuntime`. The text passes after the build do not change.
- `src/runtime/bake/package.json` lists `debug.ts` in `sideEffects`. With `"sideEffects": false`, esbuild dropped `import "./debug"`, so `DEBUG` was undefined in debug builds.
- `minifySyntax` is on in debug builds too. Bun.build removed the branches that the `side` define makes dead. esbuild does that only with `minifySyntax`. One server-only branch uses `import.meta`, which the client runtime cannot parse.
- Verified: node and bun write the same files, on Linux and on Windows. With the new runtimes, a debug build passes the same 7 `test/bake/dev` suites as before.

### Background
- Bake is the framework layer of the dev server. `bake.client.js` runs in the browser, and `bake.server.js` runs in bun.
- A debug build reads these files from the codegen directory at run time. So the new files can be tested with a debug binary that was built before this change.

<details><summary>Notes</summary>

- The A/B run: `esm`, `hot`, `css`, `bundle`, `html`, `sourcemap`, and `production` in `test/bake/dev`, 90 tests, 0 failures with the old files and with the new files. Two production tests take 5 to 6 s in a debug build with both sets of files, so they need `--timeout` there.
- esbuild's `drop` accepts only `console` and `debugger`. `pure` with `minifySyntax` removes the `DEBUG` and `ASSERT` calls in release builds.
- The server runtime runs through `executeProgram`, which gives it no `require`. A banner sets `require` from `import.meta.require`, and its `node:` imports stay external.
- The overlay CSS is a JSON string in `define`. The SVG icons become data URLs, as with `bun build`.
- `logLevel` is `warning`, so esbuild reports an ignored import in the build log.
- Release sizes, bun and then esbuild: client 48557 and 47728 bytes, server 10989 and 11186, error 23844 and 23412.

</details>
