### PR TITLE
libuv(win): poll a listening socket with AFD requests that are not exclusive

### DIFF
--- a/patches/libuv/win-poll-not-exclusive.patch
+++ b/patches/libuv/win-poll-not-exclusive.patch
@@ -1,0 +1,118 @@
+--- a/src/uv-common.h
++++ b/src/uv-common.h
+@@ -136,6 +136,7 @@
+ 
+   /* Only used by uv_poll_t handles. */
+   UV_HANDLE_POLL_SLOW                   = 0x01000000,
++  UV_HANDLE_POLL_NOT_EXCLUSIVE          = 0x02000000,
+ 
+   /* Only used by uv_process_t handles. */
+   UV_HANDLE_REAP                        = 0x10000000
+--- a/src/win/poll.c
++++ b/src/win/poll.c
+@@ -76,18 +76,21 @@
+ 
+ static void uv__fast_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
+   uv_req_t* req;
++  uv_req_t* other_req;
+   AFD_POLL_INFO* afd_poll_info;
+   int result;
+ 
+   /* Find a yet unsubmitted req to submit. */
+   if (handle->submitted_events_1 == 0) {
+     req = &handle->poll_req_1;
++    other_req = handle->submitted_events_2 != 0 ? &handle->poll_req_2 : NULL;
+     afd_poll_info = &handle->afd_poll_info_1;
+     handle->submitted_events_1 = handle->events;
+     handle->mask_events_1 = 0;
+     handle->mask_events_2 = handle->events;
+   } else if (handle->submitted_events_2 == 0) {
+     req = &handle->poll_req_2;
++    other_req = &handle->poll_req_1;
+     afd_poll_info = &handle->afd_poll_info_2;
+     handle->submitted_events_2 = handle->events;
+     handle->mask_events_1 = handle->events;
+@@ -101,9 +104,21 @@
+     return;
+   }
+ 
+-  /* Setting Exclusive to TRUE makes the other poll request return if there is
+-   * any. */
+-  afd_poll_info->Exclusive = TRUE;
++  if (handle->flags & UV_HANDLE_POLL_NOT_EXCLUSIVE) {
++    /* This req does not complete the other req, so cancel the other req, and
++     * do it before this req is submitted. AFD can miss an event for a poll
++     * that arrives while another poll of the same handle is still pending on
++     * the socket. The cancelled req completes with STATUS_CANCELLED, which is
++     * reported as WSAEINTR and is ignored. */
++    afd_poll_info->Exclusive = FALSE;
++    if (other_req != NULL) {
++      CancelIoEx((HANDLE) handle->peer_socket, &other_req->u.io.overlapped);
++    }
++  } else {
++    /* Setting Exclusive to TRUE makes the other poll request return if there
++     * is any. */
++    afd_poll_info->Exclusive = TRUE;
++  }
+   afd_poll_info->NumberOfHandles = 1;
+   afd_poll_info->Timeout.QuadPart = INT64_MAX;
+   afd_poll_info->Handles[0].Handle = (HANDLE) handle->socket;
+@@ -462,6 +477,7 @@
+   SOCKET peer_socket, base_socket;
+   DWORD bytes;
+   DWORD yes = 1;
++  BOOL listening;
+ 
+   uv__winsock_ensure();
+ 
+@@ -511,6 +527,24 @@
+   if (peer_socket != INVALID_SOCKET) {
+     /* Initialize fast poll specific fields. */
+     handle->peer_socket = peer_socket;
++
++    /* Processes share listening sockets: a server handle that is sent to a
++     * child process, or the socket of a cluster worker. An exclusive poll
++     * completes the exclusive polls of every process on the socket. Two
++     * processes that poll one socket that way complete each other's polls,
++     * and each one submits again at once, so both spin while idle. A socket
++     * that listens when the handle is initialized is polled with requests
++     * that are not exclusive. Other sockets keep exclusive requests, see
++     * uv__poll_close. */
++    listening = FALSE;
++    len = sizeof listening;
++    if (getsockopt(socket,
++                   SOL_SOCKET,
++                   SO_ACCEPTCONN,
++                   (char*) &listening,
++                   &len) == 0 && listening) {
++      handle->flags |= UV_HANDLE_POLL_NOT_EXCLUSIVE;
++    }
+   } else {
+     /* Initialize slow poll specific fields. */
+     handle->flags |= UV_HANDLE_POLL_SLOW;
+@@ -596,6 +630,25 @@
+   if (handle->flags & UV_HANDLE_POLL_SLOW)
+     return 0;
+ 
++  if (handle->flags & UV_HANDLE_POLL_NOT_EXCLUSIVE) {
++    /* The exclusive poll below does not complete requests that are not
++     * exclusive, so cancel each one by its overlapped. A cancelled request
++     * completes with STATUS_CANCELLED, and the last one queues the endgame.
++     * CancelIoEx searches all the pending requests of the peer socket, and
++     * every handle of the loop submits on that socket. So the cost grows with
++     * the number of polled sockets, and the other handles keep the
++     * exclusive poll. */
++    if (handle->submitted_events_1 != 0) {
++      CancelIoEx((HANDLE) handle->peer_socket,
++                 &handle->poll_req_1.u.io.overlapped);
++    }
++    if (handle->submitted_events_2 != 0) {
++      CancelIoEx((HANDLE) handle->peer_socket,
++                 &handle->poll_req_2.u.io.overlapped);
++    }
++    return 0;
++  }
++
+   /* Cancel outstanding poll requests by executing another, unique poll
+    * request that forces the outstanding ones to return. */
+   afd_poll_info.Exclusive = TRUE;

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -60,7 +60,18 @@ export const libuv: Dependency = {
   // an in-process loopback fetch().abort() can fall into. To upstream:
   // send to libuv/libuv with the wepoll/ReactOS references in the patch
   // comment as the rationale.
-  patches: ["patches/libuv/win-poll-rearm-before-callback.patch", "patches/libuv/win-poll-abort-with-disconnect.patch"],
+  //
+  // Poll a listening socket with AFD requests that are not exclusive. An
+  // exclusive request completes the exclusive requests of every process on the
+  // socket, so two processes that share a listening socket spin while idle.
+  // Other sockets keep exclusive requests. A request that is not exclusive is
+  // cancelled with CancelIoEx, and that cost grows with the number of polled
+  // sockets. Upstream libuv (v1.x) still submits exclusive requests only.
+  patches: [
+    "patches/libuv/win-poll-rearm-before-callback.patch",
+    "patches/libuv/win-poll-abort-with-disconnect.patch",
+    "patches/libuv/win-poll-not-exclusive.patch",
+  ],
 
   build: () => ({
     kind: "direct",

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -3,6 +3,65 @@ import { bunEnv, bunExe, isWindows, nodeExe, tempDir, tls } from "harness";
 
 const node = nodeExe();
 
+// After the handoff, the parent and the child both poll one listening socket. On Windows, libuv
+// submitted each AFD poll as exclusive. An exclusive poll completes the exclusive polls of every
+// process that shares the socket, so the two processes completed each other's polls in a loop.
+// There is no event to wait for, so the test measures the CPU time of both processes while idle.
+test.concurrent("a parent and a child that share a listening socket do not spin while idle", async () => {
+  using dir = tempDir("ipc-handle-shared-idle", {
+    "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const child = fork('child.js');
+const server = net.createServer();
+server.listen(0, '127.0.0.1', () => child.send('server', server));
+child.once('message', () => {
+  const start = process.cpuUsage();
+  setTimeout(() => {
+    const usage = process.cpuUsage(start);
+    child.once('message', childMs => {
+      console.log(JSON.stringify({ parentMs: Math.round((usage.user + usage.system) / 1000), childMs }));
+      server.close();
+      child.disconnect();
+    });
+    child.send('report');
+  }, 2000);
+});
+`,
+    "child.js": `
+let server, start;
+process.on('message', (m, handle) => {
+  if (m === 'server') {
+    server = handle;
+    start = process.cpuUsage();
+    process.send('listening');
+  } else if (m === 'report') {
+    const usage = process.cpuUsage(start);
+    process.send(Math.round((usage.user + usage.system) / 1000));
+  }
+});
+process.on('disconnect', () => server.close());
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: expect.stringMatching(/^\{.*\}\n$/),
+    stderr: "",
+    exitCode: 0,
+  });
+  const { parentMs, childMs } = JSON.parse(stdout);
+  // In the 2 s window, the spin costs the two processes 1000 ms or more of CPU time. Without the
+  // spin, the two processes use less than 250 ms, also on a debug build.
+  expect(parentMs + childMs).toBeLessThan(600);
+});
+
 describe.skipIf(isWindows)("process.send(message, handle)", () => {
   test.concurrent("bun parent -> bun child: net.Server handle and message both arrive", async () => {
     using dir = tempDir("ipc-handle-bun-bun", {


### PR DESCRIPTION
### Problem
- On Windows, two processes that share a listening socket both use CPU while idle. This happens for `child.send(msg, server)` and for cluster `SCHED_NONE`. The pair uses 650 to 1400 ms of CPU per idle second on a release build.
- libuv's `uv_poll` submits each AFD poll with `Exclusive = TRUE` (`src/win/poll.c`, `uv__fast_poll_submit_poll_req`). An exclusive poll completes the exclusive polls of every process on the socket. Each process submits again at once, so neither process sleeps.

### Fix
- A new libuv patch, `patches/libuv/win-poll-not-exclusive.patch`, polls a listening socket with requests that are not exclusive. `uv_poll_init_socket` checks `SO_ACCEPTCONN`.
- Such a handle cancels its superseded request with `CancelIoEx` before the new submit. AFD misses events for a poll that arrives while another poll of the same handle is pending.
- Other sockets keep exclusive polls. `CancelIoEx` searches every pending request of the peer socket. With 10000 idle connections, a version for all sockets made connect and close 3 times slower.
- Verified on Windows x64 and arm64: the new test in `test/js/node/child_process/child_process_ipc_handle.test.ts` fails on the canary (1375 ms, limit 600) and passes with the patch. Suites: see Notes.

### Background
- AFD is the kernel driver behind Winsock. `IOCTL_AFD_POLL` is an overlapped request that completes when the socket has one of the requested events.
- libuv submits the requests of all `uv_poll` handles of a loop through one "peer socket".
- `child.send(msg, server)` duplicates the socket into the child with `WSADuplicateSocketW`. Both processes then poll one socket.

<details><summary>Notes</summary>

**Idle CPU of both processes, from the new test (2 s window).** Canary: 1375 ms on x64, 1954 ms on arm64. Unpatched debug build: 4079 ms. Patched: 0 ms on x64. On arm64 the patched build shows 15 to 200 ms of noise, the same with and without a shared socket, so the limit is 600 ms.

**Why only listening sockets.** A first version made every poll not exclusive. A `CancelIoEx` call then took 243 µs on average with 20100 pending requests, because it searches all the requests of the peer socket. Connect and close cycles on Windows x64, debug builds, in µs per cycle:

| idle connections | unpatched | all sockets | listening sockets (this PR) |
| --- | --- | --- | --- |
| 0 | 1109 | 1126 | 1139 |
| 1000 | 994 | 1169 | 978 |
| 10000 | 1567 | 4867 | 1553 |

With this PR, the benchmark with 10000 idle connections calls `CancelIoEx` 0 times. A process that shares a listening socket calls it once or twice, when it closes the socket.

**Upstream.** libuv/libuv#5216 (open) changes `uv_close` to `CancelIoEx` for every handle. That has the same search cost, so this PR does not backport it. Upstream libuv (`v1.x`) still submits exclusive polls only.

**Cancel order.** With every poll not exclusive, four builds ran `test-net-write-fully-async-buffer.js`, `test-net-throttle.js` and `test-net-stream.js`:

| variant | result |
| --- | --- |
| exclusive (before this PR) | pass |
| not exclusive, cancel after submit | hang |
| not exclusive, cancel before submit | pass |
| not exclusive, no cancel | hang |

A trace showed the writer's new poll never completing with `AFD_POLL_SEND`. This PR keeps the cancel before the submit.

**Polls of other processes are independent.** A child that blocks its loop for 150 ms after each accept shares the socket with its parent. With the patch, both accept connections (parent 11 to 13, child 7 to 9, of 20).

**Suites, debug builds, patched and unpatched at the same commit, `--parallel`:**
- Windows x64, `test/js/node/net`, `test/js/bun/net`, `test/js/node/child_process`, `cluster.test.ts`, `test/js/node/dgram`, and vendored `test-net-*`, `test-cluster-*`, `test-child-process-fork*`, `test-dgram-*` (350 files): 347 pass. The 3 failures also fail unpatched: `child_process_send_cb.test.js`, `child_process.test.ts` (a debug assertion), and `socket.test.ts` "upgradeTLS handles errors" (a 20 s timeout under load).
- Windows x64, `test/js/bun/http`, `test/js/web/fetch`, `test/js/node/http`, WebSocket, DNS, TLS (246 files): 14 failing files. Two unpatched runs had 14 and 16, and those runs include 13 of the 14 files. The other file is `async-iterator-stream.test.ts`, which expects two chunks 30 ms apart. With 32 copies at once, it fails 1 of 96 runs on both builds.
- Windows 11 arm64, the first group without dgram (273 files): 270 pass. Unpatched: 268, with the same failures plus the new test and `child_process.test.ts`.
- The first version had 17 failing files in the HTTP group. The 3 extra files passed alone, and 2 of them failed unpatched in a second run.
- Linux: the new test passes with the debug build and the system build.

**Not changed.** With two children on one listening socket, one child can block inside `accept()` (#37815). That fails 5 of 5 runs on both builds. #41358 fixes it with `AcceptEx`, and it does not change the polls. The two PRs add tests to the same file at different places, so they merge without a conflict.

**Proof.** The fix is under `patches/`, and the bug is Windows-only. A fail-before check that reverts `src/` and `packages/` on Linux cannot show it. The test runs on all platforms.

**Related.** #37815 and #37896 stop sharing the socket for cluster TCP and TLS workers on Windows. `child.send(msg, server)` still shares it, as in Node. #37104 and #38024 add other `poll.c` patches. The patches apply in either order, and the list in `libuv.ts` needs a one-line merge.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/child_process/child_process_ipc_handle.test.ts

<!-- robobun:evidence:end -->