### PR TITLE
Bump WebKit (oven-sh/WebKit#565 preview): keep out of range doubles on the x64 ToInt32 fast path

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "preview-pr-565-93569bfc";
+export const WEBKIT_VERSION = "preview-pr-565-cf95ae44";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "d4e7e206dc9b1c58eb8aca8f06eed7a6f4abb98a";
+export const WEBKIT_VERSION = "preview-pr-565-93569bfc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/to-int32-out-of-int32-range-doubles.js
+++ b/test/js/bun/jsc-stress/fixtures/to-int32-out-of-int32-range-doubles.js
@@ -25,10 +25,15 @@ const inputs = [
     2 ** 63 + 2048, -(2 ** 63 + 2048), 2 ** 64, 2 ** 84, 2 ** 85, 2 ** 100,
     Number.MAX_VALUE, -Number.MAX_VALUE, Number.MIN_VALUE, Infinity, -Infinity, NaN,
 ];
-
-// Plain arrays with a double butterfly, so the loads feed ValueToInt32 with DoubleRepUse.
-const doubles = inputs.map(x => x);
 const expected = inputs.map(toInt32Reference);
+
+// A Float64Array load is DoubleRepUse for every input, NaN included.
+const float64 = new Float64Array(inputs);
+
+// A plain array keeps a double butterfly only without NaN, which forces a
+// contiguous (JSValue) butterfly. The loads of this one are DoubleRepUse too.
+const doubles = inputs.filter(x => x === x);
+const expectedDoubles = doubles.map(toInt32Reference);
 
 function bitOr(array, i)
 {
@@ -48,6 +53,25 @@ function shiftRight(array, i)
 }
 noInline(shiftRight);
 
+// Separate functions for the typed array, so each GetByVal stays monomorphic.
+function bitOrTyped(array, i)
+{
+    return array[i] | 0;
+}
+noInline(bitOrTyped);
+
+function xorWithTyped(array, i, other)
+{
+    return array[i] ^ other;
+}
+noInline(xorWithTyped);
+
+function shiftRightTyped(array, i)
+{
+    return array[i] >> 0;
+}
+noInline(shiftRightTyped);
+
 // A JSValue operand, so the conversion takes the NumberUse path.
 function bitOrValue(object)
 {
@@ -57,9 +81,14 @@ noInline(bitOrValue);
 
 for (let iteration = 0; iteration < testLoopCount; ++iteration) {
     for (let i = 0; i < inputs.length; ++i) {
-        shouldBe(bitOr(doubles, i), expected[i], inputs[i]);
-        shouldBe(xorWith(doubles, i, 0x5a5a5a5a), expected[i] ^ 0x5a5a5a5a, inputs[i]);
-        shouldBe(shiftRight(doubles, i), expected[i], inputs[i]);
+        shouldBe(bitOrTyped(float64, i), expected[i], inputs[i]);
+        shouldBe(xorWithTyped(float64, i, 0x5a5a5a5a), expected[i] ^ 0x5a5a5a5a, inputs[i]);
+        shouldBe(shiftRightTyped(float64, i), expected[i], inputs[i]);
         shouldBe(bitOrValue({ value: inputs[i] }), expected[i], inputs[i]);
+    }
+    for (let i = 0; i < doubles.length; ++i) {
+        shouldBe(bitOr(doubles, i), expectedDoubles[i], doubles[i]);
+        shouldBe(xorWith(doubles, i, 0x5a5a5a5a), expectedDoubles[i] ^ 0x5a5a5a5a, doubles[i]);
+        shouldBe(shiftRight(doubles, i), expectedDoubles[i], doubles[i]);
     }
 }

--- a/test/js/bun/jsc-stress/fixtures/to-int32-out-of-int32-range-doubles.js
+++ b/test/js/bun/jsc-stress/fixtures/to-int32-out-of-int32-range-doubles.js
@@ -1,0 +1,65 @@
+// @bun
+// ToInt32 on doubles outside the int32 range. The JIT fast path must agree with
+// the interpreter for every magnitude, including the values that the 64 bit
+// truncation cannot represent.
+
+function shouldBe(actual, expected, input)
+{
+    if (actual !== expected)
+        throw new Error(`bad value for ${input}: ${actual}, expected ${expected}`);
+}
+
+// Reference ToInt32 through BigInt, independent of the JIT.
+function toInt32Reference(x)
+{
+    if (!Number.isFinite(x))
+        return 0;
+    return Number(BigInt.asIntN(32, BigInt(Math.trunc(x))));
+}
+
+const inputs = [
+    0, -0, 1, -1, 0.5, -0.5, 2147483647, -2147483648, 2147483648, -2147483649,
+    2147483647.9, -2147483648.9, 0xc66363a5, 0xffffffff, 0x100000000, 0x100000001,
+    4294967295.5, -4294967296, 2 ** 52 + 1, -(2 ** 52 + 1), 2 ** 53, 2 ** 53 + 2,
+    2 ** 62, -(2 ** 62), 2 ** 63 - 1024, -(2 ** 63 - 1024), 2 ** 63, -(2 ** 63),
+    2 ** 63 + 2048, -(2 ** 63 + 2048), 2 ** 64, 2 ** 84, 2 ** 85, 2 ** 100,
+    Number.MAX_VALUE, -Number.MAX_VALUE, Number.MIN_VALUE, Infinity, -Infinity, NaN,
+];
+
+// Plain arrays with a double butterfly, so the loads feed ValueToInt32 with DoubleRepUse.
+const doubles = inputs.map(x => x);
+const expected = inputs.map(toInt32Reference);
+
+function bitOr(array, i)
+{
+    return array[i] | 0;
+}
+noInline(bitOr);
+
+function xorWith(array, i, other)
+{
+    return array[i] ^ other;
+}
+noInline(xorWith);
+
+function shiftRight(array, i)
+{
+    return array[i] >> 0;
+}
+noInline(shiftRight);
+
+// A JSValue operand, so the conversion takes the NumberUse path.
+function bitOrValue(object)
+{
+    return object.value | 0;
+}
+noInline(bitOrValue);
+
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (let i = 0; i < inputs.length; ++i) {
+        shouldBe(bitOr(doubles, i), expected[i], inputs[i]);
+        shouldBe(xorWith(doubles, i, 0x5a5a5a5a), expected[i] ^ 0x5a5a5a5a, inputs[i]);
+        shouldBe(shiftRight(doubles, i), expected[i], inputs[i]);
+        shouldBe(bitOrValue({ value: inputs[i] }), expected[i], inputs[i]);
+    }
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // ToInt32 of doubles outside the int32 range (oven-sh/WebKit#565)
+  "to-int32-out-of-int32-range-doubles.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/jsc/to-int32-out-of-range-double.test.ts
+++ b/test/js/bun/jsc/to-int32-out-of-range-double.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Coverage for oven-sh/WebKit#565 (oven-sh/bun#41399). On x64, ToInt32 of a
+// double outside [-2^31, 2^31) left the JIT for a C++ call on every operand.
+// A table of 32 bit constants such as the aes-js T1..T4 tables is stored as
+// doubles, so half of its entries took that call. The fix keeps every |x| < 2^63
+// in JIT code, so the table with large values costs the same as the table with
+// small values. The unfixed engine is 8x to 10x slower on the large table.
+
+test("ToInt32 of a double outside the int32 range stays on the JIT fast path", async () => {
+  const source = `
+    const N = 4_000_000;
+    // Both tables are Float64Array, so both loops load a double and convert it
+    // with ToInt32. Only the magnitude of the values differs.
+    const small = new Float64Array(256);
+    const large = new Float64Array(256);
+    for (let i = 0; i < 256; i++) {
+      small[i] = 0x0c66363a + i;
+      large[i] = i % 2 ? 0xc66363a5 + i : 0x0c66363a + i;
+    }
+    // A data dependent index, so the unfixed slow path branch mispredicts too.
+    const index = new Uint8Array(N);
+    let state = 0x6d2b79f5;
+    for (let i = 0; i < N; i++) {
+      state ^= state << 13;
+      state ^= state >>> 17;
+      state ^= state << 5;
+      index[i] = state & 0xff;
+    }
+
+    function xorAll(table) {
+      let s = 0;
+      for (let i = 0; i < N; i++) s ^= table[index[i]];
+      return s;
+    }
+
+    function best(table) {
+      let result = Infinity;
+      for (let run = 0; run < 7; run++) {
+        const start = performance.now();
+        xorAll(table);
+        result = Math.min(result, performance.now() - start);
+      }
+      return result;
+    }
+
+    // Warm up: reach the optimizing tiers on both tables before timing.
+    for (let run = 0; run < 3; run++) {
+      xorAll(small);
+      xorAll(large);
+    }
+    console.log(JSON.stringify({ small: best(small), large: best(large) }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  const { small, large } = JSON.parse(stdout);
+  expect(small).toBeGreaterThan(0);
+  expect(large / small).toBeLessThan(3);
+});

--- a/test/js/bun/jsc/to-int32-out-of-range-double.test.ts
+++ b/test/js/bun/jsc/to-int32-out-of-range-double.test.ts
@@ -7,9 +7,14 @@ import { bunEnv, bunExe } from "harness";
 // doubles, so half of its entries took that call. The fix keeps every |x| < 2^63
 // in JIT code, so the table with large values costs the same as the table with
 // small values. The unfixed engine is 8x to 10x slower on the large table.
+//
+// x64 only: arm64 with the FJCVTZS instruction has no slow path at all, and
+// arm64 without it (Neoverse N1) still takes a C++ call for every such value.
 
-test("ToInt32 of a double outside the int32 range stays on the JIT fast path", async () => {
-  const source = `
+test.skipIf(process.arch !== "x64")(
+  "ToInt32 of a double outside the int32 range stays on the JIT fast path",
+  async () => {
+    const source = `
     const N = 4_000_000;
     // Both tables are Float64Array, so both loops load a double and convert it
     // with ToInt32. Only the magnitude of the values differs.
@@ -53,17 +58,18 @@ test("ToInt32 of a double outside the int32 range stays on the JIT fast path", a
     console.log(JSON.stringify({ small: best(small), large: best(large) }));
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", source],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
 
-  const { small, large } = JSON.parse(stdout);
-  expect(small).toBeGreaterThan(0);
-  expect(large / small).toBeLessThan(3);
-});
+    const { small, large } = JSON.parse(stdout);
+    expect(small).toBeGreaterThan(0);
+    expect(large / small).toBeLessThan(3);
+  },
+);


### PR DESCRIPTION
### What does this PR do?

Pins `WEBKIT_VERSION` at the preview build of oven-sh/WebKit#565 (`preview-pr-565-cf95ae44`) and adds the tests for it.

**Do not merge while the pin is a preview tag.** Once oven-sh/WebKit#565 lands, `scripts/build/deps/webkit.ts` must move to the merged SHA with its prebuilt artifacts.

### Problem
- On x86_64, `ToInt32` of a double outside `[-2^31, 2^31)` leaves the JIT. The DFG and the FTL truncate with the 32 bit `cvttsd2si`, which reports every such value as `0x80000000`, and the code then calls `operationToInt32SensibleSlow`. A lookup table of 32 bit constants such as `0xc66363a5` (the aes-js `T1..T4` tables) is stored as doubles, so about half of its entries take the call, and a data dependent index makes the branch mispredict. arm64 has no such cost because it uses `fjcvtzs`.
- Effect (#41399): aes-js CTR over 8 MiB takes 1020 ms on bun and 350 ms on Node, Linux x64. On arm64 bun is 24% faster than Node.

### Fix (engine side, oven-sh/WebKit#565)
- Truncate with the 64 bit `cvttsd2siq` and keep the low 32 bits. That is `ToInt32` for every `|x| < 2^63`. The slow path now only sees NaN, the infinities, and `|x| >= 2^63`, which `cvttsd2siq` all report as `INT64_MIN`.
- Applied in the DFG `compileValueToInt32` (`DoubleRepUse` and the boxed double case of `NumberUse`, which always called `operationToInt32` on x86_64 before), both through the new `SpeculativeJIT::compileDoubleToInt32` helper, and in the FTL `doubleToInt32`. Gated by `CPU(X86_64)` and `hasSensibleDoubleToInt()`; arm64 and the `useArchitectureSpecificOptimizations=0` path are unchanged.

| Linux x64 release, bun built on this branch | before | after |
|---|---:|---:|
| aes-js CTR, 8 MiB, median of 7 | 1020 ms | 272 ms |
| `s ^= table[idx[i]]`, 256 doubles, half >= 2^31, 100M iterations | 754 ms | 64 ms |
| same, constant index | 260 ms | 88 ms |
| same table with int32 values | 86 ms | 59 ms |
| same values in a `Uint32Array` | 59 ms | 59 ms |

### Bun side
- `test/js/bun/jsc-stress/fixtures/to-int32-out-of-int32-range-doubles.js`: the JSTests stress file, checks `| 0`, `^`, `>> 0` on a double-butterfly array and on a `Float64Array` (DoubleRepUse) and `| 0` on a JSValue operand (NumberUse) against a `BigInt.asIntN` reference at 2^31, 2^32, 2^52, 2^63, NaN, Inf across tiers.
- `test/js/bun/jsc/to-int32-out-of-range-double.test.ts`: asserts a `Float64Array` lookup table with values >= 2^31 is less than 3x slower to xor-reduce than one with int32 values. Unfixed the ratio is 9x to 14x. x64 only: arm64 without FJCVTZS still takes the C++ call.

### How did you verify your code works?
- `bun bd test test/js/bun/jsc/to-int32-out-of-range-double.test.ts test/js/bun/jsc-stress/jsc-stress.test.ts` with the preview tarball: 118 pass, 0 fail.
- The timing test fails with `USE_SYSTEM_BUN=1` (ratio 9x to 14x) and passes with the preview build.

Fixes #41399

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 1 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-stress.test.ts' 'test/js/bun/jsc/to-int32-out-of-range-double.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-stress.test.ts "test/js/bun/jsc/to-int32-out-of-range-double.test.ts"
bun test v1.4.1 (e0a2b82fd)

test/js/bun/jsc/to-int32-out-of-range-double.test.ts:
(pass) ToInt32 of a double outside the int32 range stays on the JIT fast path [1206.11ms]

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [282.61ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [265.52ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [263.41ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [265.60ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [265.01ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [249.19ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [267.05ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [273.18ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [304.99ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [317.02ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [265.27ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val.js [280.15ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength.js [322.93ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined.js [284.00ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined-and-not-inlined.js [387.37ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception.js [302.17ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception-no-catch.js [286.51ms]
(pass) JSC JIT Stress Tests > JS (Baseline
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 .../to-int32-out-of-int32-range-doubles.js         | 94 ++++++++++++++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts          |  2 +
 .../bun/jsc/to-int32-out-of-range-double.test.ts   | 75 +++++++++++++++++
 4 files changed, 172 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  0      0     19
…-stress/fixtures/to-int32-out-of-int32-range-doubles.js      0      0     21
test/js/bun/jsc-stress/jsc-stress.test.ts                     1      2     12
test/js/bun/jsc/to-int32-out-of-range-double.test.ts          1      5     11
```

</details>

**root cause** · written by the author bot

On x86_64, JSC's DFG and FTL double-to-int32 conversion used the 32-bit cvttsd2si instruction, which fails for any value with magnitude of 2^31 or greater and spills to the operationToInt32SensibleSlow C++ call, so aes-js CTR mode, whose xor tables routinely produce such doubles before `| 0`, paid that slow path on every block. The fix adds a 64-bit cvttsd2siq path behind CPU(X86_64) and hasSensibleDoubleToInt(), folded into a shared SpeculativeJIT::compileDoubleToInt32 helper for both DFG arms and the FTL block, with an INT64_MIN check so only true failures (NaN, infinities, values beyond …

<!-- robobun:evidence:end -->
