### PR TITLE
node:net: honor the callback in server.listen(port, host, undefined, cb)

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3686,6 +3686,10 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
     } else if (typeof hostname === "string" && typeof onListen === "number") {
       backlog = onListen;
       onListen = argsLength > 3 ? arguments[3] : undefined;
+    } else if (typeof hostname === "string" && onListen === undefined && argsLength > 3) {
+      // listen(port, host, undefined, callback): an omitted backlog still
+      // leaves the callback in the fourth slot, as Node's normalizeArgs does.
+      onListen = typeof arguments[3] === "function" ? arguments[3] : undefined;
     }
 
     if (typeof port === "function") {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3688,8 +3688,10 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
       onListen = argsLength > 3 ? arguments[3] : undefined;
     } else if (typeof hostname === "string" && onListen === undefined && argsLength > 3) {
       // listen(port, host, undefined, callback): an omitted backlog still
-      // leaves the callback in the fourth slot, as Node's normalizeArgs does.
-      onListen = typeof arguments[3] === "function" ? arguments[3] : undefined;
+      // leaves the callback as the last argument, which is where Node's
+      // normalizeArgs reads it from.
+      const last = arguments[argsLength - 1];
+      onListen = typeof last === "function" ? last : undefined;
     }
 
     if (typeof port === "function") {

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -45,6 +45,25 @@ describe("net.createServer listen", () => {
     );
   });
 
+  it("should call the listening callback when backlog is undefined", done => {
+    const { mustCall } = createCallCheckCtx(done);
+
+    const server: Server = createServer();
+    server.on("error", failOnError(server, done));
+
+    server.listen(
+      0,
+      "127.0.0.1",
+      undefined,
+      mustCall(() => {
+        const address = server.address() as AddressInfo;
+        expect(address.address).toStrictEqual("127.0.0.1");
+        server.close();
+        done();
+      }),
+    );
+  });
+
   it("should listen on IPv4", done => {
     const { mustCall } = createCallCheckCtx(done);
 

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -64,6 +64,24 @@ describe("net.createServer listen", () => {
     );
   });
 
+  it("should read the listening callback from the last argument", done => {
+    const { mustCall } = createCallCheckCtx(done);
+
+    const server: Server = createServer();
+    server.on("error", failOnError(server, done));
+
+    server.listen(
+      0,
+      "127.0.0.1",
+      undefined,
+      undefined,
+      mustCall(() => {
+        server.close();
+        done();
+      }),
+    );
+  });
+
   it("should listen on IPv4", done => {
     const { mustCall } = createCallCheckCtx(done);
 


### PR DESCRIPTION
Node's `server.listen(port, host, backlog, callback)` accepts an omitted
backlog: `normalizeArgs` takes the callback from the last argument whatever
sits in the third slot. Bun only looked at the fourth argument when the third
was a number, so `listen(0, "127.0.0.1", undefined, cb)` started the server
and never called `cb`. Libraries that forward an optional backlog this way
(supertest, get-port style helpers) hang waiting for the listening callback.

Repro:

    const s = require("net").createServer();
    s.listen(0, "127.0.0.1", undefined, () => console.log("listening"));
    // Node prints "listening"; Bun 1.4.0 never does.

When the host is a string, the third argument is undefined and a fourth
argument was passed, the fourth argument is used as the callback.
