### PR TITLE
Upgrade WebKit to 0d58b764

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "6119947592b6e1c1faef02a4c2e03174cf05d062";
+export const WEBKIT_VERSION = "d4e7e206dc9b1c58eb8aca8f06eed7a6f4abb98a";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -258,8 +258,7 @@ void Cookie::appendTo(JSC::VM& vm, StringBuilder& builder) const
         builder.append("; Expires="_s);
         // RFC 6265 wants an IMF-fixdate ("Thu, 01 Jan 1970 00:00:00 GMT"). Reuse the
         // Date.prototype.toUTCString() formatter, which emits exactly that.
-        WTF::GregorianDateTime dateTime;
-        vm.dateCache.msToGregorianDateTime(m_expires, WTF::TimeType::UTCTime, dateTime);
+        auto dateTime = vm.dateCache.msToGregorianDateTime(m_expires, WTF::TimeType::UTCTime);
         builder.append(JSC::formatDateTime(dateTime, JSC::DateTimeFormat::DateAndTime, /* asUTCVariant */ true, vm.dateCache));
     }
 

--- a/src/jsc/bindings/ExceptionOr.h
+++ b/src/jsc/bindings/ExceptionOr.h
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "Exception.h"
 #include <wtf/CrossThreadCopier.h>
-#include <wtf/Expected.h>
+#include <expected>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {
@@ -50,7 +50,7 @@ public:
     ReturnType releaseReturnValue();
 
 private:
-    Expected<ReturnType, Exception> m_value;
+    std::expected<ReturnType, Exception> m_value;
 #if ASSERT_ENABLED
     bool m_wasReleased { false };
 #endif
@@ -86,7 +86,7 @@ public:
     Exception releaseException();
 
 private:
-    Expected<void, Exception> m_value;
+    std::expected<void, Exception> m_value;
 };
 
 ExceptionOr<void> isolatedCopy(ExceptionOr<void>&&);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -11,7 +11,6 @@
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/JSStringInlines.h>
 #include <JavaScriptCore/DateInstance.h>
-#include <JavaScriptCore/DateInstanceCache.h>
 #include <JavaScriptCore/JSCast.h>
 #include <JavaScriptCore/HeapIterationScope.h>
 #include <JavaScriptCore/MarkedSpaceInlines.h>
@@ -49,16 +48,9 @@ using namespace WebCore;
 
 void invalidateLiveDateInstanceCaches(JSC::VM& vm)
 {
-    // HeapIterationScope stops every allocator (walks all BlockDirectories); only
-    // forEachLiveCell is subspace-local. Acceptable for rare TZ writes — V8's O(1)
-    // alternative is a tz-generation counter on DateInstanceData.
     JSC::HeapIterationScope iterationScope(vm.heap);
     vm.heap.dateInstanceSpace.forEachLiveCell([](JSC::HeapCell* cell, JSC::HeapCell::Kind) -> IterationStatus {
-        auto* date = static_cast<JSC::DateInstance*>(static_cast<JSC::JSCell*>(cell));
-        // m_data is private, but its offset is exported for the JIT.
-        auto& dataSlot = *reinterpret_cast<RefPtr<JSC::DateInstanceData>*>(reinterpret_cast<uint8_t*>(date) + JSC::DateInstance::offsetOfData());
-        if (dataSlot)
-            dataSlot->m_gregorianDateTimeCachedForMS = PNaN;
+        static_cast<JSC::DateInstance*>(static_cast<JSC::JSCell*>(cell))->invalidateCachedLocalGregorianDateTime();
         return IterationStatus::Continue;
     });
 }

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -56,8 +56,8 @@ private:
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
 // Setting TZ must make *existing* Date instances recompute local time. JSC's DateCache
-// reset only clears shared slots; live DateInstances keep a Ref to DateInstanceData
-// whose gregorian cache still matches, so walk the heap and invalidate those.
+// reset only clears shared slots; live DateInstances keep their own cached fields
+// that still match, so walk the heap and invalidate those.
 void invalidateLiveDateInstanceCaches(JSC::VM&);
 
 // The shared DateCache reset and invalidateLiveDateInstanceCaches() must travel

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6016,22 +6016,14 @@ extern "C" [[ZIG_EXPORT(check_slow)]] double Bun__parseDate(JSC::JSGlobalObject*
 extern "C" [[ZIG_EXPORT(check_slow)]] double Bun__gregorianDateTimeToMS(JSC::JSGlobalObject* globalObject, int year, int month, int day, int hour, int minute, int second, int millisecond, bool localTime)
 {
     auto& vm = JSC::getVM(globalObject);
-    WTF::GregorianDateTime dateTime;
-    dateTime.setYear(year);
-    dateTime.setMonth(month - 1);
-    dateTime.setMonthDay(day);
-    dateTime.setHour(hour);
-    dateTime.setMinute(minute);
-    dateTime.setSecond(second);
-    return vm.dateCache.gregorianDateTimeToMS(dateTime, millisecond, localTime ? WTF::TimeType::LocalTime : WTF::TimeType::UTCTime);
+    return vm.dateCache.gregorianDateTimeToMS(year, month - 1, day, hour, minute, second, millisecond, localTime ? WTF::TimeType::LocalTime : WTF::TimeType::UTCTime);
 }
 
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__msToGregorianDateTime(JSC::JSGlobalObject* globalObject, double ms, bool localTime,
     int* year, int* month, int* day, int* hour, int* minute, int* second, int* weekday)
 {
     auto& vm = JSC::getVM(globalObject);
-    WTF::GregorianDateTime dt;
-    vm.dateCache.msToGregorianDateTime(ms, localTime ? WTF::TimeType::LocalTime : WTF::TimeType::UTCTime, dt);
+    auto dt = vm.dateCache.msToGregorianDateTime(ms, localTime ? WTF::TimeType::LocalTime : WTF::TimeType::UTCTime);
     *year = dt.year();
     *month = dt.month() + 1;
     *day = dt.monthDay();
@@ -6275,7 +6267,7 @@ extern "C" int JSC__JSValue__DateNowISOString(JSC::JSGlobalObject* globalObject,
 
     auto& vm = JSC::getVM(globalObject);
 
-    const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
+    auto gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
     if (!gregorianDateTime)
         return -1;
 
@@ -6285,10 +6277,10 @@ extern "C" int JSC__JSValue__DateNowISOString(JSC::JSGlobalObject* globalObject,
         ms += msPerSecond;
 
     int charactersWritten;
-    if (gregorianDateTime->year() > 9999 || gregorianDateTime->year() < 0)
-        charactersWritten = snprintf(buffer, sizeof(buffer), "%+07d-%02d-%02dT%02d:%02d:%02d.%03dZ", gregorianDateTime->year(), gregorianDateTime->month() + 1, gregorianDateTime->monthDay(), gregorianDateTime->hour(), gregorianDateTime->minute(), gregorianDateTime->second(), ms);
+    if (gregorianDateTime.year() > 9999 || gregorianDateTime.year() < 0)
+        charactersWritten = snprintf(buffer, sizeof(buffer), "%+07d-%02d-%02dT%02d:%02d:%02d.%03dZ", gregorianDateTime.year(), gregorianDateTime.month() + 1, gregorianDateTime.monthDay(), gregorianDateTime.hour(), gregorianDateTime.minute(), gregorianDateTime.second(), ms);
     else
-        charactersWritten = snprintf(buffer, sizeof(buffer), "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ", gregorianDateTime->year(), gregorianDateTime->month() + 1, gregorianDateTime->monthDay(), gregorianDateTime->hour(), gregorianDateTime->minute(), gregorianDateTime->second(), ms);
+        charactersWritten = snprintf(buffer, sizeof(buffer), "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ", gregorianDateTime.year(), gregorianDateTime.month() + 1, gregorianDateTime.monthDay(), gregorianDateTime.hour(), gregorianDateTime.minute(), gregorianDateTime.second(), ms);
 
     memcpy(buf, buffer, charactersWritten);
 

--- a/src/jsc/bindings/webcore/CallbackResult.h
+++ b/src/jsc/bindings/webcore/CallbackResult.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/Expected.h>
+#include <expected>
 
 namespace WebCore {
 
@@ -44,7 +44,7 @@ public:
     ReturnType&& releaseReturnValue();
 
 private:
-    Expected<ReturnType, CallbackResultType> m_value;
+    std::expected<ReturnType, CallbackResultType> m_value;
 };
 
 template<> class CallbackResult<void> {

--- a/src/jsc/bindings/webcore/JSDOMConvertResult.h
+++ b/src/jsc/bindings/webcore/JSDOMConvertResult.h
@@ -29,7 +29,7 @@
 #include <functional>
 #include <type_traits>
 #include <utility>
-#include <wtf/Expected.h>
+#include <expected>
 
 namespace WebCore {
 
@@ -61,7 +61,7 @@ struct ConversionResultStorage {
 
     template<typename U>
     ConversionResultStorage(ConversionResultStorage<U>&& other)
-        : value([&]() -> Expected<Type, ConversionResultException> {
+        : value([&]() -> std::expected<Type, ConversionResultException> {
             if (other.hasException())
                 return makeUnexpected(ConversionResultException());
             return ReturnType { other.releaseReturnValue() };
@@ -72,7 +72,7 @@ struct ConversionResultStorage {
     template<typename U>
         requires(std::is_pointer_v<Type> && std::is_lvalue_reference_v<U>)
     ConversionResultStorage(ConversionResultStorage<U>&& other)
-        : value([&]() -> Expected<Type, ConversionResultException> {
+        : value([&]() -> std::expected<Type, ConversionResultException> {
             if (other.hasException())
                 return makeUnexpected(ConversionResultException());
             return ReturnType { &other.releaseReturnValue() };
@@ -103,7 +103,7 @@ struct ConversionResultStorage {
         return WTF::move(value.value());
     }
 
-    Expected<Type, ConversionResultException> value;
+    std::expected<Type, ConversionResultException> value;
 #if ASSERT_ENABLED
     bool wasReleased { false };
 #endif
@@ -125,7 +125,7 @@ struct ConversionResultStorage<T&> {
 
     template<typename U>
     ConversionResultStorage(ConversionResultStorage<U>&& other)
-        : value([&]() -> Expected<std::reference_wrapper<Type>, ConversionResultException> {
+        : value([&]() -> std::expected<std::reference_wrapper<Type>, ConversionResultException> {
             if (other.hasException())
                 return makeUnexpected(ConversionResultException());
             return static_cast<ReturnType>(other.releaseReturnValue());
@@ -156,7 +156,7 @@ struct ConversionResultStorage<T&> {
         return WTF::move(value.value()).get();
     }
 
-    Expected<std::reference_wrapper<Type>, ConversionResultException> value;
+    std::expected<std::reference_wrapper<Type>, ConversionResultException> value;
 #if ASSERT_ENABLED
     bool wasReleased { false };
 #endif

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -267,8 +267,7 @@ size_t toISOString(JSC::VM& vm, double date, char in[64])
     if (!std::isfinite(date))
         return 0;
 
-    GregorianDateTime gregorianDateTime;
-    vm.dateCache.msToGregorianDateTime(date, WTF::TimeType::UTCTime, gregorianDateTime);
+    auto gregorianDateTime = vm.dateCache.msToGregorianDateTime(date, WTF::TimeType::UTCTime);
 
     // Maximum amount of space we need in buffer: 8 (max. digits in year) + 2 * 5 (2 characters each for month, day, hour, minute, second) + 4 (. + 3 digits for milliseconds)
     // 6 for formatting and one for null termination = 29.


### PR DESCRIPTION
# WebKit upgrade: upstream changes

Range: `c119008088192c83b7861bcbaf24a675f9d7e837..0d58b764f34b86ecf520ac7954b7aa1ded15cc5e` (354 upstream commits, 67 touch JavaScriptCore, WTF, or bmalloc).

## Notes for Bun

- Upstream removed `wtf/Expected.h`. WTF now uses `std::expected`. Bun's `ExceptionOr.h`, `CallbackResult.h`, and `JSDOMConvertResult.h` are updated to match.
- Upstream replaced the per-field DFG Date getter operations with `operationDateGetStorage` and `operationDateGetStorageUTC`. It also removed `DateInstanceCache`. The fork's `JSGlobalObject::jsDateNow()` hook (used for fake timers) is kept in `operationDateNow` and `callDate`.
- `DateInstance` no longer holds a `RefPtr<DateInstanceData>`. It stores a packed `PlainGregorianDateTime` inline and is no longer destructible.
- `JSEnvironmentVariableMap.cpp` used `DateInstanceCache.h` and `DateInstance::offsetOfData()`. Both are gone. The heap walk now calls `DateInstance::invalidateCachedLocalGregorianDateTime()`.
- Keep Bun's own heap walk. Upstream now walks `dateInstanceSpace` on VM entry, but only when `DateCache::hasTimeZoneChange()` is true. Bun calls `clearForTimeZoneChange()` directly, so that upstream path does not run for `process.env.TZ` writes.
- `JSType.h` did not change.
- The WebCore bindings generator output changed only cosmetically (`SUPPRESS_UNCOUNTED_LOCAL` removed).
- `JSValueRegs` and `SnippetReg` are removed from the JIT. The fork's DFG buffer ops and FFI stubs now use `GPRReg`.
- `useGlobalInliningPlanner` now defaults to `true`. This changes DFG/FTL inlining choices. It has no observable JS behavior change.
- No public C API changes. `JSValue.mm` had a small Objective-C cleanup.

## Runtime and builtins

- Deleting a property from a dictionary prototype now invalidates the megamorphic store cache. Before, a later store could skip a setter. https://bugs.webkit.org/show_bug.cgi?id=323254
- `Object.freeze` on a prototype now invalidates the megamorphic cache. https://bugs.webkit.org/show_bug.cgi?id=323131
- One accessor on a prototype no longer disables the megamorphic store cache for every other property name. https://bugs.webkit.org/show_bug.cgi?id=322708
- Proxy handler trap caching now requires a mono-proto structure. This fixes a crash with poly-proto handlers. https://bugs.webkit.org/show_bug.cgi?id=323085
- `new TypedArray(array)` now copies the array first when `ToNumber` can run user code. https://bugs.webkit.org/show_bug.cgi?id=322954
- `TypedArray.prototype.set` no longer uses `memmove` when overlapping regions need spec-order reads. https://bugs.webkit.org/show_bug.cgi?id=322892
- `indexOf`, `includes`, `lastIndexOf`, `startsWith`, and `endsWith` return early when the search string is longer than the subject. https://bugs.webkit.org/show_bug.cgi?id=322924

## Date

- `DateInstance` stores its broken-down time inline. A new `BrokenDownDateCache` replaces `DateInstanceCache`. https://bugs.webkit.org/show_bug.cgi?id=323204
- On a time zone change, JSC now invalidates every live `DateInstance`, not only the ones still in the cache.
- DFG and FTL use a new `DateGetStorage` node. Getters such as `getFullYear` read fields from it.

## Intl and Temporal

- `Intl.PluralRules.prototype.select` and `selectRange` accept `BigInt`. https://bugs.webkit.org/show_bug.cgi?id=323092
- `Intl.DurationFormat` omits the separator when minutes are hidden. https://bugs.webkit.org/show_bug.cgi?id=317486
- `Temporal.ZonedDateTime.prototype.round` resolves the offset exactly, not to the minute. https://bugs.webkit.org/show_bug.cgi?id=322923

## RegExp (Yarr)

- In a `/v` class, a character after a nested class or `\q{}` no longer adds `U+0000` to the set. https://bugs.webkit.org/show_bug.cgi?id=322962
- The YarrJIT non-BMP backtrack path now adds the extra read size to the index. Before, a match could report start > end. https://bugs.webkit.org/show_bug.cgi?id=316996

## JIT (Baseline, DFG, FTL, B3)

- The global inlining planner is on by default. https://bugs.webkit.org/show_bug.cgi?id=323126
- DFG `ObjectCreate` folding now emits its edge checks. https://bugs.webkit.org/show_bug.cgi?id=317570
- Object allocation sinking handles allocations inside inlined closure-call and varargs frames correctly. https://bugs.webkit.org/show_bug.cgi?id=315674
- DFG and FTL scan `toLowerCase` and `toUpperCase` strings inline. https://bugs.webkit.org/show_bug.cgi?id=323033
- DFG OSR entry values and FTL OSR exit value reps are stored as byte streams. This saves memory. https://bugs.webkit.org/show_bug.cgi?id=323169 https://bugs.webkit.org/show_bug.cgi?id=322888
- The Baseline JIT no longer builds `GCOwnedDataScope` on the compiler thread. https://bugs.webkit.org/show_bug.cgi?id=323102
- `CodeBlock::m_lock` is held for less time. https://bugs.webkit.org/show_bug.cgi?id=322895
- FTL fixes: `Output::load` emitted the wrong instruction; validation patchpoints and `cachedPutById` register constraints are tighter. https://bugs.webkit.org/show_bug.cgi?id=323238 https://bugs.webkit.org/show_bug.cgi?id=323249 https://bugs.webkit.org/show_bug.cgi?id=323248
- offlineasm emits `tbz`/`tbnz` for single-bit tests on ARM64. https://bugs.webkit.org/show_bug.cgi?id=322779
- Two earlier reverts are undone. This restores the single `ldp` metadata load in the Baseline JIT and the add/sub-zero-to-mov change in the macro assemblers. https://bugs.webkit.org/show_bug.cgi?id=323058 https://bugs.webkit.org/show_bug.cgi?id=323056

## WebAssembly

- ESM-imported `.wasm` modules get the JS string builtins and `wasm:js/string-constants`. https://bugs.webkit.org/show_bug.cgi?id=322238
- `WebAssembly.Exception` treats `null` options like `undefined` and throws `TypeError` for non-objects. https://bugs.webkit.org/show_bug.cgi?id=322948
- IPInt handles overlong LEB128 opcodes for `br_on_cast` and `br_on_cast_fail`. https://bugs.webkit.org/show_bug.cgi?id=317349
- The OMG `addReturn` patchpoint clobbers macro registers. https://bugs.webkit.org/show_bug.cgi?id=323245
- Faster code: inlined `table.get` for funcref and `any.convert_extern`, no write barrier for constant non-cells, and `Shl` folded into ARM64 addresses. https://bugs.webkit.org/show_bug.cgi?id=322528 https://bugs.webkit.org/show_bug.cgi?id=322781 https://bugs.webkit.org/show_bug.cgi?id=322500 https://bugs.webkit.org/show_bug.cgi?id=323211
- Constant expressions are validated and evaluated in separate steps, without a byte copy. Import names are atomized once. https://bugs.webkit.org/show_bug.cgi?id=323289 https://bugs.webkit.org/show_bug.cgi?id=323269 https://bugs.webkit.org/show_bug.cgi?id=323281

## WTF

- `wtf/Expected.h` is removed. Use `std::expected` and `std::unexpected`. https://bugs.webkit.org/show_bug.cgi?id=322947 https://bugs.webkit.org/show_bug.cgi?id=322894

## Build and refactors

- `JSValueRegs` and `SnippetReg` are removed from the JIT. The fork's DFG buffer ops and FFI stubs now use `GPRReg`.
- The `jsc` shell sets its main thread QoS to user-interactive on Darwin. https://bugs.webkit.org/show_bug.cgi?id=323207
- 21 other commits are Cocoa/Xcode/CMake build changes, Safer CPP macro cleanups, test-tool fixes, or WebCore-only work that touched shared files.
- The remaining 287 commits do not touch JavaScriptCore, WTF, or bmalloc.
