### PR TITLE
test(websocket): bind the close-code test servers to 127.0.0.1

### DIFF
--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -32,8 +32,12 @@ describe.concurrent("WebSocket close() argument validation", () => {
     expect(error!.message).toContain(messageContains);
   }
 
+  // Bind the address that the clients dial. On macOS, a port-0 bind to the
+  // default dual-stack [::] address can get a port that an IPv4 socket already
+  // listens on, and a dial to 127.0.0.1 then reaches that socket.
   function upgradeServer(onClose?: (event: { code: number; reason: string }) => void) {
     return Bun.serve({
+      hostname: "127.0.0.1",
       port: 0,
       fetch(req, server) {
         if (server.upgrade(req)) return;


### PR DESCRIPTION
### Problem
- `test/js/web/websocket/websocket-close-code.test.ts` failed on darwin aarch64 in build [109998](https://buildkite.com/bun/bun/builds/109998): `error: WebSocket failed to connect` at line 55. Since #41204, a failure is final.
- The servers bind the default dual-stack `[::]` address. The clients dial `127.0.0.1`. On macOS, the port-0 search for an IPv6 socket does not check IPv4 sockets (XNU `in6_pcbsetport`). So a server can get a port that another process listens on at `127.0.0.1`, and the dial reaches that process. The race dates from #32820.

### Fix
- Bind the servers to `127.0.0.1`. The port-0 search for an IPv4 socket skips each port that an IPv4 or a dual-stack socket uses.
- The code under test does not change. #37141 used the same fix in `bun-server.test.ts`.
- Verified on a macOS 15 CI host, with the canary from build 109998 and a second process that listens on `127.0.0.1` at the next ports. Before: 19 of 24 tests fail with `WebSocket failed to connect`. After: 24 of 24 pass (three runs). Linux passes (release, debug ASAN).

### Background
- The macOS kernel hands out port-0 ports in order, from one counter for all TCP sockets (`net.inet.tcp.randomize_ports=0`). After a wrap, it can reach a port that a long-lived listener holds.
- `Bun.serve()` with no `hostname` binds `[::]` with `IPV6_V6ONLY` off, so it also accepts IPv4 (`packages/bun-usockets/src/bsd.c:1158`, `:1347`).
- An IPv4 dial goes to a listener on the exact address first. A dual-stack listener comes last. On Linux, a port-0 bind skips each listener's port, so only macOS fails.

<details><summary>Notes</summary>

**Kernel probe.** A Python script binds listeners on the next ports (the holders), then one port-0 listener, then dials `127.0.0.1`. The result is the same on macOS 15.7.9 and 26.6.1:

| holder | new port-0 listener | same port | the dial reaches |
|---|---|---|---|
| `127.0.0.1` | `[::]`, dual-stack, `SO_REUSEADDR` | yes | the holder |
| `127.0.0.1` | `[::]`, dual-stack, no `SO_REUSEADDR` | yes | the holder |
| `0.0.0.0` | `[::]`, dual-stack, `SO_REUSEADDR` | yes | the holder |
| `127.0.0.1` | `0.0.0.0` | no | |
| `127.0.0.1` | `127.0.0.1` | no | |
| `[::]`, dual-stack | `127.0.0.1` | no | |
| `[::]`, dual-stack | `[::]`, dual-stack | no | |

On Linux, no row gives the same port.

**Bun probe.** The canary from build 109998, on the macOS 15 host. A second process holds `127.0.0.1` at every other port after the counter:

```
Bun.serve({ port: 0 })
  ports held by the other process: 5 of 10
  status of GET http://127.0.0.1:<port>/: 404 200 404 200 404 200 404 200 404 200
Bun.serve({ hostname: "127.0.0.1", port: 0 })
  ports held by the other process: 0 of 10
  status of GET http://127.0.0.1:<port>/: 200 200 200 200 200 200 200 200 200 200
```

**XNU source** (apple-oss-distributions/xnu):
- `bsd/netinet6/in6_src.c`, `in6_pcbsetport`: the port search calls `in6_pcblookup_local`. That function skips each PCB without `INP_IPV6`. With `SO_REUSEADDR`, it also matches only the exact local address.
- `bsd/netinet/in_pcb.c`, `in_pcbbind`: for port 0 it sets `wild = 1` ("For implicit bind (lport == 0), we always use an unused port"). So `in_pcblookup_local` matches each IPv4 or dual-stack socket on the port.
- `bsd/skywalk/namespace/netns.c`: a `NETNS_BSD` reservation does not check other `NETNS_BSD` reservations. So the Skywalk step in `in6_pcbsetport` does not catch the shared port.

**The other listener in build 109998.** The log does not show the port, so I cannot name the other listener. It either used a fixed or random port, or it lived through one wrap of the counter.

**Scope.** Other test files that bind the default address and dial `127.0.0.1` have the same race on macOS. This PR changes only this file. A change in `bsd_create_listen_socket` could cover all of them. For example, a port-0 bind on an IPv4 socket could choose the port for the dual-stack bind. libuv binds the same way as Bun does now, so Node has the same behavior.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/websocket/websocket-close-code.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/websocket/websocket-close-code.test.ts
bun test v1.4.1 (e0a2b82fd)

test/js/web/websocket/websocket-close-code.test.ts:
(pass) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [172.18ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [141.42ms]
(pass) WebSocket close() argument validation > validates arguments while the socket is still connecting [97.11ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [136.95ms]
(pass) WebSocket close() argument validation > accepts a reason of exactly 123 UTF-8 bytes [166.08ms]
(pass) WebSocket close() argument validation > close(1000) is allowed > and the code and reason reach the server [82.71ms]
(pass) WebSocket close() argument validation > close(1001) is allowed > and the code and reason reach the server [73.93ms]
(pass) WebSocket close() argument validation > close(1002) is allowed > and the code and reason reach the server [70.81ms]
(pass) WebSocket close() argument validation > close(1003) is allowed > and the code and reason reach the server [55.60ms]
(pass) WebSocket close() argument validation > close(1007) is allowed > and the code and reason reach the server [51.78ms]
(pass) WebSocket close() argument validation > close(1008) is allowed > and the code and reason reach the server [51.41ms]
(pass) WebSocket close() argument validation > close(1009) is allowed > and the code and reason reach the server [44.99ms]
(pass) WebSocket close() argument validation > close(1010) is allowed > and the code and reason reach the server [53.36ms]
(pass) WebSocket close() argument validation > close(1011) is allowed > and the code and reason reach the server [53.99ms]
(pass) WebSocket close() argument validation > close(1012) is allowed > and the code an
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/websocket/websocket-close-code.test.ts | 4 ++++
 1 file changed, 4 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
test/js/web/websocket/websocket-close-code.test.ts      1      1      5
```

</details>

<!-- robobun:evidence:end -->