### PR TITLE
node:net: keep the autoSelectFamily defaults per Worker

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -58,9 +58,7 @@ const isWindows = process.platform === "win32";
 
 // Module state, like Node's lib/net.js, so each Worker has its own copy.
 let autoSelectFamilyDefault = true;
-// Node's default is 250ms with a documented floor of 10ms, but the CLI
-// default in node_options.h is 500ms; the vendored test/common multiplies
-// the default by 5 (upstream) assuming 500.
+// Node's docs say 250, but its CLI default in node_options.h is 500.
 let autoSelectFamilyAttemptTimeoutDefault = 500;
 
 function getDefaultAutoSelectFamily() {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -56,10 +56,33 @@ function uv() {
 }
 const isWindows = process.platform === "win32";
 
-const getDefaultAutoSelectFamily = $rust("node_net_binding.rs", "getDefaultAutoSelectFamily");
-const setDefaultAutoSelectFamily = $rust("node_net_binding.rs", "setDefaultAutoSelectFamily");
-const getDefaultAutoSelectFamilyAttemptTimeout = $rust("node_net_binding.rs", "getDefaultAutoSelectFamilyAttemptTimeout"); // prettier-ignore
-const setDefaultAutoSelectFamilyAttemptTimeout = $rust("node_net_binding.rs", "setDefaultAutoSelectFamilyAttemptTimeout"); // prettier-ignore
+// Module state, like Node's lib/net.js, so each Worker has its own copy.
+let autoSelectFamilyDefault = true;
+// Node's default is 250ms with a documented floor of 10ms, but the CLI
+// default in node_options.h is 500ms; the vendored test/common multiplies
+// the default by 5 (upstream) assuming 500.
+let autoSelectFamilyAttemptTimeoutDefault = 500;
+
+function getDefaultAutoSelectFamily() {
+  return autoSelectFamilyDefault;
+}
+
+function setDefaultAutoSelectFamily(value) {
+  validateBoolean(value, "value");
+  autoSelectFamilyDefault = value;
+}
+
+function getDefaultAutoSelectFamilyAttemptTimeout() {
+  return autoSelectFamilyAttemptTimeoutDefault;
+}
+
+function setDefaultAutoSelectFamilyAttemptTimeout(value) {
+  validateInt32(value, "value", 1);
+  if (value < 10) {
+    value = 10;
+  }
+  autoSelectFamilyAttemptTimeoutDefault = value;
+}
 
 /**
  * `--tls-keylog=<file>`: every TLS socket appends its NSS key-log lines here,

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -2,111 +2,12 @@
 //
 
 use core::cell::Cell;
-use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_io::KeepAlive;
-use bun_jsc::{self as jsc, CallFrame, JSFunction, JSGlobalObject, JSValue, JsCell, JsResult};
+use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsCell, JsResult};
 use bun_uws as uws;
 
-use crate::node::util::validators;
 use crate::socket::{Listener, NativeCallbacks, NewSocket, SocketFlags, TCPSocket, TLSSocket};
-
-static AUTO_SELECT_FAMILY_DEFAULT: AtomicBool = AtomicBool::new(true);
-
-// This is only used to provide the getDefaultAutoSelectFamilyAttemptTimeout and
-// setDefaultAutoSelectFamilyAttemptTimeout functions, not currently read by any other code. It's
-// `threadlocal` because Node.js expects each Worker to have its own copy of this, and currently
-// it can only be accessed by accessor functions which run on each Worker's main JavaScript thread.
-//
-// If this becomes used in more places, and especially if it can be read by other threads, we may
-// need to store it as a field in the VirtualMachine instead of in a `threadlocal`.
-thread_local! {
-    // Node's default is 250ms with a documented floor of 10ms, but the CLI
-    // default in node_options.h is 500ms; the vendored test/common multiplies
-    // the default by 5 (upstream) assuming 500.
-    pub(crate) static AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_DEFAULT: Cell<u32> = const { Cell::new(500) };
-}
-
-pub(crate) fn get_default_auto_select_family(global: &JSGlobalObject) -> JSValue {
-    #[bun_jsc::host_fn(export = "Bun__NodeNet__getDefaultAutoSelectFamily")]
-    fn getter(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-        Ok(JSValue::from(
-            AUTO_SELECT_FAMILY_DEFAULT.load(Ordering::Relaxed),
-        ))
-    }
-    // `#[bun_jsc::host_fn]` emits a `__jsc_host_<name>` shim with the raw `JSHostFn` ABI.
-    JSFunction::create(
-        global,
-        "getDefaultAutoSelectFamily",
-        __jsc_host_getter,
-        0,
-        Default::default(),
-    )
-}
-
-pub(crate) fn set_default_auto_select_family(global: &JSGlobalObject) -> JSValue {
-    #[bun_jsc::host_fn(export = "Bun__NodeNet__setDefaultAutoSelectFamily")]
-    fn setter(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        let [arg] = frame.arguments_as_array::<1>();
-        if frame.arguments_count() < 1 {
-            return Err(global.throw(format_args!("missing argument")));
-        }
-        if !arg.is_boolean() {
-            return Err(global.throw_invalid_arguments(format_args!("autoSelectFamilyDefault")));
-        }
-        let value = arg.to_boolean();
-        AUTO_SELECT_FAMILY_DEFAULT.store(value, Ordering::Relaxed);
-        Ok(JSValue::from(value))
-    }
-    JSFunction::create(
-        global,
-        "setDefaultAutoSelectFamily",
-        __jsc_host_setter,
-        1,
-        Default::default(),
-    )
-}
-
-pub(crate) fn get_default_auto_select_family_attempt_timeout(global: &JSGlobalObject) -> JSValue {
-    #[bun_jsc::host_fn(export = "Bun__NodeNet__getDefaultAutoSelectFamilyAttemptTimeout")]
-    fn getter(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-        Ok(JSValue::js_number(f64::from(
-            AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_DEFAULT.with(|v| v.get()),
-        )))
-    }
-    JSFunction::create(
-        global,
-        "getDefaultAutoSelectFamilyAttemptTimeout",
-        __jsc_host_getter,
-        0,
-        Default::default(),
-    )
-}
-
-pub(crate) fn set_default_auto_select_family_attempt_timeout(global: &JSGlobalObject) -> JSValue {
-    #[bun_jsc::host_fn(export = "Bun__NodeNet__setDefaultAutoSelectFamilyAttemptTimeout")]
-    fn setter(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        let [arg] = frame.arguments_as_array::<1>();
-        if frame.arguments_count() < 1 {
-            return Err(global.throw(format_args!("missing argument")));
-        }
-        let mut value =
-            validators::validate_int32(global, arg, format_args!("value"), Some(1), None)?;
-        if value < 10 {
-            value = 10;
-        }
-        AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_DEFAULT
-            .with(|v| v.set(u32::try_from(value).expect("int cast")));
-        Ok(JSValue::js_number(f64::from(value)))
-    }
-    JSFunction::create(
-        global,
-        "setDefaultAutoSelectFamilyAttemptTimeout",
-        __jsc_host_setter,
-        1,
-        Default::default(),
-    )
-}
 
 // codegen (`generated_js2native.rs`) snake-cases the symbol; alias the
 // PascalCase fns so both spellings resolve.

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -345,23 +345,40 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
-// Node keeps this default in the module state of lib/net.js, so each thread has its own copy.
-describe.concurrent("net.setDefaultAutoSelectFamily() is per thread", () => {
-  // Runs `main` as an ES module. In it, `await workerDefault(options)` starts a worker and
-  // resolves to the default that the worker reads, after it applies `workerData.set`.
-  async function expectDefaults(main: string, expected: Record<string, boolean>, execArgv: string[] = []) {
+// Node keeps these defaults in the module state of lib/net.js, so each thread has its own copy.
+describe.concurrent("node:net autoSelectFamily defaults are per thread", () => {
+  type Defaults = { family: boolean; timeout: number };
+  // 500 is the attempt timeout default of Node and of Bun.
+  const initial: Defaults = { family: true, timeout: 500 };
+  const changed: Defaults = { family: false, timeout: 1234 };
+  const flags = ["--no-network-family-autoselection", "--network-family-autoselection-attempt-timeout=1234"];
+
+  // Runs `main` as an ES module. In it, `defaults()` reads the defaults of the main thread, and
+  // `await workerDefaults(options)` starts a worker and resolves to the defaults that the worker
+  // reads, after it applies `workerData.family` and `workerData.timeout`.
+  async function expectDefaults(main: string, expected: Record<string, Defaults>, execArgv: string[] = []) {
     using dir = tempDir("net-autoselect-default", {
       "worker.mjs": `
         import net from "node:net";
         import { parentPort, workerData } from "node:worker_threads";
-        if (workerData?.set !== undefined) net.setDefaultAutoSelectFamily(workerData.set);
-        parentPort.postMessage(net.getDefaultAutoSelectFamily());
+        if (workerData?.family !== undefined) net.setDefaultAutoSelectFamily(workerData.family);
+        if (workerData?.timeout !== undefined) net.setDefaultAutoSelectFamilyAttemptTimeout(workerData.timeout);
+        parentPort.postMessage({
+          family: net.getDefaultAutoSelectFamily(),
+          timeout: net.getDefaultAutoSelectFamilyAttemptTimeout(),
+        });
       `,
       "main.mjs": `
         import { once } from "node:events";
         import net from "node:net";
         import { Worker } from "node:worker_threads";
-        async function workerDefault(options) {
+        function defaults() {
+          return {
+            family: net.getDefaultAutoSelectFamily(),
+            timeout: net.getDefaultAutoSelectFamilyAttemptTimeout(),
+          };
+        }
+        async function workerDefaults(options) {
           const worker = new Worker(new URL("./worker.mjs", import.meta.url), options);
           const [value] = await once(worker, "message");
           return value;
@@ -382,47 +399,48 @@ describe.concurrent("net.setDefaultAutoSelectFamily() is per thread", () => {
     expect(exitCode).toBe(0);
   }
 
-  test("a worker that sets it does not change the main thread or a later worker", async () => {
+  test("a worker that sets them does not change the main thread or a later worker", async () => {
     await expectDefaults(
       `
-      const worker = await workerDefault({ workerData: { set: false } });
-      const main = net.getDefaultAutoSelectFamily();
-      const laterWorker = await workerDefault();
+      const worker = await workerDefaults({ workerData: { family: false, timeout: 1234 } });
+      const main = defaults();
+      const laterWorker = await workerDefaults();
       console.log(JSON.stringify({ worker, main, laterWorker }));
       `,
-      { worker: false, main: true, laterWorker: true },
+      { worker: changed, main: initial, laterWorker: initial },
     );
   });
 
-  test("a worker with --no-network-family-autoselection in execArgv does not change the main thread", async () => {
+  test("a worker with the flags in execArgv does not change the main thread", async () => {
     await expectDefaults(
       `
-      const worker = await workerDefault({ execArgv: ["--no-network-family-autoselection"] });
-      console.log(JSON.stringify({ worker, main: net.getDefaultAutoSelectFamily() }));
+      const worker = await workerDefaults({ execArgv: ${JSON.stringify(flags)} });
+      console.log(JSON.stringify({ worker, main: defaults() }));
       `,
-      { worker: false, main: true },
+      { worker: changed, main: initial },
     );
   });
 
-  test("a main thread that sets it does not change a new worker", async () => {
+  test("a main thread that sets them does not change a new worker", async () => {
     await expectDefaults(
       `
       net.setDefaultAutoSelectFamily(false);
-      const worker = await workerDefault();
-      console.log(JSON.stringify({ main: net.getDefaultAutoSelectFamily(), worker }));
+      net.setDefaultAutoSelectFamilyAttemptTimeout(1234);
+      const worker = await workerDefaults();
+      console.log(JSON.stringify({ main: defaults(), worker }));
       `,
-      { main: false, worker: true },
+      { main: changed, worker: initial },
     );
   });
 
-  test("a worker inherits --no-network-family-autoselection from the process", async () => {
+  test("a worker inherits the flags of the process", async () => {
     await expectDefaults(
       `
-      const worker = await workerDefault();
-      console.log(JSON.stringify({ main: net.getDefaultAutoSelectFamily(), worker }));
+      const worker = await workerDefaults();
+      console.log(JSON.stringify({ main: defaults(), worker }));
       `,
-      { main: false, worker: false },
-      ["--no-network-family-autoselection"],
+      { main: changed, worker: changed },
+      flags,
     );
   });
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -345,6 +345,88 @@ describe("execArgv option", async () => {
   // TODO(@190n) get our handling of non-string array elements in line with Node's
 });
 
+// Node keeps this default in the module state of lib/net.js, so each thread has its own copy.
+describe.concurrent("net.setDefaultAutoSelectFamily() is per thread", () => {
+  // Runs `main` as an ES module. In it, `await workerDefault(options)` starts a worker and
+  // resolves to the default that the worker reads, after it applies `workerData.set`.
+  async function expectDefaults(main: string, expected: Record<string, boolean>, execArgv: string[] = []) {
+    using dir = tempDir("net-autoselect-default", {
+      "worker.mjs": `
+        import net from "node:net";
+        import { parentPort, workerData } from "node:worker_threads";
+        if (workerData?.set !== undefined) net.setDefaultAutoSelectFamily(workerData.set);
+        parentPort.postMessage(net.getDefaultAutoSelectFamily());
+      `,
+      "main.mjs": `
+        import { once } from "node:events";
+        import net from "node:net";
+        import { Worker } from "node:worker_threads";
+        async function workerDefault(options) {
+          const worker = new Worker(new URL("./worker.mjs", import.meta.url), options);
+          const [value] = await once(worker, "message");
+          return value;
+        }
+        ${main}
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...execArgv, "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(expected);
+    expect(exitCode).toBe(0);
+  }
+
+  test("a worker that sets it does not change the main thread or a later worker", async () => {
+    await expectDefaults(
+      `
+      const worker = await workerDefault({ workerData: { set: false } });
+      const main = net.getDefaultAutoSelectFamily();
+      const laterWorker = await workerDefault();
+      console.log(JSON.stringify({ worker, main, laterWorker }));
+      `,
+      { worker: false, main: true, laterWorker: true },
+    );
+  });
+
+  test("a worker with --no-network-family-autoselection in execArgv does not change the main thread", async () => {
+    await expectDefaults(
+      `
+      const worker = await workerDefault({ execArgv: ["--no-network-family-autoselection"] });
+      console.log(JSON.stringify({ worker, main: net.getDefaultAutoSelectFamily() }));
+      `,
+      { worker: false, main: true },
+    );
+  });
+
+  test("a main thread that sets it does not change a new worker", async () => {
+    await expectDefaults(
+      `
+      net.setDefaultAutoSelectFamily(false);
+      const worker = await workerDefault();
+      console.log(JSON.stringify({ main: net.getDefaultAutoSelectFamily(), worker }));
+      `,
+      { main: false, worker: true },
+    );
+  });
+
+  test("a worker inherits --no-network-family-autoselection from the process", async () => {
+    await expectDefaults(
+      `
+      const worker = await workerDefault();
+      console.log(JSON.stringify({ main: net.getDefaultAutoSelectFamily(), worker }));
+      `,
+      { main: false, worker: false },
+      ["--no-network-family-autoselection"],
+    );
+  });
+});
+
 test("eval does not leak source code", async () => {
   const proc = Bun.spawn({
     cmd: [bunExe(), "eval-source-leak-fixture.js"],


### PR DESCRIPTION
### Problem
- `net.setDefaultAutoSelectFamily(false)` in a Worker changes the default for the main thread and for every later Worker. A Worker with `execArgv: ["--no-network-family-autoselection"]` does the same, because `src/js/node/net.ts:89` calls the setter at module load.
- The cause is `src/runtime/node/node_net_binding.rs:14`. It stores the default in a process-global `static AtomicBool`. No user reported this. A comparison with Node.js found it.

### Fix
- Keep both defaults in the module state of `src/js/node/net.ts`, as Node's `lib/net.js` does. Only `net.ts` read them, so the Rust storage and its four host functions go away.
- Each Worker has its own copy now. A `setDefaultAutoSelectFamily(false)` on the main thread no longer reaches workers. A Worker with no `execArgv` option still inherits the CLI flags through `process.execArgv`.
- Side effects, as in Node: the setters return `undefined`, and a bad argument throws Node's error text. Under `bun test --isolate`, each file starts with the initial defaults.
- Verified: `test/js/node/worker_threads/worker_threads.test.ts` has four new tests, for both defaults. The released build fails three, and the fourth guards the flag inheritance. Self-reviewed: 1 concern raised, 1 addressed.

### Background
- Each Worker has its own global object and its own instance of each built-in module. So a `let` at the top of `net.ts` has one copy per Worker.
- `bun test --isolate` runs each test file in a fresh global object.
- `getDefaultAutoSelectFamily()` is the default for the `autoSelectFamily` option of `net.connect()`. When it is on, a connect tries the IPv6 and IPv4 addresses of a host in turn.

<details><summary>Notes</summary>

- Repro with one process: a worker sets `false`, then a worker starts with the flag, then a plain worker starts, then the main thread sets `false` and starts one more worker. Node v26.3.0 prints `true` for the main thread and for the plain workers. The released build prints `false` for all of them. The debug build with this change prints the same output as Node, with and without the flag on the main process.
- Setter results: 13 calls with bad arguments and good arguments give the same output as Node v26.3.0, for example `setDefaultAutoSelectFamily()`, `setDefaultAutoSelectFamily("x")`, and `setDefaultAutoSelectFamilyAttemptTimeout(0)`, `(1.5)`, `("50")`, `(2 ** 31)`, `(5)`.
- Self-review: a first version kept the value in a Rust `thread_local!`. `REVIEW.md` forbids thread-locals for per-VM state. That version also still carried the value from one `--isolate` file to the next (checked with two test files).
- Nested workers: a nested Worker with no `execArgv` option gets the `execArgv` of the process, not the one of its parent worker (`src/runtime/node/node_process.rs:229`). Node inherits from the parent thread. So the default of a nested worker follows the process flags. Before this change it followed the thread that set the value last. That gap is in `process.execArgv`, and it shows without `node:net`. This PR does not change it.
- #40824 edits the four host functions that this PR deletes. The conflict is small: drop that hunk.
- The tests are in `worker_threads.test.ts` because that file sets a longer timeout for debug builds. A worker takes about 1 s to start there.
- Suites run on the debug build: `worker_threads.test.ts` (141 pass). Twelve upstream tests pass on the debug build and on the released build: `test-{net,http,https}-autoselectfamily*.js`, `test-net-socket-connect-invalid-autoselectfamily*.js`, and `test-{https,tls}-connect-address-family.js`. The two CLI flag tests also pass with their `// Flags:` values. `connect-autoselectfamily-stale-timer.test.ts` passes. `cargo clippy -p bun_runtime` is clean.
- `node-net.test.ts` on the debug build: `should allow reconnecting after end()` failed in 2 of 4 full-file runs with this change, and passed in 3 of 3 on main. It passes alone, and it waits on a 3 ms timer. The error is `ERR_STREAM_WRITE_AFTER_END` on the second `connect()`, the path of #38980. The test connects to `127.0.0.1`, so the default does not apply.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (e0a2b82fd)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1027.04ms]
(pass) all worker_threads module properties are present [22.76ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.40ms]
(pass) all worker_threads worker instance properties are present [143.47ms]
(pass) threadId module and worker property is consistent [194.87ms]
(pass) receiveMessageOnPort works across threads [962.76ms]
(pass) receiveMessageOnPort works as FIFO [11.10ms]
(pass) you can override globalThis.postMessage [960.93ms]
(pass) support require in eval [942.37ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [968.77ms]
(pass) support require in eval for a file that doesnt exist [951.38ms]
(pass) support worker eval that throws [931.89ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [4052.16ms]
(pass) e
... (truncated)

release without fix: 3 FAILED
bun test v1.4.1-canary.1 (e0a2b82fd)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [17.46ms]
(pass) all worker_threads module properties are present [0.30ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.34ms]
(pass) all worker_threads worker instance properties are present [1.81ms]
(pass) threadId module and worker property is consistent [0.73ms]
(pass) receiveMessageOnPort works across threads [14.89ms]
(pass) receiveMessageOnPort works as FIFO [0.18ms]
(pass) you can override globalThis.postMessage [15.54ms]
(pass) support require in eval [14.15ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [14.33ms]
(pass) support require in eval for a file that doesnt exist [13.68ms]
(pass) support worker eval that throws [13.07ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [64.82ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [32.04ms]
(pass) execArgv option > can specify an array of strings [31.28ms]
393 |       stdout: "pipe",
394 |       stderr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (e0a2b82fd)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1026.41ms]
(pass) all worker_threads module properties are present [22.38ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.52ms]
(pass) all worker_threads worker instance properties are present [143.72ms]
(pass) threadId module and worker property is consistent [174.84ms]
(pass) receiveMessageOnPort works across threads [966.83ms]
(pass) receiveMessageOnPort works as FIFO [10.84ms]
(pass) you can override globalThis.postMessage [969.10ms]
(pass) support require in eval [954.75ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [951.69ms]
(pass) support require in eval for a file that doesnt exist [941.17ms]
(pass) support worker eval that throws [922.32ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [3917.96ms]
(pass) e
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9d8c658521
  features     baseline

23 deps, 131 codegen, 1172 objects in 608ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 22 installs across 61 packages (no changes) [3.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 1 install across 2 packages (no changes) [3.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (e0a2b82fd)

Checked 111 installs across 104 packages (no changes) [3.00ms]
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                                 |  29 +++++-
 src/runtime/node/node_net_binding.rs               | 101 +--------------------
 test/js/node/worker_threads/worker_threads.test.ts | 100 ++++++++++++++++++++
 3 files changed, 126 insertions(+), 104 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/net.ts                                      2      3     17
src/runtime/node/node_net_binding.rs                    2      4     18
test/js/node/worker_threads/worker_threads.test.ts      3      1     16
```

</details>

<!-- robobun:evidence:end -->