### PR TITLE
Pin a real simdutf kernel when CPUID dispatch picks the unsupported stub

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1607,6 +1607,10 @@ pub(crate) mod strings_impl {
                     break;
                 }
                 Some(i) => {
+                    debug_assert!(
+                        rest[i] >= 0x80,
+                        "first_non_ascii_usize pointed at an ASCII byte"
+                    );
                     list.extend_from_slice(&rest[..i]);
                     rest = &rest[i..];
                     while let Some(&c) = rest.first() {

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -157,6 +157,11 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
     // 1. Crash handler first so anything below gets a usable trace.
     bun_crash_handler::init();
 
+    // simdutf's CPUID dispatch may land on a stub that returns 0 for every
+    // call (QEMU's default CPU model hides SSE4.2). Pin a real kernel before
+    // the first string conversion.
+    bun_simdutf_sys::simdutf::init();
+
     use_mimalloc_in_dependencies();
 
     // SIGPIPE/SIGXFSZ → SIG_IGN.

--- a/src/runtime/bin_entry/mod.rs
+++ b/src/runtime/bin_entry/mod.rs
@@ -157,9 +157,8 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
     // 1. Crash handler first so anything below gets a usable trace.
     bun_crash_handler::init();
 
-    // simdutf's CPUID dispatch may land on a stub that returns 0 for every
-    // call (QEMU's default CPU model hides SSE4.2). Pin a real kernel before
-    // the first string conversion.
+    // Before the first string conversion: simdutf's CPUID dispatch may have
+    // picked a stub that returns 0 for every call.
     bun_simdutf_sys::simdutf::init();
 
     use_mimalloc_in_dependencies();

--- a/src/simdutf_sys/bun-simdutf.cpp
+++ b/src/simdutf_sys/bun-simdutf.cpp
@@ -7,17 +7,11 @@ typedef struct SIMDUTFResult {
 
 extern "C" {
 
-// simdutf picks its kernel by CPUID. When no compiled-in kernel matches the
-// advertised feature set (QEMU's default qemu64 model hides SSE4.2 even though
-// the host executes it; or SIMDUTF_FORCE_IMPLEMENTATION names an unknown
-// kernel), it installs a stub whose every method returns 0 / false /
-// error_code::OTHER. Callers cannot tell that from a real result: validate_ascii
-// says "not ASCII" for ASCII input, length queries return 0, and transcoding
-// loops that rely on forward progress spin forever.
-//
-// The scalar fallback kernel is not compiled into WTF's simdutf, so the least
-// demanding kernel in the list is what the binary's -march baseline already
-// assumes everywhere else. If the process reached main(), the CPU runs it.
+// When CPUID advertises none of the compiled-in kernels (QEMU's default CPU
+// model hides SSE4.2 that the host executes), simdutf installs a stub whose
+// every method returns 0 / false. WTF builds simdutf without the scalar
+// fallback, so pick the last kernel in the priority-ordered list: on x64 that
+// is westmere, the same -march=nehalem baseline the whole binary runs.
 void simdutf__init()
 {
     if (simdutf::get_active_implementation()->name() != "unsupported")

--- a/src/simdutf_sys/bun-simdutf.cpp
+++ b/src/simdutf_sys/bun-simdutf.cpp
@@ -7,6 +7,30 @@ typedef struct SIMDUTFResult {
 
 extern "C" {
 
+// simdutf picks its kernel by CPUID. When no compiled-in kernel matches the
+// advertised feature set (QEMU's default qemu64 model hides SSE4.2 even though
+// the host executes it; or SIMDUTF_FORCE_IMPLEMENTATION names an unknown
+// kernel), it installs a stub whose every method returns 0 / false /
+// error_code::OTHER. Callers cannot tell that from a real result: validate_ascii
+// says "not ASCII" for ASCII input, length queries return 0, and transcoding
+// loops that rely on forward progress spin forever.
+//
+// The scalar fallback kernel is not compiled into WTF's simdutf, so the least
+// demanding kernel in the list is what the binary's -march baseline already
+// assumes everywhere else. If the process reached main(), the CPU runs it.
+void simdutf__init()
+{
+    if (simdutf::get_active_implementation()->name() != "unsupported")
+        return;
+
+    const simdutf::implementation* least_demanding = nullptr;
+    for (const simdutf::implementation* impl : simdutf::get_available_implementations())
+        least_demanding = impl;
+
+    if (least_demanding)
+        simdutf::get_active_implementation() = least_demanding;
+}
+
 bool simdutf__validate_utf8(const char* buf, size_t len)
 {
     return simdutf::validate_utf8(buf, len);

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -31,6 +31,7 @@ impl Status {
 }
 
 unsafe extern "C" {
+    safe fn simdutf__init();
     pub(crate) fn simdutf__validate_utf8(buf: *const u8, len: usize) -> bool;
     pub(crate) fn simdutf__validate_utf8_with_errors(buf: *const u8, len: usize) -> SIMDUTFResult;
     pub fn simdutf__validate_ascii(buf: *const u8, len: usize) -> bool;
@@ -58,6 +59,14 @@ unsafe extern "C" {
     ) -> usize;
     pub fn simdutf__utf16_length_from_utf8(input: *const u8, length: usize) -> usize;
     pub fn simdutf__utf8_length_from_latin1(input: *const u8, length: usize) -> usize;
+}
+
+/// Replaces simdutf's "unsupported" stub (every call returns 0 / false) with the
+/// least demanding compiled-in kernel. simdutf installs the stub when CPUID
+/// advertises none of the compiled-in feature sets, which happens under QEMU's
+/// default CPU model. Call once at process start, before any thread.
+pub fn init() {
+    simdutf__init();
 }
 
 pub mod validate {

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -61,10 +61,8 @@ unsafe extern "C" {
     pub fn simdutf__utf8_length_from_latin1(input: *const u8, length: usize) -> usize;
 }
 
-/// Replaces simdutf's "unsupported" stub (every call returns 0 / false) with the
-/// least demanding compiled-in kernel. simdutf installs the stub when CPUID
-/// advertises none of the compiled-in feature sets, which happens under QEMU's
-/// default CPU model. Call once at process start, before any thread.
+/// Replaces simdutf's "unsupported" stub (every call returns 0 / false) with a
+/// compiled-in kernel. Call once at process start, before any thread.
 pub fn init() {
     simdutf__init();
 }

--- a/test/regression/issue/41361.test.ts
+++ b/test/regression/issue/41361.test.ts
@@ -21,5 +21,6 @@ test("bun starts when simdutf finds no supported kernel", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("ok\n");
   expect(stderr).toBe("");
+  expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/41361.test.ts
+++ b/test/regression/issue/41361.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// simdutf picks its SIMD kernel by CPUID at first use. When no compiled-in
+// kernel matches (QEMU's default CPU model hides SSE4.2), it installs a stub
+// whose every call returns 0 or false. SIMDUTF_FORCE_IMPLEMENTATION with an
+// unknown name installs the same stub on any machine. Bun used to spin forever
+// in a Latin-1 to UTF-8 loop on the first ASCII string longer than 32 bytes,
+// which is the entry point path, before it opened the entry file.
+test("bun starts when simdutf finds no supported kernel", async () => {
+  using dir = tempDir("simdutf-no-supported-kernel", {
+    "entry-file-with-a-name-longer-than-thirty-two-bytes.mjs": `console.log("ok");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), `${dir}/entry-file-with-a-name-longer-than-thirty-two-bytes.mjs`],
+    env: { ...bunEnv, SIMDUTF_FORCE_IMPLEMENTATION: "bogus" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 10_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/41361.test.ts
+++ b/test/regression/issue/41361.test.ts
@@ -17,7 +17,6 @@ test("bun starts when simdutf finds no supported kernel", async () => {
     cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
-    timeout: 10_000,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("ok\n");


### PR DESCRIPTION
### Problem
- On a KVM guest with QEMU's default CPU model (CPUID reports SSE2 and SSE3 only), `bun <file>` spins at 100% CPU before it opens the entry file. Top frame: `allocate_latin1_into_utf8_with_list` (`src/bun_core/lib.rs:1595`).
- Cause: x64 builds use `-march=nehalem`, so WTF's simdutf drops its scalar fallback kernel. At first use simdutf reads CPUID, matches no kernel, and installs its `unsupported` stub. Every stub method returns 0 or false. `first_non_ascii_usize` then returns `Some(0)` for an ASCII byte and the loop never advances.

### Fix
- `simdutf__init` (`src/simdutf_sys/bun-simdutf.cpp`) runs once in `main()`. If the active implementation is the stub, it selects the least demanding compiled-in kernel. On x64 that is westmere, which needs only SSE4.2, the baseline the whole binary already assumes.
- `SIMDUTF_FORCE_IMPLEMENTATION=<unknown name>` installs the same stub, so the test reproduces on any machine.
- Verified: `test/regression/issue/41361.test.ts` hangs on the unfixed debug build and passes on the fixed one. The reporter's 80 MB bundle loads under a CPUID-masking shim. Also ran the encoding and `buffer` suites.

### Background
- simdutf is the SIMD text library that WebKit and bun share. It is compiled inside the prebuilt WebKit, so keeping its scalar fallback needs a new WebKit release.
- simdutf picks a kernel at first use by reading CPUID. A hypervisor can hide CPU features from CPUID while the host executes them. QEMU's `qemu64` model does this for SSE4.2.
- oven-sh/WebKit#266 keeps the fallback kernel in the WebKit build. Once a release with it ships, simdutf never installs the stub and this init is a no-op. #30642 handles the same root cause (#30613, #14745) by aborting at startup with a diagnostic. That does not help here: the CPU executes SSE4.2, only CPUID hides it.

Fixes #41361

<details><summary>Notes</summary>

- The 1.3.x memory blow-up in the report has the same cause: simdutf length and conversion calls return 0 from the stub and callers misbehave. The stub first appeared in v1.3.9, when the prebuilt WebKit started to receive `-march` flags.
- A `debug_assert!` in `allocate_latin1_into_utf8_with_list` turns a future dispatch failure into a crash in debug builds instead of a silent spin.
- `init()` runs after `bun_crash_handler::init()`. That init converts no strings, so the order is safe, and it keeps the crash handler first as the existing comment asks.
- Repro without a VM: an `LD_PRELOAD` shim that calls `arch_prctl(ARCH_SET_CPUID, 0)` (Intel `cpuid_fault`) and answers every `cpuid` from a SIGSEGV handler with a qemu64-like feature set. Under it, the unfixed 1.4.0 baseline binary and the unfixed debug build both hang on any entry path longer than 32 bytes. The fixed debug build prints the script output. With the reporter's 80 MB `server.mjs`, the fixed build opens the file and reads 171 MB within 40 s (debug ASAN); the unfixed baseline reads 23 KB and sits at 11 MB RSS.
- `nm` on the 1.4.0 profile build: 103 `simdutf::westmere::` symbols, 0 `simdutf::fallback::`. The debug build here also has haswell and icelake. The list is in priority order, so the last entry is the least demanding. westmere requires `instruction_set::SSE42` at runtime and is compiled with `SIMDUTF_TARGET_REGION("sse4.2,popcnt")`.
- The trigger is an ASCII string longer than 32 bytes reaching `to_utf8`, not the file size. `is_all_ascii` has a scalar fast path up to 32 bytes, which is why `bun --version` and a short path work.
- Suites run on the fixed debug build: `test/js/web/encoding/text-encoder.test.js`, `test/js/web/encoding/text-decoder.test.js`, `test/js/bun/util/toUTF16Alloc.test.ts`, `test/js/node/buffer.test.js`, `test/js/bun/util/highway-strings.test.ts` (one highway test exceeds the 5 s default under ASAN in this container, unrelated to simdutf).
- Self-reviewed: the review raised framing points (cite #30613, #14745, #30642 and the WebKit-side fix, and explain the init order). All are folded into this body. No code concern survived.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/regression/issue/41361.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/regression/issue/41361.test.ts:
killed 1 dangling process
(fail) bun starts when simdutf finds no supported kernel [5007.80ms]
  ^ this test timed out after 5000ms.

 0 pass
 1 fail
Ran 1 test across 1 file. [6.94s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (e0a2b82fd)

test/regression/issue/41361.test.ts:
killed 1 dangling process
(fail) bun starts when simdutf finds no supported kernel [5000.86ms]
  ^ this test timed out after 5000ms.

 0 pass
 1 fail
Ran 1 test across 1 file. [5.07s]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/regression/issue/41361.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/regression/issue/41361.test.ts:
(pass) bun starts when simdutf finds no supported kernel [366.78ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [2.27s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 637ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/simdutf_sys/bun-simdutf.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_simdutf_sys v0.0.0 (/workspace/bun/src/simdutf_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/lib.rs                 |  4 ++++
 src/runtime/bin_entry/mod.rs        |  4 ++++
 src/simdutf_sys/bun-simdutf.cpp     | 18 ++++++++++++++++++
 src/simdutf_sys/simdutf.rs          |  7 +++++++
 test/regression/issue/41361.test.ts | 26 ++++++++++++++++++++++++++
 5 files changed, 59 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/bun_core/lib.rs                      2      3      7
src/runtime/bin_entry/mod.rs             3      3      7
src/simdutf_sys/bun-simdutf.cpp          3      4      7
src/simdutf_sys/simdutf.rs               3      5      7
test/regression/issue/41361.test.ts      1      5      7
```

</details>

**root cause** · written by the author bot

simdutf selects its SIMD kernel by CPUID at first use, and on CPUs that hide SSE4.2 (such as QEMU's default CPU model) no compiled-in kernel matched, so it installed a stub whose every call returned 0 or false, causing Bun to spin forever in the Latin-1 to UTF-8 conversion loop on the first ASCII string longer than 32 bytes before the entry file was even opened. The fix initializes simdutf early in runtime startup and, when the active implementation is the unsupported stub, replaces it with the least-demanding compiled kernel so conversions make progress. A regression test forces an unsuppo…

<!-- robobun:evidence:end -->