### PR TITLE
Error.prepareStackTrace default accepts any object, like Error.captureStackTrace

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -686,10 +686,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    auto errorObject = dynamicDowncast<JSC::ErrorInstance>(callFrame->argument(0));
+    // Error.captureStackTrace accepts any object, so the default formatter
+    // must too: user code commonly wraps the original prepareStackTrace and
+    // forwards whatever it was given (source-map-support, jest, depd).
+    auto* errorObject = callFrame->argument(0).getObject();
     auto callSites = dynamicDowncast<JSC::JSArray>(callFrame->argument(1));
     if (!errorObject) {
-        throwTypeError(lexicalGlobalObject, scope, "First argument must be an Error object"_s);
+        throwTypeError(lexicalGlobalObject, scope, "First argument must be an object"_s);
         return {};
     }
     if (!callSites) {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1249,3 +1249,19 @@ test("default Error.prepareStackTrace formats a non-Error object", () => {
     Error.prepareStackTrace = original;
   }
 });
+
+test("captureStackTrace with a delegating prepareStackTrace and a caller not on the stack", () => {
+  // Repro from https://github.com/oven-sh/bun/issues/41151: `this.constructor` is Error, which is
+  // not on the stack, so every frame is elided and the stack is just the header, as in Node.
+  const original = Error.prepareStackTrace;
+  Error.prepareStackTrace = (err, callSites) => original(err, callSites);
+  try {
+    function CustomError() {
+      Error.captureStackTrace(this, this.constructor);
+    }
+    CustomError.prototype = new Error();
+    expect(new CustomError().stack).toBe("Error");
+  } finally {
+    Error.prepareStackTrace = original;
+  }
+});

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1241,6 +1241,10 @@ test("default Error.prepareStackTrace formats a non-Error object", () => {
     expect(typeof bare.stack).toBe("string");
 
     expect(() => Error.captureStackTrace(1)).toThrow(TypeError);
+    // The default formatter itself: any object is accepted, primitives are still rejected.
+    expect(typeof original({ message: "plain" }, [])).toBe("string");
+    expect(() => original(1, [])).toThrow(TypeError);
+    expect(() => original(null, [])).toThrow(TypeError);
   } finally {
     Error.prepareStackTrace = original;
   }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1223,3 +1223,25 @@ test.concurrent.each([[{}], [{ BUN_JSC_useSourceProviderCache: "0" }]])(
     expect(exitCode).toBe(0);
   },
 );
+
+test("default Error.prepareStackTrace formats a non-Error object", () => {
+  // The original prepareStackTrace is forwarded whatever captureStackTrace was
+  // given; Node's default formatter accepts any object, not only Errors.
+  const original = Error.prepareStackTrace;
+  Error.prepareStackTrace = (err, callSites) => original(err, callSites);
+  try {
+    const target = { message: "not an error" };
+    expect(() => Error.captureStackTrace(target)).not.toThrow();
+    expect(typeof target.stack).toBe("string");
+    expect(target.stack).toStartWith("Error: not an error");
+    expect(target.stack).toMatch(/\n    at /);
+
+    const bare = Object.create(null);
+    expect(() => Error.captureStackTrace(bare)).not.toThrow();
+    expect(typeof bare.stack).toBe("string");
+
+    expect(() => Error.captureStackTrace(1)).toThrow(TypeError);
+  } finally {
+    Error.prepareStackTrace = original;
+  }
+});


### PR DESCRIPTION
Error.captureStackTrace(obj) accepts any object, and the default value of
Error.prepareStackTrace is exposed as a callable function, so code that wraps
it and forwards its arguments (source-map-support, jest, depd) ends up calling
the default formatter with a plain object. Bun rejected that with
"TypeError: First argument must be an Error object", while Node formats the
object (its stack is "Error: <message>" plus the frames).

Repro on bun 1.4.0:

  const orig = Error.prepareStackTrace;
  Error.prepareStackTrace = (e, s) => orig(e, s);
  Error.captureStackTrace({});
  // TypeError: First argument must be an Error object

Node 24 prints a stack. This surfaced in a large Jest suite running under bun
test: React Testing Library's cleanup captures a stack on a plain object while
a source-map wrapper is installed, failing 150 to 270 of 2,000 jsdom files
depending on which module installed the wrapper first.

The default formatter now takes any object (only non-objects throw, as V8's
captureStackTrace does) and formats it through the same default path.


Fixes #41151
