### PR TITLE
node:url: return a plain null-prototype object from url.parse(input, true)

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -30,6 +30,20 @@ const [domainToASCII, domainToUnicode, idnaToASCII] = $cpp("NodeURL.cpp", "Bun::
 const { urlToHttpOptions } = require("internal/url");
 const { validateString, validateObject } = require("internal/validators");
 const ObjectSetPrototypeOf = Object.setPrototypeOf;
+const ObjectKeys = Object.keys;
+
+// url.parse(input, true) returns a null-prototype object holding only the
+// query keys, like Node's querystring.parse(). URLSearchParams#toJSON() tags
+// its result with Symbol.toStringTag, so its keys are copied instead of its
+// object being reused.
+function queryObjectFromSearchParams(search) {
+  const parsed = new URLSearchParams(search).toJSON();
+  const query = { __proto__: null };
+  for (const key of ObjectKeys(parsed)) {
+    query[key] = parsed[key];
+  }
+  return query;
+}
 
 function Url() {
   this.protocol = null;
@@ -221,7 +235,7 @@ Url.prototype.parse = function parse(url: string, parseQueryString?: boolean, sl
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = ObjectSetPrototypeOf(new URLSearchParams(this.search.slice(1)).toJSON(), null);
+          this.query = queryObjectFromSearchParams(this.search.slice(1));
         } else {
           this.query = this.search.slice(1);
         }
@@ -436,7 +450,7 @@ Url.prototype.parse = function parse(url: string, parseQueryString?: boolean, sl
     this.query = rest.substring(qm + 1);
     if (parseQueryString) {
       const query = this.query;
-      this.query = ObjectSetPrototypeOf(new URLSearchParams(query).toJSON(), null);
+      this.query = queryObjectFromSearchParams(query);
     }
     rest = rest.slice(0, qm);
   } else if (parseQueryString) {

--- a/test/js/node/url/url-parse-query.test.js
+++ b/test/js/node/url/url-parse-query.test.js
@@ -17,6 +17,15 @@ describe("url.parse", () => {
     assert.strictEqual(query.toString, undefined);
   });
 
+  test("parseQueryString query object carries no symbol keys", () => {
+    for (const input of ["/foo/bar?baz=quux&baz=2", "http://example.com/a?b=1"]) {
+      const { query } = url.parse(input, true);
+      assert.deepStrictEqual(Object.getOwnPropertySymbols(query), []);
+      assert.strictEqual(Object.getPrototypeOf(query), null);
+      assert.strictEqual(query[Symbol.toStringTag], undefined);
+    }
+  });
+
   test("with query string", () => {
     function createWithNoPrototype(properties = []) {
       const noProto = { __proto__: null };

--- a/test/js/node/url/url-parse-query.test.js
+++ b/test/js/node/url/url-parse-query.test.js
@@ -3,28 +3,35 @@ import assert from "node:assert";
 import url from "node:url";
 
 describe("url.parse", () => {
-  // TODO: Support correct prototype and null values.
-  test("parseQueryString returns a null-prototype query object", () => {
-    const inputs = ["/foo/bar?baz=quux", "/foo/bar", "http://example.com/a?baz=quux", "http://example.com/a"];
-    for (const input of inputs) {
-      const { query } = url.parse(input, true);
-      assert.strictEqual(Object.getPrototypeOf(query), null);
-    }
+  describe.each(["/foo/bar?baz=quux", "/foo/bar", "http://example.com/a?baz=quux", "http://example.com/a"])(
+    "parseQueryString for %s",
+    input => {
+      test("returns a null-prototype query object", () => {
+        const { query } = url.parse(input, true);
+        assert.strictEqual(Object.getPrototypeOf(query), null);
+        assert.strictEqual(query.hasOwnProperty, undefined);
+        assert.strictEqual(query.toString, undefined);
+      });
+    },
+  );
 
-    const { query } = url.parse("/foo/bar?baz=quux", true);
-    assert.strictEqual(query.baz, "quux");
-    assert.strictEqual(query.hasOwnProperty, undefined);
-    assert.strictEqual(query.toString, undefined);
+  test("parseQueryString keeps single values and repeated keys", () => {
+    const { query } = url.parse("/foo/bar?baz=quux&baz=2&single=1", true);
+    assert.strictEqual(query.single, "1");
+    assert.deepStrictEqual(query.baz, ["quux", "2"]);
   });
 
-  test("parseQueryString query object carries no symbol keys", () => {
-    for (const input of ["/foo/bar?baz=quux&baz=2", "http://example.com/a?b=1"]) {
-      const { query } = url.parse(input, true);
-      assert.deepStrictEqual(Object.getOwnPropertySymbols(query), []);
-      assert.strictEqual(Object.getPrototypeOf(query), null);
-      assert.strictEqual(query[Symbol.toStringTag], undefined);
-    }
-  });
+  describe.each(["/foo/bar?baz=quux&baz=2", "http://example.com/a?b=1"])(
+    "parseQueryString query object for %s",
+    input => {
+      test("carries no symbol keys", () => {
+        const { query } = url.parse(input, true);
+        assert.deepStrictEqual(Object.getOwnPropertySymbols(query), []);
+        assert.strictEqual(Object.getPrototypeOf(query), null);
+        assert.strictEqual(query[Symbol.toStringTag], undefined);
+      });
+    },
+  );
 
   test("with query string", () => {
     function createWithNoPrototype(properties = []) {


### PR DESCRIPTION
`url.parse(input, true).query` is built from `URLSearchParams#toJSON()`, whose
result carries an own `Symbol.toStringTag` property. Node's `querystring.parse()`
returns a null-prototype object with only the query keys, so code that reflects
over the query (`Object.getOwnPropertySymbols`, `assert.deepStrictEqual` against
a plain object, snapshot serializers) sees an extra symbol under Bun.

Repro:

    const { query } = require("node:url").parse("http://x/a?b=1", true);
    console.log(Object.getOwnPropertySymbols(query));
    // Node: []    Bun 1.4.0: [ Symbol(Symbol.toStringTag) ]

The query object is now assembled by copying the string keys of the toJSON()
result onto a `{ __proto__: null }` object. Repeated keys keep the array shape
toJSON() already produces.
