### PR TITLE
terminal: add pause()/resume() for pty read backpressure

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -403,9 +403,17 @@ proc.terminal.setRawMode(true);
 proc.terminal.ref();
 proc.terminal.unref();
 
+// Pause reading the PTY master until resume() is called
+proc.terminal.pause();
+proc.terminal.resume();
+
 // Close the terminal
 proc.terminal.close();
 ```
+
+### Backpressure
+
+A child that writes faster than the consumer can process keeps the `data` callback spinning. Call `pause()` when the consumer falls behind. Bun stops reading the PTY master, and the child blocks in `write(2)` on a full PTY buffer. Call `resume()` to start reading again. `terminal.paused` reports whether reads are paused. Both methods are safe to call from inside the `data` callback.
 
 ### Reusable Terminal
 
@@ -615,6 +623,7 @@ interface TerminalOptions {
 
 interface Terminal extends AsyncDisposable {
   readonly closed: boolean;
+  readonly paused: boolean;
   inputFlags: number; // termios c_iflag
   outputFlags: number; // termios c_oflag
   localFlags: number; // termios c_lflag
@@ -624,6 +633,8 @@ interface Terminal extends AsyncDisposable {
   setRawMode(enabled: boolean): void;
   ref(): void;
   unref(): void;
+  pause(): void;
+  resume(): void;
   close(): void;
 }
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8601,6 +8601,12 @@ declare module "bun" {
     readonly closed: boolean;
 
     /**
+     * Whether reads are currently paused via `pause()`. Always `false` once
+     * the terminal is closed.
+     */
+    readonly paused: boolean;
+
+    /**
      * Write data to the terminal.
      *
      * All bytes are accepted; any portion that cannot be flushed to the PTY
@@ -8636,6 +8642,23 @@ declare module "bun" {
      * Unreference the terminal to allow the event loop to exit.
      */
     unref(): void;
+
+    /**
+     * Stop reading the PTY master until `resume()` is called.
+     *
+     * While paused, a child that keeps writing blocks in `write(2)` on a
+     * full PTY buffer instead of spinning the `data` callback, which bounds
+     * host CPU when the consumer has fallen behind. Safe to call from inside
+     * the `data` callback. Idempotent; a no-op on a closed terminal.
+     */
+    pause(): void;
+
+    /**
+     * Restart reading the PTY master after `pause()`.
+     *
+     * A no-op unless paused, on a closed terminal, or after the reader hit EOF.
+     */
+    resume(): void;
 
     /**
      * Close the terminal.

--- a/src/runtime/api/Terminal.classes.ts
+++ b/src/runtime/api/Terminal.classes.ts
@@ -32,6 +32,14 @@ export default [
         fn: "doUnref",
         length: 0,
       },
+      pause: {
+        fn: "pause",
+        length: 0,
+      },
+      resume: {
+        fn: "resume",
+        length: 0,
+      },
       close: {
         fn: "close",
         length: 0,
@@ -42,6 +50,9 @@ export default [
       },
       closed: {
         getter: "getClosed",
+      },
+      paused: {
+        getter: "getPaused",
       },
       inputFlags: {
         getter: "getInputFlags",

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -164,7 +164,7 @@ pub struct Terminal {
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Default)]
-    pub struct Flags: u8 {
+    pub struct Flags: u16 {
         const CLOSED         = 1 << 0;
         const FINALIZED      = 1 << 1;
         const RAW_MODE       = 1 << 2;
@@ -176,6 +176,10 @@ bitflags::bitflags! {
         /// reuse. Windows: the ConDrv `\Reference` handle is released at spawn.
         /// POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
+        /// Reads paused via `pause()`; cleared by `resume()`. While set the
+        /// reader poll stays unregistered (POSIX) or the libuv read stays
+        /// stopped (Windows), applying backpressure to the child.
+        const PAUSED         = 1 << 8;
     }
 }
 
@@ -1641,6 +1645,63 @@ impl Terminal {
     pub(crate) fn do_unref(&self, _g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
         self.update_ref(false);
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// Stop reading the PTY master until `resume()` is called.
+    ///
+    /// While paused the read poll stays unregistered (POSIX) or the libuv
+    /// read stays stopped (Windows), so a child that keeps writing blocks in
+    /// `write(2)` on a full PTY buffer instead of spinning the `data`
+    /// callback. Safe to call from inside the `data` callback. Idempotent;
+    /// a no-op on a closed terminal.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn pause(&self, _g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
+        let flags = self.flags.get();
+        if flags.contains(Flags::CLOSED) || flags.contains(Flags::PAUSED) {
+            return Ok(JSValue::UNDEFINED);
+        }
+        self.update_flags(|f| f.insert(Flags::PAUSED));
+        self.reader.with_mut(|r| r.pause());
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// Restart reading the PTY master after `pause()`.
+    ///
+    /// Clears the paused state and kicks the reader so already-buffered
+    /// output is delivered without waiting for the next poll event. A no-op
+    /// unless paused, on a closed terminal, or after the reader hit EOF.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn resume(&self, _g: &JSGlobalObject, _f: &CallFrame) -> JsResult<JSValue> {
+        if !self.flags.get().contains(Flags::PAUSED) {
+            return Ok(JSValue::UNDEFINED);
+        }
+        self.update_flags(|f| f.remove(Flags::PAUSED));
+        let flags = self.flags.get();
+        if flags.contains(Flags::CLOSED)
+            || !flags.contains(Flags::READER_STARTED)
+            || flags.contains(Flags::READER_DONE)
+        {
+            return Ok(JSValue::UNDEFINED);
+        }
+        // The kick below dispatches `data` callbacks that may re-enter user
+        // JS and drop the last ref; hold one across it (cf.
+        // `drain_and_close_slave_fd`). Windows completes reads through libuv,
+        // never synchronously, so no guard is needed there.
+        #[cfg(unix)]
+        let _guard = self.ref_guard();
+        self.reader.with_mut(|r| r.unpause());
+        // SAFETY: the reader cell is live for the terminal's lifetime; `read`
+        // is the raw re-entrancy-safe entry (its dispatch runs user JS).
+        unsafe { IOReader::read(self.reader.as_ptr()) };
+        Ok(JSValue::UNDEFINED)
+    }
+
+    /// Whether reads are currently paused via `pause()`. Always false once
+    /// the terminal is closed.
+    #[bun_jsc::host_fn(getter)]
+    pub(crate) fn get_paused(&self, _global: &JSGlobalObject) -> JSValue {
+        let flags = self.flags.get();
+        JSValue::from(flags.contains(Flags::PAUSED) && !flags.contains(Flags::CLOSED))
     }
 
     fn update_ref(&self, add: bool) {

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1760,6 +1760,17 @@ impl Terminal {
             if let Some(hpcon) = self.hpcon.take() {
                 self.close_pseudoconsole_off_thread(hpcon);
             }
+            // A paused reader stopped its libuv read, so it would never
+            // observe the EOF this early return waits for: the reader ref
+            // would leak and the handle would keep the event loop alive.
+            // Resume so the final drain and onReaderDone still happen;
+            // post-close data delivery then matches an unpaused close.
+            // (pause() is a no-op once CLOSED, so the resumed drain cannot
+            // re-pause from a callback.)
+            if self.flags.get().contains(Flags::PAUSED) {
+                self.update_flags(|f| f.remove(Flags::PAUSED));
+                self.reader.with_mut(|r| r.unpause());
+            }
             // Leave the reader open; onReaderDone closes it on EOF.
             let flags = self.flags.get();
             if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1982,6 +1982,9 @@ impl Terminal {
 
         // Each chunk's `data` callback is its own top-level call: reported and
         // reading continues, as a stream 'data' listener that throws does.
+        // A `pause()` from inside the callback must stop the active dispatch
+        // immediately: report whether PAUSED is still clear so the reader
+        // does not deliver more chunks to a paused consumer.
         global_this.bun_vm().event_loop_mut().run_callback(
             callback,
             global_this,
@@ -1989,7 +1992,7 @@ impl Terminal {
             &[this_jsvalue, data],
         );
 
-        true // Continue reading
+        !self.flags.get().contains(Flags::PAUSED)
     }
 
     fn loop_(&self) -> *mut AsyncLoop {

--- a/test/integration/bun-types/fixture/terminal.ts
+++ b/test/integration/bun-types/fixture/terminal.ts
@@ -1,0 +1,29 @@
+// Fixture: Bun.Terminal pause/resume backpressure API (issue #41410).
+const terminal = new Bun.Terminal({
+  cols: 80,
+  rows: 24,
+  data(term, data) {
+    const bytes: Uint8Array<ArrayBuffer> = data;
+    term.pause();
+    console.log(bytes.byteLength);
+  },
+  exit(term, exitCode, signal) {
+    const code: number = exitCode;
+    const sig: string | null = signal;
+    console.log(code, sig, term.closed);
+  },
+  drain(term) {
+    term.resume();
+  },
+});
+
+const terminalPaused: boolean = terminal.paused;
+const terminalClosed: boolean = terminal.closed;
+terminal.pause();
+terminal.resume();
+terminal.write("echo hi\n");
+terminal.resize(120, 40);
+terminal.setRawMode(true);
+terminal.ref();
+terminal.unref();
+terminal.close();

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -670,6 +670,51 @@ describe("Bun.Terminal", () => {
         await proc.exited;
       }
     });
+
+    test("close after pause still finishes (exit fires)", async () => {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      let exitCode: number | null = null;
+
+      const terminal = new Bun.Terminal({
+        exit(term, code) {
+          exitCode = code;
+          resolve();
+        },
+      });
+
+      terminal.pause();
+      expect(terminal.paused).toBe(true);
+      terminal.close();
+      expect(terminal.closed).toBe(true);
+
+      // On Windows close() waits for EOF with the reader left open; a paused
+      // reader must be resumed so EOF (and the exit callback) still arrives
+      // instead of hanging the event loop on the leaked reader ref.
+      await promise;
+
+      expect(exitCode).toBe(0);
+      expect(terminal.paused).toBe(false);
+    });
+
+    test("asyncDispose after pause resolves and closes", async () => {
+      let exited = false;
+
+      const terminal = new Bun.Terminal({
+        exit() {
+          exited = true;
+        },
+      });
+
+      terminal.pause();
+      expect(terminal.paused).toBe(true);
+
+      await terminal[Symbol.asyncDispose]();
+
+      expect(terminal.closed).toBe(true);
+      expect(terminal.paused).toBe(false);
+      // Dispose suppresses the exit callback like an unpaused dispose does.
+      expect(exited).toBe(false);
+    });
   });
 
   // ConPTY has no line discipline echo without a child process, so termios-echo

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -561,6 +561,117 @@ describe("Bun.Terminal", () => {
     });
   });
 
+  describe("pause and resume", () => {
+    test("paused starts false and toggles", async () => {
+      await using terminal = new Bun.Terminal({});
+
+      expect(terminal.paused).toBe(false);
+      terminal.pause();
+      expect(terminal.paused).toBe(true);
+      terminal.pause(); // Second pause is idempotent
+      expect(terminal.paused).toBe(true);
+      terminal.resume();
+      expect(terminal.paused).toBe(false);
+      terminal.resume(); // Second resume is idempotent
+      expect(terminal.paused).toBe(false);
+    });
+
+    test("pause and resume on a closed terminal are no-ops", async () => {
+      const terminal = new Bun.Terminal({});
+
+      terminal.pause();
+      expect(terminal.paused).toBe(true);
+      terminal.close();
+      expect(terminal.paused).toBe(false);
+      terminal.pause();
+      terminal.resume();
+      expect(terminal.paused).toBe(false);
+    });
+
+    test("pause stops data delivery and resume restarts it", async () => {
+      let chunks = 0;
+      const { promise: firstChunk, resolve: resolveFirstChunk } = Promise.withResolvers<void>();
+
+      await using terminal = new Bun.Terminal({
+        data(term, data) {
+          chunks += 1;
+          resolveFirstChunk();
+        },
+      });
+
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "-e", "while (true) { console.log('0123456789abcdef'); }"],
+        env: bunEnv,
+        terminal,
+      });
+
+      try {
+        // Wait for the first chunk instead of sleeping for an arbitrary duration.
+        await firstChunk;
+
+        terminal.pause();
+        expect(terminal.paused).toBe(true);
+
+        // Bounded poll: no new chunks may arrive while paused because the
+        // runtime stops reading the PTY master.
+        const frozen = chunks;
+        const quietDeadline = Date.now() + 500;
+        while (Date.now() < quietDeadline) {
+          await Bun.sleep(50);
+          expect(chunks).toBe(frozen);
+        }
+
+        terminal.resume();
+        expect(terminal.paused).toBe(false);
+
+        // Wait for delivery to restart, with a deadline generous enough for
+        // debug+ASAN builds.
+        const growthDeadline = Date.now() + 10_000;
+        while (chunks <= frozen && Date.now() < growthDeadline) {
+          await Bun.sleep(25);
+        }
+        expect(chunks).toBeGreaterThan(frozen);
+      } finally {
+        proc.kill("SIGKILL");
+        await proc.exited;
+      }
+    });
+
+    test("pause can be called from inside the data callback", async () => {
+      let chunks = 0;
+      const { promise: paused, resolve: resolvePaused } = Promise.withResolvers<void>();
+
+      await using terminal = new Bun.Terminal({
+        data(term, data) {
+          chunks += 1;
+          term.pause();
+          resolvePaused();
+        },
+      });
+
+      // ConPTY has no line-discipline echo without a child process, so echo
+      // through a stdin->stdout passthrough child instead of a raw write.
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+        env: bunEnv,
+        terminal,
+      });
+
+      try {
+        terminal.write("hello from test\n");
+        await paused;
+
+        expect(terminal.paused).toBe(true);
+        expect(chunks).toBeGreaterThan(0);
+        terminal.resume();
+        expect(terminal.paused).toBe(false);
+      } finally {
+        proc.kill();
+        await proc.exited;
+      }
+    });
+  });
+
   // ConPTY has no line discipline echo without a child process, so termios-echo
   // tests are POSIX-only.
   describe.concurrent.todoIf(isWindows)("data callback", () => {


### PR DESCRIPTION
### What does this PR do?

Bun.Terminal gave consumers no way to stop reading the pty master: the reader polled continuously, so the data callback fired at whatever rate the child produced. A slow consumer (e.g. a multiplexer fanning output to sockets) burned host CPU with no lever to slow the child down. ref()/unref() only affect event-loop keepalive, and close() ends the attachment.

This adds Terminal.pause()/resume() plus a readonly paused getter, backed by the BufferedReader's existing pause/unpause (poll unregister on POSIX, uv_read_stop on Windows). While paused, a writing child blocks in write(2) on a full pty buffer, like under any other terminal emulator. resume() clears the flag and kicks the reader so buffered output is delivered without waiting for the next poll event. Both are idempotent no-ops on a closed terminal and safe to call from inside the data callback. Naming follows node-pty IPty and Bun Socket pause/resume precedent; the paused getter mirrors the existing closed getter in the same class.

Fixes #41410

### How did you verify your code works?

- New tests in test/js/bun/terminal/terminal.test.ts (flag toggling, closed-terminal no-ops, pause stops delivery / resume restarts it against a flooding child, pause from inside the data callback). The two non-child tests fail on the unfixed build for the right reason (paused is undefined, pause is not a function); the child tests need a build with this change.
- New type fixture test/integration/bun-types/fixture/terminal.ts exercising pause()/resume()/paused; type-checked clean under strict tsc. Docs (docs/runtime/child-process.mdx) and packages/bun-types/bun.d.ts updated in the same PR.
- Codegen verified by running src/codegen/generate-classes.ts over the edited Terminal.classes.ts: it emits TerminalPrototype__pause/__resume/__getPaused thunks calling Terminal::pause/resume/get_paused.
- Full bun bd build and test run were not possible in this environment (no LLVM 21 / Rust toolchain, 12GB free vs ~10GB needed), so CI must confirm. Happy to iterate on review feedback.