### PR TITLE
Release the poll and surface the error when a Bun.file() stream read fails

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -56,6 +56,10 @@ pub struct FileReader {
     pub(crate) event_loop: Cell<EventLoopHandle>,
     pub(crate) lazy: JsCell<Lazy>,
     pub(crate) buffered: JsCell<Vec<u8>>,
+    /// A read error that arrived with no pending pull to settle: the failing
+    /// read ran synchronously inside `on_pull`, or landed between pulls. The
+    /// next `on_pull` returns it once the buffered bytes are delivered.
+    pub(crate) read_error: JsCell<Option<sys::Error>>,
     /// Read-only after construction.
     pub(crate) highwater_mark: usize,
     pub(crate) flowing: Cell<bool>,
@@ -83,6 +87,7 @@ impl Default for FileReader {
             event_loop: Cell::new(EventLoopHandle::init(core::ptr::null_mut())),
             lazy: JsCell::new(Lazy::None),
             buffered: JsCell::new(Vec::new()),
+            read_error: JsCell::new(None),
             highwater_mark: 16384,
             flowing: Cell::new(true),
             sink: JsCell::new(SinkHandle::None),
@@ -779,7 +784,7 @@ impl FileReader {
                 // `drained` here — freeing `self.buffered` would be a no-op.
                 drop(drained);
 
-                if self.reader().is_done() {
+                if self.reader_finished() {
                     return streams::Result::IntoArrayAndDone(streams::IntoArray {
                         value: array,
                         len: drained_len as u64,
@@ -792,7 +797,7 @@ impl FileReader {
                 }
             }
 
-            if self.reader().is_done() {
+            if self.reader_finished() {
                 return streams::Result::OwnedAndDone(drained);
             } else {
                 return streams::Result::Owned(drained);
@@ -800,14 +805,14 @@ impl FileReader {
         }
 
         if self.reader().is_done() {
-            return streams::Result::Done;
+            return self.end_of_reader();
         }
 
         if !self.reader().has_pending_read() && self.flowing.get() {
             // SAFETY: the reader cell is live for `self`'s lifetime; `read_into` is the raw re-entrancy-safe entry (EOF/error dispatch runs user JS).
             let (amount_read, state) = unsafe { IOReader::read_into(self.reader.get(), buffer) };
             bun_core::scoped_log!(FileReader, "onPull({}) = {}", buffer.len(), amount_read);
-            let done = state == ReadState::Eof || self.reader().is_done();
+            let done = state == ReadState::Eof || self.reader_finished();
             if amount_read > 0 {
                 let into = streams::IntoArray {
                     value: array,
@@ -828,8 +833,8 @@ impl FileReader {
                     streams::Result::Owned(drained)
                 };
             }
-            if done {
-                return streams::Result::Done;
+            if done || self.reader().is_done() {
+                return self.end_of_reader();
             }
         }
 
@@ -934,39 +939,66 @@ impl FileReader {
             self.buffered.set(Vec::new());
         }
 
+        // Pin across the dispatch below: `sink.end()` and `p.run()` run user
+        // JS, and anything there that reaches on_reader_done would drop the
+        // across-read ref and let a GC free this box before the
+        // `waiting_for_on_reader_done` read below.
+        let parent = self.parent();
+        // SAFETY: see `parent()`.
+        unsafe { (*parent).increment_count() };
+
         let sink = *self.sink.get();
         if sink.is_some() {
             self.sink.set(SinkHandle::None);
             self.sink_paused.set(false);
             sink.end(Some(streams::StreamError::Error(err)));
-            let parent = self.parent();
-            if self.waiting_for_on_reader_done.get() && !self.done.get() {
-                self.waiting_for_on_reader_done.set(false);
-                // SAFETY: see `parent()`.
-                let _ = unsafe { Source::decrement_count(parent) };
-            }
-            return;
+        } else if self.pending.get().state == streams::PendingState::Pending {
+            self.pending.with_mut(|p| {
+                p.result = streams::Result::Err(streams::StreamError::Error(err));
+            });
+            self.pending.with_mut(|p| p.run());
+        } else {
+            // `p.run()` would no-op and the pull promise would never settle.
+            self.read_error.set(Some(err));
         }
-
-        self.pending.with_mut(|p| {
-            p.result = streams::Result::Err(streams::StreamError::Error(err));
-        });
-        // Pin across `p.run()`: it runs user JS, and anything there that
-        // reaches on_reader_done would drop the across-read ref and let a GC
-        // free this box before the `waiting_for_on_reader_done` read below.
-        let parent = self.parent();
-        // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
-        self.pending.with_mut(|p| p.run());
 
         if self.waiting_for_on_reader_done.get() && !self.done.get() {
             self.waiting_for_on_reader_done.set(false);
             // SAFETY: see `parent()`; the pin above keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
+        self.close_after_error();
         // SAFETY: see `parent()`; the pin keeps the count >= 1, so this never
         // frees. Tail call, `self` is not accessed after.
         let _ = unsafe { Source::decrement_count(parent) };
+    }
+
+    /// A read error is terminal, and a consumer never cancels an errored
+    /// stream. Release the poll and the fd here: a registered poll keeps the
+    /// event loop alive.
+    fn close_after_error(&self) {
+        if self.done.get() {
+            return;
+        }
+        self.done.set(true);
+        self.reader().update_ref(false);
+        self.reader().deinit();
+    }
+
+    /// `true` once the reader has nothing more to deliver. A stored read error
+    /// still has to reach the consumer, so it keeps the stream open for one
+    /// more pull.
+    fn reader_finished(&self) -> bool {
+        self.reader().is_done() && self.read_error.get().is_none()
+    }
+
+    /// What a pull gets once the reader is done: the stored read error, or a
+    /// clean end.
+    fn end_of_reader(&self) -> streams::Result {
+        match self.read_error.replace(None) {
+            Some(err) => streams::Result::Err(streams::StreamError::Error(err)),
+            None => streams::Result::Done,
+        }
     }
 
     pub(crate) fn set_raw_mode(&self, _flag: bool) -> sys::Result<()> {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -541,7 +541,7 @@ impl FileReader {
         if sink.is_none() {
             return;
         }
-        let reader_done = self.reader().is_done();
+        let reader_done = self.reader_finished();
         let buffered = self.drain();
         if !buffered.is_empty() {
             let chunk = if reader_done {
@@ -570,7 +570,12 @@ impl FileReader {
         }
         if reader_done || self.done.get() {
             self.sink.set(SinkHandle::None);
-            sink.end(None);
+            // A read error from before the sink was attached ends it here.
+            sink.end(
+                self.read_error
+                    .replace(None)
+                    .map(streams::StreamError::Error),
+            );
             return;
         }
         if !self.reader().has_pending_read() {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -754,16 +754,12 @@ impl FileReader {
         self.pending_value
             .with_mut(|p| p.clear_without_deallocation());
         self.pending_view.set(&mut []);
-        // Pin across `run()`: a re-entrant cancel() reaches on_reader_done, which drops the across-read ref and lets a GC free this box while the io caller still holds `&mut` into it.
-        let parent = self.parent();
+        // A re-entrant cancel() inside `run()` reaches on_reader_done, which drops the across-read ref and lets a GC free this box while the io caller still holds `&mut` into it.
         // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
+        let _pin = unsafe { SourcePin::new(self.parent()) };
         self.pending.with_mut(|p| p.run());
         // Re-entrant cancel or a nested pull that read to EOF closed the reader; tell the io caller to stop so it does not re-read the captured fd.
-        let ret = ret && !self.done.get() && !self.reader().is_done();
-        // SAFETY: see `parent()`; the pin keeps the count >= 1, so this never frees. `self` is not accessed after.
-        let _ = unsafe { Source::decrement_count(parent) };
-        ret
+        ret && !self.done.get() && !self.reader().is_done()
     }
 
     pub(crate) fn on_pull(&self, buffer: &'static mut [u8], array: JSValue) -> streams::Result {
@@ -884,12 +880,11 @@ impl FileReader {
 
     pub(crate) fn on_reader_done(&self) {
         bun_core::scoped_log!(FileReader, "onReaderDone()");
-        // Pin across `p.run()` and `on_close()`: both can run user JS, and the
-        // `self.buffered` / `waiting_for_on_reader_done` reads below must not
-        // land on a freed box. Same bracket as on_read_chunk / on_reader_error.
+        // `p.run()` and `on_close()` can run user JS, and the `self.buffered` /
+        // `waiting_for_on_reader_done` reads below must not land on a freed box.
         let parent = self.parent();
         // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
+        let _pin = unsafe { SourcePin::new(parent) };
         let sink = *self.sink.get();
         if sink.is_some() {
             self.consume_reader_buffer();
@@ -927,13 +922,9 @@ impl FileReader {
         }
         if self.waiting_for_on_reader_done.get() {
             self.waiting_for_on_reader_done.set(false);
-            // SAFETY: see `parent()`; the pin above keeps the count > 0.
+            // SAFETY: see `parent()`; `_pin` keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
-        // SAFETY: see `parent()`; releases the pin. Tail position — `self` (a
-        // field of `*parent`) is not accessed after this call, which may free
-        // the allocation when the refcount hits zero.
-        let _ = unsafe { Source::decrement_count(parent) };
     }
 
     pub(crate) fn on_reader_error(&self, err: sys::Error) {
@@ -942,12 +933,11 @@ impl FileReader {
             self.buffered.set(Vec::new());
         }
 
-        // Pin across `sink.end()` / `p.run()`: they run user JS, which can
-        // reach on_reader_done and drop the across-read ref before the
-        // `waiting_for_on_reader_done` read below.
+        // `sink.end()` and `p.run()` run user JS, which can reach on_reader_done
+        // and drop the across-read ref before the read of it below.
         let parent = self.parent();
         // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
+        let _pin = unsafe { SourcePin::new(parent) };
 
         let sink = *self.sink.get();
         if sink.is_some() {
@@ -966,13 +956,10 @@ impl FileReader {
 
         if self.waiting_for_on_reader_done.get() && !self.done.get() {
             self.waiting_for_on_reader_done.set(false);
-            // SAFETY: see `parent()`; the pin above keeps the count > 0.
+            // SAFETY: see `parent()`; `_pin` keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
         self.close_after_error();
-        // SAFETY: see `parent()`; the pin keeps the count >= 1, so this never
-        // frees. Tail call, `self` is not accessed after.
-        let _ = unsafe { Source::decrement_count(parent) };
     }
 
     /// An errored stream is never cancelled, so release the poll and the fd here.
@@ -1046,6 +1033,28 @@ impl FileReader {
 }
 
 pub type Source = readable_stream::NewSource<FileReader>;
+
+/// Holds a ref on the `Source` that embeds a `FileReader` while a dispatch runs
+/// user JS. Dropping it releases the ref and can free the source, so a pin must
+/// outlive every use of the reader it protects.
+struct SourcePin(*mut Source);
+
+impl SourcePin {
+    /// # Safety
+    /// `parent` is the live `Source` that embeds the caller.
+    unsafe fn new(parent: *mut Source) -> Self {
+        // SAFETY: fn contract.
+        unsafe { (*parent).increment_count() };
+        Self(parent)
+    }
+}
+
+impl Drop for SourcePin {
+    fn drop(&mut self) {
+        // SAFETY: balances the ref taken in `new`.
+        let _ = unsafe { Source::decrement_count(self.0) };
+    }
+}
 
 // SAFETY: `FileReader` is always the `context` field of a heap-allocated
 // `Source`. `parent` is the `raw` arm because the ref-count pin

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -56,9 +56,7 @@ pub struct FileReader {
     pub(crate) event_loop: Cell<EventLoopHandle>,
     pub(crate) lazy: JsCell<Lazy>,
     pub(crate) buffered: JsCell<Vec<u8>>,
-    /// A read error that arrived with no pending pull to settle: the failing
-    /// read ran synchronously inside `on_pull`, or landed between pulls. The
-    /// next `on_pull` returns it once the buffered bytes are delivered.
+    /// A read error that arrived with no pending pull. The next `on_pull` returns it.
     pub(crate) read_error: JsCell<Option<sys::Error>>,
     /// Read-only after construction.
     pub(crate) highwater_mark: usize,
@@ -939,9 +937,8 @@ impl FileReader {
             self.buffered.set(Vec::new());
         }
 
-        // Pin across the dispatch below: `sink.end()` and `p.run()` run user
-        // JS, and anything there that reaches on_reader_done would drop the
-        // across-read ref and let a GC free this box before the
+        // Pin across `sink.end()` / `p.run()`: they run user JS, which can
+        // reach on_reader_done and drop the across-read ref before the
         // `waiting_for_on_reader_done` read below.
         let parent = self.parent();
         // SAFETY: see `parent()`.
@@ -973,9 +970,7 @@ impl FileReader {
         let _ = unsafe { Source::decrement_count(parent) };
     }
 
-    /// A read error is terminal, and a consumer never cancels an errored
-    /// stream. Release the poll and the fd here: a registered poll keeps the
-    /// event loop alive.
+    /// An errored stream is never cancelled, so release the poll and the fd here.
     fn close_after_error(&self) {
         if self.done.get() {
             return;
@@ -985,15 +980,12 @@ impl FileReader {
         self.reader().deinit();
     }
 
-    /// `true` once the reader has nothing more to deliver. A stored read error
-    /// still has to reach the consumer, so it keeps the stream open for one
-    /// more pull.
+    /// Done, with no stored read error left for one more pull to return.
     fn reader_finished(&self) -> bool {
         self.reader().is_done() && self.read_error.get().is_none()
     }
 
-    /// What a pull gets once the reader is done: the stored read error, or a
-    /// clean end.
+    /// The stored read error, or a clean end.
     fn end_of_reader(&self) -> streams::Result {
         match self.read_error.replace(None) {
             Some(err) => streams::Result::Err(streams::StreamError::Error(err)),

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2049,8 +2049,7 @@ describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toMatch(/^first x\nsettled (EIO|done)\n$/);
     expect(exitCode).toBe(0);
   });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -7,9 +7,9 @@ import {
   readableStreamToText,
 } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
-import { createReadStream, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, createReadStream, openSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 it("TransformStream", async () => {
@@ -1944,6 +1944,116 @@ it("Bun.file().stream() read text from large file", async () => {
   } finally {
     unlinkSync(tmpfile);
   }
+});
+
+// A POSIX file is read synchronously inside the stream's pull, so a failing
+// read(2) arrives with no pending read to reject. Windows reads files through
+// libuv, where the error always lands on a pending read.
+describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
+  // read(2) on /proc/self/mem fails with EIO: nothing is mapped at address 0.
+  const eioPath = "/proc/self/mem";
+  const itEIO = isLinux ? it : it.skip;
+
+  async function expectReadError(promise, code) {
+    const err = await promise.then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe(code);
+    return err;
+  }
+
+  itEIO("for await rejects with the read error", async () => {
+    const chunks = [];
+    await expectReadError(
+      (async () => {
+        for await (const chunk of Bun.file(eioPath).stream()) chunks.push(chunk);
+      })(),
+      "EIO",
+    );
+    expect(chunks).toHaveLength(0);
+  });
+
+  itEIO("getReader().read() rejects with the read error", async () => {
+    await expectReadError(Bun.file(eioPath).stream().getReader().read(), "EIO");
+  });
+
+  itEIO("pipeTo() rejects with the read error", async () => {
+    await expectReadError(
+      Bun.file(eioPath)
+        .stream()
+        .pipeTo(new WritableStream({ write() {} })),
+      "EIO",
+    );
+  });
+
+  itEIO("Bun.file().text() reports the same read error", async () => {
+    const err = await expectReadError(Bun.file(eioPath).text(), "EIO");
+    expect(err.syscall).toBe("read");
+  });
+
+  it("a stream over a write-only fd rejects with EBADF", async () => {
+    using dir = tempDir("file-stream-read-error", { "x.bin": "hello" });
+    const fd = openSync(join(String(dir), "x.bin"), "w");
+    try {
+      await expectReadError(Bun.file(fd).stream().getReader().read(), "EBADF");
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  // A pollable fd (here a non-blocking pty master, as node-pty sets it up) is
+  // read when its poll fires. A read error must release that poll, or the
+  // process never exits. The slave hangup fails the master read with EIO on
+  // Linux and ends it on macOS.
+  it("a read error on a pollable fd releases the poll so the process can exit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { CString, dlopen } = require("bun:ffi");
+        const { closeSync, constants, openSync, writeSync } = require("node:fs");
+        const arch = process.arch === "x64" ? "x86_64" : process.arch === "arm64" ? "aarch64" : process.arch;
+        const candidates = process.platform === "darwin" ? ["libSystem.B.dylib"] : ["libc.so.6", "libc.musl-" + arch + ".so.1"];
+        let libc, lastError;
+        for (const lib of candidates) {
+          try {
+            libc = dlopen(lib, {
+              posix_openpt: { args: ["int"], returns: "int" },
+              grantpt: { args: ["int"], returns: "int" },
+              unlockpt: { args: ["int"], returns: "int" },
+              ptsname: { args: ["int"], returns: "ptr" },
+            }).symbols;
+            break;
+          } catch (err) {
+            lastError = err;
+          }
+        }
+        if (!libc) throw lastError;
+        const master = libc.posix_openpt(constants.O_RDWR | constants.O_NOCTTY | constants.O_NONBLOCK);
+        if (master < 0 || libc.grantpt(master) !== 0 || libc.unlockpt(master) !== 0) throw new Error("pty setup failed");
+        const slave = openSync(new CString(libc.ptsname(master)).toString(), constants.O_RDWR | constants.O_NOCTTY);
+        const reader = Bun.file(master).stream().getReader();
+        writeSync(slave, "x");
+        const first = await reader.read();
+        console.log("first", Buffer.from(first.value).toString());
+        // This read finds no data and waits on the poll. The hangup fires it.
+        const pending = reader.read();
+        closeSync(slave);
+        const result = await pending.then(r => (r.done ? "done" : "data"), e => e.code);
+        console.log("settled", result);
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/^first x\nsettled (EIO|done)\n$/);
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("fs.createReadStream(filename) should be able to break inside async loop", async () => {


### PR DESCRIPTION
### Problem
- A `Bun.file().stream()` whose `read(2)` fails with no pull pending never settles. `for await (const c of Bun.file("/proc/self/mem").stream())` hangs forever, while `Bun.file(path).text()` rejects with `EIO` (#33362).
- After a read error on a pollable fd (a pty master, a non-blocking pipe) the process never exits. `reader.read()` rejects with `EIO: i/o error, read`, but the `FilePoll` stays registered and the dup'd fd open. An errored stream is never cancelled, so nothing releases them.
- Both come from `FileReader::on_reader_error` (`src/runtime/webcore/FileReader.rs`). It only runs `pending`, a no-op unless a pull is pending (`Pending::run`), and it never closes the reader.

### Fix
- `on_reader_error` settles the pending pull when there is one. Otherwise it stores the error in a new `read_error` slot, and the next `on_pull` returns it after any buffered bytes (`reader_finished`, `end_of_reader`).
- `on_reader_error` then closes the reader (`close_after_error`): it marks the source done and releases the poll and the fd through `deinit`, which reports no second completion.
- Verified: `test/js/web/streams/streams.test.js` (6 new tests, 5 fail on 1.4.1). Also the rest of `test/js/web/streams/`, the fs, stream and spawn suites.

### Background
- `FileReader` is the native source behind `Bun.file().stream()`. A pull first tries a synchronous read (`read_into`). With no data on a pollable fd, the `BufferedReader` registers a poll and the pull becomes pending. A registered poll keeps the event loop alive.
- The reader reports through `on_read_chunk`, `on_reader_done` or `on_reader_error`. On EOF it closes itself before it reports. On error it did not.
- `sink` is the native consumer path (a fetch body). It gets the error through `sink.end` and needs the same reader close.

<details><summary>Notes</summary>

This supersedes #33362, which stores the error in a `read_error` slot in the same way but does not release the poll and the fd. Its tests are carried over unchanged.

A stream over a non-blocking pty master with a pending read: before this change the rejection lands and the process then hangs, with or without `reader.cancel()` or `releaseLock()` afterwards. `cancel()` on an errored stream rejects with the stored error and never reaches the native source.

The sync pull path reaches `on_reader_error` from inside `on_pull`. The reader is closed by the time `read_into` returns, so `on_pull` returns the stored error through `end_of_reader` in the same call, where it previously returned `Pending` with no poll registered.

The second PR, for `tty.ReadStream` on a non-blocking fd (#41414), is built on this branch and needs the poll release: node-pty's pty master reports the child's exit as `EIO`.

Pre-existing failures on a debug build, with or without this change: `test/js/node/process/stdin/stdin-fixtures.test.ts` (the runner kills the child after 1 s, a debug child needs 1.1 s) and `test/js/web/streams/streams-leak.test.ts` "Absolute memory usage" (times out at 5 s).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->