### PR TITLE
Bun.serve: accept an HTMLBundle as a Response body

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -97,7 +97,7 @@ Bun.serve({
 });
 ```
 
-Bun bundles the page on the first request that returns it and serves its `<script>` and `<link>` assets as static routes, like a page in `routes`. Hot module reloading applies to a page a handler returns only when the server also has an HTML file in `routes`, because that is what starts the dev server. A `Response` that carries an HTML import cannot be read outside of `Bun.serve`: `.text()` and `.body` reject, and `Bun.write` rejects it.
+Bun bundles the page on the first request that returns it and serves its `<script>` and `<link>` assets as static routes, like a page in `routes`. Hot module reloading applies to a page a handler returns only when the server also has an HTML file in `routes`, because that is what starts the dev server. A `Response` that carries an HTML import cannot be read outside of `Bun.serve`: `.text()` and `.body` reject, and `Bun.write` rejects it. After `bun build --target=bun`, the import is a manifest object, not an `HTMLBundle`, so a handler cannot return it. Put the page in `routes` for that build.
 
 ### HTML Processing Example
 

--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -83,7 +83,7 @@ When you make a request to `/dashboard` or `/`, Bun automatically bundles the `<
 
 ### HTML Imports in a Response
 
-A route handler or `fetch` can also return an imported HTML file. Wrap it in a `Response` to set the status or headers. A bare return is `new Response(page)`.
+A route handler or `fetch` can also send an imported HTML file: pass it to `new Response()`, with a status or headers when you need them.
 
 ```ts title="app.ts" icon="/icons/typescript.svg"
 import homepage from "./index.html";
@@ -91,7 +91,7 @@ import login from "./login.html";
 
 Bun.serve({
   routes: {
-    "/": req => (isLoggedIn(req) ? homepage : new Response(login, { status: 401 })),
+    "/": req => (isLoggedIn(req) ? new Response(homepage) : new Response(login, { status: 401 })),
     "/*": () => new Response(homepage, { status: 404 }),
   },
 });

--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -81,6 +81,24 @@ Bun.serve({
 
 When you make a request to `/dashboard` or `/`, Bun automatically bundles the `<script>` and `<link>` tags in the HTML files, exposes them as static routes, and serves the result.
 
+### HTML Imports in a Response
+
+A route handler or `fetch` can also return an imported HTML file. Wrap it in a `Response` to set the status or headers. A bare return is `new Response(page)`.
+
+```ts title="app.ts" icon="/icons/typescript.svg"
+import homepage from "./index.html";
+import login from "./login.html";
+
+Bun.serve({
+  routes: {
+    "/": req => (isLoggedIn(req) ? homepage : new Response(login, { status: 401 })),
+    "/*": () => new Response(homepage, { status: 404 }),
+  },
+});
+```
+
+Bun bundles the page on the first request that returns it and serves its `<script>` and `<link>` assets as static routes, like a page in `routes`. Hot module reloading applies to a page a handler returns only when the server also has an HTML file in `routes`, because that is what starts the dev server. A `Response` that carries an HTML import cannot be read outside of `Bun.serve`: `.text()` and `.body` reject, and `Bun.write` rejects it.
+
 ### HTML Processing Example
 
 An `index.html` file like this:

--- a/packages/bun-types/fetch.d.ts
+++ b/packages/bun-types/fetch.d.ts
@@ -18,7 +18,8 @@ declare module "bun" {
     | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
     | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
     | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>)
-    | import("bun").Image;
+    | import("bun").Image
+    | import("bun").HTMLBundle;
 
   namespace __internal {
     type LibOrFallbackHeaders = LibDomIsLoaded extends true ? {} : import("undici-types").Headers;

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -637,16 +637,21 @@ declare module "bun" {
     type Routes<WebSocketData, R extends string> = {
       [Path in R]:
         | BaseRouteValue
-        | Handler<BunRequest<Path>, Server<WebSocketData>, Response>
-        | Partial<Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Response>>;
+        | Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle>
+        | Partial<
+            Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle> | Response>
+          >;
     };
 
     type RoutesWithUpgrade<WebSocketData, R extends string> = {
       [Path in R]:
         | BaseRouteValue
-        | Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void>
+        | Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle | undefined | void>
         | Partial<
-            Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void> | Response>
+            Record<
+              HTTPMethod,
+              Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle | undefined | void> | Response
+            >
           >;
     };
 
@@ -657,7 +662,11 @@ declare module "bun" {
            *
            * Respond to {@link Request} objects with a {@link Response} object.
            */
-          fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>;
+          fetch?(
+            this: Server<WebSocketData>,
+            req: Request,
+            server: Server<WebSocketData>,
+          ): MaybePromise<Response | HTMLBundle>;
 
           routes: Routes<WebSocketData, R>;
         }
@@ -667,7 +676,11 @@ declare module "bun" {
            *
            * Respond to {@link Request} objects with a {@link Response} object.
            */
-          fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>;
+          fetch(
+            this: Server<WebSocketData>,
+            req: Request,
+            server: Server<WebSocketData>,
+          ): MaybePromise<Response | HTMLBundle>;
 
           routes?: Routes<WebSocketData, R>;
         };
@@ -719,7 +732,7 @@ declare module "bun" {
             this: Server<WebSocketData>,
             req: Request,
             server: Server<WebSocketData>,
-          ): MaybePromise<Response | void | undefined>;
+          ): MaybePromise<Response | HTMLBundle | void | undefined>;
 
           routes: RoutesWithUpgrade<WebSocketData, R>;
         }
@@ -733,7 +746,7 @@ declare module "bun" {
             this: Server<WebSocketData>,
             req: Request,
             server: Server<WebSocketData>,
-          ): MaybePromise<Response | void | undefined>;
+          ): MaybePromise<Response | HTMLBundle | void | undefined>;
 
           routes?: RoutesWithUpgrade<WebSocketData, R>;
         }

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -637,21 +637,16 @@ declare module "bun" {
     type Routes<WebSocketData, R extends string> = {
       [Path in R]:
         | BaseRouteValue
-        | Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle>
-        | Partial<
-            Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle> | Response>
-          >;
+        | Handler<BunRequest<Path>, Server<WebSocketData>, Response>
+        | Partial<Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Response>>;
     };
 
     type RoutesWithUpgrade<WebSocketData, R extends string> = {
       [Path in R]:
         | BaseRouteValue
-        | Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle | undefined | void>
+        | Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void>
         | Partial<
-            Record<
-              HTTPMethod,
-              Handler<BunRequest<Path>, Server<WebSocketData>, Response | HTMLBundle | undefined | void> | Response
-            >
+            Record<HTTPMethod, Handler<BunRequest<Path>, Server<WebSocketData>, Response | undefined | void> | Response>
           >;
     };
 
@@ -662,11 +657,7 @@ declare module "bun" {
            *
            * Respond to {@link Request} objects with a {@link Response} object.
            */
-          fetch?(
-            this: Server<WebSocketData>,
-            req: Request,
-            server: Server<WebSocketData>,
-          ): MaybePromise<Response | HTMLBundle>;
+          fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>;
 
           routes: Routes<WebSocketData, R>;
         }
@@ -676,11 +667,7 @@ declare module "bun" {
            *
            * Respond to {@link Request} objects with a {@link Response} object.
            */
-          fetch(
-            this: Server<WebSocketData>,
-            req: Request,
-            server: Server<WebSocketData>,
-          ): MaybePromise<Response | HTMLBundle>;
+          fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>;
 
           routes?: Routes<WebSocketData, R>;
         };
@@ -732,7 +719,7 @@ declare module "bun" {
             this: Server<WebSocketData>,
             req: Request,
             server: Server<WebSocketData>,
-          ): MaybePromise<Response | HTMLBundle | void | undefined>;
+          ): MaybePromise<Response | void | undefined>;
 
           routes: RoutesWithUpgrade<WebSocketData, R>;
         }
@@ -746,7 +733,7 @@ declare module "bun" {
             this: Server<WebSocketData>,
             req: Request,
             server: Server<WebSocketData>,
-          ): MaybePromise<Response | HTMLBundle | void | undefined>;
+          ): MaybePromise<Response | void | undefined>;
 
           routes?: RoutesWithUpgrade<WebSocketData, R>;
         }

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -349,7 +349,8 @@ impl Stdio {
             }
             webcore::body::Value::HTMLBundle(_) => {
                 return Err(global.throw_invalid_arguments(format_args!(
-                    "An HTMLBundle body can only be sent by Bun.serve()"
+                    "{}",
+                    crate::webcore::body::HTML_BUNDLE_BODY_UNREADABLE
                 )));
             }
 

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -347,6 +347,11 @@ impl Stdio {
             webcore::body::Value::Error(err) => {
                 return Err(global.throw_value(err.to_js(global)));
             }
+            webcore::body::Value::HTMLBundle(_) => {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "An HTMLBundle body can only be sent by Bun.serve()"
+                )));
+            }
 
             // handled above.
             webcore::body::Value::Blob(_)

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -425,6 +425,7 @@ impl HTMLRewriter {
             if let webcore::body::Value::Error(err) = body_value {
                 return Err(global.throw_value(err.to_js(global)));
             }
+            body_value.throw_if_html_bundle(global)?;
             if matches!(*body_value, webcore::body::Value::Used) {
                 return Err(
                     global.throw_invalid_arguments(format_args!("Response body already used"))
@@ -454,6 +455,7 @@ impl HTMLRewriter {
 
         if kind != ResponseKind::Other {
             let body_value = webcore::body::extract(global, response_value)?;
+            body_value.value_mut().throw_if_html_bundle(global)?;
             let resp = RefPtr::new(Response::init(
                 webcore::response::Init {
                     status_code: 200,

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -455,7 +455,6 @@ impl HTMLRewriter {
 
         if kind != ResponseKind::Other {
             let body_value = webcore::body::extract(global, response_value)?;
-            body_value.value_mut().throw_if_html_bundle(global)?;
             let resp = RefPtr::new(Response::init(
                 webcore::response::Init {
                     status_code: 200,

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -425,7 +425,6 @@ impl HTMLRewriter {
             if let webcore::body::Value::Error(err) = body_value {
                 return Err(global.throw_value(err.to_js(global)));
             }
-            body_value.throw_if_html_bundle(global)?;
             if matches!(*body_value, webcore::body::Value::Used) {
                 return Err(
                     global.throw_invalid_arguments(format_args!("Response body already used"))
@@ -1136,7 +1135,13 @@ impl RewriterPipe {
         let Some(stream) = stream else {
             // lol-html consumes UTF-8; `use_as_any_blob()` encodes a non-ASCII
             // WTFStringImpl into an InternalBlob so `.slice()` is always UTF-8.
-            let mut any_blob = value.use_as_any_blob();
+            let mut any_blob = match value.use_as_any_blob_or_throw(global) {
+                Ok(blob) => blob,
+                Err(e) => {
+                    this.set_handler_error(global.take_exception(e));
+                    return;
+                }
+            };
             let bytes = any_blob.slice();
             // Mark EOF first so a handler that suspends mid-feed resumes into
             // `end_rewrite` once its promise settles.

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -34,6 +34,7 @@ use crate::api::server::StaticRoute;
 use crate::api::{AnyServer, SavedRequest};
 use crate::bake;
 use crate::bake::framework_router::{self as framework_router, FrameworkRouter, OpaqueFileId};
+use crate::server::AnyRequestContext;
 use crate::server::html_bundle::HTMLBundleRoute;
 use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 use crate::webcore::{Request as WebRequest, Response};
@@ -1860,7 +1861,7 @@ impl RequestEnsureRouteBundledCtx {
                         // SAFETY: `r` is a uWS `Request*` valid for the handler callback's duration.
                         SavedRequestUnion::Stack(unsafe { &mut *r })
                     }
-                    ReqOrSaved::Aborted => unreachable!(),
+                    ReqOrSaved::RequestContext(_) | ReqOrSaved::Aborted => unreachable!(),
                 };
                 self.dev_mut()
                     .on_framework_request_with_bundle(route_bundle_index, req, resp)
@@ -1873,16 +1874,36 @@ impl RequestEnsureRouteBundledCtx {
                     .on_html_request_with_bundle(route_bundle_index, resp, method);
                 Ok(())
             }
+            deferred_request::HandlerKind::HtmlBundleBody => {
+                let route_bundle_index = self.route_bundle_index;
+                let ctx = self.req.request_context();
+                self.dev_mut()
+                    .on_html_bundle_body_with_bundle(route_bundle_index, ctx);
+                Ok(())
+            }
         }
     }
 
     fn on_plugin_error(&mut self) -> JsResult<()> {
-        self.resp.end(b"Plugin Error", false);
+        let resp = match self.kind {
+            deferred_request::HandlerKind::HtmlBundleBody => {
+                take_html_bundle_body_response(self.req.request_context())
+            }
+            _ => Some(self.resp),
+        };
+        if let Some(resp) = resp {
+            resp.end(b"Plugin Error", false);
+        }
         Ok(())
     }
 
     fn to_dev_response(&mut self) -> DevResponse<'_> {
-        DevResponse::Http(self.resp)
+        match self.kind {
+            deferred_request::HandlerKind::HtmlBundleBody => {
+                DevResponse::RequestContext(self.req.request_context())
+            }
+            _ => DevResponse::Http(self.resp),
+        }
     }
 }
 
@@ -2077,6 +2098,9 @@ fn ensure_route_is_bundled<Ctx: EnsureRouteCtx>(
 #[derive(Clone, Copy)]
 enum ReqOrSaved {
     Req(*mut Request), // FFI: uws C request ptr from handler callback
+    /// The context of a handler that returned `new Response(htmlBundle)`.
+    /// It renders the page itself once bundled (`HandlerKind::HtmlBundleBody`).
+    RequestContext(AnyRequestContext),
     Aborted,
 }
 
@@ -2087,9 +2111,25 @@ impl ReqOrSaved {
                 // SAFETY: `req` is a uWS `Request*` valid for the handler callback's duration.
                 Method::which(unsafe { &**req }.method()).unwrap_or(Method::POST)
             }
-            ReqOrSaved::Aborted => unreachable!(),
+            ReqOrSaved::RequestContext(_) | ReqOrSaved::Aborted => unreachable!(),
         }
     }
+
+    fn request_context(&self) -> AnyRequestContext {
+        match self {
+            ReqOrSaved::RequestContext(ctx) => *ctx,
+            ReqOrSaved::Req(_) | ReqOrSaved::Aborted => unreachable!(),
+        }
+    }
+}
+
+/// The request context of an `HtmlBundleBody` request takes the response
+/// back from its context to answer with the dev server's own page (a bundling
+/// error or a plugin error). Releases the +1 the dev server held on `ctx`.
+fn take_html_bundle_body_response(ctx: AnyRequestContext) -> Option<AnyResponse> {
+    let resp = ctx.take_response();
+    ctx.deref();
+    resp
 }
 
 impl DevServer {
@@ -2116,7 +2156,8 @@ impl DevServer {
         let method = match &req {
             // SAFETY: r is a uws Request ptr valid for the duration of the handler callback
             ReqOrSaved::Req(r) => Method::which(unsafe { &**r }.method()).unwrap_or(Method::GET),
-            _ => unreachable!(),
+            ReqOrSaved::RequestContext(_) => Method::GET,
+            ReqOrSaved::Aborted => unreachable!(),
         };
 
         let mut deferred_data = DeferredRequest {
@@ -2125,6 +2166,11 @@ impl DevServer {
             referenced_by_devserver: true,
             weakly_referenced_by_requestcontext: false,
             handler: match kind {
+                // No abort callback: the context marks itself aborted, and
+                // `on_html_bundle_built` checks that before it renders.
+                deferred_request::HandlerKind::HtmlBundleBody => {
+                    Handler::HtmlBundleBody(req.request_context())
+                }
                 deferred_request::HandlerKind::BundledHtmlPage => 'brk: {
                     // Note: `on_aborted<U: 'static>` rejects `DeferredRequest`;
                     // erase to `c_void` and cast back inside the trampoline.
@@ -2649,6 +2695,28 @@ impl DevServer {
         resp: AnyResponse,
         method: Method,
     ) {
+        let blob = self.bundled_html_page(route_bundle_index);
+        StaticRoute::on_with_method(blob, method, resp);
+    }
+
+    /// A handler returned `new Response(htmlBundle)`: the request context
+    /// renders the bundled page with the Response's status and headers.
+    /// Consumes the +1 on `ctx` that `respond_for_html_bundle_body` took.
+    fn on_html_bundle_body_with_bundle(
+        &mut self,
+        route_bundle_index: route_bundle::Index,
+        ctx: AnyRequestContext,
+    ) {
+        let blob = self.bundled_html_page(route_bundle_index);
+        ctx.on_html_bundle_built(blob);
+    }
+
+    /// The bundled page of an HTML route, with the HMR script spliced in.
+    /// Cached on the route bundle until the next rebuild.
+    fn bundled_html_page(
+        &mut self,
+        route_bundle_index: route_bundle::Index,
+    ) -> bun_ptr::ThisPtr<StaticRoute> {
         // Note: erase `self` to a raw pointer so the `route_bundle` borrow
         // doesn't conflict with the `&mut self` calls below. Per docs/PORTING.md §Global mutable state: hold
         // `*mut T` and deref per-access; do not bind a long-lived `&mut`.
@@ -2694,7 +2762,7 @@ impl DevServer {
                 break 'generate blob;
             }
         };
-        StaticRoute::on_with_method(blob, method, resp);
+        blob
     }
 }
 
@@ -2912,6 +2980,9 @@ impl DevServer {
 
 enum DevResponse<'a> {
     Http(AnyResponse),
+    /// The context of a `Handler::HtmlBundleBody` request. It gives up its
+    /// response to the dev server's page (`take_html_bundle_body_response`).
+    RequestContext(AnyRequestContext),
     Promise(PromiseResponse<'a>),
 }
 
@@ -2953,6 +3024,9 @@ pub mod deferred_request {
         ServerHandler(SavedRequest),
         /// For a .html route. Serve the bundled HTML page.
         BundledHtmlPage(ResponseAndMethod),
+        /// For a handler that returned `new Response(htmlBundle)`. The
+        /// context renders the bundled page. Holds a +1 on the context.
+        HtmlBundleBody(AnyRequestContext),
         /// Do nothing and free this node. To simplify lifetimes,
         /// the `DeferredRequest` is not freed upon abortion. Which
         /// is okay since most requests do not abort.
@@ -2965,6 +3039,7 @@ pub mod deferred_request {
     pub enum HandlerKind {
         ServerHandler,
         BundledHtmlPage,
+        HtmlBundleBody,
     }
 }
 use deferred_request::{DlogeferredRequest, Handler, PromiseResponse};
@@ -3057,7 +3132,7 @@ impl DeferredRequest {
                 saved.deinit();
                 // `saved` (incl. `js_request: jsc::Strong`) drops at scope exit.
             }
-            Handler::BundledHtmlPage(_) | Handler::Aborted => {}
+            Handler::BundledHtmlPage(_) | Handler::HtmlBundleBody(_) | Handler::Aborted => {}
         }
     }
 
@@ -3089,6 +3164,13 @@ impl DeferredRequest {
                 r.response.write_status(b"500 Internal Server Error");
                 r.response.write_header_int(b"Content-Length", 0);
                 r.response.end_without_body(true);
+            }
+            Handler::HtmlBundleBody(ctx) => {
+                if let Some(resp) = take_html_bundle_body_response(ctx) {
+                    resp.write_status(b"500 Internal Server Error");
+                    resp.write_header_int(b"Content-Length", 0);
+                    resp.end_without_body(true);
+                }
             }
             Handler::Aborted => {}
         }
@@ -4656,6 +4738,7 @@ pub(super) fn finalize_bundle(
                     break 'brk DevResponse::Http(resp);
                 }
                 Handler::BundledHtmlPage(ram) => DevResponse::Http(ram.response),
+                Handler::HtmlBundleBody(ctx) => DevResponse::RequestContext(*ctx),
             };
 
             // SAFETY: see Note on `failures` above; `dev_ptr` is live and
@@ -4866,6 +4949,9 @@ pub(super) fn finalize_bundle(
             }
             Handler::BundledHtmlPage(ram) => {
                 dev.on_html_request_with_bundle(req.route_bundle_index, ram.response, ram.method)
+            }
+            Handler::HtmlBundleBody(ctx) => {
+                dev.on_html_bundle_body_with_bundle(req.route_bundle_index, ctx)
             }
         }
     }
@@ -5223,6 +5309,36 @@ impl DevServer {
         Ok(())
     }
 
+    /// A handler returned `new Response(htmlBundle)` for `html`. Bundles the
+    /// page, then `ctx` renders it (`AnyRequestContext::on_html_bundle_built`).
+    /// `ctx` carries a +1 on the context, released with the page or with the
+    /// error page. `resp` is the context's own response handle.
+    pub(crate) fn respond_for_html_bundle_body(
+        &mut self,
+        html: bun_ptr::ThisPtr<HTMLBundleRoute>,
+        ctx: AnyRequestContext,
+        resp: AnyResponse,
+    ) -> Result<(), AllocError> {
+        let route_bundle_index = self
+            .get_or_put_route_bundle(route_bundle::UnresolvedIndex::Html(html))
+            .map_err(|_| AllocError)?;
+        let mut ensure_ctx = RequestEnsureRouteBundledCtx {
+            dev: std::ptr::from_mut::<DevServer>(self),
+            req: ReqOrSaved::RequestContext(ctx),
+            resp,
+            kind: deferred_request::HandlerKind::HtmlBundleBody,
+            route_bundle_index,
+        };
+        match ensure_route_is_bundled(self, route_bundle_index, &mut ensure_ctx) {
+            Ok(()) => {}
+            Err(err @ (jsc::JsError::Thrown | jsc::JsError::Terminated)) => {
+                crate::dispatch::fold(Err(err))
+            }
+            Err(jsc::JsError::OutOfMemory) => return Err(AllocError),
+        }
+        Ok(())
+    }
+
     fn get_or_put_route_bundle(
         &mut self,
         route: route_bundle::UnresolvedIndex,
@@ -5385,8 +5501,17 @@ impl DevServer {
         buf.extend_from_slice(bun_zstd::embed_compressed!(codegen "bake.error.js"));
         buf.extend_from_slice(post.as_bytes());
 
+        let resp = match resp {
+            DevResponse::RequestContext(ctx) => {
+                take_html_bundle_body_response(ctx).map(DevResponse::Http)
+            }
+            resp => Some(resp),
+        };
         match resp {
-            DevResponse::Http(r) => StaticRoute::send_blob_then_deinit(
+            // The client went away while the bundle was building.
+            None => {}
+            Some(DevResponse::RequestContext(_)) => unreachable!(),
+            Some(DevResponse::Http(r)) => StaticRoute::send_blob_then_deinit(
                 r,
                 crate::webcore::blob::Any::from_array_list(buf),
                 crate::server::static_route::InitFromBytesOptions {
@@ -5396,7 +5521,7 @@ impl DevServer {
                     ..Default::default()
                 },
             ),
-            DevResponse::Promise(mut r) => {
+            Some(DevResponse::Promise(mut r)) => {
                 let global = r.global;
                 let mut any_blob = crate::webcore::blob::Any::from_array_list(buf);
                 let mut headers = bun_http_jsc::headers_jsc::from_fetch_headers(

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1885,14 +1885,13 @@ impl RequestEnsureRouteBundledCtx {
     }
 
     fn on_plugin_error(&mut self) -> JsResult<()> {
-        let resp = match self.kind {
+        match self.kind {
             deferred_request::HandlerKind::HtmlBundleBody => {
-                take_html_bundle_body_response(self.req.request_context())
+                answer_html_bundle_body(self.req.request_context(), |resp| {
+                    resp.end(b"Plugin Error", false)
+                });
             }
-            _ => Some(self.resp),
-        };
-        if let Some(resp) = resp {
-            resp.end(b"Plugin Error", false);
+            _ => self.resp.end(b"Plugin Error", false),
         }
         Ok(())
     }
@@ -2122,11 +2121,15 @@ impl ReqOrSaved {
     }
 }
 
-/// Releases the dev server's +1 on `ctx`.
-fn take_html_bundle_body_response(ctx: AnyRequestContext) -> Option<AnyResponse> {
-    let resp = ctx.take_response();
+/// Answers an `HtmlBundleBody` request with the dev server's own page through
+/// `write`, then releases the context, including the dev server's +1.
+/// `write` does not run once the connection closed.
+fn answer_html_bundle_body(ctx: AnyRequestContext, write: impl FnOnce(AnyResponse)) {
+    if let Some(resp) = ctx.take_response() {
+        write(resp);
+        ctx.release_taken_response();
+    }
     ctx.deref();
-    resp
 }
 
 impl DevServer {
@@ -2973,7 +2976,7 @@ impl DevServer {
 
 enum DevResponse<'a> {
     Http(AnyResponse),
-    /// Resolved with `take_html_bundle_body_response`.
+    /// Answered with `answer_html_bundle_body`.
     RequestContext(AnyRequestContext),
     Promise(PromiseResponse<'a>),
 }
@@ -3157,13 +3160,11 @@ impl DeferredRequest {
                 r.response.write_header_int(b"Content-Length", 0);
                 r.response.end_without_body(true);
             }
-            Handler::HtmlBundleBody(ctx) => {
-                if let Some(resp) = take_html_bundle_body_response(ctx) {
-                    resp.write_status(b"500 Internal Server Error");
-                    resp.write_header_int(b"Content-Length", 0);
-                    resp.end_without_body(true);
-                }
-            }
+            Handler::HtmlBundleBody(ctx) => answer_html_bundle_body(ctx, |resp| {
+                resp.write_status(b"500 Internal Server Error");
+                resp.write_header_int(b"Content-Length", 0);
+                resp.end_without_body(true);
+            }),
             Handler::Aborted => {}
         }
     }
@@ -5496,27 +5497,26 @@ impl DevServer {
         buf.extend_from_slice(bun_zstd::embed_compressed!(codegen "bake.error.js"));
         buf.extend_from_slice(post.as_bytes());
 
-        let resp = match resp {
-            DevResponse::RequestContext(ctx) => {
-                take_html_bundle_body_response(ctx).map(DevResponse::Http)
-            }
-            resp => Some(resp),
+        let http_options = crate::server::static_route::InitFromBytesOptions {
+            mime_type: Some(&MimeType::HTML),
+            server: self.server,
+            status_code: 500,
+            ..Default::default()
         };
         match resp {
-            // The client went away while the bundle was building.
-            None => {}
-            Some(DevResponse::RequestContext(_)) => unreachable!(),
-            Some(DevResponse::Http(r)) => StaticRoute::send_blob_then_deinit(
+            DevResponse::RequestContext(ctx) => answer_html_bundle_body(ctx, |r| {
+                StaticRoute::send_blob_then_deinit(
+                    r,
+                    crate::webcore::blob::Any::from_array_list(buf),
+                    http_options,
+                )
+            }),
+            DevResponse::Http(r) => StaticRoute::send_blob_then_deinit(
                 r,
                 crate::webcore::blob::Any::from_array_list(buf),
-                crate::server::static_route::InitFromBytesOptions {
-                    mime_type: Some(&MimeType::HTML),
-                    server: self.server,
-                    status_code: 500,
-                    ..Default::default()
-                },
+                http_options,
             ),
-            Some(DevResponse::Promise(mut r)) => {
+            DevResponse::Promise(mut r) => {
                 let global = r.global;
                 let mut any_blob = crate::webcore::blob::Any::from_array_list(buf);
                 let mut headers = bun_http_jsc::headers_jsc::from_fetch_headers(

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1819,8 +1819,8 @@ enum EnsureRequest {
     HtmlBundleBody(AnyRequestContext),
 }
 
-/// SAFETY: `req` is a uWS `Request*` valid for the handler callback's duration.
 fn request_method(req: *mut Request) -> Method {
+    // SAFETY: `req` is a uWS `Request*` valid for the handler callback's duration.
     Method::which(unsafe { &*req }.method()).unwrap_or(Method::GET)
 }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5270,13 +5270,13 @@ impl DevServer {
             route_bundle_index,
         };
         match ensure_route_is_bundled(self, route_bundle_index, &mut ensure_ctx) {
-            Ok(()) => {}
-            Err(err @ (jsc::JsError::Thrown | jsc::JsError::Terminated)) => {
-                crate::dispatch::fold(Err(err))
+            Err(jsc::JsError::OutOfMemory) => Err(AllocError),
+            // A thrown error has no frame to return to here; report it as uncaught.
+            result => {
+                crate::dispatch::fold(result);
+                Ok(())
             }
-            Err(jsc::JsError::OutOfMemory) => return Err(AllocError),
         }
-        Ok(())
     }
 
     fn get_or_put_route_bundle(

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2162,9 +2162,7 @@ impl DevServer {
                             Some(request_method(r)),
                         )? {
                         Some(saved) => saved,
-                        // Abort the deferral on failure.
-                        // `deferred_slot` drops here, releasing the
-                        // still-uninitialized slot without `drop_in_place`.
+                        // `deferred_slot` drops here and releases the uninitialized slot.
                         None => return Ok(()),
                     };
                     server_handler.ctx.ref_();

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5300,8 +5300,7 @@ impl DevServer {
         Ok(())
     }
 
-    /// `ctx` carries a +1 on the context, released by `on_html_bundle_built`
-    /// or by `take_html_bundle_body_response`.
+    /// `ctx` carries a +1 on the context.
     pub(crate) fn respond_for_html_bundle_body(
         &mut self,
         html: bun_ptr::ThisPtr<HTMLBundleRoute>,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1803,10 +1803,25 @@ struct RequestEnsureRouteBundledCtx {
     // Note: erased to raw pointer — a `&mut DevServer` field would alias the
     // caller's borrow.
     dev: *mut DevServer,
-    req: ReqOrSaved,
+    request: EnsureRequest,
     resp: AnyResponse,
-    kind: deferred_request::HandlerKind,
     route_bundle_index: route_bundle::Index,
+}
+
+/// What answers the request once its route bundle is ready.
+#[derive(Clone, Copy)]
+enum EnsureRequest {
+    /// A framework route: the server handler runs with the uWS request.
+    ServerHandler(*mut Request), // FFI: uws C request ptr from handler callback
+    /// An HTML route: the bundled page.
+    BundledHtmlPage(*mut Request),
+    /// `new Response(htmlBundle)` from a handler: the context renders the page.
+    HtmlBundleBody(AnyRequestContext),
+}
+
+/// SAFETY: `req` is a uWS `Request*` valid for the handler callback's duration.
+fn request_method(req: *mut Request) -> Method {
+    Method::which(unsafe { &*req }.method()).unwrap_or(Method::GET)
 }
 
 impl RequestEnsureRouteBundledCtx {
@@ -1824,8 +1839,7 @@ impl RequestEnsureRouteBundledCtx {
     fn on_defer(&mut self, bundle_field: BundleQueueType) -> JsResult<()> {
         // Note: reshaped for borrowck — captured args before re-borrowing dev
         let route_bundle_index = self.route_bundle_index;
-        let kind = self.kind;
-        let req = ::core::mem::replace(&mut self.req, ReqOrSaved::Aborted);
+        let request = self.request;
         let resp = self.resp;
         let dev = self.dev_mut();
         let requests_array: *mut deferred_request::List = match bundle_field {
@@ -1842,41 +1856,29 @@ impl RequestEnsureRouteBundledCtx {
             // SAFETY: `requests_array` points into `*self.dev`, which outlives this call.
             unsafe { &mut *requests_array },
             route_bundle_index,
-            kind,
-            req,
+            request,
             resp,
         )?;
         Ok(())
     }
 
     fn on_loaded(&mut self) -> JsResult<()> {
-        match self.kind {
-            deferred_request::HandlerKind::ServerHandler => {
-                let route_bundle_index = self.route_bundle_index;
-                let resp = self.resp;
-                // The `Strong` field is move-only. Take ownership out of `self.req`
-                // (it is consumed by `on_framework_request_with_bundle`).
-                let req = match ::core::mem::replace(&mut self.req, ReqOrSaved::Aborted) {
-                    ReqOrSaved::Req(r) => {
-                        // SAFETY: `r` is a uWS `Request*` valid for the handler callback's duration.
-                        SavedRequestUnion::Stack(unsafe { &mut *r })
-                    }
-                    ReqOrSaved::RequestContext(_) | ReqOrSaved::Aborted => unreachable!(),
-                };
+        let route_bundle_index = self.route_bundle_index;
+        let resp = self.resp;
+        match self.request {
+            EnsureRequest::ServerHandler(r) => {
+                // SAFETY: `r` is a uWS `Request*` valid for the handler callback's duration.
+                let req = SavedRequestUnion::Stack(unsafe { &mut *r });
                 self.dev_mut()
                     .on_framework_request_with_bundle(route_bundle_index, req, resp)
             }
-            deferred_request::HandlerKind::BundledHtmlPage => {
-                let route_bundle_index = self.route_bundle_index;
-                let resp = self.resp;
-                let method = self.req.method();
+            EnsureRequest::BundledHtmlPage(r) => {
+                let method = request_method(r);
                 self.dev_mut()
                     .on_html_request_with_bundle(route_bundle_index, resp, method);
                 Ok(())
             }
-            deferred_request::HandlerKind::HtmlBundleBody => {
-                let route_bundle_index = self.route_bundle_index;
-                let ctx = self.req.request_context();
+            EnsureRequest::HtmlBundleBody(ctx) => {
                 self.dev_mut()
                     .on_html_bundle_body_with_bundle(route_bundle_index, ctx);
                 Ok(())
@@ -1885,23 +1887,23 @@ impl RequestEnsureRouteBundledCtx {
     }
 
     fn on_plugin_error(&mut self) -> JsResult<()> {
-        match self.kind {
-            deferred_request::HandlerKind::HtmlBundleBody => {
-                answer_html_bundle_body(self.req.request_context(), |resp| {
-                    resp.end(b"Plugin Error", false)
-                });
+        match self.request {
+            EnsureRequest::HtmlBundleBody(ctx) => {
+                answer_html_bundle_body(ctx, |resp| resp.end(b"Plugin Error", false));
             }
-            _ => self.resp.end(b"Plugin Error", false),
+            EnsureRequest::ServerHandler(_) | EnsureRequest::BundledHtmlPage(_) => {
+                self.resp.end(b"Plugin Error", false)
+            }
         }
         Ok(())
     }
 
     fn to_dev_response(&mut self) -> DevResponse<'_> {
-        match self.kind {
-            deferred_request::HandlerKind::HtmlBundleBody => {
-                DevResponse::RequestContext(self.req.request_context())
+        match self.request {
+            EnsureRequest::HtmlBundleBody(ctx) => DevResponse::RequestContext(ctx),
+            EnsureRequest::ServerHandler(_) | EnsureRequest::BundledHtmlPage(_) => {
+                DevResponse::Http(self.resp)
             }
-            _ => DevResponse::Http(self.resp),
         }
     }
 }
@@ -2094,33 +2096,6 @@ fn ensure_route_is_bundled<Ctx: EnsureRouteCtx>(
     }
 }
 
-#[derive(Clone, Copy)]
-enum ReqOrSaved {
-    Req(*mut Request), // FFI: uws C request ptr from handler callback
-    /// `HandlerKind::HtmlBundleBody`: the context renders the page itself.
-    RequestContext(AnyRequestContext),
-    Aborted,
-}
-
-impl ReqOrSaved {
-    fn method(&self) -> Method {
-        match self {
-            ReqOrSaved::Req(req) => {
-                // SAFETY: `req` is a uWS `Request*` valid for the handler callback's duration.
-                Method::which(unsafe { &**req }.method()).unwrap_or(Method::POST)
-            }
-            ReqOrSaved::RequestContext(_) | ReqOrSaved::Aborted => unreachable!(),
-        }
-    }
-
-    fn request_context(&self) -> AnyRequestContext {
-        match self {
-            ReqOrSaved::RequestContext(ctx) => *ctx,
-            ReqOrSaved::Req(_) | ReqOrSaved::Aborted => unreachable!(),
-        }
-    }
-}
-
 /// `write` answers the request, then the context and the dev server's +1 go.
 fn answer_html_bundle_body(ctx: AnyRequestContext, write: impl FnOnce(AnyResponse)) {
     if let Some(resp) = ctx.take_response() {
@@ -2135,8 +2110,7 @@ impl DevServer {
         &mut self,
         requests_array: &mut deferred_request::List,
         route_bundle_index: route_bundle::Index,
-        kind: deferred_request::HandlerKind,
-        req: ReqOrSaved,
+        request: EnsureRequest,
         resp: AnyResponse,
     ) -> crate::Result<()> {
         let deferred_slot = self.deferred_request_pool.claim();
@@ -2151,24 +2125,15 @@ impl DevServer {
             unsafe { ::core::ptr::addr_of_mut!((*deferred_node_ptr).data) }.cast::<c_void>();
         debug_log!("DeferredRequest(0x{:x}).init", deferred_data_ptr as usize);
 
-        let method = match &req {
-            // SAFETY: r is a uws Request ptr valid for the duration of the handler callback
-            ReqOrSaved::Req(r) => Method::which(unsafe { &**r }.method()).unwrap_or(Method::GET),
-            ReqOrSaved::RequestContext(_) => Method::GET,
-            ReqOrSaved::Aborted => unreachable!(),
-        };
-
         let mut deferred_data = DeferredRequest {
             route_bundle_index,
             dev: std::ptr::from_ref(self),
             referenced_by_devserver: true,
             weakly_referenced_by_requestcontext: false,
-            handler: match kind {
+            handler: match request {
                 // The context tracks its own abort; `on_html_bundle_built` checks it.
-                deferred_request::HandlerKind::HtmlBundleBody => {
-                    Handler::HtmlBundleBody(req.request_context())
-                }
-                deferred_request::HandlerKind::BundledHtmlPage => 'brk: {
+                EnsureRequest::HtmlBundleBody(ctx) => Handler::HtmlBundleBody(ctx),
+                EnsureRequest::BundledHtmlPage(r) => 'brk: {
                     // Note: `on_aborted<U: 'static>` rejects `DeferredRequest`;
                     // erase to `c_void` and cast back inside the trampoline.
                     resp.on_aborted(
@@ -2180,32 +2145,27 @@ impl DevServer {
                     );
                     break 'brk Handler::BundledHtmlPage(ResponseAndMethod {
                         response: resp,
-                        method,
+                        method: request_method(r),
                     });
                 }
-                deferred_request::HandlerKind::ServerHandler => 'brk: {
-                    let server_handler: SavedRequest = match req {
-                        ReqOrSaved::Req(r) => {
-                            let global = self.vm().global();
-                            match self
-                                .server
-                                .as_ref()
-                                .unwrap()
-                                .prepare_and_save_js_request_context(
-                                    // SAFETY: r is the live µWS request for this handler frame.
-                                    unsafe { &mut *r },
-                                    resp,
-                                    global,
-                                    Some(method),
-                                )? {
-                                Some(saved) => saved,
-                                // Abort the deferral on failure.
-                                // `deferred_slot` drops here, releasing the
-                                // still-uninitialized slot without `drop_in_place`.
-                                None => return Ok(()),
-                            }
-                        }
-                        _ => unreachable!(),
+                EnsureRequest::ServerHandler(r) => 'brk: {
+                    let global = self.vm().global();
+                    let server_handler: SavedRequest = match self
+                        .server
+                        .as_ref()
+                        .unwrap()
+                        .prepare_and_save_js_request_context(
+                            // SAFETY: r is the live µWS request for this handler frame.
+                            unsafe { &mut *r },
+                            resp,
+                            global,
+                            Some(request_method(r)),
+                        )? {
+                        Some(saved) => saved,
+                        // Abort the deferral on failure.
+                        // `deferred_slot` drops here, releasing the
+                        // still-uninitialized slot without `drop_in_place`.
+                        None => return Ok(()),
                     };
                     server_handler.ctx.ref_();
                     server_handler.ctx.set_additional_on_abort_callback(Some(
@@ -3023,15 +2983,6 @@ pub mod deferred_request {
         /// the `DeferredRequest` is not freed upon abortion. Which
         /// is okay since most requests do not abort.
         Aborted,
-    }
-
-    /// Does not include `aborted` because branching on that value
-    /// has no meaningful purpose, so it is excluded.
-    #[derive(Copy, Clone)]
-    pub enum HandlerKind {
-        ServerHandler,
-        BundledHtmlPage,
-        HtmlBundleBody,
     }
 }
 use deferred_request::{DlogeferredRequest, Handler, PromiseResponse};
@@ -5240,9 +5191,8 @@ fn on_request(dev: &mut DevServer, req: &mut Request, mut resp: AnyResponse) -> 
             .expect("oom");
         let mut ctx = RequestEnsureRouteBundledCtx {
             dev: std::ptr::from_mut::<DevServer>(dev),
-            req: ReqOrSaved::Req(req),
+            request: EnsureRequest::ServerHandler(req),
             resp,
-            kind: deferred_request::HandlerKind::ServerHandler,
             route_bundle_index,
         };
         let rbi = ctx.route_bundle_index;
@@ -5287,9 +5237,8 @@ impl DevServer {
             .map_err(|_| AllocError)?;
         let mut ctx = RequestEnsureRouteBundledCtx {
             dev: std::ptr::from_mut::<DevServer>(self),
-            req: ReqOrSaved::Req(req),
+            request: EnsureRequest::BundledHtmlPage(req),
             resp,
-            kind: deferred_request::HandlerKind::BundledHtmlPage,
             route_bundle_index,
         };
         let rbi = ctx.route_bundle_index;
@@ -5318,9 +5267,8 @@ impl DevServer {
             .map_err(|_| AllocError)?;
         let mut ensure_ctx = RequestEnsureRouteBundledCtx {
             dev: std::ptr::from_mut::<DevServer>(self),
-            req: ReqOrSaved::RequestContext(ctx),
+            request: EnsureRequest::HtmlBundleBody(ctx),
             resp,
-            kind: deferred_request::HandlerKind::HtmlBundleBody,
             route_bundle_index,
         };
         match ensure_route_is_bundled(self, route_bundle_index, &mut ensure_ctx) {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3123,7 +3123,8 @@ impl DeferredRequest {
                 saved.deinit();
                 // `saved` (incl. `js_request: jsc::Strong`) drops at scope exit.
             }
-            Handler::BundledHtmlPage(_) | Handler::HtmlBundleBody(_) | Handler::Aborted => {}
+            Handler::HtmlBundleBody(ctx) => ctx.deref(),
+            Handler::BundledHtmlPage(_) | Handler::Aborted => {}
         }
     }
 
@@ -4729,7 +4730,13 @@ pub(super) fn finalize_bundle(
                     break 'brk DevResponse::Http(resp);
                 }
                 Handler::BundledHtmlPage(ram) => DevResponse::Http(ram.response),
-                Handler::HtmlBundleBody(ctx) => DevResponse::RequestContext(*ctx),
+                // `send_serialized_failures` releases the context; `deref_` must not.
+                Handler::HtmlBundleBody(_) => {
+                    match ::core::mem::replace(&mut req.handler, Handler::Aborted) {
+                        Handler::HtmlBundleBody(ctx) => DevResponse::RequestContext(ctx),
+                        _ => unreachable!(),
+                    }
+                }
             };
 
             // SAFETY: see Note on `failures` above; `dev_ptr` is live and

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2098,8 +2098,7 @@ fn ensure_route_is_bundled<Ctx: EnsureRouteCtx>(
 #[derive(Clone, Copy)]
 enum ReqOrSaved {
     Req(*mut Request), // FFI: uws C request ptr from handler callback
-    /// The context of a handler that returned `new Response(htmlBundle)`.
-    /// It renders the page itself once bundled (`HandlerKind::HtmlBundleBody`).
+    /// `HandlerKind::HtmlBundleBody`: the context renders the page itself.
     RequestContext(AnyRequestContext),
     Aborted,
 }
@@ -2123,9 +2122,7 @@ impl ReqOrSaved {
     }
 }
 
-/// The request context of an `HtmlBundleBody` request takes the response
-/// back from its context to answer with the dev server's own page (a bundling
-/// error or a plugin error). Releases the +1 the dev server held on `ctx`.
+/// Releases the dev server's +1 on `ctx`.
 fn take_html_bundle_body_response(ctx: AnyRequestContext) -> Option<AnyResponse> {
     let resp = ctx.take_response();
     ctx.deref();
@@ -2166,8 +2163,7 @@ impl DevServer {
             referenced_by_devserver: true,
             weakly_referenced_by_requestcontext: false,
             handler: match kind {
-                // No abort callback: the context marks itself aborted, and
-                // `on_html_bundle_built` checks that before it renders.
+                // The context tracks its own abort; `on_html_bundle_built` checks it.
                 deferred_request::HandlerKind::HtmlBundleBody => {
                     Handler::HtmlBundleBody(req.request_context())
                 }
@@ -2699,8 +2695,6 @@ impl DevServer {
         StaticRoute::on_with_method(blob, method, resp);
     }
 
-    /// A handler returned `new Response(htmlBundle)`: the request context
-    /// renders the bundled page with the Response's status and headers.
     /// Consumes the +1 on `ctx` that `respond_for_html_bundle_body` took.
     fn on_html_bundle_body_with_bundle(
         &mut self,
@@ -2711,7 +2705,6 @@ impl DevServer {
         ctx.on_html_bundle_built(blob);
     }
 
-    /// The bundled page of an HTML route, with the HMR script spliced in.
     /// Cached on the route bundle until the next rebuild.
     fn bundled_html_page(
         &mut self,
@@ -2980,8 +2973,7 @@ impl DevServer {
 
 enum DevResponse<'a> {
     Http(AnyResponse),
-    /// The context of a `Handler::HtmlBundleBody` request. It gives up its
-    /// response to the dev server's page (`take_html_bundle_body_response`).
+    /// Resolved with `take_html_bundle_body_response`.
     RequestContext(AnyRequestContext),
     Promise(PromiseResponse<'a>),
 }
@@ -3024,8 +3016,7 @@ pub mod deferred_request {
         ServerHandler(SavedRequest),
         /// For a .html route. Serve the bundled HTML page.
         BundledHtmlPage(ResponseAndMethod),
-        /// For a handler that returned `new Response(htmlBundle)`. The
-        /// context renders the bundled page. Holds a +1 on the context.
+        /// For `new Response(htmlBundle)` from a handler. Holds a +1 on the context.
         HtmlBundleBody(AnyRequestContext),
         /// Do nothing and free this node. To simplify lifetimes,
         /// the `DeferredRequest` is not freed upon abortion. Which
@@ -5309,10 +5300,8 @@ impl DevServer {
         Ok(())
     }
 
-    /// A handler returned `new Response(htmlBundle)` for `html`. Bundles the
-    /// page, then `ctx` renders it (`AnyRequestContext::on_html_bundle_built`).
-    /// `ctx` carries a +1 on the context, released with the page or with the
-    /// error page. `resp` is the context's own response handle.
+    /// `ctx` carries a +1 on the context, released by `on_html_bundle_built`
+    /// or by `take_html_bundle_body_response`.
     pub(crate) fn respond_for_html_bundle_body(
         &mut self,
         html: bun_ptr::ThisPtr<HTMLBundleRoute>,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2121,9 +2121,7 @@ impl ReqOrSaved {
     }
 }
 
-/// Answers an `HtmlBundleBody` request with the dev server's own page through
-/// `write`, then releases the context, including the dev server's +1.
-/// `write` does not run once the connection closed.
+/// `write` answers the request, then the context and the dev server's +1 go.
 fn answer_html_bundle_body(ctx: AnyRequestContext, write: impl FnOnce(AnyResponse)) {
     if let Some(resp) = ctx.take_response() {
         write(resp);

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -261,6 +261,11 @@ impl AnyRequestContext {
         dispatch!(self, None, |_T, ctx| ctx.take_response())
     }
 
+    /// After the last write to the response `take_response` handed out.
+    pub(crate) fn release_taken_response(self) {
+        dispatch!(self, (), |_T, ctx| ctx.release_taken_response())
+    }
+
     pub fn on_request_body_stream_drained(self) {
         dispatch!(
             self,

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -251,15 +251,12 @@ impl AnyRequestContext {
         dispatch!(self, (), |_T, ctx| ctx.deref())
     }
 
-    /// The dev server bundled the page of a handler-returned
-    /// `new Response(htmlBundle)`. Consumes the +1 the dev server held.
+    /// Consumes the +1 the dev server held.
     pub(crate) fn on_html_bundle_built(self, html: bun_ptr::ThisPtr<crate::server::StaticRoute>) {
         dispatch!(self, (), ptr | T, ptr | T::on_html_bundle_built(ptr, html))
     }
 
-    /// Detach the response from the context so another owner can answer it.
-    /// Ends the context's own claim on the request. `None` once the
-    /// connection closed or the context already answered.
+    /// `None` once the connection closed or the context already answered.
     pub(crate) fn take_response(self) -> Option<uws::AnyResponse> {
         dispatch!(self, None, |_T, ctx| ctx.take_response())
     }

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -251,6 +251,19 @@ impl AnyRequestContext {
         dispatch!(self, (), |_T, ctx| ctx.deref())
     }
 
+    /// The dev server bundled the page of a handler-returned
+    /// `new Response(htmlBundle)`. Consumes the +1 the dev server held.
+    pub(crate) fn on_html_bundle_built(self, html: bun_ptr::ThisPtr<crate::server::StaticRoute>) {
+        dispatch!(self, (), ptr | T, ptr | T::on_html_bundle_built(ptr, html))
+    }
+
+    /// Detach the response from the context so another owner can answer it.
+    /// Ends the context's own claim on the request. `None` once the
+    /// connection closed or the context already answered.
+    pub(crate) fn take_response(self) -> Option<uws::AnyResponse> {
+        dispatch!(self, None, |_T, ctx| ctx.take_response())
+    }
+
     pub fn on_request_body_stream_drained(self) {
         dispatch!(
             self,

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -159,13 +159,15 @@ pub struct Route {
     /// When state == .pending, incomplete responses are stored here.
     pending_responses: JsCell<Vec<PendingResponse>>,
     build_waiters: JsCell<Vec<BuildWaiter>>,
+    /// The route's own ref while it is in `State::Building`, so the waiters
+    /// above always have a route to resume on (`StaticRoute::pending_ref`).
+    building_ref: Cell<Option<RefPtr<Route>>>,
 }
 
 /// Run by `finish_building`. The callback reads `Route::built_html`.
 pub(crate) struct BuildWaiter {
     callback: fn(NonNull<core::ffi::c_void>, ThisPtr<Route>),
     ctx: NonNull<core::ffi::c_void>,
-    _route: RefPtr<Route>,
 }
 
 pub enum State {
@@ -206,6 +208,7 @@ impl Route {
             bundle: RefPtr::from_this(html_bundle),
             pending_responses: JsCell::new(Vec::new()),
             build_waiters: JsCell::new(Vec::new()),
+            building_ref: Cell::new(None),
             ref_count: RefCount::init(),
             server: Cell::new(None),
             state: JsCell::new(State::Pending),
@@ -245,13 +248,8 @@ impl Route {
         ctx: NonNull<core::ffi::c_void>,
     ) {
         debug_assert!(matches!(this.state.get(), State::Building));
-        this.build_waiters.with_mut(|v| {
-            v.push(BuildWaiter {
-                callback,
-                ctx,
-                _route: RefPtr::from_this(this),
-            })
-        });
+        this.build_waiters
+            .with_mut(|v| v.push(BuildWaiter { callback, ctx }));
     }
 
     pub(crate) fn on_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse) {
@@ -386,10 +384,12 @@ impl Route {
             GetOrStartLoadResult::Ready(plugins) => {
                 let plugins = plugins.map(NonNull::from);
                 server.on_pending_request();
+                this.building_ref.set(Some(RefPtr::from_this(this)));
                 Self::on_plugins_resolved(this, plugins)?;
             }
             GetOrStartLoadResult::Pending => {
                 server.on_pending_request();
+                this.building_ref.set(Some(RefPtr::from_this(this)));
                 this.state.set(State::Building);
             }
         }
@@ -403,17 +403,19 @@ impl Route {
     /// this build was the only thing still keeping a stopped server alive.
     fn finish_building(&self) {
         debug_assert!(matches!(self.state.get(), State::Err(_) | State::Html(_)));
+        // Dropped last: the route may have no other ref by then.
+        let building_ref = self.building_ref.take();
         self.resume_pending_responses();
-        let _waiters = self.resume_build_waiters();
-        self.server.get().expect("server set").on_request_complete();
-    }
-
-    fn resume_build_waiters(&self) -> Vec<BuildWaiter> {
         let waiters = self.build_waiters.replace(Vec::new());
-        for waiter in &waiters {
-            (waiter.callback)(waiter.ctx, waiter._route.this_ptr());
+        match &building_ref {
+            Some(route) => {
+                for waiter in &waiters {
+                    (waiter.callback)(waiter.ctx, route.this_ptr());
+                }
+            }
+            None => debug_assert!(waiters.is_empty()),
         }
-        waiters
+        self.server.get().expect("server set").on_request_complete();
     }
 
     /// Production keeps the reason to itself, see `resume_pending_responses`.

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -163,7 +163,7 @@ pub struct Route {
 
 /// Run by `finish_building`. The callback reads `Route::built_html`.
 pub(crate) struct BuildWaiter {
-    callback: fn(NonNull<core::ffi::c_void>, &Route),
+    callback: fn(NonNull<core::ffi::c_void>, ThisPtr<Route>),
     ctx: NonNull<core::ffi::c_void>,
     _route: RefPtr<Route>,
 }
@@ -241,7 +241,7 @@ impl Route {
 
     pub(crate) fn add_build_waiter(
         this: ThisPtr<Self>,
-        callback: fn(NonNull<core::ffi::c_void>, &Route),
+        callback: fn(NonNull<core::ffi::c_void>, ThisPtr<Route>),
         ctx: NonNull<core::ffi::c_void>,
     ) {
         debug_assert!(matches!(this.state.get(), State::Building));
@@ -411,7 +411,7 @@ impl Route {
     fn resume_build_waiters(&self) -> Vec<BuildWaiter> {
         let waiters = self.build_waiters.replace(Vec::new());
         for waiter in &waiters {
-            (waiter.callback)(waiter.ctx, self);
+            (waiter.callback)(waiter.ctx, waiter._route.this_ptr());
         }
         waiters
     }

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -158,6 +158,19 @@ pub struct Route {
     pub(crate) dev_server_id: Cell<Option<route_bundle::Index>>,
     /// When state == .pending, incomplete responses are stored here.
     pending_responses: JsCell<Vec<PendingResponse>>,
+    /// Request contexts that render the page themselves once the build is
+    /// done (a handler returned `new Response(htmlBundle)`).
+    build_waiters: JsCell<Vec<BuildWaiter>>,
+}
+
+/// A callback `finish_building` runs once the route leaves `State::Building`.
+/// The callback reads the result from `Route::built_html`.
+pub(crate) struct BuildWaiter {
+    callback: fn(NonNull<core::ffi::c_void>, &Route),
+    ctx: NonNull<core::ffi::c_void>,
+    /// Keeps the route alive while this waiter waits on it, as a
+    /// `PendingResponse` does.
+    _route: RefPtr<Route>,
 }
 
 pub enum State {
@@ -187,6 +200,7 @@ impl Route {
         let mut cost: usize = 0;
         cost += mem::size_of::<Route>();
         cost += self.pending_responses.get().len() * mem::size_of::<PendingResponse>();
+        cost += self.build_waiters.get().len() * mem::size_of::<BuildWaiter>();
         cost += self.state.get().memory_cost();
         cost
     }
@@ -196,11 +210,57 @@ impl Route {
         RefPtr::new(Route {
             bundle: RefPtr::from_this(html_bundle),
             pending_responses: JsCell::new(Vec::new()),
+            build_waiters: JsCell::new(Vec::new()),
             ref_count: RefCount::init(),
             server: Cell::new(None),
             state: JsCell::new(State::Pending),
             dev_server_id: Cell::new(None),
         })
+    }
+
+    /// The built page for a handler-returned `new Response(htmlBundle)`.
+    /// `Some` when the build is done: the page, or `Err` when it failed.
+    /// `None` while it runs: the caller registers a `BuildWaiter`.
+    /// Schedules the build when nothing has yet. Only for a route without a
+    /// dev server, which serves its page through `DevServer` instead.
+    pub(crate) fn built_html_or_schedule(
+        this: ThisPtr<Self>,
+    ) -> Option<Result<ThisPtr<StaticRoute>, ()>> {
+        let server = this.server.get().expect("server set");
+        // Without a dev server, development mode rebundles on every request.
+        if server.config().is_development()
+            && matches!(this.state.get(), State::Html(_) | State::Err(_))
+        {
+            this.state.set(State::Pending);
+        }
+        if matches!(this.state.get(), State::Pending) {
+            bun_core::handle_oom(Self::schedule_bundle(this, server));
+        }
+        this.built_html()
+    }
+
+    /// `None` while the build runs.
+    pub(crate) fn built_html(&self) -> Option<Result<ThisPtr<StaticRoute>, ()>> {
+        match self.state.get() {
+            State::Pending | State::Building => None,
+            State::Err(_) => Some(Err(())),
+            State::Html(html) => Some(Ok(html.this_ptr())),
+        }
+    }
+
+    pub(crate) fn add_build_waiter(
+        this: ThisPtr<Self>,
+        callback: fn(NonNull<core::ffi::c_void>, &Route),
+        ctx: NonNull<core::ffi::c_void>,
+    ) {
+        debug_assert!(matches!(this.state.get(), State::Building));
+        this.build_waiters.with_mut(|v| {
+            v.push(BuildWaiter {
+                callback,
+                ctx,
+                _route: RefPtr::from_this(this),
+            })
+        });
     }
 
     pub(crate) fn on_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse) {
@@ -353,7 +413,19 @@ impl Route {
     fn finish_building(&self) {
         debug_assert!(matches!(self.state.get(), State::Err(_) | State::Html(_)));
         self.resume_pending_responses();
+        // The waiters' route refs outlive the release below.
+        let _waiters = self.resume_build_waiters();
         self.server.get().expect("server set").on_request_complete();
+    }
+
+    fn resume_build_waiters(&self) -> Vec<BuildWaiter> {
+        // R-2: take the list first. A callback renders a response, which can
+        // re-enter this route through uws callbacks.
+        let waiters = self.build_waiters.replace(Vec::new());
+        for waiter in &waiters {
+            (waiter.callback)(waiter.ctx, self);
+        }
+        waiters
     }
 
     /// Production keeps the reason to itself, see `resume_pending_responses`.
@@ -707,6 +779,8 @@ impl Drop for Route {
     fn drop(&mut self) {
         // pending responses keep a ref to the route
         debug_assert!(self.pending_responses.get().is_empty());
+        // the build task keeps a ref to the route until the waiters ran
+        debug_assert!(self.build_waiters.get().is_empty());
     }
 }
 

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -159,8 +159,7 @@ pub struct Route {
     /// When state == .pending, incomplete responses are stored here.
     pending_responses: JsCell<Vec<PendingResponse>>,
     build_waiters: JsCell<Vec<BuildWaiter>>,
-    /// The route's own ref while it is in `State::Building`, so the waiters
-    /// above always have a route to resume on (`StaticRoute::pending_ref`).
+    /// The route's own ref while in `State::Building`, like `StaticRoute::pending_ref`.
     building_ref: Cell<Option<RefPtr<Route>>>,
 }
 

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -158,18 +158,13 @@ pub struct Route {
     pub(crate) dev_server_id: Cell<Option<route_bundle::Index>>,
     /// When state == .pending, incomplete responses are stored here.
     pending_responses: JsCell<Vec<PendingResponse>>,
-    /// Request contexts that render the page themselves once the build is
-    /// done (a handler returned `new Response(htmlBundle)`).
     build_waiters: JsCell<Vec<BuildWaiter>>,
 }
 
-/// A callback `finish_building` runs once the route leaves `State::Building`.
-/// The callback reads the result from `Route::built_html`.
+/// Run by `finish_building`. The callback reads `Route::built_html`.
 pub(crate) struct BuildWaiter {
     callback: fn(NonNull<core::ffi::c_void>, &Route),
     ctx: NonNull<core::ffi::c_void>,
-    /// Keeps the route alive while this waiter waits on it, as a
-    /// `PendingResponse` does.
     _route: RefPtr<Route>,
 }
 
@@ -218,11 +213,7 @@ impl Route {
         })
     }
 
-    /// The built page for a handler-returned `new Response(htmlBundle)`.
-    /// `Some` when the build is done: the page, or `Err` when it failed.
-    /// `None` while it runs: the caller registers a `BuildWaiter`.
-    /// Schedules the build when nothing has yet. Only for a route without a
-    /// dev server, which serves its page through `DevServer` instead.
+    /// `None` while the build runs: the caller registers a `BuildWaiter`.
     pub(crate) fn built_html_or_schedule(
         this: ThisPtr<Self>,
     ) -> Option<Result<ThisPtr<StaticRoute>, ()>> {
@@ -413,14 +404,11 @@ impl Route {
     fn finish_building(&self) {
         debug_assert!(matches!(self.state.get(), State::Err(_) | State::Html(_)));
         self.resume_pending_responses();
-        // The waiters' route refs outlive the release below.
         let _waiters = self.resume_build_waiters();
         self.server.get().expect("server set").on_request_complete();
     }
 
     fn resume_build_waiters(&self) -> Vec<BuildWaiter> {
-        // R-2: take the list first. A callback renders a response, which can
-        // re-enter this route through uws callbacks.
         let waiters = self.build_waiters.replace(Vec::new());
         for waiter in &waiters {
             (waiter.callback)(waiter.ctx, self);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2089,9 +2089,14 @@ where
     }
 
     /// `html_bundle::BuildWaiter` callback.
-    fn on_html_route_built(ctx: NonNull<c_void>, route: &html_bundle::Route) {
+    fn on_html_route_built(ctx: NonNull<c_void>, route: ThisPtr<html_bundle::Route>) {
+        let Some(built) = route.built_html() else {
+            // An earlier waiter scheduled a new build (development mode
+            // rebundles). Wait for that one; the +1 stays with the waiter.
+            html_bundle::Route::add_build_waiter(route, Self::on_html_route_built, ctx);
+            return;
+        };
         let pinned = RequestContextRef::adopt(ctx.cast::<Self>().as_ptr());
-        let built = route.built_html().expect("the route left State::Building");
         pinned
             .ctx()
             .render_built_html_bundle(built.map_err(|()| &*route.bundle.path));
@@ -3844,24 +3849,28 @@ where
                         return;
                     // `result` is GC-rooted by `_keep` (EnsureStillAlive)
                     // across the render() call.
-                    } else if let Some(response) = as_response(result) {
-                        // An unsendable Response from the error handler itself
-                        // falls through to the default error page below.
-                        // SAFETY: `response` is the live, rooted cell pointer.
-                        if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
-                            // A file or streaming body defers `render_metadata`
-                            // past this frame, where `_keep` is the only root,
-                            // so root the Response the way the async error
-                            // path does or the deferred flush can read a
-                            // collected weakref.
-                            if self.flags.response_protected() {
-                                self.response_jsvalue.get().unprotect();
+                    } else {
+                        let result = wrap_html_bundle(server.global_this(), result);
+                        let _keep = jsc::EnsureStillAlive(result);
+                        if let Some(response) = as_response(result) {
+                            // An unsendable Response from the error handler itself
+                            // falls through to the default error page below.
+                            // SAFETY: `response` is the live, rooted cell pointer.
+                            if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                                // A file or streaming body defers `render_metadata`
+                                // past this frame, where `_keep` is the only root,
+                                // so root the Response the way the async error
+                                // path does or the deferred flush can read a
+                                // collected weakref.
+                                if self.flags.response_protected() {
+                                    self.response_jsvalue.get().unprotect();
+                                }
+                                self.response_jsvalue.set(result);
+                                self.flags.set_response_protected(false);
+                                // SAFETY: as above.
+                                unsafe { self.protect_for_body_and_render(result, response) };
+                                return;
                             }
-                            self.response_jsvalue.set(result);
-                            self.flags.set_response_protected(false);
-                            // SAFETY: as above.
-                            unsafe { self.protect_for_body_and_render(result, response) };
-                            return;
                         }
                     }
                 }
@@ -3897,6 +3906,7 @@ where
             jsc::PromiseResult::Fulfilled(fulfilled_value) => {
                 // `fulfilled_value` is rooted via ensure_still_alive() below for
                 // as long as `response` is used.
+                let fulfilled_value = wrap_html_bundle(server.global_this(), fulfilled_value);
                 let Some(response) = as_response(fulfilled_value) else {
                     ctx.finish_running_error_handler(value, status);
                     return;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -356,8 +356,7 @@ fn as_response(value: JSValue) -> Option<*mut Response> {
     response::from_js(value).map(|p| p.cast::<Response>())
 }
 
-/// The page's own headers (Content-Type, ETag, Cache-Control) fill in behind
-/// the handler's. Non-generic and out of line, like `release_body_stream`.
+/// The page's headers fill in behind the handler's. Non-generic, like `release_body_stream`.
 #[inline(never)]
 fn add_html_page_headers(
     response: &mut Response,

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -356,27 +356,6 @@ fn as_response(value: JSValue) -> Option<*mut Response> {
     response::from_js(value).map(|p| p.cast::<Response>())
 }
 
-/// A bare `HTMLBundle` means `new Response(htmlBundle)`.
-fn wrap_html_bundle(global_this: &JSGlobalObject, value: JSValue) -> JSValue {
-    let Some(html_bundle) = value.as_class_this_ptr::<crate::server::HTMLBundle>() else {
-        return value;
-    };
-    let response = bun_core::heap::into_raw(Box::new(Response::init(
-        response::Init {
-            status_code: 200,
-            status_text: BunString::create_atom(b"OK"),
-            ..Default::default()
-        },
-        WebCore::Body::new(Body::Value::HTMLBundle(bun_ptr::RefPtr::from_this(
-            html_bundle,
-        ))),
-        BunString::EMPTY,
-        false,
-    )));
-    // SAFETY: a fresh heap `Response`; the wrapper takes ownership.
-    Response::make_maybe_pooled(global_this, response)
-}
-
 /// Release the body's hold on a stream the sink is done with, and mark a
 /// `Locked` body used. Non-generic and out of line: the eight `RequestContext`
 /// monomorphizations share one copy.
@@ -852,7 +831,6 @@ where
             return;
         }
 
-        let value = wrap_html_bundle(global_this, value);
         let Some(response) = as_response(value) else {
             self.render_missing_invalid_response(value);
             return;
@@ -2923,7 +2901,6 @@ where
 
         // `response_value` is rooted via ensure_still_alive() / protect() below
         // for as long as `response` is used.
-        let response_value = wrap_html_bundle(this.global_this(), response_value);
         if let Some(response) = as_response(response_value) {
             // SAFETY: `response` is the live, rooted cell pointer.
             if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
@@ -2978,7 +2955,6 @@ where
                     }
                     // `fulfilled_value` is rooted via ensure_still_alive() /
                     // protect() below for as long as `response` is used.
-                    let fulfilled_value = wrap_html_bundle(this.global_this(), fulfilled_value);
                     let Some(response) = as_response(fulfilled_value) else {
                         ctx.render_missing_invalid_response(fulfilled_value);
                         return;
@@ -3853,24 +3829,24 @@ where
                         return;
                     // `result` is GC-rooted by `_keep` (EnsureStillAlive)
                     // across the render() call.
-                    } else {
-                        let result = wrap_html_bundle(server.global_this(), result);
-                        let _keep = jsc::EnsureStillAlive(result);
-                        if let Some(response) = as_response(result) {
-                            // An unsendable Response from the error handler itself
-                            // falls through to the default error page below.
-                            // SAFETY: `response` is the live, rooted cell pointer.
-                            if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
-                                // Root it like the async error path: a deferred body outlives `_keep`.
-                                if self.flags.response_protected() {
-                                    self.response_jsvalue.get().unprotect();
-                                }
-                                self.response_jsvalue.set(result);
-                                self.flags.set_response_protected(false);
-                                // SAFETY: as above.
-                                unsafe { self.protect_for_body_and_render(result, response) };
-                                return;
+                    } else if let Some(response) = as_response(result) {
+                        // An unsendable Response from the error handler itself
+                        // falls through to the default error page below.
+                        // SAFETY: `response` is the live, rooted cell pointer.
+                        if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
+                            // A file or streaming body defers `render_metadata`
+                            // past this frame, where `_keep` is the only root,
+                            // so root the Response the way the async error
+                            // path does or the deferred flush can read a
+                            // collected weakref.
+                            if self.flags.response_protected() {
+                                self.response_jsvalue.get().unprotect();
                             }
+                            self.response_jsvalue.set(result);
+                            self.flags.set_response_protected(false);
+                            // SAFETY: as above.
+                            unsafe { self.protect_for_body_and_render(result, response) };
+                            return;
                         }
                     }
                 }
@@ -3906,7 +3882,6 @@ where
             jsc::PromiseResult::Fulfilled(fulfilled_value) => {
                 // `fulfilled_value` is rooted via ensure_still_alive() below for
                 // as long as `response` is used.
-                let fulfilled_value = wrap_html_bundle(server.global_this(), fulfilled_value);
                 let Some(response) = as_response(fulfilled_value) else {
                     ctx.finish_running_error_handler(value, status);
                     return;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2091,8 +2091,7 @@ where
     /// `html_bundle::BuildWaiter` callback.
     fn on_html_route_built(ctx: NonNull<c_void>, route: ThisPtr<html_bundle::Route>) {
         let Some(built) = route.built_html() else {
-            // An earlier waiter scheduled a new build (development mode
-            // rebundles). Wait for that one; the +1 stays with the waiter.
+            // An earlier waiter started a new build; wait for that one.
             html_bundle::Route::add_build_waiter(route, Self::on_html_route_built, ctx);
             return;
         };
@@ -3857,11 +3856,7 @@ where
                             // falls through to the default error page below.
                             // SAFETY: `response` is the live, rooted cell pointer.
                             if HTTPStatusText::is_sendable(unsafe { (*response).status_code() }) {
-                                // A file or streaming body defers `render_metadata`
-                                // past this frame, where `_keep` is the only root,
-                                // so root the Response the way the async error
-                                // path does or the deferred flush can read a
-                                // collected weakref.
+                                // Root it like the async error path: a deferred body outlives `_keep`.
                                 if self.flags.response_protected() {
                                     self.response_jsvalue.get().unprotect();
                                 }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2055,7 +2055,7 @@ where
     /// The handler returned a `Response` whose body is `route`'s HTML bundle.
     /// Once the bundle is built, the page is rendered here as a blob body, so
     /// the Response's status, headers and cookies apply to it.
-    fn render_html_bundle(&self, route: bun_ptr::RefPtr<html_bundle::Route>) {
+    fn render_html_bundle(&self, route: &bun_ptr::RefPtr<html_bundle::Route>) {
         // The build can finish after this frame returns. The Response (its
         // status and headers) must still be there then.
         if !self.flags.response_protected() {
@@ -2850,7 +2850,7 @@ where
                 // The built page gives the Content-Length a GET would send.
                 let route = this.server().html_bundle_route(bundle.this_ptr());
                 *body_value = Body::Value::Used;
-                this.render_html_bundle(route);
+                this.render_html_bundle(&route);
             }
             Body::Value::Used | Body::Value::Null | Body::Value::Empty | Body::Value::Error(_) => {
                 this.render_metadata();
@@ -3324,7 +3324,7 @@ where
                 // releases the one it holds.
                 let route = this.server().html_bundle_route(bundle.this_ptr());
                 *value = Body::Value::Used;
-                this.render_html_bundle(route);
+                this.render_html_bundle(&route);
                 return;
             }
             Body::Value::Locked(lock) => {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2170,14 +2170,21 @@ where
         this.end_without_body(this.should_close_connection());
     }
 
-    /// `end_without_body` without the write: another owner answers `resp`.
+    /// Detach `resp` so another owner answers it. The caller calls
+    /// `release_taken_response` after its last write to `resp`.
     pub(crate) fn take_response(&self) -> Option<uws::AnyResponse> {
         let resp = self.resp.get()?;
         self.detach_response();
         self.reclaim_promise_cell();
+        Some(resp)
+    }
+
+    /// The end of a request whose response `take_response` handed out. The
+    /// microtask drain can free an H3 stream, so it runs after the last write.
+    pub(crate) fn release_taken_response(&self) {
+        debug_assert!(self.resp.get().is_none());
         self.end_request_streaming_and_drain();
         self.deref();
-        Some(resp)
     }
 
     fn render_with_blob_from_body_value(&self) {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -9,8 +9,10 @@ use bun_http_types::Method::Method;
 use bun_jsc::JsCell;
 use bun_uws::{self as uws, WebSocketUpgradeContext};
 
+use bun_ptr::ThisPtr;
+
 use crate::server::jsc::{self, JSGlobalObject, JSValue, JsResult};
-use crate::server::{RangeRequest, ServerLike};
+use crate::server::{RangeRequest, ServerLike, StaticRoute, html_bundle};
 use crate::webcore::{
     self as WebCore, AbortSignal, AnyBlob, ByteStream, CookieMap, CookieMapRef, FetchHeaders,
     Request, Response, blob::SizeType as BlobSizeType, body, readable_stream, request, response,
@@ -352,6 +354,28 @@ where
 #[inline]
 fn as_response(value: JSValue) -> Option<*mut Response> {
     response::from_js(value).map(|p| p.cast::<Response>())
+}
+
+/// A handler that returns the `HTMLBundle` of an HTML import means
+/// `new Response(htmlBundle)`. Any other value comes back as is.
+fn wrap_html_bundle(global_this: &JSGlobalObject, value: JSValue) -> JSValue {
+    let Some(html_bundle) = value.as_class_this_ptr::<crate::server::HTMLBundle>() else {
+        return value;
+    };
+    let response = bun_core::heap::into_raw(Box::new(Response::init(
+        response::Init {
+            status_code: 200,
+            status_text: BunString::create_atom(b"OK"),
+            ..Default::default()
+        },
+        WebCore::Body::new(Body::Value::HTMLBundle(bun_ptr::RefPtr::from_this(
+            html_bundle,
+        ))),
+        BunString::EMPTY,
+        false,
+    )));
+    // SAFETY: a fresh heap `Response`; the wrapper takes ownership.
+    Response::make_maybe_pooled(global_this, response)
 }
 
 /// Release the body's hold on a stream the sink is done with, and mark a
@@ -829,6 +853,7 @@ where
             return;
         }
 
+        let value = wrap_html_bundle(global_this, value);
         let Some(response) = as_response(value) else {
             self.render_missing_invalid_response(value);
             return;
@@ -2027,6 +2052,141 @@ where
             .do_render_with_body(std::ptr::from_mut(value), None);
     }
 
+    /// The handler returned a `Response` whose body is `route`'s HTML bundle.
+    /// Once the bundle is built, the page is rendered here as a blob body, so
+    /// the Response's status, headers and cookies apply to it.
+    fn render_html_bundle(&self, route: bun_ptr::RefPtr<html_bundle::Route>) {
+        // The build can finish after this frame returns. The Response (its
+        // status and headers) must still be there then.
+        if !self.flags.response_protected() {
+            self.response_jsvalue.get().protect();
+            self.flags.set_response_protected(true);
+        }
+        let any_ctx = AnyRequestContext::init(self.as_ctx_ptr());
+        if self.server().config().is_development() {
+            if let Some(dev) = any_ctx.dev_server_mut() {
+                let resp = self.resp.get().expect("infallible: not aborted or ended");
+                // The dev server calls `on_html_bundle_built` once the page is
+                // bundled. Until then it owns this +1.
+                self.ref_();
+                self.flags.set_has_marked_pending(true);
+                // SAFETY: the server boxes the dev server and outlives this
+                // context; no other `&mut` to it is live here.
+                bun_core::handle_oom(unsafe { &mut *dev }.respond_for_html_bundle_body(
+                    route.this_ptr(),
+                    any_ctx,
+                    resp,
+                ));
+                return;
+            }
+        }
+        match html_bundle::Route::built_html_or_schedule(route.this_ptr()) {
+            Some(built) => self.render_built_html_bundle(built.map_err(|()| &*route.bundle.path)),
+            None => {
+                // `on_html_route_built` consumes this +1.
+                self.ref_();
+                self.flags.set_has_marked_pending(true);
+                html_bundle::Route::add_build_waiter(
+                    route.this_ptr(),
+                    Self::on_html_route_built,
+                    NonNull::new(self.as_ctx_ptr().cast::<c_void>()).unwrap(),
+                );
+            }
+        }
+    }
+
+    /// `html_bundle::BuildWaiter` callback.
+    fn on_html_route_built(ctx: NonNull<c_void>, route: &html_bundle::Route) {
+        let pinned = RequestContextRef::adopt(ctx.cast::<Self>().as_ptr());
+        let built = route.built_html().expect("the route left State::Building");
+        pinned
+            .ctx()
+            .render_built_html_bundle(built.map_err(|()| &*route.bundle.path));
+    }
+
+    /// The dev server's callback. Consumes the +1 `render_html_bundle` took.
+    pub(crate) fn on_html_bundle_built(this: *mut Self, html: ThisPtr<StaticRoute>) {
+        let pinned = RequestContextRef::adopt(this);
+        pinned.ctx().render_built_html_bundle(Ok(html));
+    }
+
+    /// `Err` carries the path of the bundle that failed to build.
+    fn render_built_html_bundle(&self, built: Result<ThisPtr<StaticRoute>, &[u8]>) {
+        if self.is_aborted_or_ended() {
+            return;
+        }
+        let global_this = self.server().global_this();
+        let html = match built {
+            Ok(html) => html,
+            Err(path) => {
+                let err = global_this.create_error_instance(format_args!(
+                    "Failed to bundle {}",
+                    bun_core::fmt::quote(path)
+                ));
+                self.run_error_handler(err);
+                return;
+            }
+        };
+
+        // The page's own headers (Content-Type, ETag, Cache-Control) fill in
+        // behind the handler's.
+        let response: &mut Response = self.response_mut().expect("the Response is protected");
+        let mut headers =
+            bun_http_jsc::headers_jsc::from_fetch_headers(response.get_init_headers(), None);
+        {
+            use bun_http_types::ETag::HeaderEntryColumns;
+            let entries = html.headers.entries.slice();
+            for (name, value) in entries.items_name().iter().zip(entries.items_value()) {
+                let name = html.headers.as_str(*name);
+                if headers.get(name).is_none() {
+                    headers.append(name, html.headers.as_str(*value));
+                }
+            }
+        }
+        match bun_http_jsc::headers_jsc::to_fetch_headers(&headers, global_this) {
+            // SAFETY: `to_fetch_headers` returns a fresh +1 `FetchHeaders*`.
+            Ok(fetch_headers) => response
+                .set_init_headers(Some(unsafe { response::HeadersRef::adopt(fetch_headers) })),
+            Err(err) => {
+                self.run_error_handler(global_this.take_exception(err));
+                return;
+            }
+        }
+
+        self.blob.set(html.dupe_blob());
+        if self.method == Method::HEAD {
+            let resp = self.resp.get().expect("infallible: not aborted or ended");
+            resp.run_corked_with_type(Self::render_html_bundle_head_corked, self.as_ctx_ptr());
+            return;
+        }
+        self.render_with_blob_from_body_value();
+    }
+
+    fn render_html_bundle_head_corked(this: *mut Self) {
+        // SAFETY: `this` is live for the synchronous cork call; only a shared
+        // view is formed.
+        let this = unsafe { &*this };
+        let size = this.blob.get().size();
+        this.flags.set_needs_content_length(false);
+        this.render_metadata();
+        if let Some(resp) = this.resp.get() {
+            resp.write_header_int(b"content-length", size as u64);
+        }
+        this.end_without_body(this.should_close_connection());
+    }
+
+    /// Detach the response so another owner can answer it. Ends this
+    /// context's own claim on the request, like `end_without_body` does,
+    /// without a write to the socket.
+    pub(crate) fn take_response(&self) -> Option<uws::AnyResponse> {
+        let resp = self.resp.get()?;
+        self.detach_response();
+        self.reclaim_promise_cell();
+        self.end_request_streaming_and_drain();
+        self.deref();
+        Some(resp)
+    }
+
     fn render_with_blob_from_body_value(&self) {
         if self.is_aborted_or_ended() {
             return;
@@ -2686,6 +2846,12 @@ where
                 }
                 this.end_without_body(this.should_close_connection());
             }
+            Body::Value::HTMLBundle(bundle) => {
+                // The built page gives the Content-Length a GET would send.
+                let route = this.server().html_bundle_route(bundle.this_ptr());
+                *body_value = Body::Value::Used;
+                this.render_html_bundle(route);
+            }
             Body::Value::Used | Body::Value::Null | Body::Value::Empty | Body::Value::Error(_) => {
                 this.render_metadata();
                 // SAFETY: FFI handle
@@ -2760,6 +2926,7 @@ where
 
         // `response_value` is rooted via ensure_still_alive() / protect() below
         // for as long as `response` is used.
+        let response_value = wrap_html_bundle(this.global_this(), response_value);
         if let Some(response) = as_response(response_value) {
             // SAFETY: `response` is the live, rooted cell pointer.
             if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
@@ -2814,6 +2981,7 @@ where
                     }
                     // `fulfilled_value` is rooted via ensure_still_alive() /
                     // protect() below for as long as `response` is used.
+                    let fulfilled_value = wrap_html_bundle(this.global_this(), fulfilled_value);
                     let Some(response) = as_response(fulfilled_value) else {
                         ctx.render_missing_invalid_response(fulfilled_value);
                         return;
@@ -3146,6 +3314,17 @@ where
                 // toBlobIfPossible checks for WTFString needing a conversion.
                 this.blob.set(value.use_as_any_blob_allow_non_utf8_string());
                 this.render_with_blob_from_body_value();
+                return;
+            }
+            Body::Value::HTMLBundle(bundle) => {
+                if this.is_aborted_or_ended() {
+                    return;
+                }
+                // The route takes its own ref on the bundle before the body
+                // releases the one it holds.
+                let route = this.server().html_bundle_route(bundle.this_ptr());
+                *value = Body::Value::Used;
+                this.render_html_bundle(route);
                 return;
             }
             Body::Value::Locked(lock) => {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -356,8 +356,7 @@ fn as_response(value: JSValue) -> Option<*mut Response> {
     response::from_js(value).map(|p| p.cast::<Response>())
 }
 
-/// A handler that returns the `HTMLBundle` of an HTML import means
-/// `new Response(htmlBundle)`. Any other value comes back as is.
+/// A bare `HTMLBundle` means `new Response(htmlBundle)`.
 fn wrap_html_bundle(global_this: &JSGlobalObject, value: JSValue) -> JSValue {
     let Some(html_bundle) = value.as_class_this_ptr::<crate::server::HTMLBundle>() else {
         return value;
@@ -2052,12 +2051,7 @@ where
             .do_render_with_body(std::ptr::from_mut(value), None);
     }
 
-    /// The handler returned a `Response` whose body is `route`'s HTML bundle.
-    /// Once the bundle is built, the page is rendered here as a blob body, so
-    /// the Response's status, headers and cookies apply to it.
     fn render_html_bundle(&self, route: &bun_ptr::RefPtr<html_bundle::Route>) {
-        // The build can finish after this frame returns. The Response (its
-        // status and headers) must still be there then.
         if !self.flags.response_protected() {
             self.response_jsvalue.get().protect();
             self.flags.set_response_protected(true);
@@ -2066,8 +2060,7 @@ where
         if self.server().config().is_development() {
             if let Some(dev) = any_ctx.dev_server_mut() {
                 let resp = self.resp.get().expect("infallible: not aborted or ended");
-                // The dev server calls `on_html_bundle_built` once the page is
-                // bundled. Until then it owns this +1.
+                // `on_html_bundle_built` consumes this +1.
                 self.ref_();
                 self.flags.set_has_marked_pending(true);
                 // SAFETY: the server boxes the dev server and outlives this
@@ -2128,8 +2121,6 @@ where
             }
         };
 
-        // The page's own headers (Content-Type, ETag, Cache-Control) fill in
-        // behind the handler's.
         let response: &mut Response = self.response_mut().expect("the Response is protected");
         let mut headers =
             bun_http_jsc::headers_jsc::from_fetch_headers(response.get_init_headers(), None);
@@ -2175,9 +2166,7 @@ where
         this.end_without_body(this.should_close_connection());
     }
 
-    /// Detach the response so another owner can answer it. Ends this
-    /// context's own claim on the request, like `end_without_body` does,
-    /// without a write to the socket.
+    /// `end_without_body` without the write: another owner answers `resp`.
     pub(crate) fn take_response(&self) -> Option<uws::AnyResponse> {
         let resp = self.resp.get()?;
         self.detach_response();
@@ -2847,7 +2836,6 @@ where
                 this.end_without_body(this.should_close_connection());
             }
             Body::Value::HTMLBundle(bundle) => {
-                // The built page gives the Content-Length a GET would send.
                 let route = this.server().html_bundle_route(bundle.this_ptr());
                 *body_value = Body::Value::Used;
                 this.render_html_bundle(&route);
@@ -3320,8 +3308,6 @@ where
                 if this.is_aborted_or_ended() {
                     return;
                 }
-                // The route takes its own ref on the bundle before the body
-                // releases the one it holds.
                 let route = this.server().html_bundle_route(bundle.this_ptr());
                 *value = Body::Value::Used;
                 this.render_html_bundle(&route);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -356,6 +356,30 @@ fn as_response(value: JSValue) -> Option<*mut Response> {
     response::from_js(value).map(|p| p.cast::<Response>())
 }
 
+/// The page's own headers (Content-Type, ETag, Cache-Control) fill in behind
+/// the handler's. Non-generic and out of line, like `release_body_stream`.
+#[inline(never)]
+fn add_html_page_headers(
+    response: &mut Response,
+    html: &StaticRoute,
+    global_this: &JSGlobalObject,
+) -> JsResult<()> {
+    use bun_http_types::ETag::HeaderEntryColumns;
+    let mut headers =
+        bun_http_jsc::headers_jsc::from_fetch_headers(response.get_init_headers(), None);
+    let entries = html.headers.entries.slice();
+    for (name, value) in entries.items_name().iter().zip(entries.items_value()) {
+        let name = html.headers.as_str(*name);
+        if headers.get(name).is_none() {
+            headers.append(name, html.headers.as_str(*value));
+        }
+    }
+    let fetch_headers = bun_http_jsc::headers_jsc::to_fetch_headers(&headers, global_this)?;
+    // SAFETY: `to_fetch_headers` returns a fresh +1 `FetchHeaders*`.
+    response.set_init_headers(Some(unsafe { response::HeadersRef::adopt(fetch_headers) }));
+    Ok(())
+}
+
 /// Release the body's hold on a stream the sink is done with, and mark a
 /// `Locked` body used. Non-generic and out of line: the eight `RequestContext`
 /// monomorphizations share one copy.
@@ -2104,26 +2128,9 @@ where
         };
 
         let response: &mut Response = self.response_mut().expect("the Response is protected");
-        let mut headers =
-            bun_http_jsc::headers_jsc::from_fetch_headers(response.get_init_headers(), None);
-        {
-            use bun_http_types::ETag::HeaderEntryColumns;
-            let entries = html.headers.entries.slice();
-            for (name, value) in entries.items_name().iter().zip(entries.items_value()) {
-                let name = html.headers.as_str(*name);
-                if headers.get(name).is_none() {
-                    headers.append(name, html.headers.as_str(*value));
-                }
-            }
-        }
-        match bun_http_jsc::headers_jsc::to_fetch_headers(&headers, global_this) {
-            // SAFETY: `to_fetch_headers` returns a fresh +1 `FetchHeaders*`.
-            Ok(fetch_headers) => response
-                .set_init_headers(Some(unsafe { response::HeadersRef::adopt(fetch_headers) })),
-            Err(err) => {
-                self.run_error_handler(global_this.take_exception(err));
-                return;
-            }
+        if let Err(err) = add_html_page_headers(response, &html, global_this) {
+            self.run_error_handler(global_this.take_exception(err));
+            return;
         }
 
         self.blob.set(html.dupe_blob());

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2170,8 +2170,7 @@ where
         this.end_without_body(this.should_close_connection());
     }
 
-    /// Detach `resp` so another owner answers it. The caller calls
-    /// `release_taken_response` after its last write to `resp`.
+    /// Another owner answers `resp`, then calls `release_taken_response`.
     pub(crate) fn take_response(&self) -> Option<uws::AnyResponse> {
         let resp = self.resp.get()?;
         self.detach_response();
@@ -2179,8 +2178,7 @@ where
         Some(resp)
     }
 
-    /// The end of a request whose response `take_response` handed out. The
-    /// microtask drain can free an H3 stream, so it runs after the last write.
+    /// After the last write to the response: the microtask drain can free an H3 stream.
     pub(crate) fn release_taken_response(&self) {
         debug_assert!(self.resp.get().is_none());
         self.end_request_streaming_and_drain();

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -141,6 +141,22 @@ impl StaticRoute {
         size_of::<StaticRoute>() + self.blob.memory_cost() + self.headers.memory_cost()
     }
 
+    /// A copy of the body for a response this route does not send itself.
+    pub(crate) fn dupe_blob(&self) -> AnyBlob {
+        match &self.blob {
+            AnyBlob::Blob(blob) => AnyBlob::Blob(blob.dupe()),
+            AnyBlob::InternalBlob(blob) => AnyBlob::InternalBlob(InternalBlob {
+                bytes: blob.bytes.clone(),
+                was_string: blob.was_string,
+            }),
+            AnyBlob::WTFStringImpl(s) => {
+                // SAFETY: the route holds a +1 on the impl while this variant is active.
+                unsafe { (**s).r#ref() };
+                AnyBlob::WTFStringImpl(*s)
+            }
+        }
+    }
+
     pub fn from_js(
         global_this: &JSGlobalObject,
         argument: JSValue,

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -297,10 +297,7 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// times due to SNI, so we have to store them.
     pub(crate) user_routes: Vec<UserRoute<SSL, DEBUG>>,
 
-    /// One route per `HTMLBundle` a handler returned in a `Response`, so the
-    /// bundle builds once and its assets register once. A bundle that is
-    /// also in `routes` reuses the route in `config.static_routes` instead.
-    /// `reload()` clears it with the static routes.
+    /// Routes for bundles that handlers return. `reload()` clears it.
     pub(crate) handler_html_routes: bun_jsc::JsCell<Vec<bun_ptr::RefPtr<html_bundle::Route>>>,
 
     /// Raw shadow of the wrapper's `m_onClientError` WriteBarrier slot.
@@ -1549,8 +1546,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.deinit_if_we_can();
     }
 
-    /// The route that builds and serves `bundle` on this server, for a
-    /// handler that returned `new Response(bundle)`.
     pub(crate) fn html_bundle_route(
         &self,
         bundle: bun_ptr::ThisPtr<HTMLBundle>,

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -297,6 +297,12 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// times due to SNI, so we have to store them.
     pub(crate) user_routes: Vec<UserRoute<SSL, DEBUG>>,
 
+    /// One route per `HTMLBundle` a handler returned in a `Response`, so the
+    /// bundle builds once and its assets register once. A bundle that is
+    /// also in `routes` reuses the route in `config.static_routes` instead.
+    /// `reload()` clears it with the static routes.
+    pub(crate) handler_html_routes: bun_jsc::JsCell<Vec<bun_ptr::RefPtr<html_bundle::Route>>>,
+
     /// Raw shadow of the wrapper's `m_onClientError` WriteBarrier slot.
     /// `JSValue::ZERO` when unset; written by `server_set_on_client_error`.
     pub(crate) on_clienterror: JSValue,
@@ -1543,6 +1549,41 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.deinit_if_we_can();
     }
 
+    /// The route that builds and serves `bundle` on this server, for a
+    /// handler that returned `new Response(bundle)`.
+    pub(crate) fn html_bundle_route(
+        &self,
+        bundle: bun_ptr::ThisPtr<HTMLBundle>,
+    ) -> bun_ptr::RefPtr<html_bundle::Route> {
+        let is_bundle =
+            |route: &html_bundle::Route| core::ptr::eq(route.bundle.as_ptr(), bundle.as_ptr());
+        if let Some(route) = self
+            .handler_html_routes
+            .get()
+            .iter()
+            .find(|route| is_bundle(route))
+        {
+            return route.clone();
+        }
+        let route = self
+            .config
+            .static_routes
+            .iter()
+            .find_map(|entry| match &entry.route {
+                AnyRoute::Html(route) if is_bundle(route) => Some(route.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                let route = html_bundle::Route::init(bundle);
+                route
+                    .server
+                    .set(Some(AnyServer::from(core::ptr::from_ref(self))));
+                route
+            });
+        self.handler_html_routes.with_mut(|v| v.push(route.clone()));
+        route
+    }
+
     pub(crate) fn active_sockets_count(&self) -> u32 {
         self.active_websocket_count.get()
     }
@@ -2175,6 +2216,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             flags: ServerFlags::default(),
             plugins: None,
             user_routes: Vec::new(),
+            handler_html_routes: bun_jsc::JsCell::new(Vec::new()),
             on_clienterror: JSValue::ZERO,
             on_connection: JSValue::ZERO,
             inspector_server_id: jsc::DebuggerId::init(0),
@@ -3616,6 +3658,10 @@ pub trait ServerLike {
     fn js_value(&self) -> &jsc::JsRef;
     fn h3_alt_svc(&self) -> Option<&[u8]>;
     fn terminated(&self) -> bool;
+    fn html_bundle_route(
+        &self,
+        bundle: bun_ptr::ThisPtr<HTMLBundle>,
+    ) -> bun_ptr::RefPtr<html_bundle::Route>;
     /// Return `ctx` to the per-server HiveArray pool for the matching transport.
     /// Erased to `*mut c_void` so the trait stays object-safe and doesn't need
     /// to name `RequestContext<Self, ..>` (which would re-introduce the
@@ -3660,6 +3706,12 @@ impl<const SSL: bool, const DEBUG: bool> ServerLike for NewServer<SSL, DEBUG> {
     #[inline(always)]
     fn terminated(&self) -> bool {
         self.flags.contains(ServerFlags::TERMINATED)
+    }
+    fn html_bundle_route(
+        &self,
+        bundle: bun_ptr::ThisPtr<HTMLBundle>,
+    ) -> bun_ptr::RefPtr<html_bundle::Route> {
+        Self::html_bundle_route(self, bundle)
     }
     fn release_request_context(&self, ctx: *mut c_void, is_mux: bool) {
         // SAFETY: ctx was allocated from this exact pool by `prepare_js_request_context`;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -757,9 +757,6 @@ impl AnyRoute {
         use bun_collections::zig_hash_map::MapEntry as StdEntry;
         let html_bundle = match argument.as_class_this_ptr::<HTMLBundle>() {
             Some(html_bundle) => Some(html_bundle),
-            // `new Response(index)` as a route value is the bundle itself. An
-            // init cannot apply here: the route serves the page and its assets
-            // through the bundle's own route.
             None => match argument.as_class_ref::<Response>() {
                 Some(response) => match response.get_body_value() {
                     BodyValue::HTMLBundle(html_bundle) => {
@@ -2177,8 +2174,6 @@ where
         // a move-assign frees the old `static_routes`.
         self.config.static_routes = core::mem::take(&mut new_config.static_routes);
         self.config.negative_routes = core::mem::take(&mut new_config.negative_routes);
-        // Their asset routes went with the old `static_routes`: the next
-        // handler-returned bundle builds again and registers them again.
         self.handler_html_routes.with_mut(Vec::clear);
 
         if new_config.had_routes_object {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -750,31 +750,37 @@ impl AnyRoute {
         )))
     }
 
+    /// `index` or `new Response(index)` from an HTML import, as a route value.
+    fn html_bundle_route_value(
+        argument: JSValue,
+        global: &JSGlobalObject,
+    ) -> JsResult<Option<bun_ptr::ThisPtr<HTMLBundle>>> {
+        if let Some(html_bundle) = argument.as_class_this_ptr::<HTMLBundle>() {
+            return Ok(Some(html_bundle));
+        }
+        let Some(response) = argument.as_class_ref::<Response>() else {
+            return Ok(None);
+        };
+        let BodyValue::HTMLBundle(html_bundle) = response.get_body_value() else {
+            return Ok(None);
+        };
+        let has_headers = response
+            .get_init_headers_mut()
+            .is_some_and(|headers| !headers.is_empty());
+        if response.status_code() != 200 || has_headers {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "A Response with an HTML import body does not support a status or headers as a route value yet. Use the HTML import itself as the route value, or return new Response(index, init) from a route handler.",
+            )));
+        }
+        Ok(Some(html_bundle.this_ptr()))
+    }
+
     pub(crate) fn html_route_from_js(
         argument: JSValue,
         init_ctx: &mut ServerInitContext,
     ) -> JsResult<Option<AnyRoute>> {
         use bun_collections::zig_hash_map::MapEntry as StdEntry;
-        let html_bundle = match argument.as_class_this_ptr::<HTMLBundle>() {
-            Some(html_bundle) => Some(html_bundle),
-            None => match argument.as_class_ref::<Response>() {
-                Some(response) => match response.get_body_value() {
-                    BodyValue::HTMLBundle(html_bundle) => {
-                        let has_headers = response
-                            .get_init_headers_mut()
-                            .is_some_and(|headers| !headers.is_empty());
-                        if response.status_code() != 200 || has_headers {
-                            return Err(init_ctx.global.throw_invalid_arguments(format_args!(
-                                "A Response with an HTML import body does not support a status or headers as a route value yet. Use the HTML import itself as the route value, or return new Response(index, init) from a route handler.",
-                            )));
-                        }
-                        Some(html_bundle.this_ptr())
-                    }
-                    _ => None,
-                },
-                None => None,
-            },
-        };
+        let html_bundle = Self::html_bundle_route_value(argument, init_ctx.global)?;
         if let Some(html_bundle) = html_bundle {
             let entry = init_ctx
                 .dedupe_html_bundle_map

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -765,7 +765,7 @@ impl AnyRoute {
                             .is_some_and(|headers| !headers.is_empty());
                         if response.status_code() != 200 || has_headers {
                             return Err(init_ctx.global.throw_invalid_arguments(format_args!(
-                                "A Response with an HTML bundle body cannot carry a status or headers as a route value. Use the HTML import itself as the route value, or return new Response(index, init) from a route handler.",
+                                "A Response with an HTML import body does not support a status or headers as a route value yet. Use the HTML import itself as the route value, or return new Response(index, init) from a route handler.",
                             )));
                         }
                         Some(html_bundle.this_ptr())

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -755,7 +755,30 @@ impl AnyRoute {
         init_ctx: &mut ServerInitContext,
     ) -> JsResult<Option<AnyRoute>> {
         use bun_collections::zig_hash_map::MapEntry as StdEntry;
-        if let Some(html_bundle) = argument.as_class_this_ptr::<HTMLBundle>() {
+        let html_bundle = match argument.as_class_this_ptr::<HTMLBundle>() {
+            Some(html_bundle) => Some(html_bundle),
+            // `new Response(index)` as a route value is the bundle itself. An
+            // init cannot apply here: the route serves the page and its assets
+            // through the bundle's own route.
+            None => match argument.as_class_ref::<Response>() {
+                Some(response) => match response.get_body_value() {
+                    BodyValue::HTMLBundle(html_bundle) => {
+                        let has_headers = response
+                            .get_init_headers_mut()
+                            .is_some_and(|headers| !headers.is_empty());
+                        if response.status_code() != 200 || has_headers {
+                            return Err(init_ctx.global.throw_invalid_arguments(format_args!(
+                                "A Response with an HTML bundle body cannot carry a status or headers as a route value. Use the HTML import itself as the route value, or return new Response(index, init) from a route handler.",
+                            )));
+                        }
+                        Some(html_bundle.this_ptr())
+                    }
+                    _ => None,
+                },
+                None => None,
+            },
+        };
+        if let Some(html_bundle) = html_bundle {
             let entry = init_ctx
                 .dedupe_html_bundle_map
                 .entry(html_bundle.as_ptr().cast_const());
@@ -2154,6 +2177,9 @@ where
         // a move-assign frees the old `static_routes`.
         self.config.static_routes = core::mem::take(&mut new_config.static_routes);
         self.config.negative_routes = core::mem::take(&mut new_config.negative_routes);
+        // Their asset routes went with the old `static_routes`: the next
+        // handler-returned bundle builds again and registers them again.
+        self.handler_html_routes.with_mut(Vec::clear);
 
         if new_config.had_routes_object {
             self.config.user_routes_to_build =

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -774,17 +774,16 @@ impl Cmd {
                     // `get_body_value` is `&self`.
                     let req = unsafe { &*req };
                     req.get_body_value().to_blob_if_possible();
-                    req.get_body_value().throw_if_html_bundle(global)?;
                     if flags.stdin() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = req.get_body_value().use_as_any_blob_or_throw(global)?;
                         stdio[STDIN_NO].extract_blob(global, b, STDIN_NO as i32)?;
                     }
                     if flags.stdout() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = req.get_body_value().use_as_any_blob_or_throw(global)?;
                         stdio[STDOUT_NO].extract_blob(global, b, STDOUT_NO as i32)?;
                     }
                     if flags.stderr() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = req.get_body_value().use_as_any_blob_or_throw(global)?;
                         stdio[STDERR_NO].extract_blob(global, b, STDERR_NO as i32)?;
                     }
                 } else {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -774,6 +774,7 @@ impl Cmd {
                     // `get_body_value` is `&self`.
                     let req = unsafe { &*req };
                     req.get_body_value().to_blob_if_possible();
+                    req.get_body_value().throw_if_html_bundle(global)?;
                     if flags.stdin() {
                         let b = req.get_body_value().use_as_any_blob();
                         stdio[STDIN_NO].extract_blob(global, b, STDIN_NO as i32)?;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4925,7 +4925,8 @@ pub(crate) fn write_file_internal(
                         JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
                             global_this.create_type_error_instance(format_args!(
-                                "An HTMLBundle body can only be sent by Bun.serve()"
+                                "{}",
+                                crate::webcore::body::HTML_BUNDLE_BODY_UNREADABLE
                             )),
                         ),
                     ));

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4919,6 +4919,17 @@ pub(crate) fn write_file_internal(
                     destination_blob.detach();
                     return Ok(ControlFlow::Break(body_used_rejection(global_this)));
                 }
+                BodyValue::HTMLBundle(_) => {
+                    destination_blob.detach();
+                    return Ok(ControlFlow::Break(
+                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                            global_this,
+                            global_this.create_type_error_instance(format_args!(
+                                "An HTMLBundle body can only be sent by Bun.serve()"
+                            )),
+                        ),
+                    ));
+                }
                 _ => BodyTag::Use,
             };
             match tag {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -523,6 +523,11 @@ pub enum Value {
     /// Single-use Blob
     /// Avoids a heap allocation.
     InternalBlob(InternalBlob),
+    /// `new Response(htmlBundle)`: the page an `import index from
+    /// "./index.html"` bundles to. Only `Bun.serve` can send it (it builds
+    /// the bundle on the server that serves it), so the body readers
+    /// (`.text()`, `.body`, ...) reject it.
+    HTMLBundle(bun_ptr::RefPtr<crate::server::HTMLBundle>),
     Locked(PendingValue),
     Used,
     Empty,
@@ -556,6 +561,7 @@ pub enum Tag {
     Blob,
     WTFStringImpl,
     InternalBlob,
+    HTMLBundle,
     Locked,
     Used,
     Empty,
@@ -773,6 +779,7 @@ impl Value {
                 }
                 self.locked_to_native_stream(global_this, false)
             }
+            Value::HTMLBundle(_) => Err(throw_html_bundle_body_unreadable(global_this)),
             Value::Error(err) => {
                 let reason = err.to_js(global_this);
                 let value = ReadableStream::errored(global_this, reason)?;
@@ -829,6 +836,7 @@ impl Value {
                 Ok(stream)
             }
             Value::Locked(_) => self.locked_to_native_stream(global_this, true),
+            Value::HTMLBundle(_) => Err(throw_html_bundle_body_unreadable(global_this)),
             Value::Error(err) => {
                 let reason = err.to_js(global_this);
                 let stream = ReadableStream::errored(global_this, reason)?;
@@ -994,6 +1002,10 @@ impl Value {
                 blob.content_type_was_set.set(true);
                 return Ok(Value::Blob(blob));
             }
+        }
+
+        if let Some(html_bundle) = value.as_class_this_ptr::<crate::server::HTMLBundle>() {
+            return Ok(Value::HTMLBundle(bun_ptr::RefPtr::from_this(html_bundle)));
         }
 
         value.ensure_still_alive();
@@ -1404,8 +1416,13 @@ impl Drop for Value {
             Value::WTFStringImpl(s) => wtf_impl(s).deref(),
             Value::Blob(b) => b.deinit(),
             Value::Error(e) => e.reset(),
-            // `InternalBlob`'s `Vec<u8>` is freed by the compiler's drop glue.
-            Value::InternalBlob(_) | Value::Used | Value::Empty | Value::Null => {}
+            // `InternalBlob`'s `Vec<u8>` and `HTMLBundle`'s `RefPtr` are
+            // released by the compiler's drop glue.
+            Value::InternalBlob(_)
+            | Value::HTMLBundle(_)
+            | Value::Used
+            | Value::Empty
+            | Value::Null => {}
         }
     }
 }
@@ -1551,6 +1568,10 @@ impl Value {
 
         if matches!(self, Value::Null) {
             return Ok(Value::Null);
+        }
+
+        if let Value::HTMLBundle(html_bundle) = self {
+            return Ok(Value::HTMLBundle(html_bundle.clone()));
         }
 
         // A failed body clones as failed, so the clone's readers reject via
@@ -2175,10 +2196,21 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
 /// reader must call this before its `Locked` handling: `Value::Error` would
 /// otherwise fall through to `use_as_any_blob_*` and resolve empty.
 fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Option<JSValue> {
+    if matches!(value, Value::HTMLBundle(_)) {
+        let js =
+            global_object.create_type_error_instance(format_args!("{HTML_BUNDLE_BODY_UNREADABLE}"));
+        return Some(JSPromise::rejected_promise(global_object, js).to_js());
+    }
     let Value::Error(err) = value else {
         return None;
     };
     let js = err.to_js(global_object);
     *value = Value::Used;
     Some(JSPromise::rejected_promise(global_object, js).to_js())
+}
+
+const HTML_BUNDLE_BODY_UNREADABLE: &str = "An HTMLBundle body can only be sent by Bun.serve(). To read the page, build it with Bun.build() or fetch it from the server.";
+
+fn throw_html_bundle_body_unreadable(global_object: &JSGlobalObject) -> jsc::JsError {
+    global_object.throw_type_error(format_args!("{HTML_BUNDLE_BODY_UNREADABLE}"))
 }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2210,3 +2210,13 @@ pub(crate) const HTML_BUNDLE_BODY_UNREADABLE: &str = "An HTMLBundle body can onl
 fn throw_html_bundle_body_unreadable(global_object: &JSGlobalObject) -> jsc::JsError {
     global_object.throw_type_error(format_args!("{HTML_BUNDLE_BODY_UNREADABLE}"))
 }
+
+impl Value {
+    /// For a consumer other than `Bun.serve`, which cannot read an `HTMLBundle`.
+    pub(crate) fn throw_if_html_bundle(&self, global_object: &JSGlobalObject) -> JsResult<()> {
+        if matches!(self, Value::HTMLBundle(_)) {
+            return Err(throw_html_bundle_body_unreadable(global_object));
+        }
+        Ok(())
+    }
+}

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1273,6 +1273,10 @@ impl Value {
             Value::Locked(l) => l
                 .to_any_blob_allow_promise()
                 .unwrap_or(AnyBlob::Blob(Blob::default())),
+            Value::HTMLBundle(_) => {
+                debug_assert!(false, "the caller rejects an HTMLBundle body first");
+                AnyBlob::Blob(Blob::default())
+            }
             _ => AnyBlob::Blob(Blob::default()),
         };
 
@@ -1295,6 +1299,10 @@ impl Value {
             Value::Locked(l) => l
                 .to_any_blob_allow_promise()
                 .unwrap_or(AnyBlob::Blob(Blob::default())),
+            Value::HTMLBundle(_) => {
+                debug_assert!(false, "the caller rejects an HTMLBundle body first");
+                AnyBlob::Blob(Blob::default())
+            }
             _ => AnyBlob::Blob(Blob::default()),
         };
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -523,10 +523,8 @@ pub enum Value {
     /// Single-use Blob
     /// Avoids a heap allocation.
     InternalBlob(InternalBlob),
-    /// `new Response(htmlBundle)`: the page an `import index from
-    /// "./index.html"` bundles to. Only `Bun.serve` can send it (it builds
-    /// the bundle on the server that serves it), so the body readers
-    /// (`.text()`, `.body`, ...) reject it.
+    /// `new Response(htmlBundle)`. Only `Bun.serve` can send it; the body
+    /// readers reject it.
     HTMLBundle(bun_ptr::RefPtr<crate::server::HTMLBundle>),
     Locked(PendingValue),
     Used,
@@ -1416,8 +1414,7 @@ impl Drop for Value {
             Value::WTFStringImpl(s) => wtf_impl(s).deref(),
             Value::Blob(b) => b.deinit(),
             Value::Error(e) => e.reset(),
-            // `InternalBlob`'s `Vec<u8>` and `HTMLBundle`'s `RefPtr` are
-            // released by the compiler's drop glue.
+            // Freed by the compiler's drop glue.
             Value::InternalBlob(_)
             | Value::HTMLBundle(_)
             | Value::Used

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1001,8 +1001,11 @@ impl Value {
             }
         }
 
-        if let Some(html_bundle) = value.as_class_this_ptr::<crate::server::HTMLBundle>() {
-            return Ok(Value::HTMLBundle(bun_ptr::RefPtr::from_this(html_bundle)));
+        if value
+            .as_class_this_ptr::<crate::server::HTMLBundle>()
+            .is_some()
+        {
+            return Err(throw_html_bundle_body_unreadable(global_this));
         }
 
         value.ensure_still_alive();
@@ -1594,7 +1597,13 @@ impl Value {
 // ────────────────────────────────────────────────────────────────────────────
 
 // https://github.com/WebKit/webkit/blob/main/Source/WebCore/Modules/fetch/FetchBody.cpp#L45
+/// The `Response` constructor's body. Only a `Response` carries an `HTMLBundle`.
 pub(crate) fn extract(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Body> {
+    if let Some(html_bundle) = value.as_class_this_ptr::<crate::server::HTMLBundle>() {
+        return Ok(Body::new(Value::HTMLBundle(bun_ptr::RefPtr::from_this(
+            html_bundle,
+        ))));
+    }
     let body_value = Value::from_js(global_this, value)?;
     if let Value::Blob(b) = &body_value {
         debug_assert!(!b.is_heap_allocated()); // owned by Body
@@ -2220,11 +2229,14 @@ fn throw_html_bundle_body_unreadable(global_object: &JSGlobalObject) -> jsc::JsE
 }
 
 impl Value {
-    /// For a consumer other than `Bun.serve`, which cannot read an `HTMLBundle`.
-    pub(crate) fn throw_if_html_bundle(&self, global_object: &JSGlobalObject) -> JsResult<()> {
-        if matches!(self, Value::HTMLBundle(_)) {
-            return Err(throw_html_bundle_body_unreadable(global_object));
+    /// `use_as_any_blob` for a reader other than `Bun.serve`: an `HTMLBundle` is an error.
+    pub(crate) fn use_as_any_blob_or_throw(
+        &mut self,
+        global_object: &JSGlobalObject,
+    ) -> JsResult<AnyBlob> {
+        match self {
+            Value::HTMLBundle(_) => Err(throw_html_bundle_body_unreadable(global_object)),
+            _ => Ok(self.use_as_any_blob()),
         }
-        Ok(())
     }
 }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -523,8 +523,7 @@ pub enum Value {
     /// Single-use Blob
     /// Avoids a heap allocation.
     InternalBlob(InternalBlob),
-    /// `new Response(htmlBundle)`. Only `Bun.serve` can send it; the body
-    /// readers reject it.
+    /// `new Response(htmlBundle)`. Only `Bun.serve` can send it.
     HTMLBundle(bun_ptr::RefPtr<crate::server::HTMLBundle>),
     Locked(PendingValue),
     Used,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2205,7 +2205,7 @@ fn handle_body_error(value: &mut Value, global_object: &JSGlobalObject) -> Optio
     Some(JSPromise::rejected_promise(global_object, js).to_js())
 }
 
-const HTML_BUNDLE_BODY_UNREADABLE: &str = "An HTMLBundle body can only be sent by Bun.serve(). To read the page, build it with Bun.build() or fetch it from the server.";
+pub(crate) const HTML_BUNDLE_BODY_UNREADABLE: &str = "An HTMLBundle body can only be sent by Bun.serve(). To read the page, build it with Bun.build() or fetch it from the server.";
 
 fn throw_html_bundle_body_unreadable(global_object: &JSGlobalObject) -> jsc::JsError {
     global_object.throw_type_error(format_args!("{HTML_BUNDLE_BODY_UNREADABLE}"))

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1183,12 +1183,13 @@ impl Request {
                     if !fields.contains(Fields::Body) {
                         match response.get_body_value() {
                             BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
+                            BodyValue::HTMLBundle(_) => {
+                                bail!(Err(global_this.throw_type_error(format_args!(
+                                    "{}",
+                                    crate::webcore::body::HTML_BUNDLE_BODY_UNREADABLE
+                                ))))
+                            }
                             _ => {
-                                if let Err(e) =
-                                    response.get_body_value().throw_if_html_bundle(global_this)
-                                {
-                                    bail!(Err(e));
-                                }
                                 match response.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
@@ -1221,9 +1222,6 @@ impl Request {
                         }
                         match BodyValue::from_js(global_this, body_) {
                             Ok(v) => {
-                                if let Err(e) = v.throw_if_html_bundle(global_this) {
-                                    bail!(Err(e));
-                                }
                                 *req.body_value_mut() = v;
                             }
                             Err(e) => bail!(Err(e)),

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1216,6 +1216,9 @@ impl Request {
                         }
                         match BodyValue::from_js(global_this, body_) {
                             Ok(v) => {
+                                if let Err(e) = v.throw_if_html_bundle(global_this) {
+                                    bail!(Err(e));
+                                }
                                 *req.body_value_mut() = v;
                             }
                             Err(e) => bail!(Err(e)),

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1184,6 +1184,11 @@ impl Request {
                         match response.get_body_value() {
                             BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
                             _ => {
+                                if let Err(e) =
+                                    response.get_body_value().throw_if_html_bundle(global_this)
+                                {
+                                    bail!(Err(e));
+                                }
                                 match response.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1288,6 +1288,20 @@ impl WriteFileWaitFromLockedValueTask {
                     )?;
                 }
             }
+            body::Value::HTMLBundle(_) => {
+                file_blob.detach();
+                let _ = value.use_();
+                drop(this);
+                // SAFETY: GC-owned promise cell; exclusive borrow scoped to the call.
+                unsafe {
+                    (*promise).reject(
+                        global_this,
+                        Ok(global_this.create_type_error_instance(format_args!(
+                            "An HTMLBundle body can only be sent by Bun.serve()"
+                        ))),
+                    )?;
+                }
+            }
             body::Value::WTFStringImpl(_)
             | body::Value::InternalBlob(_)
             | body::Value::Null

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1297,7 +1297,8 @@ impl WriteFileWaitFromLockedValueTask {
                     (*promise).reject(
                         global_this,
                         Ok(global_this.create_type_error_instance(format_args!(
-                            "An HTMLBundle body can only be sent by Bun.serve()"
+                            "{}",
+                            crate::webcore::body::HTML_BUNDLE_BODY_UNREADABLE
                         ))),
                     )?;
                 }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -203,7 +203,6 @@ impl HTTPRequestBody {
 
     pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<HTTPRequestBody> {
         let mut body_value = BodyValue::from_js(global_this, value)?;
-        body_value.throw_if_html_bundle(global_this)?;
         if matches!(body_value, BodyValue::Used)
             || (matches!(&body_value, BodyValue::Locked(l) if !l.action.is_none() || l.is_disturbed2(global_this)))
         {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -203,6 +203,7 @@ impl HTTPRequestBody {
 
     pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<HTTPRequestBody> {
         let mut body_value = BodyValue::from_js(global_this, value)?;
+        body_value.throw_if_html_bundle(global_this)?;
         if matches!(body_value, BodyValue::Used)
             || (matches!(&body_value, BodyValue::Locked(l) if !l.action.is_none() || l.is_disturbed2(global_this)))
         {

--- a/src/runtime/webcore/wasm_streaming.rs
+++ b/src/runtime/webcore/wasm_streaming.rs
@@ -101,6 +101,7 @@ fn get_body_stream_or_bytes_for_wasm_streaming(
         if let BodyValue::Error(err) = body {
             return Err(this.throw_value(err.to_js(this)));
         }
+        body.throw_if_html_bundle(this)?;
 
         // We're done validating. From now on, deal with extracting the body.
         body.to_blob_if_possible();

--- a/src/runtime/webcore/wasm_streaming.rs
+++ b/src/runtime/webcore/wasm_streaming.rs
@@ -101,7 +101,6 @@ fn get_body_stream_or_bytes_for_wasm_streaming(
         if let BodyValue::Error(err) = body {
             return Err(this.throw_value(err.to_js(this)));
         }
-        body.throw_if_html_bundle(this)?;
 
         // We're done validating. From now on, deal with extracting the body.
         body.to_blob_if_possible();
@@ -119,7 +118,7 @@ fn get_body_stream_or_bytes_for_wasm_streaming(
             Some(b) => b,
             None => return body.to_readable_stream(this),
         },
-        _ => body.use_as_any_blob(),
+        _ => body.use_as_any_blob_or_throw(this)?,
     };
 
     // `Any::store()` only yields `Some` for the `Blob` variant; non-`Bytes` data means

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -914,6 +914,18 @@ describe("@types/bun integration test", () => {
             "Argument of type '{ headers: { \"x-bun\": string; }; }' is not assignable to parameter of type 'number'.",
         },
         {
+          code: 2345,
+          line: "serve-types.test.ts:520:33",
+          message:
+            "Argument of type 'HTMLBundle' is not assignable to parameter of type 'BodyInit | null | undefined'.",
+        },
+        {
+          code: 2345,
+          line: "serve-types.test.ts:522:45",
+          message:
+            "Argument of type 'HTMLBundle' is not assignable to parameter of type 'BodyInit | null | undefined'.",
+        },
+        {
           code: 2339,
           line: "spawn.ts:62:38",
           message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -921,7 +921,7 @@ describe("@types/bun integration test", () => {
         },
         {
           code: 2345,
-          line: "serve-types.test.ts:522:45",
+          line: "serve-types.test.ts:521:45",
           message:
             "Argument of type 'HTMLBundle' is not assignable to parameter of type 'BodyInit | null | undefined'.",
         },

--- a/test/integration/bun-types/fixture/serve-types.test.ts
+++ b/test/integration/bun-types/fixture/serve-types.test.ts
@@ -517,8 +517,9 @@ test("permutations of valid route values", {
     "/index.test-d.ts.2": () => Bun.file("index.test-d.ts"),
     "/ping": new Response("pong"),
     "/": html,
-    // @ts-expect-error this is invalid, but hopefully not for too long
     "/index.html": new Response(html),
+    "/handler": () => html,
+    "/handler-response": () => new Response(html, { status: 404 }),
     ...files,
   },
 

--- a/test/integration/bun-types/fixture/serve-types.test.ts
+++ b/test/integration/bun-types/fixture/serve-types.test.ts
@@ -518,7 +518,6 @@ test("permutations of valid route values", {
     "/ping": new Response("pong"),
     "/": html,
     "/index.html": new Response(html),
-    "/handler": () => html,
     "/handler-response": () => new Response(html, { status: 404 }),
     ...files,
   },

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// A handler returns `new Response(htmlBundle, init)` for an `import index from
+// "./index.html"`. Bun.serve builds the bundle and sends the page with the
+// Response's status and headers (#41362, #17595).
+
+const files = {
+  "index.html": `<!DOCTYPE html><html><head><title>t</title><script type="module" src="./app.ts"></script></head><body><h1>Hello HTML</h1></body></html>`,
+  "app.ts": `console.log("hello from app");`,
+};
+
+function scriptSrc(html: string): string {
+  const match = html.match(/<script[^>]*src="([^"]+)"/);
+  expect(match).not.toBeNull();
+  return match![1];
+}
+
+describe.each([false, true])("development: %p", development => {
+  test("handler returns new Response(htmlBundle, init)", async () => {
+    await using dir = tempDir("html-response", files);
+    const { default: html } = await import(join(dir, "index.html"));
+
+    let cookies = false;
+    using server = Bun.serve({
+      port: 0,
+      development,
+      routes: {
+        "/": req => {
+          if (cookies) req.cookies.set("session", "abc");
+          return new Response(html, {
+            status: 401,
+            headers: { "x-custom": "yes", "cache-control": "private" },
+          });
+        },
+      },
+      fetch() {
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const res = await fetch(server.url);
+    const page = await res.text();
+    expect(page).toContain("<h1>Hello HTML</h1>");
+    expect(page).not.toContain("app.ts");
+    expect({
+      status: res.status,
+      contentType: res.headers.get("content-type"),
+      custom: res.headers.get("x-custom"),
+      cacheControl: res.headers.get("cache-control"),
+      hasEtag: res.headers.has("etag"),
+    }).toEqual({
+      status: 401,
+      contentType: "text/html;charset=utf-8",
+      custom: "yes",
+      cacheControl: "private",
+      hasEtag: true,
+    });
+
+    // The bundled script is served next to the page.
+    const script = await fetch(new URL(scriptSrc(page), server.url));
+    expect(script.status).toBe(200);
+    expect(await script.text()).toContain("hello from app");
+
+    // HEAD frames the page a GET sends.
+    const head = await fetch(server.url, { method: "HEAD" });
+    expect(await head.text()).toBe("");
+    expect({
+      status: head.status,
+      contentLength: head.headers.get("content-length"),
+      contentType: head.headers.get("content-type"),
+    }).toEqual({
+      status: 401,
+      contentLength: String(Buffer.byteLength(page)),
+      contentType: "text/html;charset=utf-8",
+    });
+
+    // The same bundle again, with cookies from the request.
+    cookies = true;
+    const again = await fetch(server.url);
+    expect(await again.text()).toBe(page);
+    expect(again.headers.get("set-cookie")).toContain("session=abc");
+  });
+});
+
+test("a bare htmlBundle return is new Response(htmlBundle)", async () => {
+  await using dir = tempDir("html-response-bare", files);
+  const { default: html } = await import(join(dir, "index.html"));
+  using server = Bun.serve({
+    port: 0,
+    development: false,
+    async fetch() {
+      return html;
+    },
+  });
+  const res = await fetch(server.url);
+  const page = await res.text();
+  expect(page).toContain("<h1>Hello HTML</h1>");
+  expect({ status: res.status, contentType: res.headers.get("content-type") }).toEqual({
+    status: 200,
+    contentType: "text/html;charset=utf-8",
+  });
+  const script = await fetch(new URL(scriptSrc(page), server.url));
+  expect(await script.text()).toContain("hello from app");
+  expect(script.status).toBe(200);
+});
+
+test("with the dev server: a handler-returned bundle gets the HMR script", async () => {
+  await using dir = tempDir("html-response-hmr", files);
+  const { default: html } = await import(join(dir, "index.html"));
+  using server = Bun.serve({
+    port: 0,
+    development: true,
+    routes: { "/app": html },
+    fetch() {
+      return new Response(html, { status: 404, headers: { "x-fallback": "1" } });
+    },
+  });
+
+  const route = await fetch(new URL("/app", server.url));
+  const routePage = await route.text();
+  expect(route.status).toBe(200);
+  expect(routePage).toContain("data-bun-dev-server-script");
+
+  const fallback = await fetch(new URL("/missing", server.url));
+  const fallbackPage = await fallback.text();
+  expect({
+    status: fallback.status,
+    contentType: fallback.headers.get("content-type"),
+    fallbackHeader: fallback.headers.get("x-fallback"),
+  }).toEqual({
+    status: 404,
+    contentType: "text/html;charset=utf-8",
+    fallbackHeader: "1",
+  });
+  expect(fallbackPage).toContain("<h1>Hello HTML</h1>");
+  expect(fallbackPage).toContain("data-bun-dev-server-script");
+
+  const script = await fetch(new URL(scriptSrc(fallbackPage), server.url));
+  expect(script.status).toBe(200);
+  expect(await script.text()).toContain("hello from app");
+});
+
+describe.each([false, true])("development: %p", development => {
+  test("requests that arrive while the bundle builds all get the page", async () => {
+    await using dir = tempDir("html-response-concurrent", files);
+    const { default: html } = await import(join(dir, "index.html"));
+    using server = Bun.serve({
+      port: 0,
+      development,
+      routes: development ? { "/app": html } : {},
+      fetch() {
+        return new Response(html, { status: 202 });
+      },
+    });
+
+    // One of them is aborted while the bundle builds.
+    const aborted = new AbortController();
+    const abortedFetch = fetch(server.url, { signal: aborted.signal });
+    aborted.abort();
+    expect(abortedFetch).rejects.toThrow();
+
+    const responses = await Promise.all(Array.from({ length: 16 }, () => fetch(server.url)));
+    const pages = await Promise.all(responses.map(res => res.text()));
+    expect(responses.map(res => res.status)).toEqual(Array(16).fill(202));
+    expect(new Set(pages).size).toBe(1);
+    expect(pages[0]).toContain("<h1>Hello HTML</h1>");
+  });
+});
+
+const brokenFiles = {
+  "index.html": `<!DOCTYPE html><html><head><script type="module" src="./app.ts"></script></head><body>broken</body></html>`,
+  "app.ts": `import "./does-not-exist";`,
+};
+
+test("a build failure reaches the error handler", async () => {
+  await using dir = tempDir("html-response-build-error", brokenFiles);
+  const { default: html } = await import(join(dir, "index.html"));
+  let error: unknown;
+  using server = Bun.serve({
+    port: 0,
+    development: false,
+    fetch() {
+      return new Response(html);
+    },
+    error(err) {
+      error = err;
+      return new Response("handled", { status: 503 });
+    },
+  });
+  const res = await fetch(server.url);
+  expect(await res.text()).toBe("handled");
+  expect(res.status).toBe(503);
+  expect((error as Error).message).toContain("Failed to bundle");
+});
+
+test("with the dev server: a build failure renders the error page", async () => {
+  await using dir = tempDir("html-response-build-error-hmr", brokenFiles);
+  const { default: html } = await import(join(dir, "index.html"));
+  using server = Bun.serve({
+    port: 0,
+    development: true,
+    routes: { "/app": html },
+    fetch() {
+      return new Response(html);
+    },
+  });
+  const res = await fetch(new URL("/missing", server.url));
+  const page = await res.text();
+  expect(page).toContain("Build Failed");
+  expect(res.status).toBe(500);
+});
+
+test("new Response(htmlBundle) as a route value is the bundle route", async () => {
+  await using dir = tempDir("html-response-route-value", files);
+  const { default: html } = await import(join(dir, "index.html"));
+  using server = Bun.serve({
+    port: 0,
+    development: false,
+    routes: { "/": new Response(html) },
+  });
+  const res = await fetch(server.url);
+  expect(await res.text()).toContain("<h1>Hello HTML</h1>");
+  expect(res.status).toBe(200);
+
+  // An init needs a handler: a route value cannot carry it.
+  expect(() =>
+    Bun.serve({
+      port: 0,
+      development: false,
+      routes: { "/": new Response(html, { status: 404 }) },
+    }),
+  ).toThrow("return new Response(index, init) from a route handler");
+});
+
+// The handler path takes refs on the bundle, its route, the request context
+// and the Response. LeakSanitizer reports any of them left at VM teardown.
+test.skipIf(!isASAN || isWindows)(
+  "a handler-returned bundle is freed at VM teardown",
+  async () => {
+    await using dir = tempDir("html-response-teardown-leak", files);
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { default: html } = await import(process.argv[1]);
+          for (const development of [false, true]) {
+            const server = Bun.serve({
+              port: 0,
+              development,
+              routes: development ? { "/app": html } : {},
+              fetch: () => new Response(html, { status: 404 }),
+            });
+            await Promise.all(Array.from({ length: 4 }, () => fetch(server.url).then(res => res.text())));
+            await (await fetch(server.url, { method: "HEAD" })).text();
+            server.stop(true);
+          }
+        `,
+        join(dir, "index.html"),
+      ],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const filtered = stderr
+      .split("\n")
+      .filter(l => !l.includes("Bundled page in "))
+      .join("\n")
+      .trim();
+    expect({ stdout, stderr: filtered, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+  30_000,
+);
+
+test("an HTMLBundle body cannot be read outside Bun.serve", async () => {
+  await using dir = tempDir("html-response-read", files);
+  const { default: html } = await import(join(dir, "index.html"));
+  const response = new Response(html);
+  expect(response.text()).rejects.toThrow(TypeError);
+  expect(() => response.body).toThrow(TypeError);
+  expect(Bun.write(join(dir, "out.html"), new Response(html))).rejects.toThrow(TypeError);
+});

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -19,7 +19,7 @@ function scriptSrc(html: string): string {
 
 describe.each([false, true])("development: %p", development => {
   test("handler returns new Response(htmlBundle, init)", async () => {
-    await using dir = tempDir("html-response", files);
+    using dir = tempDir("html-response", files);
     const { default: html } = await import(join(dir, "index.html"));
 
     let cookies = false;
@@ -85,7 +85,7 @@ describe.each([false, true])("development: %p", development => {
 });
 
 test("a bare htmlBundle return is new Response(htmlBundle)", async () => {
-  await using dir = tempDir("html-response-bare", files);
+  using dir = tempDir("html-response-bare", files);
   const { default: html } = await import(join(dir, "index.html"));
   using server = Bun.serve({
     port: 0,
@@ -107,7 +107,7 @@ test("a bare htmlBundle return is new Response(htmlBundle)", async () => {
 });
 
 test("with the dev server: a handler-returned bundle gets the HMR script", async () => {
-  await using dir = tempDir("html-response-hmr", files);
+  using dir = tempDir("html-response-hmr", files);
   const { default: html } = await import(join(dir, "index.html"));
   using server = Bun.serve({
     port: 0,
@@ -144,7 +144,7 @@ test("with the dev server: a handler-returned bundle gets the HMR script", async
 
 describe.each([false, true])("development: %p", development => {
   test("requests that arrive while the bundle builds all get the page", async () => {
-    await using dir = tempDir("html-response-concurrent", files);
+    using dir = tempDir("html-response-concurrent", files);
     const { default: html } = await import(join(dir, "index.html"));
     using server = Bun.serve({
       port: 0,
@@ -159,7 +159,7 @@ describe.each([false, true])("development: %p", development => {
     const aborted = new AbortController();
     const abortedFetch = fetch(server.url, { signal: aborted.signal });
     aborted.abort();
-    expect(abortedFetch).rejects.toThrow();
+    await expect(abortedFetch).rejects.toThrow();
 
     const responses = await Promise.all(Array.from({ length: 16 }, () => fetch(server.url)));
     const pages = await Promise.all(responses.map(res => res.text()));
@@ -175,7 +175,7 @@ const brokenFiles = {
 };
 
 test("a build failure reaches the error handler", async () => {
-  await using dir = tempDir("html-response-build-error", brokenFiles);
+  using dir = tempDir("html-response-build-error", brokenFiles);
   const { default: html } = await import(join(dir, "index.html"));
   let error: unknown;
   using server = Bun.serve({
@@ -196,7 +196,7 @@ test("a build failure reaches the error handler", async () => {
 });
 
 test("with the dev server: a build failure renders the error page", async () => {
-  await using dir = tempDir("html-response-build-error-hmr", brokenFiles);
+  using dir = tempDir("html-response-build-error-hmr", brokenFiles);
   const { default: html } = await import(join(dir, "index.html"));
   using server = Bun.serve({
     port: 0,
@@ -213,7 +213,7 @@ test("with the dev server: a build failure renders the error page", async () => 
 });
 
 test("new Response(htmlBundle) as a route value is the bundle route", async () => {
-  await using dir = tempDir("html-response-route-value", files);
+  using dir = tempDir("html-response-route-value", files);
   const { default: html } = await import(join(dir, "index.html"));
   using server = Bun.serve({
     port: 0,
@@ -239,7 +239,7 @@ test("new Response(htmlBundle) as a route value is the bundle route", async () =
 test.skipIf(!isASAN || isWindows)(
   "a handler-returned bundle is freed at VM teardown",
   async () => {
-    await using dir = tempDir("html-response-teardown-leak", files);
+    using dir = tempDir("html-response-teardown-leak", files);
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -281,10 +281,10 @@ test.skipIf(!isASAN || isWindows)(
 );
 
 test("an HTMLBundle body cannot be read outside Bun.serve", async () => {
-  await using dir = tempDir("html-response-read", files);
+  using dir = tempDir("html-response-read", files);
   const { default: html } = await import(join(dir, "index.html"));
   const response = new Response(html);
-  expect(response.text()).rejects.toThrow(TypeError);
+  await expect(response.text()).rejects.toThrow(TypeError);
   expect(() => response.body).toThrow(TypeError);
-  expect(Bun.write(join(dir, "out.html"), new Response(html))).rejects.toThrow(TypeError);
+  await expect(Bun.write(join(dir, "out.html"), new Response(html))).rejects.toThrow(TypeError);
 });

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -335,6 +335,7 @@ test("an HTMLBundle body cannot be read outside Bun.serve", async () => {
   expect(() => response.body).toThrow(TypeError);
   await expect(Bun.write(join(dir, "out.html"), new Response(html))).rejects.toThrow(TypeError);
   expect(() => new Request("http://localhost/", { method: "POST", body: html })).toThrow(TypeError);
+  expect(() => new Request("http://localhost/", new Response(html) as any)).toThrow(TypeError);
   expect(() => new HTMLRewriter().transform(new Response(html))).toThrow(TypeError);
   await expect(WebAssembly.compileStreaming(new Response(html))).rejects.toThrow(TypeError);
   await expect(Bun.$`cat < ${new Response(html)}`.text()).rejects.toThrow("HTMLBundle");

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -337,4 +337,5 @@ test("an HTMLBundle body cannot be read outside Bun.serve", async () => {
   expect(() => new Request("http://localhost/", { method: "POST", body: html })).toThrow(TypeError);
   expect(() => new HTMLRewriter().transform(new Response(html))).toThrow(TypeError);
   await expect(WebAssembly.compileStreaming(new Response(html))).rejects.toThrow(TypeError);
+  await expect(Bun.$`cat < ${new Response(html)}`.text()).rejects.toThrow("HTMLBundle");
 });

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -5,7 +5,8 @@ import { join } from "path";
 
 // A handler returns `new Response(htmlBundle, init)` for an `import index from
 // "./index.html"`. Bun.serve builds the bundle and sends the page with the
-// Response's status and headers (#41362, #17595).
+// Response's status and headers (#41362, #17595). A bare `return htmlBundle`
+// is not a Response and stays rejected.
 
 const files = {
   "index.html": `<!DOCTYPE html><html><head><title>t</title><script type="module" src="./app.ts"></script></head><body><h1>Hello HTML</h1></body></html>`,
@@ -85,26 +86,18 @@ describe.each([false, true])("development: %p", development => {
   });
 });
 
-test("a bare htmlBundle return is new Response(htmlBundle)", async () => {
+test("a bare htmlBundle return is not a Response", async () => {
   using dir = tempDir("html-response-bare", files);
   const { default: html } = await import(join(dir, "index.html"));
   using server = Bun.serve({
     port: 0,
     development: false,
-    async fetch() {
-      return html;
+    fetch() {
+      return html as any;
     },
   });
   const res = await fetch(server.url);
-  const page = await res.text();
-  expect(page).toContain("<h1>Hello HTML</h1>");
-  expect({ status: res.status, contentType: res.headers.get("content-type") }).toEqual({
-    status: 200,
-    contentType: "text/html;charset=utf-8",
-  });
-  const script = await fetch(new URL(scriptSrc(page), server.url));
-  expect(await script.text()).toContain("hello from app");
-  expect(script.status).toBe(200);
+  expect(await res.text()).not.toContain("<h1>Hello HTML</h1>");
 });
 
 test("with the dev server: a handler-returned bundle gets the HMR script", async () => {
@@ -206,7 +199,7 @@ describe.each(["sync", "async"])("the error handler returns a bundle (%s)", kind
       fetch() {
         throw new Error("boom");
       },
-      error: kind === "sync" ? () => html : () => Promise.resolve(new Response(html, { status: 500 })),
+      error: kind === "sync" ? () => new Response(html) : () => Promise.resolve(new Response(html, { status: 500 })),
     });
     const res = await fetch(server.url);
     const page = await res.text();

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -171,7 +171,7 @@ describe.each([false, true])("development: %p", development => {
 
 const brokenFiles = {
   "index.html": `<!DOCTYPE html><html><head><script type="module" src="./app.ts"></script></head><body>broken</body></html>`,
-  "app.ts": `import "./does-not-exist";`,
+  "app.ts": `export const broken = ;`,
 };
 
 test("a build failure reaches the error handler", async () => {

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -338,5 +338,8 @@ test("an HTMLBundle body cannot be read outside Bun.serve", async () => {
   expect(() => new Request("http://localhost/", new Response(html) as any)).toThrow(TypeError);
   expect(() => new HTMLRewriter().transform(new Response(html))).toThrow(TypeError);
   await expect(WebAssembly.compileStreaming(new Response(html))).rejects.toThrow(TypeError);
-  await expect(Bun.$`cat < ${new Response(html)}`.text()).rejects.toThrow("HTMLBundle");
+  // On Windows `cat` is a shell builtin, and builtins take no Response redirect.
+  if (!isWindows) {
+    await expect(Bun.$`cat < ${new Response(html)}`.text()).rejects.toThrow("HTMLBundle");
+  }
 });

--- a/test/js/bun/http/bun-serve-html-response.test.ts
+++ b/test/js/bun/http/bun-serve-html-response.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { writeFileSync } from "fs";
 import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
 import { join } from "path";
 
@@ -195,6 +196,52 @@ test("a build failure reaches the error handler", async () => {
   expect((error as Error).message).toContain("Failed to bundle");
 });
 
+describe.each(["sync", "async"])("the error handler returns a bundle (%s)", kind => {
+  test("the page is sent like any other Response", async () => {
+    using dir = tempDir("html-response-error-handler", files);
+    const { default: html } = await import(join(dir, "index.html"));
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch() {
+        throw new Error("boom");
+      },
+      error: kind === "sync" ? () => html : () => Promise.resolve(new Response(html, { status: 500 })),
+    });
+    const res = await fetch(server.url);
+    const page = await res.text();
+    expect(page).toContain("<h1>Hello HTML</h1>");
+    expect(res.status).toBe(kind === "sync" ? 200 : 500);
+  });
+});
+
+// Several requests wait on one failing build. The first waiter's error handler
+// repairs the source and returns the same bundle, which starts a new build
+// while the other waiters are still being resumed. They wait for that build.
+test("a waiter whose error handler rebuilds the bundle does not strand the others", async () => {
+  using dir = tempDir("html-response-rebuild", brokenFiles);
+  const { default: html } = await import(join(dir, "index.html"));
+  let errors = 0;
+  using server = Bun.serve({
+    port: 0,
+    development: true,
+    fetch() {
+      return new Response(html);
+    },
+    error() {
+      errors++;
+      writeFileSync(join(dir, "app.ts"), files["app.ts"]);
+      return new Response(html, { status: 503 });
+    },
+  });
+  const responses = await Promise.all(Array.from({ length: 4 }, () => fetch(server.url)));
+  const pages = await Promise.all(responses.map(res => res.text()));
+  expect(errors).toBe(1);
+  expect(responses.map(res => res.status).sort()).toEqual([200, 200, 200, 503]);
+  expect(new Set(pages).size).toBe(1);
+  expect(pages[0]).toContain("<body>broken</body>");
+});
+
 test("with the dev server: a build failure renders the error page", async () => {
   using dir = tempDir("html-response-build-error-hmr", brokenFiles);
   const { default: html } = await import(join(dir, "index.html"));
@@ -287,4 +334,7 @@ test("an HTMLBundle body cannot be read outside Bun.serve", async () => {
   await expect(response.text()).rejects.toThrow(TypeError);
   expect(() => response.body).toThrow(TypeError);
   await expect(Bun.write(join(dir, "out.html"), new Response(html))).rejects.toThrow(TypeError);
+  expect(() => new Request("http://localhost/", { method: "POST", body: html })).toThrow(TypeError);
+  expect(() => new HTMLRewriter().transform(new Response(html))).toThrow(TypeError);
+  await expect(WebAssembly.compileStreaming(new Response(html))).rejects.toThrow(TypeError);
 });


### PR DESCRIPTION
### Problem
- A `Bun.serve` handler cannot send an imported HTML page. `new Response(index)` sends the text `[object HTMLBundle]`.
- `Body::Value::from_js` (`src/runtime/webcore/Body.rs`) has no arm for `HTMLBundle`, so the bundle falls through to the generic `Blob::get` and is stringified. `handle_resolve` (`src/runtime/server/RequestContext.rs`) only accepts a native `Response`.
- Fixes #41362, #17595. A page with a status or headers (a 401 login page, a 404 fallback) has no route-only answer today.

### Fix
- `Body::Value` gets an `HTMLBundle(RefPtr<HTMLBundle>)` arm. `new Response(index, init)` carries the bundle. A bare `return index` stays an invalid handler result (`Expected a Response object`), as requested in review. `routes: { "/": new Response(index) }` is the bundle route, and an init there throws and points at the handler form.
- The request context asks the server for the bundle's `html_bundle::Route` (`NewServer::html_bundle_route`, reused from `routes` when present, else created and cached on the server). Without a dev server the route builds once (`Route::built_html_or_schedule`, `BuildWaiter`; the route keeps a ref on itself while it builds). With one, `DevServer::respond_for_html_bundle_body` bundles the page with the HMR script (`EnsureRequest::HtmlBundleBody`, `Handler::HtmlBundleBody`). In both cases the context renders the built `StaticRoute` as a blob body, so the Response's status, headers and cookies apply. The page's Content-Type, ETag and Cache-Control fill in behind the handler's headers. Assets register as static routes as for a page in `routes`.
- Outside `Bun.serve` the body is not readable: `.text()`, `.body`, `Bun.write`, `Bun.spawn` stdin, `new Request()`, `fetch()`, `HTMLRewriter.transform()`, `WebAssembly.compileStreaming()` and shell redirects reject it with one TypeError.
- Verified: `test/js/bun/http/bun-serve-html-response.test.ts` (15 tests, all fail on stock bun). Also `test/js/bun/http/` (the 7 failures also fail without this diff), `test/bake/dev/html.test.ts`, `test/bake/dev-and-prod.test.ts`, and the bun-types integration test.

### Background
- `HTMLBundle` is the object an `import index from "./index.html"` evaluates to at runtime. `html_bundle::Route` owns the build state for one bundle on one server: `Pending`, `Building`, `Html(StaticRoute)` or `Err`. It runs the bundler on the first request and registers the output files as static routes.
- `DevServer` (`src/runtime/bake/DevServer.rs`) replaces that route when `development.hmr` is on and an HTML file is in `routes`. It bundles incrementally and splices the HMR client into the page. A request that arrives mid-bundle waits in a `DeferredRequest` with a `Handler` that says how to answer it.
- `RequestContext` is the per-request state machine of `Bun.serve`. It renders a `Response` body in `do_render_with_body` and keeps a +1 on itself while a body is pending (`has_marked_pending`), released by the callback that resumes it.

### Limits
- HMR applies to a handler-returned page only when an HTML file is also in `routes`: that is what starts the dev server. Otherwise `development: true` rebundles the page on each request, as a plain HTML route does.
- `bun build --target=bun` replaces the HTML import with a manifest object, not an `HTMLBundle`. The handler path does not apply to that output. The docs say so.
- `routes: { "/": new Response(index, { status, headers }) }` (#16873) throws with a message that points at the handler form. That replaces today's `[object HTMLBundle]` body. It does not decide #16873: a later change can accept the init there.

<details><summary>Notes</summary>

- Self-reviewed: 8 concerns raised, 6 addressed (body readers and consumers reject uniformly, the dev server releases its context ref at teardown, a waiter re-waits when a build restarts, the manifest limit is in the docs, the route-value message says "yet"). Rejected: a DOM `Response` overload for `HTMLBundle` alone (every Bun-only `BodyInit` extra fails the same way under lib.dom), and splitting the dev server part into a second PR (the production path would then serve a page without HMR in development, which is the case #17595 asks for).

- Prior art: #20193 (prototype, a new `Route` per Response and no asset routes), #20356 (review: "This should be a Body.Value"), branch `riskymh/bun-serve-html-response-custom-status` (status and headers on a route value only). This PR renders through the request context instead, so cookies set with `req.cookies` and the usual header handling apply, and the same route serves the dev server path.
- The context protects the Response JS value before it waits for a build, so the status and headers are still there when the build finishes. The route holds one ref on itself for the time it is in `State::Building` (`building_ref`, like `StaticRoute::pending_ref`), so a `BuildWaiter` is only a callback and its context.
- `reload()` clears the server's handler-created routes with the static routes. The next request builds again and registers the assets again.
- A `DeferredRequest` for `HtmlBundleBody` registers no abort callback. The context marks itself aborted, and `on_html_bundle_built` checks that before it renders. A build failure hands the context's response to the dev server's error page (`take_response`), or in production runs the `error()` handler with `Failed to bundle <path>`.
- A `BuildWaiter` whose predecessor scheduled a new build (development mode without a dev server rebundles on each request, so an `error()` handler that returns the same bundle restarts it) registers again for that build instead of reading a state that is no longer final.
- The dev-server build-failure test uses a syntax error. A missing import makes the dev server watch the directory (`track_resolution_failure`), and the watcher never frees that cloned path (`src/watcher/Watcher.rs:614`, `add_directory::<true>`). LeakSanitizer reports it at VM teardown. That leak predates this PR.
- Pre-existing failures seen while running `test/js/bun/http/` here: `bun-server.test.ts` (IPv6), `bun-connect-x509.test.ts`, `leaks-test.test.ts`, `proxy.test.js`, and two in `serve.test.ts` (root port range, `/bun:info`). All fail the same way without this diff.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-html-response.test.ts, test/integration/bun-types/fixture/serve-types.test.ts

<!-- robobun:evidence:end -->