### PR TITLE
test: share one HTMLRewriter across rounds in the onEndTag protected-count test

### DIFF
--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -132,17 +132,23 @@ test("exceptions thrown from handlers do not leak protected Exception roots", as
 // `heapStats().protectedObjectTypeCounts` reports the exact count of
 // protect()'d objects by type, so unlike an RSS high-water mark this needs no
 // threshold and is stable on debug builds.
+//
+// One rewriter serves every round. `.on()` protects the listener and its
+// `element` method until the rewriter's wrapper is swept, and the last round's
+// wrapper can outlive one `Bun.gc(true)` through a stale stack slot (Windows
+// debug builds hit this). End-tag handlers are dropped when the rewrite
+// finishes, so a shared rewriter keeps the count independent of the sweep.
 test("onEndTag callbacks are released after the rewrite", () => {
+  const rewriter = new HTMLRewriter().on("p", {
+    element(element) {
+      element.onEndTag(() => {});
+    },
+  });
+
   const rewriteWithEndTagHandlers = (count: number) => {
     let document = "";
     for (let i = 0; i < count; i++) document += "<p></p>";
-    new HTMLRewriter()
-      .on("p", {
-        element(element) {
-          element.onEndTag(() => {});
-        },
-      })
-      .transform(document);
+    rewriter.transform(document);
   };
 
   const protectedFunctions = () => {

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -134,10 +134,9 @@ test("exceptions thrown from handlers do not leak protected Exception roots", as
 // threshold and is stable on debug builds.
 //
 // One rewriter serves every round. `.on()` protects the listener and its
-// `element` method until the rewriter's wrapper is swept, and the last round's
-// wrapper can outlive one `Bun.gc(true)` through a stale stack slot (Windows
-// debug builds hit this). End-tag handlers are dropped when the rewrite
-// finishes, so a shared rewriter keeps the count independent of the sweep.
+// `element` method until the rewriter's wrapper is swept, while end-tag
+// handlers are dropped when the rewrite finishes. Sharing the rewriter keeps
+// the count independent of which wrappers the GC has swept.
 test("onEndTag callbacks are released after the rewrite", () => {
   const rewriter = new HTMLRewriter().on("p", {
     element(element) {


### PR DESCRIPTION
### Problem
- `test/js/workerd/html-rewriter-leak.test.ts` "onEndTag callbacks are released after the rewrite" fails on a Windows x64 debug build of main (4/4 runs): `expect(after - before).toBe(0)` gets `Received: 1`. Linux and the Windows release build pass.
- The extra protected Function is not an end-tag callback. It is the `element` method of the listener that the last round's `.on()` protected, together with the listener object. That round's `HTMLRewriter` wrapper survives one `Bun.gc(true)` and its handler protections with it. The next GC frees it.
- The wrapper survives through a stale stack word. The `Bun.gc` host function (`bindgen_BunObject_jsGc`) runs at the same stack depth as the round's `.on()` host call. Its return-value slot (`rbp-0x28`) is not written before the collector runs, and still holds the wrapper's cell address. JSC's conservative scan roots it. When `generateHeapSnapshotForDebugging()` replaces `Bun.gc(true)` at the same point, its own full GC frees the wrapper (no instance node, and the count returns to the baseline), so no real reference holds it.

### Fix
- The test now creates one `HTMLRewriter` with the `.on()` listener and reuses it for every round. The `.on()` protections are then constant between the two measurements, and only the per-element `onEndTag` callbacks vary.
- This still measures what the test is for. The end-tag handler boxes are dropped in `RewriterPipe::finish` when the rewrite ends, not at wrapper sweep. A build that leaks the `onEndTag` protection (simulated with an extra `protect()` in `on_end_tag_`) fails the changed test with `Received: 800`.
- Verified: `bun bd test test/js/workerd/html-rewriter-leak.test.ts` on Linux (13 pass, 1 skip) and on a Windows x64 debug build (6/6 runs of the changed test pass, 0/4 before. The full file passes).
- Test-only change. No code under `src/` changes, so the fail-before gate has nothing to flip. The test comment only states why one rewriter is shared. The retention mechanism is documented here, not in the tree.

### Background
- `heapStats().protectedObjectTypeCounts` counts cells that native code holds with `JSValue::protect()`. `.on()` protects the listener object and each handler method for the rewriter's lifetime. `element.onEndTag(fn)` protects `fn` until lol-html invokes or drops the handler.
- JSC finds roots on the machine stack by a conservative scan: every word between the current stack pointer and the stack base that looks like a cell pointer keeps that cell alive. Slots a frame has not written yet still hold whatever the previous occupant of that address left there.

<details><summary>Notes</summary>

Probe on the Windows debug build (temporary instrumentation in `JSC__VM__runGC`, not committed): before `collectNow`, list every allocated `JSHTMLRewriter` cell, then scan the stack for their addresses and map each hit to a native frame (via `RtlVirtualUnwind`) and to the JS call frames (via `vm->topCallFrame`).

At the second measurement, with 3 wrappers allocated:

```
js frame 0 cf=0000006F8DFAF8B0 host function
js frame 1 cf=0000006F8DFAF920 protectedFunctions (probe14.test.ts)
js frame 2 cf=0000006F8DFAF9A0 (probe14.test.ts)
cell 00000204EE1AD468
  stack word 0000006F8DFAF7F8 = 00000204EE1AD468 (above sp) native frame 5 (pc rva=0xf49b03)
```

`llvm-symbolizer` maps rva `0xf49b03` to `bindgen_BunObject_jsGc` (`build/debug/codegen/GeneratedBindings.cpp:283`). Its prologue is `push rbp; sub rsp,0x100; lea rbp,[rsp+0x80]`, so with frame sp `0x6F8DFAF7A0` the word at `0x6F8DFAF7F8` is `rbp-0x28`. The only stores to `rbp-0x28` are the `return {}` / `JSValue::encode(...)` result stores after `bindgen_BunObject_dispatchGc1` returns, so it is uninitialized while the GC runs.

Reductions that pointed there: the delta reproduces with `new HTMLRewriter().on("p", { element() {} })` and no `transform()` and no `onEndTag` at all. It does not reproduce when `generateHeapSnapshotForDebugging()` (a different native stack below the host call) replaces `Bun.gc(true)`. A third `Bun.gc(true)` returns the count to the baseline.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/workerd/html-rewriter-leak.test.ts

<!-- robobun:evidence:end -->