### PR TITLE
usockets: hold a tick level for the whole of close_all

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -70,6 +70,20 @@ void us_socket_group_deinit(struct us_socket_group_t *group) {
  * closes it in finalize(), so closing+freeing it here turns that into a UAF
  * (the original LSAN was only the *accepted* sockets, not the listener). */
 void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_listeners) {
+    struct us_loop_t *loop = group->loop;
+    if (!loop) {
+        /* Never init'd, so nothing is linked. A Windows named-pipe Listener
+         * keeps a group like this, and its stop(true) still calls close_all. */
+        return;
+    }
+
+    /* A close below can run a JS handler that ticks the loop (expect().resolves
+     * → waitForPromise). Called outside a tick, that nested tick is the outermost
+     * one, and its loop_post frees the sockets we already closed. This walk reads
+     * them after a dispatch, and Listener.stop closes its listen socket again
+     * after we return. Count as a tick level, so only a tick outside us frees them. */
+    loop->data.tick_depth++;
+
     if (also_listeners) {
         /* Listeners first — stops new sockets from being accepted into
          * head_sockets while we're draining it. */
@@ -152,6 +166,8 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
         }
         US_ASSERT(group->low_prio_count == 0);
     }
+
+    loop->data.tick_depth--;
 }
 
 void us_socket_group_close_all(struct us_socket_group_t *group) {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -1,6 +1,6 @@
 import { connect, listen, SocketHandler, TCPSocketListener } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { join } from "node:path";
 
 type Resolve = (value?: unknown) => void;
@@ -294,6 +294,110 @@ describe("tcp socket binaryType", () => {
       })();
     });
   }
+});
+
+// The libuv backend (Windows) does not count tick depth, so there the nested
+// tick still frees the closed sockets.
+it.skipIf(isWindows)("stop(true) outside a tick, with a close handler that ticks the loop", async () => {
+  // stop(true) closes the listen socket first, then each connection, and then
+  // closes the listen socket again (a no-op on a closed socket). The loop frees
+  // closed sockets at the end of its outermost tick. When stop() runs outside a
+  // tick, a tick that a close handler starts is the outermost one, so it freed
+  // the listen socket before stop() read it again (heap-use-after-free).
+  // Run in a subprocess so that a crash is a non-zero exit code.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { expect } = require("bun:test");
+        const events = [];
+        const { promise: bothOpen, resolve: onBothOpen } = Promise.withResolvers();
+        let opened = 0;
+        const server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open() {
+              if (++opened === 2) onBothOpen();
+            },
+            data() {},
+            close() {
+              events.push("close");
+              if (events.length === 1) {
+                // Blocks until the promise settles, and ticks the event loop
+                // while it waits. A timer fires only after the loop polls for
+                // I/O, so "timer" before "ticked" shows that a tick ran here.
+                const timer = new Promise(resolve =>
+                  setTimeout(() => {
+                    events.push("timer");
+                    resolve();
+                  }),
+                );
+                expect(timer).resolves.toBeUndefined();
+                events.push("ticked");
+              }
+            },
+          },
+        });
+        for (let i = 0; i < 2; i++) {
+          await Bun.connect({ hostname: "127.0.0.1", port: server.port, socket: { data() {} } });
+        }
+        await bothOpen;
+        // An immediate runs between event loop ticks, not inside one.
+        setImmediate(() => {
+          server.stop(true);
+          events.push("stopped");
+          console.log(events.join(","));
+        });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("close,timer,ticked,close,stopped\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+it.skipIf(!isWindows)("stop(true) on a named-pipe listener with an open connection", async () => {
+  // A named-pipe listener never initializes its socket group, and stop(true)
+  // still closes that group when a connection is open. Run in a subprocess so
+  // that a crash is a non-zero exit code.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-stop-" + Math.random().toString(36).slice(2);
+        const { promise: opened, resolve: onOpen } = Promise.withResolvers();
+        const { promise: closed, resolve: onClose } = Promise.withResolvers();
+        const server = Bun.listen({
+          unix: pipe,
+          socket: {
+            open() { onOpen(); },
+            data() {},
+            close() { onClose(); },
+          },
+        });
+        const client = await Bun.connect({ unix: pipe, socket: { data() {} } });
+        await opened;
+        server.stop(true);
+        client.end();
+        await closed;
+        console.log("stopped");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("stopped\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 it("should not leak memory", async () => {

--- a/test/js/bun/net/tcp-server.test.ts
+++ b/test/js/bun/net/tcp-server.test.ts
@@ -310,7 +310,7 @@ it.skipIf(isWindows)("stop(true) outside a tick, with a close handler that ticks
       bunExe(),
       "-e",
       `
-        const { expect } = require("bun:test");
+        import { expect } from "bun:test";
         const events = [];
         const { promise: bothOpen, resolve: onBothOpen } = Promise.withResolvers();
         let opened = 0;
@@ -364,8 +364,9 @@ it.skipIf(isWindows)("stop(true) outside a tick, with a close handler that ticks
 
 it.skipIf(!isWindows)("stop(true) on a named-pipe listener with an open connection", async () => {
   // A named-pipe listener never initializes its socket group, and stop(true)
-  // still closes that group when a connection is open. Run in a subprocess so
-  // that a crash is a non-zero exit code.
+  // still closes that group when a connection is open. The group is empty, so
+  // the pipe connection stays open until the client ends it. Run in a
+  // subprocess so that a crash is a non-zero exit code.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),


### PR DESCRIPTION
### Problem
- `listener.stop(true)` can read freed memory. ASAN reports `heap-use-after-free` in `us_socket_is_closed` (`packages/bun-usockets/src/socket.c:139`), from `Listener::do_stop` (`src/runtime/socket/Listener.rs:889`). The release build segfaults.
- `us_socket_group_close_all_ex` (`packages/bun-usockets/src/context.c:72`) runs the JS `close` handlers. It can run outside a loop tick (a timer, an immediate, the `--isolate` swap). A handler that ticks the loop (`expect(promise).resolves` with no `await`) then runs the outermost tick, which frees the sockets `close_all` closed (`loop.c:422`). `do_stop` then closes the freed listen socket.

### Fix
- `close_all_ex` increments `loop->data.tick_depth` on entry and decrements it on exit. A nested tick then runs at depth 2 or more and frees nothing. The next tick outside `close_all` frees the closed sockets.
- This also covers the read of `s` after `us_dispatch_connect_error` (`context.c:108`). The uSockets rewrite (#34037) holds the same tick level.
- A group with no loop returns at once. A Windows named-pipe `Listener` never initializes its group (`Listener.rs:250`), and `stop(true)` calls `close_all`.
- Verified: two new tests in `test/js/bun/net/tcp-server.test.ts`. Also ran `test/js/bun/net/` and the `--isolate`, `node:net`, `Bun.serve`, and WebSocket suites. Self-reviewed: 5 concerns raised, 5 addressed.

### Background
- `us_loop_run_bun_tick` increments `tick_depth` during one tick. A JS callback can nest a tick through `waitForPromise`.
- A closed socket stays on `loop->data.closed_head`. `us_internal_loop_post` frees that list only at `tick_depth <= 1`.
- On epoll and kqueue, timers and immediates run between ticks, at depth 0.
- The libuv backend (Windows) does not count `tick_depth`, so this fix does not apply there, and the first test skips Windows. #39643, #40021, and #40023 add the count.

<details><summary>Notes</summary>

- Reproduction: the first test's child script crashes in 20 of 20 runs on the Linux release build without the fix. On the debug build, ASAN reports the read in `us_listen_socket_close`. The free comes from `us_internal_loop_post` under `wait_for_promise`.
- The first test records a `timer` event inside the wait. If `expect().resolves` stops ticking the loop (#33261), the test fails and does not pass silently.
- A gdb trace on the fixed debug build shows one free of the closed list after `stop()` returns: 5 sockets, at `tick_depth` 1, from the top-level `auto_tick`. The nested tick frees nothing.
- Windows, first test: its script segfaults on a Windows debug build (address 0xFFFFFFFFFFFFFFFF), with and without this change. It passes on the Windows release canary (40 of 40 runs), because mimalloc does not overwrite freed memory in release builds.
- Windows, second test: on a Windows debug build it passes without this change. With the tick-depth change and no NULL check, it segfaults (address 0xC8). With this PR it passes (10 of 10 runs).
- On Windows, `stop(true)` does not close an accepted named-pipe connection. The listener's socket group is empty, and `close_pipe_and_deinit` closes only the listening pipe. The canary shows the same result without this change. So the second test ends the connection from the client.
- On Windows, the depth counter changes only when `close_all` calls nest. If a handler in the inner call runs `uv_run`, the free waits until after the poll handle's close callback, and `us_poll_free` then keeps the poll. Without this change, that case is a use-after-free. #39643 makes `us_poll_free` accept either order.
- #41373 changes the force-drain in the same function. The two PRs change different lines, and each one applies on top of the other.
- Failures in this container that also fail on the release build without the change: `node-net.test.ts` (10, connect to 127.0.0.1), `serve.test.ts` (2, root port and `/bun:info`), `node-tls-server.test.ts` (1, SNI), `socket.test.ts` (1, DNS for `www.example.com`). Eight tests in `websocket-server.test.ts` time out on the debug build with and without the change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/tcp-server.test.ts

<!-- robobun:evidence:end -->
