### PR TITLE
bun:test: spyOn supports accessor properties and getter-backed methods

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -107,6 +107,12 @@ declare module "bun:test" {
       obj: T,
       methodOrPropertyValue: K,
     ): Mock<Extract<T[K], (...args: any[]) => any>>;
+    function spyOn<T extends object, K extends keyof T>(obj: T, propertyName: K, accessType: "get"): Mock<() => T[K]>;
+    function spyOn<T extends object, K extends keyof T>(
+      obj: T,
+      propertyName: K,
+      accessType: "set",
+    ): Mock<(value: T[K]) => void>;
 
     /**
      * Constructs the type of a mock function, such as the return type of `jest.fn()`.
@@ -161,6 +167,19 @@ declare module "bun:test" {
     obj: T,
     methodOrPropertyValue: K,
   ): Mock<Extract<T[K], (...args: any[]) => any>>;
+  /**
+   * Create a spy on one side of an accessor property (`get` or `set`), like Jest.
+   */
+  export function spyOn<T extends object, K extends keyof T>(
+    obj: T,
+    propertyName: K,
+    accessType: "get",
+  ): Mock<() => T[K]>;
+  export function spyOn<T extends object, K extends keyof T>(
+    obj: T,
+    propertyName: K,
+    accessType: "set",
+  ): Mock<(value: T[K]) => void>;
 
   /**
    * Vitest-compatible mocking utilities, for migrating tests from Vitest to Bun.

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -271,6 +271,11 @@ public:
     unsigned spyAttributes = 0;
 
     static constexpr unsigned SpyAttributeESModuleNamespace = 1 << 30;
+    // spyOriginal holds the GetterSetter the spy replaced (or displaced with a data property).
+    static constexpr unsigned SpyAttributeRestoreAccessor = 1 << 29;
+    // The spied property lived on the prototype chain; restoring means removing the own copy.
+    static constexpr unsigned SpyAttributeDeleteOnRestore = 1 << 28;
+    static constexpr unsigned SpyAttributeFlagsMask = SpyAttributeESModuleNamespace | SpyAttributeRestoreAccessor | SpyAttributeDeleteOnRestore;
 
     JSString* jsName()
     {
@@ -382,6 +387,20 @@ public:
                 moduleNamespaceObject->overrideExportValue(globalObject, identifier, implValue);
                 RETURN_IF_EXCEPTION(scope, );
             }
+        } else if (attributes & SpyAttributeDeleteOnRestore) {
+            // The property came from the prototype chain; the own copy the spy installed goes away.
+            target->deleteProperty(globalObject, identifier);
+            RETURN_IF_EXCEPTION(scope, );
+        } else if (attributes & SpyAttributeRestoreAccessor) {
+            auto* getterSetter = implValue.isCell() ? dynamicDowncast<GetterSetter>(implValue.asCell()) : nullptr;
+            if (!getterSetter)
+                return;
+            // A getter-backed method spy replaced the accessor with a data property; a plain
+            // putDirectAccessor over it would not swap the slot kind.
+            target->deleteProperty(globalObject, identifier);
+            RETURN_IF_EXCEPTION(scope, );
+            target->putDirectAccessor(globalObject, identifier, getterSetter, (attributes & ~SpyAttributeFlagsMask) | PropertyAttribute::Accessor);
+            RETURN_IF_EXCEPTION(scope, );
         } else if (auto index = parseIndex(identifier)) {
             // Use putDirectIndex for numeric property keys (e.g., spyOn(arr, 0))
             target->putDirectIndex(globalObject, *index, implValue, attributes, PutDirectIndexLikePutDirect);
@@ -1532,6 +1551,109 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
     bool hasValue = object->getPropertySlot(globalObject, propertyKey, slot);
     RETURN_IF_EXCEPTION(scope, {});
 
+    auto registerSpy = [&](JSMockFunction* mock) {
+        if (!globalObject->mockModule.activeSpies) {
+            ActiveSpySet* activeSpies = ActiveSpySet::create(vm, globalObject->mockModule.activeSpySetStructure.getInitializedOnMainThread(globalObject));
+            globalObject->mockModule.activeSpies.set(vm, globalObject, activeSpies);
+        }
+        uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeSpies.get())->add(vm, mock, mock);
+
+        if (!globalObject->mockModule.activeMocks) {
+            ActiveSpySet* activeMocks = ActiveSpySet::create(vm, globalObject->mockModule.activeSpySetStructure.getInitializedOnMainThread(globalObject));
+            globalObject->mockModule.activeMocks.set(vm, globalObject, activeMocks);
+        }
+        uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeMocks.get())->add(vm, mock, mock);
+    };
+
+    // spyOn(target, prop, "get" | "set"): wrap one side of an accessor, as Jest does.
+    JSValue accessTypeValue = callframe->argument(2);
+    if (!accessTypeValue.isUndefined()) {
+        String accessType = accessTypeValue.isString() ? accessTypeValue.toWTFString(globalObject) : String();
+        RETURN_IF_EXCEPTION(scope, {});
+        bool isGetter = accessType == "get"_s;
+        if (!isGetter && accessType != "set"_s) {
+            throwVMError(globalObject, scope, "spyOn(target, prop, accessType) expects accessType to be \"get\" or \"set\""_s);
+            return {};
+        }
+        String keyName = propertyKey.isSymbol() ? String(propertyKey.uid()) : String(propertyKey.publicName());
+        if (!hasValue) {
+            throwVMError(globalObject, scope, makeString(keyName, " property does not exist"_s));
+            return {};
+        }
+        if (!slot.isAccessor()) {
+            throwVMError(globalObject, scope, makeString("Property `"_s, keyName, "` does not have access type "_s, accessType));
+            return {};
+        }
+        GetterSetter* getterSetter = slot.getterSetter();
+        if (isGetter ? getterSetter->isGetterNull() : getterSetter->isSetterNull()) {
+            throwVMError(globalObject, scope, makeString("Property `"_s, keyName, "` does not have access type "_s, accessType));
+            return {};
+        }
+        JSObject* original = isGetter ? getterSetter->getter() : getterSetter->setter();
+        if (auto* existing = dynamicDowncast<JSMockFunction>(original)) {
+            return JSValue::encode(existing);
+        }
+
+        auto* mock = JSMockFunction::create(vm, globalObject, globalObject->mockModule.mockFunctionStructure.getInitializedOnMainThread(globalObject), CallbackKind::Call);
+        mock->copyNameAndLength(vm, globalObject, original);
+        RETURN_IF_EXCEPTION(scope, {});
+        pushImpl(mock, globalObject, JSMockImplementation::Kind::Call, original);
+
+        bool isOwn = slot.slotBase() == object;
+        unsigned attributes = slot.attributes() & ~JSMockFunction::SpyAttributeFlagsMask;
+        GetterSetter* replacement = GetterSetter::create(vm, globalObject, isGetter ? mock : getterSetter->getter(), isGetter ? getterSetter->setter() : mock);
+        if (isOwn) {
+            object->deleteProperty(globalObject, propertyKey);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+        object->putDirectAccessor(globalObject, propertyKey, replacement, attributes | PropertyAttribute::Accessor);
+        RETURN_IF_EXCEPTION(scope, {});
+
+        mock->spyTarget = JSC::Weak<JSObject>(object, &weakValueHandleOwner(), nullptr);
+        mock->spyIdentifier = propertyKey.isSymbol() ? Identifier::fromUid(vm, propertyKey.uid()) : Identifier::fromString(vm, propertyKey.publicName());
+        mock->spyAttributes = attributes | (isOwn ? JSMockFunction::SpyAttributeRestoreAccessor : JSMockFunction::SpyAttributeDeleteOnRestore);
+        mock->spyOriginal.set(vm, mock, getterSetter);
+        registerSpy(mock);
+        return JSValue::encode(mock);
+    }
+
+    // A getter that yields a function (jsdom's named-property interfaces, lazy re-exports):
+    // Jest spies on the function the getter returns and serves the mock in its place.
+    if (hasValue && slot.isAccessor()) {
+        JSValue value = object->get(globalObject, propertyKey);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (auto* existing = dynamicDowncast<JSMockFunction>(value)) {
+            return JSValue::encode(existing);
+        }
+        if (!value.isCallable()) {
+            String keyName = propertyKey.isSymbol() ? String(propertyKey.uid()) : String(propertyKey.publicName());
+            String typeName = jsTypeStringForValue(globalObject, value)->value(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            throwVMError(globalObject, scope, makeString("Cannot spy on the `"_s, keyName, "` property because it is not a function; "_s, typeName, " given instead"_s));
+            return {};
+        }
+
+        auto* mock = JSMockFunction::create(vm, globalObject, globalObject->mockModule.mockFunctionStructure.getInitializedOnMainThread(globalObject), CallbackKind::Call);
+        mock->copyNameAndLength(vm, globalObject, value);
+        RETURN_IF_EXCEPTION(scope, {});
+        pushImpl(mock, globalObject, JSMockImplementation::Kind::Call, value);
+
+        bool isOwn = slot.slotBase() == object;
+        unsigned attributes = slot.attributes() & ~(JSMockFunction::SpyAttributeFlagsMask | static_cast<unsigned>(PropertyAttribute::Accessor));
+        if (isOwn) {
+            object->deleteProperty(globalObject, propertyKey);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+        object->putDirect(vm, propertyKey, mock, attributes);
+
+        mock->spyTarget = JSC::Weak<JSObject>(object, &weakValueHandleOwner(), nullptr);
+        mock->spyIdentifier = propertyKey.isSymbol() ? Identifier::fromUid(vm, propertyKey.uid()) : Identifier::fromString(vm, propertyKey.publicName());
+        mock->spyAttributes = attributes | (isOwn ? JSMockFunction::SpyAttributeRestoreAccessor : JSMockFunction::SpyAttributeDeleteOnRestore);
+        mock->spyOriginal.set(vm, mock, slot.getterSetter());
+        registerSpy(mock);
+        return JSValue::encode(mock);
+    }
+
     // easymode: regular property or missing property
     if (!hasValue || slot.isValue()) {
         JSValue value = jsUndefined();
@@ -1606,30 +1728,12 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
         }
 
         mock->spyOriginal.set(vm, mock, value);
-
-        {
-            if (!globalObject->mockModule.activeSpies) {
-                ActiveSpySet* activeSpies = ActiveSpySet::create(vm, globalObject->mockModule.activeSpySetStructure.getInitializedOnMainThread(globalObject));
-                globalObject->mockModule.activeSpies.set(vm, globalObject, activeSpies);
-            }
-            ActiveSpySet* activeSpies = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeSpies.get());
-            activeSpies->add(vm, mock, mock);
-        }
-
-        {
-            if (!globalObject->mockModule.activeMocks) {
-                ActiveSpySet* activeMocks = ActiveSpySet::create(vm, globalObject->mockModule.activeSpySetStructure.getInitializedOnMainThread(globalObject));
-                globalObject->mockModule.activeMocks.set(vm, globalObject, activeMocks);
-            }
-            ActiveSpySet* activeMocks = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeMocks.get());
-            activeMocks->add(vm, mock, mock);
-        }
-
+        registerSpy(mock);
         return JSValue::encode(mock);
     }
 
-    // hardmode: accessor property
-    throwVMError(globalObject, scope, "spyOn(target, prop) does not support accessor properties yet"_s);
+    // a native (custom) accessor on a built-in
+    throwVMError(globalObject, scope, "spyOn(target, prop) does not support native accessor properties"_s);
     return {};
 }
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -275,7 +275,11 @@ public:
     static constexpr unsigned SpyAttributeRestoreAccessor = 1 << 29;
     // The spied property lived on the prototype chain; restoring means removing the own copy.
     static constexpr unsigned SpyAttributeDeleteOnRestore = 1 << 28;
-    static constexpr unsigned SpyAttributeFlagsMask = SpyAttributeESModuleNamespace | SpyAttributeRestoreAccessor | SpyAttributeDeleteOnRestore;
+    // spyOn(obj, prop, "get" | "set"): the spy owns one side of the accessor; the other side is
+    // whatever is installed at restore time, possibly another spy.
+    static constexpr unsigned SpyAttributeAccessorGetter = 1 << 27;
+    static constexpr unsigned SpyAttributeAccessorSetter = 1 << 26;
+    static constexpr unsigned SpyAttributeFlagsMask = SpyAttributeESModuleNamespace | SpyAttributeRestoreAccessor | SpyAttributeDeleteOnRestore | SpyAttributeAccessorGetter | SpyAttributeAccessorSetter;
 
     JSString* jsName()
     {
@@ -387,6 +391,40 @@ public:
                 moduleNamespaceObject->overrideExportValue(globalObject, identifier, implValue);
                 RETURN_IF_EXCEPTION(scope, );
             }
+        } else if (attributes & (SpyAttributeAccessorGetter | SpyAttributeAccessorSetter)) {
+            auto* original = implValue.isCell() ? dynamicDowncast<GetterSetter>(implValue.asCell()) : nullptr;
+            if (!original)
+                return;
+            bool isGetterSide = attributes & SpyAttributeAccessorGetter;
+            // Put back only this spy's side. The other side is read from the accessor installed
+            // now, not from the saved descriptor: a spy installed later on the other side would
+            // otherwise be removed here and then resurrected by its own restore.
+            JSObject* getter = original->getter();
+            JSObject* setter = original->setter();
+            JSC::PropertySlot currentSlot(target, JSC::PropertySlot::InternalMethodType::GetOwnProperty);
+            bool hasOwn = target->getOwnPropertySlot(target, globalObject, identifier, currentSlot);
+            RETURN_IF_EXCEPTION(scope, );
+            if (hasOwn && currentSlot.isAccessor()) {
+                GetterSetter* current = currentSlot.getterSetter();
+                if (isGetterSide)
+                    setter = current->setter();
+                else
+                    getter = current->getter();
+            }
+            JSObject* otherSide = isGetterSide ? setter : getter;
+            auto* otherSpy = otherSide ? dynamicDowncast<JSMockFunction>(otherSide) : nullptr;
+            target->deleteProperty(globalObject, identifier);
+            RETURN_IF_EXCEPTION(scope, );
+            if (attributes & SpyAttributeDeleteOnRestore) {
+                // The accessor came from the prototype chain. With no other spy left, dropping the
+                // own copy is the restore; otherwise the other spy takes over removing it.
+                if (!otherSpy)
+                    return;
+                otherSpy->spyAttributes = (otherSpy->spyAttributes & ~SpyAttributeRestoreAccessor) | SpyAttributeDeleteOnRestore;
+            }
+            auto* merged = GetterSetter::create(this->vm(), globalObject, getter, setter);
+            target->putDirectAccessor(globalObject, identifier, merged, (attributes & ~SpyAttributeFlagsMask) | PropertyAttribute::Accessor);
+            RETURN_IF_EXCEPTION(scope, );
         } else if (attributes & SpyAttributeDeleteOnRestore) {
             // The property came from the prototype chain; the own copy the spy installed goes away.
             target->deleteProperty(globalObject, identifier);
@@ -1611,7 +1649,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
 
         mock->spyTarget = JSC::Weak<JSObject>(object, &weakValueHandleOwner(), nullptr);
         mock->spyIdentifier = propertyKey.isSymbol() ? Identifier::fromUid(vm, propertyKey.uid()) : Identifier::fromString(vm, propertyKey.publicName());
-        mock->spyAttributes = attributes | (isOwn ? JSMockFunction::SpyAttributeRestoreAccessor : JSMockFunction::SpyAttributeDeleteOnRestore);
+        mock->spyAttributes = attributes | (isGetter ? JSMockFunction::SpyAttributeAccessorGetter : JSMockFunction::SpyAttributeAccessorSetter) | (isOwn ? JSMockFunction::SpyAttributeRestoreAccessor : JSMockFunction::SpyAttributeDeleteOnRestore);
         mock->spyOriginal.set(vm, mock, getterSetter);
         registerSpy(mock);
         return JSValue::encode(mock);

--- a/test/js/bun/test/spyon-accessor.test.ts
+++ b/test/js/bun/test/spyon-accessor.test.ts
@@ -216,10 +216,24 @@ describe("spyOn on accessor properties", () => {
           expect(Object.getOwnPropertyDescriptor(box, "size")).toBeDefined();
           if (order === "get-first") {
             getSpy.mockRestore();
+            // the getter is back, the setter spy is still installed on the own copy
+            const own = Object.getOwnPropertyDescriptor(box, "size")!;
+            expect(own.set).toBe(setSpy);
+            expect(box.size).toBe(10);
+            box.size = 3;
+            expect(setSpy).toHaveBeenCalledWith(3);
+            expect(box.size).toBe(3);
             setSpy.mockRestore();
           } else {
             setSpy.mockRestore();
+            // the setter is back, the getter spy is still installed on the own copy
+            const own = Object.getOwnPropertyDescriptor(box, "size")!;
+            expect(own.get).toBe(getSpy);
+            expect(box.size).toBe(1);
+            box.size = 4;
+            expect(getSpy).toHaveBeenCalled();
             getSpy.mockRestore();
+            expect(box.size).toBe(4);
           }
           expect(Object.getOwnPropertyDescriptor(box, "size")).toBeUndefined();
           box.size = 5;

--- a/test/js/bun/test/spyon-accessor.test.ts
+++ b/test/js/bun/test/spyon-accessor.test.ts
@@ -197,32 +197,35 @@ describe("spyOn on accessor properties", () => {
       expect(obj.value).toBe(3);
     });
 
-    test("both sides of a prototype accessor restore by removing the own copy", () => {
-      class Box {
-        #size = 10;
-        get size() {
-          return this.#size;
-        }
-        set size(v: number) {
-          this.#size = v;
-        }
-      }
-      const box = new Box();
-      for (const order of ["get-first", "set-first"] as const) {
-        const getSpy = spyOn(box, "size", "get").mockReturnValue(1);
-        const setSpy = spyOn(box, "size", "set");
-        expect(Object.getOwnPropertyDescriptor(box, "size")).toBeDefined();
-        if (order === "get-first") {
-          getSpy.mockRestore();
-          setSpy.mockRestore();
-        } else {
-          setSpy.mockRestore();
-          getSpy.mockRestore();
-        }
-        expect(Object.getOwnPropertyDescriptor(box, "size")).toBeUndefined();
-        box.size = 5;
-        expect(box.size).toBe(5);
-      }
-    });
+    describe.each(["get-first", "set-first"] as const)(
+      "both sides of a prototype accessor restore by removing the own copy (%s)",
+      order => {
+        test("the own copy is gone after both restores", () => {
+          class Box {
+            #size = 10;
+            get size() {
+              return this.#size;
+            }
+            set size(v: number) {
+              this.#size = v;
+            }
+          }
+          const box = new Box();
+          const getSpy = spyOn(box, "size", "get").mockReturnValue(1);
+          const setSpy = spyOn(box, "size", "set");
+          expect(Object.getOwnPropertyDescriptor(box, "size")).toBeDefined();
+          if (order === "get-first") {
+            getSpy.mockRestore();
+            setSpy.mockRestore();
+          } else {
+            setSpy.mockRestore();
+            getSpy.mockRestore();
+          }
+          expect(Object.getOwnPropertyDescriptor(box, "size")).toBeUndefined();
+          box.size = 5;
+          expect(box.size).toBe(5);
+        });
+      },
+    );
   });
 });

--- a/test/js/bun/test/spyon-accessor.test.ts
+++ b/test/js/bun/test/spyon-accessor.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, jest, mock, spyOn, test } from "bun:test";
+
+describe("spyOn on accessor properties", () => {
+  test('spyOn(obj, prop, "get") wraps the getter and calls through by default', () => {
+    let reads = 0;
+    const obj = {
+      get value() {
+        reads++;
+        return 41 + 1;
+      },
+    };
+    const originalGet = Object.getOwnPropertyDescriptor(obj, "value")!.get;
+
+    const spy = spyOn(obj, "value", "get");
+    expect(obj.value).toBe(42);
+    expect(reads).toBe(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockReturnValue(7);
+    expect(obj.value).toBe(7);
+    expect(reads).toBe(1);
+
+    // spying again hands back the same mock, as Jest does
+    expect(spyOn(obj, "value", "get")).toBe(spy);
+
+    spy.mockRestore();
+    expect(Object.getOwnPropertyDescriptor(obj, "value")!.get).toBe(originalGet);
+    expect(obj.value).toBe(42);
+    expect(reads).toBe(2);
+  });
+
+  test('spyOn(obj, prop, "set") wraps the setter and keeps the getter', () => {
+    const stored: unknown[] = [];
+    const obj = {
+      get value() {
+        return stored.at(-1);
+      },
+      set value(v: unknown) {
+        stored.push(v);
+      },
+    };
+    const spy = spyOn(obj, "value", "set");
+    obj.value = 1;
+    expect(spy).toHaveBeenCalledWith(1);
+    expect(obj.value).toBe(1);
+    spy.mockImplementation(() => {});
+    obj.value = 2;
+    expect(stored).toEqual([1]);
+    spy.mockRestore();
+    obj.value = 3;
+    expect(stored).toEqual([1, 3]);
+  });
+
+  test("a prototype accessor spied through an instance is restored by removing the own copy", () => {
+    class Box {
+      get size() {
+        return 10;
+      }
+    }
+    const box = new Box();
+    const spy = spyOn(box, "size", "get").mockReturnValue(99);
+    expect(box.size).toBe(99);
+    expect(Object.hasOwn(box, "size")).toBe(true);
+    expect(new Box().size).toBe(10);
+    spy.mockRestore();
+    expect(Object.hasOwn(box, "size")).toBe(false);
+    expect(box.size).toBe(10);
+  });
+
+  test("spyOn(obj, method) accepts a getter that returns a function", () => {
+    // jsdom-style: the method lives behind a getter on the prototype
+    const calls: unknown[] = [];
+    function focus(this: unknown, ...args: unknown[]) {
+      calls.push([this, ...args]);
+      return "focused";
+    }
+    const proto = {};
+    Object.defineProperty(proto, "focus", { get: () => focus, configurable: true, enumerable: false });
+    const el = Object.create(proto);
+
+    const spy = spyOn(el, "focus");
+    expect(el.focus).toBe(spy);
+    expect(el.focus("a")).toBe("focused");
+    expect(calls).toEqual([[el, "a"]]);
+    expect(spy).toHaveBeenCalledWith("a");
+
+    spy.mockReturnValue("mocked");
+    expect(el.focus()).toBe("mocked");
+
+    spy.mockRestore();
+    expect(Object.hasOwn(el, "focus")).toBe(false);
+    expect(el.focus).toBe(focus);
+    expect(Object.getOwnPropertyDescriptor(proto, "focus")!.get).toBeDefined();
+  });
+
+  test("an own getter-backed method gets its accessor back on restore", () => {
+    const original = () => "real";
+    const obj = {};
+    Object.defineProperty(obj, "run", { get: () => original, configurable: true });
+    const spy = spyOn(obj, "run").mockReturnValue("fake");
+    expect((obj as any).run()).toBe("fake");
+    expect(Object.getOwnPropertyDescriptor(obj, "run")!.value).toBe(spy);
+    spy.mockRestore();
+    const descriptor = Object.getOwnPropertyDescriptor(obj, "run")!;
+    expect(typeof descriptor.get).toBe("function");
+    expect((obj as any).run).toBe(original);
+  });
+
+  test("jest.restoreAllMocks restores accessor spies", () => {
+    const obj = {
+      get value() {
+        return 1;
+      },
+    };
+    jest.spyOn(obj, "value", "get").mockReturnValue(2);
+    expect(obj.value).toBe(2);
+    jest.restoreAllMocks();
+    expect(obj.value).toBe(1);
+  });
+
+  test("errors match Jest", () => {
+    const data = { value: 1 };
+    expect(() => spyOn(data, "value", "get")).toThrow("does not have access type get");
+    expect(() => spyOn(data, "missing" as any, "get")).toThrow("property does not exist");
+    const getterOnly = {
+      get value() {
+        return 1;
+      },
+    };
+    expect(() => spyOn(getterOnly, "value", "set")).toThrow("does not have access type set");
+    expect(() => spyOn(getterOnly, "value", "peek" as any)).toThrow('"get" or "set"');
+    const notAFunction = {
+      get value() {
+        return 1;
+      },
+    };
+    expect(() => spyOn(notAFunction, "value")).toThrow(
+      "Cannot spy on the `value` property because it is not a function; number given instead",
+    );
+  });
+});

--- a/test/js/bun/test/spyon-accessor.test.ts
+++ b/test/js/bun/test/spyon-accessor.test.ts
@@ -138,4 +138,91 @@ describe("spyOn on accessor properties", () => {
       "Cannot spy on the `value` property because it is not a function; number given instead",
     );
   });
+
+  describe("restoring both sides of one accessor", () => {
+    function makeObject() {
+      const stored: unknown[] = [];
+      const obj = {
+        get value() {
+          return stored.at(-1);
+        },
+        set value(v: unknown) {
+          stored.push(v);
+        },
+      };
+      const { get, set } = Object.getOwnPropertyDescriptor(obj, "value")!;
+      return { obj, stored, get, set };
+    }
+
+    function expectRestored(obj: object, get: unknown, set: unknown) {
+      const descriptor = Object.getOwnPropertyDescriptor(obj, "value")!;
+      expect(descriptor.get).toBe(get);
+      expect(descriptor.set).toBe(set);
+    }
+
+    test("getter spy restored first, then setter spy", () => {
+      const { obj, stored, get, set } = makeObject();
+      const getSpy = spyOn(obj, "value", "get").mockReturnValue("mocked");
+      const setSpy = spyOn(obj, "value", "set").mockImplementation(() => {});
+      getSpy.mockRestore();
+      obj.value = 1;
+      expect(stored).toEqual([]); // the setter spy still swallows writes
+      expect(setSpy).toHaveBeenCalledWith(1);
+      setSpy.mockRestore();
+      expectRestored(obj, get, set);
+      obj.value = 2;
+      expect(obj.value).toBe(2);
+    });
+
+    test("setter spy restored first, then getter spy", () => {
+      const { obj, stored, get, set } = makeObject();
+      const getSpy = spyOn(obj, "value", "get").mockReturnValue("mocked");
+      const setSpy = spyOn(obj, "value", "set").mockImplementation(() => {});
+      setSpy.mockRestore();
+      obj.value = 1;
+      expect(stored).toEqual([1]);
+      expect(obj.value).toBe("mocked"); // the getter spy is still in place
+      getSpy.mockRestore();
+      expectRestored(obj, get, set);
+      expect(obj.value).toBe(1);
+    });
+
+    test("jest.restoreAllMocks restores both sides", () => {
+      const { obj, get, set } = makeObject();
+      spyOn(obj, "value", "get").mockReturnValue("mocked");
+      spyOn(obj, "value", "set").mockImplementation(() => {});
+      jest.restoreAllMocks();
+      expectRestored(obj, get, set);
+      obj.value = 3;
+      expect(obj.value).toBe(3);
+    });
+
+    test("both sides of a prototype accessor restore by removing the own copy", () => {
+      class Box {
+        #size = 10;
+        get size() {
+          return this.#size;
+        }
+        set size(v: number) {
+          this.#size = v;
+        }
+      }
+      const box = new Box();
+      for (const order of ["get-first", "set-first"] as const) {
+        const getSpy = spyOn(box, "size", "get").mockReturnValue(1);
+        const setSpy = spyOn(box, "size", "set");
+        expect(Object.getOwnPropertyDescriptor(box, "size")).toBeDefined();
+        if (order === "get-first") {
+          getSpy.mockRestore();
+          setSpy.mockRestore();
+        } else {
+          setSpy.mockRestore();
+          getSpy.mockRestore();
+        }
+        expect(Object.getOwnPropertyDescriptor(box, "size")).toBeUndefined();
+        box.size = 5;
+        expect(box.size).toBe(5);
+      }
+    });
+  });
 });


### PR DESCRIPTION
`spyOn(target, prop)` threw "does not support accessor properties yet" for
any property defined with a getter or setter, own or inherited. Jest supports
two things here, and both come up constantly in DOM-heavy suites:

1. `spyOn(obj, prop, "get" | "set")` wraps one side of the accessor in a mock
   that calls through to the original by default; `mockRestore()` puts the
   original accessor back.
2. `spyOn(obj, method)` where `method` is a getter that returns a function
   (jsdom's named-property interfaces such as `HTMLElement.prototype.focus`
   under user-event, Babel re-exports, lazy loaders). Jest spies on the
   function the getter returns and serves the mock in its place.

Repro on bun 1.4.0:

  const obj = { get value() { return 1; } };
  spyOn(obj, "value", "get");
  // error: spyOn(target, prop) does not support accessor properties yet

Jest and Vitest both accept it. A large Jest suite running under bun test
had 196 files spying on accessors and needed a JS shim for every one.

Implementation: the accessor is read from the PropertySlot; for "get"/"set"
a new GetterSetter with the mock on the requested side is installed on the
target itself (Jest defines the spied property on the object, even when the
accessor came from the prototype). For a getter-backed method the mock is
installed as a data property. The original GetterSetter is kept in
`spyOriginal` and two new spy attribute bits record how to restore: put the
accessor back when it was own, delete the own copy when it came from the
prototype chain. Native (custom) accessors on built-ins are still rejected.
Types: `spyOn(obj, key, "get" | "set")` overloads in bun-types.
