### PR TITLE
standalone: check every offset in the embedded module graph before reading it

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -910,6 +910,10 @@ impl StandaloneModuleGraph {
         // the bytecode/module_info regions never have a shared reference formed over them.
         let raw_const: *const u8 = raw_ptr;
 
+        // `bytes` spans `byte_count`, and `page_out` advises the kernel on that whole range.
+        if offsets.byte_count > raw_len {
+            return Err(Corruption::ByteCount.into());
+        }
         // SAFETY: modules metadata blob is a read-only subrange of `[0, raw_len)` disjoint
         // from bytecode/module_info, serialized by `to_bytes`.
         let modules_list_bytes = unsafe {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -947,8 +947,7 @@ impl StandaloneModuleGraph {
         let mut builtin_bytecode: Vec<(u32, *mut [u8])> = Vec::new();
         if offsets.flags.contains(Flags::HAS_BUILTIN_BYTECODE) {
             let count = records.read_u32(Corruption::BuiltinBytecode)? as usize;
-            // Each entry is `{ u32 id, StringPointer bytes }`. Check that `count` of them fit before
-            // `reserve` trusts it.
+            // `reserve` must not trust a count whose entries (`{ u32 id, StringPointer bytes }`) do not fit.
             if count > records.remaining() / (3 * size_of::<u32>()) {
                 return Err(Corruption::BuiltinBytecode.into());
             }
@@ -1089,8 +1088,7 @@ impl StandaloneModuleGraph {
         }
 
         let module_count = modules.count();
-        // `entry_point()` indexes `files` with this id. Two records with one name are one
-        // entry in `files`, so the bound is the entry count and not the record count.
+        // `entry_point()` indexes `files`, which has one entry per name, not one per record.
         if offsets.entry_point_id as usize >= module_count {
             return Err(Corruption::EntryPointId.into());
         }
@@ -1144,8 +1142,7 @@ impl StandaloneModuleGraph {
     }
 }
 
-/// A cursor over the records `to_bytes` chains after the module table. Every read is
-/// checked against `len`, the length of the section at `base`.
+/// A cursor over the records after the module table. Each read is checked against `len`.
 struct RecordChain {
     base: *const u8,
     len: usize,
@@ -1194,9 +1191,7 @@ fn checked_range(len: usize, ptr: StringPointer, tail: usize) -> Option<(usize, 
 /// Read-only subslice helper. Builds a `&'static [u8]` over the *subrange only* so no
 /// shared reference ever spans the writable bytecode/module_info regions of the same
 /// allocation (which would be invalidated by JSC's in-place writes).
-///
-/// `Err(what)` when the pointer reaches past `len`: every offset comes from the
-/// executable, so a damaged one is reported instead of read.
+/// `Err(what)` when the range runs past `len`.
 ///
 /// SAFETY: caller guarantees `base[..len]` is a live 'static allocation and
 /// `[ptr.offset, ptr.offset + ptr.length)` is never written through a `*mut`
@@ -1219,8 +1214,7 @@ unsafe fn slice_to(
 /// Mutable-subslice helper for `from_bytes`. Derives a `*mut [u8]` directly from the raw
 /// section base so the result carries write provenance — going through `slice_to` (which
 /// returns `&[u8]`) and casting `*const [u8] as *mut [u8]` would be UB on write.
-///
-/// `Err(what)` when the pointer reaches past `len`, as in `slice_to`.
+/// `Err(what)` when the range runs past `len`.
 ///
 /// SAFETY: caller guarantees `base[..len]` is a live allocation with write permission.
 unsafe fn slice_to_mut(

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -926,10 +926,6 @@ impl StandaloneModuleGraph {
         let modules_list_count = modules_list_bytes.len() / size_of::<CompiledModuleGraphFile>();
         let modules_list_base = modules_list_bytes.as_ptr();
 
-        if offsets.entry_point_id as usize > modules_list_count {
-            return Err(Corruption::EntryPointId.into());
-        }
-
         // The optional records `to_bytes` chains directly after the module table, in `Flags` bit order.
         let mut records = RecordChain {
             base: raw_const,
@@ -1093,6 +1089,11 @@ impl StandaloneModuleGraph {
         }
 
         let module_count = modules.count();
+        // `entry_point()` indexes `files` with this id. Two records with one name are one
+        // entry in `files`, so the bound is the entry count and not the record count.
+        if offsets.entry_point_id as usize >= module_count {
+            return Err(Corruption::EntryPointId.into());
+        }
         modules.lock_pointers(); // make the pointers stable forever
 
         // Keys are posix-separated already (see `to_bytes`), so byte-scan for `/`.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -23,6 +23,8 @@ use bun_paths::{OSPathBuffer, WPathBuffer};
 use bun_sourcemap as SourceMap;
 use bun_sys::{self as Syscall, E, Fd, FdExt as _, Stat};
 
+use crate::error::Corruption;
+
 bun_core::declare_scope!(StandaloneModuleGraph, hidden);
 
 // `bun_webcore::Blob` lives in a higher tier and `cached_blob` is only ever
@@ -780,15 +782,19 @@ impl LazySourceMap {
                         .collect();
                 for i in 0..source_files_count {
                     // SAFETY: `serialized.bytes` is a 'static read-only sourcemap subrange
-                    // (disjoint from bytecode); StringPointer offsets were serialized by
-                    // `to_bytes` and are in-bounds.
-                    file_names.push(Box::from(unsafe {
+                    // (disjoint from bytecode); `slice_to` checks the name pointer against it.
+                    let Ok(name) = (unsafe {
                         slice_to(
                             serialized.bytes.as_ptr(),
                             serialized.bytes.len(),
                             serialized.source_file_name(i),
+                            Corruption::ModuleSourceMap,
                         )
-                    }));
+                    }) else {
+                        *self = LazySourceMap::None;
+                        return None;
+                    };
+                    file_names.push(Box::from(name));
                 }
 
                 let data = Box::new(SerializedSourceMapLoaded {
@@ -905,7 +911,14 @@ impl StandaloneModuleGraph {
 
         // SAFETY: modules metadata blob is a read-only subrange of `[0, raw_len)` disjoint
         // from bytecode/module_info, serialized by `to_bytes`.
-        let modules_list_bytes = unsafe { slice_to(raw_const, raw_len, offsets.modules_ptr) };
+        let modules_list_bytes = unsafe {
+            slice_to(
+                raw_const,
+                raw_len,
+                offsets.modules_ptr,
+                Corruption::ModuleList,
+            )?
+        };
         // Note: the modules blob sits at an arbitrary byte offset in the section, and
         // `&[CompiledModuleGraphFile]` would require natural alignment (StringPointer's u32 fields
         // → 4-byte). We instead iterate by index and `read_unaligned` each fixed-size record into a
@@ -914,93 +927,66 @@ impl StandaloneModuleGraph {
         let modules_list_base = modules_list_bytes.as_ptr();
 
         if offsets.entry_point_id as usize > modules_list_count {
-            return Err(crate::Error::CorruptedModuleGraphEntryPointIDIsGreaterThanModuleListCount);
+            return Err(Corruption::EntryPointId.into());
         }
 
-        let read_u32 = |at: usize| -> u32 {
-            debug_assert!(at + 4 <= raw_len);
-            // SAFETY: callers pass offsets of records `to_bytes` wrote inside `[0, raw_len)`; unaligned-safe read.
-            unsafe { core::ptr::read_unaligned(raw_const.add(at).cast::<u32>()) }
-        };
-
         // The optional records `to_bytes` chains directly after the module table, in `Flags` bit order.
-        let mut record_at =
-            offsets.modules_ptr.offset as usize + offsets.modules_ptr.length as usize;
+        let mut records = RecordChain {
+            base: raw_const,
+            len: raw_len,
+            at: (offsets.modules_ptr.offset as usize)
+                .saturating_add(offsets.modules_ptr.length as usize),
+        };
 
         let source_hashes: Option<&[u8]> = if offsets.flags.contains(Flags::HAS_SOURCE_HASHES) {
             let length = modules_list_count * size_of::<u32>();
-            // SAFETY: written by `to_bytes` directly after the module table; read-only subrange.
-            let hashes = unsafe {
-                slice_to(
-                    raw_const,
-                    raw_len,
-                    StringPointer {
-                        offset: record_at as u32,
-                        length: length as u32,
-                    },
-                )
-            };
-            record_at += length;
-            Some(hashes)
+            let at = records.take(length, Corruption::SourceHashes)?;
+            // SAFETY: `[at, at + length)` is inside `[0, raw_len)` (checked by `take`); written by
+            // `to_bytes` directly after the module table; read-only subrange.
+            Some(unsafe { core::slice::from_raw_parts(raw_const.add(at), length) })
         } else {
             None
         };
 
         let mut builtin_bytecode: Vec<(u32, *mut [u8])> = Vec::new();
         if offsets.flags.contains(Flags::HAS_BUILTIN_BYTECODE) {
-            let count = read_u32(record_at) as usize;
-            record_at += size_of::<u32>();
+            let count = records.read_u32(Corruption::BuiltinBytecode)? as usize;
+            // Each entry is `{ u32 id, StringPointer bytes }`. Check that `count` of them fit before
+            // `reserve` trusts it.
+            if count > records.remaining() / (3 * size_of::<u32>()) {
+                return Err(Corruption::BuiltinBytecode.into());
+            }
             builtin_bytecode.reserve(count);
             for _ in 0..count {
-                let id = read_u32(record_at);
-                let pointer = StringPointer {
-                    offset: read_u32(record_at + 4),
-                    length: read_u32(record_at + 8),
-                };
-                record_at += 3 * size_of::<u32>();
+                let id = records.read_u32(Corruption::BuiltinBytecode)?;
+                let pointer = records.read_string_pointer(Corruption::BuiltinBytecode)?;
                 // SAFETY: same provenance rules as `File::bytecode`: a writable subrange JSC may patch in place.
-                let bytes = unsafe { slice_to_mut(raw_ptr, raw_len, pointer) };
+                let bytes = unsafe {
+                    slice_to_mut(raw_ptr, raw_len, pointer, Corruption::BuiltinBytecode)?
+                };
                 builtin_bytecode.push((id, bytes));
             }
         }
 
         let bytecode_string_table: &'static [u8] =
             if offsets.flags.contains(Flags::HAS_BYTECODE_STRING_TABLE) {
-                let ptr = StringPointer {
-                    offset: read_u32(record_at),
-                    length: read_u32(record_at + 4),
-                };
-                record_at += 2 * size_of::<u32>();
+                let ptr = records.read_string_pointer(Corruption::BytecodeStringTable)?;
                 // SAFETY: `to_bytes` placed the serialized table via `append_bytecode_aligned` into a read-only, disjoint subrange.
-                unsafe { slice_to(raw_const, raw_len, ptr) }
+                unsafe { slice_to(raw_const, raw_len, ptr, Corruption::BytecodeStringTable)? }
             } else {
                 &[]
             };
 
-        let startup_module_count = if offsets.flags.contains(Flags::HAS_STARTUP_MODULE_COUNT)
-            && record_at + size_of::<u32>() <= raw_len
-        {
-            let count = read_u32(record_at);
-            record_at += size_of::<u32>();
-            count
+        let startup_module_count = if offsets.flags.contains(Flags::HAS_STARTUP_MODULE_COUNT) {
+            records.read_u32(Corruption::StartupModuleCount)?
         } else {
             0
         };
         let module_info_string_table: &'static [u8] =
-            if offsets.flags.contains(Flags::HAS_MODULE_INFO_STRING_TABLE)
-                && record_at + 2 * size_of::<u32>() <= raw_len
-            {
-                let ptr = StringPointer {
-                    offset: read_u32(record_at),
-                    length: read_u32(record_at + 4),
-                };
-                if (ptr.offset as usize).saturating_add(ptr.length as usize) > raw_len {
-                    &[]
-                } else {
-                    // SAFETY: bounds checked above; read-only subrange placed by `to_bytes`, disjoint from
-                    // the writable regions.
-                    unsafe { slice_to(raw_const, raw_len, ptr) }
-                }
+            if offsets.flags.contains(Flags::HAS_MODULE_INFO_STRING_TABLE) {
+                let ptr = records.read_string_pointer(Corruption::ModuleInfoStringTable)?;
+                // SAFETY: read-only subrange placed by `to_bytes`, disjoint from the writable regions.
+                unsafe { slice_to(raw_const, raw_len, ptr, Corruption::ModuleInfoStringTable)? }
             } else {
                 &[]
             };
@@ -1017,15 +1003,30 @@ impl StandaloneModuleGraph {
                 )
             };
             let module = &module;
-            // SAFETY: each name/contents/sourcemap/bytecode_origin_path subrange is in-bounds
-            // (serialized by `to_bytes`) and disjoint from the writable bytecode/module_info
-            // subranges; section bytes are a live 'static allocation.
+            // SAFETY: each name/contents/sourcemap/bytecode_origin_path subrange is checked
+            // against `raw_len` and is disjoint from the writable bytecode/module_info
+            // subranges (serialized by `to_bytes`); section bytes are a live 'static allocation.
             let (name, contents, sourcemap_bytes, bytecode_origin) = unsafe {
                 (
-                    slice_to_z(raw_const, raw_len, module.name),
-                    slice_to_z(raw_const, raw_len, module.contents),
-                    slice_to(raw_const, raw_len, module.sourcemap),
-                    slice_to_z(raw_const, raw_len, module.bytecode_origin_path),
+                    slice_to_z(raw_const, raw_len, module.name, Corruption::ModuleName)?,
+                    slice_to_z(
+                        raw_const,
+                        raw_len,
+                        module.contents,
+                        Corruption::ModuleContents,
+                    )?,
+                    slice_to(
+                        raw_const,
+                        raw_len,
+                        module.sourcemap,
+                        Corruption::ModuleSourceMap,
+                    )?,
+                    slice_to_z(
+                        raw_const,
+                        raw_len,
+                        module.bytecode_origin_path,
+                        Corruption::BytecodeOriginPath,
+                    )?,
                 )
             };
             let _ = modules.put(
@@ -1046,16 +1047,30 @@ impl StandaloneModuleGraph {
                     },
                     bytecode: if module.bytecode.length > 0 {
                         // SAFETY: section bytes are a writable 'static allocation; JSC mutates
-                        // bytecode in place. Subrange is in-bounds (serialized by to_bytes) and
+                        // bytecode in place. Subrange is checked against `raw_len` and is
                         // disjoint from every read-only subslice handed out above — no
                         // `&[u8]` is ever formed over this range.
-                        unsafe { slice_to_mut(raw_ptr, raw_len, module.bytecode) }
+                        unsafe {
+                            slice_to_mut(
+                                raw_ptr,
+                                raw_len,
+                                module.bytecode,
+                                Corruption::ModuleBytecode,
+                            )?
+                        }
                     } else {
                         std::ptr::from_mut::<[u8]>(&mut [])
                     },
                     module_info: if module.module_info.length > 0 {
                         // SAFETY: see bytecode above.
-                        unsafe { slice_to_mut(raw_ptr, raw_len, module.module_info) }
+                        unsafe {
+                            slice_to_mut(
+                                raw_ptr,
+                                raw_len,
+                                module.module_info,
+                                Corruption::ModuleInfo,
+                            )?
+                        }
                     } else {
                         std::ptr::from_mut::<[u8]>(&mut [])
                     },
@@ -1103,7 +1118,12 @@ impl StandaloneModuleGraph {
             entry_point_id: offsets.entry_point_id,
             // SAFETY: read-only argv string subrange, disjoint from writable regions.
             compile_exec_argv: unsafe {
-                slice_to_z(raw_const, raw_len, offsets.compile_exec_argv_ptr)
+                slice_to_z(
+                    raw_const,
+                    raw_len,
+                    offsets.compile_exec_argv_ptr,
+                    Corruption::CompileExecArgv,
+                )?
             }
             .as_bytes(),
             flags: offsets.flags,
@@ -1123,52 +1143,119 @@ impl StandaloneModuleGraph {
     }
 }
 
+/// A cursor over the records `to_bytes` chains after the module table. Every read is
+/// checked against `len`, the length of the section at `base`.
+struct RecordChain {
+    base: *const u8,
+    len: usize,
+    at: usize,
+}
+
+impl RecordChain {
+    fn remaining(&self) -> usize {
+        self.len.saturating_sub(self.at)
+    }
+
+    /// The offset of the next `n` bytes, or `Err(what)` when they run past the section.
+    fn take(&mut self, n: usize, what: Corruption) -> crate::Result<usize> {
+        let at = self.at;
+        self.at = at
+            .checked_add(n)
+            .filter(|&end| end <= self.len)
+            .ok_or(what)?;
+        Ok(at)
+    }
+
+    fn read_u32(&mut self, what: Corruption) -> crate::Result<u32> {
+        let at = self.take(size_of::<u32>(), what)?;
+        // SAFETY: `[at, at + 4)` is inside the section (checked by `take`); unaligned-safe read.
+        Ok(unsafe { core::ptr::read_unaligned(self.base.add(at).cast::<u32>()) })
+    }
+
+    /// A `StringPointer` record. `slice_to` and `slice_to_mut` check the range it names.
+    fn read_string_pointer(&mut self, what: Corruption) -> crate::Result<StringPointer> {
+        let offset = self.read_u32(what)?;
+        let length = self.read_u32(what)?;
+        Ok(StringPointer { offset, length })
+    }
+}
+
+/// `(offset, length)` of `ptr` if `[offset, offset + length + tail)` fits in `len`.
+fn checked_range(len: usize, ptr: StringPointer, tail: usize) -> Option<(usize, usize)> {
+    let off = ptr.offset as usize;
+    let n = ptr.length as usize;
+    off.checked_add(n)?
+        .checked_add(tail)
+        .filter(|&end| end <= len)
+        .map(|_| (off, n))
+}
+
 /// Read-only subslice helper. Builds a `&'static [u8]` over the *subrange only* so no
 /// shared reference ever spans the writable bytecode/module_info regions of the same
 /// allocation (which would be invalidated by JSC's in-place writes).
 ///
+/// `Err(what)` when the pointer reaches past `len`: every offset comes from the
+/// executable, so a damaged one is reported instead of read.
+///
 /// SAFETY: caller guarantees `base[..len]` is a live 'static allocation and
-/// `[ptr.offset, ptr.offset + ptr.length)` is in-bounds and never written through a
-/// `*mut` alias for the lifetime of the returned reference.
-unsafe fn slice_to(base: *const u8, len: usize, ptr: StringPointer) -> &'static [u8] {
+/// `[ptr.offset, ptr.offset + ptr.length)` is never written through a `*mut`
+/// alias for the lifetime of the returned reference.
+unsafe fn slice_to(
+    base: *const u8,
+    len: usize,
+    ptr: StringPointer,
+    what: Corruption,
+) -> crate::Result<&'static [u8]> {
     if ptr.length == 0 {
-        return b"";
+        return Ok(b"");
     }
-    let off = ptr.offset as usize;
-    let n = ptr.length as usize;
-    debug_assert!(off.checked_add(n).is_some_and(|end| end <= len));
-    let _ = len;
-    // SAFETY: caller contract — `[off, off+n)` lies within a live 'static read-only allocation.
-    unsafe { core::slice::from_raw_parts(base.add(off), n) }
+    let (off, n) = checked_range(len, ptr, 0).ok_or(what)?;
+    // SAFETY: `[off, off+n)` is within `len` (checked above) and, per the caller
+    // contract, is a live 'static read-only allocation.
+    Ok(unsafe { core::slice::from_raw_parts(base.add(off), n) })
 }
 
 /// Mutable-subslice helper for `from_bytes`. Derives a `*mut [u8]` directly from the raw
 /// section base so the result carries write provenance — going through `slice_to` (which
 /// returns `&[u8]`) and casting `*const [u8] as *mut [u8]` would be UB on write.
 ///
-/// SAFETY: caller guarantees `base[..len]` is a live allocation with write permission and
-/// that `[ptr.offset, ptr.offset + ptr.length)` is in-bounds.
-unsafe fn slice_to_mut(base: *mut u8, len: usize, ptr: StringPointer) -> *mut [u8] {
-    let off = ptr.offset as usize;
-    let n = ptr.length as usize;
-    debug_assert!(off.checked_add(n).is_some_and(|end| end <= len));
-    let _ = len;
-    // SAFETY: caller contract — `off` is in-bounds of the writable allocation at `base`.
-    core::ptr::slice_from_raw_parts_mut(unsafe { base.add(off) }, n)
+/// `Err(what)` when the pointer reaches past `len`, as in `slice_to`.
+///
+/// SAFETY: caller guarantees `base[..len]` is a live allocation with write permission.
+unsafe fn slice_to_mut(
+    base: *mut u8,
+    len: usize,
+    ptr: StringPointer,
+    what: Corruption,
+) -> crate::Result<*mut [u8]> {
+    let (off, n) = checked_range(len, ptr, 0).ok_or(what)?;
+    // SAFETY: `off` is within `len` (checked above) of the writable allocation at `base`.
+    Ok(core::ptr::slice_from_raw_parts_mut(
+        unsafe { base.add(off) },
+        n,
+    ))
 }
 
-/// SAFETY: as `slice_to`, plus `base[ptr.offset + ptr.length] == 0` (written by
-/// `to_bytes` via `appendCountZ`).
-unsafe fn slice_to_z(base: *const u8, len: usize, ptr: StringPointer) -> &'static ZStr {
+/// As `slice_to`, and also `Err(what)` unless `base[ptr.offset + ptr.length] == 0`
+/// (written by `to_bytes` via `appendCountZ`).
+///
+/// SAFETY: as `slice_to`.
+unsafe fn slice_to_z(
+    base: *const u8,
+    len: usize,
+    ptr: StringPointer,
+    what: Corruption,
+) -> crate::Result<&'static ZStr> {
     if ptr.length == 0 {
-        return ZStr::EMPTY;
+        return Ok(ZStr::EMPTY);
     }
-    let off = ptr.offset as usize;
-    let n = ptr.length as usize;
-    debug_assert!(off.checked_add(n).is_some_and(|end| end < len));
-    let _ = len;
-    // SAFETY: caller contract — `[off, off+n]` is in-bounds with a NUL terminator at `base[off+n]`.
-    unsafe { ZStr::from_raw(base.add(off), n) }
+    let (off, n) = checked_range(len, ptr, 1).ok_or(what)?;
+    // SAFETY: `off + n < len` (checked above), so the terminator byte is in bounds.
+    if unsafe { *base.add(off + n) } != 0 {
+        return Err(what.into());
+    }
+    // SAFETY: `[off, off+n]` is in-bounds with a NUL terminator at `base[off+n]`.
+    Ok(unsafe { ZStr::from_raw(base.add(off), n) })
 }
 
 /// A text import the bundler emitted as an asset (`Loader::Text` arm of

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -770,6 +770,8 @@ impl LazySourceMap {
                 // Note: `from_internal` fills `internal = Some(ism)` +
                 // `input_line_count = ism.input_line_count()` and defaults the rest.
                 let mut stored = SourceMap::ParsedSourceMap::from_internal(ism);
+                // The blob is in the executable, so no drop of `stored` may free it, not even the early return below.
+                stored.is_standalone_module_graph = true;
 
                 let source_files_count = serialized.source_files_count();
                 // PERF: `external_source_names` is `Vec<Box<[u8]>>` so we
@@ -812,7 +814,6 @@ impl LazySourceMap {
                 stored.underlying_provider = SourceMap::SourceContentPtr::from_provider(
                     bun_core::heap::into_raw(data).cast::<SourceMap::SourceProviderMap>(),
                 );
-                stored.is_standalone_module_graph = true;
 
                 let parsed = Arc::new(stored);
                 // The Arc clone held in self keeps the parsed map alive.

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -1,6 +1,7 @@
 /// The field of the embedded module graph that `StandaloneModuleGraph::from_bytes` found out of range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Corruption {
+    ByteCount,
     ModuleList,
     EntryPointId,
     ModuleName,
@@ -20,6 +21,7 @@ pub enum Corruption {
 impl Corruption {
     pub const fn message(self) -> &'static str {
         match self {
+            Self::ByteCount => "Corrupted module graph: byte count is out of range",
             Self::ModuleList => "Corrupted module graph: module list is out of range",
             Self::EntryPointId => {
                 "Corrupted module graph: entry point ID is out of range for the module list"

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -24,7 +24,7 @@ impl Corruption {
         match self {
             Self::ModuleList => "Corrupted module graph: module list is out of range",
             Self::EntryPointId => {
-                "Corrupted module graph: entry point ID is greater than module list count"
+                "Corrupted module graph: entry point ID is out of range for the module list"
             }
             Self::ModuleName => "Corrupted module graph: module name is out of range",
             Self::ModuleContents => "Corrupted module graph: module contents are out of range",

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -1,6 +1,4 @@
-/// The part of the embedded module graph that `StandaloneModuleGraph::from_bytes`
-/// found out of range. Every offset comes from the executable, so a damaged one
-/// is reported instead of read.
+/// The field of the embedded module graph that `StandaloneModuleGraph::from_bytes` found out of range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Corruption {
     ModuleList,

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -1,7 +1,61 @@
+/// The part of the embedded module graph that `StandaloneModuleGraph::from_bytes`
+/// found out of range. Every offset comes from the executable, so a damaged one
+/// is reported instead of read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Corruption {
+    ModuleList,
+    EntryPointId,
+    ModuleName,
+    ModuleContents,
+    ModuleSourceMap,
+    ModuleBytecode,
+    ModuleInfo,
+    BytecodeOriginPath,
+    CompileExecArgv,
+    SourceHashes,
+    BuiltinBytecode,
+    BytecodeStringTable,
+    StartupModuleCount,
+    ModuleInfoStringTable,
+}
+
+impl Corruption {
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::ModuleList => "Corrupted module graph: module list is out of range",
+            Self::EntryPointId => {
+                "Corrupted module graph: entry point ID is greater than module list count"
+            }
+            Self::ModuleName => "Corrupted module graph: module name is out of range",
+            Self::ModuleContents => "Corrupted module graph: module contents are out of range",
+            Self::ModuleSourceMap => "Corrupted module graph: module source map is out of range",
+            Self::ModuleBytecode => "Corrupted module graph: module bytecode is out of range",
+            Self::ModuleInfo => "Corrupted module graph: module info is out of range",
+            Self::BytecodeOriginPath => {
+                "Corrupted module graph: bytecode origin path is out of range"
+            }
+            Self::CompileExecArgv => "Corrupted module graph: compile exec argv is out of range",
+            Self::SourceHashes => "Corrupted module graph: source hashes are out of range",
+            Self::BuiltinBytecode => {
+                "Corrupted module graph: builtin bytecode table is out of range"
+            }
+            Self::BytecodeStringTable => {
+                "Corrupted module graph: bytecode string table is out of range"
+            }
+            Self::StartupModuleCount => {
+                "Corrupted module graph: startup module count is out of range"
+            }
+            Self::ModuleInfoStringTable => {
+                "Corrupted module graph: module info string table is out of range"
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("Corrupted module graph: entry point ID is greater than module list count")]
-    CorruptedModuleGraphEntryPointIDIsGreaterThanModuleListCount,
+    #[error("{}", .0.message())]
+    CorruptedModuleGraph(Corruption),
     #[error("TargetNotFound")]
     TargetNotFound,
     #[error("NetworkError")]
@@ -28,6 +82,12 @@ pub enum Error {
     Options(#[from] bun_options_types::Error),
 }
 
+impl From<Corruption> for Error {
+    fn from(c: Corruption) -> Self {
+        Self::CorruptedModuleGraph(c)
+    }
+}
+
 impl From<bun_sys::Error> for Error {
     fn from(e: bun_sys::Error) -> Self {
         Self::Sys(e.into())
@@ -38,9 +98,7 @@ impl Error {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {
-            Self::CorruptedModuleGraphEntryPointIDIsGreaterThanModuleListCount => {
-                "Corrupted module graph: entry point ID is greater than module list count"
-            }
+            Self::CorruptedModuleGraph(c) => c.message(),
             Self::TargetNotFound => "TargetNotFound",
             Self::NetworkError => "NetworkError",
             Self::InvalidResponse => "InvalidResponse",

--- a/test/bundler/compile-corrupted-graph.test.ts
+++ b/test/bundler/compile-corrupted-graph.test.ts
@@ -1,15 +1,16 @@
 // A compiled executable carries its module graph in the `.bun` section. The graph ends
 // with `Offsets`, then the trailer. `Offsets` points at the module table and at the
-// compile exec argv string. Each 52-byte module record starts with six
+// compile exec argv string, and holds the index of the entry point in the module table.
+// Each 52-byte module record starts with six
 // { u32 offset, u32 length } pointers: name, contents, source map, bytecode, module info
 // and bytecode origin path. After the module table, `to_bytes` chains records in `Flags`
 // bit order: a u32 source hash per module, the builtin bytecode table (u32 count, then
 // count x { u32 id, u32 offset, u32 length }) and, with --bytecode, a pointer to the
 // bytecode string table.
 //
-// These offsets come from the file. Each case damages one of them, and the executable
+// These fields come from the file. Each case damages one of them, and the executable
 // must report it at startup. `StandaloneModuleGraph::from_bytes` used to read past the
-// end of the section instead, and a release build crashed with a segfault.
+// end of the section instead, and a release build crashed.
 
 import { expect, test } from "bun:test";
 import { bunEnv, isMacOS, tempDir } from "harness";
@@ -35,8 +36,10 @@ function locateRecords(executable: Buffer) {
   const builtinCount = executable.readUInt32LE(builtinTableAt);
   return {
     flags: executable.readUInt32LE(offsetsAt + 28),
+    moduleCount: modulesLength / MODULE_RECORD_SIZE,
     builtinCount,
     modulesLengthAt: offsetsAt + 12,
+    entryPointIdAt: offsetsAt + 16,
     execArgvOffsetAt: offsetsAt + 20,
     firstModuleNameOffsetAt: modulesAt,
     firstModuleContentsLengthAt: modulesAt + 12,
@@ -54,6 +57,14 @@ const cases = [
     field: (records: Records) => records.modulesLengthAt,
     value: 0x7ffffff0,
     error: "module list is out of range",
+  },
+  {
+    // The app is one module (the layout check below asserts it), so 1 is one past the end.
+    label: "an entry point ID equal to the module count",
+    bytecode: false,
+    field: (records: Records) => records.entryPointIdAt,
+    value: 1,
+    error: "entry point ID is out of range for the module list",
   },
   {
     label: "a compile exec argv that starts past the end of the graph",
@@ -105,7 +116,7 @@ const cases = [
 // binary (about 800 MB under debug and ASAN), and reads it into memory. So the cases run
 // one at a time, each with a higher timeout.
 test.skipIf(isMacOS).each(cases)(
-  "$label is reported instead of read",
+  "$label is reported as a corrupted module graph",
   async ({ bytecode, execArgv, field, value, error }) => {
     // node:path gives the --bytecode build some builtin bytecode entries.
     using dir = tempDir("compile-corrupted-graph", {
@@ -125,8 +136,9 @@ test.skipIf(isMacOS).each(cases)(
     const expectedFlags = HAS_SOURCE_HASHES | HAS_BUILTIN_BYTECODE | (bytecode ? HAS_BYTECODE_STRING_TABLE : 0);
     expect({
       flags: records.flags & (HAS_SOURCE_HASHES | HAS_BUILTIN_BYTECODE | HAS_BYTECODE_STRING_TABLE),
+      moduleCount: records.moduleCount,
       hasBuiltinBytecode: records.builtinCount > 0,
-    }).toEqual({ flags: expectedFlags, hasBuiltinBytecode: bytecode });
+    }).toEqual({ flags: expectedFlags, moduleCount: 1, hasBuiltinBytecode: bytecode });
 
     // Write only the damaged field. The rest of the file stays as the build wrote it.
     const bytes = Buffer.alloc(4);

--- a/test/bundler/compile-corrupted-graph.test.ts
+++ b/test/bundler/compile-corrupted-graph.test.ts
@@ -1,12 +1,11 @@
 // A compiled executable carries its module graph in the `.bun` section. The graph ends
-// with `Offsets`, then the trailer. `Offsets` points at the module table and at the
-// compile exec argv string, and holds the index of the entry point in the module table.
-// Each 52-byte module record starts with six
-// { u32 offset, u32 length } pointers: name, contents, source map, bytecode, module info
-// and bytecode origin path. After the module table, `to_bytes` chains records in `Flags`
-// bit order: a u32 source hash per module, the builtin bytecode table (u32 count, then
-// count x { u32 id, u32 offset, u32 length }) and, with --bytecode, a pointer to the
-// bytecode string table.
+// with `Offsets`, then the trailer. `Offsets` holds the size of the graph and the index of
+// the entry point, and it points at the module table and at the compile exec argv string.
+// Each 52-byte module record starts with six { u32 offset, u32 length } pointers: name,
+// contents, source map, bytecode, module info and bytecode origin path. After the module
+// table, `to_bytes` chains records in `Flags` bit order: a u32 source hash per module, the
+// builtin bytecode table (u32 count, then count x { u32 id, u32 offset, u32 length }) and,
+// with --bytecode, a pointer to the bytecode string table.
 //
 // These fields come from the file. Each case damages one of them, and the executable
 // must report it at startup. `StandaloneModuleGraph::from_bytes` used to read past the
@@ -41,6 +40,7 @@ function locateRecords(executable: Buffer) {
     moduleCount: modulesLength / MODULE_RECORD_SIZE,
     sourceMapLength: executable.readUInt32LE(modulesAt + 20),
     builtinCount,
+    byteCountLowAt: offsetsAt,
     modulesLengthAt: offsetsAt + 12,
     entryPointIdAt: offsetsAt + 16,
     execArgvOffsetAt: offsetsAt + 20,
@@ -67,6 +67,14 @@ function writeUInt32At(path: string, position: number, value: number) {
 }
 
 const cases = [
+  {
+    // `byte_count` is a u64. The graph is far smaller than 4 GiB, so its high half stays 0.
+    label: "a byte count larger than the section",
+    bytecode: false,
+    field: (records: Records) => records.byteCountLowAt,
+    value: 0x7ffffff0,
+    error: "byte count is out of range",
+  },
   {
     label: "a module list that runs past the end of the graph",
     bytecode: false,

--- a/test/bundler/compile-corrupted-graph.test.ts
+++ b/test/bundler/compile-corrupted-graph.test.ts
@@ -34,21 +34,37 @@ function locateRecords(executable: Buffer) {
   const modulesLength = executable.readUInt32LE(offsetsAt + 12);
   const builtinTableAt = modulesAt + modulesLength + (modulesLength / MODULE_RECORD_SIZE) * 4;
   const builtinCount = executable.readUInt32LE(builtinTableAt);
+  // A serialized source map starts with { u32 file count, u32 map length }, then a pointer to each file name.
+  const sourceMapAt = graphAt + executable.readUInt32LE(modulesAt + 16);
   return {
     flags: executable.readUInt32LE(offsetsAt + 28),
     moduleCount: modulesLength / MODULE_RECORD_SIZE,
+    sourceMapLength: executable.readUInt32LE(modulesAt + 20),
     builtinCount,
     modulesLengthAt: offsetsAt + 12,
     entryPointIdAt: offsetsAt + 16,
     execArgvOffsetAt: offsetsAt + 20,
     firstModuleNameOffsetAt: modulesAt,
     firstModuleContentsLengthAt: modulesAt + 12,
+    firstSourceFileNameOffsetAt: sourceMapAt + 8,
     builtinCountAt: builtinTableAt,
     firstBuiltinOffsetAt: builtinTableAt + 4 + 4,
     bytecodeStringTableOffsetAt: builtinTableAt + 4 + 12 * builtinCount,
   };
 }
 type Records = ReturnType<typeof locateRecords>;
+
+/** Writes only the damaged field. The rest of the file stays as the build wrote it. */
+function writeUInt32At(path: string, position: number, value: number) {
+  const bytes = Buffer.alloc(4);
+  bytes.writeUInt32LE(value);
+  const fd = openSync(path, "r+");
+  try {
+    expect(writeSync(fd, bytes, 0, bytes.length, position)).toBe(bytes.length);
+  } finally {
+    closeSync(fd);
+  }
+}
 
 const cases = [
   {
@@ -140,21 +156,47 @@ test.skipIf(isMacOS).each(cases)(
       hasBuiltinBytecode: records.builtinCount > 0,
     }).toEqual({ flags: expectedFlags, moduleCount: 1, hasBuiltinBytecode: bytecode });
 
-    // Write only the damaged field. The rest of the file stays as the build wrote it.
-    const bytes = Buffer.alloc(4);
-    bytes.writeUInt32LE(value);
-    const fd = openSync(outfile, "r+");
-    try {
-      expect(writeSync(fd, bytes, 0, bytes.length, field(records))).toBe(bytes.length);
-    } finally {
-      closeSync(fd);
-    }
+    writeUInt32At(outfile, field(records), value);
 
     await using proc = Bun.spawn({ cmd: [outfile], env: bunEnv, stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: "",
       stderr: expect.stringContaining(`Corrupted module graph: ${error}`),
+      exitCode: 1,
+    });
+  },
+  60_000,
+);
+
+// The source map is read only when a stack trace prints. A file name that is out of range
+// makes the map absent, so the trace shows the bundled path and not `app.js`.
+test.skipIf(isMacOS)(
+  "a source map file name that starts past the end of the source map makes the map absent",
+  async () => {
+    using dir = tempDir("compile-corrupted-source-map", {
+      "app.js": `throw new Error("thrown by the app");`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "app.js")],
+      compile: { outfile: join(String(dir), "app") },
+      sourcemap: "inline",
+    });
+    expect(result.success).toBe(true);
+    const outfile = result.outputs.find(output => output.kind === "entry-point")!.path;
+
+    const records = locateRecords(Buffer.from(await Bun.file(outfile).arrayBuffer()));
+    expect({ moduleCount: records.moduleCount, hasSourceMap: records.sourceMapLength > 0 }).toEqual({
+      moduleCount: 1,
+      hasSourceMap: true,
+    });
+    writeUInt32At(outfile, records.firstSourceFileNameOffsetAt, 0x7ffffff0);
+
+    await using proc = Bun.spawn({ cmd: [outfile], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringMatching(/thrown by the app[\s\S]*(\$bunfs|~BUN)\/root\/app/),
       exitCode: 1,
     });
   },

--- a/test/bundler/compile-corrupted-graph.test.ts
+++ b/test/bundler/compile-corrupted-graph.test.ts
@@ -1,0 +1,150 @@
+// A compiled executable carries its module graph in the `.bun` section. The graph ends
+// with `Offsets`, then the trailer. `Offsets` points at the module table and at the
+// compile exec argv string. Each 52-byte module record starts with six
+// { u32 offset, u32 length } pointers: name, contents, source map, bytecode, module info
+// and bytecode origin path. After the module table, `to_bytes` chains records in `Flags`
+// bit order: a u32 source hash per module, the builtin bytecode table (u32 count, then
+// count x { u32 id, u32 offset, u32 length }) and, with --bytecode, a pointer to the
+// bytecode string table.
+//
+// These offsets come from the file. Each case damages one of them, and the executable
+// must report it at startup. `StandaloneModuleGraph::from_bytes` used to read past the
+// end of the section instead, and a release build crashed with a segfault.
+
+import { expect, test } from "bun:test";
+import { bunEnv, isMacOS, tempDir } from "harness";
+import { closeSync, openSync, writeSync } from "node:fs";
+import { join } from "node:path";
+
+const TRAILER = "\n---- Bun! ----\n";
+// repr(C): byte_count u64, modules_ptr { offset u32, length u32 }, entry_point_id u32,
+// compile_exec_argv_ptr { offset u32, length u32 }, flags u32.
+const OFFSETS_SIZE = 32;
+const MODULE_RECORD_SIZE = 52;
+const HAS_SOURCE_HASHES = 1 << 5;
+const HAS_BUILTIN_BYTECODE = 1 << 6;
+const HAS_BYTECODE_STRING_TABLE = 1 << 7;
+
+/** File positions of the fields that the cases damage. */
+function locateRecords(executable: Buffer) {
+  const offsetsAt = executable.lastIndexOf(TRAILER) - OFFSETS_SIZE;
+  const graphAt = offsetsAt - Number(executable.readBigUInt64LE(offsetsAt));
+  const modulesAt = graphAt + executable.readUInt32LE(offsetsAt + 8);
+  const modulesLength = executable.readUInt32LE(offsetsAt + 12);
+  const builtinTableAt = modulesAt + modulesLength + (modulesLength / MODULE_RECORD_SIZE) * 4;
+  const builtinCount = executable.readUInt32LE(builtinTableAt);
+  return {
+    flags: executable.readUInt32LE(offsetsAt + 28),
+    builtinCount,
+    modulesLengthAt: offsetsAt + 12,
+    execArgvOffsetAt: offsetsAt + 20,
+    firstModuleNameOffsetAt: modulesAt,
+    firstModuleContentsLengthAt: modulesAt + 12,
+    builtinCountAt: builtinTableAt,
+    firstBuiltinOffsetAt: builtinTableAt + 4 + 4,
+    bytecodeStringTableOffsetAt: builtinTableAt + 4 + 12 * builtinCount,
+  };
+}
+type Records = ReturnType<typeof locateRecords>;
+
+const cases = [
+  {
+    label: "a module list that runs past the end of the graph",
+    bytecode: false,
+    field: (records: Records) => records.modulesLengthAt,
+    value: 0x7ffffff0,
+    error: "module list is out of range",
+  },
+  {
+    label: "a compile exec argv that starts past the end of the graph",
+    bytecode: false,
+    execArgv: ["--smol"],
+    field: (records: Records) => records.execArgvOffsetAt,
+    value: 0x7ffffff0,
+    error: "compile exec argv is out of range",
+  },
+  {
+    label: "a module name that starts past the end of the graph",
+    bytecode: false,
+    field: (records: Records) => records.firstModuleNameOffsetAt,
+    value: 0xfffffff0,
+    error: "module name is out of range",
+  },
+  {
+    label: "module contents that run past the end of the graph",
+    bytecode: false,
+    field: (records: Records) => records.firstModuleContentsLengthAt,
+    value: 0x7fffffff,
+    error: "module contents are out of range",
+  },
+  {
+    label: "a builtin bytecode count larger than the graph",
+    bytecode: false,
+    field: (records: Records) => records.builtinCountAt,
+    value: 0xfffffff0,
+    error: "builtin bytecode table is out of range",
+  },
+  {
+    label: "a builtin bytecode entry that starts past the end of the graph",
+    bytecode: true,
+    field: (records: Records) => records.firstBuiltinOffsetAt,
+    value: 0x7ffffff0,
+    error: "builtin bytecode table is out of range",
+  },
+  {
+    label: "a bytecode string table that starts past the end of the graph",
+    bytecode: true,
+    field: (records: Records) => records.bytecodeStringTableOffsetAt,
+    value: 0x7ffffff0,
+    error: "bytecode string table is out of range",
+  },
+];
+
+// macOS is skipped: a patched Mach-O needs a new signature, and `from_bytes` is the same
+// code on every platform. Each case compiles its own executable, a copy of the whole bun
+// binary (about 800 MB under debug and ASAN), and reads it into memory. So the cases run
+// one at a time, each with a higher timeout.
+test.skipIf(isMacOS).each(cases)(
+  "$label is reported instead of read",
+  async ({ bytecode, execArgv, field, value, error }) => {
+    // node:path gives the --bytecode build some builtin bytecode entries.
+    using dir = tempDir("compile-corrupted-graph", {
+      "app.js": `import { join } from "node:path";\nconsole.log(join("should", "not", "run"));`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "app.js")],
+      compile: { outfile: join(String(dir), "app"), execArgv },
+      bytecode,
+      format: "esm",
+      target: "bun",
+    });
+    expect(result.success).toBe(true);
+    const outfile = result.outputs[0].path;
+
+    const records = locateRecords(Buffer.from(await Bun.file(outfile).arrayBuffer()));
+    const expectedFlags = HAS_SOURCE_HASHES | HAS_BUILTIN_BYTECODE | (bytecode ? HAS_BYTECODE_STRING_TABLE : 0);
+    expect({
+      flags: records.flags & (HAS_SOURCE_HASHES | HAS_BUILTIN_BYTECODE | HAS_BYTECODE_STRING_TABLE),
+      hasBuiltinBytecode: records.builtinCount > 0,
+    }).toEqual({ flags: expectedFlags, hasBuiltinBytecode: bytecode });
+
+    // Write only the damaged field. The rest of the file stays as the build wrote it.
+    const bytes = Buffer.alloc(4);
+    bytes.writeUInt32LE(value);
+    const fd = openSync(outfile, "r+");
+    try {
+      expect(writeSync(fd, bytes, 0, bytes.length, field(records))).toBe(bytes.length);
+    } finally {
+      closeSync(fd);
+    }
+
+    await using proc = Bun.spawn({ cmd: [outfile], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining(`Corrupted module graph: ${error}`),
+      exitCode: 1,
+    });
+  },
+  60_000,
+);


### PR DESCRIPTION
### Problem
- A damaged offset in the embedded module graph crashes the executable at startup. Sentry BUN-4SPC (Windows x64): `Segmentation fault` in `bun_standalone_graph::StandaloneModuleGraph::from_bytes::closure$0`.
- `from_bytes` (`src/standalone_graph/StandaloneModuleGraph.rs:876`) reads every offset from the file. Only `debug_assert!`s check them. In a release build, a bad offset reads past the end of the `.bun` section.

### Fix
- `slice_to`, `slice_to_mut` and `slice_to_z` check the range against the section length. A bad range prints `Corrupted module graph: <field> is out of range` and exits with code 1. This is the check from #37639.
- The records after the module table are read through `RecordChain`, a cursor that checks each read. The builtin count is checked before `Vec::reserve`. Two records that were skipped when out of range now return the same error.
- `byte_count` and the entry point ID are checked too. Before, an ID equal to the record count made `entry_point()` panic.
- Verified: `test/bundler/compile-corrupted-graph.test.ts`. Without the fix, release builds fail all ten tests. Also the `test/bundler/` compile suites. Self-reviewed: 9 concerns raised, 9 addressed.

### Background
- `bun build --compile` appends the graph to a copy of bun. On Windows, it is the last section, `.bun`.
- A `StringPointer` is a `u32` offset and a `u32` length into the graph. `Offsets` ends the graph and points at the module table. Each module record holds six more.
- After the module table, `to_bytes` writes optional records in `Flags` bit order (#40201, #40407, #40509). v1.4.1 is the first release with them.
- #37639 predates those records. This PR takes its helper check, with credit, but not its repeated-name check.

<details><summary>Notes</summary>

**Reproduction.** Compile an app, write one damaged `u32` into the file, and run it. The test does this for ten fields:

| Field | Value | Release build without the fix |
| --- | --- | --- |
| `byte_count`, low half | `0x7ffffff0` | accepted, and the app runs |
| `modules_ptr.length` | `0x7ffffff0` | segfault at the read of the builtin count (the Sentry frame) |
| `entry_point_id` | `1`, the module count | `panic: index out of bounds: the len is 1 but the index is 1` |
| `compile_exec_argv_ptr.offset` | `0x7ffffff0` | segfault |
| first module name offset | `0xfffffff0` | segfault |
| first module contents length | `0x7fffffff` | the parser reads past the source: `SyntaxError: Invalid character: '\0'` |
| builtin bytecode count | `0xfffffff0` | Linux: segfault at a page-aligned address. Windows: `memory allocation of 103079214720 bytes failed` |
| first builtin entry offset (`--bytecode`) | `0x7ffffff0` | segfault |
| bytecode string table offset (`--bytecode`) | `0x7ffffff0` | segfault |
| first file name offset in the source map (`sourcemap: "inline"`) | `0x7ffffff0` | segfault when the stack trace prints |

A debug build without the fix panics in nine of the ten tests, on an old `debug_assert!` or on the index. It accepts the damaged `byte_count`, as the release build does.

**Sentry.** The fault addresses are of two kinds. Some are at a constant offset from the image base, which fits a bad `modules_ptr`. Others are page-aligned, which fits a garbage count that walks off the end of the image. The events come from 1.4.1 builds whose commits are not in this repository, and they are older than the v1.4.1 release. No user issue exists. This PR does not find the cause of the damaged offsets.

**Crash reports.** The new error goes through `handle_root_error`, which prints and exits with code 1. It sends no crash report. So after this PR, a damaged graph does not show in Sentry. The old entry-point error worked the same way.

**Source map fallback.** A source map with a file name out of range is absent, as in #37639. The map sets `is_standalone_module_graph` before that early return. Without the flag, `Drop` frees the mapping blob, and the blob is in the executable.

**`byte_count`.** On Linux, `page_out` calls `madvise(MADV_PAGEOUT)` on the whole `bytes` range when the process is idle. A damaged `byte_count` made that range cover memory outside the graph.

**Error, not skip.** A record that the flags announce must be in range, or the graph is corrupted. #40934 adds a record to the chain and skips a bad one. Whichever PR lands second reads that record through `RecordChain` with one policy.

**Layers.** `pe::get_data`, `elf::get_data` and `macho::get_data` find the section and its length. #31787 checks that length against the section, and #38251 handles a truncated file on Linux. `from_executable` returns `Ok(None)` when there is no section, when the payload is too small, or when the trailer does not match. Then the process runs as `bun`. This PR does not change those cases. `from_bytes` is the only reader of the offsets inside the graph.

**Out of scope.**
- A pointer into the `Offsets` footer. It is inside the section, so it is safe to read.
- Overlapping ranges. Every range is inside the section, and `to_bytes` writes disjoint regions.
- A `startup_module_count` above the module count. It is a prefetch hint, and the existing `min` keeps it in range.
- The offsets inside a serialized source map, other than the file names. The sourcemap crate reads them with checked indexing when a stack trace prints, so a bad one panics and does not read past the section.
- The enum bytes of each module record. #39507 checks them.

**#37639 after this PR.** Its offset checks are here, in the same shape: the `Corruption` enum and `Error::CorruptedModuleGraph(Corruption)`. Its entry point check is here in another form. This PR compares the ID with the entries of `files`, after the loop that builds it. A rebase of #37639 keeps its repeated-name check. I did not take the repeated-name check. `to_bytes` writes unique names only since #40177, so an older executable can have a repeated name. With this PR, such an executable still starts when its entry point ID is in range.

**Test file.** The cases are in a new file next to the other `compile-*.test.ts` topic files. Each case compiles its own executable and reads it into memory (about 800 MB under debug and ASAN), so the cases run one at a time. macOS is skipped, because a patched Mach-O needs a new signature.

**Windows x64.** The ten tests pass with the fix (debug build). The current canary fails all ten.

**Suites run with the fix (debug build, Linux):** `bundler_compile`, `bundler_compile_splitting`, `bundler_compile_autoload`, `bundler_bytecode_portable`, `bun-build-compile`, `bun-build-compile-sourcemap`, `compile-argv`, `compile-process-execargv`, `compile-asset-bunfs`, `compile-sourcemap-internal`, `standalone`. All pass. In `bun-build-compile`, one `--bytecode` test runs longer than its 60 s timeout on this machine. It passes with a longer timeout.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/compile-corrupted-graph.test.ts

<!-- robobun:evidence:end -->