### PR TITLE
Windows: wait for close completions when closing a worker's uv loop

### DIFF
--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -15,7 +15,7 @@
     clippy::missing_safety_doc
 )]
 
-use core::cell::{Cell, UnsafeCell};
+use core::cell::Cell;
 use core::ffi::{c_char, c_int, c_long, c_uint, c_ulong, c_ushort, c_void};
 use core::mem::MaybeUninit;
 use core::time::Duration;
@@ -364,23 +364,11 @@ pub struct Loop {
 }
 pub type uv_loop_t = Loop;
 
-// `Loop::get()` escapes a raw pointer into this TLS slot out of the
-// `LocalKey::with` closure and hands it to libuv for the thread lifetime.
-// That is sound only because the slot has NO destructor: with no `Drop`, std
-// registers no TLS dtor, so the `LocalKey` storage outlives every per-thread
-// caller and the escaped address stays valid until thread exit. Guard the
-// no-Drop invariant at compile time so adding `impl Drop for Loop` (or
-// wrapping the cell) fails loudly here rather than becoming silent UB.
-const _: () = assert!(!core::mem::needs_drop::<Loop>());
-const _: () = assert!(!core::mem::needs_drop::<UnsafeCell<MaybeUninit<Loop>>>());
-
 thread_local! {
-    /// Static TLS storage (zero-alloc). `MaybeUninit` because the slot is
-    /// only valid after `uv_loop_init`.
-    static THREADLOCAL_LOOP_DATA: UnsafeCell<MaybeUninit<Loop>> =
-        const { UnsafeCell::new(MaybeUninit::uninit()) };
-    /// `threadlocal var threadlocal_loop: ?*Loop = null` — null until `get()`
-    /// initializes `THREADLOCAL_LOOP_DATA`.
+    /// This thread's loop, heap-allocated by `get()` and freed by
+    /// `close_thread_loop` once `uv_loop_close` succeeds. Until then libuv's
+    /// loop registry points at it (`uv__wake_all_loops` walks that registry
+    /// on system resume), so its storage must not be tied to the thread.
     static THREADLOCAL_LOOP: Cell<*mut Loop> = const { Cell::new(ptr::null_mut()) };
 }
 
@@ -413,13 +401,10 @@ impl Loop {
             if !existing.is_null() {
                 return existing;
             }
-            // SAFETY: TLS slot is per-thread; no aliasing. `uv_loop_init`
-            // accepts uninitialized storage (it zero-fills internally).
-            // Escaping the pointer past `.with()` is intentional: the slot is
-            // const-initialized POD with no TLS destructor (static-asserted
-            // above), so its address is stable for the thread lifetime.
-            let ptr_ = THREADLOCAL_LOOP_DATA.with(|data| unsafe { (*data.get()).as_mut_ptr() });
-            // SAFETY: `ptr_` is `sizeof(Loop)` TLS storage owned by this thread.
+            // `uv_loop_init` accepts uninitialized storage (it zero-fills
+            // internally).
+            let ptr_ = bun_core::heap::into_raw(Box::<Loop>::new_uninit()).cast::<Loop>();
+            // SAFETY: `ptr_` is `sizeof(Loop)` heap storage owned by this thread.
             if let Some(err) = unsafe { uv_loop_init(ptr_) }.raw_errno() {
                 panic!("Failed to initialize libuv loop: errno {err}");
             }
@@ -472,7 +457,8 @@ impl Loop {
                 return;
             }
             // SAFETY: `loop_` is the live per-thread loop initialized in `get()`.
-            if let Some(err) = unsafe { uv_loop_close(loop_) }.raw_errno() {
+            let mut rc = unsafe { uv_loop_close(loop_) };
+            if let Some(err) = rc.raw_errno() {
                 // Only EBUSY means handles are still linked; walk + close any not
                 // already closing, run to flush close callbacks and endgames, then
                 // close again (must succeed). `uv_loop_close` documents no other
@@ -491,7 +477,6 @@ impl Loop {
                     // ref'd-but-idle state (Bun's virtual keep-alive count lives
                     // in active_handles) and never return.
                     let started = Instant::now();
-                    let mut rc;
                     loop {
                         // SAFETY: this thread's initialised loop; nothing else drives it.
                         let _ = unsafe { uv_run(loop_, RunMode::NoWait) };
@@ -520,6 +505,13 @@ impl Loop {
                 }
             }
             slot.set(ptr::null_mut());
+            if rc == ReturnCode::ZERO {
+                // SAFETY: `get()` allocated it; `uv_loop_close` unregistered it
+                // and nothing references it any more.
+                unsafe { bun_core::heap::destroy(loop_.cast::<MaybeUninit<Loop>>()) };
+            }
+            // Otherwise the loop stays registered with libuv and keeps its
+            // storage: a leak, not a dangling registry entry.
         });
     }
 

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -463,16 +463,8 @@ impl Loop {
     /// pre/check/async/timer, closed by us_loop_free and freed by their close
     /// callbacks when the loop next turns.
     pub fn close_thread_loop() {
-        /// How long `close_thread_loop` waits for the close completions of
-        /// handles it found still linked. A few thousand cancelled AFD polls
-        /// complete within 100ms; the kernel gets slower the more are
-        /// outstanding at once (a worker torn down with 9000 open sockets
-        /// needed 17s). The parent's `terminate()` and the process exit wait
-        /// on this, so it is a bound on a handle whose I/O never returns, not
-        /// a budget for a healthy teardown. Past it the loop is abandoned:
-        /// its storage is this thread's TLS, and it stays in libuv's loop
-        /// registry, so a later `uv__wake_all_loops` (system resume) reads a
-        /// dead loop.
+        /// Bound on a handle whose close never completes; `terminate()` and
+        /// process exit wait on this. A healthy teardown takes milliseconds.
         const CLOSE_THREAD_LOOP_DEADLINE: Duration = Duration::from_secs(10);
         THREADLOCAL_LOOP.with(|slot| {
             let loop_ = slot.get();
@@ -492,21 +484,12 @@ impl Loop {
                     // (owners are freed only after this returns).
                     unsafe { uv_walk(loop_, Some(log_unclosed_cb), ptr::null_mut()) };
                     unsafe { uv_walk(loop_, Some(close_walk_cb), ptr::null_mut()) };
-                    // Everything is closing now; only close callbacks / endgames
-                    // remain. Turn the loop without blocking until they have run —
-                    // RunMode::Default would also wait on ref'd-but-idle state
-                    // (Bun's virtual keep-alive count lives in active_handles) and
-                    // never return.
-                    //
-                    // A closing uv_poll_t (every uSockets socket) reaches its
-                    // endgame only once the kernel completes the AFD poll that
-                    // uv_close cancelled. That completion is posted to the IOCP
-                    // asynchronously, and one turn dequeues at most 128 of them
-                    // (uv__poll's GetQueuedCompletionStatusEx batch), so a fixed
-                    // number of back-to-back NoWait turns is wrong both ways: they
-                    // finish in microseconds, before the first completion lands,
-                    // and they cap how many sockets can close at all. Keep
-                    // turning, sleep 1ms between turns, bounded by a deadline.
+                    // Everything is closing now. A closing uv_poll_t is unlinked
+                    // only once the kernel posts the completion of its cancelled
+                    // AFD poll to the IOCP, and one NoWait turn dequeues at most
+                    // 128 completions. RunMode::Default would also wait on
+                    // ref'd-but-idle state (Bun's virtual keep-alive count lives
+                    // in active_handles) and never return.
                     let started = Instant::now();
                     let mut rc;
                     loop {

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -18,7 +18,9 @@
 use core::cell::{Cell, UnsafeCell};
 use core::ffi::{c_char, c_int, c_long, c_uint, c_ulong, c_ushort, c_void};
 use core::mem::MaybeUninit;
+use core::time::Duration;
 use core::{fmt, mem, ptr};
+use std::time::Instant;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Debug log scope (`bun.Output.scoped(.uv, .hidden)`). This crate is leaf
@@ -461,6 +463,17 @@ impl Loop {
     /// pre/check/async/timer, closed by us_loop_free and freed by their close
     /// callbacks when the loop next turns.
     pub fn close_thread_loop() {
+        /// How long `close_thread_loop` waits for the close completions of
+        /// handles it found still linked. A few thousand cancelled AFD polls
+        /// complete within 100ms; the kernel gets slower the more are
+        /// outstanding at once (a worker torn down with 9000 open sockets
+        /// needed 17s). The parent's `terminate()` and the process exit wait
+        /// on this, so it is a bound on a handle whose I/O never returns, not
+        /// a budget for a healthy teardown. Past it the loop is abandoned:
+        /// its storage is this thread's TLS, and it stays in libuv's loop
+        /// registry, so a later `uv__wake_all_loops` (system resume) reads a
+        /// dead loop.
+        const CLOSE_THREAD_LOOP_DEADLINE: Duration = Duration::from_secs(10);
         THREADLOCAL_LOOP.with(|slot| {
             let loop_ = slot.get();
             if loop_.is_null() {
@@ -484,20 +497,41 @@ impl Loop {
                     // RunMode::Default would also wait on ref'd-but-idle state
                     // (Bun's virtual keep-alive count lives in active_handles) and
                     // never return.
-                    let mut rc = ReturnCode::ZERO;
-                    for _ in 0..64 {
+                    //
+                    // A closing uv_poll_t (every uSockets socket) reaches its
+                    // endgame only once the kernel completes the AFD poll that
+                    // uv_close cancelled. That completion is posted to the IOCP
+                    // asynchronously, and one turn dequeues at most 128 of them
+                    // (uv__poll's GetQueuedCompletionStatusEx batch), so a fixed
+                    // number of back-to-back NoWait turns is wrong both ways: they
+                    // finish in microseconds, before the first completion lands,
+                    // and they cap how many sockets can close at all. Keep
+                    // turning, sleep 1ms between turns, bounded by a deadline.
+                    let started = Instant::now();
+                    let mut rc;
+                    loop {
                         // SAFETY: this thread's initialised loop; nothing else drives it.
                         let _ = unsafe { uv_run(loop_, RunMode::NoWait) };
                         // SAFETY: as above.
                         rc = unsafe { uv_loop_close(loop_) };
-                        if rc == ReturnCode::ZERO {
+                        if rc == ReturnCode::ZERO || started.elapsed() >= CLOSE_THREAD_LOOP_DEADLINE {
                             break;
                         }
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    if rc != ReturnCode::ZERO {
+                        log!(
+                            "close_thread_loop: loop still busy after {:?}, abandoning it",
+                            started.elapsed()
+                        );
+                        // SAFETY: as above; the walk only reads handle headers.
+                        unsafe { uv_walk(loop_, Some(log_walk_cb), ptr::null_mut()) };
                     }
                     debug_assert_eq!(
                         rc,
                         ReturnCode::ZERO,
-                        "uv loop still busy after closing every handle"
+                        "uv loop still busy {:?} after closing every handle",
+                        CLOSE_THREAD_LOOP_DEADLINE
                     );
                 }
             }
@@ -550,6 +584,7 @@ impl Loop {
 unsafe extern "C" fn log_unclosed_cb(handle: *mut uv_handle_t, data: *mut c_void) {
     // SAFETY: libuv passes live handles.
     if unsafe { uv_is_closing(handle) } == 0 {
+        log!("handle left open by its owner:");
         // SAFETY: as above.
         unsafe { log_walk_cb(handle, data) };
     }
@@ -573,7 +608,7 @@ unsafe extern "C" fn log_walk_cb(handle: *mut uv_handle_t, _data: *mut c_void) {
     // SAFETY: libuv passes a live handle; these calls only read its header.
     unsafe {
         log!(
-            "handle left open by its owner: {} @{:p} active={} closing={} ref={} data={:p}",
+            "handle still linked: {} @{:p} active={} closing={} ref={} data={:p}",
             handle_type_name(handle),
             handle,
             uv_is_active(handle),

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -514,7 +514,8 @@ impl Loop {
                         let _ = unsafe { uv_run(loop_, RunMode::NoWait) };
                         // SAFETY: as above.
                         rc = unsafe { uv_loop_close(loop_) };
-                        if rc == ReturnCode::ZERO || started.elapsed() >= CLOSE_THREAD_LOOP_DEADLINE {
+                        if rc == ReturnCode::ZERO || started.elapsed() >= CLOSE_THREAD_LOOP_DEADLINE
+                        {
                             break;
                         }
                         std::thread::sleep(Duration::from_millis(1));

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -273,8 +273,22 @@ test.skipIf(!isDebug)(
   async () => {
     // Each round keeps LANES loopback connects in flight per worker and
     // terminates once the worker reports steady state, so terminate() lands
-    // while on_open is hot. Debug+ASAN makes each round ~5s, so the pass
-    // time is ~60s; the unpatched build aborts in the first few rounds.
+    // while on_open is hot. Debug+ASAN makes each round ~1.5s, so the pass
+    // time is ~20s; the unpatched build aborts in the first few rounds.
+    //
+    // The fixture is shaped so a loopback flood cannot wedge it (it did on
+    // Windows, where a full backlog RSTs instead of dropping the SYN):
+    // - The server runs in its own worker. The accept loop of a flooded
+    //   listener never returns to its event loop, so the thread that awaits
+    //   'hot' and terminate() must not be the one accepting.
+    // - A lane reconnects only after the server answered ('x' arrives), so
+    //   at most LANES connections per worker are ever pending in the backlog.
+    // - The client closes with terminate() (RST, no TIME_WAIT). An end() on
+    //   every connection ties up the whole ephemeral port range within
+    //   seconds, and every connect after that fails.
+    // - A failed connect fires connectError() AND rejects the promise, so
+    //   only connectError() re-spawns the lane. Re-spawning from both doubles
+    //   the lanes on every failure.
     const ROUNDS = 12;
     const WORKERS = 4;
     const LANES = 32;
@@ -284,28 +298,36 @@ test.skipIf(!isDebug)(
         "-e",
         `
         const { Worker } = require("node:worker_threads");
-        const net = require("node:net");
-        const srv = net.createServer((c) => { c.on("error", () => {}); c.end(); });
-        await new Promise((r) => srv.listen(0, "127.0.0.1", r));
-        const port = srv.address().port;
+        function ready(w) {
+          return new Promise((res, rej) => {
+            const onExit = (c) => rej(new Error("worker exited " + c + " before ready"));
+            w.once("exit", onExit);
+            w.once("error", rej);
+            w.once("message", (m) => { w.off("exit", onExit); w.off("error", rej); res(m); });
+          });
+        }
+        const server = new Worker(
+          "const net = require('node:net');" +
+          "const srv = net.createServer((c) => { c.on('error', () => {}); c.end('x'); });" +
+          "srv.listen(0, '127.0.0.1', () => require('node:worker_threads').parentPort.postMessage(srv.address().port));",
+          { eval: true },
+        );
+        const port = await ready(server);
+        // Without the server every lane spins on connectError() and no worker
+        // ever reports 'hot'; fail at once instead of at the test timeout.
+        const serverGone = (c) => { console.error("server worker exited " + c); process.exit(1); };
+        server.on("exit", serverGone);
         const src =
           "const { parentPort, workerData: d } = require('node:worker_threads');" +
           "let opens = 0;" +
           "function lane() {" +
           "  Bun.connect({ hostname: '127.0.0.1', port: d.port, socket: {" +
-          "    open(s) { if (++opens === ${LANES}) parentPort.postMessage('hot'); s.end(); }," +
-          "    data() {}, close() { setImmediate(lane); }," +
+          "    open() { if (++opens === ${LANES}) parentPort.postMessage('hot'); }," +
+          "    data(s) { s.terminate(); }, close() { setImmediate(lane); }," +
           "    connectError() { setImmediate(lane); }, error() {} } })" +
-          "    .catch(() => setImmediate(lane));" +
+          "    .catch(() => {});" +
           "}" +
           "for (let i = 0; i < ${LANES}; i++) lane();";
-        function ready(w) {
-          return new Promise((res, rej) => {
-            w.once("message", res);
-            w.once("error", rej);
-            w.once("exit", (c) => rej(new Error("worker exited " + c + " before ready")));
-          });
-        }
         for (let r = 0; r < ${ROUNDS}; r++) {
           const ws = [];
           for (let i = 0; i < ${WORKERS}; i++) {
@@ -317,7 +339,8 @@ test.skipIf(!isDebug)(
           await Bun.sleep(r % 3);
           await Promise.all(ws.map((w) => w.terminate()));
         }
-        srv.close();
+        server.off("exit", serverGone);
+        await server.terminate();
         console.log("PASS");
       `,
       ],


### PR DESCRIPTION
### Problem
- On Windows, a worker terminated with many open sockets fails at teardown: `panic: assertion left == right failed: uv loop still busy after closing every handle` (`Loop::close_thread_loop`, `src/libuv_sys/libuv.rs:465`). Release skips the assert and abandons the loop. The loop lived in the thread's TLS and stayed in libuv's `uv__loops[]` registry, so the thread exit left a dangling entry there, the crash class of #28175 (`uv__wake_all_loops` SEGV after resume).
- `close_thread_loop` ran 64 `uv_run(NoWait)` turns back to back. They finish before the first close completion lands, and a turn dequeues at most 128 completions, so 64 turns cannot close more than 8192 polls.
- `worker-terminate-lifetime.test.ts` ("Bun.connect() open is firing") timed out in 2 of 3 Windows debug runs. Its fixture also wedged by itself: a full Windows backlog sends RST, the lanes retried at once, and the flood trapped the server thread in the uSockets accept loop.

### Fix
- `close_thread_loop` turns the loop until `uv_loop_close` succeeds, sleeps 1 ms between turns, and stops at a 10 s deadline. The deadline bounds what `terminate()` and process exit wait on. It is not a budget: a few thousand sockets close in under 100 ms. When it passes, the linked handles are logged under `BUN_DEBUG_uv`.
- The loop is now heap-allocated instead of TLS-embedded. A loop that did not close is leaked, so its registry entry stays valid. A closed loop is freed.
- The fixture runs the server in its own worker, reconnects a lane only after the server answered, closes with `terminate()` (RST, no TIME_WAIT), re-spawns from `connectError()` only (the promise rejection fires for the same failure), and exits at once if the server worker dies.
- Verified on windows-x64 debug: the test passes 3 of 3 in 10 s (main: 2 of 3 time out). The original fixture panicked in about 1 of 4 runs on main, 0 of 6 with the fix. Self-reviewed: 5 concerns raised, 4 addressed, plus the review that asked for the heap allocation. Rejected: "an `active_handles` residue makes the deadline wait in vain". `uv_loop_close` checks linked handles and active requests, not `active_handles`.

### Background
- On Windows, Bun's event loop is libuv. Each uSockets socket is a `uv_poll_t` watched through AFD, the kernel socket driver. `uv_close` cancels the outstanding AFD poll. The cancel completes asynchronously through the loop's I/O completion port (IOCP), and only then is the handle unlinked.
- `uv_loop_close` returns `UV_EBUSY` while a handle is linked. `close_thread_loop` runs in VM teardown step D, after every socket was closed.
- The test is `skipIf(!isDebug)` and no CI lane runs a Windows debug build, so the assert and the wedge reproduce only locally on Windows. The gate runs on Linux and cannot show this fix failing before. The Windows runs above are the fail-before proof.

<details><summary>Notes</summary>

Probes on windows-x64 (Windows Server 2019, debug build), with temporary logging in `close_thread_loop`:

- 3000 idle sockets per worker: 24 turns, 39 ms. 2000 in-flight connects: 16 turns, 26 ms. Both fit in the old 64 turns.
- 9000 idle sockets: 99 turns, 17.5 s on the first round, 71 turns, 3.3 s on the second. The old code would have asserted on both. The 10 s deadline does not cover the first case. A process that terminates a worker with 9000 open sockets is the torture case, and 60 s on the exit path was judged worse than the abandoned loop.
- The original fixture's storm (about 5000 to 7000 sockets per worker): 40 to 58 turns in about 80 ms most of the time. In 2 of 8 runs the four workers' completions arrived staggered at 4, 8, 12 and 16 s. Until then about 500 to 1000 polls per worker still had both AFD requests outstanding (`submitted_events = (6,5)`). I did not find what in the kernel serializes them.
- The original fixture on Windows: `netstat` showed 16400 TIME_WAIT entries 6 s in, the whole ephemeral range, from the client's `end()`. With `terminate()` it stays under 1200.
- With one client worker the main-thread server accepts about 2700 connections per second. With four, the accept loop in `us_internal_dispatch_ready_poll` (`packages/bun-usockets/src/loop.c:485`) never returns to the event loop: a heartbeat timer stopped and `terminate()` never resolved. Node's libuv on Windows bounds accepts per loop turn (`AcceptEx` slots). uSockets loops until `accept()` fails. I left that alone here. It is a separate change with its own test.
- The worker's connect failures in the flood are reported as `ECONNREFUSED`. `handle_connect_error` maps every errno outside its whitelist to that code, so the raw WSA code is not visible from JS.
- After the deadline the owners of the still-closing polls are freed in step E while the kernel can still post a completion into their `OVERLAPPED`. That hazard predates this change. The fix for it is to not reach the deadline.
- `us_loop_free` (`packages/bun-usockets/src/eventing/libuv.c:353`) has the same one-turn-then-delete shape for the loops `spawnSync` creates on Windows. #33015 is open for that site. This PR changes only the worker loop.
- Also ran: the whole `worker-terminate-lifetime.test.ts` on Windows (23 pass, 2 skip) and on Linux debug (24 pass, the known LSan leak in the dns test fails, #35159). `cargo check -p bun_libuv_sys --target x86_64-pc-windows-msvc`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->