### PR TITLE
bundler: count a binding's declaration as a use of its name in the scope that prints it

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2009,7 +2009,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.record_usage_impl(ref_, true);
     }
 
-    fn record_scope_use(&mut self, ref_: Ref) {
+    pub(crate) fn record_scope_use(&mut self, ref_: Ref) {
         if !self.track_scope_uses {
             return;
         }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -800,6 +800,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BData::BIdentifier(bind) => {
                 let bind = bind.get();
                 self.record_declared_symbol(bind.r#ref);
+                // The declaration prints the name here even when the symbol is
+                // hoisted to an enclosing scope.
+                self.record_scope_use(bind.r#ref);
                 // SAFETY: original_name is arena-owned, valid for 'a.
                 let name: &'a [u8] = self.symbols[bind.r#ref.inner_index() as usize]
                     .original_name

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -800,10 +800,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BData::BIdentifier(bind) => {
                 let bind = bind.get();
                 self.record_declared_symbol(bind.r#ref);
-                // A `var` below the scope it hoists to still prints its name
-                // here, and a parameter or catch binding shares a declaration
-                // space with the body after it: the renamer must see the name
-                // as used in this scope. Other bindings live in this scope.
+                // Bindings the renamer must see outside the scope that owns
+                // them (`ScopeUses::sees`): a hoisted `var`, a parameter, a
+                // catch binding.
                 let scope_kind = self.current_scope.kind;
                 if scope_kind == js_ast::scope::Kind::FunctionArgs
                     || scope_kind == js_ast::scope::Kind::CatchBinding

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -800,9 +800,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BData::BIdentifier(bind) => {
                 let bind = bind.get();
                 self.record_declared_symbol(bind.r#ref);
-                // The declaration prints the name here even when the symbol is
-                // hoisted to an enclosing scope.
-                self.record_scope_use(bind.r#ref);
+                // A `var` below the scope it hoists to still prints its name
+                // here, and a parameter or catch binding shares a declaration
+                // space with the body after it: the renamer must see the name
+                // as used in this scope. Other bindings live in this scope.
+                let scope_kind = self.current_scope.kind;
+                if scope_kind == js_ast::scope::Kind::FunctionArgs
+                    || scope_kind == js_ast::scope::Kind::CatchBinding
+                    || (self.symbols[bind.r#ref.inner_index() as usize].is_hoisted()
+                        && !self.current_scope.kind_stops_hoisting())
+                {
+                    self.record_scope_use(bind.r#ref);
+                }
                 // SAFETY: original_name is arena-owned, valid for 'a.
                 let name: &'a [u8] = self.symbols[bind.r#ref.inner_index() as usize]
                     .original_name

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1215,10 +1215,8 @@ impl<'a> ScopeUses<'a> {
 
     /// Whether a binding in `scope` would capture a reference to `symbol`,
     /// i.e. whether `symbol` is referenced in `scope` or anywhere inside it.
-    /// A declaration counts as a reference: a `var` prints its name in the
-    /// block that declares it, and a function body or catch block cannot
-    /// redeclare the parameters of the scope around it, so those are looked
-    /// at too.
+    /// A function body or catch block also sees its parameter scope, which it
+    /// cannot redeclare.
     pub fn sees(&self, symbol: Ref, scope: &js_ast::Scope) -> bool {
         let scope = match (scope.kind, scope.parent.as_deref()) {
             (js_ast::scope::Kind::FunctionBody, Some(parent)) => parent,

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1215,7 +1215,20 @@ impl<'a> ScopeUses<'a> {
 
     /// Whether a binding in `scope` would capture a reference to `symbol`,
     /// i.e. whether `symbol` is referenced in `scope` or anywhere inside it.
+    /// A declaration counts as a reference: a `var` prints its name in the
+    /// block that declares it, and a function body or catch block cannot
+    /// redeclare the parameters of the scope around it, so those are looked
+    /// at too.
     pub fn sees(&self, symbol: Ref, scope: &js_ast::Scope) -> bool {
+        let scope = match (scope.kind, scope.parent.as_deref()) {
+            (js_ast::scope::Kind::FunctionBody, Some(parent)) => parent,
+            (js_ast::scope::Kind::Block, Some(parent))
+                if parent.kind == js_ast::scope::Kind::CatchBinding =>
+            {
+                parent
+            }
+            _ => scope,
+        };
         let Some(span) = scope.visit_span() else {
             return true;
         };

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3127,21 +3127,27 @@ describe("bundler", () => {
     minifyIdentifiers: false,
     run: { stdout: `a a\nb outer\n["b-arg","local,outer","outer","L,F"]` },
   });
-  // A `var` hoisted out of a block is still declared inside that block, so a
-  // block-scoped binding there cannot take the hoisted name (#41351). The
-  // same holds for a function body and its parameters, and for a catch block
-  // and its binding. A sibling block that does not mention the `var` may.
+  // A `var` hoisted out of a block still prints its declaration inside that
+  // block, so a block-scoped binding there cannot take the hoisted name
+  // (#41351). The same holds for a function's parameters and its body, and a
+  // catch binding and its block. A sibling block that does not mention the
+  // `var` may still reuse the name.
   itBundled("identifiers/NestedBindingRenamedAroundHoistedVarDeclaration", {
     files: {
       "/entry.js": /* js */ `
-        import { make, loop, deep, sibling, param, arrow, caught } from "./lib.js";
+        import * as L from "./lib.js";
         import { Check } from "./other.js";
+        const { blockFn } = require("./sloppy.cjs");
         console.log(JSON.stringify([
-          make(true)(1), loop(), deep(), sibling(), param("p"), arrow("a"), caught(), Check(2),
+          L.make(true)(1), L.loop(), L.deep(), L.sibling(), L.param("p"), L.arrow("a"), L.dflt(),
+          L.caught(), L.caughtVar(), L.destructured(), L.forIn(), L.inSwitch(1), L.inTry(),
+          L.klass(), L.nested(), blockFn(), Check(2),
         ]));
       `,
       "/lib.js": /* js */ `
         import { Check as OuterCheck } from "./other.js";
+        // In every function the top-level "Check" is referenced, so the local
+        // "Check" is renamed to "Check2" and meets a block-scoped "Check2".
         export function make(cond) {
           OuterCheck(0);
           if (cond) {
@@ -3173,20 +3179,75 @@ describe("bundler", () => {
         export function param(Check) {
           OuterCheck(0);
           let Check2 = "body";
-          return Check2;
+          return [Check, Check2];
         }
         export const arrow = (Check) => {
           OuterCheck(0);
           let Check2 = "arrow";
-          return Check2;
+          return [Check, Check2];
         };
+        export function dflt(Check = "default") {
+          OuterCheck(0);
+          { let Check2 = "inner"; return [Check, Check2]; }
+        }
         export function caught() {
           try { throw "err"; } catch (Check) {
             OuterCheck(0);
             let Check2 = "catch";
-            return Check2;
+            return [Check, Check2];
           }
         }
+        export function caughtVar() {
+          OuterCheck(0);
+          try { throw "t"; } catch (Check) { var Check = "v"; let Check2 = Check; return Check2; }
+        }
+        export function destructured() {
+          OuterCheck(0);
+          { let Check2 = 5; var { a: Check = Check2, ...rest } = { b: 1 }; }
+          return [Check, rest];
+        }
+        export function forIn() {
+          OuterCheck(0);
+          { let Check2 = "k"; for (var Check in { [Check2]: 1 }) {} }
+          return Check;
+        }
+        export function inSwitch(x) {
+          OuterCheck(0);
+          switch (x) { case 1: let Check2 = "sw"; var Check = Check2; }
+          return Check;
+        }
+        export function inTry() {
+          OuterCheck(0);
+          try { let Check2 = "try"; var Check = Check2; } finally {}
+          return Check;
+        }
+        export function klass() {
+          OuterCheck(0);
+          { class Check2 { static tag = "cls"; } var Check = Check2; }
+          return Check.tag;
+        }
+        export function nested() {
+          OuterCheck(0);
+          {
+            let Check2 = "let";
+            function inner() { var Check = "v"; return Check; }
+            return [Check2, inner()];
+          }
+        }
+      `,
+      // Sloppy mode: a function declaration in a block is also hoisted to the
+      // enclosing function as a var (annex B), assigned where the block
+      // declares it.
+      "/sloppy.cjs": /* js */ `
+        const { g: outerG } = require("./other2.cjs");
+        exports.blockFn = function () {
+          outerG();
+          { let g2 = "let"; function g() { return "g-inner"; } var r = [g2, g()]; }
+          return [r, g()];
+        };
+      `,
+      "/other2.cjs": /* js */ `
+        exports.g = function () { return "g-outer"; };
       `,
       "/other.js": /* js */ `
         export function Check(x) { return "other " + x; }
@@ -3195,9 +3256,16 @@ describe("bundler", () => {
     minifyIdentifiers: false,
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
+      // The sibling block does not mention the var, so its binding keeps the name.
       expect(out).toContain('let Check2 = "let"');
+      // No scope declares one name twice.
+      expect(out).not.toMatch(/let Check2 = [^;]+;\s*var Check2\b/);
+      expect(out).not.toMatch(/function param\(Check2\) \{\s*[^}]*let Check2\b/);
     },
-    run: { stdout: `[1,1,["mid","var"],["let","var"],"body","arrow","catch","other 2"]` },
+    run: {
+      stdout:
+        `[1,1,["mid","var"],["let","var"],["p","body"],["a","arrow"],["default","inner"],["err","catch"],"v",[5,{"b":1}],"k","sw","try","cls",["let","v"],[["let","g-inner"],"g-inner"],"other 2"]`,
+    },
   });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {
     files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3263,8 +3263,7 @@ describe("bundler", () => {
       expect(out).not.toMatch(/function param\(Check2\) \{\s*[^}]*let Check2\b/);
     },
     run: {
-      stdout:
-        `[1,1,["mid","var"],["let","var"],["p","body"],["a","arrow"],["default","inner"],["err","catch"],"v",[5,{"b":1}],"k","sw","try","cls",["let","v"],[["let","g-inner"],"g-inner"],"other 2"]`,
+      stdout: `[1,1,["mid","var"],["let","var"],["p","body"],["a","arrow"],["default","inner"],["err","catch"],"v",[5,{"b":1}],"k","sw","try","cls",["let","v"],[["let","g-inner"],"g-inner"],"other 2"]`,
     },
   });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3140,8 +3140,9 @@ describe("bundler", () => {
         const { blockFn } = require("./sloppy.cjs");
         console.log(JSON.stringify([
           L.make(true)(1), L.loop(), L.deep(), L.sibling(), L.param("p"), L.arrow("a"), L.dflt(),
-          L.caught(), L.caughtVar(), L.paramUnused("p"), L.caughtUnused(), L.destructured(),
-          L.forIn(), L.inSwitch(1), L.inTry(), L.klass(), L.nested(), blockFn(), Check(2),
+          L.caught(), L.caughtVar(), L.paramUnused("p"), L.caughtUnused(), L.paramVar("p"),
+          L.catchParamVar(), L.destructured(), L.forIn(), L.inSwitch(1), L.inTry(), L.klass(),
+          L.nested(), blockFn(), Check(2),
         ]));
       `,
       "/lib.js": /* js */ `
@@ -3215,6 +3216,20 @@ describe("bundler", () => {
             return Check2;
           }
         }
+        // Here the renamed "var Check" is the one that would take a
+        // parameter's or catch binding's name "Check2". That output loads but
+        // merges the var with the parameter (or assigns the catch binding), so
+        // the values are wrong instead of a SyntaxError.
+        export function paramVar(Check2) {
+          OuterCheck(0);
+          var Check;
+          return Check;
+        }
+        export function catchParamVar() {
+          OuterCheck(0);
+          try { throw 0; } catch (Check2) { var Check = "set"; }
+          return Check;
+        }
         export function destructured() {
           OuterCheck(0);
           { let Check2 = 5; var { a: Check = Check2, ...rest } = { b: 1 }; }
@@ -3279,7 +3294,7 @@ describe("bundler", () => {
       expect(out).not.toMatch(/catch \(Check2\) \{\s*[^}]*let Check2\b/);
     },
     run: {
-      stdout: `[1,1,["mid","var"],["let","var"],["p","body"],["a","arrow"],["default","inner"],["err","catch"],"v","unused-param","unused-catch",[5,{"b":1}],"k","sw","try","cls",["nested","v"],[["let","g-inner"],"g-inner"],"other 2"]`,
+      stdout: `[1,1,["mid","var"],["let","var"],["p","body"],["a","arrow"],["default","inner"],["err","catch"],"v","unused-param","unused-catch",null,"set",[5,{"b":1}],"k","sw","try","cls",["nested","v"],[["let","g-inner"],"g-inner"],"other 2"]`,
     },
   });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3127,6 +3127,78 @@ describe("bundler", () => {
     minifyIdentifiers: false,
     run: { stdout: `a a\nb outer\n["b-arg","local,outer","outer","L,F"]` },
   });
+  // A `var` hoisted out of a block is still declared inside that block, so a
+  // block-scoped binding there cannot take the hoisted name (#41351). The
+  // same holds for a function body and its parameters, and for a catch block
+  // and its binding. A sibling block that does not mention the `var` may.
+  itBundled("identifiers/NestedBindingRenamedAroundHoistedVarDeclaration", {
+    files: {
+      "/entry.js": /* js */ `
+        import { make, loop, deep, sibling, param, arrow, caught } from "./lib.js";
+        import { Check } from "./other.js";
+        console.log(JSON.stringify([
+          make(true)(1), loop(), deep(), sibling(), param("p"), arrow("a"), caught(), Check(2),
+        ]));
+      `,
+      "/lib.js": /* js */ `
+        import { Check as OuterCheck } from "./other.js";
+        export function make(cond) {
+          OuterCheck(0);
+          if (cond) {
+            let Check2 = function (value) { return value; };
+            var Check = Check2;
+          }
+          return Check;
+        }
+        export function loop() {
+          OuterCheck(0);
+          for (let Check2 = 0; Check2 < 1; Check2++) { var Check = Check2 + 1; }
+          return Check;
+        }
+        export function deep() {
+          OuterCheck(0);
+          {
+            let Check2 = "mid";
+            { var Check = "var"; }
+            return [Check2, Check];
+          }
+        }
+        export function sibling() {
+          OuterCheck(0);
+          { var Check = "var"; }
+          let seen;
+          { let Check2 = "let"; seen = Check2; }
+          return [seen, Check];
+        }
+        export function param(Check) {
+          OuterCheck(0);
+          let Check2 = "body";
+          return Check2;
+        }
+        export const arrow = (Check) => {
+          OuterCheck(0);
+          let Check2 = "arrow";
+          return Check2;
+        };
+        export function caught() {
+          try { throw "err"; } catch (Check) {
+            OuterCheck(0);
+            let Check2 = "catch";
+            return Check2;
+          }
+        }
+      `,
+      "/other.js": /* js */ `
+        export function Check(x) { return "other " + x; }
+      `,
+    },
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain('let Check2 = "let"');
+    },
+    run: { stdout: `[1,1,["mid","var"],["let","var"],"body","arrow","catch","other 2"]` },
+  });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {
     files: {
       "/entry.ts": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3140,8 +3140,8 @@ describe("bundler", () => {
         const { blockFn } = require("./sloppy.cjs");
         console.log(JSON.stringify([
           L.make(true)(1), L.loop(), L.deep(), L.sibling(), L.param("p"), L.arrow("a"), L.dflt(),
-          L.caught(), L.caughtVar(), L.destructured(), L.forIn(), L.inSwitch(1), L.inTry(),
-          L.klass(), L.nested(), blockFn(), Check(2),
+          L.caught(), L.caughtVar(), L.paramUnused("p"), L.caughtUnused(), L.destructured(),
+          L.forIn(), L.inSwitch(1), L.inTry(), L.klass(), L.nested(), blockFn(), Check(2),
         ]));
       `,
       "/lib.js": /* js */ `
@@ -3201,6 +3201,20 @@ describe("bundler", () => {
           OuterCheck(0);
           try { throw "t"; } catch (Check) { var Check = "v"; let Check2 = Check; return Check2; }
         }
+        // The body never mentions the parameter or the catch binding, so only
+        // its declaration stops the body's "Check2" from taking that name.
+        export function paramUnused(Check) {
+          OuterCheck(0);
+          let Check2 = "unused-param";
+          return Check2;
+        }
+        export function caughtUnused() {
+          try { throw "err"; } catch (Check) {
+            OuterCheck(0);
+            let Check2 = "unused-catch";
+            return Check2;
+          }
+        }
         export function destructured() {
           OuterCheck(0);
           { let Check2 = 5; var { a: Check = Check2, ...rest } = { b: 1 }; }
@@ -3229,7 +3243,7 @@ describe("bundler", () => {
         export function nested() {
           OuterCheck(0);
           {
-            let Check2 = "let";
+            let Check2 = "nested";
             function inner() { var Check = "v"; return Check; }
             return [Check2, inner()];
           }
@@ -3261,9 +3275,11 @@ describe("bundler", () => {
       // No scope declares one name twice.
       expect(out).not.toMatch(/let Check2 = [^;]+;\s*var Check2\b/);
       expect(out).not.toMatch(/function param\(Check2\) \{\s*[^}]*let Check2\b/);
+      expect(out).not.toMatch(/function paramUnused\(Check2\) \{\s*[^}]*let Check2\b/);
+      expect(out).not.toMatch(/catch \(Check2\) \{\s*[^}]*let Check2\b/);
     },
     run: {
-      stdout: `[1,1,["mid","var"],["let","var"],["p","body"],["a","arrow"],["default","inner"],["err","catch"],"v",[5,{"b":1}],"k","sw","try","cls",["let","v"],[["let","g-inner"],"g-inner"],"other 2"]`,
+      stdout: `[1,1,["mid","var"],["let","var"],["p","body"],["a","arrow"],["default","inner"],["err","catch"],"v","unused-param","unused-catch",[5,{"b":1}],"k","sw","try","cls",["nested","v"],[["let","g-inner"],"g-inner"],"other 2"]`,
     },
   });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {


### PR DESCRIPTION
### Problem
- Since 1.4.1, `bun build` of any Elysia app emits `let Check2 = ...; var Check2 = Check2;` in one block. Loading it fails: `SyntaxError: Cannot declare a var variable that shadows a let/const/class variable: 'Check2'`. Fixes #41351.
- Cause: `ScopeUses::sees` (`src/js_printer/renamer.rs:1218`, from #41286) only counts identifier references. A hoisted `var` still prints its declaration in its block, so a `let` there could take the hoisted name.
- The same gap lets a `let` take a parameter's or catch binding's name. When a renamed `var` takes that name instead, the output loads but computes wrong values. 1.4.1 users should upgrade even when their bundle loads.

### Fix
- `visit_binding` (`src/js_parser/visit/mod.rs:803`) records a declaration point for a `var` declared below the scope it hoists to, a parameter, and a catch binding. Other bindings live in the scope that declares them.
- `ScopeUses::sees` looks at the parent scope for a function body (`FunctionArgs`) and a catch block (`CatchBinding`). Those pairs form one declaration region.
- Both changes only make `sees` return true more often. The worst case is a numbered name, the 1.4.0 behavior.
- Verified: `identifiers/NestedBindingRenamedAroundHoistedVarDeclaration` in `test/bundler/bundler_edgecase.test.ts` (fails on main). The Elysia 1.4.29 build from the issue serves `200 ok`. Other bundler suites pass (list in Notes).

### Background
- The number renamer names top-level symbols, then each file's nested scopes in pre-order, checking each binding against enclosing names.
- `Ast::scope_uses` lists `(scope index, symbol)` points per reference. Scopes are numbered in pre-order, so `sees(symbol, scope)` is a range check.
- A `var` in a block is hoisted to the function scope, but the block keeps its member entry and the printer writes the `var` where the source had it.

<details><summary>Notes</summary>

Minimal reproduction for each SyntaxError case, all with a top-level `Check` referenced in the function so the nested `Check` is renamed to `Check2`:

```js
function make(cond) { OuterCheck(0); if (cond) { let Check2 = 1; var Check = Check2; } return Check; }
function param(Check) { OuterCheck(0); let Check2 = "body"; return Check2; }
function caught() { try { throw 0 } catch (Check) { OuterCheck(0); let Check2 = "catch"; return Check2; } }
```

On main the output is `let Check2 = 1; var Check2 = Check2`, `function param(Check2) { let Check2 }` and `catch (Check2) { let Check2 }`. With the fix each inner `let` becomes `Check22`.

Silent value cases on main, checked with the debug build: `function paramVar(Check2) { OuterCheck(0); var Check; return Check; }` prints `var Check2; return Check2` and returns the argument instead of `undefined`. `try { throw 0 } catch (Check2) { var Check = "set" } return Check` prints `catch (Check2) { var Check2 = "set" }` and returns `undefined` instead of `"set"`. With the fix they print `var Check3` and `catch (Check22)`.

The test covers `if`, `for`, `for-in`, `switch`, `try` and `catch` bodies, destructuring, a class next to the hoisted `var`, parameter defaults, an Annex B block function, a parameter and a catch binding the body never mentions (these fail if the `sees` parent redirect is removed), and the two value cases above. A sibling block that declares `let Check2` without mentioning the `var` keeps its name, so the fix does not number every nested binding.

Suites run with the debug build: the other `NestedBinding*` tests, all of `bundler_edgecase.test.ts`, `esbuild/default`, `esbuild/lower`, `esbuild/ts`, `bundler_cjs`, `bundler_regressions`, `bun-build-api`. `bundler_bytecode_portable.test.ts` times out at the 5 s per-test ceiling under the debug build on this machine, both with and without the change. Its assertions do not depend on names.

Self-reviewed: the review asked for the two value cases and the upgrade note. Both added. An Annex B block function concern was already covered: generated hoisted symbols carry a whole-file span (`take_scope_uses`, p.rs:1839).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.1 (e0a2b82fd)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [523.54ms]
(pass) bundler > edgecase/EmptyCommonJSModule [386.39ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [497.68ms]
(pass) bundler > edgecase/ImportStarFunction [384.47ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [367.33ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [145.27ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [476.93ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [210.49ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [201.78ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [209.59ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [120.20ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [361.30ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [345.11ms]
(pass) bundler >
... (truncated)

release without fix: 2 failed, 11 skipped
bun test v1.4.1-canary.1 (e0a2b82fd)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [12.65ms]
(pass) bundler > edgecase/EmptyCommonJSModule [10.05ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [9.70ms]
(pass) bundler > edgecase/ImportStarFunction [8.51ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [9.39ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [4.59ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [9.72ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [4.85ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [4.63ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [4.63ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [3.60ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [9.39ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [9.63ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [3.71ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [2.15ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDefaultImpor
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.1 (e0a2b82fd)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [583.64ms]
(pass) bundler > edgecase/EmptyCommonJSModule [426.45ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [433.35ms]
(pass) bundler > edgecase/ImportStarFunction [460.03ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [367.14ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [117.24ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [387.09ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [283.29ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [203.65ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [208.80ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [134.73ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [467.64ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [352.95ms]
(pass) bundler >
... (truncated)

release with fix: 11 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     babb1342a6
  features     baseline

23 deps, 131 codegen, 1172 objects in 637ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 22 installs across 61 packages (no changes) [4.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] gen bindgenv2
[5/1244] fetch zlib
[zlib] up to date
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[7/1244] gen .bind.ts → GeneratedBindings.cpp
[8/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[11/1217] fetch tinycc

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                    |   2 +-
 src/js_parser/visit/mod.rs            |  11 +++
 src/js_printer/renamer.rs             |  11 +++
 test/bundler/bundler_edgecase.test.ts | 170 ++++++++++++++++++++++++++++++++++
 4 files changed, 193 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js_parser/p.rs                         5      1     15
src/js_parser/visit/mod.rs                 3      2     15
src/js_printer/renamer.rs                  3      3     15
test/bundler/bundler_edgecase.test.ts      2     10     15
```

</details>

<!-- robobun:evidence:end -->