### PR TITLE
install: link ancestor-provided peers in the isolated store with --omit=peer

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -42,7 +42,10 @@ use bun_wyhash::{Wyhash, Wyhash11};
 use crate::analytics;
 use crate::bun_bunfig::Arguments as Command;
 use crate::bun_progress::{Node as ProgressNode, Progress};
-use crate::lockfile::tree::is_filtered_dependency_or_workspace;
+use crate::lockfile::tree::{
+    DisabledPeers, dependency_features, is_filtered_dependency_or_workspace,
+    is_filtered_dependency_or_workspace_with,
+};
 use crate::lockfile::{self, Lockfile};
 use crate::package_manager::{self, PackageManager, WorkspaceFilter, run_tasks};
 use crate::package_manager_real::ProgressStrings;
@@ -685,8 +688,11 @@ pub(crate) fn build_store(
                 }
             }
 
+            // `--omit=peer` only disables the auto-install fallback below. A peer
+            // that an ancestor provides is still linked into the entry, like
+            // pnpm with `auto-install-peers=false`.
             for &dep_id in &dep_ids_sort_buf {
-                if is_filtered_dependency_or_workspace(
+                if is_filtered_dependency_or_workspace_with(
                     dep_id,
                     entry.pkg_id,
                     workspace_filters,
@@ -694,6 +700,7 @@ pub(crate) fn build_store(
                     manager,
                     lockfile,
                     resolutions,
+                    DisabledPeers::Keep,
                 ) {
                     continue;
                 }
@@ -722,6 +729,9 @@ pub(crate) fn build_store(
             }
         }
 
+        let auto_install_peers =
+            dependency_features(manager, &pkg_resolutions[entry.pkg_id as usize]).peer_dependencies;
+
         for &peer_dep_id in &peer_dep_ids {
             let (resolved_pkg_id, auto_installed) = 'resolved_pkg_id: {
                 // Go through the peers parents looking for a package with the same name.
@@ -730,6 +740,13 @@ pub(crate) fn build_store(
                 // are deduplicated only if their package id and their transitive peer package
                 // ids are equal.
                 let peer_dep = &dependencies[peer_dep_id as usize];
+
+                // The version to auto-install when no parent provides the peer.
+                let best_version = if auto_install_peers {
+                    resolutions[peer_dep_id as usize]
+                } else {
+                    invalid_package_id
+                };
 
                 // TODO: double check this
                 // Start with the current package. A package
@@ -790,8 +807,6 @@ pub(crate) fn build_store(
                         // version. Only mark all parents if resolution is
                         // different from this transitive peer.
 
-                        let best_version = resolutions[peer_dep_id as usize];
-
                         if best_version == invalid_package_id {
                             break 'resolved_pkg_id (invalid_package_id, true);
                         }
@@ -818,12 +833,12 @@ pub(crate) fn build_store(
                 }
 
                 // choose the current best version
-                break 'resolved_pkg_id (resolutions[peer_dep_id as usize], true);
+                break 'resolved_pkg_id (best_version, true);
             };
 
             if resolved_pkg_id == invalid_package_id {
-                // these are optional peers that failed to find any dependency with a matching
-                // name. they are completely excluded
+                // optional peers, and peers disabled with `--omit=peer`, that found no
+                // dependency with a matching name. they are completely excluded
                 continue;
             }
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -688,9 +688,6 @@ pub(crate) fn build_store(
                 }
             }
 
-            // `--omit=peer` only disables the auto-install fallback below. A peer
-            // that an ancestor provides is still linked into the entry, like
-            // pnpm with `auto-install-peers=false`.
             for &dep_id in &dep_ids_sort_buf {
                 if is_filtered_dependency_or_workspace_with(
                     dep_id,
@@ -741,7 +738,6 @@ pub(crate) fn build_store(
                 // ids are equal.
                 let peer_dep = &dependencies[peer_dep_id as usize];
 
-                // The version to auto-install when no parent provides the peer.
                 let best_version = if auto_install_peers {
                     resolutions[peer_dep_id as usize]
                 } else {
@@ -837,8 +833,7 @@ pub(crate) fn build_store(
             };
 
             if resolved_pkg_id == invalid_package_id {
-                // optional peers, and peers disabled with `--omit=peer`, that found no
-                // dependency with a matching name. they are completely excluded
+                // no parent provides the peer and it cannot be auto-installed
                 continue;
             }
 

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -537,8 +537,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 // is_filtered_dependency_or_workspace
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The `--omit` / `--production` feature set that applies to the dependencies
-/// of the package resolved as `parent_res`.
+/// The `--omit` feature set for the dependencies of the package resolved as `parent_res`.
 pub(crate) fn dependency_features(
     manager: &PackageManager,
     parent_res: &Resolution,
@@ -551,14 +550,12 @@ pub(crate) fn dependency_features(
     }
 }
 
-/// What to do with a peer dependency when `--omit=peer` (`install.peer = false`)
-/// turns peer dependencies off.
+/// How a peer dependency is treated under `--omit=peer`.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DisabledPeers {
-    /// Drop the edge. The hoisted linker never places the peer.
+    /// Drop the edge.
     Filter,
-    /// Keep the edge. The isolated store builder still links the peer when an
-    /// ancestor provides it, and only skips the auto-install fallback.
+    /// Keep the edge so an ancestor can still provide the peer. Nothing is auto-installed.
     Keep,
 }
 

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -537,6 +537,31 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 // is_filtered_dependency_or_workspace
 // ──────────────────────────────────────────────────────────────────────────
 
+/// The `--omit` / `--production` feature set that applies to the dependencies
+/// of the package resolved as `parent_res`.
+pub(crate) fn dependency_features(
+    manager: &PackageManager,
+    parent_res: &Resolution,
+) -> crate::Features {
+    match parent_res.tag {
+        crate::resolution::Tag::Root
+        | crate::resolution::Tag::Workspace
+        | crate::resolution::Tag::Folder => manager.options.local_package_features,
+        _ => manager.options.remote_package_features,
+    }
+}
+
+/// What to do with a peer dependency when `--omit=peer` (`install.peer = false`)
+/// turns peer dependencies off.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DisabledPeers {
+    /// Drop the edge. The hoisted linker never places the peer.
+    Filter,
+    /// Keep the edge. The isolated store builder still links the peer when an
+    /// ancestor provides it, and only skips the auto-install fallback.
+    Keep,
+}
+
 // `Builder` holds a live `&mut [PackageID]` over the resolutions buffer (see
 // `Builder.lockfile` safety contract), so callers must thread `resolutions`
 // explicitly to avoid an aliasing read through the shared `&Lockfile`.
@@ -548,6 +573,28 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     manager: &PackageManager,
     lockfile: &Lockfile,
     resolutions: &[PackageID],
+) -> bool {
+    is_filtered_dependency_or_workspace_with(
+        dep_id,
+        parent_pkg_id,
+        workspace_filters,
+        install_root_dependencies,
+        manager,
+        lockfile,
+        resolutions,
+        DisabledPeers::Filter,
+    )
+}
+
+pub(crate) fn is_filtered_dependency_or_workspace_with(
+    dep_id: DependencyID,
+    parent_pkg_id: PackageID,
+    workspace_filters: &[WorkspaceFilter],
+    install_root_dependencies: bool,
+    manager: &PackageManager,
+    lockfile: &Lockfile,
+    resolutions: &[PackageID],
+    disabled_peers: DisabledPeers,
 ) -> bool {
     let pkg_id = resolutions[dep_id as usize];
     if (pkg_id as usize) >= lockfile.packages.len() {
@@ -594,14 +641,11 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         return true;
     }
 
-    let dep_features = match parent_res.tag {
-        crate::resolution::Tag::Root
-        | crate::resolution::Tag::Workspace
-        | crate::resolution::Tag::Folder => manager.options.local_package_features,
-        _ => manager.options.remote_package_features,
-    };
+    let dep_features = dependency_features(manager, parent_res);
 
-    if !dep.behavior.is_enabled(dep_features) {
+    if !dep.behavior.is_enabled(dep_features)
+        && !(dep.behavior.is_peer() && disabled_peers == DisabledPeers::Keep)
+    {
         return true;
     }
 

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1745,26 +1745,28 @@ fn push_store_entry_names(
 }
 
 // Peer hashes differ between a full install and one narrowed by `--production`/`--omit`; entries laid out by either stay.
-fn store_entry_names(manager: &mut PackageManager, wanted: &DynamicBitSet) -> Vec<Box<[u8]>> {
-    if manager.lockfile.packages.len() == 0 {
-        return Vec::new();
-    }
+fn store_entry_names(
+    manager: &mut PackageManager,
+    own_store: &Store,
+    wanted: &DynamicBitSet,
+) -> Vec<Box<[u8]>> {
     let own = install_features(manager);
     let full = full_install_features(own);
     let mut names: Vec<Box<[u8]>> = Vec::new();
-    for features in [Some(full), (own != full).then_some(own)]
-        .into_iter()
-        .flatten()
-    {
-        let store = build_store_with(manager, features);
-        push_store_entry_names(&manager.lockfile, &store, wanted, &mut names);
+    push_store_entry_names(&manager.lockfile, own_store, wanted, &mut names);
+    if own != full {
+        let full_store = build_store_with(manager, full);
+        push_store_entry_names(&manager.lockfile, &full_store, wanted, &mut names);
     }
     sort_names(&mut names);
     names.dedup();
     names
 }
 
-fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>> {
+/// The aliases `bun install` links into the `node_modules` of the root or workspace `pkg_id`:
+/// its enabled lockfile dependencies, plus the dependencies of its store entries. The store
+/// entries add the peers an ancestor provides, which `--omit=peer` filters from the lockfile walk.
+fn direct_aliases(manager: &PackageManager, store: &Store, pkg_id: PackageID) -> Vec<Box<[u8]>> {
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
@@ -1789,6 +1791,16 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
         }
         direct.push(deps[dep_id as usize].name.slice(buf).into());
     }
+    let node_pkg_ids = store.nodes.items_pkg_id();
+    let entry_dependencies = store.entries.items_dependencies();
+    for (entry_idx, node_id) in store.entries.items_node_id().iter().enumerate() {
+        if node_pkg_ids[node_id.get() as usize] != pkg_id {
+            continue;
+        }
+        for item in entry_dependencies[entry_idx].slice() {
+            direct.push(deps[item.dep_id as usize].name.slice(buf).into());
+        }
+    }
     sort_names(&mut direct);
     direct.dedup();
     direct
@@ -1809,7 +1821,11 @@ fn plan_isolated(
     plan: &mut Plan,
 ) {
     let wanted = wanted_packages(manager, selection);
-    let names = store_entry_names(manager, &wanted);
+    let own_store = (manager.lockfile.packages.len() != 0)
+        .then(|| build_store_with(manager, install_features(manager)));
+    let names = own_store
+        .as_ref()
+        .map_or_else(Vec::new, |store| store_entry_names(manager, store, &wanted));
     let manager: &PackageManager = manager;
 
     let mut removed_store: Vec<Box<[u8]>> = Vec::new();
@@ -1831,6 +1847,9 @@ fn plan_isolated(
     sort_names(&mut removed_store);
     let store_touched = !removed_store.is_empty();
 
+    let Some(own_store) = own_store else {
+        return;
+    };
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
@@ -1856,7 +1875,7 @@ fn plan_isolated(
         let Ok(dir) = Dir::open(&folder_path) else {
             continue;
         };
-        let direct = direct_aliases(manager, pkg_id as PackageID);
+        let direct = direct_aliases(manager, &own_store, pkg_id as PackageID);
         let folder_idx = scan_folder(
             dir,
             &folder_path,

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1763,9 +1763,7 @@ fn store_entry_names(
     names
 }
 
-/// The aliases `bun install` links into the `node_modules` of the root or workspace `pkg_id`:
-/// its enabled lockfile dependencies, plus the dependencies of its store entries. The store
-/// entries add the peers an ancestor provides, which `--omit=peer` filters from the lockfile walk.
+/// The aliases `bun install` links into the `node_modules` of the root or workspace `pkg_id`.
 fn direct_aliases(manager: &PackageManager, store: &Store, pkg_id: PackageID) -> Vec<Box<[u8]>> {
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -2158,6 +2158,29 @@ test.concurrent.each(["hoisted", "isolated"] as Linker[])(
   },
 );
 
+// `bun install --omit=peer` links a workspace's peer when the root provides it. `bun prune --omit=peer` keeps that link.
+test.concurrent.each([false, true])(
+  "isolated (globalStore: %p): --omit=peer keeps a workspace peer link the root provides",
+  async globalStore => {
+    const { packageDir: dir, packageJson } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated", globalStore },
+    });
+    await writeWorkspaces(dir, packageJson, {
+      root: { dependencies: { "no-deps": "1.0.0" } },
+      packages: { a: { peerDependencies: { "no-deps": "^1.0.0" } } },
+    });
+    await install(dir, "--omit=peer", "--linker", "isolated");
+    const peerLink = join(dir, "packages", "a", "node_modules", "no-deps", "package.json");
+    expect(existsSync(peerLink)).toBeTrue();
+
+    const { stdout, exitCode } = await prune(dir, "--omit=peer", "--linker", "isolated");
+    expect(out(stdout)).toEndWith(NOTHING(3, 3));
+    expect(exitCode).toBe(0);
+    expect(existsSync(peerLink)).toBeTrue();
+    expect(await install(dir, "--omit=peer", "--linker", "isolated")).toContain("no changes");
+  },
+);
+
 // The peer edge survives --production, so `bun install --production` still installs the peer into the store; only the root's dev link goes.
 test.concurrent.each(["peer-deps-fixed", "optional-peer-deps"])(
   "isolated: --production keeps %s's peer-hash entry and the peer a devDependency pulled in, removes the dev link",

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3566,6 +3566,92 @@ describe("global virtual store", () => {
     expect(lstatSync(workspace).isSymbolicLink()).toBe(false);
     expect(await file(edited).text()).toBe("module.exports = 'USER_EDITS';\n");
   });
+
+  test("--omit=peer still links a peer that an ancestor provides", async () => {
+    // `peer-deps-lvl0` depends on `no-deps` and `peer-deps-lvl1`. `peer-deps-lvl1`
+    // depends on `peer-deps-lvl2`. Both lvl1 and lvl2 declare `no-deps` as a peer.
+    // The global store has no hoisted fallback layer, so lvl2 can only reach
+    // `no-deps` through its own store entry.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-omit-peer",
+        dependencies: { "peer-deps-lvl0": "1.0.0" },
+      }),
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--omit=peer"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error");
+    expect(stdout).toContain("peer-deps-lvl0");
+    expect(exitCode).toBe(0);
+
+    const bunDir = join(packageDir, "node_modules", ".bun");
+    const storeEntries = (await readdirSorted(bunDir)).filter(e => e !== "node_modules");
+    const lvl2 = storeEntries.find(e => e.startsWith("peer-deps-lvl2@1.0.0"));
+    expect(lvl2).toBeDefined();
+    expect(await file(join(bunDir, lvl2!, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+
+    // Every fixture `index.js` requires each of its dependencies and peers, so
+    // this walks lvl0 -> lvl1 -> lvl2 -> no-deps.
+    await using run = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `console.log(require("peer-deps-lvl0").dependencies["peer-deps-lvl1"].dependencies["peer-deps-lvl2"].peerDependencies["no-deps"].name)`,
+      ],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runStdout, runStderr, runExitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(runStderr).toBe("");
+    expect(runStdout).toBe("no-deps\n");
+    expect(runExitCode).toBe(0);
+  });
+
+  test("--omit=peer does not auto-install a peer that no ancestor provides", async () => {
+    // `peer-deps` declares `no-deps` as a peer and nothing else in the tree
+    // provides it.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-omit-peer-unprovided",
+        dependencies: { "peer-deps": "1.0.0" },
+      }),
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--omit=peer"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error");
+    expect(stdout).toContain("peer-deps");
+    expect(exitCode).toBe(0);
+
+    const bunDir = join(packageDir, "node_modules", ".bun");
+    const storeEntries = (await readdirSorted(bunDir)).filter(e => e !== "node_modules");
+    expect(storeEntries).toEqual(["peer-deps@1.0.0"]);
+    expect(existsSync(join(bunDir, "peer-deps@1.0.0", "node_modules", "no-deps"))).toBe(false);
+  });
 });
 
 test("rejects dependency aliases that traverse outside node_modules", async () => {


### PR DESCRIPTION
Issue: #41415. The store entry names in the report (no `+<peerhash>` suffix on any entry) only occur with peer dependencies disabled. The reporter has not yet confirmed the config.

### Problem
- `bun install --omit=peer` (or `install.peer = false`) with `linker = "isolated"` and `globalStore = true` drops every peer edge from the store. A package that requires a peer its parent provides then fails: `Cannot find module '@babel/core'` from `@babel/helper-module-transforms`, even though `@expo/require-utils` one level up depends on `@babel/core`.
- The cause is `is_filtered_dependency_or_workspace` (`src/install/lockfile/Tree.rs`). With the peer feature off it returns true for every peer dependency, so `build_store` (`src/install/isolated_install.rs`) never runs the ancestor search for it. The global store has no hidden hoisted layer, so nothing else covers the missing link.

### Fix
- `build_store` calls the filter with `DisabledPeers::Keep`. A disabled peer edge goes through the existing ancestor search, which links the peer when a parent provides it. The auto-install fallback (`best_version`) is `invalid_package_id` when the peer feature is off, so a peer with no provider is still excluded. This matches npm `--omit=peer` and pnpm `auto-install-peers=false`.
- `bun prune --omit=peer` derived the expected aliases of a root or workspace `node_modules` from the lockfile alone, so it removed the peer link install now creates. `direct_aliases` (`src/install/prune.rs`) now also keeps the dependencies of the importer's store entries, built with the same features as the install. Install, prune, install is a no-op round trip.
- The hoisted linker and the other call sites use the unchanged `is_filtered_dependency_or_workspace` wrapper.
- Verified: two tests in `test/cli/install/isolated-install.test.ts` and one in `test/cli/install/bun-prune.test.ts` (stock bun fails them). Also the full `isolated-install.test.ts`, `bun-prune.test.ts`, `frozen-lockfile-pruned.test.ts`, `test-dev-peer-dependency-priority.test.ts`, and the peer tests in `bun-install-registry.test.ts`.

### Background
- The isolated linker gives each package its own `node_modules` under `node_modules/.bun/<name>@<version>[+<peerhash>]`. The entry holds symlinks to the package's dependencies, including its resolved peers.
- `build_store` walks the dependency graph and resolves each peer by searching the node's ancestors for a dependency with the same name. When no ancestor has one, it auto-installs the lockfile's best version.
- With `globalStore = false`, `node_modules/.bun/node_modules` is a hoisted fallback layer that `require` reaches by walking up. The global store shares entries across projects, so it has no such layer. That is why the bug only shows with the global store.

<details><summary>Notes</summary>

Minimal repro (Bun 1.4.1, linux x64):

```json
{ "name": "repro", "dependencies": { "@expo/require-utils": "57.0.5" } }
```

```toml
[install]
linker = "isolated"
globalStore = true
```

```js
const { toCommonJS } = require("@expo/require-utils/build/transform.js");
console.log(toCommonJS("export default 1", "x.js"));
```

`bun install --omit=peer && bun test.js` fails before this change and prints the transformed source after it. Store entries after the fix: `@babel+helper-module-transforms@7.29.7+631cdf598ada32d6` and `@babel+plugin-transform-modules-commonjs@7.29.7+631cdf598ada32d6`, the same layout as a peers-on install of this project, because every peer here is provided by an ancestor.

The same project works without the change when peers are on, with `--linker hoisted`, or with `globalStore = false`.

The install test fixture `peer-deps-lvl0 -> {no-deps, peer-deps-lvl1 -> peer-deps-lvl2}`, with `no-deps` as a peer of lvl1 and lvl2, mirrors the expo chain. Each fixture `index.js` requires its own dependencies and peers, so the spawned `require("peer-deps-lvl0")` chain exercises the resolution at runtime.

The prune test is a workspace that declares a peer the root provides. Before the prune change, `bun install --omit=peer` created `packages/a/node_modules/no-deps`, `bun prune --omit=peer` removed it, and the next `bun install --omit=peer` reported no changes and left it missing.

`direct_aliases` keeps its lockfile walk because the root entry of the store omits the implicit workspace links (`node_modules/<workspace>`), which prune must still keep. The store entries add only what the lockfile walk filters: peers an ancestor provides.

`dependency_features` is the local/remote feature selection that the filter already did inline, extracted so `build_store` can read the peer flag for the node's parent.

Self-review: 10 concerns raised, the prune round trip was the one that survived and is addressed here. The claim that the hoisted linker already behaves this way was dropped from this body: it holds for the reported graph but not for every nested provider graph.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts, test/cli/install/bun-prune.test.ts

<!-- robobun:evidence:end -->