### PR TITLE
Add Bun.hash.xxHash128 (XXH3 128-bit)

### DIFF
--- a/bench/snippets/hash.mjs
+++ b/bench/snippets/hash.mjs
@@ -38,6 +38,10 @@ bench("xxHash3 (short)", () => {
   Bun.hash.xxHash3(shortStr);
 });
 
+bench("xxHash128 (short)", () => {
+  Bun.hash.xxHash128(shortStr);
+});
+
 bench("murmur32v3 (short)", () => {
   Bun.hash.murmur32v3(shortStr);
 });
@@ -84,6 +88,10 @@ bench("xxHash64 (128 KB)", () => {
 
 bench("xxHash3 (128 KB)", () => {
   Bun.hash.xxHash3(longStr);
+});
+
+bench("xxHash128 (128 KB)", () => {
+  Bun.hash.xxHash128(longStr);
 });
 
 bench("murmur32v3 (128 KB)", () => {

--- a/docs/runtime/hashing.mdx
+++ b/docs/runtime/hashing.mdx
@@ -160,7 +160,7 @@ Bun.hash(arr.buffer);
 Bun.hash(new DataView(arr.buffer));
 ```
 
-The second parameter is an optional integer seed. For 64-bit hashes, pass seeds above `Number.MAX_SAFE_INTEGER` as BigInt to avoid loss of precision.
+The second parameter is an optional integer seed. For 64-bit hashes and `xxHash128`, pass seeds above `Number.MAX_SAFE_INTEGER` as BigInt to avoid loss of precision.
 
 ```ts
 Bun.hash("some data here", 1234);

--- a/docs/runtime/hashing.mdx
+++ b/docs/runtime/hashing.mdx
@@ -167,7 +167,7 @@ Bun.hash("some data here", 1234);
 // 15724820720172937558n
 ```
 
-Additional hashing algorithms are available as properties on `Bun.hash`. The API is the same for each; 32-bit hashes return a number and 64-bit hashes return a bigint.
+Additional hashing algorithms are available as properties on `Bun.hash`. The API is the same for each. 32-bit hashes return a number. 64-bit and 128-bit hashes return a bigint.
 
 ```ts
 Bun.hash.wyhash("data", 1234); // equivalent to Bun.hash()
@@ -178,10 +178,18 @@ Bun.hash.cityHash64("data", 1234);
 Bun.hash.xxHash32("data", 1234);
 Bun.hash.xxHash64("data", 1234);
 Bun.hash.xxHash3("data", 1234);
+Bun.hash.xxHash128("data", 1234);
 Bun.hash.murmur32v3("data", 1234);
 Bun.hash.murmur32v2("data", 1234);
 Bun.hash.murmur64v2("data", 1234);
 Bun.hash.rapidhash("data", 1234);
+```
+
+`Bun.hash.xxHash128` returns the 128-bit XXH3 hash (XXH128) as an unsigned bigint. To get the canonical hex digest, pad the bigint to 32 hex digits.
+
+```ts
+Bun.hash.xxHash128("hello world").toString(16).padStart(32, "0");
+// "df8d09e93f874900a99b8775cc15b6c7"
 ```
 
 ---

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2883,6 +2883,13 @@ declare module "bun" {
     xxHash32: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     xxHash64: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
     xxHash3: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;
+    /**
+     * The 128-bit XXH3 hash (XXH128), as an unsigned bigint: `(high64 << 64n) | low64`.
+     * `hash.toString(16).padStart(32, "0")` gives the canonical hex digest.
+     *
+     * Bun reads `seed` as an unsigned 64-bit integer.
+     */
+    xxHash128: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number | bigint) => bigint;
     murmur32v3: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur32v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: number) => number;
     murmur64v2: (data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer, seed?: bigint) => bigint;

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -132,7 +132,7 @@ const noUnify: readonly string[] = [
   "src/jsc/bindings/image_resize.cpp",
   // Third highway TU — same foreach_target.h include-guard reason as
   // image_resize.cpp: it must expand its own per-ISA namespaces so
-  // HWY_EXPORT(HashLong) resolves the N_AVX2/N_AVX3/etc. variants.
+  // HWY_EXPORT(HashLongLoop) resolves the N_AVX2/N_AVX3/etc. variants.
   "src/jsc/bindings/xxhash3.cpp",
   // Fourth highway TU — same foreach_target.h include-guard reason.
   "src/jsc/bindings/highway_sourcemap.cpp",

--- a/scripts/verify-baseline-static/allowlist-aarch64.txt
+++ b/scripts/verify-baseline-static/allowlist-aarch64.txt
@@ -305,7 +305,7 @@ _ZN9bun_image10N_SVE2_128L9HorizPassEPKhmmPhmPKNS_4SpanEPKsm                  [S
 # Bun xxHash3 SVE/SVE2 targets. Gate: hwy::SupportedTargets via getauxval(AT_HWCAP). (4 symbols)
 # (Variants that don't materialize on this target show up as STALE.)
 # ----------------------------------------------------------------------------
-_ZN3bun4xxh35N_SVE8HashLongEPKhmS3_                                           [SVE]
-_ZN3bun4xxh36N_SVE28HashLongEPKhmS3_                                          [SVE]
-_ZN3bun4xxh39N_SVE_2568HashLongEPKhmS3_                                       [SVE]
-_ZN3bun4xxh310N_SVE2_1288HashLongEPKhmS3_                                     [SVE]
+_ZN3bun4xxh35N_SVE12HashLongLoopEPmPKhmS4_                                    [SVE]
+_ZN3bun4xxh36N_SVE212HashLongLoopEPmPKhmS4_                                   [SVE]
+_ZN3bun4xxh39N_SVE_25612HashLongLoopEPmPKhmS4_                                [SVE]
+_ZN3bun4xxh310N_SVE2_12812HashLongLoopEPmPKhmS4_                              [SVE]

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -1060,14 +1060,14 @@ crc32_fold_vpclmulqdq_reset  [AVX, AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, 
 
 # ----------------------------------------------------------------------------
 # Bun xxHash3 windows-x64. Gate: BUN_HWY_DISPATCH -> hwy::SupportedTargets() via CPUID. (6 symbols)
-# (PDB demangles to bun::xxh3::N_*::HashLong; unmaterialized variants show up as STALE.)
+# (PDB demangles to bun::xxh3::N_*::HashLongLoop; unmaterialized variants show up as STALE.)
 # ----------------------------------------------------------------------------
-bun::xxh3::N_AVX2::HashLong       [AVX, AVX2, BMI2]
-bun::xxh3::N_AVX3::HashLong       [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
-bun::xxh3::N_AVX3_DL::HashLong    [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
-bun::xxh3::N_AVX3_SPR::HashLong   [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
-bun::xxh3::N_AVX3_ZEN4::HashLong  [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
-bun::xxh3::N_AVX10_2::HashLong    [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+bun::xxh3::N_AVX2::HashLongLoop       [AVX, AVX2, BMI2]
+bun::xxh3::N_AVX3::HashLongLoop       [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+bun::xxh3::N_AVX3_DL::HashLongLoop    [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+bun::xxh3::N_AVX3_SPR::HashLongLoop   [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+bun::xxh3::N_AVX3_ZEN4::HashLongLoop  [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+bun::xxh3::N_AVX10_2::HashLongLoop    [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
 
 
 # ----------------------------------------------------------------------------

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -755,11 +755,11 @@ _ZN3bun11N_AVX3_ZEN417ParseMappingsImplEPKhmPiS3_S3_S3_miS3_Pm                 [
 # ----------------------------------------------------------------------------
 # Bun xxHash3 (src/jsc/bindings/xxhash3.cpp). Gate: BUN_HWY_DISPATCH (highway_dispatch.h) via hwy::SupportedTargets. (5 symbols)
 # ----------------------------------------------------------------------------
-_ZN3bun4xxh36N_AVX28HashLongEPKhmS3_                                          [AVX, AVX2, BMI2]
-_ZN3bun4xxh36N_AVX38HashLongEPKhmS3_                                          [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
-_ZN3bun4xxh39N_AVX3_DL8HashLongEPKhmS3_                                       [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
-_ZN3bun4xxh310N_AVX3_SPR8HashLongEPKhmS3_                                     [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
-_ZN3bun4xxh311N_AVX3_ZEN48HashLongEPKhmS3_                                    [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+_ZN3bun4xxh36N_AVX212HashLongLoopEPmPKhmS4_                                   [AVX, AVX2, BMI2]
+_ZN3bun4xxh36N_AVX312HashLongLoopEPmPKhmS4_                                   [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+_ZN3bun4xxh39N_AVX3_DL12HashLongLoopEPmPKhmS4_                                [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+_ZN3bun4xxh310N_AVX3_SPR12HashLongLoopEPmPKhmS4_                              [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
+_ZN3bun4xxh311N_AVX3_ZEN412HashLongLoopEPmPKhmS4_                             [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
 
 
 # ----------------------------------------------------------------------------

--- a/src/hash/lib.rs
+++ b/src/hash/lib.rs
@@ -13,6 +13,7 @@
 //! | `xxHash32`     | [`XxHash32::hash`]                            | u32 → u32     |
 //! | `xxHash64`     | [`XxHash64::hash`]                            | u64 → u64     |
 //! | `xxHash3`      | `bun_highway::xxhash3_64`                     | u64 → u64     |
+//! | `xxHash128`    | `bun_highway::xxhash3_128`                    | u64 → u128    |
 //! | `murmur32v2`   | [`Murmur2_32::hash_with_seed`]                | u32 → u32     |
 //! | `murmur32v3`   | [`Murmur3_32::hash_with_seed`]                | u32 → u32     |
 //! | `murmur64v2`   | [`Murmur2_64::hash_with_seed`]                | u64 → u64     |

--- a/src/hash/xxhash.rs
+++ b/src/hash/xxhash.rs
@@ -3,7 +3,8 @@
 //! Thin wrappers over the C++/Highway xxHash kernel in
 //! `src/jsc/bindings/xxhash3.cpp` (exposed by `bun_highway`).
 //! XXH32/XXH64 are scalar (no SIMD form exists in the reference);
-//! `HashObject.rs` calls `bun_highway::xxhash3_64` directly for XXH3. Output is
+//! `HashObject.rs` calls `bun_highway::xxhash3_64` and `bun_highway::xxhash3_128`
+//! directly for XXH3. Output is
 //! bit-identical to the xxHash
 //! reference test vectors — verified against the reference (and across every
 //! dispatch target) by `test/js/bun/util/hash.test.js`, which runs in CI.

--- a/src/hash/xxhash.rs
+++ b/src/hash/xxhash.rs
@@ -3,8 +3,7 @@
 //! Thin wrappers over the C++/Highway xxHash kernel in
 //! `src/jsc/bindings/xxhash3.cpp` (exposed by `bun_highway`).
 //! XXH32/XXH64 are scalar (no SIMD form exists in the reference);
-//! `HashObject.rs` calls `bun_highway::xxhash3_64` and `bun_highway::xxhash3_128`
-//! directly for XXH3. Output is
+//! `HashObject.rs` calls `bun_highway` directly for XXH3. Output is
 //! bit-identical to the xxHash
 //! reference test vectors — verified against the reference (and across every
 //! dispatch target) by `test/js/bun/util/hash.test.js`, which runs in CI.

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -790,18 +790,12 @@ pub fn xxhash3_64(seed: u64, input: &[u8]) -> u64 {
     unsafe { highway_xxhash3_64(input.as_ptr(), input.len(), seed) }
 }
 
-/// XxHash3 128-bit (`XXH3_128bits_withSeed`, also called XXH128). It shares
-/// the runtime-dispatched stripe loop of [`xxhash3_64`], and its output is
-/// bit-identical to the xxHash reference for every input and every `seed`.
-///
-/// Returns `(high64 << 64) | low64`. Its big-endian bytes are the canonical
-/// digest (`XXH128_canonicalFromHash` in the reference).
+/// XxHash3 128-bit (`XXH3_128bits_withSeed`). Returns `(high64 << 64) | low64`.
 #[inline(always)]
 pub fn xxhash3_128(seed: u64, input: &[u8]) -> u128 {
     let mut out = [0u64; 2];
-    // SAFETY: `input.ptr/len` are a valid readable range. The kernel only
-    // reads it, and never dereferences the pointer when `len == 0`. `out` is
-    // two writable u64s, and the kernel writes exactly `out[0]` and `out[1]`.
+    // SAFETY: `input.ptr/len` are a valid readable range (never read when empty).
+    // The kernel writes exactly `out[0]` and `out[1]`.
     unsafe { highway_xxhash3_128(input.as_ptr(), input.len(), seed, out.as_mut_ptr()) };
     (u128::from(out[1]) << 64) | u128::from(out[0])
 }

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -110,6 +110,8 @@ unsafe extern "C" {
 
     fn highway_xxhash3_64(input: *const u8, len: usize, seed: u64) -> u64;
 
+    fn highway_xxhash3_128(input: *const u8, len: usize, seed: u64, out: *mut u64);
+
     fn highway_xxhash32(input: *const u8, len: usize, seed: u32) -> u32;
 
     fn highway_xxhash64(input: *const u8, len: usize, seed: u64) -> u64;
@@ -786,6 +788,22 @@ pub fn xxhash3_64(seed: u64, input: &[u8]) -> u64 {
     // the kernel takes the `len == 0` branch and never dereferences the
     // pointer. The kernel only reads `input` and writes nothing through it.
     unsafe { highway_xxhash3_64(input.as_ptr(), input.len(), seed) }
+}
+
+/// XxHash3 128-bit (`XXH3_128bits_withSeed`, also called XXH128). It shares
+/// the runtime-dispatched stripe loop of [`xxhash3_64`], and its output is
+/// bit-identical to the xxHash reference for every input and every `seed`.
+///
+/// Returns `(high64 << 64) | low64`. Its big-endian bytes are the canonical
+/// digest (`XXH128_canonicalFromHash` in the reference).
+#[inline(always)]
+pub fn xxhash3_128(seed: u64, input: &[u8]) -> u128 {
+    let mut out = [0u64; 2];
+    // SAFETY: `input.ptr/len` are a valid readable range. The kernel only
+    // reads it, and never dereferences the pointer when `len == 0`. `out` is
+    // two writable u64s, and the kernel writes exactly `out[0]` and `out[1]`.
+    unsafe { highway_xxhash3_128(input.as_ptr(), input.len(), seed, out.as_mut_ptr()) };
+    (u128::from(out[1]) << 64) | u128::from(out[0])
 }
 
 /// XxHash32 one-shot. Bit-identical to the xxHash reference.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -653,6 +653,13 @@ impl JSValue {
     pub fn from_uint64_no_truncate(global: &JSGlobalObject, i: u64) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__fromUInt64NoTruncate(global, i))
     }
+    #[track_caller]
+    pub fn from_uint128_no_truncate(global: &JSGlobalObject, i: u128) -> JsResult<JSValue> {
+        let (low, high) = (i as u64, (i >> 64) as u64);
+        host_fn::from_js_host_call(global, || {
+            JSC__JSValue__fromUInt128NoTruncate(global, low, high)
+        })
+    }
     /// A BigInt from a decimal integer literal (optional `-`, then digits).
     /// Returns `Ok(None)` when `digits` is not such a literal.
     #[track_caller]
@@ -1976,6 +1983,11 @@ unsafe extern "C" {
     safe fn JSC__JSValue__dateInstanceFromNumber(global: &JSGlobalObject, n: f64) -> JSValue;
     safe fn JSC__JSValue__fromInt64NoTruncate(global: &JSGlobalObject, i: i64) -> JSValue;
     safe fn JSC__JSValue__fromUInt64NoTruncate(global: &JSGlobalObject, i: u64) -> JSValue;
+    safe fn JSC__JSValue__fromUInt128NoTruncate(
+        global: &JSGlobalObject,
+        low: u64,
+        high: u64,
+    ) -> JSValue;
     fn JSC__JSValue__bigIntFromLatin1(
         global: &JSGlobalObject,
         ptr: *const u8,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4418,8 +4418,7 @@ JSC::EncodedJSValue JSC__JSValue__fromUInt64NoTruncate(JSC::JSGlobalObject* glob
     return JSC::JSValue::encode(JSC::JSBigInt::createFrom(globalObject, val));
 }
 
-// The unsigned BigInt (high << 64) | low. JSBigInt::createFrom(Int128) is
-// signed, so it cannot hold a value with the top bit set.
+// Not createFrom(Int128): it is signed, and a 128-bit hash can have the top bit set.
 JSC::EncodedJSValue JSC__JSValue__fromUInt128NoTruncate(JSC::JSGlobalObject* globalObject, uint64_t low, uint64_t high)
 {
     const uint64_t words[2] = { low, high };

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4418,6 +4418,14 @@ JSC::EncodedJSValue JSC__JSValue__fromUInt64NoTruncate(JSC::JSGlobalObject* glob
     return JSC::JSValue::encode(JSC::JSBigInt::createFrom(globalObject, val));
 }
 
+// The unsigned BigInt (high << 64) | low. JSBigInt::createFrom(Int128) is
+// signed, so it cannot hold a value with the top bit set.
+JSC::EncodedJSValue JSC__JSValue__fromUInt128NoTruncate(JSC::JSGlobalObject* globalObject, uint64_t low, uint64_t high)
+{
+    const uint64_t words[2] = { low, high };
+    return JSC::JSValue::encode(JSC::JSBigInt::createFromWords(globalObject, words, false));
+}
+
 // Decimal integer literal (Latin-1) -> BigInt. Returns the empty value when
 // the text is not a valid StringToBigInt input.
 JSC::EncodedJSValue JSC__JSValue__bigIntFromLatin1(JSC::JSGlobalObject* globalObject, const uint8_t* ptr, size_t len)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -204,6 +204,7 @@ CPP_DECL void JSC__JSValue__forEachPropertyOrdered(JSC::EncodedJSValue JSValue0,
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromEntries(JSC::JSGlobalObject* arg0, EncodedSlice* arg1, EncodedSlice* arg2, size_t arg3, bool arg4);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromInt64NoTruncate(JSC::JSGlobalObject* arg0, int64_t arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromUInt64NoTruncate(JSC::JSGlobalObject* arg0, uint64_t arg1);
+CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromUInt128NoTruncate(JSC::JSGlobalObject* arg0, uint64_t low, uint64_t high);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntFromLatin1(JSC::JSGlobalObject* arg0, const uint8_t* arg1, size_t arg2);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromTimevalNoTruncate(JSC::JSGlobalObject* arg0, int64_t nsec, int64_t sec);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntSum(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1);

--- a/src/jsc/bindings/xxhash3.cpp
+++ b/src/jsc/bindings/xxhash3.cpp
@@ -1,5 +1,4 @@
-// Runtime-dispatched SIMD xxHash3 (XXH3_64bits and XXH3_128bits) via Google
-// Highway.
+// Runtime-dispatched SIMD xxHash3 (XXH3_64bits and XXH3_128bits) via Google Highway.
 //
 // Bun.hash.xxHash3 used the twox-hash Rust crate, which selects its SIMD
 // backend at compile time. On a nehalem (SSE2) target that meant the
@@ -8,14 +7,13 @@
 // mechanism as highway_strings.cpp), so a single binary picks the widest ISA
 // the CPU actually supports.
 //
-// Output is bit-identical to the reference XXH3_64bits and XXH3_128bits for
-// every input: only the long-keys stripe loop (accumulate_512 + scrambleAcc)
-// is vectorized, and that math is per-64-bit-lane, so scalar / SSE2 / AVX2 /
-// AVX-512 all produce the same accumulators. Both widths share that loop. The
-// 0..240 byte branches, the merge/avalanche finishers, and the seeded-secret
-// derivation are the reference's scalar code verbatim. They do not depend on
-// vector width. Verified against the xxHash reference test vectors and SMHasher
-// constants in test/js/bun/util/hash.test.js.
+// Output is bit-identical to the reference XXH3_64bits and XXH3_128bits for every input: only
+// the long-keys stripe loop (accumulate_512 + scrambleAcc) is vectorized, and
+// that math is per-64-bit-lane, so scalar / SSE2 / AVX2 / AVX-512 all produce
+// the same accumulators. The 0..240 byte branches, the merge/avalanche
+// finisher, and the seeded-secret derivation are the reference's scalar code
+// verbatim; they do not depend on vector width. Verified against the xxHash
+// reference test vectors and SMHasher constants in test/js/bun/util/hash.test.js.
 //
 // References (byte-identical constants): vendor/zstd/lib/common/xxhash.h
 // (XXH3_kSecret, PRIME*), and the twox-hash crate this replaces.
@@ -295,9 +293,7 @@ static inline XXH128Hash Len9to16_128(const u8* input, size_t len, const u8* sec
     XXH128Hash m128 = Mul64to128(input_lo ^ input_hi ^ bitflipl, PRIME64_1);
     m128.low64 += static_cast<u64>(len - 1) << 54;
     input_hi ^= bitfliph;
-    // The reference's 64-bit form of
-    // high64 += (input_hi & 0xFFFFFFFF00000000) + (u32)input_hi * PRIME32_2.
-    m128.high64 += input_hi + static_cast<u64>(static_cast<u32>(input_hi)) * (PRIME32_2 - 1);
+    m128.high64 += (input_hi & 0xFFFFFFFF00000000ull) + static_cast<u64>(static_cast<u32>(input_hi)) * PRIME32_2;
     m128.low64 ^= Swap64(m128.high64);
 
     // 128x64 multiply: h128 = m128 * PRIME64_2.
@@ -360,8 +356,7 @@ static inline XXH128Hash Len129to240_128(const u8* input, size_t len, const u8* 
     }
     acc.low64 = Avalanche(acc.low64);
     acc.high64 = Avalanche(acc.high64);
-    // `i <= len` mixes the last 32 bytes twice when len % 32 == 0. The
-    // reference does the same, and the output depends on it.
+    // `<=` matches the reference, which mixes the last 32 bytes twice when len % 32 == 0.
     for (size_t i = 160; i <= len; i += 32) {
         acc = Mix32B(acc, input + i - 32, input + i - 16, secret + kMidsizeStartOffset + i - 160, seed);
     }
@@ -709,10 +704,7 @@ static HWY_INLINE void ScrambleAcc(u64* HWY_RESTRICT acc, const u8* HWY_RESTRICT
     }
 }
 
-// The long-input stripe loop (len > 240), XXH3_hashLong_internal_loop. Writes
-// the eight accumulators to `out`. The 64-bit and the 128-bit hash merge them
-// with scalar code, outside the dispatched function. Dispatched once per call
-// so the ISA is resolved a single time, not per stripe.
+// XXH3_hashLong_internal_loop (len > 240). Both hash widths merge `out` in scalar code.
 void HashLongLoop(u64* HWY_RESTRICT out, const u8* HWY_RESTRICT input, size_t len, const u8* HWY_RESTRICT secret)
 {
     HWY_ALIGN u64 acc[kAccNb];
@@ -764,10 +756,7 @@ namespace xxh3 {
 
 HWY_EXPORT(HashLongLoop);
 
-// Runs the long-input stripe loop (len > 240) into `acc` and returns the
-// secret it used. Seed 0 uses the default secret. Any other seed derives a
-// secret into `customSecret` (matches XXH3_hashLong_*_withSeed_internal). The
-// merges read the same secret, so `customSecret` must outlive them.
+// Returns the secret the loop used: kSecret for seed 0, else one derived into `customSecret`.
 static const u8* HashLongWithSeed(u64* acc, u8* customSecret, const u8* input, size_t len, u64 seed)
 {
     const u8* secret = kSecret;
@@ -813,8 +802,6 @@ static XXH128Hash Hash128(const u8* input, size_t len, u64 seed)
     alignas(64) u8 customSecret[kSecretLen];
     u64 acc[kAccNb];
     const u8* const secret = HashLongWithSeed(acc, customSecret, input, len, seed);
-    // XXH3_hashLong_128b_internal: the low half is the 64-bit hash. The high
-    // half merges the same accumulators with the end of the secret.
     return {
         MergeAccs(acc, secret + kMergeAccsStart, static_cast<u64>(len) * PRIME64_1),
         MergeAccs(acc, secret + kSecretLen - sizeof(acc) - kMergeAccsStart, ~(static_cast<u64>(len) * PRIME64_2)),
@@ -838,9 +825,7 @@ uint64_t highway_xxhash3_64(const uint8_t* input, size_t len, uint64_t seed)
     return bun::xxh3::Hash64(input, len, seed);
 }
 
-// Runtime-dispatched XXH3_128bits_withSeed. Writes the low 64 bits of the hash
-// to out[0] and the high 64 bits to out[1]. `input` may be null only when
-// `len == 0`. Output is bit-identical to the xxHash reference.
+// Runtime-dispatched XXH3_128bits_withSeed. out[0] is the low half, out[1] the high half.
 void highway_xxhash3_128(const uint8_t* input, size_t len, uint64_t seed, uint64_t* out)
 {
     bun::xxh3::XXH128Hash const hash = bun::xxh3::Hash128(input, len, seed);

--- a/src/jsc/bindings/xxhash3.cpp
+++ b/src/jsc/bindings/xxhash3.cpp
@@ -1,4 +1,5 @@
-// Runtime-dispatched SIMD xxHash3 (XXH3_64bits) via Google Highway.
+// Runtime-dispatched SIMD xxHash3 (XXH3_64bits and XXH3_128bits) via Google
+// Highway.
 //
 // Bun.hash.xxHash3 used the twox-hash Rust crate, which selects its SIMD
 // backend at compile time. On a nehalem (SSE2) target that meant the
@@ -7,13 +8,14 @@
 // mechanism as highway_strings.cpp), so a single binary picks the widest ISA
 // the CPU actually supports.
 //
-// Output is bit-identical to the reference XXH3_64bits for every input: only
-// the long-keys stripe loop (accumulate_512 + scrambleAcc) is vectorized, and
-// that math is per-64-bit-lane, so scalar / SSE2 / AVX2 / AVX-512 all produce
-// the same accumulators. The 0..240 byte branches, the merge/avalanche
-// finisher, and the seeded-secret derivation are the reference's scalar code
-// verbatim; they do not depend on vector width. Verified against the xxHash
-// reference test vectors and SMHasher constants in test/js/bun/util/hash.test.js.
+// Output is bit-identical to the reference XXH3_64bits and XXH3_128bits for
+// every input: only the long-keys stripe loop (accumulate_512 + scrambleAcc)
+// is vectorized, and that math is per-64-bit-lane, so scalar / SSE2 / AVX2 /
+// AVX-512 all produce the same accumulators. Both widths share that loop. The
+// 0..240 byte branches, the merge/avalanche finishers, and the seeded-secret
+// derivation are the reference's scalar code verbatim. They do not depend on
+// vector width. Verified against the xxHash reference test vectors and SMHasher
+// constants in test/js/bun/util/hash.test.js.
 //
 // References (byte-identical constants): vendor/zstd/lib/common/xxhash.h
 // (XXH3_kSecret, PRIME*), and the twox-hash crate this replaces.
@@ -63,10 +65,15 @@ static constexpr u64 PRIME_MX1 = 0x165667919E3779F9ull;
 static constexpr u64 PRIME_MX2 = 0x9FB21C651E98DF25ull;
 
 static constexpr size_t kSecretLen = 192;
+static constexpr size_t kSecretSizeMin = 136; // XXH3_SECRET_SIZE_MIN
 static constexpr size_t kStripeLen = 64; // XXH_STRIPE_LEN
 static constexpr size_t kAccNb = kStripeLen / sizeof(u64); // 8
 static constexpr size_t kSecretConsumeRate = 8; // XXH_SECRET_CONSUME_RATE
+static constexpr size_t kLastAccStart = 7; // XXH_SECRET_LASTACC_START
+static constexpr size_t kMergeAccsStart = 11; // XXH_SECRET_MERGEACCS_START
 static constexpr size_t kMidsizeMax = 240; // XXH3_MIDSIZE_MAX
+static constexpr size_t kMidsizeStartOffset = 3; // XXH3_MIDSIZE_STARTOFFSET
+static constexpr size_t kMidsizeLastOffset = 17; // XXH3_MIDSIZE_LASTOFFSET
 
 // XXH3_kSecret — byte-for-byte the xxHash reference default secret.
 // clang-format off
@@ -102,15 +109,29 @@ static inline u64 ReadLE64(const u8* p)
 
 static inline u32 Swap32(u32 x) { return __builtin_bswap32(x); }
 static inline u64 Swap64(u64 x) { return __builtin_bswap64(x); }
+static inline u32 Rotl32(u32 x, int r) { return (x << r) | (x >> (32 - r)); }
 static inline u64 Rotl64(u64 x, int r) { return (x << r) | (x >> (64 - r)); }
 static inline u64 Xorshift64(u64 v, int shift) { return v ^ (v >> shift); }
 
-// 64x64 -> 128, fold halves. Uses the compiler's 128-bit integer.
-static inline u64 Mul128Fold64(u64 lhs, u64 rhs)
+// XXH128_hash_t: the two halves of a 128-bit value.
+struct XXH128Hash {
+    u64 low64;
+    u64 high64;
+};
+
+// 64x64 -> 128. Uses the compiler's 128-bit integer.
+static inline XXH128Hash Mul64to128(u64 lhs, u64 rhs)
 {
     __extension__ using u128 = unsigned __int128;
     u128 const product = static_cast<u128>(lhs) * static_cast<u128>(rhs);
-    return static_cast<u64>(product) ^ static_cast<u64>(product >> 64);
+    return { static_cast<u64>(product), static_cast<u64>(product >> 64) };
+}
+
+// 64x64 -> 128, fold halves.
+static inline u64 Mul128Fold64(u64 lhs, u64 rhs)
+{
+    XXH128Hash const product = Mul64to128(lhs, rhs);
+    return product.low64 ^ product.high64;
 }
 
 static inline u64 XXH64_avalanche(u64 h)
@@ -214,22 +235,139 @@ static inline u64 Len17to128(const u8* input, size_t len, const u8* secret, u64 
 
 static inline u64 Len129to240(const u8* input, size_t len, const u8* secret, u64 seed)
 {
-    static constexpr size_t kStartOffset = 3;
-    static constexpr size_t kLastOffset = 17;
-    static constexpr size_t kSecretSizeMin = 136; // XXH3_SECRET_SIZE_MIN
-
     u64 acc = static_cast<u64>(len) * PRIME64_1;
     u64 acc_end;
     unsigned int const nbRounds = static_cast<unsigned int>(len) / 16;
     for (unsigned int i = 0; i < 8; i++) {
         acc += Mix16B(input + (16 * i), secret + (16 * i), seed);
     }
-    acc_end = Mix16B(input + len - 16, secret + kSecretSizeMin - kLastOffset, seed);
+    acc_end = Mix16B(input + len - 16, secret + kSecretSizeMin - kMidsizeLastOffset, seed);
     acc = Avalanche(acc);
     for (unsigned int i = 8; i < nbRounds; i++) {
-        acc_end += Mix16B(input + (16 * i), secret + (16 * (i - 8)) + kStartOffset, seed);
+        acc_end += Mix16B(input + (16 * i), secret + (16 * (i - 8)) + kMidsizeStartOffset, seed);
     }
     return Avalanche(acc + acc_end);
+}
+
+// --- XXH3_128bits short-key branches (0..240 bytes). Scalar, width-independent. ---
+
+static inline XXH128Hash Len1to3_128(const u8* input, size_t len, const u8* secret, u64 seed)
+{
+    u8 const c1 = input[0];
+    u8 const c2 = input[len >> 1];
+    u8 const c3 = input[len - 1];
+    u32 const combinedl = (static_cast<u32>(c1) << 16) | (static_cast<u32>(c2) << 24)
+        | (static_cast<u32>(c3) << 0) | (static_cast<u32>(len) << 8);
+    u32 const combinedh = Rotl32(Swap32(combinedl), 13);
+    u64 const bitflipl = (ReadLE32(secret) ^ ReadLE32(secret + 4)) + seed;
+    u64 const bitfliph = (ReadLE32(secret + 8) ^ ReadLE32(secret + 12)) - seed;
+    u64 const keyed_lo = static_cast<u64>(combinedl) ^ bitflipl;
+    u64 const keyed_hi = static_cast<u64>(combinedh) ^ bitfliph;
+    return { XXH64_avalanche(keyed_lo), XXH64_avalanche(keyed_hi) };
+}
+
+static inline XXH128Hash Len4to8_128(const u8* input, size_t len, const u8* secret, u64 seed)
+{
+    seed ^= static_cast<u64>(Swap32(static_cast<u32>(seed))) << 32;
+    u32 const input_lo = ReadLE32(input);
+    u32 const input_hi = ReadLE32(input + len - 4);
+    u64 const input_64 = input_lo + (static_cast<u64>(input_hi) << 32);
+    u64 const bitflip = (ReadLE64(secret + 16) ^ ReadLE64(secret + 24)) + seed;
+    u64 const keyed = input_64 ^ bitflip;
+
+    XXH128Hash m128 = Mul64to128(keyed, PRIME64_1 + (static_cast<u64>(len) << 2));
+    m128.high64 += (m128.low64 << 1);
+    m128.low64 ^= (m128.high64 >> 3);
+
+    m128.low64 = Xorshift64(m128.low64, 35);
+    m128.low64 *= PRIME_MX2;
+    m128.low64 = Xorshift64(m128.low64, 28);
+    m128.high64 = Avalanche(m128.high64);
+    return m128;
+}
+
+static inline XXH128Hash Len9to16_128(const u8* input, size_t len, const u8* secret, u64 seed)
+{
+    u64 const bitflipl = (ReadLE64(secret + 32) ^ ReadLE64(secret + 40)) - seed;
+    u64 const bitfliph = (ReadLE64(secret + 48) ^ ReadLE64(secret + 56)) + seed;
+    u64 const input_lo = ReadLE64(input);
+    u64 input_hi = ReadLE64(input + len - 8);
+    XXH128Hash m128 = Mul64to128(input_lo ^ input_hi ^ bitflipl, PRIME64_1);
+    m128.low64 += static_cast<u64>(len - 1) << 54;
+    input_hi ^= bitfliph;
+    // The reference's 64-bit form of
+    // high64 += (input_hi & 0xFFFFFFFF00000000) + (u32)input_hi * PRIME32_2.
+    m128.high64 += input_hi + static_cast<u64>(static_cast<u32>(input_hi)) * (PRIME32_2 - 1);
+    m128.low64 ^= Swap64(m128.high64);
+
+    // 128x64 multiply: h128 = m128 * PRIME64_2.
+    XXH128Hash h128 = Mul64to128(m128.low64, PRIME64_2);
+    h128.high64 += m128.high64 * PRIME64_2;
+    h128.low64 = Avalanche(h128.low64);
+    h128.high64 = Avalanche(h128.high64);
+    return h128;
+}
+
+static inline XXH128Hash Len0to16_128(const u8* input, size_t len, const u8* secret, u64 seed)
+{
+    if (len > 8) return Len9to16_128(input, len, secret, seed);
+    if (len >= 4) return Len4to8_128(input, len, secret, seed);
+    if (len) return Len1to3_128(input, len, secret, seed);
+    u64 const bitflipl = ReadLE64(secret + 64) ^ ReadLE64(secret + 72);
+    u64 const bitfliph = ReadLE64(secret + 80) ^ ReadLE64(secret + 88);
+    return { XXH64_avalanche(seed ^ bitflipl), XXH64_avalanche(seed ^ bitfliph) };
+}
+
+static inline XXH128Hash Mix32B(XXH128Hash acc, const u8* input_1, const u8* input_2, const u8* secret, u64 seed)
+{
+    acc.low64 += Mix16B(input_1, secret + 0, seed);
+    acc.low64 ^= ReadLE64(input_2) + ReadLE64(input_2 + 8);
+    acc.high64 += Mix16B(input_2, secret + 16, seed);
+    acc.high64 ^= ReadLE64(input_1) + ReadLE64(input_1 + 8);
+    return acc;
+}
+
+// The finisher shared by the 17..128 and the 129..240 byte branches.
+static inline XXH128Hash MidsizeAvalanche128(XXH128Hash acc, size_t len, u64 seed)
+{
+    u64 const low64 = acc.low64 + acc.high64;
+    u64 const high64 = (acc.low64 * PRIME64_1) + (acc.high64 * PRIME64_4)
+        + ((static_cast<u64>(len) - seed) * PRIME64_2);
+    return { Avalanche(low64), 0 - Avalanche(high64) };
+}
+
+static inline XXH128Hash Len17to128_128(const u8* input, size_t len, const u8* secret, u64 seed)
+{
+    XXH128Hash acc = { static_cast<u64>(len) * PRIME64_1, 0 };
+    if (len > 32) {
+        if (len > 64) {
+            if (len > 96) {
+                acc = Mix32B(acc, input + 48, input + len - 64, secret + 96, seed);
+            }
+            acc = Mix32B(acc, input + 32, input + len - 48, secret + 64, seed);
+        }
+        acc = Mix32B(acc, input + 16, input + len - 32, secret + 32, seed);
+    }
+    acc = Mix32B(acc, input, input + len - 16, secret, seed);
+    return MidsizeAvalanche128(acc, len, seed);
+}
+
+static inline XXH128Hash Len129to240_128(const u8* input, size_t len, const u8* secret, u64 seed)
+{
+    XXH128Hash acc = { static_cast<u64>(len) * PRIME64_1, 0 };
+    for (size_t i = 32; i < 160; i += 32) {
+        acc = Mix32B(acc, input + i - 32, input + i - 16, secret + i - 32, seed);
+    }
+    acc.low64 = Avalanche(acc.low64);
+    acc.high64 = Avalanche(acc.high64);
+    // `i <= len` mixes the last 32 bytes twice when len % 32 == 0. The
+    // reference does the same, and the output depends on it.
+    for (size_t i = 160; i <= len; i += 32) {
+        acc = Mix32B(acc, input + i - 32, input + i - 16, secret + kMidsizeStartOffset + i - 160, seed);
+    }
+    acc = Mix32B(acc, input + len - 16, input + len - 32,
+        secret + kSecretSizeMin - kMidsizeLastOffset - 16, 0 - seed);
+    return MidsizeAvalanche128(acc, len, seed);
 }
 
 // --- Long-key finisher (scalar) ---
@@ -278,8 +416,6 @@ static inline void InitCustomSecret(u8* customSecret, u64 seed64)
 // verified against the reference vectors and SMHasher constants in
 // test/js/bun/util/hash.test.js.
 // ---------------------------------------------------------------------------
-
-static inline u32 Rotl32(u32 x, int r) { return (x << r) | (x >> (32 - r)); }
 
 static inline u32 XXH32_round(u32 acc, u32 input)
 {
@@ -573,9 +709,11 @@ static HWY_INLINE void ScrambleAcc(u64* HWY_RESTRICT acc, const u8* HWY_RESTRICT
     }
 }
 
-// Full long-input hash (len > 240): the stripe loop + finisher. Dispatched
-// once per call so the ISA is resolved a single time, not per stripe.
-u64 HashLong(const u8* HWY_RESTRICT input, size_t len, const u8* HWY_RESTRICT secret)
+// The long-input stripe loop (len > 240), XXH3_hashLong_internal_loop. Writes
+// the eight accumulators to `out`. The 64-bit and the 128-bit hash merge them
+// with scalar code, outside the dispatched function. Dispatched once per call
+// so the ISA is resolved a single time, not per stripe.
+void HashLongLoop(u64* HWY_RESTRICT out, const u8* HWY_RESTRICT input, size_t len, const u8* HWY_RESTRICT secret)
 {
     HWY_ALIGN u64 acc[kAccNb];
     std::memcpy(acc, kInitAcc, sizeof(acc));
@@ -600,11 +738,9 @@ u64 HashLong(const u8* HWY_RESTRICT input, size_t len, const u8* HWY_RESTRICT se
     }
 
     // Last stripe (always the final 64 bytes).
-    static constexpr size_t kLastAccStart = 7; // XXH_SECRET_LASTACC_START
     Accumulate512(acc, input + len - kStripeLen, secret + kSecretLen - kStripeLen - kLastAccStart);
 
-    static constexpr size_t kMergeAccsStart = 11; // XXH_SECRET_MERGEACCS_START
-    return MergeAccs(acc, secret + kMergeAccsStart, static_cast<u64>(len) * PRIME64_1);
+    std::memcpy(out, acc, sizeof(acc));
 }
 
 } // namespace HWY_NAMESPACE
@@ -626,7 +762,22 @@ HWY_AFTER_NAMESPACE();
 namespace bun {
 namespace xxh3 {
 
-HWY_EXPORT(HashLong);
+HWY_EXPORT(HashLongLoop);
+
+// Runs the long-input stripe loop (len > 240) into `acc` and returns the
+// secret it used. Seed 0 uses the default secret. Any other seed derives a
+// secret into `customSecret` (matches XXH3_hashLong_*_withSeed_internal). The
+// merges read the same secret, so `customSecret` must outlive them.
+static const u8* HashLongWithSeed(u64* acc, u8* customSecret, const u8* input, size_t len, u64 seed)
+{
+    const u8* secret = kSecret;
+    if (seed != 0) {
+        InitCustomSecret(customSecret, seed);
+        secret = customSecret;
+    }
+    BUN_HWY_DISPATCH(HashLongLoop)(acc, input, len, secret);
+    return secret;
+}
 
 // XXH3_64bits_withSeed. `seed` is the full 64-bit seed; callers that need the
 // JS `@truncate(seed)` semantics truncate before calling (HashObject does).
@@ -641,14 +792,33 @@ static u64 Hash64(const u8* input, size_t len, u64 seed)
     if (len <= kMidsizeMax) {
         return Len129to240(input, len, kSecret, seed);
     }
-    // Long input: seed == 0 uses the default secret directly; otherwise derive
-    // a per-seed secret (matches XXH3_hashLong_64b_withSeed_internal).
-    if (seed == 0) {
-        return BUN_HWY_DISPATCH(HashLong)(input, len, kSecret);
+    alignas(64) u8 customSecret[kSecretLen];
+    u64 acc[kAccNb];
+    const u8* const secret = HashLongWithSeed(acc, customSecret, input, len, seed);
+    return MergeAccs(acc, secret + kMergeAccsStart, static_cast<u64>(len) * PRIME64_1);
+}
+
+// XXH3_128bits_withSeed. `seed` is the full 64-bit seed.
+static XXH128Hash Hash128(const u8* input, size_t len, u64 seed)
+{
+    if (len <= 16) {
+        return Len0to16_128(input, len, kSecret, seed);
+    }
+    if (len <= 128) {
+        return Len17to128_128(input, len, kSecret, seed);
+    }
+    if (len <= kMidsizeMax) {
+        return Len129to240_128(input, len, kSecret, seed);
     }
     alignas(64) u8 customSecret[kSecretLen];
-    InitCustomSecret(customSecret, seed);
-    return BUN_HWY_DISPATCH(HashLong)(input, len, customSecret);
+    u64 acc[kAccNb];
+    const u8* const secret = HashLongWithSeed(acc, customSecret, input, len, seed);
+    // XXH3_hashLong_128b_internal: the low half is the 64-bit hash. The high
+    // half merges the same accumulators with the end of the secret.
+    return {
+        MergeAccs(acc, secret + kMergeAccsStart, static_cast<u64>(len) * PRIME64_1),
+        MergeAccs(acc, secret + kSecretLen - sizeof(acc) - kMergeAccsStart, ~(static_cast<u64>(len) * PRIME64_2)),
+    };
 }
 
 } // namespace xxh3
@@ -666,6 +836,16 @@ extern "C" {
 uint64_t highway_xxhash3_64(const uint8_t* input, size_t len, uint64_t seed)
 {
     return bun::xxh3::Hash64(input, len, seed);
+}
+
+// Runtime-dispatched XXH3_128bits_withSeed. Writes the low 64 bits of the hash
+// to out[0] and the high 64 bits to out[1]. `input` may be null only when
+// `len == 0`. Output is bit-identical to the xxHash reference.
+void highway_xxhash3_128(const uint8_t* input, size_t len, uint64_t seed, uint64_t* out)
+{
+    bun::xxh3::XXH128Hash const hash = bun::xxh3::Hash128(input, len, seed);
+    out[0] = hash.low64;
+    out[1] = hash.high64;
 }
 
 // XXH32 one-shot. Scalar; bit-identical to the reference.

--- a/src/runtime/api/HashObject.rs
+++ b/src/runtime/api/HashObject.rs
@@ -131,9 +131,7 @@ struct XxHash128;
 impl HashAlgorithm for XxHash128 {
     type Output = u128;
     fn hash(seed: u64, input: &[u8]) -> u128 {
-        // XXH3_128bits_withSeed on the same SIMD kernel as XxHash3. The seed
-        // is the full u64, as in the reference. XxHash3 truncates its seed only
-        // to keep its older output. This function has no older output.
+        // The full u64 seed, as in the reference. No older output to keep, unlike XxHash3.
         bun_highway::xxhash3_128(seed, input)
     }
 }

--- a/src/runtime/api/HashObject.rs
+++ b/src/runtime/api/HashObject.rs
@@ -29,6 +29,13 @@ impl HashOutput for u64 {
     }
 }
 
+impl HashOutput for u128 {
+    #[inline]
+    fn to_js(self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        JSValue::from_uint128_no_truncate(global, self)
+    }
+}
+
 trait HashAlgorithm {
     type Output: HashOutput;
     /// `seed` is always passed as u64 from JS; impls truncate to their native
@@ -120,6 +127,17 @@ impl HashAlgorithm for XxHash3 {
     }
 }
 
+struct XxHash128;
+impl HashAlgorithm for XxHash128 {
+    type Output = u128;
+    fn hash(seed: u64, input: &[u8]) -> u128 {
+        // XXH3_128bits_withSeed on the same SIMD kernel as XxHash3. The seed
+        // is the full u64, as in the reference. XxHash3 truncates its seed only
+        // to keep its older output. This function has no older output.
+        bun_highway::xxhash3_128(seed, input)
+    }
+}
+
 struct Murmur32v2;
 impl HashAlgorithm for Murmur32v2 {
     type Output = u32;
@@ -202,6 +220,11 @@ fn xx_hash3(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
 }
 
 #[bun_jsc::host_fn]
+fn xx_hash128(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    hash_wrap::<XxHash128>(global, frame)
+}
+
+#[bun_jsc::host_fn]
 fn murmur32v2(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     hash_wrap::<Murmur32v2>(global, frame)
 }
@@ -236,6 +259,7 @@ pub(crate) fn create(global: &JSGlobalObject) -> JSValue {
             ("xxHash32", __jsc_host_xx_hash32, 1),
             ("xxHash64", __jsc_host_xx_hash64, 1),
             ("xxHash3", __jsc_host_xx_hash3, 1),
+            ("xxHash128", __jsc_host_xx_hash128, 1),
             ("murmur32v2", __jsc_host_murmur32v2, 1),
             ("murmur32v3", __jsc_host_murmur32v3, 1),
             ("murmur64v2", __jsc_host_murmur64v2, 1),

--- a/test/integration/bun-types/fixture/hashing.ts
+++ b/test/integration/bun-types/fixture/hashing.ts
@@ -1,3 +1,5 @@
+import { expectType } from "./utilities";
+
 Bun.hash.wyhash("asdf", 1234n);
 
 // https://github.com/oven-sh/bun/issues/26043
@@ -5,3 +7,8 @@ Bun.hash.wyhash("asdf", 1234n);
 let crc = 0;
 crc = Bun.hash.crc32(new Uint8Array([1, 2, 3]), crc);
 crc = Bun.hash.crc32(new Uint8Array([4, 5, 6]), crc);
+
+// https://github.com/oven-sh/bun/issues/19573
+expectType(Bun.hash.xxHash128("asdf")).is<bigint>();
+expectType(Bun.hash.xxHash128(new Uint8Array([1, 2, 3]), 1234)).is<bigint>();
+expectType(Bun.hash.xxHash128(new ArrayBuffer(8), 1234n)).is<bigint>();

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -226,11 +226,22 @@ describe("xxHash128 reference vectors", () => {
     [17, 0n, 0x7269f7707a5633ce34fdba88610c84f0n],
     [17, 42n, 0x555cee2202f0eb819d516a87ea893f55n],
     [17, BIG_SEED, 0x22860a317c761d25942cc22202328f77n],
+    // 32, 64, and 96 are the cutoffs of the 17..128 branch.
+    [32, 0n, 0xb460d4dc6be0adcb6aa1b5185c4a1bf9n],
+    [33, 42n, 0xb5bc1de50fbcfd373e3d21799fac02b8n],
+    [64, 2882400001n, 0xcf9bfad8b3365432de19134db8892d66n],
+    [65, 0n, 0xdbb73c102b1d241fc065002853df8e7cn],
+    [96, 42n, 0x5fa3b9d4dad7646c82c57ae93f82b0c1n],
+    [97, BIG_SEED, 0xf5848ceac1e49ec83c1a9fa888f554ccn],
     [128, 0n, 0xa50923197dc0dc531198ac4ec9cfd6efn],
     [128, 2882400001n, 0x7ed5bb4719b1d4ce6569b846a8c6cbafn],
     [129, 0n, 0x7ad3d310e226eae751c73585a2dbe083n],
     [129, 42n, 0xa9cc7ecec36484a6a347abdffb1b594en],
     [129, BIG_SEED, 0xe2c3e2425bf9ad647c03504f9e24492cn],
+    // The 129..240 branch mixes one more 32-byte block at 160, 192, and 224.
+    [160, 0n, 0x66dc257dd0a336a347ff8069f9d0faf9n],
+    [192, 42n, 0xc197ea3ba8c4a096477c04659dc59d93n],
+    [224, 2882400001n, 0xa837590456378ff1fced13eed398176an],
     [240, 0n, 0xf260e5c85b249b91791c37dcce4acc6bn],
     [240, 2882400001n, 0xa88c287e75d2c554d53dcf0cc73098fcn],
     // Long-input path (> 240): the Highway-dispatched stripe loop.

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -70,6 +70,14 @@ it(`Bun.hash.xxHash3()`, () => {
   expect(Bun.hash.xxHash3(new TextEncoder().encode("hello world"))).toBe(0xd447b1ea40e6988bn);
   gcTick();
 });
+it(`Bun.hash.xxHash128()`, () => {
+  expect(Bun.hash.xxHash128("hello world")).toBe(0xdf8d09e93f874900a99b8775cc15b6c7n);
+  gcTick();
+  expect(Bun.hash.xxHash128(new TextEncoder().encode("hello world"))).toBe(0xdf8d09e93f874900a99b8775cc15b6c7n);
+  gcTick();
+  // The canonical digest (XXH128_canonicalFromHash) is the big-endian hex of the bigint.
+  expect(Bun.hash.xxHash128("hello world").toString(16).padStart(32, "0")).toBe("df8d09e93f874900a99b8775cc15b6c7");
+});
 it(`Bun.hash.murmur32v3()`, () => {
   expect(Bun.hash.murmur32v3("hello world")).toBe(0x5e928f0f);
   gcTick();
@@ -179,6 +187,95 @@ describe("xxHash3 SIMD kernel", () => {
     expect(xxHash3ForTesting(bytes, undefined)).toBe(xxHash3ForTesting(bytes));
     // a wrong-type seed is a mistaken call
     expect(() => xxHash3ForTesting(bytes, "nope")).toThrow("seed must be a number or bigint");
+  });
+});
+
+// Bun.hash.xxHash128 is XXH3_128bits_withSeed. Its short-input branches are
+// separate from the 64-bit ones, and its long-input path shares the dispatched
+// stripe loop with xxHash3. Expected values come from the xxHash reference
+// (v0.8.2), as (high64 << 64n) | low64. Input byte i = (i * 191 + 17) & 0xff.
+describe("xxHash128 reference vectors", () => {
+  const makeInput = n => {
+    const b = new Uint8Array(n);
+    for (let i = 0; i < n; i++) b[i] = (i * 191 + 17) & 0xff;
+    return b;
+  };
+
+  // 0xfedcba9876543210 does not fit in u32, so it checks that the full u64 seed is used.
+  const BIG_SEED = 18364758544493064720n;
+
+  // [length, seed, expected], from the reference XXH3_128bits_withSeed.
+  const REFERENCE = [
+    [0, 0n, 0x99aa06d3014798d86001c324468d497fn],
+    [0, 2882400001n, 0xafe8d3f6b2a21e14b232f4f01dfba019n],
+    [1, 0n, 0xf46d8182f5a4994af319fe2bdfcdfebdn],
+    [1, 42n, 0x7b1882fc7bae7d7a46d8bd2c8a4b5d7cn],
+    [1, BIG_SEED, 0xb4c5848cfa18159e6e391427ebfab897n],
+    [3, 0n, 0x8f3da70e554cba4c5f0e655f038cc17fn],
+    [3, 2882400001n, 0x597eb4168b63d9e76d433d112876736an],
+    [4, 0n, 0xebf55fd7f190de905a66c2cd13b4e76an],
+    [4, 42n, 0xe421e49b45ee4b1a997f6fefb58a9b7an],
+    [4, BIG_SEED, 0x86753af4d40598b38a2b87097619f9dfn],
+    [8, 0n, 0x12a88caa499625caf3c783fa5a1b4688n],
+    [8, 2882400001n, 0x33e662492d3e67e94a68849b238054d6n],
+    [9, 0n, 0x7c5803582b2f059ef4e29ec04b0e1e63n],
+    [9, 42n, 0xe09f93dbc753fe7ca7f7ff77e65afe49n],
+    [9, BIG_SEED, 0xffedb895b0717dd7eef194b789bcbd38n],
+    [16, 0n, 0xd5a006a6c295b0ed4fc686383b65d5aan],
+    [16, 2882400001n, 0xfd5c8ccc2b96214ec9797fba53656857n],
+    [17, 0n, 0x7269f7707a5633ce34fdba88610c84f0n],
+    [17, 42n, 0x555cee2202f0eb819d516a87ea893f55n],
+    [17, BIG_SEED, 0x22860a317c761d25942cc22202328f77n],
+    [128, 0n, 0xa50923197dc0dc531198ac4ec9cfd6efn],
+    [128, 2882400001n, 0x7ed5bb4719b1d4ce6569b846a8c6cbafn],
+    [129, 0n, 0x7ad3d310e226eae751c73585a2dbe083n],
+    [129, 42n, 0xa9cc7ecec36484a6a347abdffb1b594en],
+    [129, BIG_SEED, 0xe2c3e2425bf9ad647c03504f9e24492cn],
+    [240, 0n, 0xf260e5c85b249b91791c37dcce4acc6bn],
+    [240, 2882400001n, 0xa88c287e75d2c554d53dcf0cc73098fcn],
+    // Long-input path (> 240): the Highway-dispatched stripe loop.
+    [241, 0n, 0x1c2d14c78686163fdc3fc1135592d6e6n],
+    [241, 42n, 0x4755c37801bfb6688ad5972b519634e3n],
+    [241, BIG_SEED, 0x89b142e94b6ef433261f3da474ce402an],
+    [1024, 0n, 0x1b66ab1db0e725f2a9e2eee0215aa4e9n],
+    [1024, 2882400001n, 0x25a0c04ced7e12898863ca2656d5ca77n],
+    // Multi-block.
+    [131072, 0n, 0x51b9b08e713dd1196afc5e23ce3c83a5n],
+    [131072, 42n, 0x6f7e25a68e46bbc4e5e44b2bed110652n],
+    [131072, BIG_SEED, 0xb8bf146fcaeaffe124fd0d52bbc1bc0en],
+  ];
+
+  it("matches the xxHash reference across every length branch and seed", () => {
+    const actual = REFERENCE.map(([len, seed]) => [len, seed, Bun.hash.xxHash128(makeInput(len), seed)]);
+    expect(actual).toEqual(REFERENCE);
+  });
+
+  it("has the 64-bit hash as its low half for long inputs", () => {
+    // XXH3_hashLong_128b merges the same accumulators as the 64-bit hash. The
+    // seeds fit in u32, so xxHash3 does not truncate them.
+    for (const len of [241, 256, 513, 1024, 65536, 131072]) {
+      for (const seed of [0, 1, 0xabcdef01]) {
+        const input = makeInput(len);
+        expect(Bun.hash.xxHash128(input, seed) & 0xffffffffffffffffn).toBe(Bun.hash.xxHash3(input, seed));
+      }
+    }
+    gcTick();
+  });
+
+  it("reads a number seed and a bigint seed the same way", () => {
+    const input = makeInput(100);
+    const seeds = [0, 1, 0xabcdef01, 2 ** 32, 2 ** 53 - 1];
+    expect(seeds.map(seed => Bun.hash.xxHash128(input, seed))).toEqual(
+      seeds.map(seed => Bun.hash.xxHash128(input, BigInt(seed))),
+    );
+    expect(Bun.hash.xxHash128(input, 2 ** 32)).not.toBe(Bun.hash.xxHash128(input, 0));
+  });
+
+  it("hashes a string and its UTF-8 bytes identically for a large input", () => {
+    const str = Buffer.alloc(100 * 1024, "xABcDpQrStUvWxYz=-1]23]12312312][3123][123][").toString();
+    const bytes = new TextEncoder().encode(str);
+    expect(Bun.hash.xxHash128(str)).toBe(Bun.hash.xxHash128(bytes));
+    expect(Bun.hash.xxHash128(bytes.buffer)).toBe(Bun.hash.xxHash128(bytes));
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.hash` has no 128-bit hash. #19573 asks for XXH128, the 128-bit xxHash3 variant, to find duplicate files.
- `Bun.hash.xxHash128` is `undefined` in 1.4.1.

### Fix
- `Bun.hash.xxHash128(data, seed?)` returns `XXH3_128bits_withSeed` as an unsigned bigint, `(high64 << 64n) | low64`. The seed is the full u64, as in the reference.
- The branches for inputs up to 240 bytes are scalar ports of the reference. Longer inputs run the stripe loop that `xxHash3` already dispatches. That loop (`HashLong`, now `HashLongLoop`) writes out its accumulators, and each width merges them in scalar code.
- Correct because the output matches the xxHash v0.8.2 reference for every length up to 4 KB and 3000 random inputs, on all five x64 SIMD targets. `xxHash3` output and speed do not change.
- Verified: `test/js/bun/util/hash.test.js` (5 new tests fail on 1.4.1), and `test/integration/bun-types/bun-types.test.ts`. Self-review asked for test lengths at the mid-size cutoffs (added) and for proof of the renamed allowlist entries (the verify-baseline jobs pass).

### Background
- XXH3 hashes an input over 240 bytes in 64-byte stripes into eight u64 accumulators. The 64-bit and 128-bit hashes share that loop. They differ only in the merge.
- Highway compiles `HashLongLoop` once per ISA. `BUN_HWY_DISPATCH` picks one at run time.
- `scripts/verify-baseline-static` scans release binaries for instructions above the baseline CPU. Its allowlists name each dispatched symbol, so the rename updates all three lists.
- `JSBigInt::createFrom(Int128)` is signed. The new `JSC__JSValue__fromUInt128NoTruncate` uses `createFromWords`.

<details><summary>Notes</summary>

- Reference vectors come from `vendor/zstd/lib/common/xxhash.h` (v0.8.2) with the XXH3 guard removed. The same build reproduces the `xxHash3` values that `hash.test.js` already pins.
- Standalone check: `xxhash3.cpp` plus the vendored Highway, compared with `XXH3_64bits_withSeed` and `XXH3_128bits_withSeed`. Lengths 0 to 4096 at start offsets 0 to 6, with 7 seeds (0, 1, 42, 0xabcdef01, 0xfedcba9876543210, 2^64-1, 2^63). Then 3000 random lengths up to 1 MB, and a null pointer with length 0. All pass on SSSE3, SSE4, AVX2, AVX3, and AVX3_DL. One changed constant fails 29991 of 31681 checks.
- Timing, same harness (clang 21, `-O2 -march=nehalem`, AVX-512 host). `xxHash3` at 128 KB: 3557 ns before, 3538 ns after. At 8 bytes: 4.04 ns before, 3.53 ns after. `xxHash128`: 3544 ns at 128 KB, 5.60 ns at 8 bytes.
- Mutation check for the test table: seven one-step changes to the 17..128 and 129..240 branches (each cutoff moved by one, and `i <= len` changed to `i < len`). The first table caught none of them. The rows at 32, 33, 64, 65, 96, 97, 160, 192, and 224 catch all seven.
- Baseline check: the verify-baseline jobs pass with the new names on linux x64, aarch64, x64-musl, aarch64-musl, aarch64-android, and windows x64. Locally, `verify-baseline-static` on a `-O3 -march=nehalem` harness binary shows the features of the new loop: `[AVX, AVX2]` (AVX2 target) and `[AVX, AVX512DQ, AVX512F]` (AVX3 targets). Both fit the old ceilings, so the ceilings stay.
- `xxHash3` keeps its u32 seed. #32833 proposes to change that, and it edits the same lines in `HashObject.rs`.
- Types: `seed?: number | bigint`, because the runtime reads both. The sibling declarations say `bigint` only. This PR leaves them alone.
- Also ran: `hash.test.js` with `BUN_JSC_validateExceptionChecks=1`, and the docs example with the debug build.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 17 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/hash.test.js
bun test v1.4.1 (e0a2b82fd)

test/js/bun/util/hash.test.js:
(pass) Bun.hash() [91.72ms]
(pass) Bun.hash.wyhash() [31.01ms]
(pass) Bun.hash.adler32() [35.44ms]
(pass) Bun.hash.crc32() [30.33ms]
(pass) Bun.hash.cityHash32() [64.49ms]
(pass) Bun.hash.cityHash64() [54.91ms]
(pass) Bun.hash.xxHash32() [53.85ms]
(pass) Bun.hash.xxHash64() [80.31ms]
(pass) Bun.hash.xxHash64() reads a large Number seed exactly [12.56ms]
(pass) Bun.hash.xxHash3() [57.55ms]
69 |   gcTick();
70 |   expect(Bun.hash.xxHash3(new TextEncoder().encode("hello world"))).toBe(0xd447b1ea40e6988bn);
71 |   gcTick();
72 | });
73 | it(`Bun.hash.xxHash128()`, () => {
74 |   expect(Bun.hash.xxHash128("hello world")).toBe(0xdf8d09e93f874900a99b8775cc15b6c7n);
                       ^
TypeError: Bun.hash.xxHash128 is not a function. (In 'Bun.hash.xxHash128("hello world")', 'Bun.hash.xxHash128' is undefined)
      at <anonymous> (/workspace/bun/test/js/bun/util/hash.test.js:74:19)
(fail) Bun.hash.xxHash128() [5.50ms]
(pass) Bun.hash.murmur32v3() [33.5
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (a89904071)

test/js/bun/util/hash.test.js:
(pass) Bun.hash() [2.91ms]
(pass) Bun.hash.wyhash() [1.65ms]
(pass) Bun.hash.adler32() [1.83ms]
(pass) Bun.hash.crc32() [1.31ms]
(pass) Bun.hash.cityHash32() [4.02ms]
(pass) Bun.hash.cityHash64() [2.60ms]
(pass) Bun.hash.xxHash32() [2.07ms]
(pass) Bun.hash.xxHash64() [2.32ms]
(pass) Bun.hash.xxHash64() reads a large Number seed exactly [0.23ms]
(pass) Bun.hash.xxHash3() [1.56ms]
(pass) Bun.hash.xxHash128() [2.42ms]
(pass) Bun.hash.murmur32v3() [0.87ms]
(pass) Bun.hash.murmur32v2() [0.79ms]
(pass) Bun.hash.murmur64v2() [0.77ms]
(pass) Bun.hash.rapidhash() [1.53ms]
(pass) xxHash3 SIMD kernel > matches the xxHash reference across every length branch and seed [1.35ms]
(pass) xxHash3 SIMD kernel > the dispatched kernel agrees with Bun.hash.xxHash3 on large inputs [3.36ms]
(pass) xxHash3 SIMD kernel > hashes a string and its UTF-8 bytes identically for a large input [0.28ms]
(pass) xxHash3 SIMD kernel > treats an undefined seed as 0 and rejects other non-number/bigint seeds [0.12ms]
(pass) xxHash128 reference vectors > matches the xxHash reference across every length branch and seed [1.28ms]
(pass) xxHas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/hash.test.js
bun test v1.4.1 (e0a2b82fd)

test/js/bun/util/hash.test.js:
(pass) Bun.hash() [73.46ms]
(pass) Bun.hash.wyhash() [29.78ms]
(pass) Bun.hash.adler32() [26.06ms]
(pass) Bun.hash.crc32() [27.27ms]
(pass) Bun.hash.cityHash32() [53.91ms]
(pass) Bun.hash.cityHash64() [53.24ms]
(pass) Bun.hash.xxHash32() [55.30ms]
(pass) Bun.hash.xxHash64() [78.37ms]
(pass) Bun.hash.xxHash64() reads a large Number seed exactly [13.13ms]
(pass) Bun.hash.xxHash3() [49.64ms]
(pass) Bun.hash.xxHash128() [54.70ms]
(pass) Bun.hash.murmur32v3() [26.69ms]
(pass) Bun.hash.murmur32v2() [29.58ms]
(pass) Bun.hash.murmur64v2() [29.02ms]
(pass) Bun.hash.rapidhash() [26.82ms]
(pass) xxHash3 SIMD kernel > matches the xxHash reference across every length branch and seed [36.91ms]
(pass) xxHash3 SIMD kernel > the dispatched kernel agrees with Bun.hash.xxHash3 on large inputs [81.39ms]
(pass) xxHash3 SIMD kernel > hashes a string and its UTF-8 bytes identically for a large input [9.30ms]
(pass) xxHash3 SIMD kernel > treats an undefined seed as 0 and 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 628ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/23] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[3/23] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[4/23] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/23] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[6/23] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[7/23] cxx obj/src/jsc/bindings/BunObject.cpp.o
[8/23] cxx obj/src/jsc/bindings/napi.cpp.o
[9/23] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[10/23] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[11/23] cxx obj/src/jsc/bindings/bindings.cpp.o
[12/23] cxx obj/src/jsc/bindings/xxhash3.cpp.o
[13/23] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[14/23] cxx obj/codegen/JSSink.cpp.o
[15/23] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[16/23] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[17/23] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
bench/snippets/hash.mjs                            |   8 +
 docs/runtime/hashing.mdx                           |  12 +-
 packages/bun-types/bun.d.ts                        |   7 +
 scripts/build/unified.ts                           |   2 +-
 .../verify-baseline-static/allowlist-aarch64.txt   |   8 +-
 .../allowlist-x64-windows.txt                      |  14 +-
 scripts/verify-baseline-static/allowlist-x64.txt   |  10 +-
 src/hash/lib.rs                                    |   1 +
 src/hash/xxhash.rs                                 |   2 +-
 src/highway/lib.rs                                 |  12 ++
 src/jsc/JSValue.rs                                 |  12 ++
 src/jsc/bindings/bindings.cpp                      |   7 +
 src/jsc/bindings/headers.h                         |   1 +
 src/jsc/bindings/xxhash3.cpp                       | 217 ++++++++++++++++++---
 src/runtime/api/HashObject.rs                      |  22 +++
 test/integration/bun-types/fixture/hashing.ts      |   7 +
 test/js/bun/util/hash.test.js                      | 108 ++++++++++
 17 files changed, 404 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
bench/snippets/hash.mjs                                       0      0      8
docs/runtime/hashing.mdx                                      2      2      8
packages/bun-types/bun.d.ts                                   2      3      9
scripts/build/unified.ts                                      1      2      9
scripts/verify-baseline-static/allowlist-aarch64.txt          0      0      8
scripts/verify-baseline-static/allowlist-x64-windows.txt      0      0      8
scripts/verify-baseline-static/allowlist-x64.txt              0      0      8
src/hash/lib.rs                                               1      1      8
src/hash/xxhash.rs                                            1      2      8
src/highway/lib.rs                                            4      5      8
src/jsc/JSValue.rs                                            1      3      8
src/jsc/bindings/bindings.cpp                                 1      2      8
src/jsc/bindings/headers.h                                    1      2      8
src/jsc/bindings/xxhash3.cpp                                  3     19      8
src/runtime/api/HashObject.rs                                 1      6      8
test/integration/bun-types/fixture/hashing.ts                 1      1     11
(+ 1 more files)
```

</details>

<!-- robobun:evidence:end -->