### PR TITLE
Remove the unused function-slot vector from JSCommonJSExtensions

### DIFF
--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -124,24 +124,6 @@ impl Default for CustomLoader {
     }
 }
 
-// `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle; remaining
-// params are by-value `JSValue`/scalars → `safe fn`.
-unsafe extern "C" {
-    pub safe fn JSCommonJSExtensions__appendFunction(
-        global: &JSGlobalObject,
-        value: JSValue,
-    ) -> u32;
-    pub safe fn JSCommonJSExtensions__setFunction(
-        global: &JSGlobalObject,
-        index: u32,
-        value: JSValue,
-    );
-    /// Returns the index of the last value, which must have it's references updated to `index`
-    pub safe fn JSCommonJSExtensions__swapRemove(global: &JSGlobalObject, index: u32) -> u32;
-}
-
-// Memory management is complicated because JSValues are stored in gc-visitable
-// WriteBarriers in C++ but the hash map for extensions is in Rust for flexibility.
 fn on_require_extension_modify(
     global: &JSGlobalObject,
     str: &[u8],

--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -204,39 +204,6 @@ bool JSCommonJSExtensions::deleteProperty(JSC::JSCell* cell, JSC::JSGlobalObject
     return deleted;
 }
 
-extern "C" uint32_t JSCommonJSExtensions__appendFunction(Zig::GlobalObject* globalObject, JSC::JSValue value)
-{
-    JSCommonJSExtensions* extensions = globalObject->lazyRequireExtensionsObject();
-    extensions->m_registeredFunctions.append(JSC::WriteBarrier<Unknown>());
-    extensions->m_registeredFunctions.last().set(globalObject->vm(), extensions, value);
-    return extensions->m_registeredFunctions.size() - 1;
-}
-
-extern "C" void JSCommonJSExtensions__setFunction(Zig::GlobalObject* globalObject, uint32_t index, JSC::JSValue value)
-{
-    JSCommonJSExtensions* extensions = globalObject->lazyRequireExtensionsObject();
-    extensions->m_registeredFunctions[index].set(globalObject->vm(), globalObject, value);
-}
-
-extern "C" uint32_t JSCommonJSExtensions__swapRemove(Zig::GlobalObject* globalObject, uint32_t index)
-{
-    JSCommonJSExtensions* extensions = globalObject->lazyRequireExtensionsObject();
-    ASSERT(extensions->m_registeredFunctions.size() > 0);
-    if (extensions->m_registeredFunctions.size() == 1) {
-        extensions->m_registeredFunctions.clear();
-        return index;
-    }
-    ASSERT(index < extensions->m_registeredFunctions.size());
-    if (index < (extensions->m_registeredFunctions.size() - 1)) {
-        JSValue last = extensions->m_registeredFunctions.takeLast().get();
-        extensions->m_registeredFunctions[index].set(globalObject->vm(), globalObject, last);
-        return extensions->m_registeredFunctions.size();
-    } else {
-        extensions->m_registeredFunctions.removeLast();
-        return index;
-    }
-}
-
 // This implements `Module._extensions['.js']`, which
 // - Loads source code from a file
 //     - [not supported] Calls `fs.readFileSync`, which is usually not overridden.
@@ -296,19 +263,5 @@ JSC::EncodedJSValue builtinLoader(JSC::JSGlobalObject* globalObject, JSC::CallFr
 
     return JSC::JSValue::encode(jsUndefined());
 }
-
-template<typename Visitor>
-void JSCommonJSExtensions::visitChildrenImpl(JSCell* cell, Visitor& visitor)
-{
-    JSCommonJSExtensions* thisObject = uncheckedDowncast<JSCommonJSExtensions>(cell);
-    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
-    Base::visitChildren(thisObject, visitor);
-
-    for (auto& func : thisObject->m_registeredFunctions) {
-        visitor.append(func);
-    }
-}
-
-DEFINE_VISIT_CHILDREN(JSCommonJSExtensions);
 
 } // namespace Bun

--- a/src/jsc/bindings/JSCommonJSExtensions.h
+++ b/src/jsc/bindings/JSCommonJSExtensions.h
@@ -10,9 +10,6 @@ class JSCommonJSExtensions : public JSC::JSDestructibleObject {
 public:
     using Base = JSC::JSDestructibleObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut;
-    ~JSCommonJSExtensions();
-
-    WTF::Vector<JSC::WriteBarrier<JSC::Unknown>> m_registeredFunctions;
 
     static JSCommonJSExtensions* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
     {
@@ -35,8 +32,6 @@ public:
     {
         return Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
-
-    DECLARE_VISIT_CHILDREN;
 
 protected:
     static bool defineOwnProperty(JSC::JSObject*, JSC::JSGlobalObject*, JSC::PropertyName, const JSC::PropertyDescriptor&, bool shouldThrow);


### PR DESCRIPTION
### What does this PR do?

Deletes a leftover from the original `require.extensions` implementation. Since #19231, custom loader functions are kept alive by `Strong` handles on the Rust side (`CustomLoader::Custom`). The mechanism that change replaced — a `WTF::Vector<WriteBarrier<Unknown>>` member on the `JSCommonJSExtensions` cell, the `JSCommonJSExtensions__appendFunction` / `__setFunction` / `__swapRemove` externs that mutated it, and a `visitChildren` override that walked it — has had no callers since then; `NodeModuleModule.rs` only declared the externs. This removes the vector, the three externs, the `visitChildren` override, the declared-but-never-defined destructor, and the Rust extern block.

Worth removing rather than leaving: the vector was mutated and visited without `cellLock()`, unlike every other `Vector<WriteBarrier>` member in our cells, so reviving it as-is would have raced the concurrent marker.

No behaviour change: the vector was always empty, so the override only ever called `Base::visitChildren`.

### How did you verify your code works?

- `grep` across `src/` for the three extern names and `m_registeredFunctions`: the only references were the definitions and the Rust declarations removed here.
- Compiled `JSCommonJSExtensions.cpp` with the release flags (`-fsyntax-only`) after the change; clean. Relying on CI for the full build and the existing `require.extensions` tests (`test/js/node/module`).
