### PR TITLE
bake: skip the directory watch when the directory cannot be opened

### DIFF
--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1394,7 +1394,18 @@ impl DirectoryWatchStore {
                             return Err(DirectoryWatchInsertError::Ignore);
                         }
                         bun_sys::E::ENOTDIR => return Err(DirectoryWatchInsertError::Ignore),
-                        _ => bun_core::todo_panic!("log watcher error"),
+                        // EACCES, ELOOP, EMFILE, and the rest leave the
+                        // directory unwatched, the same as a failed
+                        // `add_directory` below.
+                        _ => {
+                            bun_core::scoped_log!(
+                                DevServer,
+                                "DirectoryWatchStore.insert: cannot open {}: {}",
+                                bun_core::fmt::quote(dir_name_to_watch),
+                                bstr::BStr::new(err.name()),
+                            );
+                            return Err(DirectoryWatchInsertError::Ignore);
+                        }
                     },
                 }
             }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,5 +1,6 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
 import { expect } from "bun:test";
+import fs from "node:fs";
 import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
@@ -917,5 +918,34 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
+  },
+});
+// After a failed import, DevServer opens the directory the file would be in,
+// to watch for its creation. "loop" is a symlink to itself, so that open fails
+// with ELOOP. The open happens only where the watcher needs a file descriptor
+// (kqueue on macOS).
+devTest("importing a file in a directory that cannot be opened", {
+  skip: ["win32"],
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { abc } from './loop/second';
+      console.log('value: ' + abc);
+    `,
+  },
+  async test(dev) {
+    fs.symlinkSync("loop", dev.join("loop"));
+    await using c = await dev.client("/", {
+      errors: [`index.ts:1:21: error: Could not resolve: "./loop/second"`],
+    });
+
+    await c.expectReload(async () => {
+      await dev.write("index.ts", `console.log('value: ' + 456);`);
+    });
+
+    await c.expectMessage("value: 456");
   },
 });


### PR DESCRIPTION
### Problem
- On macOS, the dev server crashes with `panic: TODO: log watcher error` (`src/runtime/bake/dev_server/mod.rs:1397`). The crash reports have 6 events on 1.2.8, 1.3.14, and 1.4.0, all on macOS arm64. #18717 reports the same crash, with EMFILE errors in its log.
- When an import does not resolve, `DirectoryWatchStore::insert` opens the directory where the file would be, to watch for the file. The open handles only ENOENT and ENOTDIR. Every other errno reaches `todo_panic!`.

### Fix
- Handle every other errno the same as ENOENT: skip the watch and continue. A debug log records the errno.
- This matches the other watch sites. A failed `add_directory` in the same function skips the watch. The watch opens in `bundle_v2.rs`, `jsc_hooks.rs`, and `Watcher.rs` also skip the watch on any error.
- Verified: a new test in `test/bake/dev/bundle.test.ts` imports a file through a symlink loop, so the open fails with ELOOP. The dev server must show the resolve error, then rebuild after an edit. All 23 tests in that file pass.

### Background
- The dev server watches files for hot reload. On macOS the watcher uses kqueue, which watches an open file descriptor. So the dev server opens each file and directory that it watches. Linux (inotify) and Windows watch by path and never run this open.
- The resolver already reports the failed import and the errno (`Cannot read directory "...": ELOOP`). A skipped watch means only that the dev server does not rebuild when the missing file appears.

<details><summary>Notes</summary>

- The open runs only when `bun_watcher::REQUIRES_FILE_DESCRIPTORS` is true (macOS and FreeBSD). On Linux the new test passes with and without the fix. The macOS CI lanes run the test with the fix.
- To check the test on Linux, I forced the open with a local change (not in this PR). Without the fix, the dev server crashed with `panic: TODO: log watcher error (src/runtime/bake/dev_server/mod.rs:1397)`. With the fix, the test passed, and the debug log showed `cannot open ".../loop": ELOOP`.
- The crash reports do not record the errno. The log in #18717 shows EMFILE (the process was out of file descriptors). Any other errno, for example EACCES or ELOOP, reaches the same arm.
- The crash reports come from `bun test`, `bun run`, and `bun <file>`. The dev server ran in each process.
- The early return runs the existing cleanup: the scope guard removes the new `watches` entry, and the cloned specifier drops. The ENOENT arm uses the same path.
- The test is skipped on Windows, where a symlink needs extra privileges and the watcher does not open the directory.

</details>
