### PR TITLE
worker_threads: post 'online' before the entry point runs

### DIFF
--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -172,6 +172,11 @@ extern "C" void WebWorker__entrySettled(Zig::GlobalObject* globalObject)
     CLEAR_IF_EXCEPTION(scope);
 }
 
+extern "C" void WebWorker__workerThreadStarted(WorkerMessagingProxy* proxy)
+{
+    proxy->workerThreadStarted();
+}
+
 extern "C" void WebWorker__workerGlobalScopeStarted(WorkerMessagingProxy* proxy, Zig::GlobalObject* globalObject)
 {
     WebWorker__entrySettled(globalObject);

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -378,26 +378,33 @@ void WorkerMessagingProxy::drainMessagesToWorkerObject(ScriptExecutionContext& c
 
 // ---- WorkerObjectProxy / WorkerReportingProxy (worker thread) -----------------------------------
 
-void WorkerMessagingProxy::workerGlobalScopeStarted(Zig::GlobalObject& workerGlobalObject)
+void WorkerMessagingProxy::workerThreadStarted()
 {
-    auto& context = *workerGlobalObject.scriptExecutionContext();
-    ASSERT(context.identifier() == m_workerContextIdentifier);
-
-    // Pending -> Running under the lock postTaskToWorkerGlobalScope() takes, and before 'online' is
-    // posted: a parent-side 'online' handler may immediately post a task and must find Running.
-    Deque<Function<void(ScriptExecutionContext&)>> pendingTasks;
-    {
-        Locker lock { m_pendingTasksLock };
-        m_state.store(State::Running);
-        pendingTasks = std::exchange(m_pendingTasks, {});
-    }
-
+    // Posted before the entry point loads, so it reaches the parent ahead of anything the entry's
+    // top-level code posts (node's bootstrap sends UP_AND_RUNNING before it evaluates the entry).
+    // The state stays Pending: a task or message a parent-side 'online' handler posts is queued and
+    // delivered by workerGlobalScopeStarted() once the entry has evaluated.
     ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, m_loaderLoopKind, [protectedThis = Ref { *this }](ScriptExecutionContext&) {
         RefPtr workerObject = protectedThis->m_workerObject;
         if (!workerObject || !workerObject->hasEventListeners(eventNames().openEvent))
             return;
         workerObject->dispatchEvent(Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No));
     });
+}
+
+void WorkerMessagingProxy::workerGlobalScopeStarted(Zig::GlobalObject& workerGlobalObject)
+{
+    auto& context = *workerGlobalObject.scriptExecutionContext();
+    ASSERT(context.identifier() == m_workerContextIdentifier);
+
+    // Pending -> Running under the lock postTaskToWorkerGlobalScope() takes, so a task is either
+    // queued here (and run below) or posted directly, never lost.
+    Deque<Function<void(ScriptExecutionContext&)>> pendingTasks;
+    {
+        Locker lock { m_pendingTasksLock };
+        m_state.store(State::Running);
+        pendingTasks = std::exchange(m_pendingTasks, {});
+    }
 
     // Tasks and messages that arrived while Pending. If the entry module installed a 'message'
     // listener they run now; otherwise on the next tick, so a listener added right after startup

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -384,6 +384,12 @@ void WorkerMessagingProxy::workerThreadStarted()
     // top-level code posts (node's bootstrap sends UP_AND_RUNNING before it evaluates the entry).
     // The state stays Pending: a task or message a parent-side 'online' handler posts is queued and
     // delivered by workerGlobalScopeStarted() once the entry has evaluated.
+    {
+        // An exiting parent (parentContextWillDestroy) may already have moved this to Closing.
+        Locker lock { m_pendingTasksLock };
+        if (m_state.load() != State::Pending)
+            return;
+    }
     ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, m_loaderLoopKind, [protectedThis = Ref { *this }](ScriptExecutionContext&) {
         RefPtr workerObject = protectedThis->m_workerObject;
         if (!workerObject || !workerObject->hasEventListeners(eventNames().openEvent))

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -380,12 +380,8 @@ void WorkerMessagingProxy::drainMessagesToWorkerObject(ScriptExecutionContext& c
 
 void WorkerMessagingProxy::workerThreadStarted()
 {
-    // Posted before the entry point loads, so it reaches the parent ahead of anything the entry's
-    // top-level code posts (node's bootstrap sends UP_AND_RUNNING before it evaluates the entry).
-    // The state stays Pending: a task or message a parent-side 'online' handler posts is queued and
-    // delivered by workerGlobalScopeStarted() once the entry has evaluated.
+    // Stays Pending: what an 'online' handler posts is queued until workerGlobalScopeStarted().
     {
-        // An exiting parent (parentContextWillDestroy) may already have moved this to Closing.
         Locker lock { m_pendingTasksLock };
         if (m_state.load() != State::Pending)
             return;
@@ -403,8 +399,7 @@ void WorkerMessagingProxy::workerGlobalScopeStarted(Zig::GlobalObject& workerGlo
     auto& context = *workerGlobalObject.scriptExecutionContext();
     ASSERT(context.identifier() == m_workerContextIdentifier);
 
-    // Pending -> Running under the lock postTaskToWorkerGlobalScope() takes, so a task is either
-    // queued here (and run below) or posted directly, never lost.
+    // Pending -> Running under the lock postTaskToWorkerGlobalScope() takes: no task is lost.
     Deque<Function<void(ScriptExecutionContext&)>> pendingTasks;
     {
         Locker lock { m_pendingTasksLock };

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -98,6 +98,11 @@ public:
     JSC::Strong<JSC::JSPromise> takeCrossVMRequest(uint64_t id);
 
     // -- WorkerObjectProxy / WorkerReportingProxy (worker thread) ---------------------------------
+    // The VM is up and the entry point loads next. Posts 'online' to the parent; node reports it
+    // before any user code runs.
+    void workerThreadStarted();
+    // The entry point has evaluated (up to its first top-level await): tasks and messages that
+    // arrived meanwhile are delivered and later ones are routed directly.
     void workerGlobalScopeStarted(Zig::GlobalObject&);
     void postMessageToWorkerObject(MessageWithMessagePorts&&);
     void postErrorToWorkerObject(Zig::GlobalObject&, const String& message, JSC::JSValue error);

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -98,11 +98,9 @@ public:
     JSC::Strong<JSC::JSPromise> takeCrossVMRequest(uint64_t id);
 
     // -- WorkerObjectProxy / WorkerReportingProxy (worker thread) ---------------------------------
-    // The VM is up and the entry point loads next. Posts 'online' to the parent; node reports it
-    // before any user code runs.
+    // Before the entry point loads: posts 'online' to the parent, as node does before user code.
     void workerThreadStarted();
-    // The entry point has evaluated (up to its first top-level await): tasks and messages that
-    // arrived meanwhile are delivered and later ones are routed directly.
+    // The entry point has evaluated: Pending -> Running, queued tasks and messages are delivered.
     void workerGlobalScopeStarted(Zig::GlobalObject&);
     void postMessageToWorkerObject(MessageWithMessagePorts&&);
     void postErrorToWorkerObject(Zig::GlobalObject&, const String& message, JSC::JSValue error);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -15,8 +15,7 @@
 //!
 //! Thread lifecycle (`thread_main`):
 //!   1. `start_vm()`  — arena, env snapshot, `VirtualMachine`, publish its handle (`vm_handle`).
-//!   2. `spin()`      — `workerThreadStarted` ('online'), load the entry point,
-//!                      `workerGlobalScopeStarted`, run the
+//!   2. `spin()`      — 'online', load the entry point, `workerGlobalScopeStarted`, run the
 //!                      event loop until it drains or termination is requested,
 //!                      `beforeExit` on a natural drain.
 //!   3. `shutdown()`  — 'exit' handlers, stop phase, join own children, JSC VM
@@ -796,9 +795,7 @@ impl WebWorker {
             return self.shutdown();
         }
 
-        // The thread is up: the parent sees 'online' before the entry point
-        // runs, as in node, so it precedes anything the entry's top-level code
-        // posts. Messages and tasks from the parent still wait for Running.
+        // 'online' before the entry runs, as in node: it precedes anything the entry posts.
         WebWorker__workerThreadStarted(self.messaging_proxy);
 
         // `preloads` is owned by `self` (heap `WebWorker` outlives the VM).
@@ -927,8 +924,7 @@ impl WebWorker {
 
         self.flush_logs(vm);
         log!("[{}] event loop start", self.execution_context_id);
-        // Pending -> Running: messages and tasks that arrived while the entry
-        // point was loading are delivered now, and later ones are routed directly.
+        // Pending -> Running: messages and tasks queued while the entry loaded are delivered.
         WebWorker__workerGlobalScopeStarted(self.messaging_proxy, vm.global());
         self.set_status(Status::Running);
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -15,7 +15,8 @@
 //!
 //! Thread lifecycle (`thread_main`):
 //!   1. `start_vm()`  — arena, env snapshot, `VirtualMachine`, publish its handle (`vm_handle`).
-//!   2. `spin()`      — load the entry point, `workerGlobalScopeStarted`, run the
+//!   2. `spin()`      — `workerThreadStarted` ('online'), load the entry point,
+//!                      `workerGlobalScopeStarted`, run the
 //!                      event loop until it drains or termination is requested,
 //!                      `beforeExit` on a natural drain.
 //!   3. `shutdown()`  — 'exit' handlers, stop phase, join own children, JSC VM
@@ -155,6 +156,7 @@ pub enum Status {
 // even when C++ mutates through it. `proxy` is the opaque C++ `WorkerMessagingProxy*`
 // round-tripped from `create()`; it is only ever handed back to C++.
 unsafe extern "C" {
+    safe fn WebWorker__workerThreadStarted(proxy: *mut c_void);
     safe fn WebWorker__workerGlobalScopeStarted(proxy: *mut c_void, global: &JSGlobalObject);
     safe fn WebWorker__workerGlobalScopeDestroyed(
         proxy: *mut c_void,
@@ -766,7 +768,7 @@ impl WebWorker {
         Ok(vm)
     }
 
-    /// Phase 2: load the entry point, dispatch 'online', run the event loop.
+    /// Phase 2: post 'online', load the entry point, run the event loop.
     /// Runs inside `holdAPILock`. Always ends by calling `shutdown()`.
     ///
     /// Returns `()` so the thread can unwind-free fall out of the
@@ -793,6 +795,11 @@ impl WebWorker {
             self.flush_logs(vm);
             return self.shutdown();
         }
+
+        // The thread is up: the parent sees 'online' before the entry point
+        // runs, as in node, so it precedes anything the entry's top-level code
+        // posts. Messages and tasks from the parent still wait for Running.
+        WebWorker__workerThreadStarted(self.messaging_proxy);
 
         // `preloads` is owned by `self` (heap `WebWorker` outlives the VM).
         // `preload: Vec<Box<[u8]>>` — clone the boxes (cheap, ≤handful).
@@ -920,10 +927,8 @@ impl WebWorker {
 
         self.flush_logs(vm);
         log!("[{}] event loop start", self.execution_context_id);
-        // Pending -> Running: 'online' is posted to the parent and messages/tasks
-        // that arrived while the entry point was loading are delivered. After the
-        // entry point on purpose, so the parent observes 'online' only once the
-        // worker's top-level code has run (up to its first top-level await).
+        // Pending -> Running: messages and tasks that arrived while the entry
+        // point was loading are delivered now, and later ones are routed directly.
         WebWorker__workerGlobalScopeStarted(self.messaging_proxy, vm.global());
         self.set_status(Status::Running);
 

--- a/test/js/node/test/parallel/test-sqlite-timeout.js
+++ b/test/js/node/test/parallel/test-sqlite-timeout.js
@@ -15,7 +15,7 @@ function nextDb() {
   return join(tmpdir.path, `database-${cnt++}.db`);
 }
 
-test('waits to acquire lock', { skip: typeof Bun !== 'undefined' }, async (t) => { // BUN: Worker emits 'online' only after the eval body yields; the body blocks synchronously in sqlite3_busy_timeout, so COMMIT on the parent never runs and the lock is never released. This is a Worker 'online'-timing difference (tracked separately), not a node:sqlite bug.
+test('waits to acquire lock', async (t) => {
   const DB_PATH = nextDb();
   const conn = new DatabaseSync(DB_PATH);
   t.after(() => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2123,7 +2123,7 @@ test("a top-level await rejecting while the loop is alive fails the worker then"
 });
 
 // Static imports that are still being read/transpiled are loading, not a
-// top-level await: 'online' and message delivery wait for the graph to execute.
+// top-level await: message delivery waits for the graph to execute.
 test("a file worker's static imports load before it counts as started", async () => {
   using dir = tempDir("worker-static-import-start", {
     "dep.js": `export const listeners = [];\n${"// filler\n".repeat(2000)}`,
@@ -2136,6 +2136,42 @@ parentPort.on("message", m => parentPort.postMessage("got " + m + " " + listener
   w.postMessage("hi");
   expect(await reply).toBe("got hi 0");
   await w.terminate();
+});
+
+// node posts 'online' before it evaluates the entry, so it always precedes a
+// message the entry's top-level code posts (#41375: @discordjs/ws attaches its
+// 'message' listener only after `once(worker, "online")`).
+describe("'online' precedes the worker's first message", () => {
+  test("in event order", async () => {
+    const w = new Worker(`require("worker_threads").parentPort.postMessage("ready")`, { eval: true });
+    const order: string[] = [];
+    w.on("online", () => order.push("online"));
+    w.on("message", m => order.push("message:" + m));
+    const [code] = await once(w, "exit");
+    expect(order).toEqual(["online", "message:ready"]);
+    expect(code).toBe(0);
+  });
+
+  test("a 'message' listener attached after 'online' sees it", async () => {
+    const w = new Worker(`require("worker_threads").parentPort.postMessage("ready")`, { eval: true });
+    await once(w, "online");
+    const ready = new Promise<string>(resolve => w.on("message", resolve));
+    const exited = once(w, "exit").then(() => "exited first");
+    expect(await Promise.race([ready, exited])).toBe("ready");
+    await exited;
+  });
+
+  test("a worker whose entry does not resolve reports 'online' then 'error'", async () => {
+    using dir = tempDir("worker-online-missing-entry", {});
+    const w = new Worker(join(String(dir), "missing.js"));
+    const order: string[] = [];
+    w.on("online", () => order.push("online"));
+    w.on("error", e => order.push("error:" + (e as any).code));
+    // not events.once(): it rejects on the 'error' event this test expects
+    const code = await new Promise<number>(resolve => w.on("exit", resolve));
+    expect(order).toEqual(["online", "error:MODULE_NOT_FOUND"]);
+    expect(code).toBe(1);
+  });
 });
 
 // ─── worker teardown vs. work still in flight ────────────────────────────────
@@ -2269,8 +2305,8 @@ describe("terminate with work in flight", () => {
   });
 });
 
-// A JS preload's modules are not the entry: the worker counts as started (online,
-// parent messages delivered) only once its own entry graph has executed.
+// A JS preload's modules are not the entry: parent messages are delivered only
+// once the worker's own entry graph has executed.
 test("a worker with a preload is not started before its entry module runs", async () => {
   using dir = tempDir("worker-preload-start", {
     "setup.js": `globalThis.setupRan = true;`,

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -480,10 +480,17 @@ describe("web worker", () => {
         (function burst() { for (let i = 0; i < 2000; i++) { p.n++; postMessage(p) } setImmediate(burst) })()`;
       const w = new Worker(URL.createObjectURL(new Blob([src])));
       let received = 0;
-      w.onmessage = () => received++;
+      const { promise: first, resolve: gotFirst } = Promise.withResolvers<void>();
+      w.onmessage = () => {
+        received++;
+        gotFirst();
+      };
+      // Worker startup is slow under debug/ASAN: count timer turns only once the flood has begun.
+      await first;
+      const before = received;
       // Three timer turns while the flood is running is the property; not the timing.
       for (let i = 0; i < 3; i++) await new Promise<void>(r => setTimeout(r, 10));
-      expect(received).toBeGreaterThan(0);
+      expect(received).toBeGreaterThan(before);
       w.terminate();
       await once(w, "close");
     });
@@ -530,29 +537,36 @@ describe("web worker", () => {
     // A preload's un-awaited import() finishing while the entry is still
     // fetching is not "the entry started evaluating": message delivery opens
     // only once the entry's own graph runs (and installs its handler).
-    test("preload with an un-awaited import() does not open message delivery before the entry runs", async () => {
-      using dir = tempDir("worker-preload-dynamic-import", {
-        "side.js": `globalThis.sideRan = true;`,
-        "preload.js": `import("./side.js");`,
-        // big enough that the entry graph is still transpiling when side.js evaluates
-        "big.js": Array.from(
-          { length: 4000 },
-          (_, i) => `export function f${i}(x) { return x * ${i} + ${i % 7}; }`,
-        ).join("\n"),
-        "worker.js": `import "./big.js";
+    // Three transpiles of big.js take about 2s each under debug/ASAN.
+    test(
+      "preload with an un-awaited import() does not open message delivery before the entry runs",
+      async () => {
+        using dir = tempDir("worker-preload-dynamic-import", {
+          "side.js": `globalThis.sideRan = true;`,
+          "preload.js": `import("./side.js");`,
+          // big enough that the entry graph is still transpiling when side.js evaluates
+          "big.js": Array.from(
+            { length: 4000 },
+            (_, i) => `export function f${i}(x) { return x * ${i} + ${i % 7}; }`,
+          ).join("\n"),
+          "worker.js": `import "./big.js";
           const got = [];
           self.onmessage = e => { got.push(e.data); if (e.data === "last") postMessage(got); };`,
-      });
-      for (let i = 0; i < 3; i++) {
-        const w = new Worker(path.join(String(dir), "worker.js"), { preload: [path.join(String(dir), "preload.js")] });
-        w.postMessage("first");
-        w.postMessage("second");
-        w.postMessage("last");
-        const [ev] = await once(w, "message");
-        expect(ev.data).toEqual(["first", "second", "last"]);
-        w.terminate();
-      }
-    });
+        });
+        for (let i = 0; i < 3; i++) {
+          const w = new Worker(path.join(String(dir), "worker.js"), {
+            preload: [path.join(String(dir), "preload.js")],
+          });
+          w.postMessage("first");
+          w.postMessage("second");
+          w.postMessage("last");
+          const [ev] = await once(w, "message");
+          expect(ev.data).toEqual(["first", "second", "last"]);
+          w.terminate();
+        }
+      },
+      isDebug ? 30_000 : 5_000,
+    );
 
     // Everything a worker posted before it exited arrives before 'close'.
     test("messages posted right before a natural exit are all delivered before close", async () => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -361,6 +361,29 @@ describe("web worker", () => {
     });
   });
 
+  describe("open event", () => {
+    // 'open' is posted before the entry runs, so it precedes anything the
+    // entry's top-level code posts (node:worker_threads turns it into 'online').
+    test("precedes the worker's first message", async () => {
+      const worker = new Worker("data:text/javascript,postMessage('ready')");
+      const order: string[] = [];
+      worker.addEventListener("open", () => order.push("open"));
+      worker.addEventListener("message", e => order.push("message:" + e.data));
+      await once(worker, "close");
+      expect(order).toEqual(["open", "message:ready"]);
+    });
+
+    test("is fired for a worker whose entry does not resolve", async () => {
+      using dir = tempDir("worker-open-missing-entry", {});
+      const worker = new Worker(path.join(String(dir), "missing.js"));
+      const order: string[] = [];
+      worker.addEventListener("open", () => order.push("open"));
+      worker.addEventListener("error", () => order.push("error"));
+      await once(worker, "close");
+      expect(order).toEqual(["open", "error"]);
+    });
+  });
+
   describe("error event", () => {
     test("is fired with a string of the error", async () => {
       const worker = new Worker("data:text/javascript,throw 5");


### PR DESCRIPTION
### Problem
- `@discordjs/ws` `WorkerShardingStrategy` hangs on Bun. It does `await once(worker, "online")` and then attaches its `message` listener. Its worker posts `{op: 7}` from top-level code. In Bun that message reaches the parent before `online`, so no listener sees it and `gateway.connect()` never settles. Node always delivers `online` first.
- The cause is in `WorkerMessagingProxy::workerGlobalScopeStarted` (`src/jsc/bindings/webcore/WorkerMessagingProxy.cpp:395`). Bun posted the `open` event (the `online` emit in `worker_threads.ts`) after the entry had evaluated. A `parentPort.postMessage()` from the entry's top level was already queued to the parent by then.

### Fix
- Add `WorkerMessagingProxy::workerThreadStarted()`. It posts the `open` event and nothing else. `spin()` calls it before it resolves and loads the entry point, which is where Node's bootstrap sends `UP_AND_RUNNING`. It skips the post when the state is no longer `Pending` (a parent that exits during worker startup moves it to `Closing`).
- The `Pending -> Running` transition stays in `workerGlobalScopeStarted()`, after the entry has evaluated. Messages and tasks the parent posts still wait for the entry graph, so `postMessage()` or `getHeapSnapshot()` from an `online` handler is queued and delivered as before.
- A worker whose entry does not resolve now reports `online` then `error`, as Node does. The same ordering applies to the web `Worker` `open` event.
- Verified: `test/js/node/worker_threads/worker_threads.test.ts` (3 new tests) and `test/js/web/workers/worker.test.ts` (2 new tests). All 5 fail on 1.4.1. Also ran the rest of `test/js/web/workers/`, `test/js/node/worker_threads/`, and the vendored `test-worker-*.js` Node tests.

### Background
- `WorkerMessagingProxy` is the parent/worker relationship object. Its `m_state` goes `Pending -> Running -> Closing -> Closed`. While `Pending`, messages and tasks from the parent are buffered. `Running` means the worker's entry has evaluated and they are routed directly.
- `parentPort.postMessage()` in a node worker travels over a `MessageChannel` port pair that the `Worker` constructor creates (`src/js/node/worker_threads.ts:898`). That path does not go through the proxy, so it is ordered against the `open` task only by when each is posted to the parent's loop.
- Prior work: #34424 (cirospaciari) moves the event the same way as part of a much larger change. #32908 is an older attempt against code that no longer exists. This PR is the narrow fix for #41375.
- Self-reviewed: 2 concerns raised, 2 addressed (the `Closing` guard and the web `Worker` tests).

<details><summary>Notes</summary>

Minimal repro (from the issue, reduced):

```js
// worker.js
require("node:worker_threads").parentPort.postMessage("ready");
// main.mjs
const w = new Worker(new URL("./worker.js", import.meta.url));
w.on("online", () => order.push("online"));
w.on("message", m => order.push("message:" + m));
```

Bun 1.4.1: `message:ready, online`. Node 26: `online, message:ready`. With this change Bun matches Node, and the full `@discordjs/ws` repro (stub REST, `WorkerShardingStrategy({ shardsPerWorker: 4 })`) gets past worker setup and the shards start connecting.

Three tests in `test/js/web/workers/` fail on this container on main and on this branch alike (`a message flood from a worker does not starve the parent's event loop`, `preload with an un-awaited import() does not open message delivery before the entry runs`, `terminate() while dns.lookup() is in flight`). They are timing limits of the debug/ASAN build here, not related to this change.

`isOnline()` on the proxy still means `Running`. It has no callers.

Fixes #41375
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[2/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[3/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-10.cpp.o
[4/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[5/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[6/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-7.cpp.o
[7/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-8.cpp.o
[8/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[9/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-6.cpp.o
[10/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-11.cpp.o
[11/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-15.cpp.o
[12/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-18.cpp.o
[13/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-14.cpp.o
[14/123] cxx obj/unified/UnifiedSource-src_jsc_bindings-16.cpp.o
[15/123] cxx obj/u
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (0481e341b)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.20ms]
(pass) web worker > preload > string [2.32ms]
(pass) web worker > preload > array of 2 strings [2.52ms]
(pass) web worker > preload > array of string [1.82ms]
(pass) web worker > preload > error in preload doesn't crash parent [1.72ms]
(pass) web worker > worker [1.55ms]
(pass) web worker > worker-env [1.59ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [12.42ms]
(pass) web worker > worker-env: process.env reads inside a worker reflect the worker's own environment at runtime [8.36ms]
(pass) web worker > worker-env with a lot of properties [3.64ms]
(pass) web worker > argv / execArgv defaults [5.21ms]
(pass) web worker > argv / execArgv options [5.07ms]
(pass) web worker > sending 50 messages should just work [2.23ms]
(pass) web worker > worker with event listeners doesn't close event loop [8.79ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [7.89ms]
(pass) web worker > worker with process.exit [11.97ms]
(pass) web worker > worker event > is fired with the right object [0.15ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.1 (e0a2b82fd)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [32.06ms]
(pass) web worker > preload > string [116.09ms]
(pass) web worker > preload > array of 2 strings [114.82ms]
(pass) web worker > preload > array of string [110.35ms]
(pass) web worker > preload > error in preload doesn't crash parent [106.56ms]
(pass) web worker > worker [105.83ms]
(pass) web worker > worker-env [109.61ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [651.05ms]
(pass) web worker > worker-env: process.env reads inside a worker reflect the worker's own environment at runtime [414.72ms]
(pass) web worker > worker-env with a lot of properties [289.74ms]
(pass) web worker > argv / execArgv defaults [371.01ms]
(pass) web worker > argv / execArgv options [376.89ms]
(pass) web worker > sending 50 messages should just work [133.43ms]
(pass) web worker > worker with event listeners doesn't close 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 571ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_http-0.cpp.o
[2/90] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[3/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[4/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[5/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[6/90] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[7/90] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[8/90] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[9/90] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[10/90] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[11/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[12/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-0.cpp.o
[13/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[14/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[15/90] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-1.cpp.o
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/Worker.cpp                |  5 ++
 src/jsc/bindings/webcore/WorkerMessagingProxy.cpp  | 26 ++++---
 src/jsc/bindings/webcore/WorkerMessagingProxy.h    |  3 +
 src/jsc/web_worker.rs                              | 13 ++--
 test/js/node/test/parallel/test-sqlite-timeout.js  |  2 +-
 test/js/node/worker_threads/worker_threads.test.ts | 42 ++++++++++-
 test/js/web/workers/worker.test.ts                 | 85 ++++++++++++++++------
 7 files changed, 133 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/Worker.cpp                     1      2     22
src/jsc/bindings/webcore/WorkerMessagingProxy.cpp       3      6     22
src/jsc/bindings/webcore/WorkerMessagingProxy.h         2      3     22
src/jsc/web_worker.rs                                   3      8     22
test/js/node/test/parallel/test-sqlite-timeout.js       0      0     26
test/js/node/worker_threads/worker_threads.test.ts      1      4     13
test/js/web/workers/worker.test.ts                      3      4     12
```

</details>

<!-- robobun:evidence:end -->