### PR TITLE
bun:test: treat a string passed to expect.stringMatching as a RegExp pattern

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -274,6 +274,22 @@ template bool Bun__deepMatch<false>(
 
 extern "C" bool Expect_readFlagsAndProcessPromise(JSC::EncodedJSValue instanceValue, JSC::JSGlobalObject* globalObject, ExpectFlags* flags, JSC::EncodedJSValue* value, AsymmetricMatcherConstructorType* constructorType);
 
+// expect.stringMatching(string): Jest compiles the sample with `new RegExp(sample)` when the
+// matcher is created, so an invalid pattern throws there rather than at match time.
+extern "C" bool Bun__RegExp__validatePattern(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedPattern)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    String pattern = JSValue::decode(encodedPattern).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+    RegExp* regExp = RegExp::create(vm, pattern, {});
+    if (!regExp->isValid()) {
+        throwSyntaxError(globalObject, scope, String(regExp->errorMessage()));
+        return false;
+    }
+    return true;
+}
+
 extern "C" int8_t AsymmetricMatcherConstructorType__fromJS(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
 {
     JSValue value = JSValue::decode(encodedValue);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -485,13 +485,20 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
 
         if (otherProp.isString()) {
             if (expectedTestValue.isString()) {
+                // Jest compiles a string sample with `new RegExp(sample)`; it is a
+                // pattern, not a literal substring (that is expect.stringContaining).
                 String otherString = otherProp.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
 
-                String substring = expectedTestValue.toWTFString(globalObject);
+                String pattern = expectedTestValue.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
 
-                if (otherString.find(substring) != WTF::notFound) {
+                RegExp* regExp = RegExp::create(globalObject->vm(), pattern, {});
+                if (!regExp->isValid()) {
+                    throwSyntaxError(globalObject, throwScope, String(regExp->errorMessage()));
+                    return AsymmetricMatcherResult::FAIL;
+                }
+                if (!!regExp->match(globalObject, otherString, 0)) {
                     return AsymmetricMatcherResult::PASS;
                 }
             } else if (auto* regex = dynamicDowncast<RegExpObject>(expectedTestValue)) {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -76,6 +76,7 @@ unsafe extern "C" {
         global_object: *const JSGlobalObject,
         value: JSValue,
     ) -> i8;
+    fn Bun__RegExp__validatePattern(global_object: *const JSGlobalObject, pattern: JSValue) -> bool;
 }
 
 impl AsymmetricMatcherConstructorType {
@@ -2321,6 +2322,18 @@ impl ExpectStringMatching {
         }
 
         let test_value = args[0];
+
+        if test_value.is_string() {
+            // Jest compiles a string sample with `new RegExp(sample)` up front, so an invalid
+            // pattern fails here rather than only when a string is matched against it.
+            bun_jsc::validation_scope!(scope, global_this);
+            // SAFETY: FFI call with a valid &JSGlobalObject; JSValue is Copy/repr(transparent)
+            let valid = unsafe { Bun__RegExp__validatePattern(global_this, test_value) };
+            scope.assert_exception_presence_matches(!valid);
+            if !valid {
+                return Err(JsError::Thrown);
+            }
+        }
 
         let string_matching_js_value = ExpectStringMatching { flags: Cell::new(Flags::default()) }.to_js(global_this);
         expect_string_matching_js::test_value_set_cached(string_matching_js_value, global_this, test_value);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2316,7 +2316,7 @@ impl ExpectStringMatching {
         if args.is_empty() || (!args[0].is_string() && !args[0].is_reg_exp()) {
             return Err(crate::throw_pretty_static!(
                 global_this,
-                "<d>expect.<r>stringContaining<d>(<r>string<d>)<r>\n\nExpected a string or regular expression\n",
+                "<d>expect.<r>stringMatching<d>(<r>string | regexp<d>)<r>\n\nExpected a string or regular expression\n",
             ));
         }
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -5035,3 +5035,13 @@ function tmpFile(exists) {
   }
   return tmpFile;
 }
+
+test("expect.stringMatching rejects an invalid string pattern when it is created", () => {
+  // Jest compiles the sample with `new RegExp(sample)` at construction time.
+  expect(() => expect.stringMatching("(")).toThrow(SyntaxError);
+  expect(() => expect.stringMatching("[a")).toThrow(SyntaxError);
+  expect(() => expect.stringMatching("a{2,1}")).toThrow(SyntaxError);
+  // a valid string is still a pattern
+  expect("hello world").toEqual(expect.stringMatching("^hello"));
+  expect({ a: 1 }).toEqual({ a: expect.not.stringMatching("^x") });
+});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3495,6 +3495,14 @@ describe("expect()", () => {
       expect({ a: "hello derived String" }).not.toMatchObject({ a: expect.stringContaining(new DString("rivd")) });
       expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching("wor") });
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching("word") });
+      // a string sample is a pattern, as in Jest (`new RegExp(sample)`)
+      expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching("^hel+o w.r") });
+      expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching("w[a-z]+d$") });
+      expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching("^world") });
+      expect("hello world").toEqual(expect.stringMatching("o w"));
+      expect("hello world").toEqual(expect.stringMatching("^h.*d$"));
+      expect("hello world").not.toEqual(expect.stringMatching("^d"));
+      expect(() => expect("x").toEqual(expect.stringMatching("("))).toThrow(SyntaxError);
       expect({ a: "hello world" }).toMatchObject({ a: "hello world" });
       expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching(/wor/) });
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching(/word/) });


### PR DESCRIPTION
Jest documents `expect.stringMatching(string | regexp)` as matching a string
"that matches the expected string or regular expression" and implements the
string form as `new RegExp(sample)`. Bun compared the string as a literal
substring, which is `expect.stringContaining`'s job. Anchors, classes and
quantifiers in the sample therefore never matched.

Repro:

    expect("hello world").toEqual(expect.stringMatching("^h.*d$"));
    // Jest: passes    Bun 1.4.0: fails

The string sample is now compiled with `RegExp::create` (no flags, as Jest's
`new RegExp(sample)`) and matched from offset 0; an invalid pattern throws a
SyntaxError, as `new RegExp` would. The matcher's own usage error also named
the wrong matcher (`stringContaining`) and now reads `stringMatching(string |
regexp)`.
