### PR TITLE
bun:test: toMatch and expect.stringMatching ignore a RegExp's lastIndex

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -495,9 +495,11 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                     return AsymmetricMatcherResult::PASS;
                 }
             } else if (auto* regex = dynamicDowncast<RegExpObject>(expectedTestValue)) {
-                JSString* otherString = otherProp.toString(globalObject);
+                String otherString = otherProp.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
-                bool matched = !!regex->match(globalObject, otherString);
+                // Jest tests the pattern alone; a global or sticky RegExp's lastIndex
+                // is neither read nor advanced.
+                bool matched = !!regex->regExp()->match(globalObject, otherString, 0);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                 if (matched) {
                     return AsymmetricMatcherResult::PASS;
@@ -4801,7 +4803,13 @@ JSC::JSString* JSC__JSValue__toJSStringView(JSC::EncodedJSValue JSValue0, JSC::J
     }
     JSC::RegExpObject* regexObject = dynamicDowncast<JSC::RegExpObject>(regex);
 
-    return !!regexObject->match(global, JSC::asString(str));
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    WTF::String haystack = str.toWTFString(global);
+    RETURN_IF_EXCEPTION(scope, false);
+    // Jest's toMatch tests the pattern alone; a global or sticky RegExp's
+    // lastIndex is neither read nor advanced.
+    return !!regexObject->regExp()->match(global, haystack, 0);
 }
 
 bool JSC__JSValue__stringIncludes(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue other)

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3505,6 +3505,15 @@ describe("expect()", () => {
       expect(sticky.lastIndex).toBe(9);
       expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching(sticky) });
       expect(sticky.lastIndex).toBe(9);
+      // a sticky RegExp is matched from index 0, as Jest's `new RegExp(regex)` copy is, whatever lastIndex says
+      const anchored = /wor/y;
+      anchored.lastIndex = 6;
+      expect("hello world").not.toMatch(anchored);
+      expect("world").toMatch(anchored);
+      expect(anchored.lastIndex).toBe(6);
+      expect({ a: "world" }).toMatchObject({ a: expect.stringMatching(anchored) });
+      expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching(anchored) });
+      expect(anchored.lastIndex).toBe(6);
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching(/word/) });
       expect({ a: expect.stringMatching("wor") }).toMatchObject({ a: "hello world" });
       expect({ a: expect.stringMatching("word") }).not.toMatchObject({ a: "hello world" });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3497,6 +3497,14 @@ describe("expect()", () => {
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching("word") });
       expect({ a: "hello world" }).toMatchObject({ a: "hello world" });
       expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching(/wor/) });
+      // a global RegExp matches regardless of lastIndex and does not advance it
+      const sticky = /wor/g;
+      sticky.lastIndex = 9;
+      expect("hello world").toMatch(sticky);
+      expect("hello world").toMatch(sticky);
+      expect(sticky.lastIndex).toBe(9);
+      expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching(sticky) });
+      expect(sticky.lastIndex).toBe(9);
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching(/word/) });
       expect({ a: expect.stringMatching("wor") }).toMatchObject({ a: "hello world" });
       expect({ a: expect.stringMatching("word") }).not.toMatchObject({ a: "hello world" });


### PR DESCRIPTION
`expect(str).toMatch(regexp)` and `expect.stringMatching(regexp)` called
`RegExpObject::match`, which follows `RegExp.prototype.exec` semantics: for a
global or sticky RegExp it starts at `lastIndex` and writes the new position
back. Jest matches the pattern alone, so a shared `/x/g` used across several
assertions passes in Jest and alternates pass/fail in Bun, and the assertion
mutates the caller's RegExp.

Repro:

    const re = /wor/g;
    expect("hello world").toMatch(re);
    expect("hello world").toMatch(re); // Bun 1.4.0: fails (lastIndex is 9)

Both call sites now match the underlying `RegExp` from offset 0 and leave
`lastIndex` untouched.
