### PR TITLE
Expose url and options on Bun.RedisClient

### DIFF
--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -333,6 +333,21 @@ console.log(client.connected); // boolean indicating connection status
 console.log(client.bufferedAmount);
 ```
 
+### Connection Target
+
+A client exposes the URL and the options it was constructed with. Use them to build a second client for the same server:
+
+```ts redis.ts icon="/icons/typescript.svg"
+const client = new RedisClient("redis://localhost:6380/2", { maxRetries: 5 });
+
+console.log(client.url); // "redis://localhost:6380/2"
+console.log(client.options.maxRetries); // 5
+
+const rebuilt = new RedisClient(client.url, client.options);
+```
+
+`url` is the string the constructor got, credentials included. When the constructor got no URL, `url` is the value it fell back to (`REDIS_URL`, `VALKEY_URL`, or `valkey://localhost:6379`). `options.tls` is the object passed to the constructor when one was given, otherwise a boolean. `duplicate()` copies both.
+
 ### Type Conversion
 
 The client automatically converts Redis responses to JavaScript values:

--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -346,7 +346,7 @@ console.log(client.options.maxRetries); // 5
 const rebuilt = new RedisClient(client.url, client.options);
 ```
 
-`url` is the string the constructor got, credentials included. When the constructor got no URL, `url` is the value it fell back to (`REDIS_URL`, `VALKEY_URL`, or `valkey://localhost:6379`). `options.tls` is the object passed to the constructor when one was given, otherwise a boolean. `duplicate()` copies both.
+`url` is the string the constructor got, credentials included (`console.log(client)` prints the password as `[REDACTED]`). When the constructor got no URL, `url` is the value it fell back to (`REDIS_URL`, `VALKEY_URL`, or `valkey://localhost:6379`). `options.tls` is the object passed to the constructor when one was given, otherwise a boolean. `duplicate()` copies both.
 
 ### Type Conversion
 

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -86,7 +86,8 @@ declare module "bun" {
      * URL, this is the value it fell back to: `process.env.REDIS_URL`,
      * `process.env.VALKEY_URL`, or `"valkey://localhost:6379"`.
      *
-     * Includes the credentials from the URL. `duplicate()` copies it.
+     * Includes the credentials from the URL. `console.log(client)` prints the
+     * password as `[REDACTED]`. `duplicate()` copies it.
      *
      * @example
      * ```ts
@@ -98,8 +99,9 @@ declare module "bun" {
 
     /**
      * The options the client runs with, in the shape the constructor accepts.
-     * Each access returns a new object. `tls` is the object passed to the
-     * constructor when one was given, otherwise a boolean.
+     * Each access returns a new object. Fields the constructor did not get
+     * hold their defaults. `tls` is the object passed to the constructor when
+     * one was given, otherwise a boolean (`true` for a `rediss://` URL).
      */
     readonly options: Required<RedisOptions>;
 

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -4011,8 +4011,8 @@ declare module "bun" {
    * Default Redis client
    *
    * Connection information comes from the first of these that is set:
-   * - `process.env.VALKEY_URL`
    * - `process.env.REDIS_URL`
+   * - `process.env.VALKEY_URL`
    * - `"valkey://localhost:6379"`
    */
   export const redis: RedisClient;

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -58,8 +58,8 @@ declare module "bun" {
     /**
      * Creates a new Redis client
      *
-     * @param url URL to connect to, defaults to `process.env.VALKEY_URL`,
-     * `process.env.REDIS_URL`, or `"valkey://localhost:6379"`
+     * @param url URL to connect to, defaults to `process.env.REDIS_URL`,
+     * `process.env.VALKEY_URL`, or `"valkey://localhost:6379"`
      * @param options Additional options
      *
      * @example

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -82,6 +82,28 @@ declare module "bun" {
     readonly bufferedAmount: number;
 
     /**
+     * The URL the client was constructed with. When the constructor got no
+     * URL, this is the value it fell back to: `process.env.REDIS_URL`,
+     * `process.env.VALKEY_URL`, or `"valkey://localhost:6379"`.
+     *
+     * Includes the credentials from the URL. `duplicate()` copies it.
+     *
+     * @example
+     * ```ts
+     * const client = new RedisClient("redis://localhost:6380/2");
+     * const rebuilt = new RedisClient(client.url, client.options);
+     * ```
+     */
+    readonly url: string;
+
+    /**
+     * The options the client runs with, in the shape the constructor accepts.
+     * Each access returns a new object. `tls` is the object passed to the
+     * constructor when one was given, otherwise a boolean.
+     */
+    readonly options: Required<RedisOptions>;
+
+    /**
      * Callback fired when the client connects to the Redis server
      */
     onconnect: ((this: RedisClient) => void) | null;

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1806,8 +1806,9 @@ fn get_s3_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JsResult
 fn get_valkey_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
     use crate::valkey_jsc::JSValkeyClient;
 
+    // No options are passed, so there is no `tls` object to cache on the wrapper.
     let valkey = match JSValkeyClient::create_no_js_no_pubsub(global_this, &[JSValue::UNDEFINED]) {
-        Ok(p) => p,
+        Ok((p, _)) => p,
         Err(jsc::JsError::Thrown) => return JSValue::ZERO,
         Err(err) => {
             let _ =

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2040,6 +2040,11 @@ fn console_print_runtime_object_inner<const C: bool>(
         let _ = archive.write_format::<_, _, C>(formatter, &mut w);
         return Ok(true);
     }
+    if let Some(redis) = value.as_class_ref::<crate::valkey_jsc::JSValkeyClient>() {
+        let mut w = AsFmt::new(writer_);
+        let _ = redis.write_format::<_, _, C>(formatter, &mut w);
+        return Ok(true);
+    }
     if bun_jsc::FetchHeaders::cast_(value, formatter.global_this.vm()).is_some() {
         if let Some(to_json_function) = value.get(formatter.global_this, "toJSON")? {
             formatter.add_for_new_line("Headers ".len());

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -946,9 +946,7 @@ impl JSValkeyClient {
     }
 
     /// `client.options`: a fresh object with the options the client runs
-    /// with, in the shape the constructor accepts. A subscriber reports the
-    /// `enableOfflineQueue` / `enableAutoPipelining` it was constructed with,
-    /// not the values subscribe mode forces while it is active.
+    /// with, in the shape the constructor accepts.
     ///
     /// `this: true` in valkey.classes.ts: codegen passes the JS wrapper as
     /// `this_value`, which holds the cached `tls` option object.
@@ -957,6 +955,29 @@ impl JSValkeyClient {
         this_value: JSValue,
         global: &JSGlobalObject,
     ) -> JsResult<JSValue> {
+        let tls = match self.client.get().tls {
+            valkey::TLS::None => JSValue::FALSE,
+            valkey::TLS::Enabled => JSValue::TRUE,
+            // Every path that builds a `Custom` client caches the object:
+            // `create()` from the constructor argument, `duplicate()` from the
+            // source wrapper. `Bun.redis` takes no options.
+            valkey::TLS::Custom(_) => {
+                let cached = Js::tls_get_cached(this_value);
+                debug_assert!(
+                    cached.is_some(),
+                    "custom tls client without a cached tls object"
+                );
+                cached.unwrap_or(JSValue::TRUE)
+            }
+        };
+        Ok(self.options_object(global, tls))
+    }
+
+    /// The `RedisOptions`-shaped object behind `client.options`, with `tls`
+    /// supplied by the caller. A subscriber reports the `enableOfflineQueue` /
+    /// `enableAutoPipelining` it was constructed with, not the values
+    /// subscribe mode forces while it is active.
+    fn options_object(&self, global: &JSGlobalObject, tls: JSValue) -> JSValue {
         let client = self.client.get();
         let sub_ctx = self._subscription_ctx.get();
         let (enable_offline_queue, enable_auto_pipelining) = if sub_ctx.is_subscriber {
@@ -969,11 +990,6 @@ impl JSValkeyClient {
                 client.flags.enable_offline_queue,
                 client.flags.enable_auto_pipelining,
             )
-        };
-        let tls = match client.tls {
-            valkey::TLS::None => JSValue::FALSE,
-            valkey::TLS::Enabled => JSValue::TRUE,
-            valkey::TLS::Custom(_) => Js::tls_get_cached(this_value).unwrap_or(JSValue::TRUE),
         };
 
         let object = JSValue::create_empty_object(global, 7);
@@ -1008,7 +1024,119 @@ impl JSValkeyClient {
             JSValue::from(enable_auto_pipelining),
         );
         object.put(global, b"tls", tls);
-        Ok(object)
+        object
+    }
+
+    /// `console.log(client)` / `Bun.inspect(client)`. Hand-written so the
+    /// password in `url` prints as `[REDACTED]` and a custom `tls` object,
+    /// which can hold key material, prints as `true`.
+    pub(crate) fn write_format<F, W, const ENABLE_ANSI_COLORS: bool>(
+        &self,
+        formatter: &mut F,
+        writer: &mut W,
+    ) -> core::fmt::Result
+    where
+        F: jsc::ConsoleFormatter,
+        W: core::fmt::Write,
+    {
+        macro_rules! pfmt {
+            ($fmt:expr) => {
+                if ENABLE_ANSI_COLORS {
+                    ::bun_core::pretty_fmt!($fmt, true)
+                } else {
+                    ::bun_core::pretty_fmt!($fmt, false)
+                }
+            };
+        }
+        let fmt_err = |_| core::fmt::Error;
+        let client = self.client.get();
+
+        writer.write_str(pfmt!("<r>RedisClient<r> {\n"))?;
+        {
+            let mut formatter = formatter.indented();
+
+            formatter.write_indent(writer)?;
+            writer.write_str(pfmt!("<r>url<d>:<r> \"<r><b>"))?;
+            let (before, after) = self.url_split_at_password();
+            write!(writer, "{}", bstr::BStr::new(before))?;
+            if let Some(after) = after {
+                write!(writer, "[REDACTED]{}", bstr::BStr::new(after))?;
+            }
+            writer.write_str(pfmt!("<r>\""))?;
+            formatter.print_comma::<W, ENABLE_ANSI_COLORS>(writer)?;
+            writer.write_str("\n")?;
+
+            formatter.write_indent(writer)?;
+            writer.write_str(pfmt!("<r>connected<d>:<r> "))?;
+            formatter
+                .print_as::<W, ENABLE_ANSI_COLORS>(
+                    jsc::FormatTag::Boolean,
+                    writer,
+                    JSValue::from(client.status == valkey::Status::Connected),
+                    jsc::JSType::BooleanObject,
+                )
+                .map_err(fmt_err)?;
+            formatter.print_comma::<W, ENABLE_ANSI_COLORS>(writer)?;
+            writer.write_str("\n")?;
+
+            formatter.write_indent(writer)?;
+            writer.write_str(pfmt!("<r>bufferedAmount<d>:<r> "))?;
+            let buffered = client.write_buffer.len() + client.read_buffer.len();
+            formatter
+                .print_as::<W, ENABLE_ANSI_COLORS>(
+                    jsc::FormatTag::Double,
+                    writer,
+                    JSValue::js_number(f64::from(buffered)),
+                    jsc::JSType::NumberObject,
+                )
+                .map_err(fmt_err)?;
+            formatter.print_comma::<W, ENABLE_ANSI_COLORS>(writer)?;
+            writer.write_str("\n")?;
+
+            formatter.write_indent(writer)?;
+            writer.write_str(pfmt!("<r>options<d>:<r> "))?;
+            let tls = JSValue::from(client.tls != valkey::TLS::None);
+            let options = self.options_object(formatter.global_this(), tls);
+            formatter
+                .print_as::<W, ENABLE_ANSI_COLORS>(
+                    jsc::FormatTag::Object,
+                    writer,
+                    options,
+                    jsc::JSType::Object,
+                )
+                .map_err(fmt_err)?;
+            formatter.print_comma::<W, ENABLE_ANSI_COLORS>(writer)?;
+            writer.write_str("\n")?;
+        }
+        formatter.write_indent(writer)?;
+        writer.write_str("}")?;
+        formatter.reset_line();
+        Ok(())
+    }
+
+    /// Splits `self.url` around the password in its userinfo. Returns the
+    /// bytes before the password and, when the url has a password, the bytes
+    /// from the `@` on. The authority is the text after `://` (or the whole
+    /// string when there is no scheme) up to the first `/`, `?` or `#`, and
+    /// its userinfo ends at the last `@`, as in the WHATWG URL parser.
+    fn url_split_at_password(&self) -> (&[u8], Option<&[u8]>) {
+        let url: &[u8] = &self.url;
+        let authority_start = strings::index_of(url, b"://").map_or(0, |i| i + 3);
+        let authority = &url[authority_start..];
+        let authority_end = strings::index_of_any(authority, b"/?#").unwrap_or(authority.len());
+        let authority = &authority[..authority_end];
+        let Some(at) = strings::last_index_of_char(authority, b'@') else {
+            return (url, None);
+        };
+        let Some(colon) = strings::index_of_char_usize(&authority[..at], b':') else {
+            return (url, None);
+        };
+        if colon + 1 == at {
+            return (url, None);
+        }
+        let password_start = authority_start + colon + 1;
+        let password_end = authority_start + at;
+        (&url[..password_start], Some(&url[password_end..]))
     }
 
     pub(crate) fn do_connect(

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -311,6 +311,11 @@ pub struct JSValkeyClient {
     /// `RareData.defaultClientSslCtx()` instead; `tls: false` leaves this null.
     pub(crate) _secure: JsCell<Option<boringssl::c::OwnedSslCtx>>,
 
+    /// The url the client was constructed with, as UTF-8: the first
+    /// constructor argument, or the `REDIS_URL` / `VALKEY_URL` / built-in
+    /// default it fell back to. Exposed as `client.url`.
+    pub(crate) url: Box<[u8]>,
+
     pub(crate) timer: RefCountedTimer,
     pub(crate) reconnect_timer: RefCountedTimer,
     pub(crate) ref_count: bun_ptr::RefCount<JSValkeyClient>,
@@ -478,11 +483,16 @@ impl JSValkeyClient {
 
     /// Create a Valkey client that does not have an associated JS object nor a SubscriptionCtx.
     ///
+    /// Also returns the `tls` option object the caller passed (or `UNDEFINED`),
+    /// so the caller can cache it on the JS wrapper once that exists. The
+    /// lowered `SSLConfig` cannot be turned back into the caller's object, and
+    /// `client.options.tls` has to hand it back.
+    ///
     /// This whole client needs a refactor.
     pub(crate) fn create_no_js_no_pubsub(
         global_object: &JSGlobalObject,
         arguments: &[JSValue],
-    ) -> JsResult<*mut JSValkeyClient> {
+    ) -> JsResult<(*mut JSValkeyClient, JSValue)> {
         let global_object = GlobalRef::from(global_object);
         let vm: &'static VirtualMachine = global_object.bun_vm();
         let vm_ref = vm;
@@ -496,6 +506,7 @@ impl JSValkeyClient {
                 None => BunString::static_("valkey://localhost:6379"),
             }
         };
+        let url: Box<[u8]> = Box::<[u8]>::from(url_str.to_utf8().slice());
         let mut fallback_url_buf = [0u8; 2048];
 
         // Parse and validate the URL using `Parsed::from_utf8`, which returns null for invalid URLs
@@ -625,13 +636,13 @@ impl JSValkeyClient {
             }
         };
 
-        let options = if arguments.len() >= 2
+        let (options, tls_js) = if arguments.len() >= 2
             && !arguments[1].is_undefined_or_null()
             && arguments[1].is_object()
         {
             Options::from_js(&global_object, arguments[1])?
         } else {
-            valkey::Options::default()
+            (valkey::Options::default(), JSValue::UNDEFINED)
         };
 
         // Copy strings into a persistent buffer since the URL object will be deinitialized
@@ -687,7 +698,7 @@ impl JSValkeyClient {
         bun_core::analytics::Features::VALKEY.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
         // `_subscription_ctx` is a placeholder here; properly initialized later by `create()`.
-        Ok(JSValkeyClient::new(JSValkeyClient {
+        let client = JSValkeyClient::new(JSValkeyClient {
             ref_count: bun_ptr::RefCount::init(),
             _subscription_ctx: JsCell::new(SubscriptionCtx::default()),
             client: JsCell::new(valkey::ValkeyClient {
@@ -738,9 +749,11 @@ impl JSValkeyClient {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: JsCell::new(None),
+            url,
             timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
             reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
-        }))
+        });
+        Ok((client, tls_js))
     }
 
     pub(crate) fn create(
@@ -748,12 +761,16 @@ impl JSValkeyClient {
         arguments: &[JSValue],
         js_this: JSValue,
     ) -> JsResult<*mut JSValkeyClient> {
-        let new_client_ptr = JSValkeyClient::create_no_js_no_pubsub(global_object, arguments)?;
+        let (new_client_ptr, tls_js) =
+            JSValkeyClient::create_no_js_no_pubsub(global_object, arguments)?;
         // SAFETY: just allocated above
         let new_client = unsafe { &*new_client_ptr };
 
         // Initially, we only need to hold a weak reference to the JS object.
         new_client.this_value.set(JsRef::init_weak(js_this));
+        if !tls_js.is_undefined() {
+            Js::tls_set_cached(js_this, global_object, tls_js);
+        }
 
         // Need to associate the subscription context, after the JS ref has been populated.
         new_client
@@ -850,6 +867,7 @@ impl JSValkeyClient {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: JsCell::new(None),
+            url: Box::<[u8]>::from(&self.url[..]),
             timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
             reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
         }))
@@ -920,6 +938,77 @@ impl JSValkeyClient {
         let client = self.client.get();
         let len = client.write_buffer.len() + client.read_buffer.len();
         JSValue::js_number(f64::from(len))
+    }
+
+    #[bun_jsc::host_fn(getter)]
+    pub(crate) fn get_url(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        jsc::bun_string_jsc::create_utf8_for_js(global, &self.url)
+    }
+
+    /// `client.options`: a fresh object with the options the client runs
+    /// with, in the shape the constructor accepts. A subscriber reports the
+    /// `enableOfflineQueue` / `enableAutoPipelining` it was constructed with,
+    /// not the values subscribe mode forces while it is active.
+    ///
+    /// `this: true` in valkey.classes.ts: codegen passes the JS wrapper as
+    /// `this_value`, which holds the cached `tls` option object.
+    pub(crate) fn get_options(
+        &self,
+        this_value: JSValue,
+        global: &JSGlobalObject,
+    ) -> JsResult<JSValue> {
+        let client = self.client.get();
+        let sub_ctx = self._subscription_ctx.get();
+        let (enable_offline_queue, enable_auto_pipelining) = if sub_ctx.is_subscriber {
+            (
+                sub_ctx.original_enable_offline_queue,
+                sub_ctx.original_enable_auto_pipelining,
+            )
+        } else {
+            (
+                client.flags.enable_offline_queue,
+                client.flags.enable_auto_pipelining,
+            )
+        };
+        let tls = match client.tls {
+            valkey::TLS::None => JSValue::FALSE,
+            valkey::TLS::Enabled => JSValue::TRUE,
+            valkey::TLS::Custom(_) => Js::tls_get_cached(this_value).unwrap_or(JSValue::TRUE),
+        };
+
+        let object = JSValue::create_empty_object(global, 7);
+        object.put(
+            global,
+            b"connectionTimeout",
+            JSValue::js_number(f64::from(client.connection_timeout_ms)),
+        );
+        object.put(
+            global,
+            b"idleTimeout",
+            JSValue::js_number(f64::from(client.idle_timeout_interval_ms)),
+        );
+        object.put(
+            global,
+            b"autoReconnect",
+            JSValue::from(client.flags.enable_auto_reconnect),
+        );
+        object.put(
+            global,
+            b"maxRetries",
+            JSValue::js_number(f64::from(client.max_retries)),
+        );
+        object.put(
+            global,
+            b"enableOfflineQueue",
+            JSValue::from(enable_offline_queue),
+        );
+        object.put(
+            global,
+            b"enableAutoPipelining",
+            JSValue::from(enable_auto_pipelining),
+        );
+        object.put(global, b"tls", tls);
+        Ok(object)
     }
 
     pub(crate) fn do_connect(
@@ -1877,7 +1966,13 @@ impl<const SSL: bool> SocketHandler<SSL> {
 struct Options;
 
 impl Options {
-    fn from_js(global_object: &JSGlobalObject, options_obj: JSValue) -> JsResult<valkey::Options> {
+    /// Returns the parsed options and the `tls` option object when one was
+    /// given (`UNDEFINED` otherwise), so `client.options.tls` can return it.
+    fn from_js(
+        global_object: &JSGlobalObject,
+        options_obj: JSValue,
+    ) -> JsResult<(valkey::Options, JSValue)> {
+        let mut tls_js = JSValue::UNDEFINED;
         let mut this = valkey::Options {
             enable_auto_pipelining:
                 !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING
@@ -1935,6 +2030,7 @@ impl Options {
                     SSLConfig::from_js(global_object.bun_vm(), global_object, tls)?
                 {
                     this.tls = valkey::TLS::Custom(Box::new(ssl_config));
+                    tls_js = tls;
                 } else {
                     return Err(global_object.throw_invalid_argument_type("tls", "tls", "object"));
                 }
@@ -1947,7 +2043,7 @@ impl Options {
             }
         }
 
-        Ok(this)
+        Ok((this, tls_js))
     }
 }
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -481,8 +481,7 @@ impl JSValkeyClient {
 
     /// Create a Valkey client that does not have an associated JS object nor a SubscriptionCtx.
     ///
-    /// Also returns the `tls` option object (or `UNDEFINED`) for the caller to
-    /// cache on the JS wrapper once it exists.
+    /// The second return is the `tls` option object (or `UNDEFINED`) to cache on the JS wrapper.
     ///
     /// This whole client needs a refactor.
     pub(crate) fn create_no_js_no_pubsub(
@@ -941,8 +940,7 @@ impl JSValkeyClient {
         jsc::bun_string_jsc::create_utf8_for_js(global, &self.url)
     }
 
-    /// `client.options`. `this_value` is the JS wrapper (`this: true` in
-    /// valkey.classes.ts), which holds the cached `tls` option object.
+    /// `this_value` is the JS wrapper; it holds the cached `tls` option object.
     pub(crate) fn get_options(
         &self,
         this_value: JSValue,
@@ -963,8 +961,7 @@ impl JSValkeyClient {
         Ok(self.options_object(global, tls))
     }
 
-    /// A subscriber reports the `enableOfflineQueue` / `enableAutoPipelining`
-    /// it was constructed with, not the values subscribe mode forces.
+    /// A subscriber reports the queue and pipelining flags it was constructed with.
     fn options_object(&self, global: &JSGlobalObject, tls: JSValue) -> JSValue {
         let client = self.client.get();
         let sub_ctx = self._subscription_ctx.get();
@@ -1015,8 +1012,7 @@ impl JSValkeyClient {
         object
     }
 
-    /// `console.log(client)`: the url password prints as `[REDACTED]` and a
-    /// custom `tls` object (which can hold key material) prints as `true`.
+    /// Redacts the url password and prints a custom `tls` object as `true`.
     pub(crate) fn write_format<F, W, const ENABLE_ANSI_COLORS: bool>(
         &self,
         formatter: &mut F,
@@ -1101,8 +1097,7 @@ impl JSValkeyClient {
         Ok(())
     }
 
-    /// Returns (bytes before the userinfo password, bytes from its `@` on).
-    /// Authority ends at the first `/`, `?` or `#`, userinfo at its last `@`.
+    /// Returns (bytes before the userinfo password, bytes from its `@` on), or (url, None).
     fn url_split_at_password(&self) -> (&[u8], Option<&[u8]>) {
         let url: &[u8] = &self.url;
         let authority_start = strings::index_of(url, b"://").map_or(0, |i| i + 3);

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -311,9 +311,7 @@ pub struct JSValkeyClient {
     /// `RareData.defaultClientSslCtx()` instead; `tls: false` leaves this null.
     pub(crate) _secure: JsCell<Option<boringssl::c::OwnedSslCtx>>,
 
-    /// The url the client was constructed with, as UTF-8: the first
-    /// constructor argument, or the `REDIS_URL` / `VALKEY_URL` / built-in
-    /// default it fell back to. Exposed as `client.url`.
+    /// The constructor's url argument, or the env / built-in default it fell back to, as UTF-8.
     pub(crate) url: Box<[u8]>,
 
     pub(crate) timer: RefCountedTimer,
@@ -483,10 +481,8 @@ impl JSValkeyClient {
 
     /// Create a Valkey client that does not have an associated JS object nor a SubscriptionCtx.
     ///
-    /// Also returns the `tls` option object the caller passed (or `UNDEFINED`),
-    /// so the caller can cache it on the JS wrapper once that exists. The
-    /// lowered `SSLConfig` cannot be turned back into the caller's object, and
-    /// `client.options.tls` has to hand it back.
+    /// Also returns the `tls` option object (or `UNDEFINED`) for the caller to
+    /// cache on the JS wrapper once it exists.
     ///
     /// This whole client needs a refactor.
     pub(crate) fn create_no_js_no_pubsub(
@@ -945,11 +941,8 @@ impl JSValkeyClient {
         jsc::bun_string_jsc::create_utf8_for_js(global, &self.url)
     }
 
-    /// `client.options`: a fresh object with the options the client runs
-    /// with, in the shape the constructor accepts.
-    ///
-    /// `this: true` in valkey.classes.ts: codegen passes the JS wrapper as
-    /// `this_value`, which holds the cached `tls` option object.
+    /// `client.options`. `this_value` is the JS wrapper (`this: true` in
+    /// valkey.classes.ts), which holds the cached `tls` option object.
     pub(crate) fn get_options(
         &self,
         this_value: JSValue,
@@ -958,9 +951,6 @@ impl JSValkeyClient {
         let tls = match self.client.get().tls {
             valkey::TLS::None => JSValue::FALSE,
             valkey::TLS::Enabled => JSValue::TRUE,
-            // Every path that builds a `Custom` client caches the object:
-            // `create()` from the constructor argument, `duplicate()` from the
-            // source wrapper. `Bun.redis` takes no options.
             valkey::TLS::Custom(_) => {
                 let cached = Js::tls_get_cached(this_value);
                 debug_assert!(
@@ -973,10 +963,8 @@ impl JSValkeyClient {
         Ok(self.options_object(global, tls))
     }
 
-    /// The `RedisOptions`-shaped object behind `client.options`, with `tls`
-    /// supplied by the caller. A subscriber reports the `enableOfflineQueue` /
-    /// `enableAutoPipelining` it was constructed with, not the values
-    /// subscribe mode forces while it is active.
+    /// A subscriber reports the `enableOfflineQueue` / `enableAutoPipelining`
+    /// it was constructed with, not the values subscribe mode forces.
     fn options_object(&self, global: &JSGlobalObject, tls: JSValue) -> JSValue {
         let client = self.client.get();
         let sub_ctx = self._subscription_ctx.get();
@@ -1027,9 +1015,8 @@ impl JSValkeyClient {
         object
     }
 
-    /// `console.log(client)` / `Bun.inspect(client)`. Hand-written so the
-    /// password in `url` prints as `[REDACTED]` and a custom `tls` object,
-    /// which can hold key material, prints as `true`.
+    /// `console.log(client)`: the url password prints as `[REDACTED]` and a
+    /// custom `tls` object (which can hold key material) prints as `true`.
     pub(crate) fn write_format<F, W, const ENABLE_ANSI_COLORS: bool>(
         &self,
         formatter: &mut F,
@@ -1114,11 +1101,8 @@ impl JSValkeyClient {
         Ok(())
     }
 
-    /// Splits `self.url` around the password in its userinfo. Returns the
-    /// bytes before the password and, when the url has a password, the bytes
-    /// from the `@` on. The authority is the text after `://` (or the whole
-    /// string when there is no scheme) up to the first `/`, `?` or `#`, and
-    /// its userinfo ends at the last `@`, as in the WHATWG URL parser.
+    /// Returns (bytes before the userinfo password, bytes from its `@` on).
+    /// Authority ends at the first `/`, `?` or `#`, userinfo at its last `@`.
     fn url_split_at_password(&self) -> (&[u8], Option<&[u8]>) {
         let url: &[u8] = &self.url;
         let authority_start = strings::index_of(url, b"://").map_or(0, |i| i + 3);
@@ -2094,8 +2078,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
 struct Options;
 
 impl Options {
-    /// Returns the parsed options and the `tls` option object when one was
-    /// given (`UNDEFINED` otherwise), so `client.options.tls` can return it.
+    /// Also returns the `tls` option object when one was given (`UNDEFINED` otherwise).
     fn from_js(
         global_object: &JSGlobalObject,
         options_obj: JSValue,

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -8,7 +8,7 @@ use bun_io::KeepAlive;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSArray, JSGlobalObject, JSMap, JSPromise, JSValue, JsCell,
-    JsRef, JsResult,
+    JsRef, JsResult, StringJsc as _,
 };
 use bun_ptr::{AsCtxPtr, BackRef, RefPtr};
 use bun_uws as uws;
@@ -311,8 +311,8 @@ pub struct JSValkeyClient {
     /// `RareData.defaultClientSslCtx()` instead; `tls: false` leaves this null.
     pub(crate) _secure: JsCell<Option<boringssl::c::OwnedSslCtx>>,
 
-    /// The constructor's url argument, or the env / built-in default it fell back to, as UTF-8.
-    pub(crate) url: Box<[u8]>,
+    /// The constructor's url argument, or the env / built-in default it fell back to.
+    pub(crate) url: BunString,
 
     pub(crate) timer: RefCountedTimer,
     pub(crate) reconnect_timer: RefCountedTimer,
@@ -497,11 +497,10 @@ impl JSValkeyClient {
         } else {
             let env = vm_ref.env_loader();
             match env.get(b"REDIS_URL").or_else(|| env.get(b"VALKEY_URL")) {
-                Some(url) => BunString::borrow_utf8(url),
+                Some(url) => BunString::clone_utf8(url),
                 None => BunString::static_("valkey://localhost:6379"),
             }
         };
-        let url: Box<[u8]> = Box::<[u8]>::from(url_str.to_utf8().slice());
         let mut fallback_url_buf = [0u8; 2048];
 
         // Parse and validate the URL using `Parsed::from_utf8`, which returns null for invalid URLs
@@ -744,7 +743,7 @@ impl JSValkeyClient {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: JsCell::new(None),
-            url,
+            url: url_str,
             timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
             reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
         });
@@ -862,7 +861,7 @@ impl JSValkeyClient {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: JsCell::new(None),
-            url: Box::<[u8]>::from(&self.url[..]),
+            url: self.url.clone(),
             timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
             reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
         }))
@@ -937,7 +936,7 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_url(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        jsc::bun_string_jsc::create_utf8_for_js(global, &self.url)
+        self.url.to_js(global)
     }
 
     /// `this_value` is the JS wrapper; it holds the cached `tls` option object.
@@ -1040,7 +1039,8 @@ impl JSValkeyClient {
 
             formatter.write_indent(writer)?;
             writer.write_str(pfmt!("<r>url<d>:<r> \"<r><b>"))?;
-            let (before, after) = self.url_split_at_password();
+            let url = self.url.to_utf8();
+            let (before, after) = Self::split_url_at_password(&url);
             write!(writer, "{}", bstr::BStr::new(before))?;
             if let Some(after) = after {
                 write!(writer, "[REDACTED]{}", bstr::BStr::new(after))?;
@@ -1098,8 +1098,7 @@ impl JSValkeyClient {
     }
 
     /// Returns (bytes before the userinfo password, bytes from its `@` on), or (url, None).
-    fn url_split_at_password(&self) -> (&[u8], Option<&[u8]>) {
-        let url: &[u8] = &self.url;
+    fn split_url_at_password(url: &[u8]) -> (&[u8], Option<&[u8]>) {
         let authority_start = strings::index_of(url, b"://").map_or(0, |i| i + 3);
         let authority = &url[authority_start..];
         let authority_end = strings::index_of_any(authority, b"/?#").unwrap_or(authority.len());

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -5,7 +5,7 @@ use bun_jsc::{
     JsRef, JsResult,
 };
 
-use super::js_valkey::{JSValkeyClient, SubscriptionCtx};
+use super::js_valkey::{JSValkeyClient, Js, SubscriptionCtx};
 use super::protocol_jsc as protocol;
 use super::valkey;
 use super::valkey_command_body::{Args as CommandArgs, Command, Meta as CommandMeta};
@@ -2078,8 +2078,6 @@ impl JSValkeyClient {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let _ = frame;
-
         let new_client_ptr = this.clone_without_connecting(global)?;
         // SAFETY: clone_without_connecting returns a freshly allocated, leaked
         // JSValkeyClient (heap::alloc); valid for the rest of this scope.
@@ -2087,6 +2085,9 @@ impl JSValkeyClient {
 
         let new_client_js = JSValkeyClient::ptr_to_js(new_client_ptr, global);
         new_client.this_value.set(JsRef::init_weak(new_client_js));
+        if let Some(tls) = Js::tls_get_cached(frame.this()) {
+            Js::tls_set_cached(new_client_js, global, tls);
+        }
         new_client
             ._subscription_ctx
             .set(SubscriptionCtx::init(new_client)?);

--- a/src/runtime/valkey_jsc/valkey.classes.ts
+++ b/src/runtime/valkey_jsc/valkey.classes.ts
@@ -31,6 +31,13 @@ export default [
       bufferedAmount: {
         getter: "getBufferedAmount",
       },
+      url: {
+        getter: "getUrl",
+      },
+      options: {
+        getter: "getOptions",
+        this: true,
+      },
       // Valkey commands
       get: {
         fn: "get",
@@ -638,6 +645,6 @@ export default [
       xgroup: { fn: "xgroup", length: 2 },
       xsetid: { fn: "xsetid", length: 2 },
     },
-    values: ["onconnect", "onclose", "connectionPromise", "hello", "subscriptionCallbackMap"],
+    values: ["onconnect", "onclose", "connectionPromise", "hello", "subscriptionCallbackMap", "tls"],
   }),
 ];

--- a/test/js/valkey/valkey-url-options.test.ts
+++ b/test/js/valkey/valkey-url-options.test.ts
@@ -1,0 +1,123 @@
+import { RedisClient } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as localhostTls } from "harness";
+
+// `url` and `options` are read back from the constructor input. No server is
+// needed: the client is never connected.
+describe("RedisClient url and options", () => {
+  test("url returns the constructor input verbatim", () => {
+    const url = "redis://user:pass@127.0.0.1:6380/3";
+    const client = new RedisClient(url, { autoReconnect: false });
+    expect(client.url).toBe(url);
+    expect("url" in client).toBe(true);
+    // A URL without a scheme is kept as given; the constructor adds valkey:// internally.
+    expect(new RedisClient("127.0.0.1:6381", { autoReconnect: false }).url).toBe("127.0.0.1:6381");
+  });
+
+  test("options reports the defaults for a bare constructor", () => {
+    const client = new RedisClient("redis://127.0.0.1:6380");
+    expect(client.options).toEqual({
+      connectionTimeout: 10000,
+      idleTimeout: 0,
+      autoReconnect: true,
+      maxRetries: 20,
+      enableOfflineQueue: true,
+      enableAutoPipelining: true,
+      tls: false,
+    });
+  });
+
+  test("options reflects the values passed to the constructor", () => {
+    const client = new RedisClient("redis://127.0.0.1:6380", {
+      connectionTimeout: 1234,
+      idleTimeout: 5000,
+      autoReconnect: false,
+      maxRetries: 3,
+      enableOfflineQueue: false,
+      enableAutoPipelining: false,
+      tls: true,
+    });
+    expect(client.options).toEqual({
+      connectionTimeout: 1234,
+      idleTimeout: 5000,
+      autoReconnect: false,
+      maxRetries: 3,
+      enableOfflineQueue: false,
+      enableAutoPipelining: false,
+      tls: true,
+    });
+  });
+
+  test("options.tls is true for a rediss:// url with no tls option", () => {
+    const client = new RedisClient("rediss://127.0.0.1:6380", { autoReconnect: false });
+    expect(client.options.tls).toBe(true);
+  });
+
+  test("options.tls returns the tls object passed to the constructor", () => {
+    const tls = { ca: localhostTls.cert, rejectUnauthorized: true };
+    const client = new RedisClient("rediss://127.0.0.1:6380", { tls, autoReconnect: false });
+    expect(client.options.tls).toBe(tls);
+
+    // A client rebuilt from url and options keeps the same custom certificates.
+    const rebuilt = new RedisClient(client.url, client.options);
+    expect(rebuilt.url).toBe(client.url);
+    expect(rebuilt.options).toEqual(client.options);
+    expect(rebuilt.options.tls).toBe(tls);
+  });
+
+  test("duplicate() keeps url and options", async () => {
+    const tls = { ca: localhostTls.cert };
+    const url = "rediss://user:pass@127.0.0.1:6380/2";
+    const client = new RedisClient(url, { tls, maxRetries: 7, autoReconnect: false });
+    const copy = await client.duplicate();
+    expect(copy).not.toBe(client);
+    expect(copy.url).toBe(url);
+    expect(copy.options).toEqual(client.options);
+    expect(copy.options.tls).toBe(tls);
+  });
+
+  test("url falls back to REDIS_URL, then VALKEY_URL, then the built-in default", async () => {
+    const script = `
+      console.log(JSON.stringify([
+        new Bun.RedisClient().url,
+        new Bun.RedisClient(undefined, { autoReconnect: false }).url,
+        Bun.redis.url,
+        Bun.redis.options.autoReconnect,
+      ]));
+    `;
+    const run = async (env: Record<string, string | undefined>) => {
+      const baseEnv = { ...bunEnv } as Record<string, string | undefined>;
+      delete baseEnv.REDIS_URL;
+      delete baseEnv.VALKEY_URL;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...baseEnv, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    };
+
+    expect(await run({ REDIS_URL: "redis://127.0.0.1:6390/1", VALKEY_URL: "valkey://127.0.0.1:6391" })).toEqual([
+      "redis://127.0.0.1:6390/1",
+      "redis://127.0.0.1:6390/1",
+      "redis://127.0.0.1:6390/1",
+      true,
+    ]);
+    expect(await run({ VALKEY_URL: "valkey://127.0.0.1:6391/4" })).toEqual([
+      "valkey://127.0.0.1:6391/4",
+      "valkey://127.0.0.1:6391/4",
+      "valkey://127.0.0.1:6391/4",
+      true,
+    ]);
+    expect(await run({})).toEqual([
+      "valkey://localhost:6379",
+      "valkey://localhost:6379",
+      "valkey://localhost:6379",
+      true,
+    ]);
+  });
+});

--- a/test/js/valkey/valkey-url-options.test.ts
+++ b/test/js/valkey/valkey-url-options.test.ts
@@ -76,6 +76,47 @@ describe("RedisClient url and options", () => {
     expect(copy.options.tls).toBe(tls);
   });
 
+  test("inspect redacts the password in url and does not print the tls object", () => {
+    const tls = { ca: localhostTls.cert, key: "private key material" };
+    const client = new RedisClient("rediss://user:secret@127.0.0.1:6380/2", {
+      tls,
+      autoReconnect: false,
+    });
+    const text = Bun.inspect(client);
+    expect(text).not.toContain("secret");
+    expect(text).not.toContain("private key material");
+    expect(text).toMatchInlineSnapshot(`
+      "RedisClient {
+        url: "rediss://user:[REDACTED]@127.0.0.1:6380/2",
+        connected: false,
+        bufferedAmount: 0,
+        options: {
+          connectionTimeout: 10000,
+          idleTimeout: 0,
+          autoReconnect: false,
+          maxRetries: 20,
+          enableOfflineQueue: true,
+          enableAutoPipelining: true,
+          tls: true,
+        },
+      }"
+    `);
+    // The getter itself is not redacted: a rebuild needs the password.
+    expect(client.url).toBe("rediss://user:secret@127.0.0.1:6380/2");
+  });
+
+  test("inspect leaves a url without a password as is", () => {
+    expect(Bun.inspect(new RedisClient("redis://user@127.0.0.1:6380", { autoReconnect: false }))).toContain(
+      'url: "redis://user@127.0.0.1:6380"',
+    );
+    expect(Bun.inspect(new RedisClient("redis://127.0.0.1:6380/1?x=a@b", { autoReconnect: false }))).toContain(
+      'url: "redis://127.0.0.1:6380/1?x=a@b"',
+    );
+    expect(Bun.inspect(new RedisClient("u:p@127.0.0.1:6380", { autoReconnect: false }))).toContain(
+      'url: "u:[REDACTED]@127.0.0.1:6380"',
+    );
+  });
+
   test("url falls back to REDIS_URL, then VALKEY_URL, then the built-in default", async () => {
     const script = `
       console.log(JSON.stringify([


### PR DESCRIPTION
### Problem
- `Bun.RedisClient` keeps no readable record of its target. `client.url` and `client.options` are `undefined`, and `Object.getOwnPropertyNames(client)` is `[]`. A library handed a client cannot build a second one for the same server. bullmq did `new (raw.constructor)(raw.url)` and silently connected to `localhost:6379` (taskforcesh/bullmq#4582).
- The constructor resolves the url string in `create_no_js_no_pubsub` (`src/runtime/valkey_jsc/js_valkey.rs`) and then drops it. A custom `tls` object is lowered to an `SSLConfig` in `Options::from_js` and dropped too. Nothing can read either back.

### Fix
- Add two read-only getters to `RedisClient`. `url` returns the constructor input verbatim, or the `REDIS_URL` / `VALKEY_URL` / `valkey://localhost:6379` value it fell back to. The string is stored as a `bun_core::String` on `JSValkeyClient` (the getter shares it with JS through `to_js`) and cloned in `clone_without_connecting`, so `duplicate()` keeps it.
- `options` returns a new object in the `RedisOptions` shape: `connectionTimeout`, `idleTimeout`, `autoReconnect`, `maxRetries`, `enableOfflineQueue`, `enableAutoPipelining`, `tls`. A subscriber reports the queue and pipelining values it was constructed with, not the ones subscribe mode forces. `tls` is `true` or `false`, or the caller's own object when one was given. The object is cached in a new `tls` values slot on the JS wrapper (GC-visited) and copied in `duplicate()`.
- Credentials in `url` are not redacted. This follows `sql.options`, node-redis `options`, and ioredis `options`. The purpose of the getter is a rebuild, and a redacted url cannot do that.
- Verified: `test/js/valkey/valkey-url-options.test.ts` (7 tests, all fail on the released bun, no server needed). Also `test/internal/source-lints/redis-client-types.test.ts`, `test/integration/bun-types/bun-types.test.ts`, `test/js/valkey/valkey-tls-verify.test.ts`.

### Background
- `valkey.classes.ts` is the class table the codegen turns into `RedisClient.prototype`. A `proto` entry with `this: true` gets the JS wrapper as `this_value`, which is how `get_options` reaches the wrapper's cached slots.
- `values` in that table are hidden GC-visited slots on the wrapper (`*_set_cached` / `*_get_cached` in the generated `Js` module). The new `tls` slot holds the caller's tls object so it survives as the object the caller passed, not a lowered copy.
- `create_no_js_no_pubsub` builds the native client before a JS wrapper exists. It now also returns the tls object so `create()` can cache it once the wrapper is there. `Bun.redis` calls it with no options and has nothing to cache.

<details><summary>Notes</summary>

- `url` is the input string, not the parsed URL. `new RedisClient("127.0.0.1:6381").url` is `"127.0.0.1:6381"` (the constructor prefixes `valkey://` only for parsing).
- `options.tls` is `true` for a `rediss://` url with no `tls` option, because that is what the client runs with. A rebuild with `{tls: true}` behaves the same.
- `options` is built on each access. Mutating the returned object has no effect on the client.
- `test/js/valkey/valkey-gc.test.ts` "RESP map keys are not leaked" times out under the ASAN build in this container with and without this change. The other 19 tests in that file pass.
- Docs: added a "Connection Target" section to `docs/runtime/redis.mdx`. Types: `readonly url: string` and `readonly options: Required<RedisOptions>` in `packages/bun-types/redis.d.ts`.
</details>

Fixes #41417

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/valkey/valkey-url-options.test.ts
bun test v1.4.2 (f42e98025)

test/js/valkey/valkey-url-options.test.ts:
 6 | // needed: the client is never connected.
 7 | describe("RedisClient url and options", () => {
 8 |   test("url returns the constructor input verbatim", () => {
 9 |     const url = "redis://user:pass@127.0.0.1:6380/3";
10 |     const client = new RedisClient(url, { autoReconnect: false });
11 |     expect(client.url).toBe(url);
                            ^
error: expect(received).toBe(expected)

Expected: "redis://user:pass@127.0.0.1:6380/3"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-url-options.test.ts:11:24)
(fail) RedisClient url and options > url returns the constructor input verbatim [6.22ms]
14 |     expect(new RedisClient("127.0.0.1:6381", { autoReconnect: false }).url).toBe("127.0.0.1:6381");
15 |   });
16 | 
17 |   test("options reports the defaults for a bare constructor", () => {
18 |     const client = new RedisClient("redis://127.0.0.1:6380");
19 |     expect(client.op
... (truncated)

release without fix: 9 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/valkey/valkey-url-options.test.ts:
 6 | // needed: the client is never connected.
 7 | describe("RedisClient url and options", () => {
 8 |   test("url returns the constructor input verbatim", () => {
 9 |     const url = "redis://user:pass@127.0.0.1:6380/3";
10 |     const client = new RedisClient(url, { autoReconnect: false });
11 |     expect(client.url).toBe(url);
                            ^
error: expect(received).toBe(expected)

Expected: "redis://user:pass@127.0.0.1:6380/3"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-url-options.test.ts:11:24)
(fail) RedisClient url and options > url returns the constructor input verbatim [0.25ms]
14 |     expect(new RedisClient("127.0.0.1:6381", { autoReconnect: false }).url).toBe("127.0.0.1:6381");
15 |   });
16 | 
17 |   test("options reports the defaults for a bare constructor", () => {
18 |     const client = new RedisClient("redis://127.0.0.1:6380");
19 |     expect(client.options).toEqual({
                                ^
error: expect(received).toEqual(expected)

- {
-   "autoReconnect": true,
-   "connectionTimeout": 10000,
-   "ena
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/valkey/valkey-url-options.test.ts
bun test v1.4.2 (f42e98025)

test/js/valkey/valkey-url-options.test.ts:
(pass) RedisClient url and options > url returns the constructor input verbatim [18.14ms]
(pass) RedisClient url and options > options reports the defaults for a bare constructor [5.96ms]
(pass) RedisClient url and options > options reflects the values passed to the constructor [3.14ms]
(pass) RedisClient url and options > options.tls is true for a rediss:// url with no tls option [2.52ms]
(pass) RedisClient url and options > options.tls returns the tls object passed to the constructor [6.97ms]
(pass) RedisClient url and options > duplicate() keeps url and options [8.43ms]
(pass) RedisClient url and options > inspect redacts the password in url and does not print the tls object [6.60ms]
(pass) RedisClient url and options > inspect leaves a url without a password as is [5.73ms]
(pass) RedisClient url and options > url falls back to REDIS_URL, then VALKEY_URL, then the built-in default [959.06ms]

 9 pass
 0 fail
 1 snapshots,
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 695ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/32] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/32] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/redis.mdx                        |  15 ++
 packages/bun-types/redis.d.ts                 |  30 +++-
 src/runtime/api/BunObject.rs                  |   3 +-
 src/runtime/jsc_hooks.rs                      |   5 +
 src/runtime/valkey_jsc/js_valkey.rs           | 221 ++++++++++++++++++++++++--
 src/runtime/valkey_jsc/js_valkey_functions.rs |   7 +-
 src/runtime/valkey_jsc/valkey.classes.ts      |   9 +-
 test/js/valkey/valkey-url-options.test.ts     | 164 +++++++++++++++++++
 8 files changed, 436 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
docs/runtime/redis.mdx                             1      1     15
packages/bun-types/redis.d.ts                      3      6     15
src/runtime/api/BunObject.rs                       1      2     14
src/runtime/jsc_hooks.rs                           1      1     14
src/runtime/valkey_jsc/js_valkey.rs                6     18     15
src/runtime/valkey_jsc/js_valkey_functions.rs      1      2     14
src/runtime/valkey_jsc/valkey.classes.ts           1      2     14
test/js/valkey/valkey-url-options.test.ts          0      3     14
```

</details>

**root cause** · written by the author bot

Bun.RedisClient discarded the resolved connection URL and constructor options after creating the client, leaving the instance with no readable properties, so a library rebuilding a client from an existing instance silently fell back to the default target and defaults for settings like maxRetries and autoReconnect. The fix retains the resolved URL and the original options, including the TLS value, on the client and exposes them through readonly url and options accessors that match the constructor's signature, with duplicate() preserving the same configuration and inspection redacting credent…

<!-- robobun:evidence:end -->
