### PR TITLE
test: fix the stdin race in update_interactive_snapshots.test.ts

### DIFF
--- a/test/cli/update_interactive_snapshots.test.ts
+++ b/test/cli/update_interactive_snapshots.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
+// The project has no lockfile, so `bun update --interactive` prints its header
+// and exits before the prompt. It never reads stdin. The "n" keystroke is
+// handed over as a Blob so the parent never writes to a pipe the child may
+// already have closed.
+async function runUpdateInteractive(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "update", "--interactive", "--dry-run"],
+    cwd: dir,
+    env: bunEnv,
+    stdin: new Blob(["n\n"]),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  return { stdout: normalizeOutput(stdout), stderr, exitCode };
+}
+
 describe("bun update --interactive snapshots", () => {
   it("should not crash with various package name lengths", async () => {
     await using dir = tempDir("update-interactive-snapshot-test", {
@@ -30,33 +49,16 @@ describe("bun update --interactive snapshots", () => {
       }),
     });
 
-    // Test that the command doesn't crash with mixed package lengths
-    const result = await Bun.spawn({
-      cmd: [bunExe(), "update", "--interactive", "--dry-run"],
-      cwd: dir,
-      env: bunEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    // Send 'n' to exit without selecting anything
-    result.stdin.write("n\n");
-    result.stdin.end();
-
-    const stdout = await new Response(result.stdout).text();
-    const stderr = await new Response(result.stderr).text();
-
-    // Replace version numbers and paths to avoid flakiness
-    const normalizedOutput = normalizeOutput(stdout);
+    const { stdout, stderr, exitCode } = await runUpdateInteractive(String(dir));
 
     // The output should show proper column spacing and formatting
-    expect(normalizedOutput).toMatchSnapshot("update-interactive-no-crash");
+    expect(stdout).toMatchSnapshot("update-interactive-no-crash");
 
     // Should not crash or have formatting errors
-    expect(stderr).not.toContain("panic");
+    expect(stderr).toContain("missing lockfile, nothing to update");
     expect(stderr).not.toContain("underflow");
     expect(stderr).not.toContain("overflow");
+    expect(exitCode).toBe(1);
   });
 
   it("should handle extremely long package names without crashing", async () => {
@@ -72,27 +74,13 @@ describe("bun update --interactive snapshots", () => {
       }),
     });
 
-    const result = await Bun.spawn({
-      cmd: [bunExe(), "update", "--interactive", "--dry-run"],
-      cwd: dir,
-      env: bunEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    result.stdin.write("n\n");
-    result.stdin.end();
-
-    const stdout = await new Response(result.stdout).text();
-    const stderr = await new Response(result.stderr).text();
-
-    const normalizedOutput = normalizeOutput(stdout);
+    const { stdout, stderr, exitCode } = await runUpdateInteractive(String(dir));
 
     // Should not crash
-    expect(normalizedOutput).toMatchSnapshot("update-interactive-long-names");
-    expect(stderr).not.toContain("panic");
+    expect(stdout).toMatchSnapshot("update-interactive-long-names");
+    expect(stderr).toContain("missing lockfile, nothing to update");
     expect(stderr).not.toContain("underflow");
+    expect(exitCode).toBe(1);
   });
 
   it("should handle complex version strings without crashing", async () => {
@@ -108,27 +96,13 @@ describe("bun update --interactive snapshots", () => {
       }),
     });
 
-    const result = await Bun.spawn({
-      cmd: [bunExe(), "update", "--interactive", "--dry-run"],
-      cwd: dir,
-      env: bunEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    result.stdin.write("n\n");
-    result.stdin.end();
-
-    const stdout = await new Response(result.stdout).text();
-    const stderr = await new Response(result.stderr).text();
-
-    const normalizedOutput = normalizeOutput(stdout);
+    const { stdout, stderr, exitCode } = await runUpdateInteractive(String(dir));
 
     // Should not crash
-    expect(normalizedOutput).toMatchSnapshot("update-interactive-complex-versions");
-    expect(stderr).not.toContain("panic");
+    expect(stdout).toMatchSnapshot("update-interactive-complex-versions");
+    expect(stderr).toContain("missing lockfile, nothing to update");
     expect(stderr).not.toContain("underflow");
+    expect(exitCode).toBe(1);
   });
 });
 


### PR DESCRIPTION
### Problem
- `test/cli/update_interactive_snapshots.test.ts` fails in CI with `EPIPE: broken pipe, write` at the `stdin.end()` call (builds 110021 and 110255, debian 13 aarch64).
- The cause is a race in the test. The project has no lockfile, so `bun update --interactive --dry-run` prints its header, reports `missing lockfile, nothing to update` and exits in a few ms (`src/runtime/cli/update_interactive_command.rs:518`). It never reads stdin. The test writes `n\n` to the stdin pipe after `Bun.spawn` returns. When the child exits first, the write hits a pipe with no reader. The test has had this shape since #21156.

### Fix
- Pass the keystroke as `stdin: new Blob(["n\n"])`. Bun hands the bytes to the child at spawn time. The test no longer writes to a pipe the child may have closed.
- The test now asserts what the command does: stderr contains `missing lockfile, nothing to update` and the exit code is 1. It replaces the `not.toContain("panic")` checks. The snapshots are unchanged.
- The three tests share one spawn helper and use `await using` for the process.
- Verified: `bun bd test test/cli/update_interactive_snapshots.test.ts`. With the released binary and 8 busy loops on 8 cores, the old test failed 2 of 30 runs with EPIPE. The new test passed 60 of 60 under the same load.

### Background
- `bunEnv` sets `BUN_INTERNAL_INTERACTIVE_ASSUME_TTY=1`, so the command passes the isatty gate from #35165 and goes on to load the lockfile. That is the path the snapshot captures.
- A `Blob` stdin becomes a pipe that Bun fills from the parent's event loop. An early child exit is handled inside Bun, not reported to the test.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/update_interactive_snapshots.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/update_interactive_snapshots.test.ts
bun test v1.4.1 (e0a2b82fd)

test/cli/update_interactive_snapshots.test.ts:
(pass) bun update --interactive snapshots > should not crash with various package name lengths [186.17ms]
(pass) bun update --interactive snapshots > should handle extremely long package names without crashing [192.58ms]
(pass) bun update --interactive snapshots > should handle complex version strings without crashing [123.54ms]

 3 pass
 0 fail
 3 snapshots, 13 expect() calls
Ran 3 tests across 1 file. [2.38s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/update_interactive_snapshots.test.ts | 88 ++++++++++-----------------
 1 file changed, 31 insertions(+), 57 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/cli/update_interactive_snapshots.test.ts      1      1      7
```

</details>

**root cause** · written by the author bot

The test wrote "n\n" to the child's stdin after spawning, but `bun update --interactive --dry-run` exits within milliseconds when no lockfile is present and never reads stdin, so the write raced the exit and intermittently failed with EPIPE. The fix supplies the keystroke up front as `stdin: new Blob(["n\n"])` so it is present before the child starts, uses `await using` for cleanup, and asserts the actual outcome (the missing lockfile message and exit code 1) rather than relying on an interactive prompt that never appears. This removes the race entirely, and the test passed 60 of 60 runs un…

<!-- robobun:evidence:end -->