### PR TITLE
node:http2: apply INITIAL_WINDOW_SIZE changes to open streams

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -216,6 +216,11 @@ pub trait Sink {
     /// counter moves, while the connection is mutably borrowed — the embedder must only
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
+    /// Connection-level receive window update (node's session.state window fields): `size` is
+    /// what the peer has been told it may send, `consumed` what it has sent since the last
+    /// WINDOW_UPDATE. Called whenever either moves, while the connection is mutably borrowed —
+    /// the embedder must only store the values.
+    fn on_recv_window(&self, _size: i64, _consumed: i64) {}
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
     /// inbound frames for it are not treated as frames on an idle stream.
@@ -420,6 +425,17 @@ impl Connection {
         );
     }
 
+    fn note_recv_window(&self, sink: &impl Sink) {
+        sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
+    }
+
+    /// The embedder advertised `delta` more connection-level receive window (a WINDOW_UPDATE on
+    /// stream 0 it wrote itself): accept that much more DATA before the §6.9.1 overflow check.
+    pub fn grow_recv_window(&mut self, sink: &impl Sink, delta: i64) {
+        self.recv_window.grow(delta);
+        self.note_recv_window(sink);
+    }
+
     fn send_rst_stream(&mut self, sink: &impl Sink, stream_id: u32, code: ErrorCode) {
         self.write_frame(
             sink,
@@ -571,6 +587,7 @@ impl Connection {
             let inc = self.recv_window.take_update();
             if inc > 0 {
                 self.send_window_update(sink, 0, inc);
+                self.note_recv_window(sink);
             }
         }
         let mut buf = std::mem::take(&mut self.replenish_buf);
@@ -1368,6 +1385,7 @@ impl Connection {
 
         // §6.9: the whole declared frame counts against the connection recv window on receipt.
         self.recv_window.on_data(hdr.length as i64);
+        self.note_recv_window(sink);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,
@@ -1486,6 +1504,7 @@ impl Connection {
 
         // §6.9: the whole frame counts against the connection recv window.
         self.recv_window.on_data(consumed);
+        self.note_recv_window(sink);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -708,6 +708,14 @@ impl Connection {
                     .unwrap_or(PendingLocalSettings {
                         settings: self.local_settings,
                     });
+            // §6.9.2: the peer moved its stream send windows by this delta when it applied it.
+            let delta =
+                acked.settings.initial_window_size as i64 - self.acked_local_initial_window as i64;
+            if delta != 0 {
+                for s in self.streams.values_mut() {
+                    s.recv_window.grow(delta);
+                }
+            }
             self.acked_local_initial_window = acked.settings.initial_window_size;
             // The peer has acknowledged this submission: header-list enforcement may now use the
             // limit it carried.
@@ -948,10 +956,9 @@ impl Connection {
         let end_stream = wire::flags::has(hdr.flags, wire::flags::END_STREAM);
 
         // §5.1.1: a server's inbound HEADERS opens (or continues) a client-initiated odd stream.
-        // Our receive window is sized by OUR advertised SETTINGS_INITIAL_WINDOW_SIZE; our send
-        // window by the PEER's (§6.9.2).
+        // Receive window from the INITIAL_WINDOW_SIZE the peer ACKed, send window from the peer's.
         let send_init = self.remote_settings.initial_window_size;
-        let recv_init = self.local_settings.initial_window_size;
+        let recv_init = self.acked_local_initial_window;
         let is_new = !self.streams.contains_key(&hdr.stream_id);
         // RFC 9113 5.1.1: client-initiated streams use odd ids - a server receiving HEADERS that
         // would open an even-id stream is a connection PROTOCOL_ERROR. (Monotonicity is not
@@ -1397,7 +1404,7 @@ impl Connection {
 
         if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
             let send_init = self.remote_settings.initial_window_size;
-            let recv_init = self.local_settings.initial_window_size;
+            let recv_init = self.acked_local_initial_window;
             let mut s = Stream::new(send_init, recv_init);
             s.state = State::Open;
             self.streams.insert(hdr.stream_id, s);
@@ -1538,7 +1545,7 @@ impl Connection {
         // here so it isn't mistaken for a closed/idle stream.
         if !self.streams.contains_key(&hdr.stream_id) && sink.is_local_stream(hdr.stream_id) {
             let send_init = self.remote_settings.initial_window_size;
-            let recv_init = self.local_settings.initial_window_size;
+            let recv_init = self.acked_local_initial_window;
             let mut s = Stream::new(send_init, recv_init);
             s.state = State::Open;
             self.streams.insert(hdr.stream_id, s);
@@ -1654,7 +1661,7 @@ impl Connection {
         // though this engine never saw its HEADERS go out.
         if on_idle && sink.is_local_stream(hdr.stream_id) {
             let send_init = self.remote_settings.initial_window_size;
-            let recv_init = self.local_settings.initial_window_size;
+            let recv_init = self.acked_local_initial_window;
             let s = self
                 .streams
                 .entry(hdr.stream_id)
@@ -1753,7 +1760,7 @@ impl Connection {
 
         // Reserve the promised (even) stream.
         let send_init = self.remote_settings.initial_window_size;
-        let recv_init = self.local_settings.initial_window_size;
+        let recv_init = self.acked_local_initial_window;
         let entry = self
             .streams
             .entry(promised)
@@ -1884,7 +1891,7 @@ impl Connection {
         self.enc_buf.clear();
 
         let send_init = self.remote_settings.initial_window_size;
-        let recv_init = self.local_settings.initial_window_size;
+        let recv_init = self.acked_local_initial_window;
         let s = self
             .streams
             .entry(stream_id)
@@ -2012,7 +2019,7 @@ impl Connection {
         self.enc_buf.clear();
 
         let send_init = self.remote_settings.initial_window_size;
-        let recv_init = self.local_settings.initial_window_size;
+        let recv_init = self.acked_local_initial_window;
         let s = self
             .streams
             .entry(promised_id)

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1063,10 +1063,14 @@ pub struct H2FrameParser {
     remote_settings: Cell<Option<FullSettingsPayload>>,
 
     // local Window limits the download of data
-    // current window size for the connection
+    // current window size for the connection (what setLocalWindowSize asked for)
     window_size: Cell<u64>,
-    // used window size for the connection
-    used_window_size: Cell<u64>,
+    /// The engine's connection-level receive window, mirrored through `Sink::on_recv_window`
+    /// so `state` can be read inside a dispatch (the engine cell is borrowed there):
+    /// what the peer has been told it may send, and what it has sent since the last
+    /// WINDOW_UPDATE on stream 0.
+    recv_window_size: Cell<i64>,
+    recv_window_consumed: Cell<i64>,
 
     // remote Window limits the upload of data
     // remote window size for the connection
@@ -1316,8 +1320,6 @@ pub struct Stream {
     weight: u16,
     // current window size for the stream
     window_size: u64,
-    // used window size for the stream
-    used_window_size: u64,
     // remote window size for the stream
     remote_window_size: u64,
     // remote used window size for the stream
@@ -1832,7 +1834,6 @@ impl Stream {
             // which is what stream.state.weight reports when no priority was signaled.
             weight: 16,
             window_size: initial_window_size as u64,
-            used_window_size: 0,
             remote_window_size: remote_window_size as u64,
             remote_used_window_size: 0,
             signal: None,
@@ -3565,7 +3566,7 @@ impl H2FrameParser {
             // held this borrow.
             let pending = self.pending_recv_window_growth.replace(0);
             if pending > 0 {
-                engine.recv_window.grow(pending);
+                engine.grow_recv_window(self, pending);
             }
             // Apply outbound DATA the legacy encoder wrote since the last batch, so the engine's
             // send windows reflect what is actually in flight (§6.9.1 overflow stays peer-error
@@ -3699,6 +3700,11 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_frame_counters(&self, received: u64, sent: u64) {
         self.engine_frames_received.set(received);
         self.engine_frames_sent.set(sent);
+    }
+
+    fn on_recv_window(&self, size: i64, consumed: i64) {
+        self.recv_window_size.set(size);
+        self.recv_window_consumed.set(consumed);
     }
 
     fn write(&self, bytes: &[u8]) -> crate::api::h2::connection::WriteResult {
@@ -4527,18 +4533,12 @@ impl H2FrameParser {
                 .throw_invalid_arguments(format_args!("Expected windowSize to be a number")));
         }
         let window_size_value: u32 = window_size.to_u32();
-        if this.used_window_size.get() > window_size_value as u64 {
-            return Err(global_object.throw_invalid_arguments(format_args!(
-                "Expected windowSize to be greater than usedWindowSize"
-            )));
-        }
         let old_window_size = this.window_size.get();
         this.window_size.set(window_size_value as u64);
-        if this.local_settings.get().initial_window_size < window_size_value {
-            let mut s = this.local_settings.get();
-            s.initial_window_size = window_size_value;
-            this.local_settings.set(s);
-        }
+        // Like nghttp2_session_set_local_window_size(stream_id 0): only the connection-level
+        // window moves. SETTINGS_INITIAL_WINDOW_SIZE stays as advertised; the engine sizes each
+        // new stream's receive window from it, and raising it without a SETTINGS frame leaves
+        // the peer stopped at the old stream window while we wait for half of the new one.
         if window_size_value as u64 > old_window_size {
             let increment: u32 = (window_size_value as u64 - old_window_size) as u32;
             this.send_window_update(0, UInt31WithReserved::init(increment, false));
@@ -4549,7 +4549,7 @@ impl H2FrameParser {
             // delta keeps that path panic-free.
             match this.engine.try_borrow_mut() {
                 Ok(mut guard) => match guard.as_mut() {
-                    Some(engine) => engine.recv_window.grow(increment as i64),
+                    Some(engine) => engine.grow_recv_window(this, increment as i64),
                     None => {
                         // The engine is created lazily on the first inbound read; carry the
                         // growth forward so it applies when that happens.
@@ -4564,14 +4564,6 @@ impl H2FrameParser {
                         .set(this.pending_recv_window_growth.get() + increment as i64);
                 }
             }
-        }
-        for (_, item) in this.streams.get().iter() {
-            // SAFETY: item is &*mut Stream from streams.iter(); the boxed Stream outlives the iteration
-            let stream = unsafe { &mut **item };
-            if stream.used_window_size > window_size_value as u64 {
-                continue;
-            }
-            stream.window_size = window_size_value as u64;
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -4606,6 +4598,12 @@ impl H2FrameParser {
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let result = JSValue::create_empty_object(global_object, 9);
+        // node (nghttp2_session_get_*): effectiveLocalWindowSize is the connection window we
+        // want, localWindowSize is what the peer may still send on it (advertised minus what it
+        // sent since the last WINDOW_UPDATE), effectiveRecvDataLength is that consumed amount.
+        // Growth queued for the engine is already on the wire, so it counts as advertised.
+        let advertised = this.recv_window_size.get() + this.pending_recv_window_growth.get();
+        let consumed = this.recv_window_consumed.get().max(0);
         result.put(
             global_object,
             b"effectiveLocalWindowSize",
@@ -4614,7 +4612,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"effectiveRecvDataLength",
-            JSValue::js_number((this.window_size.get() - this.used_window_size.get()) as f64),
+            JSValue::js_number(consumed as f64),
         );
         result.put(
             global_object,
@@ -4629,7 +4627,6 @@ impl H2FrameParser {
 
         let settings = this.remote_settings.get().unwrap_or_default();
         let remote_iws = settings.initial_window_size;
-        let local_iws = this.local_settings.get().initial_window_size;
         let local_hts = this.local_settings.get().header_table_size;
         result.put(
             global_object,
@@ -4639,7 +4636,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"localWindowSize",
-            JSValue::js_number(local_iws as f64),
+            JSValue::js_number((advertised - consumed).max(0) as f64),
         );
         result.put(
             global_object,
@@ -7574,7 +7571,8 @@ impl H2FrameParser {
             ),
             remote_settings: Cell::new(None),
             window_size: Cell::new(DEFAULT_WINDOW_SIZE),
-            used_window_size: Cell::new(0),
+            recv_window_size: Cell::new(DEFAULT_WINDOW_SIZE as i64),
+            recv_window_consumed: Cell::new(0),
             remote_window_size: Cell::new(DEFAULT_WINDOW_SIZE),
             remote_used_window_size: Cell::new(0),
             max_header_list_pairs: Cell::new(128),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3536,21 +3536,9 @@ impl H2FrameParser {
         }
     }
 
-    /// Feed inbound bytes through the rewrite engine, buffering the unconsumed tail (design B).
-    fn rewrite_read(&self, bytes: &[u8]) {
-        bun_output::scoped_log!(H2FrameParser, "rewriteRead {}", bytes.len());
-        // Re-entrancy guard: receive() dispatches into JS between frames, and user code can feed
-        // bytes back into the same parser from inside such a dispatch (e.g. a custom Duplex whose
-        // write path synchronously pushes back into the socket). The engine cell stays mutably
-        // borrowed across the outer receive(), so queue the bytes for the outer call to drain
-        // rather than panicking on a second borrow.
-        if self.engine.try_borrow_mut().is_err() {
-            self.rewrite_tail.with_mut(|t| t.extend_from_slice(bytes));
-            return;
-        }
-        self.ensure_engine();
-        // Keep the engine's local settings in sync with the JS-configured cell (settings() may be
-        // called after the engine was lazily created). Plain Copy structs — no allocation.
+    /// Copy what the legacy side changed since the last receive() into the engine.
+    fn sync_engine(&self) {
+        // Plain Copy structs, no allocation.
         if let Some(engine) = self.engine.borrow_mut().as_mut() {
             engine.local_settings = self.rewrite_local_settings();
             engine.max_header_list_pairs = self.max_header_list_pairs.get();
@@ -3620,6 +3608,22 @@ impl H2FrameParser {
                 });
             }
         }
+    }
+
+    /// Feed inbound bytes through the rewrite engine, buffering the unconsumed tail (design B).
+    fn rewrite_read(&self, bytes: &[u8]) {
+        bun_output::scoped_log!(H2FrameParser, "rewriteRead {}", bytes.len());
+        // Re-entrancy guard: receive() dispatches into JS between frames, and user code can feed
+        // bytes back into the same parser from inside such a dispatch (e.g. a custom Duplex whose
+        // write path synchronously pushes back into the socket). The engine cell stays mutably
+        // borrowed across the outer receive(), so queue the bytes for the outer call to drain
+        // rather than panicking on a second borrow.
+        if self.engine.try_borrow_mut().is_err() {
+            self.rewrite_tail.with_mut(|t| t.extend_from_slice(bytes));
+            return;
+        }
+        self.ensure_engine();
+        self.sync_engine();
         if self.rewrite_tail.get().is_empty() {
             let feed = {
                 let mut guard = self.engine.borrow_mut();
@@ -3665,6 +3669,8 @@ impl H2FrameParser {
             if self.rewrite_tail.get().is_empty() {
                 break;
             }
+            // A dispatch in the receive() above can have called settings() or written DATA.
+            self.sync_engine();
             let pending = self.rewrite_tail.with_mut(std::mem::take);
             let feed = {
                 let mut guard = self.engine.borrow_mut();
@@ -3803,21 +3809,24 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
             max_header_list_size: settings.max_header_list_size,
             enable_connect_protocol: settings.enable_connect_protocol,
         };
+        // handle_received_stream_id opens every stream with this value.
+        let old_initial_window = self
+            .remote_settings
+            .get()
+            .map(|s| s.initial_window_size)
+            .unwrap_or(DEFAULT_WINDOW_SIZE as u32);
         self.remote_settings.set(Some(fp));
-        // §6.9.2 (mirrors the legacy inbound): when the peer's INITIAL_WINDOW_SIZE grows, raise the
-        // send window of streams opened before its SETTINGS arrived (a client's first request is
-        // typically sent before the server's SETTINGS lands), then resume queued sends.
-        let mut window_grew = false;
-        for (_, item) in self.streams.get().iter() {
-            // SAFETY: item is &*mut Stream from streams.iter(); the boxed Stream outlives the iteration
-            let stream = unsafe { &mut **item };
-            if (settings.initial_window_size as u64) > stream.remote_window_size {
-                stream.remote_window_size = settings.initial_window_size as u64;
-                window_grew = true;
+        // §6.9.2. remote_window_size is cumulative: a decrease can leave it below the used count.
+        let delta = settings.initial_window_size as i64 - old_initial_window as i64;
+        if delta != 0 {
+            for (_, item) in self.streams.get().iter() {
+                // SAFETY: item is &*mut Stream from streams.iter(); the boxed Stream outlives the iteration
+                let stream = unsafe { &mut **item };
+                stream.remote_window_size = stream.remote_window_size.saturating_add_signed(delta);
             }
         }
         // Resume queued sends only when a window actually grew; there is nothing to flush otherwise.
-        if window_grew {
+        if delta > 0 && !self.streams.get().is_empty() {
             let _ = self.flush();
         }
         let g = self.global();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -12,7 +12,7 @@ import { bunEnv, bunExe, gcTick, normalizeBunSnapshot } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
-import { Writable } from "node:stream";
+import { Duplex, duplexPair, Writable } from "node:stream";
 
 const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
 
@@ -56,22 +56,24 @@ function encodeFrame(type: number, flags: number, streamId: number, payload: Buf
 
 /** A minimal raw HTTP/2 client: send arbitrary frames, collect parsed inbound frames. */
 class RawH2 {
-  socket: net.Socket;
+  socket: Duplex;
   private buf: Buffer = Buffer.alloc(0);
   frames: Frame[] = [];
   closed = false;
   private waiters: Array<{ pred: (f: Frame) => boolean; resolve: (f: Frame) => void }> = [];
 
-  constructor(port: number) {
-    this.socket = net.connect(port, "127.0.0.1");
+  /** `socket` is a connected transport: a TCP socket, or one side of a duplexPair(). */
+  constructor(socket: Duplex) {
+    this.socket = socket;
     this.socket.on("data", d => this.onData(d));
     this.socket.on("close", () => (this.closed = true));
     this.socket.on("error", () => {});
   }
 
   static async connect(port: number): Promise<RawH2> {
-    const c = new RawH2(port);
-    await once(c.socket, "connect");
+    const socket = net.connect(port, "127.0.0.1");
+    const c = new RawH2(socket);
+    await once(socket, "connect");
     return c;
   }
 
@@ -800,6 +802,80 @@ describe("push stream states (checklist §5.1, RFC 9113 §6.4/§8.4)", () => {
   });
 });
 
+function settingsEntries(f: Frame): Array<[number, number]> {
+  const entries: Array<[number, number]> = [];
+  for (let off = 0; off + 6 <= f.payload.length; off += 6) {
+    entries.push([f.payload.readUInt16BE(off), f.payload.readUInt32BE(off + 2)]);
+  }
+  return entries;
+}
+
+/**
+ * Upload `total` bytes of DATA on `streamId` the way a compliant sender does (RFC 9113 §6.9):
+ * never exceed the connection or stream window, grow them on WINDOW_UPDATE, and on a server
+ * SETTINGS that changes INITIAL_WINDOW_SIZE shift the stream window by the delta (§6.9.2) and
+ * ACK it. Throws with the stall position if the server stops granting window.
+ */
+async function uploadWithFlowControl(c: RawH2, streamId: number, total: number) {
+  let connWindow = 65535;
+  let streamWindow = 65535;
+  let initialWindow = 65535;
+  let harvested = 0;
+  // The caller already ACKed the SETTINGS frames received before this point.
+  const ackFrom = c.frames.length;
+  const harvest = () => {
+    for (; harvested < c.frames.length; harvested++) {
+      const f = c.frames[harvested];
+      if (f.type === FrameType.WINDOW_UPDATE) {
+        const inc = f.payload.readUInt32BE(0) & 0x7fffffff;
+        if (f.streamId === 0) connWindow += inc;
+        else if (f.streamId === streamId) streamWindow += inc;
+      } else if (f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0) {
+        for (const [id, value] of settingsEntries(f)) {
+          if (id !== 0x4) continue;
+          streamWindow += value - initialWindow;
+          initialWindow = value;
+        }
+        if (harvested >= ackFrom) c.sendSettingsAck();
+      }
+    }
+  };
+  let sent = 0;
+  while (sent < total) {
+    harvest();
+    const budget = Math.min(connWindow, streamWindow, 16384, total - sent);
+    if (budget <= 0) {
+      // Stalled on flow control: wait for the server to send anything more. If it never does,
+      // this rejects and the test fails with the stall position.
+      const before = c.frames.length;
+      await c
+        .waitFor(() => c.frames.length > before, 3000)
+        .catch(() => {
+          throw new Error(`flow control stalled: sent=${sent} connWindow=${connWindow} streamWindow=${streamWindow}`);
+        });
+      continue;
+    }
+    const last = sent + budget >= total;
+    c.sendFrame(FrameType.DATA, last ? 0x1 /* END_STREAM */ : 0, streamId, Buffer.alloc(budget, 0x61));
+    sent += budget;
+    connWindow -= budget;
+    streamWindow -= budget;
+  }
+}
+
+/** Complete the SETTINGS handshake on a raw client, then open a POST / request on stream 1. */
+async function openPostStream(c: RawH2): Promise<RawH2> {
+  c.sendPreface();
+  c.sendEmptySettings();
+  await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+  c.sendSettingsAck();
+  // POST / without END_STREAM: static-table indexed [:method POST, :scheme http, :path /]
+  // plus a literal :authority.
+  const block = Buffer.concat([Buffer.from([0x83, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
+  c.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, block);
+  return c;
+}
+
 describe("inbound flow control after local end-stream (RFC 9113 §6.9)", () => {
   // Regression coverage for the test-http2-pipe failure mode: the server responds and ends its
   // side before the request body arrives, the request body is piped into a backpressured
@@ -828,64 +904,254 @@ describe("inbound flow control after local end-stream (RFC 9113 §6.9)", () => {
     });
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
-    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    const c = await openPostStream(await RawH2.connect((server.address() as net.AddressInfo).port));
     try {
-      c.sendPreface();
-      c.sendEmptySettings();
-      await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
-      c.sendSettingsAck();
-      // POST / without END_STREAM: static-table indexed [:method POST, :scheme http, :path /]
-      // plus a literal :authority.
-      const block = Buffer.concat([Buffer.from([0x83, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
-      c.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, block);
       // Wait until the response has fully ended (HEADERS then END_STREAM) before sending any of
       // the request body — that ordering is what previously stalled the inbound windows.
       await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
       await c.waitFor(f => f.streamId === 1 && (f.flags & 0x1) !== 0);
-
-      // Send the body respecting flow control: track WINDOW_UPDATE frames the server sends and
-      // never exceed the connection/stream windows (initially 65535 each).
-      let connWindow = 65535;
-      let streamWindow = 65535;
-      let harvested = 0;
-      const harvestWindowUpdates = () => {
-        for (; harvested < c.frames.length; harvested++) {
-          const f = c.frames[harvested];
-          if (f.type !== FrameType.WINDOW_UPDATE) continue;
-          const inc = f.payload.readUInt32BE(0) & 0x7fffffff;
-          if (f.streamId === 0) connWindow += inc;
-          else if (f.streamId === 1) streamWindow += inc;
-        }
-      };
-      const windowUpdateCount = () => c.frames.filter(f => f.type === FrameType.WINDOW_UPDATE).length;
-      let sent = 0;
-      while (sent < total) {
-        harvestWindowUpdates();
-        const budget = Math.min(connWindow, streamWindow, 16384, total - sent);
-        if (budget <= 0) {
-          // Stalled on flow control: wait for the server to grant more window. If it never does,
-          // this rejects and the test fails with the stall position.
-          const before = windowUpdateCount();
-          await c
-            .waitFor(() => windowUpdateCount() > before, 3000)
-            .catch(() => {
-              throw new Error(
-                `flow control stalled: sent=${sent} connWindow=${connWindow} streamWindow=${streamWindow}`,
-              );
-            });
-          continue;
-        }
-        const last = sent + budget >= total;
-        c.sendFrame(FrameType.DATA, last ? 0x1 /* END_STREAM */ : 0, 1, Buffer.alloc(budget, 0x61));
-        sent += budget;
-        connWindow -= budget;
-        streamWindow -= budget;
-      }
+      await uploadWithFlowControl(c, 1, total);
       await finished.promise;
       expect(received).toBe(total);
     } finally {
       c.destroy();
       server.close();
+    }
+  });
+});
+
+describe("inbound flow control after a SETTINGS change (RFC 9113 §6.9.2)", () => {
+  // When the server lowers SETTINGS_INITIAL_WINDOW_SIZE mid-upload, the client shifts its stream
+  // window down by the delta. The server must then replenish against the new, smaller window: a
+  // replenish threshold still based on the old 65535 is never reached by a peer that can only
+  // send 1024 bytes per round, and the upload stalls forever.
+  test("WINDOW_UPDATE keeps flowing after the server lowers INITIAL_WINDOW_SIZE mid-upload", async () => {
+    const total = 96 * 1024;
+    let received = 0;
+    const finished = Promise.withResolvers<void>();
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.once("data", () => stream.session!.settings({ initialWindowSize: 1024 }));
+      stream.on("data", (d: Buffer) => (received += d.length));
+      stream.on("error", (err: Error) => finished.reject(err));
+      stream.on("end", () => {
+        finished.resolve();
+        if (stream.destroyed) return;
+        stream.respond({ ":status": 200 });
+        stream.end();
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const c = await openPostStream(await RawH2.connect((server.address() as net.AddressInfo).port));
+    try {
+      await uploadWithFlowControl(c, 1, total);
+      await finished.promise;
+      expect(received).toBe(total);
+      // The shrink reached the client and the server kept granting window after it.
+      const shrink = c.frames.findIndex(
+        f =>
+          f.type === FrameType.SETTINGS &&
+          (f.flags & 0x1) === 0 &&
+          settingsEntries(f).some(([id, value]) => id === 0x4 && value === 1024),
+      );
+      expect(shrink).not.toBe(-1);
+      const updatesAfterShrink = c.frames
+        .slice(shrink)
+        .filter(f => f.type === FrameType.WINDOW_UPDATE && f.streamId === 1);
+      expect(updatesAfterShrink.length).toBeGreaterThan(1);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+
+  // A transport can deliver bytes while the server is still inside a dispatch, for example a
+  // Duplex that pushes synchronously. The server reads them once that dispatch returns. A
+  // SETTINGS ACK among them must still apply the window change of the SETTINGS it acknowledges.
+  test("WINDOW_UPDATE keeps flowing when the ACK of a smaller INITIAL_WINDOW_SIZE arrives during a dispatch", async () => {
+    const [clientSide, serverSide] = duplexPair();
+    const server = http2.createServer();
+    let session: http2.ServerHttp2Session | undefined;
+    server.on("session", s => (session = s));
+    server.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.resume();
+      // This handler runs inside the dispatch of the request HEADERS.
+      stream.session!.settings({ initialWindowSize: 1024 });
+      // The client ACKs at once, and the server reads the ACK while this handler still runs.
+      serverSide.emit("data", encodeFrame(FrameType.SETTINGS, 0x1, 0));
+    });
+    const c = new RawH2(clientSide);
+    server.emit("connection", serverSide);
+    try {
+      await openPostStream(c);
+      // The client applied the smaller window after it opened stream 1, so §6.9.2 leaves
+      // 65535 + (1024 - 65535) = 1024 bytes of stream window. It uses all of them.
+      c.sendFrame(FrameType.DATA, 0, 1, Buffer.alloc(1024, 0x61));
+      // The whole window is used, so the server must open it again.
+      const update = await c.waitFor(f => f.type === FrameType.WINDOW_UPDATE && f.streamId === 1).catch(() => null);
+      expect(update?.payload.readUInt32BE(0)).toBe(1024);
+    } finally {
+      c.destroy();
+      session?.destroy();
+    }
+  });
+
+  // A stream that opens between a SETTINGS frame and its ACK starts with the value the client has
+  // ACKed, and the ACK then moves it by the delta. If the stream started with the new value, the
+  // delta would count twice, and the server would accept DATA past the window of the client.
+  test("a stream opened before the ACK of a larger INITIAL_WINDOW_SIZE gets exactly that window", async () => {
+    const server = http2.createServer({ settings: { initialWindowSize: 1000 } });
+    server.on("session", session => {
+      session.on("error", () => {});
+      session.settings({ initialWindowSize: 2000 });
+    });
+    server.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.resume();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      // The server sends two SETTINGS frames: 1000 in its preface, then 2000.
+      await c.waitFor(
+        f =>
+          f.type === FrameType.SETTINGS &&
+          (f.flags & 0x1) === 0 &&
+          settingsEntries(f).some(([id, value]) => id === 0x4 && value === 2000),
+      );
+      // The client applies both, but it ACKs only the first before it opens stream 1. So
+      // stream 1 has a 2000-byte window, and 2001 bytes overrun it.
+      c.sendSettingsAck();
+      c.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, requestHeaderBlock("POST"));
+      c.sendSettingsAck();
+      c.sendFrame(FrameType.DATA, 0, 1, Buffer.alloc(2001, 0x61));
+      const goaway = await c.waitForGoaway().catch(() => null);
+      expect(goaway && goawayErrorCode(goaway)).toBe(ErrorCode.FLOW_CONTROL_ERROR);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+});
+
+describe("outbound flow control after a SETTINGS change (RFC 9113 §6.9.2)", () => {
+  // A peer's change to SETTINGS_INITIAL_WINDOW_SIZE moves the send window of every open stream by
+  // the difference, in both directions, on top of the WINDOW_UPDATE credit the stream has.
+  const dataBytes = (raw: RawH2Server) =>
+    raw.frames.reduce((n, f) => (f.type === FrameType.DATA && f.streamId === 1 ? n + f.length : n), 0);
+  const windowUpdate = (streamId: number, increment: number) => {
+    const payload = Buffer.alloc(4);
+    payload.writeUInt32BE(increment);
+    return encodeFrame(FrameType.WINDOW_UPDATE, 0, streamId, payload);
+  };
+  const initialWindowSettings = (value: number) => {
+    const payload = Buffer.alloc(6);
+    payload.writeUInt16BE(0x4, 0);
+    payload.writeUInt32BE(value, 2);
+    return encodeFrame(FrameType.SETTINGS, 0, 0, payload);
+  };
+  const settingsAck = () => encodeFrame(FrameType.SETTINGS, 0x1, 0);
+  // A large connection window, so the stream window is the only limit.
+  const connectionGrant = () => windowUpdate(0, 16 * 1024 * 1024);
+
+  // A client that keeps the old window overruns the new one, and a compliant server (nghttp2, or
+  // bun's own) ends the connection with FLOW_CONTROL_ERROR.
+  test.each([
+    ["a later SETTINGS frame", false],
+    ["the first SETTINGS frame", true],
+  ])(
+    "client sends no more DATA than the window left after %s lowers INITIAL_WINDOW_SIZE",
+    async (_, inFirstSettings) => {
+      const total = 80 * 1024;
+      const raw = await RawH2Server.listen();
+      const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+      client.on("error", () => {});
+      try {
+        const req = client.request({ ":method": "POST", ":path": "/" });
+        req.on("error", () => {});
+        req.end(Buffer.alloc(total, 0x61));
+        await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+        if (!inFirstSettings) {
+          raw.socket!.write(Buffer.concat([encodeFrame(FrameType.SETTINGS, 0, 0), settingsAck(), connectionGrant()]));
+        }
+
+        // The client fills the default 65535-byte stream window and stalls.
+        await raw.waitFor(() => dataBytes(raw) >= 65535);
+        expect(dataBytes(raw)).toBe(65535);
+
+        // Lower the window to 1024, then return the 65535 bytes the stream used. The client
+        // applies both before it can send again, so §6.9.2 leaves it
+        // 0 + (1024 - 65535) + 65535 = 1024 bytes of window.
+        const lower = inFirstSettings
+          ? [initialWindowSettings(1024), settingsAck(), connectionGrant()]
+          : [initialWindowSettings(1024)];
+        raw.socket!.write(Buffer.concat([...lower, windowUpdate(1, 65535)]));
+
+        // From here on, grant 1024 bytes each time the client uses its whole window.
+        const endSeen = () =>
+          raw.frames.some(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0);
+        let window = 1024;
+        let accounted = 65535;
+        let overrun: string | null = null;
+        while (!endSeen()) {
+          await raw.waitFor(() => dataBytes(raw) - accounted >= window || endSeen());
+          const used = dataBytes(raw) - accounted;
+          if (used > window) {
+            overrun = `sent ${used} bytes into a ${window}-byte window`;
+            break;
+          }
+          accounted += used;
+          window -= used;
+          if (window === 0 && !endSeen()) {
+            raw.socket!.write(windowUpdate(1, 1024));
+            window = 1024;
+          }
+        }
+        expect({ overrun, received: dataBytes(raw) }).toEqual({ overrun: null, received: total });
+      } finally {
+        client.destroy();
+        raw.close();
+      }
+    },
+  );
+
+  // grpc-go raises INITIAL_WINDOW_SIZE while its streams hold WINDOW_UPDATE credit. A client that
+  // sets the window to the new value, and does not add the difference, loses that credit.
+  test("client adds a larger INITIAL_WINDOW_SIZE to the WINDOW_UPDATE credit of a stream", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" });
+      req.on("error", () => {});
+      // More than the client can send in this test.
+      req.end(Buffer.alloc(256 * 1024, 0x61));
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.socket!.write(Buffer.concat([encodeFrame(FrameType.SETTINGS, 0, 0), settingsAck(), connectionGrant()]));
+      await raw.waitFor(() => dataBytes(raw) >= 65535);
+      expect(dataBytes(raw)).toBe(65535);
+
+      // 10000 bytes of credit, and the client uses all of it.
+      raw.socket!.write(windowUpdate(1, 10000));
+      await raw.waitFor(() => dataBytes(raw) >= 75535);
+      expect(dataBytes(raw)).toBe(75535);
+
+      // Raise the window to 100000. §6.9.2 adds 100000 - 65535 = 34465 bytes to the window.
+      const expected = 75535 + (100000 - 65535);
+      raw.socket!.write(initialWindowSettings(100000));
+      await raw.waitFor(() => dataBytes(raw) >= expected).catch(() => {});
+      // The client sends its PING ACK after the DATA it already wrote, so no more DATA is on the way.
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(dataBytes(raw)).toBe(expected);
+    } finally {
+      client.destroy();
+      raw.close();
     }
   });
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5275,6 +5275,86 @@ it("Http2Stream pull-mode read() after pause() replenishes the receive window", 
   }
 });
 
+// setLocalWindowSize() grows the connection-level receive window only (nghttp2's
+// nghttp2_session_set_local_window_size with stream id 0). It used to also raise the local
+// SETTINGS_INITIAL_WINDOW_SIZE without sending a SETTINGS frame, so every new stream waited for
+// half of the raised window before replenishing while the peer still stopped at the 64 KiB it
+// was actually told: any body larger than that stalled forever.
+describe("setLocalWindowSize() and bodies larger than the initial stream window", () => {
+  const PAYLOAD = 2 * 1024 * 1024;
+  const WINDOW = 1 << 24;
+
+  it("server session: receives a POST body larger than the stream window", async () => {
+    const server = http2.createServer();
+    const { promise, resolve, reject } = Promise.withResolvers();
+    let serverSession;
+    server.on("session", session => {
+      serverSession = session;
+      session.setLocalWindowSize(WINDOW);
+    });
+    server.on("stream", stream => {
+      let received = 0;
+      stream.on("data", chunk => (received += chunk.length));
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end();
+        resolve(received);
+      });
+      stream.on("error", reject);
+    });
+    await new Promise(r => server.listen(0, "127.0.0.1", r));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      client.on("error", reject);
+      const req = client.request({ ":path": "/", ":method": "POST" });
+      req.on("error", reject);
+      req.end(Buffer.alloc(PAYLOAD, "x"));
+      expect(await promise).toBe(PAYLOAD);
+      expect({
+        effectiveLocalWindowSize: serverSession.state.effectiveLocalWindowSize,
+        initialWindowSize: serverSession.localSettings.initialWindowSize,
+      }).toEqual({
+        effectiveLocalWindowSize: WINDOW,
+        initialWindowSize: http2.getDefaultSettings().initialWindowSize,
+      });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("client session: receives a response body larger than the stream window", async () => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(Buffer.alloc(PAYLOAD, "y"));
+    });
+    await new Promise(r => server.listen(0, "127.0.0.1", r));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.setLocalWindowSize(WINDOW);
+      const req = client.request({ ":path": "/" });
+      req.on("error", reject);
+      let received = 0;
+      req.on("data", chunk => (received += chunk.length));
+      req.on("end", () => resolve(received));
+      expect(await promise).toBe(PAYLOAD);
+      expect({
+        effectiveLocalWindowSize: client.state.effectiveLocalWindowSize,
+        initialWindowSize: client.localSettings.initialWindowSize,
+      }).toEqual({
+        effectiveLocalWindowSize: WINDOW,
+        initialWindowSize: http2.getDefaultSettings().initialWindowSize,
+      });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});
+
 // The outbound cork buffer is thread-local across every Http2Session. Interleaving
 // respond()/write() across two sessions used to let the second session's corked
 // HEADERS be prepended to the first session's multi-frame DATA batch and sent to


### PR DESCRIPTION
Stacked on #40180. The first commit is that PR, unchanged. Review the second commit.

### Problem
- A `node:http2` server that lowers `initialWindowSize` mid-upload stalls every compliant client. After the client sends the 1024 bytes that the new window allows, bun sends no stream WINDOW_UPDATE.
- The engine keeps each stream's receive window at the old size (`src/runtime/api/bun/h2/connection.rs:694`). The WINDOW_UPDATE threshold stays at half of 65535.
- The send side has the same gap (`src/runtime/api/bun/h2_frame_parser.rs:3800`). It ignores a decrease, so a bun client overruns a smaller window. An increase replaces the WINDOW_UPDATE credit.

### Fix
- On the SETTINGS ACK, move each stream's receive window by the change. New streams start with the ACKed value, as in nghttp2.
- When the peer changes the value, move each stream's send window by the change. Without this, the fixed server closes the connection of a bun client.
- Sync the engine before it reads bytes that arrived during a dispatch. A SETTINGS ACK among them now finds its submission.
- Verified: six new tests in `test/js/node/http2/h2-conformance.test.ts`. Five fail on main. Also `test/js/node/http2/` and 29 node `test-http2-*` files. Self-reviewed: 5 concerns raised, 5 addressed.

### Background
- A sender sends DATA only within the receiver's window. WINDOW_UPDATE frames open it again.
- RFC 9113 section 6.9.2: a change to SETTINGS_INITIAL_WINDOW_SIZE moves the window of every open stream by the difference.
- The receiver knows that the sender applied its SETTINGS when the ACK arrives.
- The engine sends a stream WINDOW_UPDATE after the peer uses half of the stream window.

Refs #40180, #33602, #30344, #30342, #40358.

<details><summary>Notes</summary>

- Reproduction: the script from the report, a 4 MiB upload with a shrink to 1024 after the first DATA. Results before and after this change:

  | server | client | main | this PR |
  | --- | --- | --- | --- |
  | bun | node | stalls at 66559 bytes | finishes |
  | node | bun | GOAWAY FLOW_CONTROL_ERROR | finishes |
  | bun | bun | finishes (the client overruns, the server does not check) | finishes |
  | node | node | finishes | finishes |

- A frame trace of bun against bun with this change: after `SETTINGS(INITIAL_WINDOW_SIZE=1024)` and `WINDOW_UPDATE(+65496)`, the client has 985 bytes of window and sends 985. After that, the server grants 1024 bytes each round, and the client sends 1024.
- Why this needs #40180: the ACK delta uses the settings snapshot that each SETTINGS frame carries. On main, `setLocalWindowSize(n)` raises `local_settings.initial_window_size` with no SETTINGS frame. The next snapshot would carry that value, and the ACK would move open streams by a change that the peer never applied. This PR carries the #40180 commit, so it can merge in either order.
- The six new tests:
  - the server lowers the window mid-upload (receive side),
  - the ACK of that change arrives while the server is inside a dispatch (the engine sync),
  - a stream opens between a SETTINGS frame and its ACK (new streams start with the ACKed value). This one passes on main too. It fails if a stream starts with the unACKed value, because the delta then counts twice.
  - the first or a later server SETTINGS lowers the window (send side, two cases),
  - a raise after WINDOW_UPDATE credit: main sends 100000 bytes where section 6.9.2 allows 110000.
- History: #33602 made the same send-side change. It was closed as superseded by #31584, but the current code applies only an increase. #30344 was the Zig version. #30342 reported hangs with a raised window. #40360 (for #40358) changed the ACK order in the same function.
- bun-v1.3.14 moved stream windows on the SETTINGS ACK, but always from 65535 (`handleSettingsFrame`). The current engine has no such step.
- The self-review asked for the stack on #40180 (the first version had its own copy of the `setLocalWindowSize()` lines), the engine sync, the two send-side tests, and this reference list. It also said to wait until #40180 lands. I did not wait. This PR carries the #40180 commit, so the order does not matter.
- Also run with the debug build: `node-http2.test.js`, `node-http2-settings-ack-ordering.test.ts`, the other files in `test/js/node/http2/`, and `test-http2-window-size.js`, `test-http2-session-settings.js`, `test-http2-session-stream-state.js`, `test-http2-misbehaving-flow-control.js`, `test-http2-generic-streams.js`, `test-http2-pipe.js`, `test-http2-backpressure.js` and 22 more `test-http2-*` files.
- grpc-js does not change window sizes, so this change does not affect it. Four tests in `test/js/third_party/grpc-js/test-client.test.ts` fail on a debug build of main too.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
ninja: Entering directory `/workspace/bun/build/debug'
[1/133] install /workspace/bun
FAILED: stamps/install__workspace_bun.stamp ../../node_modules/@lezer/common/package.json ../../node_modules/@lezer/cpp/package.json ../../node_modules/@types/bun/package.json ../../node_modules/esbuild/package.json ../../node_modules/oxlint/package.json ../../node_modules/prettier/package.json ../../node_modules/prettier-plugin-organize-imports/package.json ../../node_modules/react/package.json ../../node_modules/react-dom/package.json ../../node_modules/source-map-js/package.json ../../node_modules/typescript/package.json 
cd /workspace/bun && /workspace/bun/build/release/bun install --frozen-lockfile && touch /workspace/bun/build/debug/stamps/install__workspace_bun.stamp
bun install v1.4.1-canary.1 (8eb439554)
error: the root package depends on workspace "@types/bun" (packages/@types/bun), which is listed in bun.lock but not on disk
note: a pruned checkout must keep 
... (truncated)

release without fix: 6 skipped
bun test v1.4.1-canary.1 (8eb439554)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.03ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.26ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.03ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.55ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.69ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.68ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.05ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [27.86ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (e0a2b82fd)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [825.58ms]
(pass) node none > Client Basics > should be able to send a POST request [553.99ms]
(pass) node none > Client Basics > constants [18.24ms]
(pass) node none > Client Basics > getDefaultSettings [6.55ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.31ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.07ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.84ms]
(pass) node none > Client Basics > should be able to send data using end [576.63ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [565.27ms]
(pass) node none > Client Basics > http2 sh
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 579ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/106] gen ErrorCode+*.h
[2/59] gen string-map defines_table
[3/59] gen compressed/completions/bun.bash.zst
[4/59] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[5/59] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[6/59] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/58] gen compressed/completions/bun.zsh.zst
[8/58] gen compressed/completions/bun.fish.zst
[9/58] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/58] gen compressed/src/runtime/bake/bun-framework-react/client.tsx.zst
[11/58] gen compressed/codegen/bake.client.js.zst
[12/58] gen compressed/codegen/bun-error
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      |  44 +++-
 src/runtime/api/bun/h2_frame_parser.rs    | 119 +++++-----
 test/js/node/http2/h2-conformance.test.ts | 372 +++++++++++++++++++++++++-----
 test/js/node/http2/node-http2.test.js     |  80 +++++++
 4 files changed, 497 insertions(+), 118 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs           7      7     62
src/runtime/api/bun/h2_frame_parser.rs        18     14     60
test/js/node/http2/h2-conformance.test.ts     11     15     52
test/js/node/http2/node-http2.test.js          0      0      8
```

</details>

<!-- robobun:evidence:end -->