### PR TITLE
node:http2: withhold connection window credit after setLocalWindowSize() decreases it

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -216,6 +216,11 @@ pub trait Sink {
     /// counter moves, while the connection is mutably borrowed — the embedder must only
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
+    /// Connection-level receive window update (node's session.state window fields): `size` is
+    /// what the peer has been told it may send, `consumed` what it has sent since the last
+    /// WINDOW_UPDATE. Called whenever either moves, while the connection is mutably borrowed —
+    /// the embedder must only store the values.
+    fn on_recv_window(&self, _size: i64, _consumed: i64) {}
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
     /// inbound frames for it are not treated as frames on an idle stream.
@@ -420,6 +425,17 @@ impl Connection {
         );
     }
 
+    fn note_recv_window(&self, sink: &impl Sink) {
+        sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
+    }
+
+    /// The embedder advertised `delta` more connection-level receive window (a WINDOW_UPDATE on
+    /// stream 0 it wrote itself): accept that much more DATA before the §6.9.1 overflow check.
+    pub fn grow_recv_window(&mut self, sink: &impl Sink, delta: i64) {
+        self.recv_window.grow(delta);
+        self.note_recv_window(sink);
+    }
+
     fn send_rst_stream(&mut self, sink: &impl Sink, stream_id: u32, code: ErrorCode) {
         self.write_frame(
             sink,
@@ -571,6 +587,7 @@ impl Connection {
             let inc = self.recv_window.take_update();
             if inc > 0 {
                 self.send_window_update(sink, 0, inc);
+                self.note_recv_window(sink);
             }
         }
         let mut buf = std::mem::take(&mut self.replenish_buf);
@@ -1368,6 +1385,7 @@ impl Connection {
 
         // §6.9: the whole declared frame counts against the connection recv window on receipt.
         self.recv_window.on_data(hdr.length as i64);
+        self.note_recv_window(sink);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,
@@ -1486,6 +1504,7 @@ impl Connection {
 
         // §6.9: the whole frame counts against the connection recv window.
         self.recv_window.on_data(consumed);
+        self.note_recv_window(sink);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -6,7 +6,7 @@
 
 #![allow(dead_code)]
 
-use super::flow_control::{RecvWindow, SendWindow};
+use super::flow_control::{RecvWindow, RecvWindowChange, SendWindow};
 use super::hpack;
 use super::settings::{self, Settings};
 use super::stream::{self, State};
@@ -217,10 +217,16 @@ pub trait Sink {
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
     /// Connection-level receive window update (node's session.state window fields): `size` is
-    /// what the peer has been told it may send, `consumed` what it has sent since the last
-    /// WINDOW_UPDATE. Called whenever either moves, while the connection is mutably borrowed —
+    /// the window the embedder asked for, and the peer may send `size - consumed` more (see
+    /// `RecvWindow`). Called whenever either moves, while the connection is mutably borrowed —
     /// the embedder must only store the values.
     fn on_recv_window(&self, _size: i64, _consumed: i64) {}
+    /// Connection-level receive-window changes the embedder queued while the connection was
+    /// borrowed (see `Connection::apply_recv_window_change`). Taken before the connection decides
+    /// on a WINDOW_UPDATE, so a change made in a callback applies to the rest of the batch.
+    fn take_recv_window_change(&self) -> RecvWindowChange {
+        RecvWindowChange::default()
+    }
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
     /// inbound frames for it are not treated as frames on an idle stream.
@@ -429,10 +435,10 @@ impl Connection {
         sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
     }
 
-    /// The embedder advertised `delta` more connection-level receive window (a WINDOW_UPDATE on
-    /// stream 0 it wrote itself): accept that much more DATA before the §6.9.1 overflow check.
-    pub fn grow_recv_window(&mut self, sink: &impl Sink, delta: i64) {
-        self.recv_window.grow(delta);
+    /// The embedder resized the connection-level receive window (`LocalWindow::resize`) and
+    /// wrote the WINDOW_UPDATE on stream 0 that the change needs itself.
+    pub fn apply_recv_window_change(&mut self, sink: &impl Sink, change: RecvWindowChange) {
+        self.recv_window.apply(change);
         self.note_recv_window(sink);
     }
 
@@ -583,6 +589,10 @@ impl Connection {
 
     /// Send WINDOW_UPDATE for every receive window that has consumed at least half its size.
     fn replenish_windows(&mut self, sink: &impl Sink) {
+        let change = sink.take_recv_window_change();
+        if change != RecvWindowChange::default() {
+            self.apply_recv_window_change(sink, change);
+        }
         if self.recv_window.needs_update() {
             let inc = self.recv_window.take_update();
             if inc > 0 {

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -436,10 +436,24 @@ impl Connection {
     }
 
     /// The embedder resized the connection-level receive window (`LocalWindow::resize`) and
-    /// wrote the WINDOW_UPDATE on stream 0 that the change needs itself.
+    /// wrote the WINDOW_UPDATE on stream 0 that the change needs itself. A raise that repays
+    /// withheld credit can make a WINDOW_UPDATE due at once. It goes out now: a peer with no
+    /// window left sends nothing, so no `receive()` would come to send it.
     pub fn apply_recv_window_change(&mut self, sink: &impl Sink, change: RecvWindowChange) {
         self.recv_window.apply(change);
         self.note_recv_window(sink);
+        self.replenish_connection_window(sink);
+    }
+
+    /// Send a WINDOW_UPDATE on stream 0 once the peer has used at least half the window.
+    fn replenish_connection_window(&mut self, sink: &impl Sink) {
+        if self.recv_window.needs_update() {
+            let inc = self.recv_window.take_update();
+            if inc > 0 {
+                self.send_window_update(sink, 0, inc);
+                self.note_recv_window(sink);
+            }
+        }
     }
 
     fn send_rst_stream(&mut self, sink: &impl Sink, stream_id: u32, code: ErrorCode) {
@@ -591,15 +605,10 @@ impl Connection {
     fn replenish_windows(&mut self, sink: &impl Sink) {
         let change = sink.take_recv_window_change();
         if change != RecvWindowChange::default() {
-            self.apply_recv_window_change(sink, change);
+            self.recv_window.apply(change);
+            self.note_recv_window(sink);
         }
-        if self.recv_window.needs_update() {
-            let inc = self.recv_window.take_update();
-            if inc > 0 {
-                self.send_window_update(sink, 0, inc);
-                self.note_recv_window(sink);
-            }
-        }
+        self.replenish_connection_window(sink);
         let mut buf = std::mem::take(&mut self.replenish_buf);
         buf.clear();
         for (id, s) in self.streams.iter_mut() {

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -218,7 +218,7 @@ pub trait Sink {
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
     /// The connection `RecvWindow` moved. Only store the values: the connection is borrowed.
     fn on_recv_window(&self, _size: i64, _consumed: i64) {}
-    /// Receive-window changes queued while the connection was borrowed. Taken before replenishing.
+    /// Receive-window changes that the embedder queued. `Connection::sync_recv_window` takes them.
     fn take_recv_window_change(&self) -> RecvWindowChange {
         RecvWindowChange::default()
     }
@@ -430,22 +430,33 @@ impl Connection {
         sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
     }
 
-    /// Applies a `LocalWindow::resize` change, then sends any WINDOW_UPDATE that it makes due.
-    pub fn apply_recv_window_change(&mut self, sink: &impl Sink, change: RecvWindowChange) {
-        self.recv_window.apply(change);
-        self.note_recv_window(sink);
-        self.replenish_connection_window(sink);
-    }
-
-    /// Send a WINDOW_UPDATE on stream 0 once the peer has used at least half the window.
-    fn replenish_connection_window(&mut self, sink: &impl Sink) {
-        if self.recv_window.needs_update() {
-            let inc = self.recv_window.take_update();
-            if inc > 0 {
-                self.send_window_update(sink, 0, inc);
+    /// Applies the queued `LocalWindow` changes, and sends each WINDOW_UPDATE that comes due.
+    pub fn sync_recv_window(&mut self, sink: &impl Sink) {
+        loop {
+            let change = sink.take_recv_window_change();
+            if change != RecvWindowChange::default() {
+                self.recv_window.apply(change);
                 self.note_recv_window(sink);
             }
+            // A WINDOW_UPDATE write can run JS that queues another change.
+            if !self.replenish_connection_window(sink) {
+                return;
+            }
         }
+    }
+
+    /// Sends a WINDOW_UPDATE on stream 0 once half the window is used. True if it wrote one.
+    fn replenish_connection_window(&mut self, sink: &impl Sink) -> bool {
+        if !self.recv_window.needs_update() {
+            return false;
+        }
+        let inc = self.recv_window.take_update();
+        if inc == 0 {
+            return false;
+        }
+        self.send_window_update(sink, 0, inc);
+        self.note_recv_window(sink);
+        true
     }
 
     fn send_rst_stream(&mut self, sink: &impl Sink, stream_id: u32, code: ErrorCode) {
@@ -595,12 +606,7 @@ impl Connection {
 
     /// Send WINDOW_UPDATE for every receive window that has consumed at least half its size.
     fn replenish_windows(&mut self, sink: &impl Sink) {
-        let change = sink.take_recv_window_change();
-        if change != RecvWindowChange::default() {
-            self.recv_window.apply(change);
-            self.note_recv_window(sink);
-        }
-        self.replenish_connection_window(sink);
+        self.sync_recv_window(sink);
         let mut buf = std::mem::take(&mut self.replenish_buf);
         buf.clear();
         for (id, s) in self.streams.iter_mut() {

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -216,14 +216,9 @@ pub trait Sink {
     /// counter moves, while the connection is mutably borrowed — the embedder must only
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
-    /// Connection-level receive window update (node's session.state window fields): `size` is
-    /// the window the embedder asked for, and the peer may send `size - consumed` more (see
-    /// `RecvWindow`). Called whenever either moves, while the connection is mutably borrowed —
-    /// the embedder must only store the values.
+    /// The connection `RecvWindow` moved. Only store the values: the connection is borrowed.
     fn on_recv_window(&self, _size: i64, _consumed: i64) {}
-    /// Connection-level receive-window changes the embedder queued while the connection was
-    /// borrowed (see `Connection::apply_recv_window_change`). Taken before the connection decides
-    /// on a WINDOW_UPDATE, so a change made in a callback applies to the rest of the batch.
+    /// Receive-window changes queued while the connection was borrowed. Taken before replenishing.
     fn take_recv_window_change(&self) -> RecvWindowChange {
         RecvWindowChange::default()
     }
@@ -435,10 +430,7 @@ impl Connection {
         sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
     }
 
-    /// The embedder resized the connection-level receive window (`LocalWindow::resize`) and
-    /// wrote the WINDOW_UPDATE on stream 0 that the change needs itself. A raise that repays
-    /// withheld credit can make a WINDOW_UPDATE due at once. It goes out now: a peer with no
-    /// window left sends nothing, so no `receive()` would come to send it.
+    /// Applies a `LocalWindow::resize` change, then sends any WINDOW_UPDATE that it makes due.
     pub fn apply_recv_window_change(&mut self, sink: &impl Sink, change: RecvWindowChange) {
         self.recv_window.apply(change);
         self.note_recv_window(sink);

--- a/src/runtime/api/bun/h2/flow_control.rs
+++ b/src/runtime/api/bun/h2/flow_control.rs
@@ -67,15 +67,12 @@ impl SendWindow {
     }
 }
 
-/// Inbound (recv) window. `size` is the window we want (nghttp2's `local_window_size`).
-/// `consumed` (`recv_window_size`) is the credit that WINDOW_UPDATE frames still have to give
-/// back, so the peer may send `size - consumed` more. DATA adds to it. Once enough is consumed we
-/// emit a WINDOW_UPDATE of the consumed amount and reset. A `LocalWindow` decrease makes it
-/// negative: the peer may still fill the window it was told about, and the first `old - new` of
-/// those bytes earn no WINDOW_UPDATE. A raise that repays the decrease adds the repaid bytes back.
+/// Inbound (recv) window. The peer may send `size - consumed` more bytes.
 #[derive(Clone, Copy, Debug)]
 pub struct RecvWindow {
+    /// The window we want (nghttp2's `local_window_size`).
     pub size: i64,
+    /// Credit still to give back (`recv_window_size`). Negative after a `LocalWindow` decrease.
     pub consumed: i64,
 }
 
@@ -150,8 +147,7 @@ pub struct RecvWindowChange {
 }
 
 impl RecvWindowChange {
-    /// The WINDOW_UPDATE increment that tells the peer about this change: the change in
-    /// `size - consumed`, which is what the peer may send.
+    /// The WINDOW_UPDATE increment for this change: the change in `size - consumed`.
     #[inline]
     pub fn increment(self) -> i64 {
         self.size - self.consumed
@@ -169,9 +165,7 @@ impl core::ops::Add for RecvWindowChange {
     }
 }
 
-/// The connection receive window that the application asks for (node's setLocalWindowSize,
-/// nghttp2's `local_window_size`), and the credit that a decrease still withholds from the peer
-/// (`recv_reduction`).
+/// nghttp2's `local_window_size` and `recv_reduction`: the window asked for, and withheld credit.
 #[derive(Clone, Copy, Debug)]
 pub struct LocalWindow {
     pub size: i64,
@@ -188,10 +182,7 @@ impl Default for LocalWindow {
 }
 
 impl LocalWindow {
-    /// nghttp2_session_set_local_window_size() for stream 0. A decrease sends nothing: the peer
-    /// may still fill the window it was told about, and the next `old - new` bytes it sends are
-    /// not granted back. A raise first repays that withheld credit. Only the rest goes out in a
-    /// WINDOW_UPDATE (`RecvWindowChange::increment`).
+    /// nghttp2_session_set_local_window_size() for stream 0. A raise repays withheld credit first.
     pub fn resize(&mut self, new_size: i64) -> RecvWindowChange {
         let delta = new_size - self.size;
         self.size = new_size;

--- a/src/runtime/api/bun/h2/flow_control.rs
+++ b/src/runtime/api/bun/h2/flow_control.rs
@@ -67,8 +67,12 @@ impl SendWindow {
     }
 }
 
-/// Inbound (recv) window. We advertise `size` and track `consumed`; once enough is consumed we
-/// emit a WINDOW_UPDATE of the consumed amount and reset.
+/// Inbound (recv) window. `size` is the window we want (nghttp2's `local_window_size`).
+/// `consumed` (`recv_window_size`) is the credit that WINDOW_UPDATE frames still have to give
+/// back, so the peer may send `size - consumed` more. DATA adds to it. Once enough is consumed we
+/// emit a WINDOW_UPDATE of the consumed amount and reset. A `LocalWindow` decrease makes it
+/// negative: the peer may still fill the window it was told about, and the first `old - new` of
+/// those bytes earn no WINDOW_UPDATE. A raise that repays the decrease adds the repaid bytes back.
 #[derive(Clone, Copy, Debug)]
 pub struct RecvWindow {
     pub size: i64,
@@ -130,6 +134,81 @@ impl RecvWindow {
     pub fn grow(&mut self, delta: i64) {
         self.size += delta;
     }
+
+    #[inline]
+    pub fn apply(&mut self, change: RecvWindowChange) {
+        self.size += change.size;
+        self.consumed += change.consumed;
+    }
+}
+
+/// A move of a `RecvWindow` that the embedder makes (see `LocalWindow::resize`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RecvWindowChange {
+    pub size: i64,
+    pub consumed: i64,
+}
+
+impl RecvWindowChange {
+    /// The WINDOW_UPDATE increment that tells the peer about this change: the change in
+    /// `size - consumed`, which is what the peer may send.
+    #[inline]
+    pub fn increment(self) -> i64 {
+        self.size - self.consumed
+    }
+}
+
+impl core::ops::Add for RecvWindowChange {
+    type Output = RecvWindowChange;
+
+    fn add(self, other: RecvWindowChange) -> RecvWindowChange {
+        RecvWindowChange {
+            size: self.size + other.size,
+            consumed: self.consumed + other.consumed,
+        }
+    }
+}
+
+/// The connection receive window that the application asks for (node's setLocalWindowSize,
+/// nghttp2's `local_window_size`), and the credit that a decrease still withholds from the peer
+/// (`recv_reduction`).
+#[derive(Clone, Copy, Debug)]
+pub struct LocalWindow {
+    pub size: i64,
+    pub reduction: i64,
+}
+
+impl Default for LocalWindow {
+    fn default() -> Self {
+        LocalWindow {
+            size: DEFAULT_WINDOW_SIZE as i64,
+            reduction: 0,
+        }
+    }
+}
+
+impl LocalWindow {
+    /// nghttp2_session_set_local_window_size() for stream 0. A decrease sends nothing: the peer
+    /// may still fill the window it was told about, and the next `old - new` bytes it sends are
+    /// not granted back. A raise first repays that withheld credit. Only the rest goes out in a
+    /// WINDOW_UPDATE (`RecvWindowChange::increment`).
+    pub fn resize(&mut self, new_size: i64) -> RecvWindowChange {
+        let delta = new_size - self.size;
+        self.size = new_size;
+        if delta < 0 {
+            self.reduction -= delta;
+            return RecvWindowChange {
+                size: delta,
+                consumed: delta,
+            };
+        }
+        let repaid = self.reduction.min(delta);
+        self.reduction -= repaid;
+        RecvWindowChange {
+            size: delta,
+            consumed: repaid,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -149,5 +228,41 @@ mod tests {
         assert!(w.needs_update());
         assert_eq!(w.take_update(), 60);
         assert_eq!(w.consumed, 0);
+    }
+
+    #[test]
+    fn local_window_decrease_withholds_credit() {
+        let mut local = LocalWindow::default();
+        let mut w = RecvWindow::default();
+
+        let shrink = local.resize(20);
+        assert_eq!(shrink.increment(), 0);
+        w.apply(shrink);
+        assert_eq!((w.size, w.consumed), (20, -65515));
+
+        // The peer fills the window it was told about. Only 20 bytes are granted back.
+        w.on_data(65535);
+        assert!(!w.is_overflowed());
+        assert_eq!(w.take_update(), 20);
+        w.on_data(21);
+        assert!(w.is_overflowed());
+    }
+
+    #[test]
+    fn local_window_raise_repays_the_reduction_first() {
+        let mut local = LocalWindow::default();
+        let mut w = RecvWindow::default();
+        w.apply(local.resize(20));
+
+        let raise = local.resize(1 << 20);
+        assert_eq!(raise.increment(), 983041);
+        w.apply(raise);
+        assert_eq!((w.size, w.consumed, local.reduction), (1 << 20, 0, 0));
+
+        // A raise that the reduction absorbs sends nothing.
+        let mut local = LocalWindow::default();
+        let change = local.resize(20) + local.resize(30000);
+        assert_eq!(change.increment(), 0);
+        assert_eq!(local.reduction, 35535);
     }
 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1063,10 +1063,14 @@ pub struct H2FrameParser {
     remote_settings: Cell<Option<FullSettingsPayload>>,
 
     // local Window limits the download of data
-    // current window size for the connection
+    // current window size for the connection (what setLocalWindowSize asked for)
     window_size: Cell<u64>,
-    // used window size for the connection
-    used_window_size: Cell<u64>,
+    /// The engine's connection-level receive window, mirrored through `Sink::on_recv_window`
+    /// so `state` can be read inside a dispatch (the engine cell is borrowed there):
+    /// what the peer has been told it may send, and what it has sent since the last
+    /// WINDOW_UPDATE on stream 0.
+    recv_window_size: Cell<i64>,
+    recv_window_consumed: Cell<i64>,
 
     // remote Window limits the upload of data
     // remote window size for the connection
@@ -1316,8 +1320,6 @@ pub struct Stream {
     weight: u16,
     // current window size for the stream
     window_size: u64,
-    // used window size for the stream
-    used_window_size: u64,
     // remote window size for the stream
     remote_window_size: u64,
     // remote used window size for the stream
@@ -1832,7 +1834,6 @@ impl Stream {
             // which is what stream.state.weight reports when no priority was signaled.
             weight: 16,
             window_size: initial_window_size as u64,
-            used_window_size: 0,
             remote_window_size: remote_window_size as u64,
             remote_used_window_size: 0,
             signal: None,
@@ -3565,7 +3566,7 @@ impl H2FrameParser {
             // held this borrow.
             let pending = self.pending_recv_window_growth.replace(0);
             if pending > 0 {
-                engine.recv_window.grow(pending);
+                engine.grow_recv_window(self, pending);
             }
             // Apply outbound DATA the legacy encoder wrote since the last batch, so the engine's
             // send windows reflect what is actually in flight (§6.9.1 overflow stays peer-error
@@ -3699,6 +3700,11 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_frame_counters(&self, received: u64, sent: u64) {
         self.engine_frames_received.set(received);
         self.engine_frames_sent.set(sent);
+    }
+
+    fn on_recv_window(&self, size: i64, consumed: i64) {
+        self.recv_window_size.set(size);
+        self.recv_window_consumed.set(consumed);
     }
 
     fn write(&self, bytes: &[u8]) -> crate::api::h2::connection::WriteResult {
@@ -4527,18 +4533,12 @@ impl H2FrameParser {
                 .throw_invalid_arguments(format_args!("Expected windowSize to be a number")));
         }
         let window_size_value: u32 = window_size.to_u32();
-        if this.used_window_size.get() > window_size_value as u64 {
-            return Err(global_object.throw_invalid_arguments(format_args!(
-                "Expected windowSize to be greater than usedWindowSize"
-            )));
-        }
         let old_window_size = this.window_size.get();
         this.window_size.set(window_size_value as u64);
-        if this.local_settings.get().initial_window_size < window_size_value {
-            let mut s = this.local_settings.get();
-            s.initial_window_size = window_size_value;
-            this.local_settings.set(s);
-        }
+        // Like nghttp2_session_set_local_window_size(stream_id 0): only the connection-level
+        // window moves. SETTINGS_INITIAL_WINDOW_SIZE stays as advertised; the engine sizes each
+        // new stream's receive window from it, and raising it without a SETTINGS frame leaves
+        // the peer stopped at the old stream window while we wait for half of the new one.
         if window_size_value as u64 > old_window_size {
             let increment: u32 = (window_size_value as u64 - old_window_size) as u32;
             this.send_window_update(0, UInt31WithReserved::init(increment, false));
@@ -4549,7 +4549,7 @@ impl H2FrameParser {
             // delta keeps that path panic-free.
             match this.engine.try_borrow_mut() {
                 Ok(mut guard) => match guard.as_mut() {
-                    Some(engine) => engine.recv_window.grow(increment as i64),
+                    Some(engine) => engine.grow_recv_window(this, increment as i64),
                     None => {
                         // The engine is created lazily on the first inbound read; carry the
                         // growth forward so it applies when that happens.
@@ -4564,14 +4564,6 @@ impl H2FrameParser {
                         .set(this.pending_recv_window_growth.get() + increment as i64);
                 }
             }
-        }
-        for (_, item) in this.streams.get().iter() {
-            // SAFETY: item is &*mut Stream from streams.iter(); the boxed Stream outlives the iteration
-            let stream = unsafe { &mut **item };
-            if stream.used_window_size > window_size_value as u64 {
-                continue;
-            }
-            stream.window_size = window_size_value as u64;
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -4606,6 +4598,12 @@ impl H2FrameParser {
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let result = JSValue::create_empty_object(global_object, 9);
+        // node (nghttp2_session_get_*): effectiveLocalWindowSize is the connection window we
+        // want, localWindowSize is what the peer may still send on it (advertised minus what it
+        // sent since the last WINDOW_UPDATE), effectiveRecvDataLength is that consumed amount.
+        // Growth queued for the engine is already on the wire, so it counts as advertised.
+        let advertised = this.recv_window_size.get() + this.pending_recv_window_growth.get();
+        let consumed = this.recv_window_consumed.get().max(0);
         result.put(
             global_object,
             b"effectiveLocalWindowSize",
@@ -4614,7 +4612,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"effectiveRecvDataLength",
-            JSValue::js_number((this.window_size.get() - this.used_window_size.get()) as f64),
+            JSValue::js_number(consumed as f64),
         );
         result.put(
             global_object,
@@ -4629,7 +4627,6 @@ impl H2FrameParser {
 
         let settings = this.remote_settings.get().unwrap_or_default();
         let remote_iws = settings.initial_window_size;
-        let local_iws = this.local_settings.get().initial_window_size;
         let local_hts = this.local_settings.get().header_table_size;
         result.put(
             global_object,
@@ -4639,7 +4636,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"localWindowSize",
-            JSValue::js_number(local_iws as f64),
+            JSValue::js_number((advertised - consumed).max(0) as f64),
         );
         result.put(
             global_object,
@@ -7574,7 +7571,8 @@ impl H2FrameParser {
             ),
             remote_settings: Cell::new(None),
             window_size: Cell::new(DEFAULT_WINDOW_SIZE),
-            used_window_size: Cell::new(0),
+            recv_window_size: Cell::new(DEFAULT_WINDOW_SIZE as i64),
+            recv_window_consumed: Cell::new(0),
             remote_window_size: Cell::new(DEFAULT_WINDOW_SIZE),
             remote_used_window_size: Cell::new(0),
             max_header_list_pairs: Cell::new(128),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1079,7 +1079,7 @@ pub struct H2FrameParser {
     max_header_list_pairs: Cell<u32>,
     /// node maxSettings session option: maximum entries accepted in a single SETTINGS frame.
     max_settings: Cell<u32>,
-    /// Changes queued while the engine was borrowed or absent (`Sink::take_recv_window_change`).
+    /// setLocalWindowSize changes that the engine has not applied yet (`sync_recv_window`).
     pending_recv_window_change: Cell<RecvWindowChange>,
     /// Bridge: outbound DATA bytes the legacy encoder wrote since the engine last ran, applied to
     /// the engine's connection-level send window in rewrite_read (the engine cell may be borrowed
@@ -3559,11 +3559,8 @@ impl H2FrameParser {
             if self.write_buffer.get().slice()[self.write_buffer_offset.get()..].is_empty() {
                 engine.note_outbound_drained();
             }
-            // Apply a change that setLocalWindowSize() queued before the engine existed.
-            let pending = self.pending_recv_window_change.take();
-            if pending != RecvWindowChange::default() {
-                engine.apply_recv_window_change(self, pending);
-            }
+            // Apply what setLocalWindowSize() queued before the engine existed or in a dispatch.
+            engine.sync_recv_window(self);
             // Apply outbound DATA the legacy encoder wrote since the last batch, so the engine's
             // send windows reflect what is actually in flight (§6.9.1 overflow stays peer-error
             // only).
@@ -4532,7 +4529,12 @@ impl H2FrameParser {
             return Err(global_object
                 .throw_invalid_arguments(format_args!("Expected windowSize to be a number")));
         }
-        let window_size_value: u32 = window_size.to_u32();
+        let window_size_value = window_size.as_number();
+        if !(0.0..=MAX_WINDOW_SIZE_F64).contains(&window_size_value) {
+            return Err(global_object.throw_invalid_arguments(format_args!(
+                "Expected windowSize to be between 0 and {MAX_WINDOW_SIZE}"
+            )));
+        }
         // Like nghttp2_session_set_local_window_size(stream 0): SETTINGS_INITIAL_WINDOW_SIZE stays.
         let mut local_window = this.local_window.get();
         let change = local_window.resize(window_size_value as i64);
@@ -4540,17 +4542,18 @@ impl H2FrameParser {
         if change == RecvWindowChange::default() {
             return Ok(JSValue::UNDEFINED);
         }
+        // Queue the change before the write below, which can run JS that calls this again.
+        this.pending_recv_window_change
+            .set(this.pending_recv_window_change.get() + change);
         let increment = change.increment();
         if increment > 0 {
             this.send_window_update(0, UInt31WithReserved::init(increment as u32, false));
         }
-        let mut guard = this.engine.try_borrow_mut();
-        match guard.as_mut().ok().and_then(|guard| guard.as_mut()) {
-            Some(engine) => engine.apply_recv_window_change(this, change),
-            // A dispatch holds the engine, or the first inbound read has not created it yet.
-            None => this
-                .pending_recv_window_change
-                .set(this.pending_recv_window_change.get() + change),
+        // If a dispatch holds the engine, or no read has created it yet, the change stays queued.
+        if let Ok(mut guard) = this.engine.try_borrow_mut()
+            && let Some(engine) = guard.as_mut()
+        {
+            engine.sync_recv_window(this);
         }
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -11,6 +11,7 @@ use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 use std::borrow::Cow;
 
+use crate::api::h2::flow_control::{LocalWindow, RecvWindowChange};
 use crate::api::socket::{TCPSocket, TLSSocket};
 use crate::node::{Encoding, StringOrBuffer};
 use crate::socket::NativeCallbacks;
@@ -1063,12 +1064,13 @@ pub struct H2FrameParser {
     remote_settings: Cell<Option<FullSettingsPayload>>,
 
     // local Window limits the download of data
-    // current window size for the connection (what setLocalWindowSize asked for)
-    window_size: Cell<u64>,
-    /// The engine's connection-level receive window, mirrored through `Sink::on_recv_window`
-    /// so `state` can be read inside a dispatch (the engine cell is borrowed there):
-    /// what the peer has been told it may send, and what it has sent since the last
-    /// WINDOW_UPDATE on stream 0.
+    /// The connection window that setLocalWindowSize asked for, and the credit a decrease still
+    /// withholds. Kept here and not in the engine: setLocalWindowSize can run inside a dispatch,
+    /// and it must know the WINDOW_UPDATE increment at once.
+    local_window: Cell<LocalWindow>,
+    /// The engine's connection-level receive window (`RecvWindow::size` and `consumed`),
+    /// mirrored through `Sink::on_recv_window` so `state` can be read inside a dispatch (the
+    /// engine cell is borrowed there).
     recv_window_size: Cell<i64>,
     recv_window_consumed: Cell<i64>,
 
@@ -1081,9 +1083,10 @@ pub struct H2FrameParser {
     max_header_list_pairs: Cell<u32>,
     /// node maxSettings session option: maximum entries accepted in a single SETTINGS frame.
     max_settings: Cell<u32>,
-    /// Receive-window growth requested by setLocalWindowSize() while a dispatch held the engine
-    /// borrow; applied by rewrite_read() on its next pass.
-    pending_recv_window_growth: Cell<i64>,
+    /// Receive-window changes made by setLocalWindowSize() while a dispatch held the engine
+    /// borrow (or before the engine existed). The engine takes them at the end of the batch
+    /// (`Sink::take_recv_window_change`); rewrite_read() applies any that are left.
+    pending_recv_window_change: Cell<RecvWindowChange>,
     /// Bridge: outbound DATA bytes the legacy encoder wrote since the engine last ran, applied to
     /// the engine's connection-level send window in rewrite_read (the engine cell may be borrowed
     /// when the DATA goes out). Without this the engine's window only ever grows and a compliant
@@ -3562,11 +3565,12 @@ impl H2FrameParser {
             if self.write_buffer.get().slice()[self.write_buffer_offset.get()..].is_empty() {
                 engine.note_outbound_drained();
             }
-            // Apply any receive-window growth setLocalWindowSize() accumulated while a dispatch
-            // held this borrow.
-            let pending = self.pending_recv_window_growth.replace(0);
-            if pending > 0 {
-                engine.grow_recv_window(self, pending);
+            // Apply a receive-window change that setLocalWindowSize() queued before the engine
+            // existed. The engine takes a change queued during a dispatch at the end of that
+            // batch (`Sink::take_recv_window_change`).
+            let pending = self.pending_recv_window_change.take();
+            if pending != RecvWindowChange::default() {
+                engine.apply_recv_window_change(self, pending);
             }
             // Apply outbound DATA the legacy encoder wrote since the last batch, so the engine's
             // send windows reflect what is actually in flight (§6.9.1 overflow stays peer-error
@@ -3705,6 +3709,10 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_recv_window(&self, size: i64, consumed: i64) {
         self.recv_window_size.set(size);
         self.recv_window_consumed.set(consumed);
+    }
+
+    fn take_recv_window_change(&self) -> RecvWindowChange {
+        self.pending_recv_window_change.take()
     }
 
     fn write(&self, bytes: &[u8]) -> crate::api::h2::connection::WriteResult {
@@ -4533,36 +4541,39 @@ impl H2FrameParser {
                 .throw_invalid_arguments(format_args!("Expected windowSize to be a number")));
         }
         let window_size_value: u32 = window_size.to_u32();
-        let old_window_size = this.window_size.get();
-        this.window_size.set(window_size_value as u64);
         // Like nghttp2_session_set_local_window_size(stream_id 0): only the connection-level
         // window moves. SETTINGS_INITIAL_WINDOW_SIZE stays as advertised; the engine sizes each
         // new stream's receive window from it, and raising it without a SETTINGS frame leaves
         // the peer stopped at the old stream window while we wait for half of the new one.
-        if window_size_value as u64 > old_window_size {
-            let increment: u32 = (window_size_value as u64 - old_window_size) as u32;
-            this.send_window_update(0, UInt31WithReserved::init(increment, false));
-            // Keep the rewrite engine's receive window in sync: we just advertised a larger
-            // window, so the engine must accept that much DATA without tripping its overflow
-            // check. try_borrow: setLocalWindowSize can be called from JS inside a dispatch
-            // (rewrite_read holds the engine borrow there); deferring the sync to the pending
-            // delta keeps that path panic-free.
-            match this.engine.try_borrow_mut() {
-                Ok(mut guard) => match guard.as_mut() {
-                    Some(engine) => engine.grow_recv_window(this, increment as i64),
-                    None => {
-                        // The engine is created lazily on the first inbound read; carry the
-                        // growth forward so it applies when that happens.
-                        this.pending_recv_window_growth
-                            .set(this.pending_recv_window_growth.get() + increment as i64);
-                    }
-                },
-                Err(_) => {
-                    // A dispatch is in progress; accumulate the delta for rewrite_read to apply
-                    // when the borrow is released.
-                    this.pending_recv_window_growth
-                        .set(this.pending_recv_window_growth.get() + increment as i64);
+        let mut local_window = this.local_window.get();
+        let change = local_window.resize(window_size_value as i64);
+        this.local_window.set(local_window);
+        if change == RecvWindowChange::default() {
+            return Ok(JSValue::UNDEFINED);
+        }
+        let increment = change.increment();
+        if increment > 0 {
+            this.send_window_update(0, UInt31WithReserved::init(increment as u32, false));
+        }
+        // Keep the rewrite engine's receive window in sync: its overflow check and its
+        // WINDOW_UPDATE threshold must use the new size. try_borrow: setLocalWindowSize can be
+        // called from JS inside a dispatch (rewrite_read holds the engine borrow there);
+        // deferring the sync to the pending change keeps that path panic-free.
+        match this.engine.try_borrow_mut() {
+            Ok(mut guard) => match guard.as_mut() {
+                Some(engine) => engine.apply_recv_window_change(this, change),
+                None => {
+                    // The engine is created lazily on the first inbound read; carry the
+                    // change forward so it applies when that happens.
+                    this.pending_recv_window_change
+                        .set(this.pending_recv_window_change.get() + change);
                 }
+            },
+            Err(_) => {
+                // A dispatch is in progress; the engine takes the change at the end of its
+                // batch, before it decides on a WINDOW_UPDATE.
+                this.pending_recv_window_change
+                    .set(this.pending_recv_window_change.get() + change);
             }
         }
         Ok(JSValue::UNDEFINED)
@@ -4599,20 +4610,22 @@ impl H2FrameParser {
     ) -> JsResult<JSValue> {
         let result = JSValue::create_empty_object(global_object, 9);
         // node (nghttp2_session_get_*): effectiveLocalWindowSize is the connection window we
-        // want, localWindowSize is what the peer may still send on it (advertised minus what it
-        // sent since the last WINDOW_UPDATE), effectiveRecvDataLength is that consumed amount.
-        // Growth queued for the engine is already on the wire, so it counts as advertised.
-        let advertised = this.recv_window_size.get() + this.pending_recv_window_growth.get();
-        let consumed = this.recv_window_consumed.get().max(0);
+        // want, localWindowSize is what the peer may still send (`size - consumed`, see
+        // `RecvWindow`), and effectiveRecvDataLength is `consumed`, clamped at 0. After a
+        // decrease `consumed` is negative, so localWindowSize still counts the window the peer
+        // was told about. A change queued for the engine counts as applied.
+        let pending = this.pending_recv_window_change.get();
+        let size = this.recv_window_size.get() + pending.size;
+        let consumed = this.recv_window_consumed.get() + pending.consumed;
         result.put(
             global_object,
             b"effectiveLocalWindowSize",
-            JSValue::js_number(this.window_size.get() as f64),
+            JSValue::js_number(this.local_window.get().size as f64),
         );
         result.put(
             global_object,
             b"effectiveRecvDataLength",
-            JSValue::js_number(consumed as f64),
+            JSValue::js_number(consumed.max(0) as f64),
         );
         result.put(
             global_object,
@@ -4636,7 +4649,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"localWindowSize",
-            JSValue::js_number((advertised - consumed).max(0) as f64),
+            JSValue::js_number((size - consumed).max(0) as f64),
         );
         result.put(
             global_object,
@@ -7570,14 +7583,14 @@ impl H2FrameParser {
                 FullSettingsPayload::default().max_header_list_size,
             ),
             remote_settings: Cell::new(None),
-            window_size: Cell::new(DEFAULT_WINDOW_SIZE),
+            local_window: Cell::new(LocalWindow::default()),
             recv_window_size: Cell::new(DEFAULT_WINDOW_SIZE as i64),
             recv_window_consumed: Cell::new(0),
             remote_window_size: Cell::new(DEFAULT_WINDOW_SIZE),
             remote_used_window_size: Cell::new(0),
             max_header_list_pairs: Cell::new(128),
             max_settings: Cell::new(32),
-            pending_recv_window_growth: Cell::new(0),
+            pending_recv_window_change: Cell::new(RecvWindowChange::default()),
             pending_send_window_consumed: Cell::new(0),
             pending_stream_send_consumed: JsCell::new(Vec::new()),
             pending_engine_stream_closes: JsCell::new(Vec::new()),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1064,13 +1064,9 @@ pub struct H2FrameParser {
     remote_settings: Cell<Option<FullSettingsPayload>>,
 
     // local Window limits the download of data
-    /// The connection window that setLocalWindowSize asked for, and the credit a decrease still
-    /// withholds. Kept here and not in the engine: setLocalWindowSize can run inside a dispatch,
-    /// and it must know the WINDOW_UPDATE increment at once.
+    /// setLocalWindowSize's window. Not in the engine, which a dispatch can hold borrowed.
     local_window: Cell<LocalWindow>,
-    /// The engine's connection-level receive window (`RecvWindow::size` and `consumed`),
-    /// mirrored through `Sink::on_recv_window` so `state` can be read inside a dispatch (the
-    /// engine cell is borrowed there).
+    /// Mirror of the engine's `RecvWindow` (`Sink::on_recv_window`), readable during a dispatch.
     recv_window_size: Cell<i64>,
     recv_window_consumed: Cell<i64>,
 
@@ -1083,9 +1079,7 @@ pub struct H2FrameParser {
     max_header_list_pairs: Cell<u32>,
     /// node maxSettings session option: maximum entries accepted in a single SETTINGS frame.
     max_settings: Cell<u32>,
-    /// Receive-window changes made by setLocalWindowSize() while a dispatch held the engine
-    /// borrow (or before the engine existed). The engine takes them at the end of the batch
-    /// (`Sink::take_recv_window_change`); rewrite_read() applies any that are left.
+    /// Changes queued while the engine was borrowed or absent (`Sink::take_recv_window_change`).
     pending_recv_window_change: Cell<RecvWindowChange>,
     /// Bridge: outbound DATA bytes the legacy encoder wrote since the engine last ran, applied to
     /// the engine's connection-level send window in rewrite_read (the engine cell may be borrowed
@@ -3565,9 +3559,7 @@ impl H2FrameParser {
             if self.write_buffer.get().slice()[self.write_buffer_offset.get()..].is_empty() {
                 engine.note_outbound_drained();
             }
-            // Apply a receive-window change that setLocalWindowSize() queued before the engine
-            // existed. The engine takes a change queued during a dispatch at the end of that
-            // batch (`Sink::take_recv_window_change`).
+            // Apply a change that setLocalWindowSize() queued before the engine existed.
             let pending = self.pending_recv_window_change.take();
             if pending != RecvWindowChange::default() {
                 engine.apply_recv_window_change(self, pending);
@@ -4541,10 +4533,7 @@ impl H2FrameParser {
                 .throw_invalid_arguments(format_args!("Expected windowSize to be a number")));
         }
         let window_size_value: u32 = window_size.to_u32();
-        // Like nghttp2_session_set_local_window_size(stream_id 0): only the connection-level
-        // window moves. SETTINGS_INITIAL_WINDOW_SIZE stays as advertised; the engine sizes each
-        // new stream's receive window from it, and raising it without a SETTINGS frame leaves
-        // the peer stopped at the old stream window while we wait for half of the new one.
+        // Like nghttp2_session_set_local_window_size(stream 0): SETTINGS_INITIAL_WINDOW_SIZE stays.
         let mut local_window = this.local_window.get();
         let change = local_window.resize(window_size_value as i64);
         this.local_window.set(local_window);
@@ -4555,26 +4544,13 @@ impl H2FrameParser {
         if increment > 0 {
             this.send_window_update(0, UInt31WithReserved::init(increment as u32, false));
         }
-        // Keep the rewrite engine's receive window in sync: its overflow check and its
-        // WINDOW_UPDATE threshold must use the new size. try_borrow: setLocalWindowSize can be
-        // called from JS inside a dispatch (rewrite_read holds the engine borrow there);
-        // deferring the sync to the pending change keeps that path panic-free.
-        match this.engine.try_borrow_mut() {
-            Ok(mut guard) => match guard.as_mut() {
-                Some(engine) => engine.apply_recv_window_change(this, change),
-                None => {
-                    // The engine is created lazily on the first inbound read; carry the
-                    // change forward so it applies when that happens.
-                    this.pending_recv_window_change
-                        .set(this.pending_recv_window_change.get() + change);
-                }
-            },
-            Err(_) => {
-                // A dispatch is in progress; the engine takes the change at the end of its
-                // batch, before it decides on a WINDOW_UPDATE.
-                this.pending_recv_window_change
-                    .set(this.pending_recv_window_change.get() + change);
-            }
+        let mut guard = this.engine.try_borrow_mut();
+        match guard.as_mut().ok().and_then(|guard| guard.as_mut()) {
+            Some(engine) => engine.apply_recv_window_change(this, change),
+            // A dispatch holds the engine, or the first inbound read has not created it yet.
+            None => this
+                .pending_recv_window_change
+                .set(this.pending_recv_window_change.get() + change),
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -4609,11 +4585,7 @@ impl H2FrameParser {
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let result = JSValue::create_empty_object(global_object, 9);
-        // node (nghttp2_session_get_*): effectiveLocalWindowSize is the connection window we
-        // want, localWindowSize is what the peer may still send (`size - consumed`, see
-        // `RecvWindow`), and effectiveRecvDataLength is `consumed`, clamped at 0. After a
-        // decrease `consumed` is negative, so localWindowSize still counts the window the peer
-        // was told about. A change queued for the engine counts as applied.
+        // The nghttp2_session_get_* values. A change queued for the engine counts as applied.
         let pending = this.pending_recv_window_change.get();
         let size = this.recv_window_size.get() + pending.size;
         let consumed = this.recv_window_consumed.get() + pending.consumed;
@@ -4649,6 +4621,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"localWindowSize",
+            // nghttp2 rejects DATA past the window before it counts it, so it is never negative.
             JSValue::js_number((size - consumed).max(0) as f64),
         );
         result.put(

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5275,6 +5275,86 @@ it("Http2Stream pull-mode read() after pause() replenishes the receive window", 
   }
 });
 
+// setLocalWindowSize() grows the connection-level receive window only (nghttp2's
+// nghttp2_session_set_local_window_size with stream id 0). It used to also raise the local
+// SETTINGS_INITIAL_WINDOW_SIZE without sending a SETTINGS frame, so every new stream waited for
+// half of the raised window before replenishing while the peer still stopped at the 64 KiB it
+// was actually told: any body larger than that stalled forever.
+describe("setLocalWindowSize() and bodies larger than the initial stream window", () => {
+  const PAYLOAD = 2 * 1024 * 1024;
+  const WINDOW = 1 << 24;
+
+  it("server session: receives a POST body larger than the stream window", async () => {
+    const server = http2.createServer();
+    const { promise, resolve, reject } = Promise.withResolvers();
+    let serverSession;
+    server.on("session", session => {
+      serverSession = session;
+      session.setLocalWindowSize(WINDOW);
+    });
+    server.on("stream", stream => {
+      let received = 0;
+      stream.on("data", chunk => (received += chunk.length));
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end();
+        resolve(received);
+      });
+      stream.on("error", reject);
+    });
+    await new Promise(r => server.listen(0, "127.0.0.1", r));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      client.on("error", reject);
+      const req = client.request({ ":path": "/", ":method": "POST" });
+      req.on("error", reject);
+      req.end(Buffer.alloc(PAYLOAD, "x"));
+      expect(await promise).toBe(PAYLOAD);
+      expect({
+        effectiveLocalWindowSize: serverSession.state.effectiveLocalWindowSize,
+        initialWindowSize: serverSession.localSettings.initialWindowSize,
+      }).toEqual({
+        effectiveLocalWindowSize: WINDOW,
+        initialWindowSize: http2.getDefaultSettings().initialWindowSize,
+      });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("client session: receives a response body larger than the stream window", async () => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(Buffer.alloc(PAYLOAD, "y"));
+    });
+    await new Promise(r => server.listen(0, "127.0.0.1", r));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.setLocalWindowSize(WINDOW);
+      const req = client.request({ ":path": "/" });
+      req.on("error", reject);
+      let received = 0;
+      req.on("data", chunk => (received += chunk.length));
+      req.on("end", () => resolve(received));
+      expect(await promise).toBe(PAYLOAD);
+      expect({
+        effectiveLocalWindowSize: client.state.effectiveLocalWindowSize,
+        initialWindowSize: client.localSettings.initialWindowSize,
+      }).toEqual({
+        effectiveLocalWindowSize: WINDOW,
+        initialWindowSize: http2.getDefaultSettings().initialWindowSize,
+      });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});
+
 // The outbound cork buffer is thread-local across every Http2Session. Interleaving
 // respond()/write() across two sessions used to let the second session's corked
 // HEADERS be prepended to the first session's multi-frame DATA batch and sent to

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5501,6 +5501,68 @@ describe("setLocalWindowSize() with a smaller window", () => {
     }
   });
 
+  // A write can run JS: it flushes what another session corked, and a JS transport runs its
+  // _write at once. A setLocalWindowSize() call from there must act like a call made after.
+  it("a setLocalWindowSize() call from inside a transport write takes effect at once", async () => {
+    let nested = () => {};
+    const duplex = new Duplex({
+      read() {},
+      write(chunk, encoding, callback) {
+        nested();
+        callback();
+      },
+    });
+    const other = http2.connect("http://127.0.0.1:1", { createConnection: () => duplex });
+    other.on("error", () => {});
+    await new Promise(resolve => other.once("connect", resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    const { server, incrementsAtPing, url } = await windowUpdateServer((socket, streamId) => {
+      socket.write(new http2utils.HeadersFrame(streamId, Buffer.from([0x88]), 0, true).data); // :status 200
+      for (const size of [16384, 16384, 16384, 16383]) {
+        socket.write(new http2utils.DataFrame(streamId, Buffer.alloc(size, "x")).data);
+      }
+    });
+    const client = http2.connect(url);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.once("connect", () => {
+        client.setLocalWindowSize(0);
+        const req = client.request({ ":path": "/" });
+        req.on("error", reject);
+        let received = 0;
+        req.on("data", chunk => {
+          received += chunk.length;
+          if (received !== 65535) return;
+          setImmediate(() => {
+            // The raise to 10 repays 10 bytes that the peer used, so a WINDOW_UPDATE goes out.
+            // That write flushes the PING that `other` corked, and the flush runs the raise to 65535.
+            nested = () => {
+              nested = () => {};
+              client.setLocalWindowSize(65535);
+            };
+            other.ping(() => {});
+            client.setLocalWindowSize(10);
+            const state = windowState(client);
+            client.ping(() => resolve({ increments: incrementsAtPing.at(-1), ...state }));
+          });
+        });
+      });
+      // The same frames as for the two calls made one after the other.
+      expect(await promise).toEqual({
+        increments: [10, 65535 - 10],
+        effectiveLocalWindowSize: 65535,
+        localWindowSize: 65535,
+        effectiveRecvDataLength: 0,
+      });
+    } finally {
+      other.destroy();
+      client.destroy();
+      server.close();
+    }
+  });
+
   // RFC 9113 section 6.9.1: a WINDOW_UPDATE that takes a window above 2^31-1 is a
   // FLOW_CONTROL_ERROR. The raise used to send all of 2^31-1, on top of the 65535 bytes that
   // the peer still had, so a compliant peer ended the session.

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5361,8 +5361,10 @@ describe("setLocalWindowSize() and bodies larger than the initial stream window"
 // The decrease used to be ignored, so the raise granted the peer more window than was asked for.
 describe("setLocalWindowSize() with a smaller window", () => {
   // A raw h2 server that records each connection-level WINDOW_UPDATE increment it receives.
+  // `incrementsAtPing` holds a copy of the increments for each PING, taken before the answer.
   async function windowUpdateServer(onRequest = () => {}) {
     const increments = [];
+    const incrementsAtPing = [];
     const server = net.createServer(socket => {
       let buf = Buffer.alloc(0);
       let sawPreface = false;
@@ -5384,14 +5386,17 @@ describe("setLocalWindowSize() with a smaller window", () => {
           const payload = buf.subarray(9, 9 + length);
           buf = buf.subarray(9 + length);
           if (type === 4 && !isAck) socket.write(new http2utils.SettingsFrame(true).data);
-          if (type === 6 && !isAck) socket.write(Buffer.concat([new http2utils.Frame(8, 6, 1, 0).data, payload]));
+          if (type === 6 && !isAck) {
+            incrementsAtPing.push([...increments]);
+            socket.write(Buffer.concat([new http2utils.Frame(8, 6, 1, 0).data, payload]));
+          }
           if (type === 8 && streamId === 0) increments.push(payload.readUInt32BE(0) & 0x7fffffff);
           if (type === 1) onRequest(socket, streamId);
         }
       });
     });
     await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
-    return { server, increments, url: `http://127.0.0.1:${server.address().port}` };
+    return { server, increments, incrementsAtPing, url: `http://127.0.0.1:${server.address().port}` };
   }
 
   function windowState(session) {
@@ -5439,7 +5444,7 @@ describe("setLocalWindowSize() with a smaller window", () => {
     });
   });
 
-  it("a raise that the withheld credit covers sends nothing", async () => {
+  it("a raise that the withheld credit covers sends nothing while the peer has window left", async () => {
     // node: the peer still has its 65535 bytes, more than the 30000 that were asked for.
     expect(await decreaseThenRaise(onConnect, 20, 30000)).toEqual({
       increments: [],
@@ -5447,6 +5452,53 @@ describe("setLocalWindowSize() with a smaller window", () => {
       localWindowSize: 65535,
       effectiveRecvDataLength: 0,
     });
+  });
+
+  // A raise repays the withheld credit first. When the peer has used that credit, a WINDOW_UPDATE
+  // is due at once. The peer has no window left, so it sends nothing that would start a read.
+  // node sends the same two frames for the raise to 100000. For the raise to 65535 it sends
+  // nothing, so its transfer stalls.
+  it.each([
+    [65535, [65535]],
+    [100000, [100000 - 65535, 65535]],
+  ])("a raise to %d between reads gives back the credit that the peer used", async (raise, expected) => {
+    // The peer uses all of the window that it was told about. The decrease to 0 withholds it all.
+    const { server, incrementsAtPing, url } = await windowUpdateServer((socket, streamId) => {
+      socket.write(new http2utils.HeadersFrame(streamId, Buffer.from([0x88]), 0, true).data); // :status 200
+      for (const size of [16384, 16384, 16384, 16383]) {
+        socket.write(new http2utils.DataFrame(streamId, Buffer.alloc(size, "x")).data);
+      }
+    });
+    const client = http2.connect(url);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.once("connect", () => {
+        client.setLocalWindowSize(0);
+        const req = client.request({ ":path": "/" });
+        req.on("error", reject);
+        let received = 0;
+        req.on("data", chunk => {
+          received += chunk.length;
+          if (received !== 65535) return;
+          setImmediate(() => {
+            client.setLocalWindowSize(raise);
+            const state = windowState(client);
+            // The server copies the increments when this PING arrives, before it answers.
+            client.ping(() => resolve({ increments: incrementsAtPing.at(-1), ...state }));
+          });
+        });
+      });
+      expect(await promise).toEqual({
+        increments: expected,
+        effectiveLocalWindowSize: raise,
+        localWindowSize: raise,
+        effectiveRecvDataLength: 0,
+      });
+    } finally {
+      client.destroy();
+      server.close();
+    }
   });
 
   // RFC 9113 section 6.9.1: a WINDOW_UPDATE that takes a window above 2^31-1 is a

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5355,6 +5355,227 @@ describe("setLocalWindowSize() and bodies larger than the initial stream window"
   });
 });
 
+// A smaller setLocalWindowSize() works like nghttp2's recv_reduction. Nothing goes on the wire.
+// The peer may still fill the window it was told about, and the first `old - new` of those bytes
+// earn no WINDOW_UPDATE. A later raise first repays the withheld credit and sends only the rest.
+// The decrease used to be ignored, so the raise granted the peer more window than was asked for.
+describe("setLocalWindowSize() with a smaller window", () => {
+  // A raw h2 server that records each connection-level WINDOW_UPDATE increment it receives.
+  async function windowUpdateServer(onRequest = () => {}) {
+    const increments = [];
+    const server = net.createServer(socket => {
+      let buf = Buffer.alloc(0);
+      let sawPreface = false;
+      socket.on("error", () => {});
+      socket.write(new http2utils.SettingsFrame(false).data);
+      socket.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        if (!sawPreface) {
+          if (buf.length < http2utils.kClientMagic.length) return;
+          buf = buf.subarray(http2utils.kClientMagic.length);
+          sawPreface = true;
+        }
+        while (buf.length >= 9) {
+          const length = buf.readUIntBE(0, 3);
+          if (buf.length < 9 + length) break;
+          const type = buf[3];
+          const isAck = (buf[4] & 1) !== 0;
+          const streamId = buf.readUInt32BE(5) & 0x7fffffff;
+          const payload = buf.subarray(9, 9 + length);
+          buf = buf.subarray(9 + length);
+          if (type === 4 && !isAck) socket.write(new http2utils.SettingsFrame(true).data);
+          if (type === 6 && !isAck) socket.write(Buffer.concat([new http2utils.Frame(8, 6, 1, 0).data, payload]));
+          if (type === 8 && streamId === 0) increments.push(payload.readUInt32BE(0) & 0x7fffffff);
+          if (type === 1) onRequest(socket, streamId);
+        }
+      });
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    return { server, increments, url: `http://127.0.0.1:${server.address().port}` };
+  }
+
+  function windowState(session) {
+    const { effectiveLocalWindowSize, localWindowSize, effectiveRecvDataLength } = session.state;
+    return { effectiveLocalWindowSize, localWindowSize, effectiveRecvDataLength };
+  }
+
+  // Lowers the window to `low` and raises it to `high` when `when` runs the calls. Resolves with
+  // the WINDOW_UPDATE increments that the server read and the window state after the calls.
+  async function decreaseThenRaise(when, low, high) {
+    const { server, increments, url } = await windowUpdateServer();
+    const client = http2.connect(url);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      when(client, () => {
+        client.setLocalWindowSize(low);
+        client.setLocalWindowSize(high);
+        const state = windowState(client);
+        // The server reads the WINDOW_UPDATE before it answers this PING.
+        client.ping(() => resolve({ increments: [...increments], ...state }));
+      });
+      return await promise;
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  }
+
+  const onConnect = (client, run) => client.once("connect", run);
+
+  // The calls take a different path in each case: the session reads nothing before 'connect',
+  // and a PING callback runs while the session is inside a read.
+  it.each([
+    ["before the first read", onConnect],
+    ["inside a frame callback", (client, run) => client.once("connect", () => client.ping(run))],
+    ["between reads", (client, run) => client.once("connect", () => client.ping(() => setImmediate(run)))],
+  ])("a raise after a decrease sends only the rest of the raise (%s)", async (_, when) => {
+    // node: 65535 - 20 bytes of the raise repay the decrease. The peer is sent the rest.
+    expect(await decreaseThenRaise(when, 20, 1 << 20)).toEqual({
+      increments: [(1 << 20) - 65535],
+      effectiveLocalWindowSize: 1 << 20,
+      localWindowSize: 1 << 20,
+      effectiveRecvDataLength: 0,
+    });
+  });
+
+  it("a raise that the withheld credit covers sends nothing", async () => {
+    // node: the peer still has its 65535 bytes, more than the 30000 that were asked for.
+    expect(await decreaseThenRaise(onConnect, 20, 30000)).toEqual({
+      increments: [],
+      effectiveLocalWindowSize: 30000,
+      localWindowSize: 65535,
+      effectiveRecvDataLength: 0,
+    });
+  });
+
+  // RFC 9113 section 6.9.1: a WINDOW_UPDATE that takes a window above 2^31-1 is a
+  // FLOW_CONTROL_ERROR. The raise used to send all of 2^31-1, on top of the 65535 bytes that
+  // the peer still had, so a compliant peer ended the session.
+  it("a raise to the largest window after a decrease to 0 takes the peer to 2^31-1", async () => {
+    expect(await decreaseThenRaise(onConnect, 0, 2 ** 31 - 1)).toEqual({
+      increments: [2 ** 31 - 1 - 65535],
+      effectiveLocalWindowSize: 2 ** 31 - 1,
+      localWindowSize: 2 ** 31 - 1,
+      effectiveRecvDataLength: 0,
+    });
+  });
+
+  it("a server keeps the session after a raise to the largest window after a decrease to 0", async () => {
+    const server = http2.createServer();
+    server.on("session", session => session.on("error", () => {}));
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.once("connect", () => {
+        client.setLocalWindowSize(0);
+        client.setLocalWindowSize(2 ** 31 - 1);
+        const req = client.request({ ":path": "/" });
+        req.on("error", reject);
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", chunk => (body += chunk));
+        req.on("end", () => resolve({ body, localWindowSize: client.state.localWindowSize }));
+      });
+      // node: the two body bytes are not granted back yet.
+      expect(await promise).toEqual({ body: "ok", localWindowSize: 2 ** 31 - 1 - 2 });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("a decrease takes effect once the peer fills the window it was told about", async () => {
+    // 65535 bytes in all. The first four frames use up the withheld credit exactly.
+    const sizes = [16384, 16384, 16384, 16363, 20];
+    const { server, increments, url } = await windowUpdateServer((socket, streamId) => {
+      socket.write(new http2utils.HeadersFrame(streamId, Buffer.from([0x88]), 0, true).data); // :status 200
+      sizes.forEach((size, i) => {
+        const last = i === sizes.length - 1;
+        socket.write(new http2utils.DataFrame(streamId, Buffer.alloc(size, "x"), 0, last).data);
+      });
+    });
+    const client = http2.connect(url);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.once("connect", () => {
+        client.setLocalWindowSize(20);
+        const req = client.request({ ":path": "/" });
+        req.on("error", reject);
+        let received = 0;
+        req.on("data", chunk => (received += chunk.length));
+        // Two round trips: the first PING can go out before the WINDOW_UPDATE for the last frame.
+        req.on("end", () =>
+          client.ping(() =>
+            client.ping(() => resolve({ received, increments: [...increments], ...windowState(client) })),
+          ),
+        );
+      });
+      // The peer sent all 65535 bytes it was allowed. Only 20 come back, so its window is now 20.
+      expect(await promise).toEqual({
+        received: 65535,
+        increments: [20],
+        effectiveLocalWindowSize: 20,
+        localWindowSize: 20,
+        effectiveRecvDataLength: 0,
+      });
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
+
+  it("a decrease in a frame callback applies to the DATA after that frame", async () => {
+    // One write: HEADERS, a PING, and 40000 bytes of DATA. The client lowers its window at the PING.
+    const { server, increments, url } = await windowUpdateServer((socket, streamId) => {
+      socket.write(
+        Buffer.concat([
+          new http2utils.HeadersFrame(streamId, Buffer.from([0x88]), 0, true).data, // :status 200
+          new http2utils.PingFrame(false).data,
+          new http2utils.DataFrame(streamId, Buffer.alloc(16384, "x")).data,
+          new http2utils.DataFrame(streamId, Buffer.alloc(16384, "x")).data,
+          new http2utils.DataFrame(streamId, Buffer.alloc(7232, "x"), 0, true).data,
+        ]),
+      );
+    });
+    const client = http2.connect(url);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      client.on("error", reject);
+      client.once("ping", () => client.setLocalWindowSize(20));
+      client.once("connect", () => {
+        const req = client.request({ ":path": "/" });
+        req.on("error", reject);
+        let received = 0;
+        req.on("data", chunk => (received += chunk.length));
+        req.on("end", () =>
+          client.ping(() =>
+            client.ping(() => resolve({ received, increments: [...increments], ...windowState(client) })),
+          ),
+        );
+      });
+      // node: the 40000 bytes count against the withheld credit, so none of them come back.
+      expect(await promise).toEqual({
+        received: 40000,
+        increments: [],
+        effectiveLocalWindowSize: 20,
+        localWindowSize: 65535 - 40000,
+        effectiveRecvDataLength: 0,
+      });
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
+});
+
 // The outbound cork buffer is thread-local across every Http2Session. Interleaving
 // respond()/write() across two sessions used to let the second session's corked
 // HEADERS be prepended to the first session's multi-frame DATA batch and sent to


### PR DESCRIPTION
Stacked on #40180. The first commit is that PR, unchanged. Review the commits after it.

### Problem
- `setLocalWindowSize(0)`, then `setLocalWindowSize(2 ** 31 - 1)`, ends the session. Bun adds +2147483647 to the 65535 that the peer has. That is a FLOW_CONTROL_ERROR (RFC 9113 §6.9.1), so the server sends GOAWAY.
- `H2FrameParser::set_local_window_size` (`src/runtime/api/bun/h2_frame_parser.rs`) ignores a decrease. The next raise counts from the smaller value. For 20, then `1 << 20`, bun sends +1048556 where node sends +983041.
- Nobody has reported this. #40180 lists it as a known gap.

### Fix
- A decrease works like nghttp2's `recv_reduction`. Nothing is sent. The next `old - new` bytes from the peer earn no WINDOW_UPDATE. A raise repays that credit first, then sends the rest.
- The binding keeps the size and the reduction (`LocalWindow`), since JS can call `setLocalWindowSize()` during a read. The engine applies queued changes before each WINDOW_UPDATE check.
- As in node, `state.localWindowSize` is the window that the peer still has.
- Verified: eleven new tests in `test/js/node/http2/node-http2.test.js` fail on main and on #40180. Node agrees, except for one stall (see Notes). Also `test/js/node/http2/` and 25 `test-http2-*` files. Self-reviewed: 7 concerns raised, 6 addressed (`RecvWindow::grow` stays for #41329).

### Background
- HTTP/2 flow control: the receiver grants the sender a window of bytes. WINDOW_UPDATE adds credit. Nothing takes it back.
- nghttp2 tracks `local_window_size` (the wanted window), `recv_window_size` (credit the peer used) and `recv_reduction` (credit to withhold). `RecvWindow` has the first two.
- `H2FrameParser` holds the engine in a `RefCell` that a read borrows. A change from JS during a read is queued.

<details><summary>Notes</summary>

- Reproduction: the script from the report (a raw server that logs connection WINDOW_UPDATE increments, and a client that calls `setLocalWindowSize(20)` and then `setLocalWindowSize(1 << 20)`):

  | runtime | increments | `state.localWindowSize` |
  | --- | --- | --- |
  | node v26.3.0 | `[983041]` | 1048576 |
  | bun 1.4.1 (main) | `[1048556]` | 1048576 |
  | #40180 alone | `[1048556]` | 1114091 |
  | this PR | `[983041]` | 1048576 |

- The teardown, with a bun client and a bun server in one process: bun 1.4.1 gets GOAWAY with code 3 (FLOW_CONTROL_ERROR) and `ERR_HTTP2_SESSION_ERROR`. Node and this PR get the response, and `state.localWindowSize` is 2147483645 in both.
- Who calls this with a smaller value: on bun, the known callers raise the window. grpc-js calls it only for a value above 65535. undici uses its `connectionWindowSize` option (default 512 KiB). http2-wrapper asks for 4 MiB. After nodejs/node#64623, the default connection window of node is 32 MiB, so that http2-wrapper call is a decrease on node. Bun still starts at 65535.
- `setLocalWindowSize()` takes one of three paths. The engine is not created yet (before the first read), the engine is borrowed (a frame callback), or the engine is free (between reads). A temporary log confirmed that the three variants of the first test cover one path each.
- A raise that the withheld credit covers sends nothing while the peer has window left. For 20, then 30000, node and this PR send no WINDOW_UPDATE, and `localWindowSize` stays 65535. Main sends +29980.
- A raise after the peer used the withheld credit: the peer sends its 65535 bytes after a decrease to 0, and the raise comes between reads. For a raise to 100000, node and this PR send +34465 and then +65535 at once. For a raise to 65535, node sends nothing, and its transfer stalls. This PR sends +65535. The first version of this PR waited for the next inbound frame.
- The last test covers a decrease in a PING callback, with 40000 bytes of DATA after the PING in the same read. Node withholds all 40000 bytes (`localWindowSize` 25535). Without the engine-side take, the WINDOW_UPDATE check at the end of the read used the old size and granted 40000.
- A write can run JS: `cork()` flushes the output of another session, and a JS transport runs its `_write` at once. A `setLocalWindowSize()` call from there goes into the same queue, so the outer change applies first. The test `a setLocalWindowSize() call from inside a transport write` covers this. With the queue applied late, it sends `[10]` where two calls in a row send `[10, 65525]`.
- `set_local_window_size` rejects a size outside 0..=2^31-1. The JS layer checks the range first.
- Interop: a 70000 byte upload and a 70000 byte response, with both windows lowered to 20. All four pairs of bun and node finish, and the final `state` matches node.
- `RecvWindow::grow` has no caller after this change. It stays, because #41329 calls it for stream windows. The commits after the first one apply cleanly on top of #41329, which also carries the #40180 commit.
- `h2-conformance.test.ts` failed once in a GC count test (`stream release after a queued END_STREAM`, 5 live streams where the limit is 3). It does not call `setLocalWindowSize()`. It passed in three filtered runs and in two runs of the whole file.
- Also run with the debug build: `node-http2.test.js`, the other files in `test/js/node/http2/`, and `test-http2-client-setLocalWindowSize.js`, `test-http2-server-setLocalWindowSize.js`, `test-http2-window-size.js`, `test-http2-session-stream-state.js`, `test-http2-misbehaving-flow-control.js`, `test-http2-window-update-overflow.js` and 19 more `test-http2-*` files. `cargo clippy -p bun_runtime` is clean.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (e0a2b82fd)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [855.40ms]
(pass) node none > Client Basics > should be able to send a POST request [584.02ms]
(pass) node none > Client Basics > constants [18.87ms]
(pass) node none > Client Basics > getDefaultSettings [7.23ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.07ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.07ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.83ms]
(pass) node none > Client Basics > should be able to send data using end [604.05ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [592.72ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.1-canary.1 (c8023f488)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.89ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.85ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.77ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.65ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.22ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [30.79ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.1 (e0a2b82fd)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [831.22ms]
(pass) node none > Client Basics > should be able to send a POST request [559.09ms]
(pass) node none > Client Basics > constants [18.49ms]
(pass) node none > Client Basics > getDefaultSettings [6.99ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [16.95ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.16ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.01ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.11ms]
(pass) node none > Client Basics > should be able to send data using end [583.88ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [574.33ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 695ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/35] gen bindgenv2
[2/32] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 classes from /workspace/bun/src/runtime/api/html_rewriter.classes.ts
  - HTMLRewriter (3 fields)
  - TextChunk (7 fields)
 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs   |  50 +++-
 src/runtime/api/bun/h2/flow_control.rs | 110 ++++++++-
 src/runtime/api/bun/h2_frame_parser.rs | 117 +++++-----
 test/js/node/http2/node-http2.test.js  | 415 +++++++++++++++++++++++++++++++++
 4 files changed, 618 insertions(+), 74 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2/connection.rs        8     13     66
src/runtime/api/bun/h2/flow_control.rs      4      9     65
src/runtime/api/bun/h2_frame_parser.rs     23     28     65
test/js/node/http2/node-http2.test.js      10     10     65
```

</details>

<!-- robobun:evidence:end -->