### PR TITLE
Remove dead code from bun_collections, libuv_sys, bun_core, and the build scripts

### DIFF
--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -37,9 +37,6 @@ export const isCI: boolean = utils.isCI;
 /** True if running under Buildkite specifically. */
 export const isBuildkite: boolean = utils.isBuildkite;
 
-/** True if running under GitHub Actions specifically. */
-export const isGithubAction: boolean = utils.isGithubAction;
-
 /**
  * Print machine/environment/repository info in collapsible groups.
  * Call at the top of a CI run so you can diagnose without SSH access.
@@ -51,9 +48,6 @@ export const printEnvironment: () => void = utils.printEnvironment;
  * If `fn` is given, runs it and closes the group (handles async).
  */
 export const startGroup: (title: string, fn?: () => unknown) => unknown = utils.startGroup;
-
-/** Close the most recent group opened with `startGroup`. */
-export const endGroup: () => void = utils.endGroup;
 
 interface SpawnAnnotatedOptions {
   /** Working directory for the subprocess. */

--- a/scripts/build/deps/index.ts
+++ b/scripts/build/deps/index.ts
@@ -77,31 +77,3 @@ export const allDeps: readonly Dependency[] = [
   // above might reference (via JavaScriptCore types in headers).
   webkit,
 ];
-
-// Re-export individuals for direct import when needed.
-export {
-  boringssl,
-  brotli,
-  cares,
-  hdrhistogram,
-  highway,
-  libarchive,
-  libdeflate,
-  libjpegTurbo,
-  libspng,
-  libuv,
-  libwebp,
-  lolhtml,
-  lshpack,
-  lsqpack,
-  lsquic,
-  mimalloc,
-  nodejsHeaders,
-  picohttpparser,
-  rustArgon2,
-  sqlite,
-  tinycc,
-  webkit,
-  zlib,
-  zstd,
-};

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -73,15 +73,6 @@ if [ "$MODE" = "check" ]; then
     # Check mode - verify formatting without modifying files
     FAILED=0
     for file in "${UNIQUE_FILES[@]}"; do
-        # Find the nearest .clang-format file for this source file
-        dir=$(dirname "$file")
-        while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
-            if [ -f "$dir/.clang-format" ]; then
-                break
-            fi
-            dir=$(dirname "$dir")
-        done
-        
         if ! $CLANG_FORMAT --dry-run --Werror "$file" 2>/dev/null; then
             echo "Format check failed: $file"
             FAILED=1

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -381,7 +381,7 @@ impl Scope {
     /// `Default::default()` chain — i.e. no temporary `Scope` is constructed
     /// and partially dropped, and `members`/`children`/`generated` come from a
     /// const-folded zero header rather than three out-of-line `default()`
-    /// calls. `AstAlloc::vec` and `StringHashMap::new_in` are both `const fn`.
+    /// calls. `AstAlloc::vec` is a `const fn` and `Members::EMPTY` is a `const`.
     pub const EMPTY: Self = Self {
         kind: Kind::Block,
         parent: None,

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -598,14 +598,6 @@ pub fn rsplit_once_char(self_: &[u8], delimiter: u8) -> Option<(&[u8], &[u8])> {
     Some((&self_[..i], &self_[i + 1..]))
 }
 
-/// `str::split_once` for bytes with a multi-byte delimiter. An empty
-/// delimiter never matches.
-#[inline]
-pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
-    let i = index_of(self_, delimiter)?;
-    Some((&self_[..i], &self_[i + delimiter.len()..]))
-}
-
 /// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
 /// delimiter never matches.
 #[inline]

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -598,6 +598,14 @@ pub fn rsplit_once_char(self_: &[u8], delimiter: u8) -> Option<(&[u8], &[u8])> {
     Some((&self_[..i], &self_[i + 1..]))
 }
 
+/// `str::split_once` for bytes with a multi-byte delimiter. An empty
+/// delimiter never matches.
+#[inline]
+pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
+    let i = index_of(self_, delimiter)?;
+    Some((&self_[..i], &self_[i + delimiter.len()..]))
+}
+
 /// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
 /// delimiter never matches.
 #[inline]

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1645,19 +1645,6 @@ impl<A: Allocator + Default> From<Box<[u8], A>> for StringHashMapKey<A> {
     }
 }
 
-impl<A: Allocator + Default> From<&'static [u8]> for StringHashMapKey<A> {
-    /// Zero-copy: the slice is stored by reference. This is the conversion
-    /// `hashbrown::VacantEntryRef::insert` calls on miss in the
-    /// [`StringHashMap::put_borrowed`] / [`StringHashMap::get_or_put_borrowed`]
-    /// fast paths, so it must NOT allocate (the `'static` here is the
-    /// caller-asserted lifetime erasure, not a literal program-lifetime
-    /// requirement — see those methods' safety docs).
-    #[inline]
-    fn from(s: &'static [u8]) -> Self {
-        Self::borrowed(s)
-    }
-}
-
 impl<V, A: Allocator + HashbrownAllocator + Clone + Default> Default for StringHashMap<V, A> {
     fn default() -> Self {
         Self {
@@ -1700,22 +1687,6 @@ fn box_key<A: Allocator + Default>(key: &[u8]) -> Box<[u8], A> {
 #[inline]
 fn owned_key<A: Allocator + Default>(key: &[u8]) -> StringHashMapKey<A> {
     StringHashMapKey::owned(box_key::<A>(key))
-}
-
-impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A> {
-    /// `const` constructor — empty map, no heap touch. Exists so aggregates
-    /// that embed a `StringHashMap` (e.g. `js_ast::Scope::EMPTY`) can be
-    /// spelled as a `const` and used with struct-update syntax in hot
-    /// allocation paths, instead of calling the `Default` chain at runtime
-    /// for every field. `hashbrown::HashMap::with_hasher_in` and
-    /// `BuildHasherDefault::new` are both `const fn`, so this is a true
-    /// compile-time value (all-zeros for ZST `A`).
-    #[inline]
-    pub const fn new_in(alloc: A) -> Self {
-        Self {
-            inner: hashbrown::HashMap::with_hasher_in(core::hash::BuildHasherDefault::new(), alloc),
-        }
-    }
 }
 
 impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A> {
@@ -1827,30 +1798,6 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
         Ok(())
     }
 
-    /// Insert `value` under `key` **without copying the key bytes** — the
-    /// arena-lifetime twin of [`put_static_key`]. The safe [`put`] heap-boxes
-    /// the key, which profiling
-    /// flagged as the dominant `_mi_malloc_generic` caller in the parser
-    /// (`Scope::members` takes one box per declared identifier per scope).
-    /// This entry point provides zero-copy insertion for callers whose
-    /// key bytes already live in an arena that outlives the map.
-    ///
-    /// # Safety
-    /// The bytes behind `key` must remain alive and unmoved for as long as the
-    /// resulting entry stays in `self` (i.e. until the entry is removed or the
-    /// map is dropped/reset). For the parser this is satisfied because keys
-    /// point into source text or the lexer string-table, both of which outlive
-    /// the `AstAlloc` arena that owns the `Scope` holding this map.
-    #[inline]
-    pub unsafe fn put_borrowed(&mut self, key: &[u8], value: V) -> Result<(), AllocError> {
-        // SAFETY: caller contract above. Erase the borrow's lifetime so it can
-        // be stored as `Static` without a heap copy; the map never inspects the
-        // lifetime, only the (ptr, len) pair.
-        let key: &'static [u8] = unsafe { &*std::ptr::from_ref::<[u8]>(key) };
-        self.inner.insert(StringHashMapKey::borrowed(key), value);
-        Ok(())
-    }
-
     /// PERF: std::HashMap cannot skip the grow check, so this is
     /// just `put` without the `Result`.
     #[inline]
@@ -1867,9 +1814,7 @@ pub use crate::hash_map::GetOrPutResult as StringHashMapGetOrPut;
 
 impl<V: Default, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A> {
     /// Single hash + single probe via `raw_entry_mut`; the key `Box` is only
-    /// allocated on miss. Callers whose key bytes already outlive the map
-    /// should prefer [`get_or_put_borrowed`] which also skips the miss-path
-    /// box.
+    /// allocated on miss.
     pub fn get_or_put(&mut self, key: &[u8]) -> Result<StringHashMapGetOrPut<'_, V>, AllocError> {
         use hashbrown::hash_map::RawEntryMut;
         let hash = self.hash_key(key);
@@ -1908,38 +1853,6 @@ impl<V: Default, A: Allocator + HashbrownAllocator + Clone + Default> StringHash
                 }
             },
         )
-    }
-
-    /// Zero-allocation `getOrPut` — the arena-lifetime twin of
-    /// [`get_or_put`]. Looks up `key` and on
-    /// miss inserts `V::default()` keyed by the **borrowed slice itself** (no
-    /// `box_key`). Single hash + single probe via `hashbrown`'s `entry_ref`;
-    /// the `From<&'static [u8]>` impl above is what `VacantEntryRef::insert`
-    /// uses to turn the lifetime-erased slice into a `Static` key.
-    ///
-    /// This is the hot path for `Scope::members` (one call per declared
-    /// identifier in `declare_symbol` / scope hoisting), where
-    /// the previous owning shape was the parser's single largest
-    /// `mi_heap_malloc` source.
-    ///
-    /// # Safety
-    /// Same contract as [`put_borrowed`]: the bytes behind `key` must outlive
-    /// the entry's residency in `self`.
-    #[inline]
-    pub unsafe fn get_or_put_borrowed(&mut self, key: &[u8]) -> StringHashMapGetOrPut<'_, V> {
-        use hashbrown::hash_map::EntryRef;
-        // SAFETY: caller contract above; see `put_borrowed`.
-        let key: &'static [u8] = unsafe { &*std::ptr::from_ref::<[u8]>(key) };
-        match self.inner.entry_ref(key) {
-            EntryRef::Occupied(o) => StringHashMapGetOrPut {
-                found_existing: true,
-                value_ptr: o.into_mut(),
-            },
-            EntryRef::Vacant(v) => StringHashMapGetOrPut {
-                found_existing: false,
-                value_ptr: v.insert(V::default()),
-            },
-        }
     }
 }
 

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -2642,7 +2642,6 @@ unsafe extern "C" {
         calloc_func: uv_calloc_func,
         free_func: uv_free_func,
     ) -> c_int;
-    pub fn uv_default_loop() -> *mut Loop;
     pub fn uv_loop_init(loop_: *mut Loop) -> ReturnCode;
     pub fn uv_loop_close(loop_: *mut Loop) -> ReturnCode;
     pub fn uv_loop_alive(loop_: *const Loop) -> c_int;
@@ -2652,10 +2651,8 @@ unsafe extern "C" {
     pub fn uv_unref(handle: *mut uv_handle_t);
     pub fn uv_has_ref(handle: *const uv_handle_t) -> c_int;
     pub fn uv_update_time(loop_: *mut Loop);
-    pub fn uv_now(loop_: *const Loop) -> u64;
 
     // handle/req
-    pub fn uv_handle_size(type_: uv_handle_type) -> usize;
     pub fn uv_handle_get_type(handle: *const uv_handle_t) -> uv_handle_type;
     pub fn uv_handle_type_name(type_: uv_handle_type) -> *const c_char;
     pub fn uv_handle_get_data(handle: *const uv_handle_t) -> *mut c_void;
@@ -2665,7 +2662,6 @@ unsafe extern "C" {
     pub fn uv_walk(loop_: *mut Loop, walk_cb: uv_walk_cb, arg: *mut c_void);
     pub fn uv_close(handle: *mut uv_handle_t, close_cb: uv_close_cb);
     pub fn uv_fileno(handle: *const uv_handle_t, fd: *mut uv_os_fd_t) -> c_int;
-    pub fn uv_buf_init(base: *mut c_char, len: c_uint) -> uv_buf_t;
     pub fn uv_pipe(fds: *mut [uv_file; 2], read_flags: c_int, write_flags: c_int) -> ReturnCode;
     pub fn uv_is_closing(handle: *const uv_handle_t) -> c_int;
     pub fn uv_cancel(req: *mut uv_req_t) -> c_int;
@@ -2775,10 +2771,8 @@ unsafe extern "C" {
 
     // misc
     pub fn uv_uptime(uptime: *mut f64) -> c_int;
-    pub fn uv_getrusage(rusage: *mut uv_rusage_t) -> c_int;
     pub fn uv_os_homedir(buffer: *mut u8, size: *mut usize) -> ReturnCode;
     pub fn uv_os_getppid() -> uv_pid_t;
-    pub fn uv_os_getpriority(pid: uv_pid_t, priority: *mut c_int) -> c_int;
     pub fn uv_translate_sys_error(sys_errno: c_int) -> c_int;
     pub fn uv_cpu_info(cpu_infos: *mut *mut uv_cpu_info_t, count: *mut c_int) -> c_int;
     pub fn uv_free_cpu_info(cpu_infos: *mut uv_cpu_info_t, count: c_int);
@@ -2788,9 +2782,7 @@ unsafe extern "C" {
     ) -> c_int;
     pub fn uv_free_interface_addresses(addresses: *mut uv_interface_address_t, count: c_int);
     pub fn uv_os_uname(buffer: *mut uv_utsname_t) -> c_int;
-    pub fn uv_cwd(buffer: *mut c_char, size: *mut usize) -> c_int;
     pub fn uv_get_total_memory() -> u64;
-    pub fn uv_disable_stdio_inheritance();
 
     // fs
     pub fn uv_fs_req_cleanup(req: *mut fs_t);

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -926,8 +926,6 @@ pub mod kernel32 {
             dwWriteCoord: COORD,
             lpNumberOfCharsWritten: *mut DWORD,
         ) -> BOOL;
-        /// `SetConsoleCursorPosition` (`wincon.h`).
-        pub fn SetConsoleCursorPosition(hConsoleOutput: HANDLE, dwCursorPosition: COORD) -> BOOL;
         /// `ExitThread` (`processthreadsapi.h`). No preconditions; terminates
         /// the calling thread.
         pub safe fn ExitThread(dwExitCode: DWORD) -> !;


### PR DESCRIPTION
### Problem
- Some items have no use on any target: three `StringHashMap` methods and one `From` impl, nine extern declarations, and three blocks in the build scripts.
- `dead_code = "deny"` cannot report them. They are `pub` items, trait impls, or extern declarations.

### Fix
- Delete each item. The two added lines fix doc comments that named a deleted method.
- Each Rust candidate got a `#[deprecated]` attribute. rustc reports every use of a deprecated item in every crate, and it does not change name resolution. No check reported a use of these items.
- The checks ran on seven configurations: linux with the debug cfgs, linux with the release cfgs, plain linux, windows x64, macOS arm64, freebsd x64, and android arm64.
- Verified: `bun bd` builds. `bun run rust:check-all` passes on all 12 targets. `test/internal/source-lints/` passes (172 tests).

### Background
- `bun_codegen_embed`, `bun_debug`, and `bun_asan` are cfgs that `scripts/build/rust.ts` sets per profile. A plain `cargo check` does not compile code under them. `zstd::inflate_embedded` looks dead without them, so it stays.
- rustc reports no deprecated use inside attribute-macro output. `#[host_fn]` pastes names, so a name that appears as a suffix of another identifier is kept.
- The probe also cannot see a name in a config file. `clippy.toml` names `strings::split_once` as the replacement for banned methods, so it stays.

<details><summary>Notes</summary>

**Method.** Candidates came from two passes.
- One crate at a time: narrow every `pub` in the crate to `pub(crate)`, then `cargo check -p <crate>`. rustc then lists the items that the crate itself does not use. This ran for linux, windows x64, and macOS arm64.
- All crates at once: narrow every `pub`, then put `pub` back on each item that a compile error names. This converged after 75 rounds. `#[allow(dead_code)]` was stripped for the last check.

That gave about 20,000 candidates. Each got a `#[deprecated(note = "DEADPROBE:<id>")]` attribute, and the seven checks ran with `--force-warn=deprecated`. A candidate is dead only when every reported use sits inside another dead candidate.

**Why this is small.** About 20 open dead-code pull requests hold most of what these passes find. The candidate list skips every item that those pull requests delete. `Tag::is_windows` is dead, but #40172 deletes it.

**Removed**
- `src/collections/array_hash_map.rs`: `StringHashMap::{new_in, put_borrowed, get_or_put_borrowed}`, and `impl From<&'static [u8]> for StringHashMapKey`. Only `get_or_put_borrowed` called `entry_ref`, which needs that impl. `Scope::EMPTY` uses `Members::EMPTY` now, so the comment in `src/ast/scope.rs` names that instead.
- `src/libuv_sys/libuv.rs`: `uv_default_loop`, `uv_now`, `uv_handle_size`, `uv_buf_init`, `uv_getrusage`, `uv_os_getpriority`, `uv_cwd`, `uv_disable_stdio_inheritance`. The N-API symbol list in `napi_body.rs` has its own declarations.
- `src/windows_sys/externs.rs`: `SetConsoleCursorPosition`.
- `scripts/build/ci.ts`: the `isGithubAction` and `endGroup` re-exports. Callers import them from `scripts/utils.mjs`.
- `scripts/build/deps/index.ts`: the `export { boringssl, ... }` block. The four importers take `allDeps` only.
- `scripts/run-clang-format.sh`: a loop in check mode that sets `dir`. Nothing reads `dir`.

**Kept on purpose**
- `bun_core::strings::split_once`. No code calls it, but `clippy.toml` names it in three `disallowed-methods` reasons. The first commit removed it, and the second commit restores it.
- `h2::wire::MAX_STREAM_ID`. The `node:http2` engine is not wired up yet.
- The Windows `WaitPidResult` stub. `src/spawn/lib.rs` re-exports it. A deprecated item in a `use` is not reported.
- `scripts/p-limit.mjs` `limitFunction`. The file is a copy of p-limit.

**Probably dead, not in this diff.** `scripts/gamble.ts`, `scripts/github-metrics.ts`, `scripts/lldb-inline.sh` with `scripts/lldb-inline-tool.cpp`, and `scripts/packer/build-image.pkr.hcl`. Nothing references them, but a person can run them by hand.

**Scanned with nothing to add.** `src/js`. Every builtin is reachable, and the few unused exports mirror Node.js constants.

**Tests** (`bun bd test`): `test/internal/source-lints/` (172 pass), `test/js/bun/transpiler/repl-transform.test.ts`, and `test/bundler/bundler_naming.test.ts` (63 pass, 3 todo).

</details>
