### PR TITLE
Reject json() with the JSON.parse SyntaxError on the buffered path

### DIFF
--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1354,13 +1354,15 @@ jsimd_ycc_rgb_convert_avx2.return                    [AVX, AVX2]
 # so every LLInt opcode handler starts with a raw 4-byte ".int <opcode_id>"
 # (LowLevelInterpreter.cpp: EMBED_OPCODE_ID_IF_NEEDED). The linear-sweep
 # decoder desyncs on those embedded ints and, depending on how preceding .text
-# code aligns, can decode a stray VEX-encoded instruction out of the garbage.
-# offlineasm's x86 backend emits SSE2 (not VEX), and the Intel SDE Nehalem
-# emulation step in this same job exercises the LLInt and passes, so any
-# single-digit hit here is decode noise. Ceiling [AVX] so a multi-feature leak
-# still fails. On ELF each opcode handler has its own symbol, so layout shifts
-# can move the desync between llint_op_* siblings; add them here as they trip.
-# (2 symbols)
+# code aligns, can decode a stray VEX-encoded instruction (or an RDPMC, 0F 33)
+# out of the garbage. offlineasm's x86 backend emits SSE2 (not VEX), and the
+# Intel SDE Nehalem emulation step in this same job exercises the LLInt and
+# passes, so any single-digit hit here is decode noise. Each ceiling is the one
+# feature that the scan reported, so a multi-feature leak still fails. On ELF
+# each opcode handler has its own symbol, so layout shifts can move the desync
+# between llint_op_* siblings; add them here as they trip.
+# (3 symbols)
 # ----------------------------------------------------------------------------
 llint_op_enter_wide32  [AVX]
+llint_op_jmp_wide32  [RDPMC]
 llint_op_wide16_wide16  [AVX]

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1357,12 +1357,14 @@ jsimd_ycc_rgb_convert_avx2.return                    [AVX, AVX2]
 # code aligns, can decode a stray VEX-encoded instruction (or an RDPMC, 0F 33)
 # out of the garbage. offlineasm's x86 backend emits SSE2 (not VEX), and the
 # Intel SDE Nehalem emulation step in this same job exercises the LLInt and
-# passes, so any single-digit hit here is decode noise. Each ceiling is the one
-# feature that the scan reported, so a multi-feature leak still fails. On ELF
-# each opcode handler has its own symbol, so layout shifts can move the desync
+# passes, so any single-digit hit here is decode noise. Blanket pass, as for
+# any data-in-.text misdecode: the handlers are offlineasm output, not compiler
+# output, and the decoded feature moves with link layout (the same desync has
+# decoded as AVX and as RDPMC), so a ceiling has nothing to bound. On ELF each
+# opcode handler has its own symbol, so layout shifts can move the desync
 # between llint_op_* siblings; add them here as they trip.
 # (3 symbols)
 # ----------------------------------------------------------------------------
-llint_op_enter_wide32  [AVX]
-llint_op_jmp_wide32  [RDPMC]
-llint_op_wide16_wide16  [AVX]
+llint_op_enter_wide32
+llint_op_jmp_wide32
+llint_op_wide16_wide16

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -519,11 +519,8 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue BunString__toJSON(
     const BunString* bunString)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    WTF::String string = bunString->toWTFString();
-    // An empty input converts to a null string, and JSONParseWithException does not throw for a
-    // null string. Parse "" instead, so the error is the one that JSON.parse("") throws.
-    if (string.isNull() && bunString->isEmpty() && !bunString->isDead())
-        string = emptyString();
+    // toWTFString() is null for an empty string, and JSONParseWithException throws nothing for null.
+    WTF::String string = !bunString->isDead() && bunString->isEmpty() ? emptyString() : bunString->toWTFString();
     JSC::JSValue result = JSC::JSONParseWithException(globalObject, string);
 
     if (!result && !scope.exception()) {

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -519,7 +519,12 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue BunString__toJSON(
     const BunString* bunString)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    JSC::JSValue result = JSC::JSONParse(globalObject, bunString->toWTFString());
+    WTF::String string = bunString->toWTFString();
+    // An empty input converts to a null string, and JSONParseWithException does not throw for a
+    // null string. Parse "" instead, so the error is the one that JSON.parse("") throws.
+    if (string.isNull() && bunString->isEmpty() && !bunString->isDead())
+        string = emptyString();
+    JSC::JSValue result = JSC::JSONParseWithException(globalObject, string);
 
     if (!result && !scope.exception()) {
         scope.throwException(globalObject, createSyntaxError(globalObject, "Failed to parse JSON"_s));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2742,10 +2742,13 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue EncodedSlice__toJSO
             scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_STRING_TOO_LONG, "Cannot parse a JSON string longer than 2147483647 characters"_s));
             return {};
         }
+        // JSONParseWithException does not throw for a null string. Parse "" instead, so an empty
+        // input gets the error that JSON.parse("") throws.
+        if (!strPtr->len)
+            str = emptyString();
     }
 
-    // JSONParseWithException does not propagate exceptions as expected. See #5859
-    JSValue result = JSONParse(globalObject, str);
+    JSValue result = JSONParseWithException(globalObject, str);
     RETURN_IF_EXCEPTION(scope, {});
     if (!result) {
         scope.throwException(globalObject, createSyntaxError(globalObject, "Failed to parse JSON"_s));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2732,20 +2732,17 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__unwrapBoxedPrimitive(JSGlobalObject
 extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue EncodedSlice__toJSONObject(const EncodedSlice* strPtr, JSC::JSGlobalObject* globalObject)
 {
     ASSERT_NO_PENDING_EXCEPTION(globalObject);
-    auto str = Zig::toString(*strPtr);
+    // Zig::toString() is null for an empty slice, and JSONParseWithException throws nothing for null.
+    auto str = strPtr->len ? Zig::toString(*strPtr) : emptyString();
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     if (str.isNull()) {
-        // isNull() will be true for empty strings and for strings which are too long.
+        // isNull() will be true for strings which are too long, and when an allocation fails.
         // So we need to check the length is plausibly due to a long string.
         if (strPtr->len > Bun__stringSyntheticAllocationLimit || strPtr->len > WTF::String::MaxLength) {
             scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_STRING_TOO_LONG, "Cannot parse a JSON string longer than 2147483647 characters"_s));
             return {};
         }
-        // JSONParseWithException does not throw for a null string. Parse "" instead, so an empty
-        // input gets the error that JSON.parse("") throws.
-        if (!strPtr->len)
-            str = emptyString();
     }
 
     JSValue result = JSONParseWithException(globalObject, str);

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2530,7 +2530,8 @@ it("#5859 json", async () => {
     body: new Uint8Array([0xfd]),
   });
 
-  expect(await response.text()).toBe("Failed to parse JSON");
+  // The body decodes to U+FFFD, so req.json() rejects with the error of JSON.parse("\uFFFD").
+  expect(await response.text()).toBe("JSON Parse error: Unrecognized token '\uFFFD'");
   expect(response.ok).toBeFalse();
 });
 

--- a/test/js/bun/spawn/readablestream-helpers.test.ts
+++ b/test/js/bun/spawn/readablestream-helpers.test.ts
@@ -126,11 +126,42 @@ describe("ReadableStream conversion methods", () => {
     // Check it doesn't throw synchronously.
     expect(result).toBeInstanceOf(Promise);
 
-    // TODO: why is the error message different here??
-    expect(async () => await result).toThrowErrorMatchingInlineSnapshot(`"Failed to parse JSON"`);
+    expect(async () => await result).toThrowErrorMatchingInlineSnapshot(`"JSON Parse error: Expected '}'"`);
 
     expect(process.exitCode).toBe(0);
   });
+
+  test.each([
+    ["invalid JSON", "{ invalid json content }", "JSON Parse error: Expected '}'"],
+    // The text of a body is the UTF-8 decode of its bytes, and the decode drops a byte order mark.
+    ["only a byte order mark", "\uFEFF", "JSON Parse error: Unexpected EOF"],
+  ])(
+    "ReadableStream.prototype.json() of %s rejects with the JSON.parse error for a buffered and a streamed source",
+    async (_label, body, message) => {
+      const bytes = new TextEncoder().encode(body);
+      expect(() => JSON.parse(new TextDecoder().decode(bytes))).toThrow(message);
+
+      // A Response body holds all of its bytes, so json() parses them in native code.
+      const buffered = new Response(bytes.slice()).body!;
+      // A stream with a JavaScript source delivers chunks, so json() reads the text first.
+      const streamed = new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes.slice());
+          controller.close();
+        },
+      });
+
+      const settle = (promise: Promise<unknown>) =>
+        promise.then(
+          () => "resolved",
+          (error: Error) => `${error.name}: ${error.message}`,
+        );
+      expect([await settle(buffered.json()), await settle(streamed.json())]).toEqual([
+        `SyntaxError: ${message}`,
+        `SyntaxError: ${message}`,
+      ]);
+    },
+  );
 
   test("Bun.spawn() process.stdout.blob() should convert stream to Blob", async () => {
     // Generate random binary data

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -49,6 +49,15 @@ function randomFilled(bufferType: (typeof bufferTypes)[number], length: number) 
   return buffer;
 }
 
+function jsonParseError(text: string): SyntaxError {
+  try {
+    JSON.parse(text);
+  } catch (error) {
+    return error as SyntaxError;
+  }
+  throw new Error(`JSON.parse accepted ${JSON.stringify(text)}`);
+}
+
 const utf8 = [
   {
     string: "",
@@ -920,6 +929,13 @@ for (const { body, fn } of bodyTypes) {
       for (const actual of invalidTests) {
         test(actual || "<empty>", async () => {
           expect(async () => await fn(actual).json()).toThrow(SyntaxError);
+          // An empty body is rejected before the parser runs, with its own message.
+          if (actual !== "") {
+            const error = await fn(actual)
+              .json()
+              .catch(error => error);
+            expect(error.message).toBe(jsonParseError(actual).message);
+          }
         });
       }
     });


### PR DESCRIPTION
### Problem
- `test/js/bun/spawn/readablestream-helpers.test.ts` fails at random. On PR builds 110091 (debian 13 aarch64) and 110186 (windows 11 aarch64), a case got `Failed to parse JSON` where it expected `JSON Parse error: Expected '}'`, or the reverse.
- `json()` on a stream that holds the whole body parses it in `BunString__toJSON` (`src/jsc/bindings/BunString.cpp:522`) or `EncodedSlice__toJSONObject` (`src/jsc/bindings/bindings.cpp:2748`). These call `JSC::JSONParse` and throw the generic message. A streamed body gets the `JSON.parse` message.
- For `proc.stdout`, timing selects the path. #20694 pinned one message per case. Since #41204, one failure is final.

### Fix
- Both helpers call `JSONParseWithException`, and parse `""` for an empty input. For the same text, they throw the SyntaxError that `JSON.parse` throws. The removed "See #5859" comment is stale (see Notes).
- `Response.json()`, `Request.json()`, `Blob.json()` and `Bun.file().json()` change the same way. The fetch spec rethrows the `JSON.parse` exception. Node does too.
- `scripts/verify-baseline-static/allowlist-x64.txt` gets `llint_op_jmp_wide32`, a documented LLInt decode false positive that moved with the code layout (see Notes).
- Verified on the ASAN build with `BUN_JSC_validateExceptionChecks=1`: `readablestream-helpers.test.ts` (new cases), `body.test.ts`, `serve.test.ts`. Self-reviewed: 5 concerns raised, 4 addressed.

### Background
- A stream that Bun creates has a native source. A Blob source returns the whole body at once, so `json()` tries it first.
- `JSC::JSONParse` returns an empty value on a syntax error and throws nothing.
- Bun creates `proc.stdout` when JS first reads it. If the pipe is at EOF then, it is a Blob stream. `Bun.spawn()` reads the pipe once before it returns, and on Windows `exited` can resolve before EOF.

<details><summary>Notes</summary>

- Reproduction on the released build (1.4.1):
  - `new Blob([s]).stream().json()` rejects with `Failed to parse JSON`. A stream with a JavaScript source rejects with `JSON Parse error: Expected '}'`.
  - `proc.stdout.json()` with no await after `Bun.spawn()`: 11 of 50 runs took the buffered path when the parent and a fast child (`/bin/echo`) share one CPU. This is the debian case.
  - After `await proc.exited`, a grandchild that keeps the pipe open makes the streamed path run. This is the Windows case.
- Empty input: `JSONParseWithException` throws nothing for a null string, and an empty input converts to one. A child that printed only a byte order mark got `JSON Parse error: Unexpected EOF` on the streamed path and `Failed to parse JSON` on the buffered path. Both paths now give the first. A zero-byte stdout was already the same on both paths.
- #5859: in 2023 the helper caught the exception and returned it as a value. Today both helpers use a throw scope. The #5859 tests pass with `BUN_JSC_validateExceptionChecks=1`.
- Baseline scan: the `:linux: x64-musl - verify-baseline` step flagged one `RDPMC` in `llint_op_jmp_wide32`. Each LLInt opcode handler starts with an embedded 4-byte opcode id, and the linear-sweep decoder desyncs on it. The allowlist already covers two sibling handlers for this reason. The same scan lists those two entries as stale, so the desync moved to this handler. The emulator phase of the same job passes, and the step passed on main at the same base commit. The three LLInt entries are blanket passes, as the triage guide in `scripts/verify-baseline-static/CLAUDE.md` says for a data-in-.text misdecode.
- The helpers keep `Failed to parse JSON` for a string that failed to convert (a dead string, or a failed allocation).
- The empty-body checks in `Blob.rs` run before the helpers. They resolve `null` or throw `Unexpected end of JSON input`. That is #24955, and this PR does not change them.
- #33658 (open since July) makes the same change to the two helpers, and also removes the empty-body checks for #24955. This PR supersedes the helper half of #33658. After it lands, #33658 only needs its `Blob.rs` change.
- Self-review, 5 concerns. Addressed: the narrowed claim, the empty-input case, the note that the failures were on PR builds, and the relation to #33658. Not addressed: `Blob::to_json_with_bytes` decodes a body that starts with FF FE as UTF-16LE, and the streamed path decodes it as UTF-8. That difference is separate from this change.
- Tests on the debug ASAN build. The first three also ran with `BUN_JSC_validateExceptionChecks=1`.
  - `test/js/bun/spawn/readablestream-helpers.test.ts`: 32 pass. The released build fails 3 (the two new cases and `(after exited)`).
  - `test/js/web/fetch/body.test.ts`: 476 pass. The released build fails 34 (17 inputs, for `Request` and `Response`).
  - `test/js/bun/http/serve.test.ts`: 295 pass, 2 fail. The 2 failures (`root range port(#7187)` and `/bun:info to loopback clients`) also fail on the released build in this environment, which runs as root.
  - Also pass: `bun-file.test.ts`, `regression/issue/02367.test.ts`, `express.json.test.ts`, `spawn.ipc.test.ts`, `spawn.ipc.bun-node.test.ts`, and the json cases of `fetch.test.ts`. The one failure there, `bad permissions throws`, also fails as root on the released build.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts, test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->

