### PR TITLE
test: deflake async-iterator-stream two-chunk assertions

### DIFF
--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -24,12 +24,11 @@ describe.concurrent("Streaming body via", () => {
     const res = await fetch(`${server.url}/`);
     const chunks = [];
     for await (const chunk of res.body) {
-      chunks.push(chunk);
+      chunks.push(new TextDecoder().decode(chunk));
       firstChunkRead.resolve();
     }
 
-    expect(Buffer.concat(chunks).toString()).toBe("Hello, world!");
-    expect(chunks).toHaveLength(2);
+    expect(chunks).toEqual(["Hello, ", "world!"]);
   });
 
   test("a hand-written async iterator without return() completes", async () => {
@@ -201,12 +200,13 @@ describe.concurrent("Streaming body via", () => {
     const res = await fetch(`${server.url}/`);
     const chunks = [];
     for await (const chunk of res.body) {
-      chunks.push(chunk);
+      chunks.push(new TextDecoder().decode(chunk));
       firstChunkRead.resolve();
     }
 
-    expect(Buffer.concat(chunks).toString()).toBe("my string goes here\nmy buffer goes here\nend!\n");
-    expect(chunks).toHaveLength(2);
+    // The two yields before the await are one chunk: the response sink queues
+    // small writes and flushes them once the microtask queue drains.
+    expect(chunks).toEqual(["my string goes here\nmy buffer goes here\n", "end!\n"]);
   });
 
   test("[Symbol.asyncIterator] with a custom iterator", async () => {

--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -3,14 +3,18 @@ import { describe, expect, mock, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 describe.concurrent("Streaming body via", () => {
+  // The two-chunk tests hold the generator until the client has read the first chunk. That is what
+  // proves the body streams; a sleep does not, because fetch hands the reader everything its HTTP
+  // thread has received since the last read as one chunk.
   test("async generator function", async () => {
+    const firstChunkRead = Promise.withResolvers<void>();
     using server = Bun.serve({
       port: 0,
 
       async fetch(req) {
         return new Response(async function* yo() {
           yield "Hello, ";
-          await Bun.sleep(30);
+          await firstChunkRead.promise;
           yield Buffer.from("world!");
           return "not a chunk";
         });
@@ -21,6 +25,7 @@ describe.concurrent("Streaming body via", () => {
     const chunks = [];
     for await (const chunk of res.body) {
       chunks.push(chunk);
+      firstChunkRead.resolve();
     }
 
     expect(Buffer.concat(chunks).toString()).toBe("Hello, world!");
@@ -173,6 +178,7 @@ describe.concurrent("Streaming body via", () => {
   });
 
   test("[Symbol.asyncIterator]", async () => {
+    const firstChunkRead = Promise.withResolvers<void>();
     using server = Bun.serve({
       port: 0,
 
@@ -181,7 +187,7 @@ describe.concurrent("Streaming body via", () => {
           async *[Symbol.asyncIterator]() {
             var controller = yield "my string goes here\n";
             var controller2 = yield Buffer.from("my buffer goes here\n");
-            await Bun.sleep(30);
+            await firstChunkRead.promise;
             yield Buffer.from("end!\n");
             if (controller !== controller2 || typeof controller.sinkId !== "number") {
               throw new Error("Controller mismatch");
@@ -196,6 +202,7 @@ describe.concurrent("Streaming body via", () => {
     const chunks = [];
     for await (const chunk of res.body) {
       chunks.push(chunk);
+      firstChunkRead.resolve();
     }
 
     expect(Buffer.concat(chunks).toString()).toBe("my string goes here\nmy buffer goes here\nend!\n");


### PR DESCRIPTION
### What does this PR do?

Makes the two chunk-count assertions in `test/js/bun/http/async-iterator-stream.test.ts` deterministic. They failed intermittently in the parallel CI batch with `Expected length: 2, Received length: 1` (e.g. build 110048).

Both tests separated the generator's yields with `Bun.sleep(30)` and expected the client to observe two chunks. `fetch()` hands the reader everything its HTTP thread has buffered since the last read as one chunk, so the assertion only held if the JS thread got to the reader within 30ms of the first chunk arriving. In this `describe.concurrent` file the same thread is also starting ~90 other tests (several spawn subprocesses, and every `expect()` GCs under `BUN_GARBAGE_COLLECTOR_LEVEL=1`), so under a loaded worker the loop was still in its I/O phase when the sleep timer came due: the timer fired first, the second chunk and the terminator were sent, the HTTP thread appended them to the same response buffer, and the reader's first read returned all 13 bytes. Confirmed with strace on a failing run: headers+`Hello, ` sent and received at t, `world!` sent at t+289ms, with no `epoll_pwait2` from the JS thread in between.

The generator now waits on a promise the client resolves after reading the first chunk. That is what actually proves the body streams, and it cannot coalesce.

### How did you verify your code works?

`bun test test/js/bun/http/async-iterator-stream.test.ts` passes. Pinning the test plus four busy loops to one core reproduced the old failure in ~1 of 4 runs; with this change 15/15 pass under the same setup.
