### PR TITLE
oven.bun-vscode crashes extension host when opening non-project directories

### DIFF
--- a/packages/bun-vscode/src/features/tasks/package.json.ts
+++ b/packages/bun-vscode/src/features/tasks/package.json.ts
@@ -156,7 +156,11 @@ interface CommandArgs {
  */
 function registerHoverProvider(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.languages.registerHoverProvider("json", {
+    vscode.languages.registerHoverProvider({
+        language: "json",
+        scheme: "file",
+        pattern: "**/package.json",
+      }, {
       provideHover(document, position) {
         const { scripts } = extractScriptsFromPackageJson(document);
 

--- a/packages/bun-vscode/src/features/tasks/package.json.ts
+++ b/packages/bun-vscode/src/features/tasks/package.json.ts
@@ -162,11 +162,13 @@ function registerHoverProvider(context: vscode.ExtensionContext) {
         pattern: "**/package.json",
       }, {
       provideHover(document, position) {
-        const { scripts } = extractScriptsFromPackageJson(document);
+        const extracted = extractScriptsFromPackageJson(document);
+        if (!extracted) return;
+        const { scripts } = extracted;
 
         return {
           contents: scripts.map(script => {
-            if (!script.range.contains(position)) return null;
+            if (!script?.range?.contains(position)) return null;
 
             const command = encodeURI(JSON.stringify({ script: script.command, name: script.name }));
 

--- a/packages/bun-vscode/src/features/tasks/package.json.ts
+++ b/packages/bun-vscode/src/features/tasks/package.json.ts
@@ -163,7 +163,7 @@ function registerHoverProvider(context: vscode.ExtensionContext) {
       }, {
       provideHover(document, position) {
         const extracted = extractScriptsFromPackageJson(document);
-        if (!extracted) return;
+        if (!extracted) return undefined;
         const { scripts } = extracted;
 
         return {

--- a/packages/bun-vscode/src/features/tasks/package.json.ts
+++ b/packages/bun-vscode/src/features/tasks/package.json.ts
@@ -167,9 +167,7 @@ function registerHoverProvider(context: vscode.ExtensionContext) {
         const { scripts } = extracted;
 
         return {
-          contents: scripts.map(script => {
-            if (!script?.range?.contains(position)) return null;
-
+          contents: scripts.filter(script => script?.range?.contains(position)).map(script => {
             const command = encodeURI(JSON.stringify({ script: script.command, name: script.name }));
 
             const markdownString = new vscode.MarkdownString(


### PR DESCRIPTION
### What does this PR do?

#### Steps to reproduce
1. Install `oven.bun-vscode`.
2. Open a non-project directory in VS Code containing arbitrary JSON files.
3. The extension host crashes immediately, even when the extension is disabled.

#### Observed behavior
- `exthost.log` shows repeated crashes:
  - `TypeError: Cannot destructure property 'range' of 'extractScriptsFromPackageJson(...)' as it is null`
  - `TypeError: Cannot convert undefined or null to object at push`
- Extension host exits with code 0 and restarts.
- This triggers a runaway `ripgrep` scan at very high CPU (`rg --files ... -g **/package.json`).

#### Expected behavior
- The extension should not crash when opening arbitrary directories.
- It should only activate on actual `package.json` files.

#### Root cause
In `packages/bun-vscode/src/features/tasks/package.json.ts`, `registerHoverProvider` registers for **all** `json` files instead of only `package.json`. When it encounters non-`package.json` JSON documents, `extractScriptsFromPackageJson()` returns `null`, causing a crash.

#### Fix
1. Restrict hover provider to `**/package.json`
2. Add null guards
 

### How did you verify your code works?

Applied the patch to the locally installed plugin.
