### PR TITLE
bundler: keep the resolver's side effects when onResolve returns nothing

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2588,6 +2588,14 @@ pub mod bv2_impl {
             };
 
             if resolve_result.flags.is_external() {
+                let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
+                    [import_record.importer_source_index as usize]
+                    .as_mut_slice()[import_record.import_record_index as usize];
+                record.flags.set(
+                    bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS,
+                    resolve_result.primary_side_effects_data
+                        != bun_ast::SideEffects::HasSideEffects,
+                );
                 return;
             }
 
@@ -3728,7 +3736,7 @@ pub mod bv2_impl {
             self.graph.input_files.append(crate::Graph::InputFile {
                 source: core::mem::take(source),
                 loader,
-                side_effects: loader.side_effects(),
+                side_effects: resolve_result.primary_side_effects_data,
                 ..Default::default()
             })?;
             // `ParseTask::init` takes `bun_ast::Index`; both Index newtypes

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -189,6 +189,95 @@ describe("bundler", () => {
     });
   }
 
+  // A plugin that returns nothing hands the import back to the resolver. The
+  // bundle must keep the same side effects as a build without the plugin.
+  itBundled("plugin/ResolveReturnsUndefinedKeepsSideEffectsFalse", {
+    files: {
+      "/entry.js": /* js */ `
+        import { used } from "demo-pkg/used.js";
+        import { unused } from "demo-pkg/unused.js";
+        console.log(used);
+      `,
+      "/node_modules/demo-pkg/package.json": /* json */ `{ "sideEffects": false }`,
+      "/node_modules/demo-pkg/used.js": /* js */ `export const used = "used";`,
+      "/node_modules/demo-pkg/unused.js": /* js */ `
+        console.log("unused.js ran");
+        export const unused = 1;
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    run: {
+      stdout: "used",
+    },
+  });
+
+  itBundled("plugin/ResolveReturnsUndefinedKeepsSideEffectsArray", {
+    files: {
+      "/entry.js": /* js */ `
+        import "demo-pkg/register.js";
+        import { used } from "demo-pkg";
+        console.log(used);
+      `,
+      "/node_modules/demo-pkg/package.json": /* json */ `{ "sideEffects": ["./register.js"] }`,
+      "/node_modules/demo-pkg/index.js": /* js */ `
+        export { used } from "./used.js";
+        export { unused } from "./unused.js";
+      `,
+      "/node_modules/demo-pkg/register.js": /* js */ `console.log("register.js ran");`,
+      "/node_modules/demo-pkg/used.js": /* js */ `export const used = "used";`,
+      "/node_modules/demo-pkg/unused.js": /* js */ `
+        console.log("unused.js ran");
+        export const unused = 1;
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    run: {
+      stdout: "register.js ran\nused",
+    },
+  });
+
+  // The loader that onLoad returns replaces the loader from the file extension.
+  itBundled("plugin/ResolveReturnsUndefinedOnLoadToJsKeepsSideEffects", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./setup.txt";
+        console.log("entry");
+      `,
+      "/setup.txt": `console.log("setup.txt ran");`,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+      builder.onLoad({ filter: /\.txt$/ }, async args => ({
+        contents: await Bun.file(args.path).text(),
+        loader: "js",
+      }));
+    },
+    run: {
+      stdout: "setup.txt ran\nentry",
+    },
+  });
+
+  // An import of a Node.js builtin has no side effects, so an unused one is dropped.
+  itBundled("plugin/ResolveReturnsUndefinedDropsUnusedBuiltinImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import fs from "node:fs";
+        console.log("entry");
+      `,
+    },
+    target: "node",
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("node:fs");
+    },
+  });
+
   // Load Plugin Errors
   itBundled("plugin/ResolveThrow", {
     files: resolveFixture,


### PR DESCRIPTION
### Problem
- With `onResolve({ filter: /.*/ }, () => undefined)`, `Bun.build` tree-shakes differently than without the plugin. An unused file from a package with `"sideEffects": false` stays in the bundle and runs.
- The cause is `run_resolver` in `src/bundler/bundle_v2.rs`. It drops the resolver's `primary_side_effects_data` in two places. `enqueue_parse_task` stores `loader.side_effects()` (line 3731 on main). The early return for an external import (line 2590) does not set `IS_EXTERNAL_WITHOUT_SIDE_EFFECTS`.

### Fix
- Both places now store the resolver's value, as the path without plugins does (`bundle_v2.rs:2754`, `bundle_v2.rs:6652` and `ParseTask::init`).
- This also fixes two cases. A data file that `onLoad` turns into JavaScript keeps its side effects. An unused import of a Node.js builtin is dropped.
- Verified: four new cases in `test/bundler/bundler_plugin.test.ts` fail on bun 1.4.1 and pass with this change. Other suites: see Notes.
- Self-reviewed. I fixed the external-import gap, and I removed the data-loader special case because it drops code. The `jsx` overwrite in `enqueue_parse_task` is a different field (see Notes).

### Background
- The resolver reads the `"sideEffects"` field of the nearest `package.json` and stores the result in `primary_side_effects_data`. It also marks a Node.js builtin as free of side effects.
- The linker reads one side-effects value for each file (`LinkerContext::file_has_no_side_effects`). If a file has no side effects, an import with no used bindings does not keep the file.
- If every `onResolve` callback returns nothing for a `file` import, the bundler resolves it in `run_resolver` (`ResolveValue::NoMatch`). That function is a separate copy of `resolve_import_records`.

<details><summary>Notes</summary>

Data files (JSON, text, TOML):
- Before this change, this path marked a data file as pure data. It took that value from the loader for the file extension, before `onLoad` ran. So when `onLoad` returned JavaScript, the bundle dropped that code. The third test covers this. The path without plugins does not have this special case.
- Now a data file gets the same value as in a build without plugins. So a build with a pass-through plugin can get larger output. Example: entry `a.js` uses `data.json`, and entry `b.js` imports it without using it. Then `b.js` also gets the JSON. A build without plugins does this today. esbuild marks data files as pure data after `onLoad`. A separate change can do that for both paths.
- I compared the output with and without a pass-through plugin for JSON, text and TOML imports (with and without splitting), the original repro, builtins with target `node` and `bun`, and the `"sideEffects"` array form. The output is the same in each case.

Not in this PR (other values on the same path):
- `enqueue_parse_task` replaces the tsconfig `jsx` value from the resolver with the transpiler's value (line 3745 on main). A fix must keep the transpiler's value for `files:` entries, as `resolve_import_records` does.
- The early return for an external import also skips the `ExternalRewritePath` path rewrite.
- #38605 and #38635 cover HTML imports on this path.
- A larger change can send this path through `resolve_import_records` and remove `run_resolver`.

Tests:
- The first test imports the two files directly. With `"sideEffects": false`, a re-export barrel does not show the bug: the barrel pass reads the resolver's value from the `ParseTask`, so it never loads the unused file. The array form does not use the barrel pass, so the second test uses a barrel.
- Suites run with the debug build: `bundler_plugin`, `esbuild/dce`, `bundler_barrel`, `bundler_plugin_chain`, `bundler_files`, `bundler_loader`, `bundler_splitting`, `bun-build-api`, `bake/dev/plugins`, `bake/dev/css`, `bun-serve-html`, and the regression tests for #40606, #22199 and #29264.

Related:
- #2952 reported this bug with `async () => null`. It still reproduces on 1.4.1.
- #31147 has the `enqueue_parse_task` hunk, together with an `optimizeImports` change. A review of that PR asked for this fix as a separate PR.
- The repro of #29445 passes on 1.4.1 and on this branch.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->