### PR TITLE
webview: fail only the view when WebKit lacks initWithDirectory:

### DIFF
--- a/src/runtime/webview/ObjCRuntime.cpp
+++ b/src/runtime/webview/ObjCRuntime.cpp
@@ -6,6 +6,7 @@
 #include "WebViewHost.h"
 #include <dlfcn.h>
 #include <mach/mach.h>
+#include <stdlib.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/HashMap.h>
 #include <mutex>
@@ -120,6 +121,7 @@ Class WKWebViewConfiguration::cls_WKWebsiteDataStoreConfiguration;
 Class WKWebViewConfiguration::cls_WKProcessPool;
 SEL WKWebViewConfiguration::s_nonPersistentDataStore;
 SEL WKWebViewConfiguration::s_initWithDirectory;
+bool WKWebViewConfiguration::s_hasInitWithDirectory;
 SEL WKWebViewConfiguration::s_initWithConfiguration;
 SEL WKWebViewConfiguration::s_setProcessPool;
 
@@ -141,6 +143,7 @@ id WKWebViewConfiguration::sharedProcessPool()
 // share committed state. Retained once on insert, never released.
 id WKWebViewConfiguration::persistentStoreForDirectory(const WTF::String& directory)
 {
+    ASSERT(s_hasInitWithDirectory);
     static NeverDestroyed<HashMap<WTF::String, id>> cache;
     auto it = cache->find(directory);
     if (it != cache->end()) return it->value;
@@ -334,6 +337,7 @@ bool ObjCRuntime::load()
     SEL (*sel)(const char*);
     Class (*allocateClassPair)(Class, const char*, size_t);
     BOOL (*addMethod)(Class, SEL, IMP, const char*);
+    BOOL (*respondsToSelector)(Class, SEL);
     BOOL (*addProtocol)(Class, Protocol*);
     Protocol* (*getProtocol)(const char*);
     void (*registerClassPair)(Class);
@@ -342,6 +346,7 @@ bool ObjCRuntime::load()
     SYM(sel, libobjc, "sel_registerName");
     SYM(allocateClassPair, libobjc, "objc_allocateClassPair");
     SYM(addMethod, libobjc, "class_addMethod");
+    SYM(respondsToSelector, libobjc, "class_respondsToSelector");
     SYM(addProtocol, libobjc, "class_addProtocol");
     SYM(getProtocol, libobjc, "objc_getProtocol");
     SYM(registerClassPair, libobjc, "objc_registerClassPair");
@@ -461,12 +466,15 @@ bool ObjCRuntime::load()
     CLS(WKWebViewConfiguration::cls, "WKWebViewConfiguration");
     CLS(WKWebViewConfiguration::cls_WKWebsiteDataStore, "WKWebsiteDataStore");
     // _WKWebsiteDataStoreConfiguration is SPI but stable since macOS 10.13.
-    // initWithDirectory: is 15.2+.
+    // initWithDirectory: is in the WebKit of macOS 15.2+, which a Safari update also installs. Ask the class.
     CLS(WKWebViewConfiguration::cls_WKWebsiteDataStoreConfiguration, "_WKWebsiteDataStoreConfiguration");
     CLS(WKWebViewConfiguration::cls_WKProcessPool, "WKProcessPool");
     WKWebViewConfiguration::s_setProcessPool = sel("setProcessPool:");
     WKWebViewConfiguration::s_nonPersistentDataStore = sel("nonPersistentDataStore");
     WKWebViewConfiguration::s_initWithDirectory = sel("initWithDirectory:");
+    // Test-only: BUN_INTERNAL_WEBVIEW_NO_INIT_WITH_DIRECTORY acts like a WebKit without it.
+    WKWebViewConfiguration::s_hasInitWithDirectory = !getenv("BUN_INTERNAL_WEBVIEW_NO_INIT_WITH_DIRECTORY")
+        && respondsToSelector(WKWebViewConfiguration::cls_WKWebsiteDataStoreConfiguration, WKWebViewConfiguration::s_initWithDirectory);
     WKWebViewConfiguration::s_initWithConfiguration = sel("_initWithConfiguration:");
     WKWebViewConfiguration::s_setWebsiteDataStore = sel("setWebsiteDataStore:");
     WKWebViewConfiguration::s_userContentController = sel("userContentController");

--- a/src/runtime/webview/ObjCRuntime.h
+++ b/src/runtime/webview/ObjCRuntime.h
@@ -481,6 +481,7 @@ struct WKWebViewConfiguration : Ref {
     static Class cls_WKProcessPool;
     static SEL s_nonPersistentDataStore;
     static SEL s_initWithDirectory; // macOS 15.2+ (SPI)
+    static bool s_hasInitWithDirectory; // false: sending initWithDirectory: raises, and the host aborts
     static SEL s_initWithConfiguration; // _initWithConfiguration: (SPI)
     static SEL s_setWebsiteDataStore;
     static SEL s_setProcessPool;

--- a/src/runtime/webview/host_main.cpp
+++ b/src/runtime/webview/host_main.cpp
@@ -143,6 +143,8 @@ struct Host {
     FrameWriter writer;
 
     std::unordered_map<uint32_t, Ref<WebViewHost>> views;
+    // Views whose Create failed. Each op on one of them fails with the reason.
+    std::unordered_map<uint32_t, WTF::String> failedViews;
 
     // CFFileDescriptor delivers one callback then disarms; read until EAGAIN,
     // then re-enable. Incomplete frame at buffer tail stays until more bytes.
@@ -172,11 +174,16 @@ struct Host {
     WebViewHost* view(uint32_t viewId, Op op)
     {
         auto it = views.find(viewId);
-        if (it == views.end()) {
+        if (it != views.end()) return it->second.ptr();
+        auto failed = failedViews.find(viewId);
+        if (failed == failedViews.end()) {
             writer.sendReplyStr(viewId, failureFor(op), "invalid viewId"_s);
             return nullptr;
         }
-        return it->second.ptr();
+        // NavFailEvent first, like navigateIPC: a constructor url's promise is marked handled.
+        if (op == Op::Navigate) writer.sendReplyStr(viewId, Reply::NavFailEvent, failed->second);
+        writer.sendReplyStr(viewId, failureFor(op), failed->second);
+        return nullptr;
     }
 };
 
@@ -243,6 +250,11 @@ void Host::dispatch(uint32_t viewId, Op op, Reader r)
         WTF::String persistDir;
         if (static_cast<DataStoreKind>(p.dataStoreKind) == DataStoreKind::Persistent)
             persistDir = r.str();
+        // Nothing here catches the exception that initWithDirectory: raises on an older WebKit.
+        if (!persistDir.isEmpty() && !objc::WKWebViewConfiguration::s_hasInitWithDirectory) {
+            failedViews.emplace(viewId, "dataStore.directory needs a newer WebKit (macOS 15.2 or later); use dataStore: \"ephemeral\" or backend: \"chrome\""_s);
+            return;
+        }
         views.emplace(viewId, WebViewHost::createForIPC(viewId, p.width, p.height, persistDir));
         // No Ack for Create — parent doesn't await it (fire-and-forget).
         return;
@@ -263,6 +275,7 @@ void Host::dispatch(uint32_t viewId, Op op, Reader r)
     }
     case Op::Close:
         views.erase(viewId);
+        failedViews.erase(viewId);
         writer.sendReply(viewId, Reply::Ack);
         return;
     case Op::Resize: {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -1225,7 +1225,9 @@ it("process exits after close()", async () => {
   expect(exitCode).toBe(0);
 });
 
-// _WKWebsiteDataStoreConfiguration initWithDirectory: is macOS 15.2+.
+// _WKWebsiteDataStoreConfiguration initWithDirectory: is in the WebKit of
+// macOS 15.2+. An older macOS has it only after a Safari update, so this gate
+// also skips some machines that could run the test.
 const itPersistentDataStore = isMacOS && isMacOSVersionAtLeast(15.2) ? test : test.skip;
 itPersistentDataStore("persistent dataStore: localStorage survives across instances", async () => {
   using dir = tempDir("webview-persist", {});
@@ -1248,6 +1250,83 @@ itPersistentDataStore("persistent dataStore: localStorage survives across instan
   await b.navigate(url);
   const got = await b.evaluate("String(localStorage.getItem('k'))");
   expect(got).toBe("survives");
+});
+
+const unsupportedDataStore =
+  'dataStore.directory needs a newer WebKit (macOS 15.2 or later); use dataStore: "ephemeral" or backend: "chrome"';
+
+// Opens an ephemeral view, then a view with dataStore.directory, and navigates
+// both. It runs in a subprocess for the same reason as the closeAll() test: an
+// unfixed build on an older WebKit kills the shared host.
+async function persistentBesideEphemeral(env: Record<string, string>) {
+  using dir = tempDir("webview-persist-old-webkit", {});
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const html = h => "data:text/html," + encodeURIComponent(h);
+        // An op on a dead view throws synchronously. An async function
+        // turns that into a rejection too.
+        const settle = fn => fn().catch(e => e.message);
+        const ephemeral = new Bun.WebView({ width: 100, height: 100 });
+        const persistent = new Bun.WebView({
+          width: 100,
+          height: 100,
+          dataStore: { directory: ${JSON.stringify(String(dir))} },
+        });
+        const failed = [];
+        persistent.onNavigationFailed = e => failed.push(e.message);
+        const result = {
+          persistent: await settle(async () => {
+            await persistent.navigate(html("<body>persistent</body>"));
+            return "navigated";
+          }),
+          ephemeral: await settle(async () => {
+            await ephemeral.navigate(html("<body>ephemeral</body>"));
+            return ephemeral.evaluate("document.body.textContent");
+          }),
+          failed,
+        };
+        persistent.close();
+        ephemeral.close();
+        console.log(JSON.stringify(result));
+      `,
+    ],
+    env: { ...bunEnv, ...env },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout, stderr).toEndWith("}\n");
+  return { result: JSON.parse(stdout), stderr, exitCode };
+}
+
+it("dataStore.directory on a WebKit without initWithDirectory: fails only that view", async () => {
+  // The env var makes the host act like a WebKit from before macOS 15.2. The
+  // host used to send initWithDirectory: there anyway. The exception aborted
+  // the host, so every view died with "killed by signal 6" and no reason.
+  const { result, stderr, exitCode } = await persistentBesideEphemeral({
+    BUN_INTERNAL_WEBVIEW_NO_INIT_WITH_DIRECTORY: "1",
+  });
+  expect(result).toEqual({
+    persistent: unsupportedDataStore,
+    ephemeral: "ephemeral",
+    failed: [unsupportedDataStore],
+  });
+  expect(exitCode, stderr).toBe(0);
+});
+
+it("dataStore.directory works or fails only that view, on this machine's WebKit", async () => {
+  const { result, stderr, exitCode } = await persistentBesideEphemeral({});
+  // macOS 15.2+ has initWithDirectory:. An older macOS has it only after a
+  // Safari update, so there the result shows which WebKit this machine has.
+  const supported = isMacOSVersionAtLeast(15.2) || result.persistent === "navigated";
+  expect(result).toEqual(
+    supported
+      ? { persistent: "navigated", ephemeral: "ephemeral", failed: [] }
+      : { persistent: unsupportedDataStore, ephemeral: "ephemeral", failed: [unsupportedDataStore] },
+  );
+  expect(exitCode, stderr).toBe(0);
 });
 
 it("ephemeral dataStore: localStorage does NOT survive across instances", async () => {


### PR DESCRIPTION
### Problem
- On a WebKit without `-[_WKWebsiteDataStoreConfiguration initWithDirectory:]`, a `Bun.WebView` with `dataStore.directory` aborts the WebKit host. Every view in the process then fails with `WebView host process killed by signal 6`, which gives no reason. Sentry BUN-4TTG: `abort() called` under `persistentStoreForDirectory` (bun 1.4.0, macOS x86_64).
- That function (`src/runtime/webview/ObjCRuntime.cpp:150`) sends `initWithDirectory:` with no check.

### Fix
- `ObjCRuntime::load()` asks the class once (`class_respondsToSelector`), not the OS version: a Safari update also installs the newer WebKit. The constructor cannot ask, since WebKit loads only in the host.
- On a WebKit without the initializer, the host skips the view. Each op on it fails with `dataStore.directory needs a newer WebKit (macOS 15.2 or later); use dataStore: "ephemeral" or backend: "chrome"`, and a navigate also fires `onNavigationFailed`. The other views keep working.
- Verified: two new tests in `test/js/bun/webview/webview.test.ts`, which only the darwin CI lanes run (I have no Mac). `BUN_INTERNAL_WEBVIEW_NO_INIT_WITH_DIRECTORY=1` makes the host act like an older WebKit, so the first test fails without the fix on any Mac.
- Self-reviewed: 4 concerns raised, 3 addressed. Rejected: a `bun:ffi` probe as the gate of the persistent-store test. The OS gate also catches a wrong class check on 15.2+.

### Background
- The WebKit backend runs `WKWebView` in a host subprocess (`host_main.cpp`). The Create frame gets no reply, so a failure shows on the next op.
- `dataStore.directory` uses the WebKit SPI class `_WKWebsiteDataStoreConfiguration`. Its header marks `initWithDirectory:` as `macos(15.2)`.
- An unrecognized selector raises `NSInvalidArgumentException`. The host has no handler, so the runtime calls `abort()`.

<details><summary>Notes</summary>

- CI hit the same abort before: build 43740 (PR #28870), on the agent `macOS-13-x64-1` (macOS 13.6.4). Commit ba09763f6a then gated the persistent-store test on the OS version "until a fallback using the individual directory setters is implemented".
- This PR does not add that fallback. It makes the failure clear and keeps it to one view. A fallback can branch on the same `s_hasInitWithDirectory` flag. @dylan-conway, please say if you want the fallback first.
- Why the class and not the OS: `vendor/WebKit/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm` implements `initWithDirectory:` with no `#if`. On macOS, a Safari update also updates the system WebKit. So a constructor that throws on macOS older than 15.2 can break a setup that works today. The note in `docs/runtime/webview.mdx:70` still holds, because macOS 15.2 and later always has the initializer.
- REVIEW.md says not to add production code only to make a test possible. `BUN_INTERNAL_WEBVIEW_NO_INIT_WITH_DIRECTORY` is such code. Without it, only an agent with an older WebKit runs the failure path. The arm64 agents run macOS 15 or 26. The x64 agents run macOS 14.8, where the WebKit depends on the installed Safari. The variable follows `BUN_INTERNAL_INTERACTIVE_ASSUME_TTY` (#35165), which also works in release builds. The darwin lanes test release builds, so a debug-only variable would never run there. The variable can only turn the feature off. The host reads it with `getenv` and gets the parent environment (`HostProcess.rs`). If you prefer no such variable, I will remove it and the first test.
- Both tests run in a subprocess, like the `closeAll()` test, because an unfixed build kills the shared host. The second test uses the real WebKit. On macOS older than 15.2, its expectation follows the result, because the WebKit there depends on the Safari version.
- The tests are skipped on Linux and Windows. The changed host code is in `#if OS(DARWIN)`.
- A syntax-only compile of `ObjCRuntime.cpp` and `host_main.cpp` passes on Linux, with the darwin branch enabled and stub Apple headers. A control with a wrong call in each changed line fails that compile.
- Other host failures, for example a failed framework load, still reach the user only as `WebView host process exited`, because the parent ignores the host's stderr by default. A reason frame from the host would fix that class. This PR does not.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview.test.ts

<!-- robobun:evidence:end -->
