### PR TITLE
node:https: export https.Server as its own class instead of aliasing http.Server

### DIFF
--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -499,7 +499,8 @@ const { shouldUseEnvProxy } = require("node:_http_agent");
 // normalized protocol list / callback on the server instance the way
 // tls.Server does (test-https-argument-of-creating.js).
 // https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L82-L97
-function createServer(options, requestListener) {
+function Server(options, requestListener): void {
+  if (!(this instanceof Server)) return new Server(options, requestListener);
   if (typeof options === "function") {
     requestListener = options;
     options = {};
@@ -514,13 +515,17 @@ function createServer(options, requestListener) {
     // ALPN requests are always answered with http/1.1.
     options.ALPNProtocols = ["http/1.1"];
   }
-  const server = http.createServer(options, requestListener);
+  http.Server.$call(this, options, requestListener);
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {
-    require("node:tls").convertALPNProtocols(optionsALPNProtocols, server);
+    require("node:tls").convertALPNProtocols(optionsALPNProtocols, this);
   }
-  server.ALPNCallback = options.ALPNCallback;
-  return server;
+  this.ALPNCallback = options.ALPNCallback;
+}
+$toClass(Server, "Server", http.Server);
+
+function createServer(options, requestListener) {
+  return new Server(options, requestListener);
 }
 
 var https = {
@@ -531,7 +536,7 @@ var https = {
     timeout: 5000,
     proxyEnv: shouldUseEnvProxy() ? process.env : undefined,
   }),
-  Server: http.Server,
+  Server,
   createServer,
   get,
   request,

--- a/test/js/node/http/node-https-server-class.test.ts
+++ b/test/js/node/http/node-https-server-class.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import http from "node:http";
 import https from "node:https";
 import { tls } from "harness";
 
 describe("https.Server", () => {
+  const servers: http.Server[] = [];
+  afterEach(() => {
+    for (const server of servers.splice(0)) {
+      server.close();
+    }
+  });
+
   test("is a distinct class that extends http.Server", () => {
     expect(https.Server).not.toBe(http.Server);
     expect(Object.getPrototypeOf(https.Server.prototype)).toBe(http.Server.prototype);
@@ -12,27 +19,28 @@ describe("https.Server", () => {
 
   test("createServer returns an https.Server that is also an http.Server", () => {
     const server = https.createServer({ ...tls }, () => {});
-    try {
-      expect(server).toBeInstanceOf(https.Server);
-      expect(server).toBeInstanceOf(http.Server);
-      expect(server.constructor).toBe(https.Server);
-      // the ALPN default that tls.Server applies
-      expect(server.ALPNProtocols).toBeDefined();
-    } finally {
-      server.close();
-    }
+    servers.push(server);
+    expect(server).toBeInstanceOf(https.Server);
+    expect(server).toBeInstanceOf(http.Server);
+    expect(server.constructor).toBe(https.Server);
+    // the ALPN default that tls.Server applies
+    expect(server.ALPNProtocols).toBeDefined();
+  });
+
+  test("a plain http.Server is not an https.Server", () => {
+    const server = http.createServer(() => {});
+    servers.push(server);
+    expect(server).toBeInstanceOf(http.Server);
+    expect(server).not.toBeInstanceOf(https.Server);
+    expect(server.constructor).toBe(http.Server);
   });
 
   test("new https.Server() and https.Server() both construct", () => {
     const a = new https.Server({ ...tls });
     // Node's https.Server can be called without `new`, like tls.Server.
     const b = (https.Server as any)({ ...tls });
-    try {
-      expect(a).toBeInstanceOf(https.Server);
-      expect(b).toBeInstanceOf(https.Server);
-    } finally {
-      a.close();
-      b.close();
-    }
+    servers.push(a, b);
+    expect(a).toBeInstanceOf(https.Server);
+    expect(b).toBeInstanceOf(https.Server);
   });
 });

--- a/test/js/node/http/node-https-server-class.test.ts
+++ b/test/js/node/http/node-https-server-class.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import http from "node:http";
+import https from "node:https";
+import { tls } from "harness";
+
+describe("https.Server", () => {
+  test("is a distinct class that extends http.Server", () => {
+    expect(https.Server).not.toBe(http.Server);
+    expect(Object.getPrototypeOf(https.Server.prototype)).toBe(http.Server.prototype);
+    expect(Object.getPrototypeOf(https.Server)).toBe(http.Server);
+  });
+
+  test("createServer returns an https.Server that is also an http.Server", () => {
+    const server = https.createServer({ ...tls }, () => {});
+    try {
+      expect(server).toBeInstanceOf(https.Server);
+      expect(server).toBeInstanceOf(http.Server);
+      expect(server.constructor).toBe(https.Server);
+      // the ALPN default that tls.Server applies
+      expect(server.ALPNProtocols).toBeDefined();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("new https.Server() and https.Server() both construct", () => {
+    const a = new https.Server({ ...tls });
+    // Node's https.Server can be called without `new`, like tls.Server.
+    const b = (https.Server as any)({ ...tls });
+    try {
+      expect(a).toBeInstanceOf(https.Server);
+      expect(b).toBeInstanceOf(https.Server);
+    } finally {
+      a.close();
+      b.close();
+    }
+  });
+});


### PR DESCRIPTION
In Node `https.Server` is a distinct constructor (it extends `tls.Server`),
so `https.Server !== http.Server`, `server instanceof https.Server` holds for
an https server and `server.constructor === https.Server`. Bun exported
`Server: http.Server`, which breaks code that branches on the class (test
doubles such as `jest.spyOn(https.Server.prototype, "listen")` land on
http.Server, and `x instanceof https.Server` is true for plain http servers).

Repro:

    const http = require("node:http"), https = require("node:https");
    console.log(https.Server === http.Server, http.createServer() instanceof https.Server);
    // Node: false false    Bun 1.4.0: true true

`https.Server` is now a constructor whose prototype chain sits on
`http.Server.prototype`; it applies the ALPN defaults `createServer` already
applied and then delegates to `http.Server`. `createServer` returns
`new Server(...)`, so its behaviour is unchanged apart from the class identity.
