### PR TITLE
Windows: run timers after the poll, so I/O immediates run first

### DIFF
--- a/src/event_loop/README.md
+++ b/src/event_loop/README.md
@@ -91,12 +91,12 @@ This is called when the event loop is active and needs to wait for I/O:
                │
                ▼
 ┌─────────────────────────────────────┐
-│  4. Tick immediate tasks (POSIX)    │ ← setImmediate() callbacks
+│  4. Tick immediate tasks            │ ← setImmediate() callbacks
 └──────────────┬──────────────────────┘
                │
                ▼
 ┌─────────────────────────────────────┐
-│  5. Drain timers (POSIX)            │ ← setTimeout/setInterval callbacks
+│  5. Drain timers                    │ ← setTimeout/setInterval callbacks
 └──────────────┬──────────────────────┘
                │
                ▼
@@ -114,7 +114,7 @@ Steps 3 to 5 follow Node's phase order: poll, check (`setImmediate`), timers. Th
 
 Node runs thread-pool completions in the poll phase. Bun runs them as tasks in `tick()`. So a `tick()` that ran tasks counts as a poll phase: before step 3, `autoTick` runs the immediates and the timers once more. If one of them ran a callback, the poll does not wait.
 
-On Windows, libuv runs the timers inside the poll call (step 3). There, the immediates run before step 1, and steps 4 and 5 do not run.
+On Windows, the poll is `uv_run`. It takes no timeout, so a wakeup keeps it from waiting while immediates are queued. A `uv_timer_t` ends it at the next timer deadline. The callback of that timer runs no timers, so step 5 runs them, as on POSIX.
 
 ## Task Draining Algorithm
 
@@ -285,23 +285,17 @@ When I/O becomes ready (socket readable/writable, file descriptor ready):
 
 ## setTimeout and setInterval Ordering
 
-Timers are handled differently based on platform:
-
-### POSIX (`event_loop.rs:396`)
-
 ```rust
 ctx.timer.drain_timers(ctx);
 ```
 
-Timers are drained after I/O polling and after the immediates. Each timer callback:
+Timers are drained after I/O polling and after the immediates, on every platform. Each timer callback:
 
 1. Is wrapped in `enter()`/`exit()`
 2. Triggers microtask draining after execution
 3. Can enqueue new tasks
 
-### Windows
-
-Uses the uv_timer_t mechanism integrated into the uSockets loop.
+On Windows, a `uv_timer_t` ends the poll at the next deadline. Its callback does nothing. The drain above runs the timers.
 
 ### Timer vs. setImmediate Ordering
 
@@ -346,8 +340,8 @@ This ensures microtasks are only drained once per top-level event loop task, eve
 
 The Bun event loop processes work in this order:
 
-1. **I/O polling** (epoll/kqueue)
-2. **Immediate tasks** (setImmediate; on Windows these run before the poll)
+1. **I/O polling** (epoll/kqueue, or libuv on Windows)
+2. **Immediate tasks** (setImmediate)
 3. **Timer callbacks** (setTimeout/setInterval)
 4. **Regular tasks** from the task queue
    - For each task:

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -959,7 +959,6 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
 ///
 /// # Safety
 /// `vm` and its event loop `el` are live.
-#[cfg(unix)]
 unsafe fn run_check_phase(vm: *mut VirtualMachine, el: *mut bun_jsc::event_loop::EventLoop) {
     // SAFETY: per fn contract.
     unsafe { (*el).drain_microtasks_if_nested() };
@@ -971,7 +970,6 @@ unsafe fn run_check_phase(vm: *mut VirtualMachine, el: *mut bun_jsc::event_loop:
 ///
 /// # Safety
 /// `vm`, its event loop `el`, and its `RuntimeState` `state` are live.
-#[cfg(unix)]
 unsafe fn run_phases_after_tasks(
     vm: *mut VirtualMachine,
     el: *mut bun_jsc::event_loop::EventLoop,
@@ -1012,20 +1010,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
     let loop_ = unsafe { (*el).usockets_loop() };
 
-    // Node's order is poll, check (setImmediate), timers. libuv runs the
-    // timers inside the Windows poll call, so there the check phase is first.
-    #[cfg(windows)]
-    {
-        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-        unsafe { (*el).tick_immediate_tasks(vm) };
-    }
     // SAFETY: `el` is the live per-thread event loop.
     let has_yielded_tasks = unsafe { (*el).promote_yield_tasks() };
-    #[cfg(windows)]
-    if has_yielded_tasks || !unsafe { &*el }.immediate_tasks.is_empty() {
-        // SAFETY: `el` is the live per-thread event loop.
-        unsafe { (*el).wakeup() };
-    }
 
     // ── pending unref ───────────────────────────────────────────────────
     #[cfg(unix)]
@@ -1068,11 +1054,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         // drain JS tasks and never touch kqueue/epoll.
         // SAFETY: `loop_` is the live per-thread uws loop.
         unsafe { (*loop_).tick_without_idle() };
-        #[cfg(unix)]
-        {
-            // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-            unsafe { run_check_phase(vm, el) };
-        }
+        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+        unsafe { run_check_phase(vm, el) };
         // Still run the post-poll hooks.
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
@@ -1084,10 +1067,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // Node runs thread-pool completions in the poll phase. Bun runs them as
     // tasks in `tick()`, so a tick that ran tasks is a poll phase here.
     // SAFETY: `el`, `state` and `vm` are live (see the timers phase below).
-    #[cfg(unix)]
     let ran_callbacks = unsafe { run_phases_after_tasks(vm, el, state) };
-    #[cfg(not(unix))]
-    let ran_callbacks = false;
 
     // Call `ctx.timer.getTimeout(..)` ONLY inside
     // `if (loop.isActive())` — `get_timeout` has side effects (pops + fires
@@ -1145,6 +1125,12 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
                 )
             };
             let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());
+            // The Windows tick takes no timeout. A wakeup keeps it from waiting.
+            #[cfg(windows)]
+            if has_pending_immediate {
+                // SAFETY: `el` is the live per-thread event loop.
+                unsafe { (*el).wakeup() };
+            }
             // SAFETY: `loop_` is the live per-thread uws loop.
             unsafe {
                 (*loop_)
@@ -1157,22 +1143,18 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     }
 
     // Check phase, then timers. The timers run last, so the caller sees what
-    // they did before the next poll.
-    #[cfg(unix)]
-    {
-        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-        unsafe { run_check_phase(vm, el) };
-        // Note (§Forbidden aliased-&mut): `drain_timers` fires user
-        // `setTimeout` callbacks which may re-enter `timer::All::insert`/
-        // `remove` via `runtime_state()`. Pass raw `*mut Self` so no
-        // long-lived `&mut (*state).timer` is held across `fire()`;
-        // `drain_timers` forms short-lived `&mut` only around heap pop/peek.
-        // SAFETY: `state` is the live per-thread `RuntimeState`; the `timer`
-        // field address is stable for the VM lifetime.
-        unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };
-    }
-    #[cfg(not(unix))]
-    let _ = state;
+    // they did before the next poll. On Windows, the uv timer only ends the
+    // poll, so the timers run here too.
+    // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+    unsafe { run_check_phase(vm, el) };
+    // Note (§Forbidden aliased-&mut): `drain_timers` fires user
+    // `setTimeout` callbacks which may re-enter `timer::All::insert`/
+    // `remove` via `runtime_state()`. Pass raw `*mut Self` so no
+    // long-lived `&mut (*state).timer` is held across `fire()`;
+    // `drain_timers` forms short-lived `&mut` only around heap pop/peek.
+    // SAFETY: `state` is the live per-thread `RuntimeState`; the `timer`
+    // field address is stable for the VM lifetime.
+    unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
@@ -1195,19 +1177,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
     let loop_ = unsafe { (*el).usockets_loop() };
 
-    // The check phase runs before the poll on Windows only. See `auto_tick`.
-    #[cfg(windows)]
-    {
-        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-        unsafe { (*el).tick_immediate_tasks(vm) };
-    }
     // SAFETY: `el` is the live per-thread event loop.
     let has_yielded_tasks = unsafe { (*el).promote_yield_tasks() };
-    #[cfg(windows)]
-    if has_yielded_tasks || !unsafe { &*el }.immediate_tasks.is_empty() {
-        // SAFETY: `el` is the live per-thread event loop.
-        unsafe { (*el).wakeup() };
-    }
 
     #[cfg(unix)]
     {
@@ -1237,11 +1208,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     if state.is_null() {
         // SAFETY: `loop_` is the live per-thread uws loop.
         unsafe { (*loop_).tick_without_idle() };
-        #[cfg(unix)]
-        {
-            // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-            unsafe { run_check_phase(vm, el) };
-        }
+        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+        unsafe { run_check_phase(vm, el) };
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
         return;
@@ -1249,10 +1217,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     // The check phase and the timers after a tick that ran tasks. See `auto_tick`.
     // SAFETY: `el` is the live per-thread event loop; `state` and `vm` are live.
-    #[cfg(unix)]
     let ran_callbacks = unsafe { run_phases_after_tasks(vm, el, state) };
-    #[cfg(not(unix))]
-    let ran_callbacks = false;
 
     {
         // SAFETY: `el` is the live per-thread event loop.
@@ -1293,6 +1258,12 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
                 )
             };
             let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());
+            // See the matching wakeup in `auto_tick`.
+            #[cfg(windows)]
+            if has_pending_immediate {
+                // SAFETY: `el` is the live per-thread event loop.
+                unsafe { (*el).wakeup() };
+            }
             // SAFETY: `loop_` is the live per-thread uws loop.
             unsafe {
                 (*loop_)
@@ -1305,16 +1276,11 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     }
 
     // Check phase, then timers. See `auto_tick`.
-    #[cfg(unix)]
-    {
-        // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
-        unsafe { run_check_phase(vm, el) };
-        // SAFETY: `state` is the live per-thread `RuntimeState`; see Note
-        // on `auto_tick` re: aliased-&mut across `fire()`.
-        unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };
-    }
-    #[cfg(not(unix))]
-    let _ = state;
+    // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
+    unsafe { run_check_phase(vm, el) };
+    // SAFETY: `state` is the live per-thread `RuntimeState`; see Note
+    // on `auto_tick` re: aliased-&mut across `fire()`.
+    unsafe { timer::All::drain_timers(&raw mut (*state).timer, vm.cast()) };
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1143,8 +1143,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     }
 
     // Check phase, then timers. The timers run last, so the caller sees what
-    // they did before the next poll. On Windows, the uv timer only ends the
-    // poll, so the timers run here too.
+    // they did before the next poll.
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { run_check_phase(vm, el) };
     // Note (§Forbidden aliased-&mut): `drain_timers` fires user

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -694,7 +694,8 @@ impl All {
     /// Lazily `uv_timer_init` the
     /// per-`All` libuv timer, then (re)start it for the soonest deadline
     /// across both heaps. On Windows there is no epoll/kqueue fallback; this
-    /// `uv_timer_t` is the ONLY thing that wakes `uv_run` for JS timers.
+    /// `uv_timer_t` is the ONLY thing that wakes `uv_run` for JS timers. It
+    /// stays unref'd: `increment_timer_ref` keeps the loop alive, as on POSIX.
     #[cfg(windows)]
     fn ensure_uv_timer(&mut self) {
         // `vm` here means the OWNING VM (the one this timer is embedded in),
@@ -758,34 +759,24 @@ impl All {
         if !(self.uv_timer.is_active() && due_in <= wait_ms) {
             self.uv_timer.start(wait_ms, 0, Some(Self::on_uv_timer));
         }
+    }
 
-        if self.active_timer_count > 0 {
-            self.uv_timer.ref_();
-        } else {
-            self.uv_timer.unref();
+    /// [`Self::ensure_uv_timer`] for a heap that may have changed since the
+    /// handle last fired. The handle is one-shot, and its callback does not
+    /// arm it again. Does nothing before the first insert or after teardown.
+    #[cfg(windows)]
+    fn rearm_uv_timer(&mut self) {
+        if !self.uv_timer.data.is_null() && !self.uv_timer.is_closing() {
+            self.ensure_uv_timer();
         }
     }
 
-    /// libuv timer callback; drain due
-    /// timers then re-arm for the next deadline. Only ever invoked by libuv
-    /// (coerces to the `uv_timer_cb` fn-pointer type at the `Timer::start`
-    /// call site); body wraps its derefs explicitly.
+    /// libuv timer callback. It only ends the poll at the deadline. The
+    /// timers run after `uv_run` returns (`auto_tick` -> `drain_timers`), after
+    /// the check phase, as on POSIX. Run here, they would come before the
+    /// immediates that the poll's I/O callbacks queued.
     #[cfg(windows)]
-    extern "C" fn on_uv_timer(uv_timer_t: *mut uv::Timer) {
-        // SAFETY: `uv_timer_t` is the address of `All.uv_timer` (libuv passes
-        // back exactly the handle pointer we registered in `ensure_uv_timer`);
-        // recover the containing `All` via container_of.
-        let all: *mut All = unsafe { bun_core::from_field_ptr!(All, uv_timer, uv_timer_t) };
-        // SAFETY: `data` was set to the VM ptr in `ensure_uv_timer` (non-null).
-        let vm: *mut () = unsafe { (*uv_timer_t).data.cast() };
-        // SAFETY: callback fires on the JS thread (libuv invokes on the loop's
-        // thread); `all` is live for the VM lifetime. `drain_timers` may
-        // re-enter `(*runtime_state()).timer` — it forms only short-lived
-        // `&mut All` around heap pop/peek, so it takes the raw pointer.
-        unsafe { All::drain_timers(all, vm) };
-        // SAFETY: see above; re-arm for the next-soonest deadline (if any).
-        unsafe { (*all).ensure_uv_timer() };
-    }
+    extern "C" fn on_uv_timer(_: *mut uv::Timer) {}
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) fn remove(&mut self, timer: *mut EventLoopTimer) {
@@ -974,6 +965,14 @@ impl All {
         // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
         let (wtf_next, _) = unsafe { Self::drain_due_wtf_timers(this, maybe_now, vm) };
 
+        // The Windows tick takes no timeout. The uv timer ends its poll, and a
+        // tick that does not drain the timers can have used up its last fire.
+        #[cfg(windows)]
+        // SAFETY: `this` is live, and the re-arm does not run JS.
+        unsafe {
+            (*this).rearm_uv_timer()
+        };
+
         // SAFETY: `this` is live, and only this thread touches the regular heap.
         let reg_next = (unsafe { &*this }).timers.peek().map(|min| {
             // SAFETY: `peek` returns a live heap node.
@@ -1096,6 +1095,11 @@ impl All {
                 break;
             }
         }
+        #[cfg(windows)]
+        // SAFETY: `this` is live, and no `&mut All` is held across a `fire()`.
+        unsafe {
+            (*this).rearm_uv_timer()
+        };
         fired
     }
 
@@ -1160,26 +1164,15 @@ impl All {
         let new = old + delta;
         debug_assert!(new >= 0);
         self.active_timer_count = new;
+        // On Windows too, the keep-alive is the loop's count, not the uv
+        // timer: the timer is inactive from its fire until the next re-arm.
         if old <= 0 && new > 0 {
-            #[cfg(not(windows))]
             // SAFETY: caller passes the VM's live uws loop
             unsafe { &mut *uws_loop }.ref_();
-            // `uv_timer.ref()` is intentionally unconditional (no `data !=
-            // null` guard). Invariant: every path that reaches a positive
-            // `active_timer_count` first inserts a timer, and `insert`
-            // → `ensure_uv_timer` lazily `uv_timer_init`s the handle. Guarding
-            // here would silently drop the ref and let the loop exit early.
-            #[cfg(windows)]
-            self.uv_timer.ref_();
         } else if old > 0 && new <= 0 {
-            #[cfg(not(windows))]
             // SAFETY: caller passes the VM's live uws loop
             unsafe { &mut *uws_loop }.unref();
-            #[cfg(windows)]
-            self.uv_timer.unref();
         }
-        #[cfg(windows)]
-        let _ = uws_loop;
     }
 
     /// VM teardown, after `cancel_all_timeout_objects`: unlink every timer still

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -694,8 +694,7 @@ impl All {
     /// Lazily `uv_timer_init` the
     /// per-`All` libuv timer, then (re)start it for the soonest deadline
     /// across both heaps. On Windows there is no epoll/kqueue fallback; this
-    /// `uv_timer_t` is the ONLY thing that wakes `uv_run` for JS timers. It
-    /// stays unref'd: `increment_timer_ref` keeps the loop alive, as on POSIX.
+    /// `uv_timer_t` is the ONLY thing that wakes `uv_run` for JS timers.
     #[cfg(windows)]
     fn ensure_uv_timer(&mut self) {
         // `vm` here means the OWNING VM (the one this timer is embedded in),
@@ -761,9 +760,7 @@ impl All {
         }
     }
 
-    /// [`Self::ensure_uv_timer`] for a heap that may have changed since the
-    /// handle last fired. The handle is one-shot, and its callback does not
-    /// arm it again. Does nothing before the first insert or after teardown.
+    /// Arms the one-shot handle again, once it exists and until teardown closes it.
     #[cfg(windows)]
     fn rearm_uv_timer(&mut self) {
         if !self.uv_timer.data.is_null() && !self.uv_timer.is_closing() {
@@ -771,10 +768,7 @@ impl All {
         }
     }
 
-    /// libuv timer callback. It only ends the poll at the deadline. The
-    /// timers run after `uv_run` returns (`auto_tick` -> `drain_timers`), after
-    /// the check phase, as on POSIX. Run here, they would come before the
-    /// immediates that the poll's I/O callbacks queued.
+    /// Only ends the poll. `auto_tick` runs the timers after the check phase, as on POSIX.
     #[cfg(windows)]
     extern "C" fn on_uv_timer(_: *mut uv::Timer) {}
 
@@ -965,8 +959,7 @@ impl All {
         // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
         let (wtf_next, _) = unsafe { Self::drain_due_wtf_timers(this, maybe_now, vm) };
 
-        // The Windows tick takes no timeout. The uv timer ends its poll, and a
-        // tick that does not drain the timers can have used up its last fire.
+        // A tick that drained no timers can have used the last fire of the uv timer.
         #[cfg(windows)]
         // SAFETY: `this` is live, and the re-arm does not run JS.
         unsafe {
@@ -1164,8 +1157,7 @@ impl All {
         let new = old + delta;
         debug_assert!(new >= 0);
         self.active_timer_count = new;
-        // On Windows too, the keep-alive is the loop's count, not the uv
-        // timer: the timer is inactive from its fire until the next re-arm.
+        // Not the uv timer on Windows: it is inactive from its fire to the next re-arm.
         if old <= 0 && new > 0 {
             // SAFETY: caller passes the VM's live uws loop
             unsafe { &mut *uws_loop }.ref_();

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -374,8 +374,7 @@ describe.concurrent("event loop phases", () => {
     }
   `;
 
-  // On Windows, libuv runs the timers inside its poll, so the timer fires first there.
-  test.skipIf(isWindows)("an immediate queued by an I/O callback runs before a timer that came due in it", async () => {
+  test("an immediate queued by an I/O callback runs before a timer that came due in it", async () => {
     const script = `${pair}
       pair((client, server) => {
         const order = [];
@@ -511,6 +510,5 @@ describe.concurrent("event loop phases", () => {
       });
     });
   preloadTest("a timer", "setTimeout(resolve, 1)");
-  // On Windows the check phase runs before the poll, so this wait still parks there.
-  if (!isWindows) preloadTest("an immediate", "setImmediate(resolve)");
+  preloadTest("an immediate", "setImmediate(resolve)");
 });


### PR DESCRIPTION
Stacked on #41355. Merge it after #41355 and #38206. The notes say why.

### Problem
- On Windows, an immediate that an I/O callback queues runs after a timer that came due in that callback. Node runs the immediate first, and so does POSIX after #41355. No user reported this. The goal is parity.
- The Windows poll is one `uv_run` call. It runs the I/O callbacks, then the libuv timers. The JS timers ran in the callback of the uv timer (`All::on_uv_timer`, `src/runtime/timer/mod.rs`), before the check phase of `auto_tick`.

### Fix
- The callback of the uv timer now does nothing. It only ends the poll. After `uv_run` returns, `auto_tick` runs the immediates, then the timers, as on POSIX (#41355).
- The uv timer is one-shot. `drain_timers` and `get_timeout` arm it again.
- A timer keeps the loop alive through the loop's count, as on POSIX. The uv timer is not active from its fire to the next re-arm.
- Verified on windows-x64: the two Windows skips in `test/js/node/timers/node-timers.test.ts` fail on the base and pass here. An A/B run of 642 files shows no other change. Timers after an unhandled error under `--hot` need #38206.

### Background
- Node's loop runs the poll (I/O callbacks), then the check phase (`setImmediate`), then the timers.
- `auto_tick` (`src/runtime/jsc_hooks.rs`) is one turn of bun's loop. On Windows, its poll is `uv_run(UV_RUN_ONCE)`, which takes no timeout.
- A libuv handle keeps the loop alive only while it is active and ref'd.

<details><summary>Notes</summary>

**Repro.** In a socket `data` callback, call `setTimeout(f, 1)`, wait 10 ms, and call `setImmediate(g)`. Bun prints `timeout,immediate`. Node prints `immediate,timeout`.

**Merge order.** Under `--hot` or `--watch`, an unhandled error makes `is_event_loop_alive()` false. The run loop then parks in `tick_possibly_forever`, which does not drain timers. POSIX has this bug today, and #38206 fixes it. On Windows the timers ran inside `uv_run`, so they still fired there. With this PR alone, they stop. I checked it on windows-x64 with the fixture from #38206: after the entry point rejects, `GET /timer` answers on the base, hangs with this PR, and answers with this PR and #38206. With both PRs, the 6 tests of #38206 pass on Windows.

**The gate.** This PR adds one commit to #41355. The change is Windows-only. On Linux, `node-timers.test.ts` passes before and after this commit (32 pass). So a fail-before check on Linux cannot show it. The Windows results are below.

**Proof on windows-x64.** Debug builds of the base (`b712570388`) and of this commit on it. The base is now `eba8838a26`. The two commits after `b712570388` change only a test and CI, so `src/` is the same.

- `test/js/node/timers/node-timers.test.ts`: the base has 29 pass and 2 fail. This branch has 31 pass and 0 fail.
- The repro prints `timeout,immediate` on the base and `immediate,timeout` here, 3 of 3 runs each. The canary prints what the base prints. Node v26.3.0 prints what this branch prints.
- The second failing test is the one from the #41355 notes. A `--preload` listens on a server and awaits `setImmediate`. The entry point waited for the next wake of the loop. With `BUN_GC_TIMER_DISABLE=1` that is longer than the 5 s timeout.

**A/B run.** Each file ran with both builds, one file after the other.

- Bun test files: `test/js/node/timers`, `test/js/web/timers`, fake timers, `Bun.sleep`, `test/js/node/process`, `worker_threads`, `test/js/web/workers`, `dns`, `net` (node and bun), `abort`, `fetch.test.ts`, `test/js/bun/spawn`, `test/js/node/http`, `test/js/bun/http/serve*`, `test/cli/run`, `test/js/node/child_process`.
- Node's `test-timers-*`, `test-net-*`, `test-child-process-*`, and `test-worker-*`.
- 642 files. 639 have the same result on both builds. 18 fail on both builds. 82 of the files (spawn, `node/http`, and part of `serve*`) ran before #41355 got its last three commits. The rest ran on `b712570388`.
- `node-timers.test.ts` is the fix.
- `test/cli/hot`, `test/cli/watch`, and `test/cli/test/parallel.test.ts` ran later, on the same builds. They have the same result on both builds.
- `worker-late-completion.test.ts` had one more failure on the base in one run. It fails 4 of 28 tests on both builds in each other run.
- `serve-http2-lifecycle.test.ts` failed here. It also failed on Linux with #41355, and the cause was in the test. See the next note.

**A test that #41355 also fails.** `serve-http2-lifecycle.test.ts:51` adds the `close` listener of an HTTP/2 session after `await slow3`. The session closes before that await returns, so the listener comes too late. On Linux, the #41355 branch fails this test 3 of 3 and the canary passes it. Line 80 of the same file uses `session.closed ? r() : session.once("close", ...)`. With that line at 51, the test passes on Linux and on Windows. #41355 fixed the test in 39d352803f, and this branch has that commit.

**Known flake.** `node-net.test.ts` "should allow reconnecting after end()" is in `test/flaky-tests.txt`. It waits 3 ms for a socket to close. On a Windows debug build it failed in 5 of 11 runs on the base and in 7 of 11 runs here. A release build passed 4 of 4.

**Behavior that changes on Windows.** Each item matches POSIX.

- A JS timer does not run inside a `uv_run` that `auto_tick` did not start. Examples: `tick_possibly_forever` in an idle `--watch` process, and a native addon that calls `uv_run`. POSIX does not support `uv_run` from an addon.
- A ref'd fake timer (`jest.useFakeTimers`) keeps the loop alive.
- After an unhandled error under `--hot` or `--watch`, timers stop until #38206 lands. See the merge order note.
- `bun test --parallel`: the coordinator passes a 5 ms bound to `tick_with_timeout`, so that it can add workers. The Windows tick ignores the bound, before and after this PR. Before, the uv timer still woke the coordinator for the GC timer, about once per second. Now the coordinator wakes at the next message from a worker. The deadline timer in #40023 makes the Windows tick honor the bound.
- The poll also gets a wakeup when a `tick()` ran tasks, or when tasks are queued. Before, only queued immediates did this.
- I checked these by hand on both builds: a timer created in `beforeExit`, a ref'd timer in `--watch`, and the CPU time of an idle `--watch` process with an unref'd interval (0 ms in 5 s on both).

**Other checks.** `cargo clippy -p bun_runtime` is clean on Linux. For `x86_64-pc-windows-msvc`, clippy reports nothing new in the two changed files.

**Related.** #40023 (open) makes the same timer change as one part of a larger change. It also makes the Windows tick honor its timeout. This PR takes only the part that the order needs. With that deadline timer, the re-arm in `get_timeout` and the two `wakeup()` calls can go. I left a note on #40023.

**Self-review.** It raised four points, and all four are addressed: the merge order with #38206, the `--parallel` wait, the parity note at the top, and the note on #40023. A review bot reported a hang when the uv timer is due as the poll starts. The pinned libuv runs timers only after the poll in `UV_RUN_ONCE`, so that case does not occur. The reply on that thread has the details.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts

<!-- robobun:evidence:end -->