### PR TITLE
test(proxy-stress): bind deadPort()'s holder before it connects

### DIFF
--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -717,6 +717,16 @@ export interface DeadPort {
  * `listen(0)`, and not listening, so `connect()` to it is refused. Do not
  * simplify to bind-then-close: that frees the port into exactly the pool
  * `listen(0)` draws from, and a sibling `test.concurrent` will take it.
+ *
+ * `localAddress` makes the holder `bind()` its port before it connects. On
+ * Linux, a later `connect()` to a port that an earlier `connect()` picked can
+ * get that same port as its source port. The socket then connects to itself
+ * (about 1 in 14k dials), and a proxy test sees `ConnectionRefused` or
+ * `Malformed_HTTP_Response`, not a 502. Linux does not do this with a port
+ * that `bind()` picked.
+ *
+ * Do not return `sink`'s port instead. On Windows, `listen(0)` hands out the
+ * port of a closed listener while its accepted socket is still open.
  */
 export async function deadPort(): Promise<DeadPort> {
   let accepted: net.Socket | undefined;
@@ -726,7 +736,11 @@ export async function deadPort(): Promise<DeadPort> {
   });
   sink.listen(0, "127.0.0.1");
   await once(sink, "listening");
-  const holder = net.connect({ host: "127.0.0.1", port: (sink.address() as net.AddressInfo).port });
+  const holder = net.connect({
+    host: "127.0.0.1",
+    port: (sink.address() as net.AddressInfo).port,
+    localAddress: "127.0.0.1",
+  });
   holder.on("error", () => {});
   await once(holder, "connect");
   const port = (holder.address() as net.AddressInfo).port;


### PR DESCRIPTION
### Problem
- `proxy-stress-errors.test.ts` flakes on Linux. The Alpine 3.23 x64 lane failed `upstream unreachable via proxy > https-proxy, CONNECT upstream refused → 502` with `TypeError: Unable to connect. Is the computer able to access the url?` (`code: "ConnectionRefused"`). #35400 saw `Malformed_HTTP_Response` from the same cause.
- `deadPort()` (`test/js/bun/http/proxy-stress-helpers.ts:721`) returns a port that `connect()` picked. Linux can give that port as the source port to a later `connect()` to the same port. That socket connects to itself. The proxy then tunnels to itself and does not send the 502.

### Fix
- The holder socket binds `127.0.0.1` (`localAddress`) before it connects.
- Linux `connect()` does not pick a port that `bind()` holds. The port stays bound, so `listen(0)` still skips it (the guard from #35269).
- This supersedes #35400, which returns the listener's port. On Windows, `listen(0)` hands out that port while the accepted socket is still open.
- Verified: `proxy-stress-errors.test.ts` passes 30 of 30 runs. All seven `proxy-stress-*` files pass on Linux (release and ASAN) and on Windows x64.

### Background
- A dead port is a port where nothing listens. A `connect()` to it fails with `ECONNREFUSED`.
- A TCP self-connect occurs when the source and the destination (address and port) are equal. The connect succeeds, and each byte the socket writes comes back to it.
- Linux picks the source port of a `connect()` in `__inet_hash_connect`. It can reuse a port that another `connect()` picked, if the 4-tuple is unique. It skips a port that `bind()` picked.

<details><summary>Notes</summary>

Probes: Linux 6.17 (port range 32768 to 60999) and Windows Server 2019, with bun canary.

| `deadPort()` shape | Linux: self-connects in 150000 dials | Linux: `listen(0)` collisions (500 held, 20000 listens) | Windows: `listen(0)` collisions (500 held, 20000 listens) |
|---|---|---|---|
| main: holder port, picked by `connect()` | 11 | 0 | 0 |
| #35400: listener port | 0 | 0 | 500 |
| this PR: holder port, picked by `bind()` | 0 | 0 | 0 |

- A self-connected upstream echoes each byte. An echo server in its place gives the CI errors: `ConnectionRefused` for an https target (the inner TLS handshake reads its own ClientHello, `src/http/ProxyTunnel.rs:432`), and `Malformed_HTTP_Response` for an http target.
- 11 in 150000 is about 1 in 14000. That is the chance that a random even port in the range is the dead port. The file dials a dead port 6 times per run.
- The Linux `listen(0)` column for main shows little. `listen(0)` prefers odd ports, and `connect()` prefers even ports.
- Windows `listen(0)` allocates ports in sequence. So the #35400 collision needs a wrap of the 16384-port range while a test holds the port. That is unlikely, but the port is not reserved.
- On Linux and Windows, the sink accepted the holder before `sink.close()` in 500 of 500 runs. So the helper does not need to wait for the accept.
- The holder's TIME_WAIT now falls on a port from the `bind(0)` range: one port per dead port, for 60 seconds.
- Suites run with `bun test test/js/bun/http/proxy-stress-*.test.ts`: Linux release 852 pass and 1 skip, Linux ASAN debug build 853 pass, Windows x64 852 pass and 1 skip. `proxy-stress-errors.test.ts` alone: Linux release 30 of 30, ASAN 3 of 3, Windows 10 of 10.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->