### PR TITLE
bun create: run git before the template's tasks and install

### DIFF
--- a/docs/runtime/templating/create.mdx
+++ b/docs/runtime/templating/create.mdx
@@ -143,8 +143,8 @@ Bun then:
 
 - Downloads the template
 - Copies all template files into the destination folder
-- Installs dependencies with `bun install`
 - Initializes a fresh Git repo. Opt out with the `--no-git` flag.
+- Installs dependencies with `bun install`
 
 <Note>By default Bun does _not overwrite_ existing files. Use the `--force` flag to overwrite them.</Note>
 
@@ -255,12 +255,12 @@ ELSE IF local template
 THEN, for remote templates, GitHub repos, and local templates alike:
 
 4. Parse the `package.json` (again!), update `name` to be `${basename(destination)}`, remove the `bun-create` section from the `package.json` and save the updated `package.json` to disk.
-5. Run any tasks defined in `"bun-create": { "preinstall" }`
-6. Run `bun install` unless you pass `--no-install` OR no dependencies are in package.json
-7. Run any tasks defined in `"bun-create": { "postinstall" }`
-8. Run `git init; git add -A .; git commit -am "Initial Commit";`
+5. Run `git init; git add -A .; git commit -am "Initial Commit";`
    - Rename `gitignore` to `.gitignore`. npm strips `.gitignore` files from published packages.
-   - If there are dependencies, this step runs in a separate thread concurrently while Bun installs node_modules
+   - Git finishes before the tasks and `bun install` start.
    - We tested using libgit2 if available, and it performed 3x slower in microbenchmarks
+6. Run any tasks defined in `"bun-create": { "preinstall" }`
+7. Run `bun install` unless you pass `--no-install` OR no dependencies are in package.json
+8. Run any tasks defined in `"bun-create": { "postinstall" }`
 
 </Accordion>

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1,5 +1,4 @@
 use bun_collections::VecExt;
-use core::sync::atomic::{AtomicU32, Ordering};
 use std::cell::Cell;
 use std::io::Write as _;
 
@@ -18,7 +17,6 @@ use bun_resolver::fs;
 use bun_sys::FdDirExt as _;
 #[cfg(not(windows))]
 use bun_sys::copy_file as CopyFile;
-use bun_threading::Futex;
 use bun_url::URL;
 use bun_which::which;
 use bun_zlib as Zlib;
@@ -33,8 +31,7 @@ use crate::cli::which_npm_client::NPMClient;
 pub mod SourceFileProjectGenerator;
 
 // PORTING.md §Global mutable state: single-thread CLI scratch buffer →
-// RacyCell. Touched on the main thread for `--open` *and* the spawned git
-// thread (sequenced — git thread writes after main is done with it).
+// RacyCell. Used by the git lookup and by `--open`.
 static BUN_PATH_BUF: bun_core::RacyCell<PathBuffer> = bun_core::RacyCell::new(PathBuffer::ZEROED);
 
 // bun.OSPathLiteral — `bun_paths` does not (yet) export an
@@ -1077,18 +1074,15 @@ impl CreateCommand {
         let user_skipped_install = create_options.skip_install;
         create_options.skip_install = create_options.skip_install || !has_dependencies;
 
+        // git must finish before the tasks and the install write to the
+        // destination, so that `git add` sees only the template's files.
         if !create_options.skip_git {
-            if !create_options.skip_install {
-                GitHandler::spawn(destination, path_env, create_options.verbose);
+            let created = if create_options.verbose {
+                GitHandler::run::<true>(destination, path_env)
             } else {
-                if create_options.verbose {
-                    create_options.skip_git =
-                        GitHandler::run::<true>(destination, path_env).unwrap_or(false);
-                } else {
-                    create_options.skip_git =
-                        GitHandler::run::<false>(destination, path_env).unwrap_or(false);
-                }
-            }
+                GitHandler::run::<false>(destination, path_env)
+            };
+            create_options.skip_git = !created.unwrap_or(false);
         }
 
         if !create_options.skip_install {
@@ -1161,10 +1155,6 @@ impl CreateCommand {
             for task in &postinstall_tasks {
                 exec_task(task, destination, path_env, npm_client_);
             }
-        }
-
-        if !create_options.skip_install && !create_options.skip_git {
-            create_options.skip_git = !GitHandler::wait();
         }
 
         Output::print_error("\n");
@@ -2354,59 +2344,7 @@ impl CreateListExamplesCommand {
 
 struct GitHandler;
 
-static SUCCESS: AtomicU32 = AtomicU32::new(0);
-// bun_threading has no top-level Thread wrapper yet,
-// so use std::thread::JoinHandle directly (CLI-only, no JSC interaction).
-// PORTING.md §Global mutable state: written in `spawn`, taken in `wait`, both
-// on the main CLI thread → RacyCell.
-static THREAD: bun_core::RacyCell<Option<std::thread::JoinHandle<()>>> =
-    bun_core::RacyCell::new(None);
-
 impl GitHandler {
-    fn spawn(destination: &[u8], path: &[u8], verbose: bool) {
-        SUCCESS.store(0, Ordering::Relaxed);
-
-        // Own copies so the spawned closure is `'static` without any lifetime
-        // extension.
-        let destination: Box<[u8]> = Box::from(destination);
-        let path: Box<[u8]> = Box::from(path);
-        let thread = match std::thread::Builder::new()
-            .spawn(move || Self::spawn_thread(&destination, &path, verbose))
-        {
-            Ok(t) => t,
-            Err(err) => {
-                bun_core::pretty_errorln!("<r><red>{}<r>", err);
-                Global::exit(1);
-            }
-        };
-        // SAFETY: single-threaded CLI; written once before wait()
-        unsafe { *THREAD.get() = Some(thread) };
-    }
-
-    fn spawn_thread(destination: &[u8], path: &[u8], verbose: bool) {
-        Output::Source::configure_named_thread(bun_core::zstr!("git"));
-        let outcome = if verbose {
-            Self::run::<true>(destination, path).unwrap_or(false)
-        } else {
-            Self::run::<false>(destination, path).unwrap_or(false)
-        };
-
-        SUCCESS.store(if outcome { 1 } else { 2 }, Ordering::Release);
-        Futex::wake(&SUCCESS, 1);
-        Output::flush();
-    }
-
-    fn wait() -> bool {
-        while SUCCESS.load(Ordering::Acquire) == 0 {
-            Futex::wait_forever(&SUCCESS, 0);
-        }
-
-        let outcome = SUCCESS.load(Ordering::Acquire) == 1;
-        // SAFETY: THREAD set in spawn() on this same thread before wait() called
-        let _ = unsafe { (*THREAD.get()).take() }.unwrap().join();
-        outcome
-    }
-
     fn run<const VERBOSE: bool>(destination: &[u8], path: &[u8]) -> crate::Result<bool> {
         let git_start = bun_core::time::nano_timestamp();
 
@@ -2429,14 +2367,9 @@ impl GitHandler {
         //   Time (mean ± σ):     306.7 ms ±   6.1 ms    [User: 31.7 ms, System: 269.8 ms]
         //   Range (min … max):   299.5 ms … 318.8 ms    10 runs
 
-        // SAFETY: single-threaded CLI access to module-level static path buffer (note: this fn
-        // may run on the git thread; BUN_PATH_BUF is also touched on main thread for `--open`.
-        // The two uses are sequenced — git runs before `--open` block.)
+        // SAFETY: single-threaded CLI access to module-level static path buffer
         let bun_path_buf = unsafe { &mut *BUN_PATH_BUF.get() };
-        // `bun.spawnSync` on Windows drives `uv_spawn` and needs a uv loop. This fn
-        // runs on the dedicated git thread (see `GitHandler::spawn`), so use the
-        // *thread-local* `MiniEventLoop` singleton — `init_global` is `thread_local!`-backed,
-        // so the main thread's loop is not touched (driving it cross-thread would be libuv UB).
+        // `bun.spawnSync` on Windows drives `uv_spawn` and needs a uv loop.
         #[cfg(windows)]
         let win_loop = bun_event_loop::EventLoopHandle::init_mini(
             bun_event_loop::MiniEventLoop::init_global(None, None),

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1074,8 +1074,7 @@ impl CreateCommand {
         let user_skipped_install = create_options.skip_install;
         create_options.skip_install = create_options.skip_install || !has_dependencies;
 
-        // git must finish before the tasks and the install write to the
-        // destination, so that `git add` sees only the template's files.
+        // `git add` reads the destination, so git must exit before the tasks and the install.
         if !create_options.skip_git {
             let created = if create_options.verbose {
                 GitHandler::run::<true>(destination, path_env)

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -282,10 +282,10 @@ it("reports an error and exits when the template's package.json entry body is tr
   expect(exitCode).toBe(1);
 });
 
-// GitHandler::wait() used Futex::wait(.., Some(1000)) (1us timeout) in a loop,
-// issuing ~18k futex syscalls/sec while the git thread ran. POSIX-only: stub
+// The wait for the old git thread used Futex::wait(.., Some(1000)) (1us timeout)
+// in a loop, issuing ~18k futex syscalls/sec while git ran. POSIX-only: stub
 // `git` is a shell script and ru_nvcsw is always 0 on Windows.
-it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () => {
+it.skipIf(!isPosix)("does not busy-wait while git runs", async () => {
   using dir = tempDir("create-git-futex", {
     "bin/git": "#!/bin/sh\nsleep 0.5\nexit 0\n",
     "bun-create/tmpl/index.js": "// hi\n",
@@ -316,6 +316,113 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
   expect(proc.exitCode).toBe(0);
   // Before the fix this was ~27,000 over the ~1.5s git wait; after, a few dozen.
   expect(proc.resourceUsage!.contextSwitches.voluntary).toBeLessThan(2000);
+});
+
+// git used to run on a thread while the template's tasks and `bun install` ran
+// in the same directory, so `git add` could index files that the install was
+// writing (on Windows CI, the lockfile's temp file just before its rename).
+// bun create prints a `$ ...` line to stdout before each task and before
+// `bun install`. For each call, the stub `git` logs whether stdout has such a
+// line yet, and the files it sees. POSIX-only: the stub is a shell script.
+it.skipIf(!isPosix)("runs git to completion before the template's tasks and install", async () => {
+  using dir = tempDir("create-git-order", {
+    "bin/git": `#!/bin/sh
+started=no
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in '$ '*) started=yes ;; esac
+done < "$CREATE_STDOUT"
+files=$(LC_ALL=C ls -A)
+echo "$1" "started=$started" $files >> "$GIT_LOG"
+`,
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({
+      name: "tmpl",
+      version: "1.0.0",
+      scripts: { pre: "echo pre > pre.txt", post: "echo post > post.txt" },
+      dependencies: { localdep: "file:./localdep" },
+      "bun-create": { preinstall: "pre", postinstall: "post" },
+    }),
+    "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
+  });
+  const root = String(dir);
+  chmodSync(join(root, "bin", "git"), 0o755);
+  const stdoutPath = join(root, "stdout.txt");
+  const gitLogPath = join(root, "git.log");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", join(root, "dest")],
+    cwd: root,
+    env: {
+      ...env,
+      PATH: join(root, "bin") + ":" + process.env.PATH,
+      BUN_CREATE_DIR: join(root, "bun-create"),
+      CREATE_STDOUT: stdoutPath,
+      GIT_LOG: gitLogPath,
+    },
+    stdin: "ignore",
+    stdout: Bun.file(stdoutPath),
+    stderr: "pipe",
+  });
+
+  const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const out = await Bun.file(stdoutPath).text();
+  const gitLog = await Bun.file(gitLogPath).text();
+
+  expect(gitLog.trim().split("\n")).toEqual([
+    "init started=no index.js localdep package.json",
+    "add started=no index.js localdep package.json",
+    "commit started=no index.js localdep package.json",
+  ]);
+  expect(out).toContain("$ bun install");
+  expect(out).toContain("A local git repository was created for you and dependencies were installed automatically.");
+  expect(err).not.toContain("error:");
+  // The git timing line comes before the install's, not in the middle of task output.
+  expect(err).toContain("] git");
+  expect(err.indexOf("] git")).toBeLessThan(err.indexOf("] bun install"));
+  const dest = join(root, "dest");
+  expect(await Bun.file(join(dest, "pre.txt")).text()).toBe("pre\n");
+  expect(await Bun.file(join(dest, "post.txt")).text()).toBe("post\n");
+  expect(await exists(join(dest, "node_modules", "localdep", "package.json"))).toBe(true);
+  expect(exitCode).toBe(0);
+});
+
+// With nothing to install, git's outcome was stored without the `!`, so the
+// message was missing when git ran and printed when git was not found.
+it.skipIf(!isPosix)("reports the git repository when there is nothing to install", async () => {
+  using dir = tempDir("create-git-no-deps", {
+    "bin/git": "#!/bin/sh\nexit 0\n",
+    "empty/.keep": "",
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({ name: "tmpl", version: "1.0.0" }),
+  });
+  const root = String(dir);
+  chmodSync(join(root, "bin", "git"), 0o755);
+
+  // `pathDir` is the whole PATH, so `git` is found only in "bin".
+  async function create(pathDir: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "tmpl", join(root, `dest-${pathDir}`)],
+      cwd: root,
+      env: { ...env, PATH: join(root, pathDir), BUN_CREATE_DIR: join(root, "bun-create") },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  const withGit = await create("bin");
+  expect(withGit.err).not.toContain("error:");
+  expect(withGit.err).toContain("] git");
+  expect(withGit.out).toContain("A local git repository was created for you.");
+  expect(withGit.exitCode).toBe(0);
+
+  const withoutGit = await create("empty");
+  expect(withoutGit.err).not.toContain("error:");
+  expect(withoutGit.err).not.toContain("] git");
+  expect(withoutGit.out).not.toContain("A local git repository");
+  expect(withoutGit.exitCode).toBe(0);
 });
 
 it("should create template from local folder", async () => {

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -92,9 +92,6 @@
       "DotenvSingleton"
     ]
   },
-  "src/runtime/cli/create_command.rs": {
-    "thread spawn": 1
-  },
   "src/runtime/cli/open.rs": {
     "thread spawn": 1
   },


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-create.test.ts` fails on Windows CI at `expect(err).not.toContain("error:")` (builds 109804 and 109988). Git prints `error: open(".lockb-053c0fbb3fe9dcc2.tmp"): No such file or directory` and `error: unable to index file '.lockb-053c0fbb3fe9dcc2.tmp'`.
- `bun create` starts `git init`, `git add`, and `git commit` on a thread. Then it runs the template's tasks and `bun install` in the same directory (`src/runtime/cli/create_command.rs:1082`). `git add` lists the lockfile's temp file, `bun install` renames it (`src/install/lockfile.rs:1922`), and git cannot open it.

### Fix
- Run git to completion before the tasks and the install. This removes the git thread and its futex wait.
- Correct because git and the install no longer use the directory at the same time. The commit holds the template's files. The thread gave that result in 2021, when the install client was npm.
- Fixes #36953: the `[Xms] git` line no longer lands in task output.
- The no-install path stored git's result without `!`, so it reported a repository only when git was missing. The shared call site fixes that.
- Verified: `test/cli/install/bun-create.test.ts`. Two new tests fail on main and pass with the fix.

### Background
- `bun install` writes the lockfile to `.lockb-<hex>.tmp`, then renames it over `bun.lockb`.
- `git add` lists the directory, then opens each file. A file that is gone at the open gives `unable to index file`.
- The race is old. Builds 107879 and 107984 hit it and passed on a retry. Since #41204, CI runs a test file once unless `test/flaky-tests.txt` lists it.

<details><summary>Notes</summary>

**Cost.** Git no longer overlaps the install. Median wall time of the released binary, with "serial" measured as `bun create --no-install` and then `bun install`. Those are the two steps that the fix runs in order. The template has one dependency (`jquery`) and an old `bun.lockb`, like the GitHub template in the test.

| Machine | Cache | Parallel (main) | Serial | git alone |
| --- | --- | --- | --- | --- |
| Linux x64 | warm | 21 ms | 26 ms | 17 ms |
| Linux x64 | cold | 58 ms | 73 ms | 17 ms |
| Windows Server 2019 x64 VM | warm | 129 ms | 145 ms | 115 ms |
| Windows Server 2019 x64 VM | cold | 132 ms | 206 ms | 115 ms |

A large template costs more. #36953 shows 2.17 s for git on Windows, measured while the install ran.

**History.** Before 10696680ff (2021), git ran after the postinstall tasks. That commit moved git onto a thread that starts before the tasks. The install client then was npm, yarn, or pnpm, so `git add` finished first and the commit held the template's files. With `bun install`, either side can win. This PR reverses the overlap on purpose, and it keeps the template-only commit.

**Repro on Linux.** With the released build and a stub `git` that logs the files it sees, `git add` already sees `bun.lock`, `node_modules`, and a file that a preinstall task writes. So the content of the first commit depended on timing.

**The new ordering test.** bun create's stdout goes to a file. bun create prints a `$ ...` line there before each task and before `bun install`. At each git call, the stub checks for such a line. The old code prints one right after it starts the thread, so the stub sees it at `git init`. The fixed code prints it after git exits. The test has no sleep. Under the debug build with the base `src/`, both new tests fail.

**Other orders.** Git after the postinstall tasks (the order before 2021) puts the lockfile in the first commit. It also commits `node_modules` for a template with no `.gitignore` (bun create writes none), and every file that a task writes. A split (`git init` first, `add` and `commit` after the tasks) is also race-free. Both change what the first commit holds, so I left that choice for a follow-up. It is a move of one block. The docs now say only that git finishes before the tasks and the install.

**Open PRs.** #37589 and #36954 are closed in favor of this PR. #37589 also removed the thread, but it started the git chain and the install chain together, so the race stayed. #36954 printed the timing line after the tasks. #38955 fixes the PATH lookup for template tasks, which is a separate bug. It changes other functions in `create_command.rs` and does not conflict with this PR, so either can merge first. `bun-create.test.ts` passes with both applied. Three other open PRs touch the git block and need a rebase after this one merges: #38485 (its test "still waits for the git thread" no longer applies), #35253 (it carries the same `skip_git` fix), and #36351 (its `.git` probe).

**Windows details.** Git for Windows takes a file's stat data from its directory listing (`core.fscache`). So a file that goes away reaches `open()`, which explains the exact message. The GitHub template tests skip when the GitHub API rate-limits the runner. On the Windows lanes they skipped in most builds before 2026-09-03, and they ran in every build I sampled after it. I could not reproduce the lost race on a Windows VM (about 100 runs). The window is a few milliseconds.

**CI history.** I scanned the annotations of 2250 builds (2026-08-28 to 2026-09-04). This file failed 4 times, all on Windows, all with the `.lockb-<hex>.tmp` error.

**Ran.** `bun bd test test/cli/install/bun-create.test.ts` on Linux (23 pass) and on Windows (20 pass, 3 POSIX-only tests skip). The two new tests 6 more times each. `test/internal/source-lints/` (the thread-door inventory drops `create_command.rs`). `cargo check` for `x86_64-pc-windows-msvc`.

**Self-review.** 4 concerns raised, 4 addressed: the links and the history in this body, the timings, task coverage in the ordering test, and the docs wording about the lockfile.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.1 (e0a2b82fd)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [130.05ms]
(pass) should not crash > ["create",""] [99.26ms]
(pass) should not crash > ["create","--"] [173.17ms]
(pass) should not crash > ["create","--",""] [168.29ms]
(pass) should not crash > ["create","--help"] [98.58ms]
(pass) should create selected template with @ prefix [442.97ms]
(pass) should create selected template with @ prefix implicit `/create` [455.25ms]
(pass) should create selected template with @ prefix implicit `/create` with version [376.56ms]
(pass) handles a close-delimited GitHub tarball body split across packets [630.38ms]
(pass) keeps tarball entry paths within the destination when checking for conflicting files [291.92ms]
(pass) reports an error and exits when the template's package.json entry body is truncated [249.30ms]
(pass) does not busy-wait while git runs [1654.54ms]
366 | 
367 |   const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
368 |   
... (truncated)

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (e0a2b82fd)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [1.78ms]
(pass) should not crash > ["create",""] [1.21ms]
(pass) should not crash > ["create","--"] [1.18ms]
(pass) should not crash > ["create","--",""] [1.08ms]
(pass) should not crash > ["create","--help"] [1.23ms]
(pass) should create selected template with @ prefix [37.78ms]
(pass) should create selected template with @ prefix implicit `/create` [39.42ms]
(pass) should create selected template with @ prefix implicit `/create` with version [40.94ms]
(pass) handles a close-delimited GitHub tarball body split across packets [17.66ms]
(pass) keeps tarball entry paths within the destination when checking for conflicting files [9.60ms]
(pass) reports an error and exits when the template's package.json entry body is truncated [7.85ms]
(pass) does not busy-wait while git runs [1509.85ms]
366 | 
367 |   const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
368 |   const out = await Bun.file(stdoutPath).text();
369 |   const gitLog = await Bun.file(gitLogPath).text();
370 | 
371 |   expect(gitLog.trim().split("\n")).toEqual([
           
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.1 (e0a2b82fd)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [132.44ms]
(pass) should not crash > ["create",""] [177.14ms]
(pass) should not crash > ["create","--"] [103.85ms]
(pass) should not crash > ["create","--",""] [100.22ms]
(pass) should not crash > ["create","--help"] [110.38ms]
(pass) should create selected template with @ prefix [315.35ms]
(pass) should create selected template with @ prefix implicit `/create` [380.24ms]
(pass) should create selected template with @ prefix implicit `/create` with version [311.12ms]
(pass) handles a close-delimited GitHub tarball body split across packets [650.32ms]
(pass) keeps tarball entry paths within the destination when checking for conflicting files [226.00ms]
(pass) reports an error and exits when the template's package.json entry body is truncated [194.01ms]
(pass) does not busy-wait while git runs [1858.54ms]
(pass) runs git to completion before the template's tasks and install [608.05ms]
(pass) reports the
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 645ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/35] gen bindgenv2
[2/32] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 classes from /workspace/bun/src/runtime/api/html_rewriter.classes.ts
  - HTMLRewriter (3 fields)
  - TextChunk (7 fields)
 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/templating/create.mdx                 |  12 +--
 src/runtime/cli/create_command.rs                  |  86 ++--------------
 test/cli/install/bun-create.test.ts                | 113 ++++++++++++++++++++-
 .../source-lints/vm-thread-door.inventory.json     |   3 -
 4 files changed, 125 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
docs/runtime/templating/create.mdx                            2      3     22
src/runtime/cli/create_command.rs                             8      7     22
test/cli/install/bun-create.test.ts                           3      7     22
test/internal/source-lints/vm-thread-door.inventory.json      0      0     24
```

</details>

<!-- robobun:evidence:end -->
