### PR TITLE
node:vm: make Script.prototype methods writable like Node

### DIFF
--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -603,10 +603,10 @@ private:
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(NodeVMScriptPrototype, NodeVMScriptPrototype::Base);
 
 static const struct HashTableValue scriptPrototypeTableValues[] = {
-    { "createCachedData"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptCreateCachedData, 1 } },
-    { "runInContext"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptRunInContext, 2 } },
-    { "runInNewContext"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptRunInNewContext, 2 } },
-    { "runInThisContext"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptRunInThisContext, 2 } },
+    { "createCachedData"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptCreateCachedData, 1 } },
+    { "runInContext"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptRunInContext, 2 } },
+    { "runInNewContext"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptRunInNewContext, 2 } },
+    { "runInThisContext"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, scriptRunInThisContext, 2 } },
     { "sourceMapURL"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, scriptGetSourceMapURL, nullptr } },
     { "cachedData"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, scriptGetCachedData, nullptr } },
     { "cachedDataProduced"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, scriptGetCachedDataProduced, nullptr } },

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1974,3 +1974,33 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     expect(position).toBeLessThanOrEqual(INT32_MAX);
   });
 });
+
+describe("Script.prototype methods", () => {
+  // Node defines them as ordinary writable methods, so test doubles can
+  // replace them (jest.spyOn(vm.Script.prototype, "runInContext")).
+  test.each(["runInContext", "runInNewContext", "runInThisContext", "createCachedData"])(
+    "%s is writable and configurable",
+    name => {
+      const descriptor = Object.getOwnPropertyDescriptor(Script.prototype, name)!;
+      expect(descriptor.writable).toBe(true);
+      expect(descriptor.configurable).toBe(true);
+      expect(descriptor.enumerable).toBe(false);
+    },
+  );
+
+  test("runInContext can be replaced and restored", () => {
+    const original = Script.prototype.runInContext;
+    const calls: unknown[] = [];
+    Script.prototype.runInContext = function (this: Script, ...args: unknown[]) {
+      calls.push(args);
+      return "replaced";
+    } as typeof original;
+    try {
+      expect(new Script("1 + 1").runInContext(createContext({}))).toBe("replaced");
+      expect(calls).toHaveLength(1);
+    } finally {
+      Script.prototype.runInContext = original;
+    }
+    expect(new Script("1 + 1").runInContext(createContext({}))).toBe(2);
+  });
+});


### PR DESCRIPTION
`vm.Script.prototype.runInContext`, `runInNewContext`, `runInThisContext` and
`createCachedData` were installed with `PropertyAttribute::ReadOnly`, so an
assignment to them is silently ignored in sloppy mode and throws in strict
mode. In Node they are ordinary class methods (writable, configurable,
non-enumerable), and test doubles rely on that: `jest.spyOn(vm.Script.prototype,
"runInContext")` and manual `Script.prototype.runInContext = ...` patches both
fail under Bun.

Repro:

    const { Script } = require("node:vm");
    console.log(Object.getOwnPropertyDescriptor(Script.prototype, "runInContext").writable);
    // Node: true    Bun 1.4.0: false

The four function entries in `scriptPrototypeTableValues` drop `ReadOnly`;
`sourceMapURL` stays a read-only accessor as in Node.

Also marks the four methods DontEnum: Node defines them as class methods, so they are not enumerable.
