### PR TITLE
WebKit 2e2aa2290fac: JSArray shift/splice/setLength cleared live butterfly slots through libc memset (oven-sh/WebKit#564)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "fbd894680a6c3635a629c4532351f92fa6cd7f5a";
+export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### What

Bumps WebKit from `fbd894680a6c` to [`2e2aa2290fac`](https://github.com/oven-sh/WebKit/commit/2e2aa2290fac856d6f451ceacb58f7f5b44dd057), the oven-sh/WebKit#564 merge commit on `main`. The range contains two changes:

**oven-sh/WebKit#564 — concurrent marker could read a torn JSValue on musl builds.** `JSArray::setLength` and `JSArray::shiftCountWithAnyIndexingType` — the Int32/Contiguous paths behind `array.length = n`, `Array.prototype.splice` and `shift` — move elements with `gcSafeMemmove()` and then cleared the vacated butterfly slots with a `WriteBarrier::clear()` loop, which clang compiles to a call to libc `memset()`. The GC's parallel marker scans that same butterfly on a helper thread without a lock, and libc makes no promise about store width: musl's `memset` writes the head and tail of the range with 1-, 2- and 4-byte and unaligned 8-byte stores (glibc happens to use 8-byte-or-wider stores for these sizes). So on `*-musl` builds (Alpine images, musl `--compile` targets) a marker thread could load a half-cleared slot — the low byte, or the low five bytes, of the pointer that was there — treat it as a `JSCell*`, and:

- SIGSEGV on a `HeapHelper` thread in `JSObject::visitChildren` / `SlotVisitor::appendHiddenSlow` at `<garbage & ~0x3fff> + 0x20` (e.g. `0x20`, `0x8f6c954020`), or
- SIGSEGV at `0xd0` in `SlotVisitor::drain` after the torn pointer was marked and pushed, or
- a mark bit / cell-state byte written at a non-cell offset in an unrelated block (later crashes anywhere), or
- a hung process with a marker parked in `MarkedBlock::aboutToMarkSlow` → `CountingLock::lockSlow` while the mutator waits in `Heap::runFixpointPhase`.

A 25-line script (64 arrays of 3000 objects, `a.splice(N - 6, 3)` + refill in a loop) crashes `oven/bun:1.4.1-alpine` within seconds with default options, 6/6 runs; the glibc image and the same musl image with an `LD_PRELOAD` memset that only does 8-byte stores both run clean. The clears now use `gcSafeZeroMemory()`, and the unlocked in-place ArrayStorage grow path in `JSObject::increaseVectorLength` fences before publishing the larger vector length.

**oven-sh/WebKit#560 — CodeBlock aging** drops the per-allocation byte counter added in oven-sh/WebKit#557 and ages idle optimized code against the last collection that saw allocation instead.

### Related reports

- Fixes #19895 — musl x64, `HeapHelper` thread in `JSObject::visitChildren` → `visitButterfly` under `SlotVisitor::drain`; the fault address `0x7623000020` is a butterfly pointer with bytes 0–2 and 5–6 zeroed, which is exactly musl `memset`'s intermediate state when clearing a single 8-byte slot.
- Fixes #17792 — musl x64-baseline, long-running `next start`, parallel marker `SlotVisitor::drain` → `visitChildren` faulting at `0xd0`, i.e. a torn pointer that was marked and then visited.
- Not this bug, deliberately not marked: the glibc reports with marker-thread stacks (#32109, #30205, #30191, #34476, #26678, #28990) — glibc's `memset` does not tear these slots, and their fault addresses (`0x703b1a408020`, `0x800000020`, `0xe00000020`, …) point at a stale block or an `IndexingHeader` read rather than a torn pointer.
