### PR TITLE
usockets: skip connecting and in-use sockets in the close_all force-drain

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -49,12 +49,15 @@ void us_socket_group_deinit(struct us_socket_group_t *group) {
     /* The owner is about to free the embedding storage. Every list head and the
      * low-prio count must be zero or some socket/listener/DNS request still
      * holds s->group / c->group / ls->accept_group into us — that's a UAF the
-     * caller must close_all() away first. close_all() leaves open a connect
-     * that one of its own handlers starts, so it empties a group only when no
-     * handler connects into it. iterator != NULL means we're inside
-     * a dispatch on this very group; the on_close that triggers deinit is fine
-     * (unlink_socket already advanced iterator), but a re-entrant deinit from
-     * inside on_timeout/on_data would tear the floor out from under the sweep. */
+     * caller must close_all() away first. close_all() leaves two kinds of
+     * socket linked: a connect that one of its handlers starts, and a socket
+     * whose SSL call is on the stack (the SSL driver closes that one when the
+     * call returns). So an owner must not free the group from inside such a
+     * call, or while a handler can still connect in it. iterator != NULL means
+     * we're inside a dispatch on this very group; the on_close that triggers
+     * deinit is fine (unlink_socket already advanced iterator), but a
+     * re-entrant deinit from inside on_timeout/on_data would tear the floor out
+     * from under the sweep. */
     US_ASSERT(group->head_sockets == NULL);
     US_ASSERT(group->head_connecting_sockets == NULL);
     US_ASSERT(group->head_listen_sockets == NULL);

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -49,7 +49,9 @@ void us_socket_group_deinit(struct us_socket_group_t *group) {
     /* The owner is about to free the embedding storage. Every list head and the
      * low-prio count must be zero or some socket/listener/DNS request still
      * holds s->group / c->group / ls->accept_group into us — that's a UAF the
-     * caller must close_all() away first. iterator != NULL means we're inside
+     * caller must close_all() away first. close_all() leaves open a connect
+     * that one of its own handlers starts, so it empties a group only when no
+     * handler connects into it. iterator != NULL means we're inside
      * a dispatch on this very group; the on_close that triggers deinit is fine
      * (unlink_socket already advanced iterator), but a re-entrant deinit from
      * inside on_timeout/on_data would tear the floor out from under the sweep. */
@@ -103,7 +105,7 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
              * after drainClosedSockets(). Deliver the same on_connect_error
              * the natural failure path would have, which detaches the
              * wrapper. The handler then closes; if it doesn't, the
-             * force-drain below catches it. */
+             * close_raw below does. */
             us_dispatch_connect_error(s, ECONNABORTED);
             if (!us_socket_is_closed(s)) {
                 us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET, 0);
@@ -119,9 +121,27 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
      * open in head_sockets waiting for the peer's reply. Callers of close_all
      * (e.g. Listener.deinit) free the embedding storage immediately after, so
      * any survivor's s->group becomes a dangling pointer. The graceful walk
-     * already flushed close_notify; force-drain the rest synchronously now. */
-    while (group->head_sockets) {
-        us_internal_socket_close_raw(group->head_sockets, LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET, 0);
+     * already flushed close_notify; force-drain the rest synchronously now.
+     *
+     * Skip a connecting socket. The walk did not reach it: a handler opened it
+     * behind the walk, or a handler ticked the loop and the timer sweep cleared
+     * group->iterator. close_raw sends no event for a SEMI_SOCKET, so the owner
+     * would keep a freed pointer. The socket stays open, like a
+     * us_connecting_socket_t that a handler opens. A group that takes connects
+     * (RareData, HTTPContext) is not freed while a client can connect in it.
+     *
+     * Skip a socket with an SSL call on the stack too. Its close is deferred,
+     * so it stays linked. Every other close_raw unlinks its socket, so rescan
+     * from the head after each close. */
+    for (;;) {
+        struct us_socket_t *s = group->head_sockets;
+        while (s && ((us_internal_poll_type(&s->p) & POLL_TYPE_SEMI_SOCKET) || (s->ssl && s->ssl_in_use))) {
+            s = s->next;
+        }
+        if (!s) {
+            break;
+        }
+        us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET, 0);
     }
 
     /* Sockets parked in the loop-wide low-prio queue aren't in head_sockets

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -341,8 +341,10 @@ void us_socket_group_init(us_socket_group_r group, us_loop_r loop,
  * to free the embedding storage. */
 void us_socket_group_deinit(us_socket_group_r group) nonnull_fn_decl;
 
-/* Close every socket in the group (fires on_close for each). Used by server
- * shutdown. The group itself stays valid. */
+/* Close every socket in the group. Each one gets the event its owner waits
+ * for: on_close, or a connect error for a connect in flight. A connect that a
+ * handler starts during the call stays open. Used by server shutdown. The
+ * group itself stays valid. */
 void us_socket_group_close_all(us_socket_group_r group) nonnull_fn_decl;
 /* As above; `also_listeners=0` leaves head_listen_sockets alone (process-exit
  * teardown — listen sockets are owned by a Listener/App that frees them in

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -341,10 +341,13 @@ void us_socket_group_init(us_socket_group_r group, us_loop_r loop,
  * to free the embedding storage. */
 void us_socket_group_deinit(us_socket_group_r group) nonnull_fn_decl;
 
-/* Close every socket in the group. Each one gets the event its owner waits
- * for: on_close, or a connect error for a connect in flight. A connect that a
- * handler starts during the call stays open. Used by server shutdown. The
- * group itself stays valid. */
+/* Close the sockets in the group. Each one gets the event its owner waits for:
+ * on_close, or a connect error for a connect in flight. Two kinds of socket are
+ * still in the group when the call returns:
+ * - A connect that a handler starts during the call. It stays open.
+ * - A socket whose SSL call is on the stack, because the call came from one of
+ *   its callbacks. The SSL driver closes it when that SSL call returns.
+ * Used by server shutdown. The group itself stays valid. */
 void us_socket_group_close_all(us_socket_group_r group) nonnull_fn_decl;
 /* As above; `also_listeners=0` leaves head_listen_sockets alone (process-exit
  * teardown — listen sockets are owned by a Listener/App that frees them in

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -409,6 +409,86 @@ describe.concurrent("bun test --isolate", () => {
     }
   });
 
+  // The swap closes every socket group. JS that runs inside one of those
+  // closes (the close handler, or a reaction to a promise that the close
+  // rejects) can connect again, and the new socket lands in the group that is
+  // being closed. The swap must not free that socket without a close event:
+  // the client keeps the pointer and uses it when its connection timer fires.
+  test.each([
+    ["an onclose handler", "onclose"],
+    ["a rejection handler", "rejection"],
+  ])("with --isolate, a socket that %s opens during the swap keeps its close event", async (_, reconnectFrom) => {
+    using dir = tempDir("isolate-reconnect", {
+      "a-reconnect.test.ts": `
+        import { test } from "bun:test";
+        import { RedisClient } from "bun";
+        import fs from "node:fs";
+
+        const closesFile = process.env.CLOSES_FILE!;
+        const fromOnclose = process.env.RECONNECT_FROM === "onclose";
+
+        test("leave a TLS client that reconnects when the swap closes it", () => {
+          const client = new RedisClient("rediss://127.0.0.1:" + process.env.PORT, {
+            autoReconnect: false,
+            connectionTimeout: 3000,
+          });
+          let closes = 0;
+          client.onclose = () => {
+            closes++;
+            fs.writeFileSync(closesFile, String(closes));
+            // The first close comes from the swap after this file.
+            if (fromOnclose && closes === 1) client.connect().catch(() => {});
+          };
+          client.connect().catch(() => {
+            if (!fromOnclose) client.connect().catch(() => {});
+          });
+        });
+      `,
+      "b-wait.test.ts": `
+        import { test, expect } from "bun:test";
+        import fs from "node:fs";
+
+        test("the connect from the swap reports its close", async () => {
+          const closesFile = process.env.CLOSES_FILE!;
+          const closes = () => (fs.existsSync(closesFile) ? fs.readFileSync(closesFile, "utf8") : "0");
+          for (let i = 0; i < 400 && closes() !== "2"; i++) await Bun.sleep(10);
+          expect(closes()).toBe("2");
+        });
+      `,
+    });
+
+    // The first connection stays open without a TLS handshake, so the swap
+    // closes it. Each later connection is dropped, so the connect made during
+    // the swap fails at once.
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer(sock => {
+      sock.on("error", () => {});
+      sockets.add(sock);
+      if (sockets.size > 1) sock.destroy();
+    });
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
+
+    try {
+      const { stderr, exitCode } = await runTests(
+        String(dir),
+        ["--isolate"],
+        ["./a-reconnect.test.ts", "./b-wait.test.ts"],
+        {
+          ...bunEnv,
+          PORT: String((server.address() as net.AddressInfo).port),
+          CLOSES_FILE: join(String(dir), "closes.txt"),
+          RECONNECT_FROM: reconnectFrom,
+        },
+      );
+      expect(normalizeBunSnapshot(stderr, dir)).toContain("2 pass");
+      expect(normalizeBunSnapshot(stderr, dir)).toContain("0 fail");
+      expect(exitCode).toBe(0);
+    } finally {
+      for (const sock of sockets) sock.destroy();
+      server.close();
+    }
+  });
+
   test("with --isolate, leaked fs.watch is closed before next file", async () => {
     using dir = tempDir("isolate-fswatch", {
       "watched/.keep": "",

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -312,3 +312,25 @@ it("should not leak memory", async () => {
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
 });
+
+// stop(true) from alpnCallback or serverName closes the socket whose SSL call
+// is on the stack, so that close waits until the callback returns. The
+// force-drain in us_socket_group_close_all_ex took the same socket again and
+// again, and stop(true) never returned. The fixture runs in a child process,
+// because the spin also blocks the event loop that times a test out. The cases
+// are not concurrent: the runner kills a child that a timed-out test leaves
+// behind only when that test runs alone.
+describe("TLS listener: stop(true) from inside a selection callback", () => {
+  it.each(["alpnCallback", "serverName"])("%s: stop(true) returns and the connection closes", async hook => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "tls-stop-from-selection-fixture.ts"), hook],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ events: ["returned", "handshake:false", "close"], clientConnected: false });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/net/tls-stop-from-selection-fixture.ts
+++ b/test/js/bun/net/tls-stop-from-selection-fixture.ts
@@ -1,0 +1,56 @@
+// listener.stop(true) called from alpnCallback or serverName.
+//
+// Both hooks run inside the SSL read that processes the ClientHello, so the
+// accepted socket's SSL call is still on the stack when stop(true) closes every
+// connection. That close waits until the SSL call returns, and the socket stays
+// in the group. The force-drain in us_socket_group_close_all_ex took the head
+// socket again and again, so stop(true) never returned.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { connect } from "node:tls";
+
+const hook = process.argv[2];
+const fixtures = join(import.meta.dir, "../../node/tls/fixtures");
+const events: string[] = [];
+const serverClosed = Promise.withResolvers<void>();
+
+const server = Bun.listen({
+  hostname: "127.0.0.1",
+  port: 0,
+  tls: {
+    key: readFileSync(join(fixtures, "agent1-key.pem")),
+    cert: readFileSync(join(fixtures, "agent1-cert.pem")),
+  },
+  socket: {
+    [hook]() {
+      server.stop(true);
+      events.push("returned");
+      return hook === "alpnCallback" ? "x/1" : undefined;
+    },
+    handshake(_socket, success) {
+      events.push(`handshake:${success}`);
+    },
+    data() {},
+    close() {
+      events.push("close");
+      serverClosed.resolve();
+    },
+  },
+});
+
+// The handshake never completes, so the client does not verify the certificate.
+const client = connect({
+  port: server.port,
+  host: "127.0.0.1",
+  servername: "localhost",
+  ALPNProtocols: ["x/1"],
+  rejectUnauthorized: false,
+});
+const clientConnected = await new Promise<boolean>(resolve => {
+  client.on("secureConnect", () => resolve(true));
+  client.on("error", () => resolve(false));
+  client.on("close", () => resolve(false));
+});
+await serverClosed.promise;
+
+console.log(JSON.stringify({ events, clientConnected }));


### PR DESCRIPTION
### Problem
- `bun test --parallel` or `--isolate` can segfault in `ssl_release_spill`, called from `ValkeyClient::close` ← `ValkeyClient::fail` ← `JSValkeyClient::on_connection_timeout`. ASAN reports a use-after-free of a `us_socket_t`.
- The cause is the force-drain in `us_socket_group_close_all_ex` (`packages/bun-usockets/src/context.c:123`). The isolation swap runs it on every group. A valkey client that reconnects from `onclose`, or from a rejection handler, gets a new connecting socket in that group. `us_internal_socket_close_raw` frees it with no event, and the client's connection timer uses it in a later file.
- The same drain spins on a socket whose SSL call is on the stack, so `listener.stop(true)` from `alpnCallback` or `serverName` never returns.

### Fix
- The drain skips a connecting socket and a socket with an SSL call on the stack. It rescans from the head after each close.
- A connecting socket at the drain was opened during the call, because the walk closes each one it reaches. It stays open, as a `us_connecting_socket_t` that a handler opens already does. The SSL driver closes the deferred socket later.
- Verified: new cases in `test/cli/test/isolation.test.ts` and `test/js/bun/net/tcp-server.test.ts`. They fail on main and pass with the fix, on Linux and Windows.

### Background
- A socket group lists the sockets of one kind. `close_all` closes each one with the event its owner waits for.
- A connecting socket gets a connect error, not `on_close`. Its owner holds the raw `us_socket_t*` until then.
- The swap runs JS inside `close_all`. A socket that JS opens goes to the head of the list.

<details><summary>Notes</summary>

**Reproduction.** A crash report from bun 1.4.0 (macOS arm64, a `bun test --parallel` worker) had this stack. It reproduces on Linux under ASAN, so it is not specific to kqueue. The new isolation cases are the minimal form:

- File A leaves a `rediss://127.0.0.1:PORT` client in its TLS handshake, and reconnects on its first close.
- The swap closes the socket. The handshake fails, `fail()` runs, and JS runs inside the close: `onclose`, or a `.catch` on the `connect()` promise, which runs when the event-loop scope exits.
- The reconnect links a connecting socket at the head of the valkey TLS group. The force-drain frees it with no event.
- File B: the connection timer fires and `ValkeyClient::close` reads the freed socket.

On a release build the freed block is often not reused yet, so `us_socket_is_closed` reads 1 and nothing crashes, but the close event is lost. The crash needs the block to be reused.

**Why a connecting socket can stay open.** The JS thread connects only into `RareData` groups, which live as long as the VM. `Listener` and uWS groups get accepted sockets only, never connecting ones. `HTTPContext` is refcounted by its sockets, so no client connects in it when it drops. At VM teardown, script is forbidden and `close_all_socket_groups` runs up to 8 rounds, so a later round still closes a survivor.

**A handler that ticks the loop.** The timer sweep clears `group->iterator`, so it can end the walk early. The drain rescans from the head, as main does, so it still closes every established socket. A connecting socket that the walk missed stays open. Main freed it with no event.

**The stop(true) spin on main.** Under gdb, `us_internal_socket_close_raw` is hit 2000 times on the same socket, from `context.c:124` via `Listener::do_stop`.

**Related PRs.**
- #34556 changes the close code on the same drain line (Windows). It is a different change.
- #34037 deletes `context.c`. Its `group.rs` force-drain has the same hole. Whichever PR lands second needs the skip there: `!is_established()` and the in-use case. Its `drain_connecting` backstop aborts connects that a handler opens and restarts from the head, which does not end for a handler that reconnects on every error. The two trees need one rule.

**Not fixed here.** `close_all` runs at tick depth 0 when JS calls it. A handler that ticks the loop frees the sockets that `close_all` already closed, and `Listener::do_stop` then reads its listen socket after the free (ASAN). That is a separate change.

**Suites run (debug, ASAN).** `isolation`, `tcp-server`, `socket-syscall-fault`, `valkey-tls-verify`, `node-net-server`, `serve-listen`, `node-tls-connect-hostname-verification`: all pass. `socket.test.ts` and `node-tls-server.test.ts` pass except one case each that also fails on main in this environment (`www.example.com` needs the network, and `localhost` resolves only to `::1` here).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/isolation.test.ts test/js/bun/net/tcp-server.test.ts
bun test v1.4.1 (e0a2b82fd)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [346.24ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [389.81ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [321.12ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [287.57ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [368.21ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1282.60ms]
(pass) bun test --isolate > with --isolate, a file's process.env writes with native side effects are undone before the next file [1388.03ms]
(pass) bun test --isolate > with --isolate, cached module records keep short, Latin-1 and UTF-16 names [1320.85ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed bef
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (ee6e4c328)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > with --isolate, each file gets a fresh global [29.34ms]
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [33.41ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [32.43ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [34.57ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [34.89ms]
(pass) --isolate: JSC options survive a bunfig.toml with an install hoist pattern [24.39ms]
(pass) bun test --isolate > with --isolate, cached module records keep short, Latin-1 and UTF-16 names [42.46ms]
(pass) bun test --isolate > module-scope subprocesses are killed for every isolated file, not just the first (--isolate) [33.98ms]
(pass) bun test --isolate > leaked subprocesses are killed for every isolated file, not just the first [35.57ms]
(pass) --isolate: delete require.cache evicts the SourceProvider cache [31.53ms]
(pass) bun test --isolate > with --isolate, a socket that an onclose handler opens during the swap keeps its clos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/isolation.test.ts test/js/bun/net/tcp-server.test.ts
bun test v1.4.1 (e0a2b82fd)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [338.25ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [397.77ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [399.01ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [366.89ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [307.54ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1294.60ms]
(pass) bun test --isolate > with --isolate, a file's process.env writes with native side effects are undone before the next file [1327.58ms]
(pass) bun test --isolate > with --isolate, a socket that a rejection handler opens during the swap keeps its close event [621.61ms]
(pass) bun test --isolate > with --isolate, a socket that an o
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 667ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/27] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/context.c                | 39 ++++++++---
 packages/bun-usockets/src/libusockets.h            |  9 ++-
 test/cli/test/isolation.test.ts                    | 80 ++++++++++++++++++++++
 test/js/bun/net/tcp-server.test.ts                 | 22 ++++++
 test/js/bun/net/tls-stop-from-selection-fixture.ts | 56 +++++++++++++++
 5 files changed, 196 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
packages/bun-usockets/src/context.c                     8     10     33
packages/bun-usockets/src/libusockets.h                 3      6     32
test/cli/test/isolation.test.ts                         4      4     26
test/js/bun/net/tcp-server.test.ts                      2      2     13
test/js/bun/net/tls-stop-from-selection-fixture.ts      0      3     32
```

</details>

<!-- robobun:evidence:end -->