### PR TITLE
bundler: no export table for a lifted CommonJS file that stays wrapped

### DIFF
--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -22,7 +22,7 @@ use bun_ast::{
 
 use crate::options::Format;
 use crate::perf;
-use crate::{BundleV2, Index, LinkerContext, RefImportData, ResolvedExports, js_meta};
+use crate::{BundleV2, Index, LinkerContext, RefImportData, ResolvedExports, WrapKind, js_meta};
 
 pub use crate::ThreadPool;
 
@@ -144,7 +144,21 @@ impl LinkerContext<'_> {
         // counting in here saves us an extra pass through the array
         let mut re_exports_count: usize = 0;
 
-        {
+        // SAFETY: read of this task's own row; only `create_exports_for_file`
+        // below writes it, after this read.
+        let is_lifted_commonjs = unsafe { *ast.flags.cast::<AstFlags>().add(id as usize) }
+            .contains(AstFlags::COMMONJS_LIFTED_TO_ESM);
+        // A lifted CommonJS file that is wrapped again (`require()` reaches it)
+        // prints its `exports.x = ...` assignments as written. Its namespace is
+        // the real `module.exports`, so it gets no export getters: they would
+        // read bindings the wrapped file never declares.
+        // SAFETY: read of this task's own row, before `create_exports_for_file`
+        // below takes `&mut` to it.
+        let is_wrapped_commonjs = is_lifted_commonjs
+            && unsafe { *meta.flags.cast::<js_meta::Flags>().add(id as usize) }.wrap
+                == WrapKind::Cjs;
+
+        if !is_wrapped_commonjs {
             // SAFETY: see above.
             let mut alias_iter = unsafe { (*resolved_exports).iterator() };
             'next_alias: while let Some(entry) = alias_iter.next() {
@@ -202,10 +216,6 @@ impl LinkerContext<'_> {
         // namespace of a CommonJS module whose `exports.foo = ...` assignments
         // were lifted to ES module exports stands in for `module.exports`, so
         // it keeps the assignment order (the order of `resolved_exports`).
-        // SAFETY: read of this task's own row; only `create_exports_for_file`
-        // below writes it, after this read.
-        let is_lifted_commonjs = unsafe { *ast.flags.cast::<AstFlags>().add(id as usize) }
-            .contains(AstFlags::COMMONJS_LIFTED_TO_ESM);
         if !is_lifted_commonjs {
             strings::sort_asc(aliases.as_mut_slice());
         }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -601,9 +601,7 @@ pub(crate) fn scan_imports_and_exports(
                     // The wrapper prints `exports.x = ...` again, so it takes `exports`.
                     col!(ast_flags_list)[source_index].insert(AstFlags::USES_EXPORTS_REF);
                 } else if is_lifted_commonjs && export_kind != ExportsKind::Cjs {
-                    // The namespace of a lifted file stands in for `module.exports`: its
-                    // properties get setters. Step 5 runs in parallel, so the setters'
-                    // parameter symbol is created here.
+                    // Step 5 runs in parallel, so the export setters' parameter is made here.
                     col!(lifted_setter_params)[source_index] = this.graph.generate_new_symbol(
                         source_index_.get(),
                         SymbolKind::Other,

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -598,15 +598,12 @@ pub(crate) fn scan_imports_and_exports(
                 let is_lifted_commonjs = col_ref!(ast_flags_list)[source_index]
                     .contains(AstFlags::COMMONJS_LIFTED_TO_ESM);
                 if is_lifted_commonjs && flag.wrap == WrapKind::Cjs {
-                    // A lifted file that is wrapped again prints its
-                    // `exports.x = ...` assignments as written, so the wrapper
-                    // takes `exports`. The parser counted no use of it.
+                    // The wrapper prints `exports.x = ...` again, so it takes `exports`.
                     col!(ast_flags_list)[source_index].insert(AstFlags::USES_EXPORTS_REF);
                 } else if is_lifted_commonjs && export_kind != ExportsKind::Cjs {
-                    // The namespace object of a lifted CommonJS module stands in for
-                    // `module.exports`, so its properties get setters that assign the
-                    // lifted bindings. Step 5 runs in parallel and cannot create the
-                    // setters' parameter symbol, so create it here.
+                    // The namespace of a lifted file stands in for `module.exports`: its
+                    // properties get setters. Step 5 runs in parallel, so the setters'
+                    // parameter symbol is created here.
                     col!(lifted_setter_params)[source_index] = this.graph.generate_new_symbol(
                         source_index_.get(),
                         SymbolKind::Other,

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -595,15 +595,18 @@ pub(crate) fn scan_imports_and_exports(
                     col!(flags)[source_index] = flag;
                 }
 
-                // The namespace object of a lifted CommonJS module stands in for
-                // `module.exports`, so its properties get setters that assign the
-                // lifted bindings. Step 5 runs in parallel and cannot create the
-                // setters' parameter symbol, so create it here.
-                if export_kind != ExportsKind::Cjs
-                    && flag.wrap != WrapKind::Cjs
-                    && col_ref!(ast_flags_list)[source_index]
-                        .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)
-                {
+                let is_lifted_commonjs = col_ref!(ast_flags_list)[source_index]
+                    .contains(AstFlags::COMMONJS_LIFTED_TO_ESM);
+                if is_lifted_commonjs && flag.wrap == WrapKind::Cjs {
+                    // A lifted file that is wrapped again prints its
+                    // `exports.x = ...` assignments as written, so the wrapper
+                    // takes `exports`. The parser counted no use of it.
+                    col!(ast_flags_list)[source_index].insert(AstFlags::USES_EXPORTS_REF);
+                } else if is_lifted_commonjs && export_kind != ExportsKind::Cjs {
+                    // The namespace object of a lifted CommonJS module stands in for
+                    // `module.exports`, so its properties get setters that assign the
+                    // lifted bindings. Step 5 runs in parallel and cannot create the
+                    // setters' parameter symbol, so create it here.
                     col!(lifted_setter_params)[source_index] = this.graph.generate_new_symbol(
                         source_index_.get(),
                         SymbolKind::Other,

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1605,6 +1605,68 @@ describe("bundler", () => {
       stdout: "function",
     },
   });
+  // `require()` of a lifted file keeps it in a `__commonJS` wrapper. A call of its own
+  // export must not bring an export table for the lifted bindings into the wrapper.
+  itBundled("cjs2esm/SelfMethodCallInRequiredFileKeepsExports", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as m from "./index.cjs";
+        console.log(typeof m.publicEncrypt, typeof m.privateEncrypt, m.privateEncrypt("x"));
+      `,
+      "/index.cjs": /* js */ `
+        var c = require("./empty.cjs");
+        if (typeof c.publicEncrypt !== "function") c = require("./lib.cjs");
+        exports.publicEncrypt = c.publicEncrypt;
+        exports.privateEncrypt = c.privateEncrypt;
+      `,
+      "/lib.cjs": /* js */ `
+        exports.publicEncrypt = require("./pe.cjs");
+        exports.privateEncrypt = function (k) { return exports.publicEncrypt(k); };
+      `,
+      "/pe.cjs": /* js */ `
+        module.exports = function publicEncrypt(k) { return "enc:" + k; };
+      `,
+      "/empty.cjs": /* js */ `
+        module.exports = {};
+      `,
+    },
+    cjs2esm: { unhandled: ["/lib.cjs", "/pe.cjs", "/empty.cjs"] },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toContain("__export(");
+      expect(out).toContain("var require_lib = __commonJS(function(exports) {");
+    },
+    run: {
+      stdout: "function function enc:x",
+    },
+  });
+  // The same, with export names that no other file declares.
+  itBundled("cjs2esm/SelfMethodCallInRequiredFileDistinctNames", {
+    files: {
+      "/entry.js": /* js */ `
+        import { run } from "./index.cjs";
+        console.log(run());
+      `,
+      "/index.cjs": /* js */ `
+        var lib = require("./lib.cjs");
+        exports.run = function () { return lib.parse("in"); };
+      `,
+      "/lib.cjs": /* js */ `
+        exports.parse = function (s) { return this._helper(s); };
+        exports._helper = function (s) { return "helped:" + s; };
+        exports.internal = function () { return exports.parse("x"); };
+      `,
+    },
+    cjs2esm: { unhandled: ["/lib.cjs"] },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toContain("__export(");
+      expect(out).not.toContain("$parse");
+    },
+    run: {
+      stdout: "helped:in",
+    },
+  });
   itBundled("cjs2esm/DefaultImportJsxClassicRuntime", {
     files: {
       "/entry.jsx": /* jsx */ `


### PR DESCRIPTION
### Problem
- A lifted CommonJS file that `require()` reaches stays in a `__commonJS` wrapper. If it calls one of its own exports (`exports.publicEncrypt(k)`), the bundle prints `__export(exports, { publicEncrypt: () => $publicEncrypt, ... })` inside that wrapper. `$publicEncrypt` is never declared there, so the getters return `undefined` or throw `ReferenceError: $publicEncrypt is not defined`. The `crypto` browser polyfill (`public-encrypt` through `crypto-browserify`) has this shape.
- Cause: #41273 records the call as a use of `exports`, which makes the namespace export part live. Step 5 (`src/bundler/linker_context/doStep5.rs`) still built that part for a wrapped lifted file, with getters for the lifted bindings. Before #41273 the part existed but was dead.

### Fix
- Step 5 skips the export aliases of a lifted file whose `wrap` is `Cjs`. Its namespace is the real `module.exports`, so it gets no export getters. This matches a plain CommonJS file, which has no resolved exports.
- Step 4 (`scanImportsAndExports.rs`) sets `USES_EXPORTS_REF` on such a file. The parser counts no use of `exports` after it lifts the assignments, and the `__export` part used to set the flag as a side effect. The wrapper needs the `exports` parameter to print `exports.x = ...`.
- Self-reviewed. The `crypto` polyfill built with this branch loads in node and `publicEncrypt` is a function.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (2 new tests, both fail on main). Also `bundler_cjs`, `bundler_browser`, `bundler_splitting`, `bundler_edgecase`, `bundler_esbuild_default`, `esbuild/importstar`, `esbuild/default`.

### Background
- Lifting (`COMMONJS_LIFTED_TO_ESM`) turns `exports.foo = x` into `var $foo = x` plus an ES module export, so importers bind to `$foo` directly.
- The linker can undo that choice per file. When another file reaches the lifted file through `require()`, step 1 sets `wrap = Cjs`. The printer then prints the original `exports.foo = x` form inside a `__commonJS(function(exports, module) { ... })` wrapper.
- The namespace export part (part index 0) holds `__export(exports, {...})`: getters that expose a file's ES module bindings on a namespace object. Any part that uses the file's `exports` symbol pulls it in.

<details><summary>Notes</summary>

- Repro from the issue: `bun build entry.js --outfile=out.js && node out.js` prints `undefined undefined` on main and `function function` with this branch.
- The two new tests: one with names that collide with the importer's lifted bindings (the issue's shape, values become `undefined`), one with distinct names (the getter would throw `ReferenceError`).
- `wrap == Cjs` is the same condition the printer uses for `commonjs_named_exports_deoptimized`, so step 5 and the printer agree on which files print `exports.x = ...`.
- For a wrapped lifted file, `sorted_and_filtered_export_aliases` is now empty, as for a plain CommonJS file. The consumers of that list (entry point export clauses, cross-chunk exports, reserved names, metafile) already treat a `wrap == Cjs` entry point as `default` only.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [795.05ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [344.08ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [335.57ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [318.47ms]
(pass) bundler > cjs2esm/ExportsFunction [320.54ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [392.07ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [387.86ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [429.30ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [374.92ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [378.07ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [410.52ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [515.96ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [434
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (e0a2b82fd)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [20.81ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [8.72ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [7.45ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [7.19ms]
(pass) bundler > cjs2esm/ExportsFunction [8.91ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [7.83ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [7.49ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [8.83ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [8.44ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [9.70ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [7.64ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [9.05ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [8.86ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [9.79ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [7.93ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [719.04ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [332.80ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [402.09ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [388.61ms]
(pass) bundler > cjs2esm/ExportsFunction [387.06ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [390.34ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [383.98ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [358.33ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [378.05ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [447.54ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [349.82ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [578.04ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [495
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 607ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/141] gen JS modules (bundle-modules)
Preprocess modules (7326ms)
Bundle modules (673ms)
Postprocesss modules (999ms)
Bundle Functions (725ms)
Generate Code (36ms)

[9.78s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/141] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_opaque v0.0.0 (/workspace/bun/src/opaque)
[1m[92m   Compiling[0m bun_wyhash v0.0.0 (/workspace/bun/src/wyhash)
[1m[92m   Compiling[0m bun_highway v0.0.0 (/workspace/bun/src/highway)
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_simdutf_sys v0.0.0 (/workspace/bun/src/simdutf_sys)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m bun_core_macros v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/linker_context/doStep5.rs              | 22 +++++---
 .../linker_context/scanImportsAndExports.rs        | 21 ++++----
 test/bundler/bundler_cjs2esm.test.ts               | 62 ++++++++++++++++++++++
 3 files changed, 90 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/linker_context/doStep5.rs                    1      4      5
src/bundler/linker_context/scanImportsAndExports.rs      1      1      5
test/bundler/bundler_cjs2esm.test.ts                     1      1      5
```

</details>

<!-- robobun:evidence:end -->