### PR TITLE
bun:test: toThrow(regexp) ignores a RegExp's lastIndex (stacked on #41394)

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -495,9 +495,11 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                     return AsymmetricMatcherResult::PASS;
                 }
             } else if (auto* regex = dynamicDowncast<RegExpObject>(expectedTestValue)) {
-                JSString* otherString = otherProp.toString(globalObject);
+                String otherString = otherProp.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
-                bool matched = !!regex->match(globalObject, otherString);
+                // Jest tests the pattern alone; a global or sticky RegExp's lastIndex
+                // is neither read nor advanced.
+                bool matched = !!regex->regExp()->match(globalObject, otherString, 0);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                 if (matched) {
                     return AsymmetricMatcherResult::PASS;
@@ -4801,7 +4803,13 @@ JSC::JSString* JSC__JSValue__toJSStringView(JSC::EncodedJSValue JSValue0, JSC::J
     }
     JSC::RegExpObject* regexObject = dynamicDowncast<JSC::RegExpObject>(regex);
 
-    return !!regexObject->match(global, JSC::asString(str));
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    WTF::String haystack = str.toWTFString(global);
+    RETURN_IF_EXCEPTION(scope, false);
+    // Jest's toMatch tests the pattern alone; a global or sticky RegExp's
+    // lastIndex is neither read nor advanced.
+    return !!regexObject->regExp()->match(global, haystack, 0);
 }
 
 bool JSC__JSValue__stringIncludes(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue other)

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -143,12 +143,9 @@ pub(crate) fn to_throw(
             })
             .unwrap_or(JSValue::UNDEFINED);
 
-            // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
-            if let Some(test_fn) = expected_value.get(global, "test")? {
-                let matches = test_fn.call(global, expected_value, &[received_message])?;
-                if !matches.to_boolean() {
-                    return Ok(JSValue::UNDEFINED);
-                }
+            let received_message_str = JSValue::from_cell(received_message.to_js_string(global)?);
+            if !expected_value.to_match(global, received_message_str)? {
+                return Ok(JSValue::UNDEFINED);
             }
 
             let mut formatter2 = super::make_formatter(global);
@@ -259,12 +256,9 @@ pub(crate) fn to_throw(
 
         if expected_value.is_reg_exp() {
             if let Some(received_message) = received_message_opt {
-                // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
-                if let Some(test_fn) = expected_value.get(global, "test")? {
-                    let matches = test_fn.call(global, expected_value, &[received_message])?;
-                    if matches.to_boolean() {
-                        return Ok(JSValue::UNDEFINED);
-                    }
+                let received_message_str = JSValue::from_cell(received_message.to_js_string(global)?);
+                if expected_value.to_match(global, received_message_str)? {
+                    return Ok(JSValue::UNDEFINED);
                 }
             }
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3505,6 +3505,15 @@ describe("expect()", () => {
       expect(sticky.lastIndex).toBe(9);
       expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching(sticky) });
       expect(sticky.lastIndex).toBe(9);
+      // a sticky RegExp is matched from index 0, as Jest's `new RegExp(regex)` copy is, whatever lastIndex says
+      const anchored = /wor/y;
+      anchored.lastIndex = 6;
+      expect("hello world").not.toMatch(anchored);
+      expect("world").toMatch(anchored);
+      expect(anchored.lastIndex).toBe(6);
+      expect({ a: "world" }).toMatchObject({ a: expect.stringMatching(anchored) });
+      expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching(anchored) });
+      expect(anchored.lastIndex).toBe(6);
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching(/word/) });
       expect({ a: expect.stringMatching("wor") }).toMatchObject({ a: "hello world" });
       expect({ a: expect.stringMatching("word") }).not.toMatchObject({ a: "hello world" });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3497,6 +3497,14 @@ describe("expect()", () => {
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching("word") });
       expect({ a: "hello world" }).toMatchObject({ a: "hello world" });
       expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching(/wor/) });
+      // a global RegExp matches regardless of lastIndex and does not advance it
+      const sticky = /wor/g;
+      sticky.lastIndex = 9;
+      expect("hello world").toMatch(sticky);
+      expect("hello world").toMatch(sticky);
+      expect(sticky.lastIndex).toBe(9);
+      expect({ a: "hello world" }).toMatchObject({ a: expect.stringMatching(sticky) });
+      expect(sticky.lastIndex).toBe(9);
       expect({ a: "hello world" }).not.toMatchObject({ a: expect.stringMatching(/word/) });
       expect({ a: expect.stringMatching("wor") }).toMatchObject({ a: "hello world" });
       expect({ a: expect.stringMatching("word") }).not.toMatchObject({ a: "hello world" });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -932,19 +932,21 @@ describe("expect()", () => {
       }).toThrow(/baz/),
     ).toThrow("/baz/");
 
-    // If matching the message against the RegExp throws, that error propagates
-    // instead of being read as the match result.
+    // If converting the message to a string for the RegExp throws, that error
+    // propagates instead of being read as the match result.
     for (const not of [false, true]) {
-      const re = /bar/;
-      re.test = () => {
-        throw new Error("from test()");
-      };
       expect(() => {
         const e = expect(() => {
-          throw new Error("bar");
+          throw {
+            message: {
+              toString() {
+                throw new Error("from toString()");
+              },
+            },
+          };
         });
-        (not ? e.not : e).toThrow(re);
-      }).toThrow("from test()");
+        (not ? e.not : e).toThrow(/bar/);
+      }).toThrow("from toString()");
     }
 
     expect(() => {
@@ -995,6 +997,36 @@ describe("expect()", () => {
         throw null;
       }).toThrow(err);
     }
+  });
+
+  // jest and vitest call RegExp#test here, which reads and advances lastIndex for /g and /y
+  test_skipIf(!isBun)("toThrow with a global RegExp ignores lastIndex", () => {
+    const re = /oops/g;
+    re.lastIndex = 9;
+    const fn = () => {
+      throw new Error("oops");
+    };
+    expect(fn).toThrow(re);
+    expect(fn).toThrow(re);
+    expect(re.lastIndex).toBe(9);
+    // The message matches, so not.toThrow must reject every time, not only the first.
+    expect(() => expect(fn).not.toThrow(re)).toThrow();
+    expect(() => expect(fn).not.toThrow(re)).toThrow();
+    expect(re.lastIndex).toBe(9);
+  });
+
+  test_skipIf(!isBun)("toThrow with a sticky RegExp matches from index 0", () => {
+    const re = /oops/y;
+    re.lastIndex = 6;
+    const fn = () => {
+      throw new Error("oops");
+    };
+    expect(fn).toThrow(re);
+    expect(fn).toThrow(re);
+    expect(() => {
+      throw new Error("well, oops");
+    }).not.toThrow(re);
+    expect(re.lastIndex).toBe(6);
   });
 
   test("deepEquals derived strings and strings", () => {


### PR DESCRIPTION
Stacked on #41394. The first two commits are that PR's commits, rebased on main. Only the last commit (toThrow) is new. Draft until #41394 merges, then this rebases down to the toThrow commit alone.

### Problem
- `expect(fn).toThrow(re)` with a global or sticky RegExp passes once and then fails. `expect(fn).not.toThrow(re)` has the opposite shape: it rejects once, then passes silently. Error text: `error: expect(received).toThrow(expected)`.
- The cause is `src/runtime/test_runner/expect/toThrow.rs:147` and `:263`. Both sites look up `test` on the RegExp and call it. `RegExp.prototype.test` starts at `lastIndex` and writes the match end back.

### Fix
- Both sites now call `JSValue::to_match`, the binding `toMatch` uses. With #41394 that binding matches the underlying RegExp from offset 0 and does not touch `lastIndex`.
- This is stricter than Jest, Vitest, and `assert.throws`, which all call `.test()` on the caller's RegExp for `toThrow`. Bun chooses pattern-only semantics so that the three RegExp matchers (`toMatch`, `expect.stringMatching`, `toThrow`) agree. A stale `lastIndex` can only turn a true match into a false result, so this direction is safe. The new tests are gated to bun for that reason.
- The matcher no longer calls a user-overridden `re.test`. The test from #39804 that used such an override to prove that a throw inside matching propagates now throws from `message.toString()` instead. That path propagates before and after this change.
- Verified: `test/js/bun/test/expect.test.js` (the two new tests fail on bun 1.4.3 and pass with this branch, 418 pass in the file). Also `test/js/bun/test/expect/`.

### Background
- `JSC__JSValue__toMatch` in `src/jsc/bindings/bindings.cpp` is the native matcher behind `toMatch`. It takes a RegExpObject and a string. On main it calls `RegExpObject::match`, which follows `exec` semantics. #41394 changes it to `regExp()->match(global, haystack, 0)`, which ignores and does not update `lastIndex`.
- `toThrow.rs` has two RegExp sites: one for `.not` (line 138) and one for the positive case (line 260). They had a `TODO: REMOVE THIS GETTER` comment that asked for exactly this binding.

<details><summary>Notes</summary>

- #32941 carried the same toThrow hunk plus the same bindings.cpp change. It is closed in favour of #41394 and this follow-up.
- Reference behaviour for a `/g` RegExp reused across two `toThrow` calls: jest 30 fails, vitest 4 fails, bun before fails, bun after passes.
- Self-reviewed: 3 concerns raised. Addressed: do not open a standalone third PR (this is a draft stacked on #41394), state the Jest divergence in plain words, close #32941. Rejected: none.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (e0a2b82fd)

test/js/bun/test/expect.test.js:
(pass) expect() > () [308.75ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.73ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.47ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.26ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.26ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.26ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.26ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.23ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.28ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.26ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.34ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.50ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.33ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.34ms]
(pass) ex
... (truncated)

release without fix: 3 failed, 2 skipped
bun test v1.4.1-canary.1 (e0a2b82fd)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.59ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.04ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.01ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (e0a2b82fd)

test/js/bun/test/expect.test.js:
(pass) expect() > () [301.12ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.48ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.52ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.29ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.28ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.27ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.24ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.24ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.23ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.48ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.53ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.32ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.34ms]
(pass) ex
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 597ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp             | 14 +++++--
 src/runtime/test_runner/expect/toThrow.rs | 18 +++------
 test/js/bun/test/expect.test.js           | 67 ++++++++++++++++++++++++++-----
 3 files changed, 75 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/bindings.cpp                  1      0     10
src/runtime/test_runner/expect/toThrow.rs      1      2      9
test/js/bun/test/expect.test.js                2      2      9
```

</details>

**root cause** · written by the author bot

The bun:test matchers that accept a RegExp (toMatch, expect.stringMatching, and toThrow) invoked the regex with exec or test semantics, so a global or sticky pattern started from the caller's lastIndex and wrote the match end back, making a shared /x/g alternate pass and fail across assertions and mutate the user's object. The fix routes all three matchers through a single binding that calls match on the underlying RegExp from offset 0 and never touches lastIndex, and toThrow additionally stops looking up the user-overridable test property. The toMatch and stringMatching half lands through …

<!-- robobun:evidence:end -->