### PR TITLE
bun:test: .resolves and .rejects return a Promise instead of blocking the thread

### DIFF
--- a/src/js/builtins/ExpectAsync.ts
+++ b/src/js/builtins/ExpectAsync.ts
@@ -15,14 +15,22 @@ export function createAsyncMatcher(expectFn, value, isRejects: boolean, isNot: b
     }
   }
 
-  async function run(name: string, args: unknown[]) {
+  // Jest prints a custom label as the first line of every failure, including the
+  // ones raised before the matcher itself runs.
+  function withLabel(message: string) {
+    return label === undefined ? message : `${label}\n\n${message}`;
+  }
+
+  async function run(name: string, args: unknown[], negated: boolean) {
     if (
       value === null ||
       (typeof value !== "object" && typeof value !== "function") ||
       typeof value.then !== "function"
     ) {
       throw new Error(
-        `expect(received).${kind}.${name}()\n\nMatcher error: received value must be a promise or a function returning a promise\nReceived: ${describe(value)}`,
+        withLabel(
+          `expect(received).${kind}.${name}()\n\nMatcher error: received value must be a promise or a function returning a promise\nReceived: ${describe(value)}`,
+        ),
       );
     }
     let settled;
@@ -35,12 +43,16 @@ export function createAsyncMatcher(expectFn, value, isRejects: boolean, isNot: b
     }
     if (fulfilled && isRejects) {
       throw new Error(
-        `expect(received).rejects.${name}()\n\nExpected promise that rejects\nReceived promise that resolved: ${describe(settled)}`,
+        withLabel(
+          `expect(received).rejects.${name}()\n\nExpected promise that rejects\nReceived promise that resolved: ${describe(settled)}`,
+        ),
       );
     }
     if (!fulfilled && !isRejects) {
       throw new Error(
-        `expect(received).resolves.${name}()\n\nExpected promise that resolves\nReceived promise that rejected: ${describe(settled)}`,
+        withLabel(
+          `expect(received).resolves.${name}()\n\nExpected promise that resolves\nReceived promise that rejected: ${describe(settled)}`,
+        ),
       );
     }
     let received = settled;
@@ -52,7 +64,7 @@ export function createAsyncMatcher(expectFn, value, isRejects: boolean, isNot: b
       };
     }
     let expectation = label === undefined ? expectFn(received) : expectFn(received, label);
-    if (isNot) expectation = expectation.not;
+    if (negated) expectation = expectation.not;
     const matcher = expectation[name];
     if (typeof matcher !== "function") {
       throw new TypeError(`expect(...).${kind}.${name} is not a function`);
@@ -70,8 +82,7 @@ export function createAsyncMatcher(expectFn, value, isRejects: boolean, isNot: b
         // Not thenable: `await expect(p).resolves` must not await the proxy itself.
         if (typeof name !== "string" || name === "then") return undefined;
         return function (...args) {
-          isNot = negated;
-          return run(name, args);
+          return run(name, args, negated);
         };
       },
     });

--- a/src/js/builtins/ExpectAsync.ts
+++ b/src/js/builtins/ExpectAsync.ts
@@ -1,0 +1,81 @@
+// `expect(promise).resolves` / `.rejects` return a Proxy whose matcher calls run once the
+// promise settles and return a Promise, as in Jest. Nothing here blocks the event loop.
+export function createAsyncMatcher(expectFn, value, isRejects: boolean, isNot: boolean, label) {
+  const kind = isRejects ? "rejects" : "resolves";
+
+  function isError(candidate) {
+    return candidate instanceof Error || Object.prototype.toString.$call(candidate) === "[object Error]";
+  }
+
+  function describe(received) {
+    try {
+      return Bun.inspect(received);
+    } catch {
+      return String(received);
+    }
+  }
+
+  async function run(name: string, args: unknown[]) {
+    if (
+      value === null ||
+      (typeof value !== "object" && typeof value !== "function") ||
+      typeof value.then !== "function"
+    ) {
+      throw new Error(
+        `expect(received).${kind}.${name}()\n\nMatcher error: received value must be a promise or a function returning a promise\nReceived: ${describe(value)}`,
+      );
+    }
+    let settled;
+    let fulfilled = true;
+    try {
+      settled = await value;
+    } catch (error) {
+      fulfilled = false;
+      settled = error;
+    }
+    if (fulfilled && isRejects) {
+      throw new Error(
+        `expect(received).rejects.${name}()\n\nExpected promise that rejects\nReceived promise that resolved: ${describe(settled)}`,
+      );
+    }
+    if (!fulfilled && !isRejects) {
+      throw new Error(
+        `expect(received).resolves.${name}()\n\nExpected promise that resolves\nReceived promise that rejected: ${describe(settled)}`,
+      );
+    }
+    let received = settled;
+    // Jest's toThrow accepts the settled value itself when it is an Error (the rejection
+    // reason, or a resolved Error); everything else must be a throwing function.
+    if ((name === "toThrow" || name === "toThrowError") && typeof settled !== "function" && isError(settled)) {
+      received = () => {
+        throw settled;
+      };
+    }
+    let expectation = label === undefined ? expectFn(received) : expectFn(received, label);
+    if (isNot) expectation = expectation.not;
+    const matcher = expectation[name];
+    if (typeof matcher !== "function") {
+      throw new TypeError(`expect(...).${kind}.${name} is not a function`);
+    }
+    return matcher.$apply(expectation, args);
+  }
+
+  function make(negated: boolean) {
+    return new Proxy(Object.create(null), {
+      get(_target, name) {
+        if (name === "not") return make(!negated);
+        if (name === "resolves" || name === "rejects") {
+          throw new TypeError(`Cannot chain .${name}() after .${kind}()`);
+        }
+        // Not thenable: `await expect(p).resolves` must not await the proxy itself.
+        if (typeof name !== "string" || name === "then") return undefined;
+        return function (...args) {
+          isNot = negated;
+          return run(name, args);
+        };
+      },
+    });
+  }
+
+  return make(isNot);
+}

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7170,3 +7170,22 @@ extern "C" void JSC__ArrayBuffer__asBunArrayBuffer(JSC::ArrayBuffer* self, Bun__
     out->resizable = self->isResizableOrGrowableShared();
     out->pinned = false;
 }
+
+// `expect(value).resolves` / `.rejects`: hands back the Proxy built by
+// src/js/builtins/ExpectAsync.ts, whose matcher calls return a Promise (Jest semantics).
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__Expect__createAsyncMatcher(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue expectFn, JSC::EncodedJSValue value, bool isRejects, bool isNot, JSC::EncodedJSValue label)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* factory = JSC::JSFunction::create(vm, globalObject, WebCore::expectAsyncCreateAsyncMatcherCodeGenerator(vm), globalObject);
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(JSC::JSValue::decode(expectFn));
+    arguments.append(JSC::JSValue::decode(value));
+    arguments.append(JSC::jsBoolean(isRejects));
+    arguments.append(JSC::jsBoolean(isNot));
+    arguments.append(JSC::JSValue::decode(label));
+    auto callData = JSC::getCallData(factory);
+    JSC::JSValue result = JSC::call(globalObject, factory, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSC::JSValue::encode(result);
+}

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -383,13 +383,29 @@ impl Expect {
         this_value: JSValue,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        match this.flags.get().promise() {
-            Promise::Resolves | Promise::None => this.update_flags(|f| f.set_promise(Promise::Resolves)),
-            Promise::Rejects => {
-                return Err(global_this.throw(format_args!("Cannot chain .resolves() after .rejects()")));
-            }
+        if matches!(this.flags.get().promise(), Promise::Rejects) {
+            return Err(global_this.throw(format_args!("Cannot chain .resolves() after .rejects()")));
         }
-        Ok(this_value)
+        this.async_matcher(this_value, global_this, false)
+    }
+
+    /// `.resolves` / `.rejects` return a Proxy whose matcher calls await the promise and
+    /// return a Promise (Jest semantics) instead of blocking the thread on the promise.
+    fn async_matcher(&self, this_value: JSValue, global_this: &JSGlobalObject, is_rejects: bool) -> JsResult<JSValue> {
+        let Some(value) = super::expect::js::captured_value_get_cached(this_value) else {
+            return Err(global_this.throw2(
+                "Internal error: the expect(value) was garbage collected but it should not have been!",
+                (),
+            ));
+        };
+        value.ensure_still_alive();
+        let expect_fn = bun_jsc::codegen::js::get_constructor::<Expect>(global_this);
+        let label = if self.custom_label.is_empty() {
+            JSValue::UNDEFINED
+        } else {
+            self.custom_label.clone().to_js(global_this)?
+        };
+        mock::Bun__Expect__createAsyncMatcher(global_this, expect_fn, value, is_rejects, self.flags.get().not(), label)
     }
 
     // see `get_not` — `host_fn(getter)` shim signature mismatch.
@@ -398,13 +414,10 @@ impl Expect {
         this_value: JSValue,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        match this.flags.get().promise() {
-            Promise::None | Promise::Rejects => this.update_flags(|f| f.set_promise(Promise::Rejects)),
-            Promise::Resolves => {
-                return Err(global_this.throw(format_args!("Cannot chain .rejects() after .resolves()")));
-            }
+        if matches!(this.flags.get().promise(), Promise::Resolves) {
+            return Err(global_this.throw(format_args!("Cannot chain .rejects() after .resolves()")));
         }
-        Ok(this_value)
+        this.async_matcher(this_value, global_this, true)
     }
 
     pub(crate) fn get_value(
@@ -2898,10 +2911,38 @@ pub mod mock {
     // into the pointer slot and dereferences a garbage `JSGlobalObject*`
     // (UBSan: null `VM&` bind in JSGlobalObject.h).
     unsafe extern "C" {
+        #[link_name = "Bun__Expect__createAsyncMatcher"]
+        fn Bun__Expect__createAsyncMatcher_raw(
+            global: *mut JSGlobalObject,
+            expect_fn: JSValue,
+            value: JSValue,
+            is_rejects: bool,
+            is_not: bool,
+            label: JSValue,
+        ) -> JSValue;
         #[link_name = "JSMockFunction__getCalls"]
         fn JSMockFunction__getCalls_raw(global: *mut JSGlobalObject, value: JSValue) -> JSValue;
         #[link_name = "JSMockFunction__getReturns"]
         fn JSMockFunction__getReturns_raw(global: *mut JSGlobalObject, value: JSValue) -> JSValue;
+    }
+
+    /// `bun.cpp.Bun__Expect__createAsyncMatcher` — the `.resolves`/`.rejects` Proxy from
+    /// src/js/builtins/ExpectAsync.ts. `zero_is_throw`: a `.zero` return means the throw scope is set.
+    #[allow(non_snake_case)]
+    #[track_caller]
+    #[inline]
+    pub(crate) fn Bun__Expect__createAsyncMatcher(
+        global: &JSGlobalObject,
+        expect_fn: JSValue,
+        value: JSValue,
+        is_rejects: bool,
+        is_not: bool,
+        label: JSValue,
+    ) -> JsResult<JSValue> {
+        // SAFETY: `global` is live; JSValue is repr(transparent) i64; bools are passed as C bool.
+        bun_jsc::call_zero_is_throw(global, || unsafe {
+            Bun__Expect__createAsyncMatcher_raw(global.as_ptr(), expect_fn, value, is_rejects, is_not, label)
+        })
     }
 
     /// `bun.cpp.JSMockFunction__getCalls` — returns the `mock.calls` array for a

--- a/test/js/bun/test/expect-resolves-rejects-async.test.ts
+++ b/test/js/bun/test/expect-resolves-rejects-async.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+describe(".resolves and .rejects return promises (Jest semantics)", () => {
+  test("a pending promise does not block the thread", async () => {
+    let reject!: (e: unknown) => void;
+    const pending = new Promise((_, r) => {
+      reject = r;
+    });
+    // Under the old blocking semantics this line never returned.
+    const assertion = expect(pending).rejects.toThrow("later");
+    expect(assertion).toBeInstanceOf(Promise);
+    reject(new Error("later"));
+    await assertion;
+  });
+
+  test("resolves with a value", async () => {
+    await expect(Promise.resolve(1)).resolves.toBe(1);
+    await expect(Promise.resolve({ a: 1 })).resolves.toEqual({ a: 1 });
+    await expect(Promise.resolve(1)).resolves.not.toBe(2);
+    await expect(Promise.resolve(2)).not.resolves.toBe(1);
+  });
+
+  test("rejects with a value", async () => {
+    await expect(Promise.reject(new Error("boom"))).rejects.toThrow("boom");
+    await expect(Promise.reject("x")).rejects.toBe("x");
+    await expect(Promise.reject("x")).rejects.not.toBe("y");
+  });
+
+  test("a thenable is accepted", async () => {
+    const thenable = { then: (resolve: (v: number) => void) => resolve(5) };
+    await expect(thenable).resolves.toBe(5);
+  });
+
+  test("mismatched settlement rejects with a matcher error", async () => {
+    await expect(expect(Promise.resolve(1)).rejects.toBe(1)).rejects.toThrow("Expected promise that rejects");
+    await expect(expect(Promise.reject(1)).resolves.toBe(1)).rejects.toThrow("Expected promise that resolves");
+  });
+
+  test("a non-promise rejects with Jest's matcher error", async () => {
+    await expect(expect(4).resolves.toBe(4)).rejects.toThrow("received value must be a promise");
+    await expect(expect(4).rejects.toBe(4)).rejects.toThrow("received value must be a promise");
+  });
+
+  test("a failing matcher rejects the returned promise", async () => {
+    await expect(expect(Promise.resolve(1)).resolves.toBe(2)).rejects.toThrow();
+  });
+
+  test("resolves cannot be chained with rejects", () => {
+    expect(() => (expect(Promise.resolve(1)).resolves as any).rejects).toThrow(
+      "Cannot chain .rejects() after .resolves()",
+    );
+    expect(() => (expect(Promise.resolve(1)).rejects as any).resolves).toThrow(
+      "Cannot chain .resolves() after .rejects()",
+    );
+  });
+
+  test("unknown matcher names reject", async () => {
+    await expect((expect(Promise.resolve(1)).resolves as any).toBeWhatever()).rejects.toThrow("is not a function");
+  });
+
+  test("custom labels are kept", async () => {
+    await expect(expect(Promise.resolve(1), "my label").resolves.toBe(2)).rejects.toThrow("my label");
+  });
+
+  test("unawaited chains do not block and settle later", async () => {
+    let resolve!: (v: number) => void;
+    const p = new Promise<number>(r => {
+      resolve = r;
+    });
+    const unawaited = expect(p).resolves.toBe(3);
+    let settled = false;
+    unawaited.then(() => {
+      settled = true;
+    });
+    expect(settled).toBe(false);
+    resolve(3);
+    await unawaited;
+    expect(settled).toBe(true);
+  });
+});

--- a/test/js/bun/test/expect-resolves-rejects-async.test.ts
+++ b/test/js/bun/test/expect-resolves-rejects-async.test.ts
@@ -62,6 +62,29 @@ describe(".resolves and .rejects return promises (Jest semantics)", () => {
     await expect(expect(Promise.resolve(1), "my label").resolves.toBe(2)).rejects.toThrow("my label");
   });
 
+  test("custom labels are kept on failures raised before the matcher runs", async () => {
+    await expect(expect(4, "my label").resolves.toBe(4)).rejects.toThrow(/^my label\n\nexpect\(received\)\.resolves/);
+    await expect(expect(Promise.resolve(1), "my label").rejects.toBe(1)).rejects.toThrow(
+      /^my label\n\nexpect\(received\)\.rejects/,
+    );
+    await expect(expect(Promise.reject(1), "my label").resolves.toBe(1)).rejects.toThrow(
+      /^my label\n\nexpect\(received\)\.resolves/,
+    );
+  });
+
+  test("negation is captured per matcher call", async () => {
+    let resolve!: (v: number) => void;
+    const p = new Promise<number>(r => {
+      resolve = r;
+    });
+    const matchers = expect(p).resolves;
+    const plain = matchers.toBe(1);
+    const negated = matchers.not.toBe(1);
+    resolve(1);
+    await plain;
+    await expect(negated).rejects.toThrow();
+  });
+
   test("unawaited chains do not block and settle later", async () => {
     let resolve!: (v: number) => void;
     const p = new Promise<number>(r => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4788,11 +4788,15 @@ describe("expect()", () => {
   test("pass to return undefined", () => {
     expect(expect().pass()).toBeUndefined();
   });
-  test("rejects to return undefined", () => {
-    expect(expect(Promise.reject("error")).rejects.toBe("error")).toBeUndefined();
+  test("rejects to return a promise", async () => {
+    const result = expect(Promise.reject("error")).rejects.toBe("error");
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toBeUndefined();
   });
-  test("resolves to return undefined", () => {
-    expect(expect(Promise.resolve(1)).resolves.toBe(1)).toBeUndefined();
+  test("resolves to return a promise", async () => {
+    const result = expect(Promise.resolve(1)).resolves.toBe(1);
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toBeUndefined();
   });
   test("toBe to return undefined", () => {
     expect(expect(true).toBe(true)).toBeUndefined();


### PR DESCRIPTION
`expect(promise).resolves.toBe(x)` blocked the JavaScript thread inside the
matcher (`vm.wait_for_promise`) until the promise settled. Jest returns a
Promise that the test awaits. The difference is observable whenever the
promise settles through code that has not run yet:

  const p = expect(pending).rejects.toThrow("later");
  resolveLater();   // never reached under bun 1.4.0: the line above hangs
  await p;

Because the whole event loop is spun inside the matcher, any test that sets
up the assertion before triggering the work deadlocks, and the same pattern
appears with `.resolves`, `.rejects`, `.not`, and custom labels. In a large
Jest suite running under bun test, 3,116 files use `.resolves`/`.rejects`
and the ordering shows up in dozens of them.

Implementation: `.resolves` and `.rejects` now hand back a Proxy built by a
JS builtin (src/js/builtins/ExpectAsync.ts). Reading any matcher name on it
returns a function that awaits the promise, checks the settlement matches
the requested side (with the existing "Expected promise that rejects" /
"received value must be a promise" wording), builds `expect(settled)` with
the same `.not` and label, and dispatches the real matcher. `.rejects` and
`.resolves.toThrow(...)` accept a settled Error the way Jest's `fromPromise`
does. The Proxy is not thenable, so `await expect(p).resolves` alone is not
mistaken for the assertion. Nothing in the matcher implementations changed;
the blocking `process_promise` path stays for the asymmetric
`expect.resolvesTo` / `expect.rejectsTo` matchers.

Behaviour change: the two Bun tests that asserted the sync return value now
assert a Promise, and every other existing test already awaited the chain.
