### PR TITLE
docs: correct stale claims on the Node.js compatibility page

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -49,7 +49,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:https`](https://nodejs.org/api/https.html)
 
-🟡 `request`, `get`, `Agent` and `globalAgent` are implemented, including connection pooling. `https.Server` is `http.Server` with TLS options rather than a `tls.Server`. Request sockets are not `tls.TLSSocket`s: `encrypted`, `authorized` and `servername` work, but `getPeerCertificate()` and `getCipher()` are missing. `setSecureContext()`, `addContext()`, `SNICallback` and `handshakeTimeout` are not supported.
+🟡 `request`, `get`, `Agent` and `globalAgent` are implemented, including connection pooling. Client sockets are `tls.TLSSocket`s. `https.Server` is `http.Server` with TLS options rather than a `tls.Server`. Its request sockets (`req.socket`) are not `tls.TLSSocket`s: `encrypted`, `authorized` and `servername` work, but `getPeerCertificate()` and `getCipher()` are missing. `setSecureContext()`, `addContext()`, `SNICallback` and `handshakeTimeout` are not supported.
 
 ### [`node:os`](https://nodejs.org/api/os.html)
 
@@ -109,7 +109,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:crypto`](https://nodejs.org/api/crypto.html)
 
-🟡 Missing `encapsulate`/`decapsulate` (you can use ML-KEM keys through `crypto.subtle`). `argon2()` and custom engines (`setEngine()`) throw, `setFips()` is a no-op and `secureHeapUsed()` returns `undefined`. Bun's crypto is backed by BoringSSL, which lacks the `ed448`, `x448`, `rsa-pss`, `dsa` and `dh` key types, EC curves other than P-224/256/384/521 (no `secp256k1`), and the CCM, OCB, XTS and `chacha20-poly1305` ciphers.
+🟡 Missing `encapsulate`/`decapsulate` (you can use ML-KEM keys through `crypto.subtle`). `argon2()` and `argon2Sync()` are implemented. Custom engines (`setEngine()`) throw, `setFips()` is a no-op and `secureHeapUsed()` returns `undefined`. Bun's crypto is backed by BoringSSL, which lacks the `ed448`, `x448`, `rsa-pss`, `dsa`, `dh` and `ml-kem-512` key types, EC curves other than P-224/256/384/521 (no `secp256k1`), and the CCM, OCB, XTS and `chacha20-poly1305` ciphers. The `DiffieHellman` class (`createDiffieHellman()`, `getDiffieHellman()`) works.
 
 ### [`node:domain`](https://nodejs.org/api/domain.html)
 
@@ -117,7 +117,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:http2`](https://nodejs.org/api/http2.html)
 
-🟢 Client & server are implemented. 94% of Node.js's test suite passes. The `maxDeflateDynamicTableSize`, `peerMaxConcurrentStreams`, `streamResetBurst`/`streamResetRate` and `maxOriginSetSize` options are accepted but ignored.
+🟢 Client & server are implemented. 94% of Node.js's test suite passes. The `maxDeflateDynamicTableSize`, `peerMaxConcurrentStreams` and `streamResetBurst`/`streamResetRate` options are accepted but ignored.
 
 ### [`node:module`](https://nodejs.org/api/module.html)
 
@@ -137,7 +137,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:sys`](https://nodejs.org/api/util.html)
 
-🟡 See [`node:util`](#node-util).
+🟢 See [`node:util`](#node-util).
 
 ### [`node:tls`](https://nodejs.org/api/tls.html)
 
@@ -145,7 +145,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:util`](https://nodejs.org/api/util.html)
 
-🟡 Missing `diff`, `transferableAbortSignal` and `transferableAbortController`. `debuglog()` ignores its `callback` argument and the returned function has no `enabled` property.
+🟢 Fully implemented. Missing `diff` (experimental in Node.js), `transferableAbortSignal` and `transferableAbortController`. `debuglog()` ignores its `callback` argument and the returned function has no `enabled` property.
 
 ### [`node:v8`](https://nodejs.org/api/v8.html)
 
@@ -153,7 +153,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:vm`](https://nodejs.org/api/vm.html)
 
-🟡 Core functionality and ES modules are implemented, including `vm.Script`, `vm.createContext`, `vm.runInContext`, `vm.runInNewContext`, `vm.runInThisContext`, `vm.compileFunction`, `vm.isContext`, `vm.Module`, `vm.SourceTextModule`, `vm.SyntheticModule` (exported without `--experimental-vm-modules`), and `importModuleDynamically` support. The `timeout`, `breakOnSigint`, `cachedData`, `microtaskMode` and `codeGeneration` options are supported. An `importModuleDynamically` callback that returns a promise for a `vm.Module` resolves `import()` to the module object rather than its namespace. `vm.measureMemory()` reports whole-heap figures for every context.
+🟢 Fully implemented, including `vm.Script`, `vm.createContext`, `vm.runInContext`, `vm.runInNewContext`, `vm.runInThisContext`, `vm.compileFunction`, `vm.isContext`, the ES module classes `vm.Module`, `vm.SourceTextModule` and `vm.SyntheticModule` (exported without `--experimental-vm-modules`), and `importModuleDynamically` support. The `timeout`, `breakOnSigint`, `cachedData`, `microtaskMode` and `codeGeneration` options are supported. An `importModuleDynamically` callback that returns a promise for a `vm.Module` resolves `import()` to the module object rather than its namespace. `vm.measureMemory()` reports whole-heap figures for every context.
 
 ### [`node:wasi`](https://nodejs.org/api/wasi.html)
 
@@ -161,11 +161,11 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:worker_threads`](https://nodejs.org/api/worker_threads.html)
 
-🟡 `Worker` ignores the `resourceLimits` and `trackUnmanagedFds` options, and `execArgv` only sets `process.execArgv` in the worker. `worker.performance.eventLoopUtilization()` is a stub. Missing `moveMessagePortToContext` and `locks`.
+🟡 `Worker` ignores the `resourceLimits` and `trackUnmanagedFds` options. In `execArgv`, only `--no-addons` and `--no-ffi-cc` take effect. Other flags only set `process.execArgv` in the worker. `worker.performance.eventLoopUtilization()` is a stub. Missing `moveMessagePortToContext` and `locks`.
 
 ### [`node:inspector`](https://nodejs.org/api/inspector.html)
 
-🟡 Partially implemented. `Session` supports the `Profiler` domain (including precise coverage), `Runtime.enable` and `NodeTracing`, from both `node:inspector` and `node:inspector/promises`. Other `Session` commands such as `Runtime.evaluate` and the `HeapProfiler` domain are not implemented. `open()`, `url()`, `close()` and `waitForDebugger()` are implemented. `open()` serves the `Debugger` and `Runtime` domains and throws in workers. Missing `Network`.
+🟡 Partially implemented. `Session` supports the `Profiler` domain (including precise coverage), `Runtime.enable` and `NodeTracing`, from both `node:inspector` and `node:inspector/promises`. After `open()`, `Session` also forwards `Debugger` configuration commands such as `Debugger.enable` and `Debugger.setBreakpointByUrl` to the inspector server. Their results, such as `breakpointId`, are not returned. Other `Session` commands such as `Runtime.evaluate` and the `HeapProfiler` domain are not implemented. `open()`, `url()`, `close()` and `waitForDebugger()` are implemented. `open()` serves the `Debugger` and `Runtime` domains and throws in workers. Missing `Network`.
 
 ### [`node:repl`](https://nodejs.org/api/repl.html)
 
@@ -251,6 +251,10 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 
 🟢 Fully implemented.
 
+### [`CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent)
+
+🟢 Fully implemented.
+
 ### [`CompressionStream`](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream)
 
 🟢 Fully implemented.
@@ -283,6 +287,10 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 
 🟢 Fully implemented.
 
+### [`ErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent)
+
+🟢 Fully implemented.
+
 ### [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event)
 
 🟢 Fully implemented.
@@ -298,6 +306,10 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 ### [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch)
 
 🟢 Fully implemented. The `integrity` option is ignored.
+
+### [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File)
+
+🟢 Fully implemented. `File` objects report `Blob` as their `constructor` and `Symbol.toStringTag`.
 
 ### [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
 
@@ -331,6 +343,10 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 
 🟢 Fully implemented. Missing `module.isPreloading`.
 
+### [`navigator`](https://nodejs.org/api/globals.html#navigator)
+
+🟡 `userAgent`, `platform` and `hardwareConcurrency` are implemented. Missing `language`, `languages` and `locks`. The `Navigator` class is not a global.
+
 ### [`PerformanceEntry`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry)
 
 🟢 Fully implemented.
@@ -361,11 +377,15 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 
 ### [`process`](https://nodejs.org/api/process.html)
 
-🟡 Mostly implemented. `process.binding` (internal Node.js bindings some packages rely on) is partially implemented: `buffer`, `config`, `constants`, `fs`, `natives`, `tty_wrap`, `util` and `uv` are available, the rest throw. Setting `process.title` is a no-op on macOS & Linux. `getActiveResourcesInfo()`, `_getActiveHandles()` and `_getActiveRequests()` always return an empty array, `setSourceMapsEnabled()` is a no-op, and `process.report.writeReport()` writes nothing. Missing `sourceMapsEnabled` and `addUncaughtExceptionCaptureCallback`.
+🟡 Mostly implemented. `process.binding` (internal Node.js bindings some packages rely on) is partially implemented: `buffer`, `config`, `constants`, `crypto/x509`, `fs`, `http_parser`, `natives`, `tty_wrap`, `util` and `uv` are available, the rest throw. Setting `process.title` is a no-op on macOS & Linux. `getActiveResourcesInfo()`, `_getActiveHandles()` and `_getActiveRequests()` always return an empty array, `setSourceMapsEnabled()` is a no-op, and `process.report.writeReport()` writes nothing. Missing `sourceMapsEnabled` and `addUncaughtExceptionCaptureCallback`.
 
 ### [`queueMicrotask()`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
 
 🟢 Fully implemented.
+
+### [`QuotaExceededError`](https://developer.mozilla.org/en-US/docs/Web/API/QuotaExceededError)
+
+🔴 Not implemented.
 
 ### [`ReadableByteStreamController`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController)
 
@@ -419,6 +439,10 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 
 🟢 Fully implemented. Only `ArrayBuffer` and `MessagePort` can be transferred, and cloned `Error`s lose their `cause`.
 
+### [`Storage`](https://developer.mozilla.org/en-US/docs/Web/API/Storage)
+
+🔴 Not implemented. Bun has no `Storage`, `localStorage` or `sessionStorage` globals.
+
 ### [`SubtleCrypto`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto)
 
 🟢 Fully implemented, including `supports()`, `getPublicKey()`, the `encapsulate*()`/`decapsulate*()` methods, `ML-DSA`, `ML-KEM-768`/`ML-KEM-1024`, `SHA3-*` and `ChaCha20-Poly1305`. Missing the `Ed448`, `X448`, `AES-OCB`, `Argon2*`, `cSHAKE*`, `KMAC*`, `KT128`/`KT256`, `TurboSHAKE*` and `ML-KEM-512` algorithms (all experimental in Node.js).
@@ -455,6 +479,10 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 
 🟢 Fully implemented.
 
+### [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern)
+
+🟢 Fully implemented.
+
 ### [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
 
 🟢 Fully implemented.
@@ -462,6 +490,10 @@ The following list covers the globals implemented by Node.js and Bun's compatibi
 ### [`WebAssembly`](https://nodejs.org/api/globals.html#webassembly)
 
 🟢 Fully implemented. Memory64 is disabled by default (set `BUN_JSC_useWasmMemory64=1` to enable it).
+
+### [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
+
+🟢 Fully implemented. `binaryType` defaults to `"nodebuffer"`, so binary messages arrive as `Buffer`s. Node.js defaults to `"blob"`.
 
 ### [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream)
 

--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -161,7 +161,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:worker_threads`](https://nodejs.org/api/worker_threads.html)
 
-🟡 `Worker` ignores the `resourceLimits` and `trackUnmanagedFds` options. In `execArgv`, only `--no-addons` and `--no-ffi-cc` take effect. Other flags only set `process.execArgv` in the worker. `worker.performance.eventLoopUtilization()` is a stub. Missing `moveMessagePortToContext` and `locks`.
+🟡 `Worker` ignores the `resourceLimits` and `trackUnmanagedFds` options. Some `execArgv` flags take effect in the worker, for example `--no-addons`, `--stack-trace-limit` and `--tls-min-v1.3`. Others, for example `--conditions` and `--no-deprecation`, only set `process.execArgv`. `worker.performance.eventLoopUtilization()` is a stub. Missing `moveMessagePortToContext` and `locks`.
 
 ### [`node:inspector`](https://nodejs.org/api/inspector.html)
 


### PR DESCRIPTION
### Problem
- `docs/runtime/nodejs-compat.mdx` had six claims that are wrong on main. For example, it says that `crypto.argon2()` throws. `argon2()` and `argon2Sync()` work since #37015.
- The page also did not list eight globals that Node.js has, for example `WebSocket` and `URLPattern`.

### Fix
- Correct the six claims: `node:crypto`, `node:https` (client sockets are `tls.TLSSocket`s), `node:http2` (`maxOriginSetSize` is not a Node.js option), `node:worker_threads` (`execArgv`), `node:inspector` (`Debugger` commands), and the `process.binding` list.
- Move `node:util`, `node:sys` and `node:vm` to 🟢. Their remaining gaps are experimental APIs or edge cases.
- Add `CloseEvent`, `ErrorEvent`, `File`, `navigator`, `QuotaExceededError`, `Storage`, `URLPattern` and `WebSocket`.
- Verified: each claim on the page has a probe that ran under bun 1.4.1-canary.1 (23 commits behind this base) and Node.js v26.3.0, or a source read for macOS, Windows and arm64 claims.

### Background
- The page lists each `node:` module and each global with a status. 🟢 means that only edge cases are missing. 🟡 means that a commonly used API is missing.
- The last audit of the page was #38441 on 2026-08-14.

<details><summary>Notes</summary>

- Every other "missing", "no-op" and "ignored" claim still holds. Examples that are still missing on main: `util.diff`, `module.findPackageJSON`, `module.registerHooks`, `v8.Serializer`, `worker_threads.locks`, `dns.resolveTlsa`, `Request.keepalive`, `crypto.encapsulate`.
- The "N% of Node.js's test suite passes" figures were not measured again.
- Two differences are new on the page: `File` objects report `Blob` as their `constructor` and `Symbol.toStringTag`, and the `WebSocket` `binaryType` default is `"nodebuffer"`.
- `process.binding('http_parser')` and `process.binding('crypto/x509')` return objects in Bun. Node.js v26 throws "No such module" for both.
- Real bugs that the probes found (for example `url.format()` with an array in `query`, and `new DOMException().stack`) are not documented here. They go to separate fixes.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->