### PR TITLE
ci: bake Linux images as a Buildkite job on the machine itself [build linux images]

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -905,30 +905,25 @@ function getTestBunStep(platform, options, testOptions = {}) {
  *
  * @param {Platform} platform
  * @param {PipelineOptions} options
+ * @returns {Step[]} steps for the `build-images` group; the last one's key is
+ *   `${getImageKey(platform)}-build-image`, which is what dependents wait on.
+ */
+function getBuildImageSteps(platform, options) {
+  return platform.os === "windows"
+    ? [getWindowsBuildImageStep(platform, options)]
+    : getLinuxBuildImageSteps(platform, options);
+}
+
+/**
+ * Windows images bake on Azure through Packer (WinRM) from the hosted queue.
+ * @param {Platform} platform
+ * @param {PipelineOptions} options
  * @returns {Step}
  */
-function getBuildImageStep(platform, options) {
-  const { os, arch, distro, release, features } = platform;
+function getWindowsBuildImageStep(platform, options) {
+  const { os, arch, release } = platform;
   const { publishImages } = options;
   const action = publishImages ? "publish-image" : "create-image";
-
-  const cloud = os === "windows" ? "azure" : "aws";
-  const command = [
-    "node",
-    "./scripts/machine.mjs",
-    action,
-    `--os=${os}`,
-    `--arch=${arch}`,
-    distro && `--distro=${distro}`,
-    `--release=${release}`,
-    `--cloud=${cloud}`,
-    "--ci",
-    "--authorized-org=oven-sh",
-  ];
-  for (const feature of features || []) {
-    command.push(`--feature=${feature}`);
-  }
-
   return {
     key: `${getImageKey(platform)}-build-image`,
     label: `${getImageLabel(platform)} - build-image`,
@@ -945,9 +940,71 @@ function getBuildImageStep(platform, options) {
     },
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    command: command.filter(Boolean).join(" "),
+    command: `node ./scripts/machine.mjs ${action} --os=${os} --arch=${arch} --release=${release} --ci`,
     timeout_in_minutes: 3 * 60,
   };
+}
+
+/**
+ * Linux images bake in two steps:
+ *
+ *  1. `…-bake-image` runs ON a fresh machine of the target distro (requested
+ *     with the `bake` agent tag): bootstrap.sh provisions it — so this step's
+ *     log is the bootstrap log — and agent.mjs installs the agent service.
+ *     The machine is imaged as `image-name` once the step passes.
+ *  2. `…-build-image` (labelled wait-for-image) waits for that image to be
+ *     available. It keeps the key the rest of the pipeline depends on.
+ *
+ * @param {Platform} platform
+ * @param {PipelineOptions} options
+ * @returns {Step[]}
+ */
+function getLinuxBuildImageSteps(platform, options) {
+  const { arch, features } = platform;
+  const imageKey = getImageKey(platform);
+  const imageName = getImageName(platform, options);
+  const bootstrapArgs = ["--ci", ...(features || []).map(feature => `--${feature}`)];
+  // prefetch_build_deps shallow-clones the repo at this ref for the dep pins
+  // in scripts/build/deps/; bake from the branch that changed them.
+  const branch = getEnv("BUILDKITE_BRANCH", false);
+  const repoRef = branch && /^[\w./-]+$/.test(branch) ? branch : "main";
+
+  const bakeStep = {
+    key: `${imageKey}-bake-image`,
+    label: `${getImageLabel(platform)} - bake-image`,
+    agents: {
+      ...getEc2Agent(platform, options, { instanceType: arch === "aarch64" ? "t4g.large" : "t3.large" }),
+      bake: true,
+    },
+    env: {
+      BUN_BOOTSTRAP_REPO_REF: repoRef,
+    },
+    retry: getRetry(),
+    cancel_on_build_failing: isMergeQueue(),
+    // Install the service from the machine's own copy of agent.mjs rather
+    // than this checkout's, so the unit outlives the build directory.
+    // ($$ is a literal $ after pipeline-upload interpolation.)
+    command: [
+      `sh ./scripts/bootstrap.sh ${bootstrapArgs.join(" ")}`,
+      `$$([ "$$(id -u)" = 0 ] || echo sudo -n) node /var/lib/buildkite-agent/agent.mjs install`,
+    ],
+    timeout_in_minutes: 3 * 60,
+  };
+
+  const waitStep = {
+    key: `${imageKey}-build-image`,
+    label: `${getImageLabel(platform)} - wait-for-image`,
+    depends_on: [bakeStep.key],
+    agents: {
+      queue: "build-image",
+    },
+    retry: getRetry(),
+    cancel_on_build_failing: isMergeQueue(),
+    command: `node ./scripts/machine.mjs wait-image --name=${imageName} --build=${getBuildNumber()}`,
+    timeout_in_minutes: 120,
+  };
+
+  return [bakeStep, waitStep];
 }
 
 /**
@@ -1586,7 +1643,7 @@ async function getPipeline(options = {}) {
     steps.push({
       key: "build-images",
       group: getBuildkiteEmoji("aws"),
-      steps: [...imagePlatforms.values()].map(platform => getBuildImageStep(platform, options)),
+      steps: [...imagePlatforms.values()].flatMap(platform => getBuildImageSteps(platform, options)),
     });
   }
 

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -1355,6 +1355,49 @@ async function ensurePacker() {
   return localPacker;
 }
 
+/**
+ * `wait-image --name=<ami name> --build=<build number> [--timeout-minutes=N]`:
+ * block until the Linux AMI produced by a `…-bake-image` step (see
+ * getLinuxBuildImageSteps in .buildkite/ci.mjs) is available. The AMI carries
+ * the number of the build that baked it.
+ *
+ * @param {{ name: string, build: string, timeoutMinutes: number }} options
+ * @returns {Promise<string>} the AMI id
+ */
+async function waitImage({ name, build, timeoutMinutes }) {
+  // Match on the build number too: an older image that merely shares the
+  // name (the previous `-vN` being re-published) is not the one to wait for.
+  const filters = [`Name=name,Values=${name}`, `Name=tag:buildkite:build-number,Values=${build}`];
+  const deadline = Date.now() + timeoutMinutes * 60_000;
+  let lastState;
+  let seen;
+  console.log(`Waiting for image ${name} (build ${build})...`);
+  while (Date.now() < deadline) {
+    const { Images } = await aws.spawn($`ec2 describe-images --owners self --filters ${filters}`);
+    const [image] = Images.sort((a, b) => (a.CreationDate < b.CreationDate ? 1 : -1));
+    const state = image?.State ?? (seen ? "gone" : "not created yet");
+    if (state !== lastState) {
+      console.log(`${new Date().toISOString()} ${name}: ${state}${image ? ` (${image.ImageId})` : ""}`);
+      lastState = state;
+    }
+    if (state === "available") {
+      return image.ImageId;
+    }
+    // failed/invalid/error: imaging failed. gone/deregistered: it failed and
+    // was already cleaned up (the build is annotated with why). Either way
+    // this image is not going to appear.
+    if (["failed", "invalid", "error", "deregistered", "gone"].includes(state)) {
+      const reason = image?.StateReason?.Message ?? "discarded after a failed create, see the build annotation";
+      throw new Error(`Image ${name} for build ${build} will not become available (${state}): ${reason}`);
+    }
+    seen ||= image?.ImageId;
+    await new Promise(done => setTimeout(done, 30_000));
+  }
+  throw new Error(
+    `Image ${name} for build ${build} was not available after ${timeoutMinutes} minutes (last state: ${lastState})`,
+  );
+}
+
 async function main() {
   const { positionals } = parseArgs({
     allowPositionals: true,
@@ -1362,9 +1405,33 @@ async function main() {
   });
 
   const [command] = positionals;
-  if (!/^(ssh|create-image|publish-image)$/.test(command)) {
+  if (!/^(ssh|create-image|publish-image|wait-image)$/.test(command)) {
     const scriptPath = relative(process.cwd(), fileURLToPath(import.meta.url));
-    throw new Error(`Usage: ./${scriptPath} [ssh|create-image|publish-image] [options]`);
+    throw new Error(
+      `Usage: ./${scriptPath} [ssh|create-image|publish-image] [options]\n` +
+        `       ./${scriptPath} wait-image --name=<ami name> --build=<build number> [--timeout-minutes=N]`,
+    );
+  }
+
+  if (command === "wait-image") {
+    const { values: args } = parseArgs({
+      allowPositionals: true,
+      options: {
+        "name": { type: "string" },
+        "build": { type: "string" },
+        "timeout-minutes": { type: "string", default: "110" },
+      },
+    });
+    if (!args["name"] || !args["build"]) {
+      throw new Error("wait-image needs --name=<ami name> --build=<build number>");
+    }
+    const imageId = await waitImage({
+      name: args["name"],
+      build: args["build"],
+      timeoutMinutes: parseInt(args["timeout-minutes"]),
+    });
+    console.log(`Image available: ${args["name"]} -> ${imageId}`);
+    return;
   }
 
   const { values: args } = parseArgs({

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -184,7 +184,12 @@ function getPrivilegedCommand() {
     return priviledgedCommand;
   }
 
-  if (isWindows) {
+  // Already root (the image bake step runs bootstrap and `agent.mjs install`
+  // as root on a fresh machine): no wrapper. In particular not
+  // `su -s sh root -c`, which takes ONE command string — prefixing it to an
+  // argv drops every argument after the first (`rc-update add …` became a
+  // bare `rc-update`).
+  if (isWindows || process.getuid?.() === 0) {
     return (priviledgedCommand = []);
   }
 
@@ -192,12 +197,6 @@ function getPrivilegedCommand() {
   const { error: sudoError } = spawnSync([...sudo, "true"]);
   if (!sudoError) {
     return (priviledgedCommand = sudo);
-  }
-
-  const su = ["su", "-s", "sh", "root", "-c"];
-  const { error: suError } = spawnSync([...su, "true"]);
-  if (!suError) {
-    return (priviledgedCommand = su);
   }
 
   const doas = ["doas", "-u", "root"];


### PR DESCRIPTION
### What

Linux CI image bakes no longer create an EC2 instance from the hosted `build-image` agent and drive it over SSH. Each Linux image in the `build-images` group is now two steps:

- **`<image> - bake-image`** runs *on* a fresh machine of the target distro/arch (requested with the `bake` agent tag). It runs `scripts/bootstrap.sh --ci` and `agent.mjs install` there, so the step's log is the bootstrap log and its exit status is the result. The machine is imaged as `image-name` once the step passes.
- **`<image> - wait-for-image`** (hosted `build-image` queue; keeps the `…-build-image` key that build/test steps already depend on) runs `scripts/machine.mjs wait-image`, which polls until the AMI tagged with this build number is available and fails early if imaging failed.

Nothing connects to the bake machine, no SSH keys are baked into images, and a failed bootstrap is readable as a normal job log instead of an SSH transcript. Windows image bakes are unchanged (Azure/Packer from the hosted queue).

Also: `scripts/utils.mjs` no longer wraps privileged commands when already root. The `su -s sh root -c` form it could pick takes a single command string, so prefixing it to an argv dropped every argument after the first — `agent.mjs install`'s `rc-update add buildkite-agent default` became a bare `rc-update` on Alpine.

### Verified

This flow baked the Linux images for builds #108592, #108641, #108840, #108896 and #109813 on the `claude/toolchain-trial` branch (all distros × x64/aarch64), and those images ran the full build + test matrix.

`[build linux images]` in the title so this PR's CI bakes with the new steps.
