### PR TITLE
bundler: preserve split cycle initialization order

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -391,9 +391,8 @@ impl Order {
         (a.distance < b.distance) || (a.distance == b.distance && a.tie_breaker < b.tie_breaker)
     }
 
-    /// Sort so files closest to an entry point come first. If two files are
-    /// equidistant to an entry point, then break the tie by sorting on the
-    /// stable source index derived from the DFS over all entry points.
+    /// Sort so files closest to an entry point come first. The caller supplies
+    /// a stable tie-breaker for files equidistant from an entry point.
     pub(crate) fn sort(a: &mut [Order]) {
         index_sort::sort_slice_unstable_by(a, |a, b| {
             if Order::less_than(Order::default(), *a, *b) {

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -251,6 +251,10 @@ pub struct LinkerGraph<'a> {
     /// Index from `.parse_graph.input_files` to index in `.files`
     pub(crate) stable_source_indices: Vec<u32>,
 
+    /// DFS entry order selects cycle roots; post-order remains the stable index
+    /// used for symbol naming and cross-chunk dependencies.
+    pub(crate) dfs_pre_order: Vec<u32>,
+
     pub(crate) is_scb_bitset: BitSet,
 
     /// This is for cross-module inlining of detected inlinable constants
@@ -268,7 +272,7 @@ pub struct LinkerGraph<'a> {
 //   (no new allocations) for the duration of any worker-pool fan-out that
 //   holds `&LinkerGraph`.
 // - `files_live` / `parts_live` / `is_scb_bitset` / `reachable_files` /
-//   `stable_source_indices` / `code_splitting` / `ts_enums` are populated
+//   `stable_source_indices` / `dfs_pre_order` / `code_splitting` / `ts_enums` are populated
 //   before fan-out and only read by workers.
 // - `ast` / `meta` / `files` columns that workers mutate are split out via
 //   `split_mut()` into disjoint `&mut [_]` *before* the pool runs (see
@@ -316,6 +320,7 @@ impl Default for LinkerGraph<'_> {
             meta: MultiArrayList::default(),
             reachable_files: Vec::new(),
             stable_source_indices: Vec::new(),
+            dfs_pre_order: Vec::new(),
             is_scb_bitset: BitSet::default(),
             ts_enums: bun_ast::ast_result::TsEnumsMap::default(),
             import_member_bindings: bun_ast::ast_result::ImportMemberBindings::default(),

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1808,6 +1808,8 @@ pub mod bv2_impl {
 
     pub(crate) struct ReachableFileVisitor<'a> {
         pub(crate) reachable: Vec<Index>,
+        pub(crate) pre_order: Vec<u32>,
+        pub(crate) next_pre_order: u32,
         pub(crate) visited: DynamicBitSet,
         pub(crate) all_import_records: &'a mut [import_record::List<'a>],
         pub(crate) all_loaders: &'a [Loader],
@@ -1899,6 +1901,8 @@ pub mod bv2_impl {
                     continue;
                 }
                 self.visited.set(source_index.get() as usize);
+                self.pre_order[source_index.get() as usize] = self.next_pre_order;
+                self.next_pre_order += 1;
 
                 let mark = self.stack.len();
 
@@ -2108,6 +2112,8 @@ pub mod bv2_impl {
 
             let mut visitor = ReachableFileVisitor {
                 reachable: Vec::with_capacity(self.graph.entry_points.len() + 1),
+                pre_order: vec![u32::MAX; self.graph.input_files.len()],
+                next_pre_order: 0,
                 visited: DynamicBitSet::init_empty(self.graph.input_files.len())?,
                 redirects: self.graph.ast.items_redirect_import_record_index(),
                 all_import_records,
@@ -2165,7 +2171,12 @@ pub mod bv2_impl {
             // reshaped for borrowck — release the visitor's `&mut`
             // borrows on the two bitsets and `input_files` columns before the
             // cleanup loop reads them.
-            let ReachableFileVisitor { reachable, .. } = visitor;
+            let ReachableFileVisitor {
+                reachable,
+                pre_order,
+                ..
+            } = visitor;
+            self.linker.graph.dfs_pre_order = pre_order;
 
             // reshaped for borrowck — three disjoint mutable SoA
             // columns via `split_mut()` on a value-type `Slice` snapshot.

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -100,12 +100,14 @@ pub(crate) fn find_imported_parts_in_js_order(
         Vec::with_capacity(chunk.files_with_parts_in_chunk.count());
     {
         let distances = this.graph.files.items_distance_from_entry_point();
-        let stable_source_indices = this.graph.stable_source_indices.slice();
+        // Enter a cycle through the same file as the original import DFS.
+        // Post-order can select the opposite root and reverse initialization.
+        let dfs_pre_order = this.graph.dfs_pre_order.slice();
         for &source_index in chunk.files_with_parts_in_chunk.keys() {
             chunk_order_array.push(Order {
                 source_index,
                 distance: distances[source_index as usize],
-                tie_breaker: stable_source_indices[source_index as usize],
+                tie_breaker: dfs_pre_order[source_index as usize],
             });
         }
     }

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1490,6 +1490,179 @@ describe("bundler", () => {
     run: { file: "/out/e1.js", stdout: 'e1 ab ["b","a"]' },
   });
 
+  // Removing a tree-shaken importer from a shared chunk must not discard its
+  // import order when selecting the root of the A/B cycle. Otherwise A runs
+  // first and permanently captures B's uninitialized namespace property.
+  itBundled("splitting/TreeShakenImporterPreservesCyclicChunkOrder", {
+    files: {
+      "/a.ts": /* js */ `
+        export * as A from "./a";
+        import { B } from "./b";
+        export const node = { name: "a", deps: [B.node] };
+      `,
+      "/b.ts": /* js */ `
+        export * as B from "./b";
+        import { A } from "./a";
+        export const readA = () => A.node.name;
+        export const node = { name: "b", deps: [] };
+      `,
+      "/p.ts": /* js */ `
+        export * as P from "./p";
+        import { A } from "./a";
+        export const node = { name: "p", deps: [A.node] };
+      `,
+      "/group.ts": /* js */ `
+        import { A } from "./a";
+        import { B } from "./b";
+        import { P } from "./p";
+        export const nodes = [P.node, B.node, A.node];
+      `,
+      "/hub1.ts": /* js */ `
+        import { A } from "./a";
+        import { B } from "./b";
+        import { P } from "./p";
+        export const orderAnchor = "HUB1_ORDER_ANCHOR";
+        export const a = A.node;
+        export const b = B.node;
+        export const p = P.node;
+      `,
+      "/hub3.ts": /* js */ `
+        import { A } from "./a";
+        import { B } from "./b";
+        import { P } from "./p";
+        export const a = A.node;
+        export const b = B.node;
+        export const p = P.node;
+      `,
+      "/hub4.ts": /* js */ `
+        import { A } from "./a";
+        import { B } from "./b";
+        import { P } from "./p";
+        export const a = A.node;
+        export const b = B.node;
+        export const p = P.node;
+      `,
+      "/lazy.ts": /* js */ `
+        import { p as lazyP } from "./hub4";
+        import { p as deadP } from "./hub1";
+        console.log("lazy", lazyP.name);
+      `,
+      "/entry.ts": /* js */ `
+        import { nodes } from "./group";
+        import { p as entryP } from "./hub3";
+        import { b as entryB, orderAnchor } from "./hub1";
+        await import("./lazy");
+        if (orderAnchor !== "HUB1_ORDER_ANCHOR") throw new Error("bad anchor");
+        console.log("entry", entryB.name, entryP.name);
+        console.log("dependency", nodes[2].deps[0]?.name ?? "undefined");
+      `,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      const outputs = jsFilesIn(api);
+      expect(outputs).toHaveLength(3);
+      expect(api.readFile("/out/entry.js")).toContain("HUB1_ORDER_ANCHOR");
+      for (const output of outputs) {
+        if (output !== "entry.js") expect(api.readFile("/out/" + output)).not.toContain("HUB1_ORDER_ANCHOR");
+      }
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "lazy p\nentry b p\ndependency b",
+    },
+  });
+
+  // Do not topologically sort the initializer parts. Here the live importer
+  // intentionally reaches B before A, so A must observe B before B initializes.
+  itBundled("splitting/CyclicChunkPreservesLiveImporterOrder", {
+    files: {
+      "/a.ts": /* js */ `
+        export * as A from "./a";
+        import { B } from "./b";
+        export var node = { name: "a", dependency: B.node?.name ?? "undefined" };
+      `,
+      "/b.ts": /* js */ `
+        export * as B from "./b";
+        import { A } from "./a";
+        export var node = { name: "b" };
+        export const readA = () => A.node.name;
+      `,
+      "/hub.ts": /* js */ `
+        import { B } from "./b";
+        import { A } from "./a";
+        export const nodes = [B.node, A.node];
+        export const readA = () => B.readA();
+      `,
+      "/lazy.ts": /* js */ `
+        import { nodes } from "./hub";
+        console.log("lazy", nodes[1].dependency);
+      `,
+      "/entry.ts": /* js */ `
+        import { nodes, readA } from "./hub";
+        await import("./lazy");
+        console.log("entry", nodes[0].name, readA());
+      `,
+    },
+    entryPoints: ["/entry.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "lazy undefined\nentry b a",
+    },
+  });
+
+  // The first DFS path reaches A through X, but BFS reaches B through M first.
+  // Both the static entry and the lazy entry require B to initialize before A.
+  describe.each([false, true])("cyclic chunk deep importer order", splitting => {
+    itBundled(`splitting/CyclicChunkPreservesDeepImporterOrder${splitting ? "Split" : "Unsplit"}`, {
+      files: {
+        "/a.js": `
+          import { B } from "./b.js";
+          export * as A from "./a.js";
+          export var node = { name: "a", dependency: B.node?.name ?? "undefined" };
+        `,
+        "/b.js": `
+          import { A } from "./a.js";
+          export * as B from "./b.js";
+          export var node = { name: "b" };
+          export const readA = () => A.node.name;
+        `,
+        "/x.js": `import { A } from "./a.js"; export const a = A.node;`,
+        "/m.js": `
+          import { a } from "./x.js";
+          import { B } from "./b.js";
+          export const nodes = [a, B.node];
+          export const readA = B.readA;
+        `,
+        "/n.js": `import { A } from "./a.js"; export const a = A.node;`,
+        "/w.js": `import { A } from "./a.js"; export const a = A.node;`,
+        "/lazy.js": `
+          import { a } from "./w.js";
+          console.log("lazy", a.dependency);
+        `,
+        "/entry.js": `
+          import { nodes, readA } from "./m.js";
+          import { a } from "./n.js";
+          await import("./lazy.js");
+          console.log("entry", nodes[0].dependency, nodes[1].name, readA(), a.dependency);
+        `,
+      },
+      entryPoints: ["/entry.js", "/lazy.js"],
+      splitting,
+      outdir: "/out",
+      format: "esm",
+      run: [
+        { file: "/out/entry.js", stdout: "lazy b\nentry b b a b" },
+        { file: "/out/lazy.js", stdout: "lazy b" },
+      ],
+    });
+  });
+
   // import() of another chunk is printed as import(); it does not pull the
   // runtime's __require into the bundle.
   itBundled("splitting/DynamicImportDoesNotNeedRequireShim", {


### PR DESCRIPTION
### What does this PR do?

Fix the traversal-root tie-breaker used to order files in a chunk.

`stable_source_indices` records DFS **post-order**. For an `a → b → a` cycle first entered at `a`, post-order puts `b` first. Selecting `b` as the chunk traversal root can then emit `a` before `b`, so an initializer captures an uninitialized namespace property.

This is a longstanding ordering defect, not a new defect introduced by #41145. That change correctly made chunk membership follow live parts; removing an ordering anchor from a shared chunk exposed the existing problem again.

#### Fix

- Record DFS **pre-order** during the existing `find_reachable_files` traversal.
- Use pre-order as `Order.tie_breaker` in both splitting and non-splitting builds.
- Keep the existing live-walk distances and chunk membership logic.
- Preserve post-order indices for symbol naming and cross-chunk dependencies.
- Remove the previous revision's extra BFS pass and full-graph distance recomputation.

The load-bearing change is the tie-breaker in `findAllImportedPartsInJSOrder.rs`. No second graph traversal is added; pre-order storage adds one `u32` per input file.

This does not resolve the longstanding limitation where separate entrypoints require opposite evaluation orders for a cycle placed in one shared chunk.

### How did you verify your code works?

Retained the original two tests and added the review's deeper-import-path counterexample in split and unsplit modes:

- `splitting/TreeShakenImporterPreservesCyclicChunkOrder`: Bun 1.4.1 prints `dependency undefined`; the patched build prints `dependency b`. It also checks that the tree-shaken ordering anchor stays out of the shared/lazy chunks.
- `splitting/CyclicChunkPreservesLiveImporterOrder`: preserves an intentional B-before-A import order, including the expected `undefined` read.
- `splitting/CyclicChunkPreservesDeepImporterOrderSplit` and `...Unsplit`: DFS reaches A through a deeper path before BFS would. Both entrypoints are executed separately. The split case fails on Bun 1.4.1 **and on the previous BFS-patched binary**; the new implementation passes. Unbundled Node matches the expected output.

Local verification on Linux with the debug build:

- Before the final main rebase, `bun bd test test/bundler/bundler_splitting.test.ts`: **111 pass, 0 fail**.
- After rebasing onto `d316760e8cae0d69ae927898d5afc933ecf34671` and converting the parameter loop to `describe.each()`, `bun bd test test/bundler/bundler_splitting.test.ts -t CyclicChunkPreservesDeepImporterOrder`: **2 pass, 0 fail**.
- `bun bd test test/bundler/bundler_cjs.test.ts test/bundler/bundler_regressions.test.ts test/bundler/bundler_edgecase.test.ts`: **241 pass, 11 existing todo, 1 timeout** in `edgecase/DeepImportDiamondDAG` (its 60-second child-process deadline). An isolated rerun with `bun bd test test/bundler/bundler_edgecase.test.ts -t DeepImportDiamondDAG` then **passed**, with no code, test, or timeout changes. The combined run was not fully green; the isolated pass does not establish the cause of the timeout.
- Real `bun bd build ../compile-repro/entry.ts --compile --splitting --outfile=...`, followed by executing the generated binary: **`RESULT b`**.
- Source-lint suite: **172 pass, 0 fail**.
- `cargo fmt --all -- --check`, Prettier check for the changed test file, and `git diff --check`: passed.

These are local debug-build results, not a claim that upstream release-build or cross-platform CI has passed.
