### PR TITLE
event loop: run setImmediate callbacks after the poll, like node

### DIFF
--- a/src/event_loop/README.md
+++ b/src/event_loop/README.md
@@ -73,25 +73,25 @@ This is called when the event loop is active and needs to wait for I/O:
 
 ```
 ┌─────────────────────────────────────┐
-│  1. Tick immediate tasks            │ ← setImmediate() callbacks
+│  1. Update date header timer        │
 └──────────────┬──────────────────────┘
                │
                ▼
 ┌─────────────────────────────────────┐
-│  2. Update date header timer        │
+│  2. Process GC timer                │
 └──────────────┬──────────────────────┘
                │
                ▼
 ┌─────────────────────────────────────┐
-│  3. Process GC timer                │
-└──────────────┬──────────────────────┘
-               │
-               ▼
-┌─────────────────────────────────────┐
-│  4. Poll I/O via uSockets            │ ← epoll_wait/kevent with timeout
-│     (epoll_kqueue.c:251-320)        │
+│  3. Poll I/O via uSockets            │ ← epoll_wait/kevent with timeout
+│     (epoll_kqueue.c:251-320)        │   (zero while immediates are queued)
 │     - Dispatch ready polls          │
 │     - Each I/O event treated as task│
+└──────────────┬──────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────┐
+│  4. Tick immediate tasks (POSIX)    │ ← setImmediate() callbacks
 └──────────────┬──────────────────────┘
                │
                ▼
@@ -109,6 +109,12 @@ This is called when the event loop is active and needs to wait for I/O:
 │  7. Handle rejected promises        │
 └─────────────────────────────────────┘
 ```
+
+Steps 3 to 5 follow Node's phase order: poll, check (`setImmediate`), timers. The timers run last, so the caller of `autoTick` sees what they did before the next poll.
+
+Node runs thread-pool completions in the poll phase. Bun runs them as tasks in `tick()`. So a `tick()` that ran tasks counts as a poll phase: before step 3, `autoTick` runs the immediates and the timers once more. If one of them ran a callback, the poll does not wait.
+
+On Windows, libuv runs the timers inside the poll call (step 3). There, the immediates run before step 1, and steps 4 and 5 do not run.
 
 ## Task Draining Algorithm
 
@@ -287,7 +293,7 @@ Timers are handled differently based on platform:
 ctx.timer.drain_timers(ctx);
 ```
 
-Timers are drained after I/O polling. Each timer callback:
+Timers are drained after I/O polling and after the immediates. Each timer callback:
 
 1. Is wrapped in `enter()`/`exit()`
 2. Triggers microtask draining after execution
@@ -310,9 +316,11 @@ setImmediate(() => console.log("immediate"));
 
 This is because:
 
-- `setImmediate` runs in `tickImmediateTasks()` before I/O polling
-- `setTimeout` fires after I/O polling (even with 0ms)
+- `setImmediate` runs in `tickImmediateTasks()`, after I/O polling and before the timers
+- `setTimeout` fires after the immediates (even with 0ms)
 - However, this can vary based on timing and event loop state
+
+Inside an I/O callback the order is fixed, as in Node. An immediate that the callback queues runs before any timer, even a timer that came due while the callback ran.
 
 ## Enter/Exit Mechanism
 
@@ -338,8 +346,8 @@ This ensures microtasks are only drained once per top-level event loop task, eve
 
 The Bun event loop processes work in this order:
 
-1. **Immediate tasks** (setImmediate)
-2. **I/O polling** (epoll/kqueue)
+1. **I/O polling** (epoll/kqueue)
+2. **Immediate tasks** (setImmediate; on Windows these run before the poll)
 3. **Timer callbacks** (setTimeout/setInterval)
 4. **Regular tasks** from the task queue
    - For each task:

--- a/src/event_loop/README.md
+++ b/src/event_loop/README.md
@@ -316,9 +316,9 @@ setImmediate(() => console.log("immediate"));
 
 This is because:
 
-- `setImmediate` runs in `tickImmediateTasks()`, after I/O polling and before the timers
-- `setTimeout` fires after the immediates (even with 0ms)
-- However, this can vary based on timing and event loop state
+- In one turn of the loop, `tickImmediateTasks()` runs the queued immediates after I/O polling
+- The timers that are due run after them, in the same turn (a 0ms timer is due after 1ms)
+- This is not a guarantee for code at the top level: it can vary with timing and event loop state
 
 Inside an I/O callback the order is fixed, as in Node. An immediate that the callback queues runs before any timer, even a timer that came due while the callback ran.
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1860,6 +1860,7 @@ function getNodeHTTPServerSocket() {
     }
 
     ref() {
+      this[kHandle]?.response?.ref();
       return this;
     }
 
@@ -1945,6 +1946,7 @@ function getNodeHTTPServerSocket() {
     }
 
     unref() {
+      this[kHandle]?.response?.unref();
       return this;
     }
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -71,6 +71,10 @@ pub struct EventLoop {
     /// until the queue is empty (a task that re-posts itself there never lets
     /// the loop poll). Promoted into `tasks` by `auto_tick`, like immediates.
     pub yield_tasks: Vec<Task>,
+    /// A `tick()` ran a task since `auto_tick` last took this. Node runs
+    /// thread-pool completions in the poll phase, and Bun runs them as tasks,
+    /// so `auto_tick` treats such a tick as a poll phase.
+    ran_tasks: bool,
 
     pub concurrent_tasks: ConcurrentQueue,
     /// Set only on Bun.spawnSync's isolated loop: how other threads reach *this*
@@ -121,6 +125,7 @@ impl Default for EventLoop {
             immediate_tasks: Vec::new(),
             next_immediate_tasks: Vec::new(),
             yield_tasks: Vec::new(),
+            ran_tasks: false,
             concurrent_tasks: ConcurrentQueue::default(),
             isolated_poster: None,
             global: None,
@@ -539,7 +544,11 @@ impl EventLoop {
     /// turn is over (`tick()` / `tick_tasks_only()` return rather than run more against that VM).
     fn tick_with_count(&mut self, virtual_machine: *mut VirtualMachine) -> Result<u32, Stopped> {
         let mut counter: u32 = 0;
-        tick_queue_with_count(self, virtual_machine, &mut counter)?;
+        let result = tick_queue_with_count(self, virtual_machine, &mut counter);
+        if counter > 0 {
+            self.ran_tasks = true;
+        }
+        result?;
         Ok(counter)
     }
 
@@ -948,6 +957,11 @@ impl EventLoop {
             return self.enqueue_task(task);
         }
         self.yield_tasks.push(task);
+    }
+
+    /// `auto_tick`: whether a `tick()` ran a task since the last call.
+    pub fn take_ran_tasks(&mut self) -> bool {
+        core::mem::take(&mut self.ran_tasks)
     }
 
     /// `auto_tick`, before it polls: last iteration's yielded tasks become

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -71,9 +71,7 @@ pub struct EventLoop {
     /// until the queue is empty (a task that re-posts itself there never lets
     /// the loop poll). Promoted into `tasks` by `auto_tick`, like immediates.
     pub yield_tasks: Vec<Task>,
-    /// A `tick()` ran a task since `auto_tick` last took this. Node runs
-    /// thread-pool completions in the poll phase, and Bun runs them as tasks,
-    /// so `auto_tick` treats such a tick as a poll phase.
+    /// A `tick()` ran a task since `auto_tick` last took this.
     ran_tasks: bool,
 
     pub concurrent_tasks: ConcurrentQueue,

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -454,6 +454,15 @@ impl EventLoop {
         self.drain_microtasks_with_global(global, jsc_vm)
     }
 
+    /// `auto_tick`, after the poll. A callback that ran inside an entered scope
+    /// (a nested loop, such as a wait for a promise) did not drain the
+    /// microtask queue at its exit.
+    pub fn drain_microtasks_if_nested(&mut self) {
+        if self.entered_event_loop_count > 0 {
+            let _ = self.drain_microtasks();
+        }
+    }
+
     // should be called after exit()
     pub fn maybe_drain_microtasks(&mut self) -> Result<(), Stopped> {
         if self.entered_event_loop_count == 0 && !self.vm_ref().is_inside_deferred_task_queue.get()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -954,12 +954,10 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
     }
 }
 
-/// The check phase and the timers, when a `tick()` ran tasks since the last
-/// call (see `auto_tick`). Returns whether a callback ran.
+/// Runs the check phase and the timers if a `tick()` ran tasks. Returns whether a callback ran.
 ///
 /// # Safety
-/// `vm` is the live per-thread VM, `el` is its event loop, and `state` is its
-/// live `RuntimeState`.
+/// `vm`, its event loop `el`, and its `RuntimeState` `state` are live.
 #[cfg(unix)]
 unsafe fn run_phases_after_tasks(
     vm: *mut VirtualMachine,
@@ -977,8 +975,7 @@ unsafe fn run_phases_after_tasks(
     // SAFETY: per fn contract. See the Note on `drain_timers` in `auto_tick`.
     let fired = unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };
     if ran_immediates || fired {
-        // Node reports a rejection after each callback. An I/O callback in
-        // the poll must not handle it first.
+        // Report a rejection before an I/O callback in the poll can handle it, as Node does.
         // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
         let _ = unsafe { (*(*vm).global).handle_rejected_promises() };
     }
@@ -1002,10 +999,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
     let loop_ = unsafe { (*el).usockets_loop() };
 
-    // ── check phase (Windows) ───────────────────────────────────────────
-    // Node's loop order is poll, check (setImmediate), timers. On POSIX the
-    // check phase runs after the poll, below. On Windows, libuv runs the
-    // timers inside the poll call, so the check phase runs before it.
+    // Node's order is poll, check (setImmediate), timers. libuv runs the
+    // timers inside the Windows poll call, so there the check phase is first.
     #[cfg(windows)]
     {
         // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
@@ -1073,13 +1068,9 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         return;
     }
 
-    // ── check phase and timers after a tick that ran tasks (POSIX) ──────
-    // Node runs thread-pool completions in the poll phase, and Bun runs them
-    // as tasks in `tick()`. So a tick that ran tasks counts as a poll phase,
-    // and the check phase and the timers run before this poll. An immediate
-    // queued by a completion then runs before the I/O that completion began.
-    // SAFETY: `el` is the live per-thread event loop; `state` and `vm` are
-    // live (see the timers phase below).
+    // Node runs thread-pool completions in the poll phase. Bun runs them as
+    // tasks in `tick()`, so a tick that ran tasks is a poll phase here.
+    // SAFETY: `el`, `state` and `vm` are live (see the timers phase below).
     #[cfg(unix)]
     let ran_callbacks = unsafe { run_phases_after_tasks(vm, el, state) };
     #[cfg(not(unix))]
@@ -1090,10 +1081,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // due `WTFTimer` heap entries), so it must stay guarded by `is_active()`
     // rather than running unconditionally.
     {
-        // `immediate_tasks` holds the immediates that no check phase has run
-        // yet. The poll must not wait while there are any. It must not wait
-        // after a callback above either: that callback can have settled what
-        // the caller waits for.
+        // Do not wait while immediates are queued, or after a callback above:
+        // it can have settled what the caller waits for.
         // SAFETY: `el` is the live per-thread event loop.
         // SAFETY: `el` is the live per-thread event loop.
         let has_pending_immediate = ran_callbacks
@@ -1154,10 +1143,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         }
     }
 
-    // ── check phase, then timers (POSIX) ────────────────────────────────
-    // An immediate queued by an I/O callback runs before any timer, even
-    // one that came due while that callback ran. The timers run last, so the
-    // caller sees what they did before the next poll.
+    // Check phase, then timers. The timers run last, so the caller sees what
+    // they did before the next poll.
     #[cfg(unix)]
     {
         // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -954,6 +954,37 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
     }
 }
 
+/// The check phase and the timers, when a `tick()` ran tasks since the last
+/// call (see `auto_tick`). Returns whether a callback ran.
+///
+/// # Safety
+/// `vm` is the live per-thread VM, `el` is its event loop, and `state` is its
+/// live `RuntimeState`.
+#[cfg(unix)]
+unsafe fn run_phases_after_tasks(
+    vm: *mut VirtualMachine,
+    el: *mut bun_jsc::event_loop::EventLoop,
+    state: *mut RuntimeState,
+) -> bool {
+    // SAFETY: per fn contract.
+    if !unsafe { (*el).take_ran_tasks() } {
+        return false;
+    }
+    // SAFETY: per fn contract.
+    let ran_immediates = !unsafe { &*el }.immediate_tasks.is_empty();
+    // SAFETY: per fn contract.
+    unsafe { (*el).tick_immediate_tasks(vm) };
+    // SAFETY: per fn contract. See the Note on `drain_timers` in `auto_tick`.
+    let fired = unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };
+    if ran_immediates || fired {
+        // Node reports a rejection after each callback. An I/O callback in
+        // the poll must not handle it first.
+        // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
+        let _ = unsafe { (*(*vm).global).handle_rejected_promises() };
+    }
+    ran_immediates || fired
+}
+
 /// `eventLoop().autoTick()`. Needs
 /// `timer::All` for the poll-timeout calculation, hence dispatched here.
 ///
@@ -971,12 +1002,16 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
     let loop_ = unsafe { (*el).usockets_loop() };
 
-    // ── tick_immediate_tasks ────────────────────────────────────────────
-    // After this call `immediate_tasks` reflects next-tick immediates, so
-    // the `has_pending_immediate` read below is correct.
-    // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-    unsafe { (*el).tick_immediate_tasks(vm) };
-    // SAFETY: as above.
+    // ── check phase (Windows) ───────────────────────────────────────────
+    // Node's loop order is poll, check (setImmediate), timers. On POSIX the
+    // check phase runs after the poll, below. On Windows, libuv runs the
+    // timers inside the poll call, so the check phase runs before it.
+    #[cfg(windows)]
+    {
+        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+        unsafe { (*el).tick_immediate_tasks(vm) };
+    }
+    // SAFETY: `el` is the live per-thread event loop.
     let has_yielded_tasks = unsafe { (*el).promote_yield_tasks() };
     #[cfg(windows)]
     if has_yielded_tasks || !unsafe { &*el }.immediate_tasks.is_empty() {
@@ -1025,6 +1060,11 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         // drain JS tasks and never touch kqueue/epoll.
         // SAFETY: `loop_` is the live per-thread uws loop.
         unsafe { (*loop_).tick_without_idle() };
+        #[cfg(unix)]
+        {
+            // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+            unsafe { (*el).tick_immediate_tasks(vm) };
+        }
         // Still run the post-poll hooks.
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
@@ -1033,17 +1073,31 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         return;
     }
 
+    // ── check phase and timers after a tick that ran tasks (POSIX) ──────
+    // Node runs thread-pool completions in the poll phase, and Bun runs them
+    // as tasks in `tick()`. So a tick that ran tasks counts as a poll phase,
+    // and the check phase and the timers run before this poll. An immediate
+    // queued by a completion then runs before the I/O that completion began.
+    // SAFETY: `el` is the live per-thread event loop; `state` and `vm` are
+    // live (see the timers phase below).
+    #[cfg(unix)]
+    let ran_callbacks = unsafe { run_phases_after_tasks(vm, el, state) };
+    #[cfg(not(unix))]
+    let ran_callbacks = false;
+
     // Call `ctx.timer.getTimeout(..)` ONLY inside
     // `if (loop.isActive())` — `get_timeout` has side effects (pops + fires
     // due `WTFTimer` heap entries), so it must stay guarded by `is_active()`
     // rather than running unconditionally.
     {
-        // Read `immediate_tasks` AFTER
-        // `tickImmediateTasks` swaps `next_immediate_tasks` in, so this
-        // reflects next-tick immediates (queued during the drain above).
+        // `immediate_tasks` holds the immediates that no check phase has run
+        // yet. The poll must not wait while there are any. It must not wait
+        // after a callback above either: that callback can have settled what
+        // the caller waits for.
         // SAFETY: `el` is the live per-thread event loop.
         // SAFETY: `el` is the live per-thread event loop.
-        let has_pending_immediate = has_yielded_tasks
+        let has_pending_immediate = ran_callbacks
+            || has_yielded_tasks
             || !unsafe { &*el }.immediate_tasks.is_empty()
             || unsafe { &*el }.has_pending_tasks();
         // Fold the QUIC deadline into the poll timeout.
@@ -1100,8 +1154,14 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         }
     }
 
+    // ── check phase, then timers (POSIX) ────────────────────────────────
+    // An immediate queued by an I/O callback runs before any timer, even
+    // one that came due while that callback ran. The timers run last, so the
+    // caller sees what they did before the next poll.
     #[cfg(unix)]
     {
+        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+        unsafe { (*el).tick_immediate_tasks(vm) };
         // Note (§Forbidden aliased-&mut): `drain_timers` fires user
         // `setTimeout` callbacks which may re-enter `timer::All::insert`/
         // `remove` via `runtime_state()`. Pass raw `*mut Self` so no
@@ -1135,9 +1195,13 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
     let loop_ = unsafe { (*el).usockets_loop() };
 
-    // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-    unsafe { (*el).tick_immediate_tasks(vm) };
-    // SAFETY: as above.
+    // The check phase runs before the poll on Windows only. See `auto_tick`.
+    #[cfg(windows)]
+    {
+        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+        unsafe { (*el).tick_immediate_tasks(vm) };
+    }
+    // SAFETY: `el` is the live per-thread event loop.
     let has_yielded_tasks = unsafe { (*el).promote_yield_tasks() };
     #[cfg(windows)]
     if has_yielded_tasks || !unsafe { &*el }.immediate_tasks.is_empty() {
@@ -1173,15 +1237,28 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     if state.is_null() {
         // SAFETY: `loop_` is the live per-thread uws loop.
         unsafe { (*loop_).tick_without_idle() };
+        #[cfg(unix)]
+        {
+            // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+            unsafe { (*el).tick_immediate_tasks(vm) };
+        }
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
         return;
     }
 
+    // The check phase and the timers after a tick that ran tasks. See `auto_tick`.
+    // SAFETY: `el` is the live per-thread event loop; `state` and `vm` are live.
+    #[cfg(unix)]
+    let ran_callbacks = unsafe { run_phases_after_tasks(vm, el, state) };
+    #[cfg(not(unix))]
+    let ran_callbacks = false;
+
     {
         // SAFETY: `el` is the live per-thread event loop.
         // SAFETY: `el` is the live per-thread event loop.
-        let has_pending_immediate = has_yielded_tasks
+        let has_pending_immediate = ran_callbacks
+            || has_yielded_tasks
             || !unsafe { &*el }.immediate_tasks.is_empty()
             || unsafe { &*el }.has_pending_tasks();
         // SAFETY: `loop_` is the live per-thread uws loop.
@@ -1227,8 +1304,11 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         }
     }
 
+    // Check phase, then timers. See `auto_tick`.
     #[cfg(unix)]
     {
+        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+        unsafe { (*el).tick_immediate_tasks(vm) };
         // SAFETY: `state` is the live per-thread `RuntimeState`; see Note
         // on `auto_tick` re: aliased-&mut across `fire()`.
         unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -954,6 +954,19 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
     }
 }
 
+/// The check phase after a poll. The microtasks that the poll's callbacks
+/// queued run first, as they do in Node.
+///
+/// # Safety
+/// `vm` and its event loop `el` are live.
+#[cfg(unix)]
+unsafe fn run_check_phase(vm: *mut VirtualMachine, el: *mut bun_jsc::event_loop::EventLoop) {
+    // SAFETY: per fn contract.
+    unsafe { (*el).drain_microtasks_if_nested() };
+    // SAFETY: per fn contract.
+    unsafe { (*el).tick_immediate_tasks(vm) };
+}
+
 /// Runs the check phase and the timers if a `tick()` ran tasks. Returns whether a callback ran.
 ///
 /// # Safety
@@ -1058,7 +1071,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         #[cfg(unix)]
         {
             // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-            unsafe { (*el).tick_immediate_tasks(vm) };
+            unsafe { run_check_phase(vm, el) };
         }
         // Still run the post-poll hooks.
         // SAFETY: per fn contract.
@@ -1148,7 +1161,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     #[cfg(unix)]
     {
         // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-        unsafe { (*el).tick_immediate_tasks(vm) };
+        unsafe { run_check_phase(vm, el) };
         // Note (§Forbidden aliased-&mut): `drain_timers` fires user
         // `setTimeout` callbacks which may re-enter `timer::All::insert`/
         // `remove` via `runtime_state()`. Pass raw `*mut Self` so no
@@ -1227,7 +1240,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         #[cfg(unix)]
         {
             // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-            unsafe { (*el).tick_immediate_tasks(vm) };
+            unsafe { run_check_phase(vm, el) };
         }
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
@@ -1295,7 +1308,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     #[cfg(unix)]
     {
         // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-        unsafe { (*el).tick_immediate_tasks(vm) };
+        unsafe { run_check_phase(vm, el) };
         // SAFETY: `state` is the live per-thread `RuntimeState`; see Note
         // on `auto_tick` re: aliased-&mut across `fire()`.
         unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -973,7 +973,7 @@ unsafe fn run_phases_after_tasks(
     // SAFETY: per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
     // SAFETY: per fn contract. See the Note on `drain_timers` in `auto_tick`.
-    let fired = unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };
+    let fired = unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };
     if ran_immediates || fired {
         // Report a rejection before an I/O callback in the poll can handle it, as Node does.
         // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
@@ -1156,7 +1156,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         // `drain_timers` forms short-lived `&mut` only around heap pop/peek.
         // SAFETY: `state` is the live per-thread `RuntimeState`; the `timer`
         // field address is stable for the VM lifetime.
-        unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };
+        unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };
     }
     #[cfg(not(unix))]
     let _ = state;
@@ -1298,7 +1298,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         unsafe { (*el).tick_immediate_tasks(vm) };
         // SAFETY: `state` is the live per-thread `RuntimeState`; see Note
         // on `auto_tick` re: aliased-&mut across `fire()`.
-        unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };
+        unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };
     }
     #[cfg(not(unix))]
     let _ = state;

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -726,7 +726,9 @@ impl NodeHTTPResponse {
         self.buffered_request_body_data_during_pause
             .with_mut(|b| b.clear_and_free());
         let mut server = self.server;
-        self.poll_ref.with_mut(|r| r.unref(vm));
+        if !self.is_open_tunnel() {
+            self.poll_ref.with_mut(|r| r.unref(vm));
+        }
         self.unregister_auto_flush();
 
         server.on_request_complete();
@@ -820,7 +822,7 @@ impl NodeHTTPResponse {
     }
 
     pub(crate) fn js_ref(&self, global_object: &JSGlobalObject, _frame: &CallFrame) -> JSValue {
-        if !self.is_done() {
+        if !self.is_done() || self.is_open_tunnel() {
             self.poll_ref
                 .with_mut(|r| r.r#ref(bun_vm_mut(global_object)));
         }
@@ -828,7 +830,7 @@ impl NodeHTTPResponse {
     }
 
     pub(crate) fn js_unref(&self, global_object: &JSGlobalObject, _frame: &CallFrame) -> JSValue {
-        if !self.is_done() {
+        if !self.is_done() || self.is_open_tunnel() {
             self.poll_ref
                 .with_mut(|r| r.unref(bun_vm_mut(global_object)));
         }
@@ -1307,14 +1309,24 @@ impl NodeHTTPResponse {
     #[uws::uws_callback(export = "Bun__NodeHTTPResponse_setClosed", no_catch)]
     pub(crate) fn set_closed(&self) {
         self.update_flags(|f| f.insert(Flags::SOCKET_CLOSED));
+        self.poll_ref.with_mut(|r| r.unref(vm_get()));
     }
 
-    /// Flag-only: the pending-request release happens deterministically in
-    /// the dispatch tail (`on_node_http_request*` in `mod.rs`) or, for an
-    /// Upgrade with a body, at the body's fin chunk.
+    /// The pending-request release happens deterministically in the dispatch
+    /// tail (`on_node_http_request*` in `mod.rs`) or, for an Upgrade with a
+    /// body, at the body's fin chunk.
     #[uws::uws_callback(export = "Bun__NodeHTTPResponse_markTunneled", no_catch)]
     pub(crate) fn mark_tunneled(&self) {
         self.update_flags(|f| f.insert(Flags::TUNNELED));
+        if self.is_open_tunnel() {
+            self.poll_ref.with_mut(|r| r.r#ref(vm_get()));
+        }
+    }
+
+    /// Like a Node socket, a tunnel holds the loop until it reads EOF or closes.
+    fn is_open_tunnel(&self) -> bool {
+        let flags = self.flags.get();
+        flags.contains(Flags::TUNNELED) && !flags.contains(Flags::SOCKET_CLOSED)
     }
 
     fn on_timeout(&self, _resp: uws::AnyResponse) {
@@ -1434,7 +1446,9 @@ impl NodeHTTPResponse {
         }
         scoped_log!(NodeHTTPResponse, "onRequestComplete");
         self.update_flags(|f| f.insert(Flags::REQUEST_HAS_COMPLETED));
-        self.poll_ref.with_mut(|r| r.unref(vm_get()));
+        if !self.is_open_tunnel() {
+            self.poll_ref.with_mut(|r| r.unref(vm_get()));
+        }
 
         self.mark_request_as_done_if_necessary();
     }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1055,7 +1055,10 @@ impl All {
     // Forwards `vm` to `__bun_fire_timer` without dereferencing it;
     // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn drain_timers(&mut self, vm: *mut () /* erased *mut VirtualMachine */) -> bool {
+    pub(crate) fn drain_timers(
+        &mut self,
+        vm: *mut (), /* erased *mut VirtualMachine */
+    ) -> bool {
         // Note (§Forbidden aliased-&mut): fired handlers re-enter `vm.timer`
         // (e.g. setInterval reschedule → `vm.timer.update(...)`, `cancel()` →
         // `vm.timer.remove(...)`). In Rust those re-entrant calls resolve to

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -781,8 +781,8 @@ impl All {
         // SAFETY: callback fires on the JS thread (libuv invokes on the loop's
         // thread); `all` is live for the VM lifetime. `drain_timers` may
         // re-enter `(*runtime_state()).timer` — it forms only short-lived
-        // `&mut All` around heap pop/peek, so the raw-ptr deref here is sound.
-        unsafe { (*all).drain_timers(vm) };
+        // `&mut All` around heap pop/peek, so it takes the raw pointer.
+        unsafe { All::drain_timers(all, vm) };
         // SAFETY: see above; re-arm for the next-soonest deadline (if any).
         unsafe { (*all).ensure_uv_timer() };
     }
@@ -1050,31 +1050,22 @@ impl All {
     /// Fires the due timers. Returns whether it fired one.
     ///
     /// # Safety
-    /// `vm` is the erased `*mut VirtualMachine` for the calling JS thread and
-    /// must remain live across any `EventLoopTimer::fire` re-entry.
-    // Forwards `vm` to `__bun_fire_timer` without dereferencing it;
-    // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn drain_timers(
-        &mut self,
+    /// `this` is the live per-thread `All`. `vm` is the erased
+    /// `*mut VirtualMachine` for the calling JS thread and must remain live
+    /// across any `EventLoopTimer::fire` re-entry.
+    pub(crate) unsafe fn drain_timers(
+        this: *mut Self,
         vm: *mut (), /* erased *mut VirtualMachine */
     ) -> bool {
         // Note (§Forbidden aliased-&mut): fired handlers re-enter `vm.timer`
         // (e.g. setInterval reschedule → `vm.timer.update(...)`, `cancel()` →
         // `vm.timer.remove(...)`). In Rust those re-entrant calls resolve to
         // `(*runtime_state()).timer.{update,remove}()`, minting a fresh
-        // `&mut All` to this same allocation while the outer `&mut self` is
-        // live → UB under Stacked Borrows. Convert `self` to a raw pointer
-        // up-front and form a *short-lived* `&mut` only around `next()`,
-        // dropping it before `fire()` so no `&mut All` is held across the
-        // re-entrant call (mirroring the raw-ptr pattern in
+        // `&mut All` to this same allocation. So this takes a raw pointer and
+        // forms a *short-lived* `&mut` only around `next()`, dropping it
+        // before `fire()` so no `&mut All` is held across the re-entrant call
+        // (mirroring the raw-ptr pattern in
         // `TimerObjectInternals::run_immediate_task`).
-        //
-        // TODO: the call-site auto-ref at jsc_hooks.rs (`(*state).timer
-        // .drain_timers(...)`) still creates a `&mut All` for the call frame
-        // itself; switch it to `All::drain_timers(core::ptr::addr_of_mut!(
-        // (*state).timer), vm)` and change this signature to `this: *mut Self`.
-        let this: *mut Self = self;
 
         let mut wtf_now: Option<Timespec> = None;
         // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -882,16 +882,20 @@ impl All {
         }
     }
 
+    /// Returns the next deadline, and whether it fired a timer.
     unsafe fn drain_due_wtf_timers(
         this: *mut Self,
         maybe_now: &mut Option<Timespec>,
         vm: *mut (),
-    ) -> Option<Timespec> {
+    ) -> (Option<Timespec>, bool) {
+        let mut fired = false;
         loop {
             let min = {
                 // SAFETY: `this` is live; the guard drops before `fire`.
                 let mut wtf = unsafe { &(*this).wtf_timers }.lock();
-                let min = wtf.peek()?;
+                let Some(min) = wtf.peek() else {
+                    return (None, fired);
+                };
                 // SAFETY: `peek` returned a live heap node.
                 let min_next = unsafe {
                     Timespec {
@@ -902,7 +906,7 @@ impl All {
                 let now = *maybe_now
                     .get_or_insert_with(|| Timespec::now(TimespecMockMode::ForceRealTime));
                 if min_next.greater(&now) {
-                    return Some(min_next);
+                    return (Some(min_next), fired);
                 }
                 let min = wtf.delete_min().expect("peek succeeded");
                 // SAFETY: `min` is the node `peek` returned above.
@@ -914,13 +918,14 @@ impl All {
                 sec: now.sec,
                 nsec: now.nsec,
             };
+            fired = true;
             // SAFETY: `min` is live; no guard or borrow of `All` is held here.
-            let fired = unsafe { EventLoopTimer::fire(min, &el_now, vm) };
+            let result = unsafe { EventLoopTimer::fire(min, &el_now, vm) };
             // WTF timers run JSC-internal work, not user JS; a stop found here
             // is the loop's to act on at its next gate, and the heap's next
             // deadline is still reported to the poll.
             // SAFETY: `vm` is the erased per-thread VM per fn contract.
-            let _ = unsafe { fold_timer(vm, fired) };
+            let _ = unsafe { fold_timer(vm, result) };
         }
     }
 
@@ -967,7 +972,7 @@ impl All {
         let maybe_now: &mut Option<Timespec> = now_out;
 
         // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
-        let wtf_next = unsafe { Self::drain_due_wtf_timers(this, maybe_now, vm) };
+        let (wtf_next, _) = unsafe { Self::drain_due_wtf_timers(this, maybe_now, vm) };
 
         // SAFETY: `this` is live, and only this thread touches the regular heap.
         let reg_next = (unsafe { &*this }).timers.peek().map(|min| {
@@ -1042,13 +1047,15 @@ impl All {
         Some(timer)
     }
 
+    /// Fires the due timers. Returns whether it fired one.
+    ///
     /// # Safety
     /// `vm` is the erased `*mut VirtualMachine` for the calling JS thread and
     /// must remain live across any `EventLoopTimer::fire` re-entry.
     // Forwards `vm` to `__bun_fire_timer` without dereferencing it;
     // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn drain_timers(&mut self, vm: *mut () /* erased *mut VirtualMachine */) {
+    pub(crate) fn drain_timers(&mut self, vm: *mut () /* erased *mut VirtualMachine */) -> bool {
         // Note (§Forbidden aliased-&mut): fired handlers re-enter `vm.timer`
         // (e.g. setInterval reschedule → `vm.timer.update(...)`, `cancel()` →
         // `vm.timer.remove(...)`). In Rust those re-entrant calls resolve to
@@ -1068,7 +1075,7 @@ impl All {
 
         let mut wtf_now: Option<Timespec> = None;
         // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
-        let _ = unsafe { Self::drain_due_wtf_timers(this, &mut wtf_now, vm) };
+        let (_, mut fired) = unsafe { Self::drain_due_wtf_timers(this, &mut wtf_now, vm) };
 
         let mut now = Timespec { sec: 0, nsec: 0 };
         let mut has_set_now = false;
@@ -1078,6 +1085,7 @@ impl All {
             let Some(t) = (unsafe { &mut *this }).next(&mut has_set_now, &mut now) else {
                 break;
             };
+            fired = true;
             // Note: re-pack into bun_event_loop's local Timespec stub
             // until the lower tier unifies on bun_core::Timespec.
             let el_now = ElTimespec {
@@ -1088,12 +1096,13 @@ impl All {
             // `fire` dispatches through the FIRE_TIMER hook (§Dispatch hot
             // path) and may re-enter `(*runtime_state()).timer` — no `&mut`
             // to `All` is live here.
-            let fired = unsafe { EventLoopTimer::fire(t, &el_now, vm) };
+            let result = unsafe { EventLoopTimer::fire(t, &el_now, vm) };
             // SAFETY: `vm` per fn contract.
-            if unsafe { fold_timer(vm, fired) }.is_err() {
+            if unsafe { fold_timer(vm, result) }.is_err() {
                 break;
             }
         }
+        fired
     }
 
     /// # Safety

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -42,13 +42,15 @@ describe("Bun.serve http2 + http3 on one port", () => {
     expect((await request(session, { ":path": "/reload" })).body.toString()).toBe("reloaded");
     expect((await request(session, { ":path": "/reloaded-route" })).body.toString()).toBe("after-reload");
     expect(await (await fetchH3(fx.port, "/reloaded-route")).text()).toBe("after-reload");
-    // graceful stop with one slow stream in flight on each transport
+    // graceful stop with one slow stream in flight on each transport. The h2
+    // session can close before slow3's body arrives over h3, so listen first.
+    const closed = new Promise<void>(r => session.once("close", () => r()));
     const slow2 = request(session, { ":path": "/slow?ms=300" });
     const slow3 = fetchH3(fx.port, "/slow?ms=300").then(r => r.text());
     expect((await request(session, { ":path": "/stop" })).body.toString()).toBe("stopping");
     expect((await slow2).body.toString()).toBe("slow");
     expect(await slow3).toBe("slow");
-    await new Promise<void>(r => session.once("close", () => r()));
+    await closed;
   }, 30000);
 
   test("http1: false with both h2 and h3", async () => {

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -841,3 +841,46 @@ test("CONNECT: process exits after the tunnel socket is re-emitted as a connecti
     signalCode: null,
   });
 });
+
+// The client socket is unref'd, so only the server side of the tunnel can keep
+// the process alive. Like a Node socket, it does so until it reads EOF.
+test("CONNECT: an open tunnel keeps the process alive after the server closes", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const http = require("node:http");
+       const server = http.createServer();
+       server.on("connect", (req, socket) => {
+         socket.write("HTTP/1.1 200 Connection Established\\r\\n\\r\\n");
+         socket.on("data", data => socket.write(data));
+         socket.on("end", () => {
+           console.log("server end");
+           socket.end();
+         });
+         server.close();
+       });
+       server.listen(0, () => {
+         const req = http.request({ port: server.address().port, method: "CONNECT" });
+         req.on("connect", (res, client) => {
+           client.unref();
+           client.on("data", data => {
+             console.log("client got " + data);
+             client.end();
+           });
+           client.write("ping");
+         });
+         req.end();
+       });`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "client got ping\nserver end\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,6 +1,7 @@
 import jsc from "bun:jsc";
 import { describe, expect, it, mock, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
+import net, { type AddressInfo } from "node:net";
 import path from "node:path";
 import { clearInterval, clearTimeout, promises, setImmediate, setInterval, setTimeout } from "node:timers";
 import { promisify } from "util";
@@ -437,11 +438,17 @@ describe.concurrent("event loop phases", () => {
     expect(await run(["-e", script])).toEqual({ stdout: "unref,timeout\n", stderr: "", exitCode: 0 });
   });
 
+  // The 'unhandledRejection' listener runs only if the rejection is still
+  // unhandled when it is reported. The process then closes its sockets and exits.
   test("a rejection in a timer is reported before the next I/O callback can handle it", async () => {
     const script = `${pair}
+      const order = [];
+      process.on("unhandledRejection", error => order.push("unhandled: " + error.message));
+      process.on("exit", () => console.log(order.join(",")));
       let rejected;
       pair((client, server, serverSocket) => {
         serverSocket.on("data", () => {
+          order.push("data");
           rejected.catch(() => {});
           client.destroy();
           server.close();
@@ -452,9 +459,31 @@ describe.concurrent("event loop phases", () => {
         }, 1);
       });
     `;
-    const { stderr, exitCode } = await run(["-e", script]);
-    expect(stderr).toContain("error: rejected in a timer");
-    expect(exitCode).toBe(1);
+    const { stdout, exitCode } = await run(["-e", script]);
+    expect(stdout).toBe("unhandled: rejected in a timer,data\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // `expect(promise).resolves` waits for a pending promise in a nested loop.
+  // There, an I/O callback does not drain the nextTick queue when it returns.
+  test("in a nested loop, a nextTick queued by an I/O callback runs before an immediate it queued", async () => {
+    const order: string[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const server = net.createServer(socket => socket.end("x"));
+    server.listen(0, () => {
+      const client = net.connect((server.address() as AddressInfo).port);
+      client.on("data", () => {
+        setImmediate(() => {
+          order.push("immediate");
+          client.destroy();
+          server.close();
+          resolve();
+        });
+        process.nextTick(() => order.push("tick"));
+      });
+    });
+    await expect(promise).resolves.toBeUndefined();
+    expect(order).toEqual(["tick", "immediate"]);
   });
 
   // A preload's promise is awaited by the loop's caller. The listening server

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -1,6 +1,6 @@
 import jsc from "bun:jsc";
 import { describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, isWindows } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
 import path from "node:path";
 import { clearInterval, clearTimeout, promises, setImmediate, setInterval, setTimeout } from "node:timers";
 import { promisify } from "util";
@@ -340,4 +340,148 @@ describe.each(["with", "without"])("setImmediate %s timers running", mode => {
 
 it("should defer microtasks when an exception is thrown in an immediate", async () => {
   expect(await bunRun(["run", path.join(import.meta.dir, "timers-immediate-exception-fixture.js")])).toSpawn();
+});
+
+// Node's loop runs the poll (I/O callbacks), then the check phase
+// (setImmediate), then the timers. The caller of the loop checks its own
+// condition (a promise, an unhandled rejection, whether the loop is alive)
+// after the timers, before the next poll.
+describe.concurrent("event loop phases", () => {
+  async function run(cmd: string[], env: Record<string, string | undefined> = bunEnv, cwd?: string) {
+    await using proc = Bun.spawn({ cmd: [bunExe(), ...cmd], env, cwd, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // A connected loopback pair. `onData` runs in the client's first I/O callback.
+  const pair = `
+    const net = require("net");
+    function pair(onData) {
+      let serverSocket;
+      const server = net.createServer(socket => {
+        serverSocket = socket;
+        socket.write("go");
+      });
+      server.listen(0, () => {
+        const client = net.connect(server.address().port);
+        client.once("data", () => onData(client, server, serverSocket));
+      });
+    }
+    function busy(ms) {
+      const end = performance.now() + ms;
+      while (performance.now() < end) {}
+    }
+  `;
+
+  // On Windows, libuv runs the timers inside its poll, so the timer fires first there.
+  test.skipIf(isWindows)("an immediate queued by an I/O callback runs before a timer that came due in it", async () => {
+    const script = `${pair}
+      pair((client, server) => {
+        const order = [];
+        const done = () => order.length === 2 && (console.log(order.join(",")), client.destroy(), server.close());
+        setTimeout(() => (order.push("timeout"), done()), 1);
+        busy(5);
+        setImmediate(() => (order.push("immediate"), done()));
+      });
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "immediate,timeout\n", stderr: "", exitCode: 0 });
+  });
+
+  test("a timer that came due in an I/O callback runs before a thread pool callback", async () => {
+    const script = `${pair}
+      const crypto = require("crypto");
+      pair((client, server) => {
+        const order = [];
+        const done = () => order.length === 2 && (console.log(order.join(",")), client.destroy(), server.close());
+        crypto.pbkdf2("a", "b", 1, 8, "sha256", () => (order.push("pool"), done()));
+        setTimeout(() => (order.push("timeout"), done()), 1);
+        busy(20);
+      });
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "timeout,pool\n", stderr: "", exitCode: 0 });
+  });
+
+  // Node runs a thread pool callback in the poll phase, so the connect it
+  // starts completes in a later poll, after the check phase.
+  test("an immediate queued by a thread pool callback runs before the connect that callback started", async () => {
+    const script = `
+      const fs = require("fs");
+      const net = require("net");
+      const server = net.createServer(socket => socket.end());
+      server.listen(0, () => {
+        fs.stat(".", () => {
+          const order = [];
+          const client = net.connect(server.address().port, "127.0.0.1");
+          client.on("connect", () => order.push("connect"));
+          setImmediate(() => order.push("immediate"));
+          client.on("close", () => (console.log(order.join(",")), server.close()));
+        });
+      });
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "immediate,connect\n", stderr: "", exitCode: 0 });
+  });
+
+  test("a due unref'd timer runs after an I/O callback unrefs the last handle", async () => {
+    const script = `${pair}
+      const order = [];
+      process.on("exit", () => console.log(order.join(",")));
+      pair((client, server, serverSocket) => {
+        setTimeout(() => order.push("timeout"), 1).unref();
+        busy(5);
+        client.unref();
+        serverSocket.unref();
+        server.unref();
+        order.push("unref");
+      });
+    `;
+    expect(await run(["-e", script])).toEqual({ stdout: "unref,timeout\n", stderr: "", exitCode: 0 });
+  });
+
+  test("a rejection in a timer is reported before the next I/O callback can handle it", async () => {
+    const script = `${pair}
+      let rejected;
+      pair((client, server, serverSocket) => {
+        serverSocket.on("data", () => {
+          rejected.catch(() => {});
+          client.destroy();
+          server.close();
+        });
+        setTimeout(() => {
+          client.write("x");
+          rejected = Promise.reject(new Error("rejected in a timer"));
+        }, 1);
+      });
+    `;
+    const { stderr, exitCode } = await run(["-e", script]);
+    expect(stderr).toContain("error: rejected in a timer");
+    expect(exitCode).toBe(1);
+  });
+
+  // A preload's promise is awaited by the loop's caller. The listening server
+  // keeps the loop active and the GC timer is off, so a poll that waited after
+  // the promise settled would not return before the test times out.
+  const preloadTest = (what: string, awaited: string) =>
+    test(`a preload that awaits ${what} does not wait for I/O before the entry point runs`, async () => {
+      using dir = tempDir("timers-phase-preload", {
+        "preload.mjs": `
+          import net from "node:net";
+          globalThis.server = net.createServer();
+          await new Promise(resolve => globalThis.server.listen(0, resolve));
+          await new Promise(resolve => ${awaited});
+        `,
+        "main.mjs": `
+          console.log("main");
+          globalThis.server.close();
+        `,
+      });
+      const env = { ...bunEnv, BUN_GC_TIMER_DISABLE: "1" };
+      expect(await run(["--preload", "./preload.mjs", "./main.mjs"], env, String(dir))).toEqual({
+        stdout: "main\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  preloadTest("a timer", "setTimeout(resolve, 1)");
+  // On Windows the check phase runs before the poll, so this wait still parks there.
+  if (!isWindows) preloadTest("an immediate", "setImmediate(resolve)");
 });


### PR DESCRIPTION
### Problem
- Node runs the poll, then the check phase (`setImmediate`), then the timers. On POSIX, `auto_tick` (`src/runtime/jsc_hooks.rs`) ran the immediates before the poll. So a timer that came due in an I/O callback ran before the immediates that callback queued.
- `node:net` emits a socket's `'close'` from an immediate (`src/js/node/net.ts:4297`). So `test/js/node/test/parallel/test-http-agent-keepalive.js` fails on slow builds: `AssertionError` at `:120`.

### Fix
- On POSIX, run the immediates after the poll and before the timers. The timers still run last, so the caller sees their effects before the next poll.
- Bun runs thread-pool completions in `tick()`, not in the poll. So a tick that ran tasks counts as a poll phase, and the immediates and the timers run once before the next poll.
- Two things relied on the old order. In a nested loop, the poll's nextTicks now run before the check phase. An open `node:http` CONNECT or upgrade tunnel now holds the loop, like a Node socket.
- Verified: new tests in `test/js/node/timers/node-timers.test.ts` and `node-http-connect.test.ts`. On a debug build, the keepalive test fails 7 of 10 runs on main and 0 of 10 here.

### Background
- `auto_tick` is one turn of the loop. Its callers run `tick()` between turns and check a condition.
- A task is work that `tick()` runs, such as the callback of an `fs.stat`.
- A nested loop runs inside a JS call, such as the wait in `expect(promise).resolves`. A callback there does not drain the nextTick queue when it returns.

<details><summary>Notes</summary>

**Order, compared with Node v26.3.0.** A matrix of 21 cases (an I/O callback, a timer, an immediate, a thread-pool callback, or the main script queues work, and the cell records the order). Each cell ran 3 times on Node, on a debug build of main, and on a debug build of this branch.

- This branch matches Node in 15 cells. Main matches Node in 12 of them.
- The 3 cells this branch fixes: an immediate and a due timer from an I/O callback, a timer that queues an immediate while I/O is ready, and an immediate that arms a due timer while I/O is ready.
- The 6 other cells differ from Node in the same way on main. They are the first turn after the main script, `beforeExit`, and thread-pool chains (#33509, #32807, #36548).

**Why the check phase also runs after a tick that ran tasks.** A first version moved only the timers. A second version moved only the immediates. Each broke one case that main gets right:

- A rejection in a timer that an I/O callback handles in the same turn: Node and main exit 1.
- A due unref'd timer after an I/O callback unrefs the last handle: Node and main fire it.
- A timer that comes due in an I/O callback, and a thread-pool callback: Node and main run the timer first.
- A thread-pool callback that starts a connect and queues an immediate: Node and main run the immediate first. `test-http2-goaway-delayed-request.js` depends on this, and it hung on the second version.

Each of these cases is a test now. The connect test fails on the second version.

**A wait that an immediate settles.** The immediates now run before the caller checks its promise, so a `--preload` that awaits an immediate no longer waits for the next I/O event. On main, with a listening server and `BUN_GC_TIMER_DISABLE=1`, the entry point ran 10.7 s late. This is the case of #39268, for POSIX. On Windows it still waits (12 s on the canary), so that test skips Windows.

**Cost.** Release builds without LTO, 100k round trips, median of 7, pinned to one core:

| shape | main | this branch |
| --- | --- | --- |
| `fs.stat` callback chain | 1426 ms | 1407 ms |
| `fs.stat`, then `setImmediate` | 1541 ms | 1636 ms |
| `setImmediate` chain | 193 ms | 201 ms |

The second shape makes one more non-blocking `epoll_pwait2` per round trip, about 1 µs. The poll must not wait after a callback in the early check phase: that callback can settle what the caller waits for. The worker loop checks its entry promise there, for example.

**Three tests that CI found.** All relied on the old order.

- `proxy-stress-errors.test.ts` failed on darwin and on alpine aarch64. A concurrent test waited in `expect(...).rejects`, so the proxy's connect errors arrived in a nested loop. There the socket's `'error'` nextTick waited, and its `'close'` immediate ran first. The proxy then ended the client before it wrote its 502. I reproduced it on a darwin host with the CI binary. The nested-loop test reproduces it on linux.
- `node-http-connect.test.ts` expects the server side of a tunnel to see `'end'` before the process exits. The tunnel did not hold the loop, so the process exited once the client closed. Node stays alive there. Main passed only because the old order polled once more after the immediates.
- `serve-http2-lifecycle.test.ts` attached its `'close'` listener after it awaited an h3 request. The h2 session emits `'close'` from an immediate that a poll callback queued, and the h3 response arrives as a task. The old order ran that task first, most of the time. So the test timed out on main now and then, and `test/flaky-tests.txt` lists this symptom. With the new order it timed out every time. The test now creates the promise before the requests, as its sibling test does.

**Windows.** Windows keeps the old order, because libuv runs the timers inside its poll.

**`drain_timers`.** It returns whether it fired a timer. It also takes `*mut Self` now. Fired handlers re-enter `timer::All`, so a `&mut self` must not stay live across them. A TODO on the function asked for this change.

**Why the test went red on 09-03.** The old order is older than the Rust port. The Zig `autoTick` had it too. #41204 made a first failure final for test files that `test/flaky-tests.txt` does not list. Before it, a failed attempt ran again and was reported as flaky. In 300 builds from 09-01 to 09-03, no attempt of this file failed. The first red build came at 22:20Z on 09-03. No commit in that window touches the loop or `node:net`. Release builds from each side of the window fail at the same low rate under CPU contention. So the trigger is load on the lane, and #41204 makes each failure final.

**Other suites.** Each file that failed only with the change was run alone on both builds.

- 1815 files in `test/js/node/test/parallel` (net, http, http2, tls, stream, process, child-process, timers, worker, fs-watch). No file fails only with the change.
- 353 `bun test` files in `test/js/web/{timers,fetch}`, `test/js/bun/{http,spawn,test}`, `test/js/node/{http,net,stream,process,child_process,worker_threads}`, and `test/cli/run`. Each failure that appeared only with the change was a 5 s timeout under parallel load. Each of those tests passes alone on both builds in the same time.
- `bun run rust:check-all x86_64-pc-windows-msvc aarch64-apple-darwin` passes, and clippy is clean.
- On the Windows canary, the new tests pass (5), and the I/O order test skips.

**Self-review.** It raised six points, and all are addressed: the three cases above, the phase order in `src/event_loop/README.md`, release-build numbers, and the related work below.

**Related.** #40023 (open) moves the Windows timer drain to the site after the poll that this PR also uses. Once both land, the check phase can move on Windows too. #38378 (draft) rebuilds these drive loops. #33509 adds a timers phase before the first turn, and this PR does not change the first turn.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts, test/js/node/http/node-http-connect.test.ts

<!-- robobun:evidence:end -->