### PR TITLE
test(serve): report the retainer chain when an aborted response body stream survives GC

### DIFF
--- a/test/flaky-tests.txt
+++ b/test/flaky-tests.txt
@@ -65,6 +65,7 @@ test/js/bun/http/request-smuggling.test.ts  # 3 of 80 builds; mac
 test/js/bun/http/serve-http2-lifecycle.test.ts  # stop with a stream open on each: test timed out (17 of the last 20 failures), HTTP3HandshakeFailed (2 of 20); PING frames do not keep a connection alive: no GOAWAY before the close (1 of 20)
 test/js/bun/http/serve-http2.test.ts  # 4 of 80 builds; parallel batch; 2 MB request body streamed to the handler (WINDOW_UPDATE path): expect(received).toBe(...
 test/js/bun/http/serve-http3.test.ts  # 3 of 80 builds; mac, windows
+test/js/bun/http/serve-pending-promise-abort-leak.test.ts  # 2 of about 500 builds since 2026-08-31 (109108 debian x64-asan solo, 110257 alpine x64 parallel batch); client abort of a streaming Response releases the body stream it held: 1 of 8 streams survives 20 full GCs. Not reproduced locally; the test prints the retainer chain when it fails
 test/js/bun/http/serve-stream-body-error.test.ts  # 1 of 80 builds; start-async-reject: the rejection is handled and the error is still reported: expect(r...
 test/js/bun/http/serve.test.ts  # 4 of 80 builds; mac
 test/js/bun/io/bun-write.test.js  # 1 of 80 builds; parallel batch; Bun.write() without uv_fs_copyfile: test timed out

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -506,23 +506,10 @@ test.each(["sync", "async"])(
 // (a bun_jsc::Strong slot or a protect()), every object that points at it,
 // and the shortest path from a GC root, read from a debugging heap snapshot.
 function describeRetainers(streams: WeakRef<ReadableStream>[], stash: WeakMap<ReadableStream, Response>): string {
-  const out: string[] = [];
-  const protectedObjects: unknown[] = jsc.getProtectedObjects();
-  const tagged: number[] = [];
-  for (let i = 0; i < streams.length; i++) {
-    const stream = streams[i].deref();
-    if (!stream) continue;
-    const response = stash.get(stream);
-    // Tag each survivor with a unique property so its node can be found in the snapshot.
-    (stream as any)[`__leak_stream_${i}`] = {};
-    if (response) (response as any)[`__leak_response_${i}`] = {};
-    tagged.push(i);
-    out.push(
-      `index ${i}: stream ${protectedObjects.includes(stream) ? "IS" : "is not"} a native root; ` +
-        `response ${response ? (protectedObjects.includes(response) ? "IS" : "is not") : "(not in stash)"} a native root`,
-    );
-  }
+  const { out, tagged } = tagSurvivors(streams, stash);
 
+  // The survivors and the protected-object list are out of scope here, so the
+  // snapshot does not see this function's own references.
   jsc.releaseWeakRefs();
   // GCDebugging snapshot: nodes are 7-tuples [id, size, classIndex, flags, labelIndex, cell, wrapped],
   // edges are 4-tuples [from, to, typeIndex, data], roots are 3-tuples [id, reasonLabel, reachabilityLabel].
@@ -549,9 +536,9 @@ function describeRetainers(streams: WeakRef<ReadableStream>[], stash: WeakMap<Re
   for (let p = 0; p < snap.edges.length; p += 4) {
     const [from, to] = [snap.edges[p], snap.edges[p + 1]];
     const type = snap.edgeTypes[snap.edges[p + 2]];
-    const name =
+    const name: string =
       type === "Property" || type === "Variable"
-        ? snap.edgeNames[snap.edges[p + 3]]
+        ? (snap.edgeNames[snap.edges[p + 3]] ?? "")
         : type === "Index"
           ? String(snap.edges[p + 3])
           : "";
@@ -608,6 +595,30 @@ function describeRetainers(streams: WeakRef<ReadableStream>[], stash: WeakMap<Re
     }
   }
   return out.join("\n");
+}
+
+// Tag each survivor with a unique property so its node can be found in the
+// snapshot, and record whether it and its Response are native roots.
+function tagSurvivors(
+  streams: WeakRef<ReadableStream>[],
+  stash: WeakMap<ReadableStream, Response>,
+): { out: string[]; tagged: number[] } {
+  const out: string[] = [];
+  const tagged: number[] = [];
+  const protectedObjects: unknown[] = jsc.getProtectedObjects();
+  for (let i = 0; i < streams.length; i++) {
+    const stream = streams[i].deref();
+    if (!stream) continue;
+    const response = stash.get(stream);
+    (stream as any)[`__leak_stream_${i}`] = {};
+    if (response) (response as any)[`__leak_response_${i}`] = {};
+    tagged.push(i);
+    out.push(
+      `index ${i}: stream ${protectedObjects.includes(stream) ? "IS" : "is not"} a native root; ` +
+        `response ${response ? (protectedObjects.includes(response) ? "IS" : "is not") : "(not in stash)"} a native root`,
+    );
+  }
+  return { out, tagged };
 }
 
 // Between the abort and the late settle, the server itself goes away: stop()

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -1,3 +1,4 @@
+import * as jsc from "bun:jsc";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { connect } from "node:net";
@@ -495,9 +496,119 @@ test.each(["sync", "async"])(
       await Bun.sleep(1);
       alive = streams.filter(ref => ref.deref() !== undefined).length;
     }
-    expect(alive).toBe(0);
+    // A survivor is rare and does not reproduce locally. Report what holds it
+    // instead of the bare count.
+    expect(alive === 0 ? "" : describeRetainers(streams, stash)).toBe("");
   },
 );
+
+// For each stream still alive: whether it and its Response are native roots
+// (a bun_jsc::Strong slot or a protect()), every object that points at it,
+// and the shortest path from a GC root, read from a debugging heap snapshot.
+function describeRetainers(streams: WeakRef<ReadableStream>[], stash: WeakMap<ReadableStream, Response>): string {
+  const out: string[] = [];
+  const protectedObjects: unknown[] = jsc.getProtectedObjects();
+  const tagged: number[] = [];
+  for (let i = 0; i < streams.length; i++) {
+    const stream = streams[i].deref();
+    if (!stream) continue;
+    const response = stash.get(stream);
+    // Tag each survivor with a unique property so its node can be found in the snapshot.
+    (stream as any)[`__leak_stream_${i}`] = {};
+    if (response) (response as any)[`__leak_response_${i}`] = {};
+    tagged.push(i);
+    out.push(
+      `index ${i}: stream ${protectedObjects.includes(stream) ? "IS" : "is not"} a native root; ` +
+        `response ${response ? (protectedObjects.includes(response) ? "IS" : "is not") : "(not in stash)"} a native root`,
+    );
+  }
+
+  jsc.releaseWeakRefs();
+  // GCDebugging snapshot: nodes are 7-tuples [id, size, classIndex, flags, labelIndex, cell, wrapped],
+  // edges are 4-tuples [from, to, typeIndex, data], roots are 3-tuples [id, reasonLabel, reachabilityLabel].
+  const snap = (jsc as any).generateHeapSnapshotForDebugging();
+  const nodes: Map<number, string> = new Map();
+  for (let p = 0; p < snap.nodes.length; p += 7) {
+    const label = snap.labels[snap.nodes[p + 4]];
+    const wrapped = snap.nodes[p + 6];
+    nodes.set(
+      snap.nodes[p],
+      snap.nodeClassNames[snap.nodes[p + 2]] +
+        (label ? `(${label})` : "") +
+        (wrapped && wrapped !== "0x0" ? `{wrapped ${wrapped}}` : ""),
+    );
+  }
+  const rootReason: Map<number, string> = new Map();
+  for (let p = 0; p < snap.roots.length; p += 3) {
+    const reach = snap.labels[snap.roots[p + 2]];
+    rootReason.set(snap.roots[p], snap.labels[snap.roots[p + 1]] + (reach ? ` (${reach})` : ""));
+  }
+  type Edge = { from: number; to: number; label: string };
+  const incoming: Map<number, Edge[]> = new Map();
+  const taggedNode: Map<string, number> = new Map();
+  for (let p = 0; p < snap.edges.length; p += 4) {
+    const [from, to] = [snap.edges[p], snap.edges[p + 1]];
+    const type = snap.edgeTypes[snap.edges[p + 2]];
+    const name =
+      type === "Property" || type === "Variable"
+        ? snap.edgeNames[snap.edges[p + 3]]
+        : type === "Index"
+          ? String(snap.edges[p + 3])
+          : "";
+    const edge = { from, to, label: name ? `${type}:${name}` : type };
+    let list = incoming.get(to);
+    if (!list) incoming.set(to, (list = []));
+    list.push(edge);
+    if (type === "Property" && name.startsWith("__leak_")) taggedNode.set(name, from);
+  }
+  const fmt = (id: number) => {
+    const root = rootReason.get(id);
+    return `${nodes.get(id) ?? "?"}#${id}${root ? ` [ROOT: ${root}]` : ""}`;
+  };
+  // Shortest path from a root to `id`. Weak containers only reach an object
+  // that is already alive, so they are skipped.
+  const chainToRoot = (id: number): string => {
+    const prev: Map<number, Edge | null> = new Map([[id, null]]);
+    const queue = [id];
+    let found = -1;
+    while (queue.length && found < 0) {
+      const cur = queue.shift()!;
+      for (const edge of incoming.get(cur) ?? []) {
+        if (prev.has(edge.from)) continue;
+        const cls = nodes.get(edge.from) ?? "";
+        if (cls.startsWith("WeakRef") || cls.startsWith("WeakMap") || cls.startsWith("WeakSet")) continue;
+        prev.set(edge.from, edge);
+        if (edge.from === 0 || rootReason.has(edge.from)) {
+          found = edge.from;
+          break;
+        }
+        queue.push(edge.from);
+      }
+    }
+    if (found < 0) return "  (no path from a root outside weak containers)";
+    const parts: string[] = [];
+    for (let cur = found; ; ) {
+      const edge = prev.get(cur);
+      if (!edge) break;
+      parts.push(`${fmt(cur)} -${edge.label}-> `);
+      cur = edge.to;
+    }
+    return "  " + parts.join("") + fmt(id);
+  };
+  for (const i of tagged) {
+    for (const what of ["stream", "response"]) {
+      const id = taggedNode.get(`__leak_${what}_${i}`);
+      if (id === undefined) {
+        if (what === "stream") out.push(`index ${i}: stream node not found in the snapshot`);
+        continue;
+      }
+      out.push(`index ${i}: ${what} = ${fmt(id)}`);
+      for (const edge of incoming.get(id) ?? []) out.push(`    <- ${edge.label} from ${fmt(edge.from)}`);
+      out.push(chainToRoot(id));
+    }
+  }
+  return out.join("\n");
+}
 
 // Between the abort and the late settle, the server itself goes away: stop()
 // (issued before or after the abort) plus pendingRequests reaching 0 lets the

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -555,6 +555,7 @@ function describeRetainers(streams: WeakRef<ReadableStream>[], stash: WeakMap<Re
   // Shortest path from a root to `id`. Weak containers only reach an object
   // that is already alive, so they are skipped.
   const chainToRoot = (id: number): string => {
+    if (rootReason.has(id)) return `  ${fmt(id)}`;
     const prev: Map<number, Edge | null> = new Map([[id, null]]);
     const queue = [id];
     let found = -1;


### PR DESCRIPTION
### Problem
- `test/js/bun/http/serve-pending-promise-abort-leak.test.ts`, test `client abort of a streaming Response releases the body stream it held (sync handler)`, fails in CI with `expect(received).toBe(expected) Expected: 0 Received: 1`: one of the eight body streams is still alive after 20 rounds of `Bun.gc(true)`. Seen in build 110257 (alpine 3.23 x64, parallel batch) and build 109108 (debian 13 x64-asan, solo run, where the async variant failed the same way). The file is not in `test/flaky-tests.txt`, so the failure is final for the PR.
- The cause is not known. The test landed in e5a18d5225 (#41080). The teardown it covers (`on_abort` to `finalize_without_deinit` to `release_body_stream` in `src/runtime/server/RequestContext.rs`) releases every native root on the stream and the Response on every path I could trace, and the failure does not reproduce here: about 25,000 aborts across release, debug and ASAN builds, the CI GC environment, CPU load, `bun test --parallel` batches, and six abort orderings all pass.

### Fix
- A test-only change. When a stream survives, the assertion now carries a report instead of the count `1`: whether the stream and its Response are native roots (`jsc.getProtectedObjects()`), every object that points at the stream, and the shortest path from a GC root, read from `generateHeapSnapshotForDebugging()`. The next CI failure then names the retainer.
- The file is listed in `test/flaky-tests.txt` with the symptom, so the runner retries it. The first attempt's output, with the report, still lands in the annotation.
- The assertion is unchanged when no stream survives: the report is the empty string.
- Verified: `bun bd test test/js/bun/http/serve-pending-promise-abort-leak.test.ts` (27 pass). With a deliberate `globalThis.__keep = stream` the report reads `GlobalObject [ROOT: ProtectedValues] -Property:__keep-> ReadableStream`.

### Background
- A streaming `Response` is sent by a pump (`readStreamIntoSink`) whose promise the request context subscribes to. `on_abort` tears the context down at once; the pump's settle reaction runs later as a no-op.
- Until the abort, the stream is a native root twice: a `bun_jsc::Strong` in `Body::Value::Locked` and the `protect()` on the Response. `finalize_without_deinit` drops both.
- The test keeps a `WeakMap` from the stream to its Response, so a stream that stays rooted also keeps the Response: this is the hono `streamSSE` shape #41080 fixed.

<details><summary>Notes</summary>

Sightings. Build 110257 (PR #38955, base d296efbb4e): sync variant, alpine 3.23 x64, parallel batch. Build 109108 (PR #40423, base 4057f64cd1, 2026-09-01): sync and async variants, debian 13 x64-asan, solo run, each with exactly 1 of 8 alive, 77 ms per test. The other failures of this file in the window (108932, 109387, 109462) are timeouts of other tests in parallel batches.

What was ruled out by code reading: `release_body_stream` is skipped only when `response_mut()` is None, which needs the Response wrapper finalized while it is protected. The JS `stream` slot is cleared unless `js_ref()` is None, which needs `isPendingDestruction()` true for a live cell. `response_body_readable_stream_ref` holds the downgraded `Weak`, not a `Strong`. `StrongRootBlock::clear` empties the slot at once. The pump cluster (op, reader, sink controller, bound handlers, result promise, NativePromiseContext cell) has no root after the abort in the cancel path, the skipped-cancel path, and the null `m_weakReadableStream` path. `vm.lastException` pins a caught throw's callees only until the VM entry ends. `WeakRef.deref()` keep-alive is released by `Bun.gc(true)` through `finalizeSynchronousJSExecution`.

Local runs that passed: the file 15 times under the debug ASAN build and 80 more times in the background with `BUN_GARBAGE_COLLECTOR_LEVEL=1 BUN_JSC_randomIntegrityAuditRate=1.0`; the file 160 times under the release build, 8 at a time; `bun test --parallel=2` with six sibling files, 5 rounds; a standalone probe with 200 to 500 aborts per run, 72 runs under 14 busy-loop processes, single-CPU pinned runs, and variants that open all eight first, do not await `reader.closed`, call `server.stop()` before the aborts, abort from a microtask, or run `Bun.gc(false)` and `Bun.gc(true)` around each abort.

The report format comes from the GCDebugging snapshot: nodes are 7-tuples, edges 4-tuples, roots 3-tuples. Weak containers are skipped in the path search because they reach an object only once it is alive.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-pending-promise-abort-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/serve-pending-promise-abort-leak.test.ts
bun test v1.4.1 (e0a2b82fd)

test/js/bun/http/serve-pending-promise-abort-leak.test.ts:
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: false) [2533.80ms]
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: true) [2037.13ms]
(pass) Promise<Response> still works normally when not aborted [31.27ms]
(pass) resolve() inside abort handler is handled safely [30.59ms]
(pass) streaming 413 detaches the response so a late resolve/reject is a no-op [7095.24ms]
(pass) chunked request body consumed as a ReadableStream is capped at maxRequestBodySize [447.82ms]
(pass) client abort frees the context even while the resolve function stays reachable [34.73ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.text() read [45.00ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending for await (req.body) read [37.75ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.textStream() read [38.22ms]
(pass) pendingRequests drops when the client aborts a parked direct-stream pull(), and the late pull() settle is a no-op [96.74ms]
(pass) client abort of a streaming Response releases the body stream it held (sync handler) [110.87ms]
(pass) client abort of a streaming Response releases the body stream it held (async handler) [89.02ms]
(pass) releasing a parked pull() after the abort tore down the context and the server is a no-op (stop-then-abort) [332.76ms]
(pass) releasing a parked pull() after the abort tore down the context and the server is a no-op (abort-then-stop) [320.74ms]
(pass) async server.upgrade() frees the context while the handler promise stays parked [37.02ms]
(pass) 413 on a chunked upload frees the 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/flaky-tests.txt                               |   1 +
 .../http/serve-pending-promise-abort-leak.test.ts  | 125 ++++++++++++++++++++-
 2 files changed, 125 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/flaky-tests.txt                                          1      2     21
…st/js/bun/http/serve-pending-promise-abort-leak.test.ts      4      6     19
```

</details>

**root cause** · written by the author bot

The underlying retainer of the surviving aborted response body stream was not identified, so the root cause of the leak itself remains open rather than fixed. The change instead instruments the test so that when a WeakRef'd stream outlives the post-abort garbage collection cycles, it captures a heap snapshot through bun:jsc and reports the retained stream, its incoming references, and its path to a GC root, including the case where the stream is directly rooted. The test is also listed as retryable so the intermittent failure no longer blocks unrelated work while the diagnostics gather the …

<!-- robobun:evidence:end -->