### PR TITLE
ci: give the N-API addon prebuild its node headers on macOS guests

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -932,7 +932,18 @@ setup_node_gyp_cache() {
 	nodejs_version="$1"
 	headers_source="$2"
 
-	cache_dir="$home/.cache/node-gyp/$nodejs_version"
+	# node-gyp reads its cache from ~/Library/Caches/node-gyp on macOS. That parent
+	# already belongs to the user, so grant only the node-gyp directory there.
+	case "$os" in
+	darwin)
+		cache_dir="$home/Library/Caches/node-gyp/$nodejs_version"
+		grant_dir="$home/Library/Caches/node-gyp"
+		;;
+	*)
+		cache_dir="$home/.cache/node-gyp/$nodejs_version"
+		grant_dir="$home/.cache"
+		;;
+	esac
 
 	create_directory "$cache_dir"
 
@@ -959,7 +970,7 @@ setup_node_gyp_cache() {
 	esac
 
 	# Ensure entire path is accessible, not just last component
-	grant_to_user "$home/.cache"
+	grant_to_user "$grant_dir"
 }
 
 bun_version_exact() {

--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -153,16 +153,21 @@ async function tryBuildFast(dir: string): Promise<boolean> {
 // links its bin dependencies (nopt, which, glob, semver) into the shared bin dir.
 // Several addon builds doing that at once race on those links (EEXIST) and fail,
 // so callers that build concurrently warm the cache once, serially, first.
+//
+// The warm-up also installs the node headers when they are not cached. Without them
+// tryBuildFast() falls back to node-gyp, and on a cold machine each concurrent build
+// then downloads and extracts the same header tree (about 65 MB in 2,700 files).
 export async function warmNodeGyp() {
+  const command = findNodeHeaders() === null ? "install" : "--version";
   // Best effort: a failed warm-up must never stop the addon builds, which
-  // install node-gyp themselves if the cache is cold.
+  // install node-gyp and the headers themselves if the cache is cold.
   try {
     const child = spawn({
-      cmd: [bunExe(), "--bun", "x", "node-gyp@11", "--version"],
+      cmd: [bunExe(), "--bun", "x", "node-gyp@11", command],
       stderr: "pipe",
       stdout: "ignore",
       stdin: "ignore",
-      env: bunEnv,
+      env: { ...bunEnv, npm_config_target: `v${NODE_HEADERS_VERSION}` },
     });
     const [stderr, exitCode] = await Promise.all([new Response(child.stderr).text(), child.exited]);
     if (exitCode !== 0) console.warn(`warming node-gyp failed (builds will install it themselves):\n${stderr}`);


### PR DESCRIPTION
### Problem
- On macOS 15 tart guests, `http2 server with minimal maxSessionMemory handles multiple requests` in `node-http2.test.js` times out at 15000 ms in builds 109616, 110008 and 110028. In each, the file ran first in the job because the PR modified it.
- The runner builds the N-API test addons in the background while the first test files run (`scripts/runner.node.mjs:808`). On a guest this takes 35 to 47 s. `tryBuildFast()` finds no headers, so each of the 8 workers runs a full node-gyp build.
- The guest has the headers in the wrong place. `setup_node_gyp_cache` (`scripts/bootstrap.sh:931`) writes them to `~/.cache/node-gyp`. On macOS, node-gyp and `findNodeHeaders()` read `~/Library/Caches/node-gyp`.

### Fix
- `bootstrap.sh` writes the headers to `~/Library/Caches/node-gyp` on macOS. The tart images get them at their next bake. Linux is unchanged.
- `warmNodeGyp()` runs once before the workers. It now runs `node-gyp install` when the headers are missing. This covers the time until the next bake, and each Node version bump.
- Verified locally with an empty `HOME` and 29 addons: about 30 CPU seconds before, 4 after. All 55 `do.test.ts` files pass. No test can fail before this CI change.
- Self-reviewed: 4 concerns raised, 3 addressed, 1 rejected (see the notes).

### Background
- A tart guest is a macOS VM that each job starts from a baked image. The bake runs `scripts/bootstrap.sh` as the job user.
- `test/napi/node-napi-tests/prebuild.ts` compiles the addons of a shard. `tryBuildFast()` calls the compiler directly when it finds the headers.
- The maxSessionMemory test sends 10000 sequential requests. Under load, it times out first.

<details><summary>Notes</summary>

**Timeline of the failures.** Times are seconds after the first `bun install` step of the job.

| build | agent | prebuild | node-http2.test.js | result |
|---|---|---|---|---|
| 109616 | sourdough-tart-15-2 | 0 to 35.3 | 1.5 to 23.8 | timeout |
| 109616 (attempt 2) | sourdough-tart-15-2 | 0 to 35.3 | 30.5 to 44.8 | pass |
| 110008 | ciabatta-tart-15-2 | 0 to 37.2 | 3.1 to 26.4 | timeout |
| 110028 | ciabatta-tart-15-2 | 0 to 47.1 | 2.9 to 27.2 | timeout |
| 110022 | ciabatta-tart-15-2 | 0 to 45.5 | 313 to 324 | pass |
| 110028 | darwin-x64-14.8.9-1 (bare metal) | 0 to 2.0 | 12.3 to 21.0 | pass |

**Other files in the same window.** `bake/dev/css.test.ts` took 24.0 s inside the window and 9.1 to 10.6 s after it. `bake/dev-and-prod.test.ts` took 10.8 to 11.0 s inside and 3.6 s after. On a macOS 26 guest with a 15.5 s prebuild, the files after 16 s ran at normal speed. On the macOS 15 guests, the same files stayed slow until about 40 s. So the slow window follows the prebuild, not the guest boot.

**Prebuild time per agent.** Bare metal Macs keep `~/Library/Caches/node-gyp` between jobs. They build 26 to 28 addons in 1.4 to 2.5 s. The macOS 15 guests take 35 to 47 s for 26 to 31 addons.

**Where the guest headers are.** `scripts/darwin-ci/guest/bake.sh` runs `bootstrap.sh` as the admin user, without `--ci`. So `$home` is `/Users/admin`, and the seed goes to `/Users/admin/.cache/node-gyp/26.3.0`. The job log shows node-gyp on the guest with `-Dnode_root_dir=/Users/admin/Library/Caches/node-gyp/26.3.0`. I read this from the scripts. I did not list the directory in a guest.

**Local measurement** (Linux, `HOME` set to an empty directory, 8 workers):

| addons | before | after |
|---|---|---|
| 29 | 8 node-gyp, 21 direct. 3.1 s wall, 15 s user, 15 s sys | 29 direct. 1.9 s wall, 2.6 s user, 1.6 s sys |
| 55 | 3.6 s wall, about 32 CPU seconds | 2.4 s wall, about 6.5 CPU seconds |

The v26.3.0 header tarball is 9.96 MB. It extracts to 65 MB in 2,727 files.

**Checks.**
- After a cold prebuild, the 55 `do.test.ts` files give 127 pass and 0 fail, the same as `main`.
- A single `do.test.ts` on a cold cache still builds through the node-gyp fallback.
- `setup_node_gyp_cache` with `os=darwin` in a scratch home writes `Library/Caches/node-gyp/26.3.0` and changes no other entry of `Library/Caches`. With `os=linux` it writes the same tree as before.

**After merge.** Run `scripts/darwin-ci/main.ts bake` on each tart host. The bake clones the repository, so it needs this change on `main` first. The `# Version:` line of `bootstrap.sh` names the Linux and Windows images. Linux is unchanged, so the line stays.

**Self-review.**
- The first version of this PR said that the guests have no header cache. They have one, in the wrong place. Fixed in `bootstrap.sh`.
- Rejected: add `~/.cache/node-gyp` to `findNodeHeaders()` on macOS. That probe would avoid one download per job until the next bake. After the bake it is dead code, and node-gyp does not read that path on macOS.
- #31354 batches the requests of this test. It makes the test faster and does not conflict with this change.

**Alternatives.**
- Wait for the prebuild before the first test file. On build 110022 the prebuild took 11 to 34 s on the Linux lanes and about 50 s on Windows. That wait would add to each shard.
- Add `node-http2.test.js` to `test/flaky-tests.txt`. This hides the timeout. The other early files stay 2 to 3 times slower.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->