### PR TITLE
Read a non-blocking fd through the pollable reader in tty.ReadStream

### DIFF
--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -22,16 +22,10 @@ const kNativeReader = Symbol("nativeReader");
 const kNativeSource = Symbol("nativeSource");
 const kKeepAlive = Symbol("keepAlive");
 
-// Node's tty.ReadStream is a net.Socket: libuv waits for the fd to become
-// readable and never sees EAGAIN. Here it is an fs.ReadStream, whose reads
-// run on the thread pool and fail with EAGAIN on a non-blocking fd (node-pty
-// sets O_NONBLOCK on the pty master). The first EAGAIN switches the stream to
-// the pollable native reader, which reads only when the fd is readable.
-//
-// The switch waits for an EAGAIN instead of checking O_NONBLOCK up front
-// because a blocking tty fd must stay on the thread pool: Bun.file(fd) only
-// polls a non-stdio fd that is a FIFO, a socket, or non-blocking, and it
-// reads any other fd synchronously on the JS thread.
+// A thread pool read of a non-blocking fd (node-pty's pty master) fails with
+// EAGAIN. The first EAGAIN switches the stream to the pollable native reader,
+// which reads on readiness like Node's net.Socket based tty.ReadStream. A
+// blocking fd stays on the thread pool: Bun.file(fd) would read it on the JS thread.
 function ttyRead(stream, fd, buf, offset, length, position, cb) {
   const reader = stream[kNativeReader];
   if (reader !== undefined) {

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -51,7 +51,7 @@ function ttyRead(stream, fd, buf, offset, length, position, cb) {
 }
 
 function readFromNative(stream, reader, buf, cb) {
-  reader.read().then(
+  reader.read().$then(
     ({ value, done }) => {
       if (done || stream[kNativeReader] !== reader) {
         cb(null, 0, buf);
@@ -116,7 +116,7 @@ Object.defineProperty(ReadStream, "prototype", {
       if (reader !== undefined) {
         // Settles the pending read so fs.ReadStream's _destroy gets its kIoDone.
         this[kNativeReader] = undefined;
-        reader.cancel().catch(() => {});
+        reader.cancel().$then(undefined, () => {});
       }
       fs.ReadStream.prototype._destroy.$call(this, err, cb);
     };

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -12,17 +12,79 @@ const {
 
 const { validateInteger } = require("internal/validators");
 const fs = require("internal/fs/streams");
+const { read: fsRead, open: fsOpen, close: fsClose } = require("node:fs");
 
 // libuv stores the mode and the saved termios on each uv_tty_t, so a stream
 // going back to cooked never disturbs another one on the same terminal. Keep
 // that state per ReadStream rather than per process.
 const kRawModeState = Symbol("rawModeState");
+const kNativeReader = Symbol("nativeReader");
+const kNativeSource = Symbol("nativeSource");
+const kKeepAlive = Symbol("keepAlive");
+
+// Node's tty.ReadStream is a net.Socket: libuv waits for the fd to become
+// readable and never sees EAGAIN. Here it is an fs.ReadStream, whose reads
+// run on the thread pool and fail with EAGAIN on a non-blocking fd (node-pty
+// sets O_NONBLOCK on the pty master). The first EAGAIN switches the stream to
+// the pollable native reader, which reads only when the fd is readable.
+//
+// The switch waits for an EAGAIN instead of checking O_NONBLOCK up front
+// because a blocking tty fd must stay on the thread pool: Bun.file(fd) only
+// polls a non-stdio fd that is a FIFO, a socket, or non-blocking, and it
+// reads any other fd synchronously on the JS thread.
+function ttyRead(stream, fd, buf, offset, length, position, cb) {
+  const reader = stream[kNativeReader];
+  if (reader !== undefined) {
+    readFromNative(stream, reader, buf, cb);
+    return;
+  }
+  fsRead(fd, buf, offset, length, position, (err, bytesRead, buffer) => {
+    if (err && (err.code === "EAGAIN" || err.code === "EWOULDBLOCK")) {
+      if (stream.destroyed) {
+        cb(null, 0, buf);
+        return;
+      }
+      const native = Bun.file(fd).stream();
+      const source = native.$bunNativePtr;
+      stream[kNativeSource] = source;
+      if (stream[kKeepAlive] === false) source?.updateRef?.(false);
+      const reader = (stream[kNativeReader] = native.getReader());
+      readFromNative(stream, reader, buf, cb);
+      return;
+    }
+    cb(err, bytesRead, buffer);
+  });
+}
+
+function readFromNative(stream, reader, buf, cb) {
+  reader.read().then(
+    ({ value, done }) => {
+      if (done || stream[kNativeReader] !== reader) {
+        cb(null, 0, buf);
+        return;
+      }
+      cb(null, value.byteLength, Buffer.from(value.buffer, value.byteOffset, value.byteLength));
+    },
+    err => cb(err, 0, buf),
+  );
+}
 
 function ReadStream(fd): void {
   if (!(this instanceof ReadStream)) {
     return new ReadStream(fd);
   }
-  fs.ReadStream.$apply(this, ["", { fd }]);
+  const stream = this;
+  fs.ReadStream.$apply(this, [
+    "",
+    {
+      fd,
+      fs: {
+        open: fsOpen,
+        close: fsClose,
+        read: (fd, buf, offset, length, position, cb) => ttyRead(stream, fd, buf, offset, length, position, cb),
+      },
+    },
+  ]);
   this.isRaw = false;
   // Only set isTTY to true if the fd is actually a TTY
   this.isTTY = isatty(fd);
@@ -36,8 +98,9 @@ Object.defineProperty(ReadStream, "prototype", {
     // Add ref/unref methods to make tty.ReadStream behave like Node.js
     // where TTY streams have socket-like behavior
     Prototype.ref = function () {
+      this[kKeepAlive] = true;
       // Get the underlying native stream source if available
-      const source = this.$bunNativePtr;
+      const source = this[kNativeSource] ?? this.$bunNativePtr;
       if (source?.updateRef) {
         source.updateRef(true);
       }
@@ -45,12 +108,23 @@ Object.defineProperty(ReadStream, "prototype", {
     };
 
     Prototype.unref = function () {
+      this[kKeepAlive] = false;
       // Get the underlying native stream source if available
-      const source = this.$bunNativePtr;
+      const source = this[kNativeSource] ?? this.$bunNativePtr;
       if (source?.updateRef) {
         source.updateRef(false);
       }
       return this;
+    };
+
+    Prototype._destroy = function (err, cb) {
+      const reader = this[kNativeReader];
+      if (reader !== undefined) {
+        // Settles the pending read so fs.ReadStream's _destroy gets its kIoDone.
+        this[kNativeReader] = undefined;
+        reader.cancel().catch(() => {});
+      }
+      fs.ReadStream.prototype._destroy.$call(this, err, cb);
     };
 
     Prototype.setRawMode = function (flag) {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -56,6 +56,10 @@ pub struct FileReader {
     pub(crate) event_loop: Cell<EventLoopHandle>,
     pub(crate) lazy: JsCell<Lazy>,
     pub(crate) buffered: JsCell<Vec<u8>>,
+    /// A read error that arrived with no pending pull to settle: the failing
+    /// read ran synchronously inside `on_pull`, or landed between pulls. The
+    /// next `on_pull` returns it once the buffered bytes are delivered.
+    pub(crate) read_error: JsCell<Option<sys::Error>>,
     /// Read-only after construction.
     pub(crate) highwater_mark: usize,
     pub(crate) flowing: Cell<bool>,
@@ -83,6 +87,7 @@ impl Default for FileReader {
             event_loop: Cell::new(EventLoopHandle::init(core::ptr::null_mut())),
             lazy: JsCell::new(Lazy::None),
             buffered: JsCell::new(Vec::new()),
+            read_error: JsCell::new(None),
             highwater_mark: 16384,
             flowing: Cell::new(true),
             sink: JsCell::new(SinkHandle::None),
@@ -779,7 +784,7 @@ impl FileReader {
                 // `drained` here — freeing `self.buffered` would be a no-op.
                 drop(drained);
 
-                if self.reader().is_done() {
+                if self.reader_finished() {
                     return streams::Result::IntoArrayAndDone(streams::IntoArray {
                         value: array,
                         len: drained_len as u64,
@@ -792,7 +797,7 @@ impl FileReader {
                 }
             }
 
-            if self.reader().is_done() {
+            if self.reader_finished() {
                 return streams::Result::OwnedAndDone(drained);
             } else {
                 return streams::Result::Owned(drained);
@@ -800,14 +805,14 @@ impl FileReader {
         }
 
         if self.reader().is_done() {
-            return streams::Result::Done;
+            return self.end_of_reader();
         }
 
         if !self.reader().has_pending_read() && self.flowing.get() {
             // SAFETY: the reader cell is live for `self`'s lifetime; `read_into` is the raw re-entrancy-safe entry (EOF/error dispatch runs user JS).
             let (amount_read, state) = unsafe { IOReader::read_into(self.reader.get(), buffer) };
             bun_core::scoped_log!(FileReader, "onPull({}) = {}", buffer.len(), amount_read);
-            let done = state == ReadState::Eof || self.reader().is_done();
+            let done = state == ReadState::Eof || self.reader_finished();
             if amount_read > 0 {
                 let into = streams::IntoArray {
                     value: array,
@@ -828,8 +833,8 @@ impl FileReader {
                     streams::Result::Owned(drained)
                 };
             }
-            if done {
-                return streams::Result::Done;
+            if done || self.reader().is_done() {
+                return self.end_of_reader();
             }
         }
 
@@ -934,39 +939,66 @@ impl FileReader {
             self.buffered.set(Vec::new());
         }
 
+        // Pin across the dispatch below: `sink.end()` and `p.run()` run user
+        // JS, and anything there that reaches on_reader_done would drop the
+        // across-read ref and let a GC free this box before the
+        // `waiting_for_on_reader_done` read below.
+        let parent = self.parent();
+        // SAFETY: see `parent()`.
+        unsafe { (*parent).increment_count() };
+
         let sink = *self.sink.get();
         if sink.is_some() {
             self.sink.set(SinkHandle::None);
             self.sink_paused.set(false);
             sink.end(Some(streams::StreamError::Error(err)));
-            let parent = self.parent();
-            if self.waiting_for_on_reader_done.get() && !self.done.get() {
-                self.waiting_for_on_reader_done.set(false);
-                // SAFETY: see `parent()`.
-                let _ = unsafe { Source::decrement_count(parent) };
-            }
-            return;
+        } else if self.pending.get().state == streams::PendingState::Pending {
+            self.pending.with_mut(|p| {
+                p.result = streams::Result::Err(streams::StreamError::Error(err));
+            });
+            self.pending.with_mut(|p| p.run());
+        } else {
+            // `p.run()` would no-op and the pull promise would never settle.
+            self.read_error.set(Some(err));
         }
-
-        self.pending.with_mut(|p| {
-            p.result = streams::Result::Err(streams::StreamError::Error(err));
-        });
-        // Pin across `p.run()`: it runs user JS, and anything there that
-        // reaches on_reader_done would drop the across-read ref and let a GC
-        // free this box before the `waiting_for_on_reader_done` read below.
-        let parent = self.parent();
-        // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
-        self.pending.with_mut(|p| p.run());
 
         if self.waiting_for_on_reader_done.get() && !self.done.get() {
             self.waiting_for_on_reader_done.set(false);
             // SAFETY: see `parent()`; the pin above keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
+        self.close_after_error();
         // SAFETY: see `parent()`; the pin keeps the count >= 1, so this never
         // frees. Tail call, `self` is not accessed after.
         let _ = unsafe { Source::decrement_count(parent) };
+    }
+
+    /// A read error is terminal, and a consumer never cancels an errored
+    /// stream. Release the poll and the fd here: a registered poll keeps the
+    /// event loop alive.
+    fn close_after_error(&self) {
+        if self.done.get() {
+            return;
+        }
+        self.done.set(true);
+        self.reader().update_ref(false);
+        self.reader().deinit();
+    }
+
+    /// `true` once the reader has nothing more to deliver. A stored read error
+    /// still has to reach the consumer, so it keeps the stream open for one
+    /// more pull.
+    fn reader_finished(&self) -> bool {
+        self.reader().is_done() && self.read_error.get().is_none()
+    }
+
+    /// What a pull gets once the reader is done: the stored read error, or a
+    /// clean end.
+    fn end_of_reader(&self) -> streams::Result {
+        match self.read_error.replace(None) {
+            Some(err) => streams::Result::Err(streams::StreamError::Error(err)),
+            None => streams::Result::Done,
+        }
     }
 
     pub(crate) fn set_raw_mode(&self, _flag: bool) -> sys::Result<()> {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -541,7 +541,7 @@ impl FileReader {
         if sink.is_none() {
             return;
         }
-        let reader_done = self.reader().is_done();
+        let reader_done = self.reader_finished();
         let buffered = self.drain();
         if !buffered.is_empty() {
             let chunk = if reader_done {
@@ -570,7 +570,12 @@ impl FileReader {
         }
         if reader_done || self.done.get() {
             self.sink.set(SinkHandle::None);
-            sink.end(None);
+            // A read error from before the sink was attached ends it here.
+            sink.end(
+                self.read_error
+                    .replace(None)
+                    .map(streams::StreamError::Error),
+            );
             return;
         }
         if !self.reader().has_pending_read() {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -754,16 +754,12 @@ impl FileReader {
         self.pending_value
             .with_mut(|p| p.clear_without_deallocation());
         self.pending_view.set(&mut []);
-        // Pin across `run()`: a re-entrant cancel() reaches on_reader_done, which drops the across-read ref and lets a GC free this box while the io caller still holds `&mut` into it.
-        let parent = self.parent();
+        // A re-entrant cancel() inside `run()` reaches on_reader_done, which drops the across-read ref and lets a GC free this box while the io caller still holds `&mut` into it.
         // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
+        let _pin = unsafe { SourcePin::new(self.parent()) };
         self.pending.with_mut(|p| p.run());
         // Re-entrant cancel or a nested pull that read to EOF closed the reader; tell the io caller to stop so it does not re-read the captured fd.
-        let ret = ret && !self.done.get() && !self.reader().is_done();
-        // SAFETY: see `parent()`; the pin keeps the count >= 1, so this never frees. `self` is not accessed after.
-        let _ = unsafe { Source::decrement_count(parent) };
-        ret
+        ret && !self.done.get() && !self.reader().is_done()
     }
 
     pub(crate) fn on_pull(&self, buffer: &'static mut [u8], array: JSValue) -> streams::Result {
@@ -884,12 +880,11 @@ impl FileReader {
 
     pub(crate) fn on_reader_done(&self) {
         bun_core::scoped_log!(FileReader, "onReaderDone()");
-        // Pin across `p.run()` and `on_close()`: both can run user JS, and the
-        // `self.buffered` / `waiting_for_on_reader_done` reads below must not
-        // land on a freed box. Same bracket as on_read_chunk / on_reader_error.
+        // `p.run()` and `on_close()` can run user JS, and the `self.buffered` /
+        // `waiting_for_on_reader_done` reads below must not land on a freed box.
         let parent = self.parent();
         // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
+        let _pin = unsafe { SourcePin::new(parent) };
         let sink = *self.sink.get();
         if sink.is_some() {
             self.consume_reader_buffer();
@@ -927,13 +922,9 @@ impl FileReader {
         }
         if self.waiting_for_on_reader_done.get() {
             self.waiting_for_on_reader_done.set(false);
-            // SAFETY: see `parent()`; the pin above keeps the count > 0.
+            // SAFETY: see `parent()`; `_pin` keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
-        // SAFETY: see `parent()`; releases the pin. Tail position — `self` (a
-        // field of `*parent`) is not accessed after this call, which may free
-        // the allocation when the refcount hits zero.
-        let _ = unsafe { Source::decrement_count(parent) };
     }
 
     pub(crate) fn on_reader_error(&self, err: sys::Error) {
@@ -942,12 +933,11 @@ impl FileReader {
             self.buffered.set(Vec::new());
         }
 
-        // Pin across `sink.end()` / `p.run()`: they run user JS, which can
-        // reach on_reader_done and drop the across-read ref before the
-        // `waiting_for_on_reader_done` read below.
+        // `sink.end()` and `p.run()` run user JS, which can reach on_reader_done
+        // and drop the across-read ref before the read of it below.
         let parent = self.parent();
         // SAFETY: see `parent()`.
-        unsafe { (*parent).increment_count() };
+        let _pin = unsafe { SourcePin::new(parent) };
 
         let sink = *self.sink.get();
         if sink.is_some() {
@@ -966,13 +956,10 @@ impl FileReader {
 
         if self.waiting_for_on_reader_done.get() && !self.done.get() {
             self.waiting_for_on_reader_done.set(false);
-            // SAFETY: see `parent()`; the pin above keeps the count > 0.
+            // SAFETY: see `parent()`; `_pin` keeps the count > 0.
             let _ = unsafe { Source::decrement_count(parent) };
         }
         self.close_after_error();
-        // SAFETY: see `parent()`; the pin keeps the count >= 1, so this never
-        // frees. Tail call, `self` is not accessed after.
-        let _ = unsafe { Source::decrement_count(parent) };
     }
 
     /// An errored stream is never cancelled, so release the poll and the fd here.
@@ -1046,6 +1033,28 @@ impl FileReader {
 }
 
 pub type Source = readable_stream::NewSource<FileReader>;
+
+/// Holds a ref on the `Source` that embeds a `FileReader` while a dispatch runs
+/// user JS. Dropping it releases the ref and can free the source, so a pin must
+/// outlive every use of the reader it protects.
+struct SourcePin(*mut Source);
+
+impl SourcePin {
+    /// # Safety
+    /// `parent` is the live `Source` that embeds the caller.
+    unsafe fn new(parent: *mut Source) -> Self {
+        // SAFETY: fn contract.
+        unsafe { (*parent).increment_count() };
+        Self(parent)
+    }
+}
+
+impl Drop for SourcePin {
+    fn drop(&mut self) {
+        // SAFETY: balances the ref taken in `new`.
+        let _ = unsafe { Source::decrement_count(self.0) };
+    }
+}
 
 // SAFETY: `FileReader` is always the `context` field of a heap-allocated
 // `Source`. `parent` is the `raw` arm because the ref-count pin

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -56,9 +56,7 @@ pub struct FileReader {
     pub(crate) event_loop: Cell<EventLoopHandle>,
     pub(crate) lazy: JsCell<Lazy>,
     pub(crate) buffered: JsCell<Vec<u8>>,
-    /// A read error that arrived with no pending pull to settle: the failing
-    /// read ran synchronously inside `on_pull`, or landed between pulls. The
-    /// next `on_pull` returns it once the buffered bytes are delivered.
+    /// A read error that arrived with no pending pull. The next `on_pull` returns it.
     pub(crate) read_error: JsCell<Option<sys::Error>>,
     /// Read-only after construction.
     pub(crate) highwater_mark: usize,
@@ -939,9 +937,8 @@ impl FileReader {
             self.buffered.set(Vec::new());
         }
 
-        // Pin across the dispatch below: `sink.end()` and `p.run()` run user
-        // JS, and anything there that reaches on_reader_done would drop the
-        // across-read ref and let a GC free this box before the
+        // Pin across `sink.end()` / `p.run()`: they run user JS, which can
+        // reach on_reader_done and drop the across-read ref before the
         // `waiting_for_on_reader_done` read below.
         let parent = self.parent();
         // SAFETY: see `parent()`.
@@ -973,9 +970,7 @@ impl FileReader {
         let _ = unsafe { Source::decrement_count(parent) };
     }
 
-    /// A read error is terminal, and a consumer never cancels an errored
-    /// stream. Release the poll and the fd here: a registered poll keeps the
-    /// event loop alive.
+    /// An errored stream is never cancelled, so release the poll and the fd here.
     fn close_after_error(&self) {
         if self.done.get() {
             return;
@@ -985,15 +980,12 @@ impl FileReader {
         self.reader().deinit();
     }
 
-    /// `true` once the reader has nothing more to deliver. A stored read error
-    /// still has to reach the consumer, so it keeps the stream open for one
-    /// more pull.
+    /// Done, with no stored read error left for one more pull to return.
     fn reader_finished(&self) -> bool {
         self.reader().is_done() && self.read_error.get().is_none()
     }
 
-    /// What a pull gets once the reader is done: the stored read error, or a
-    /// clean end.
+    /// The stored read error, or a clean end.
     fn end_of_reader(&self) -> streams::Result {
         match self.read_error.replace(None) {
             Some(err) => streams::Result::Err(streams::StreamError::Error(err)),

--- a/test/js/node/tty-readstream-nonblocking.fixture.ts
+++ b/test/js/node/tty-readstream-nonblocking.fixture.ts
@@ -1,0 +1,74 @@
+// Opens a pty the way node-pty does (master with O_NONBLOCK), wraps the master
+// in tty.ReadStream and reports every stream event on stdout. The test writes
+// to the slave and ends the stream with one command on stdin:
+//   "destroy": the fixture calls stream.destroy()
+//   "hangup":  the fixture closes its slave fd. Once the test has closed its own
+//              slave, the master read fails (EIO) or ends.
+import { CString, dlopen } from "bun:ffi";
+import { closeSync, constants, fstatSync, openSync } from "node:fs";
+import { ReadStream } from "node:tty";
+
+const arch = process.arch === "x64" ? "x86_64" : process.arch === "arm64" ? "aarch64" : process.arch;
+const candidates = process.platform === "darwin" ? ["libSystem.B.dylib"] : ["libc.so.6", `libc.musl-${arch}.so.1`];
+let libc;
+let lastError;
+for (const lib of candidates) {
+  try {
+    libc = dlopen(lib, {
+      posix_openpt: { args: ["int"], returns: "int" },
+      grantpt: { args: ["int"], returns: "int" },
+      unlockpt: { args: ["int"], returns: "int" },
+      ptsname: { args: ["int"], returns: "ptr" },
+    }).symbols;
+    break;
+  } catch (err) {
+    lastError = err;
+  }
+}
+if (!libc) throw lastError;
+
+const master = libc.posix_openpt(constants.O_RDWR | constants.O_NOCTTY | constants.O_NONBLOCK);
+if (master < 0) throw new Error("posix_openpt failed");
+if (libc.grantpt(master) !== 0) throw new Error("grantpt failed");
+if (libc.unlockpt(master) !== 0) throw new Error("unlockpt failed");
+const slavePath = new CString(libc.ptsname(master)).toString();
+// Keep the slave open on our side too, so a master read never fails before the
+// test has opened the slave.
+const slave = openSync(slavePath, constants.O_RDWR | constants.O_NOCTTY);
+
+function say(line: string) {
+  process.stdout.write(line + "\n");
+}
+
+function masterIsOpen() {
+  try {
+    fstatSync(master);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const stream = new ReadStream(master);
+stream.on("error", err => say("ERROR " + err.code));
+stream.on("end", () => say("END"));
+stream.on("close", () => {
+  say(`CLOSE destroyed=${stream.destroyed} masterOpen=${masterIsOpen()}`);
+  // Nothing else keeps the process alive once the command channel is gone.
+  process.stdin.destroy();
+});
+stream.on("data", chunk => {
+  say("DATA " + JSON.stringify(chunk.toString()));
+  say("READY");
+});
+
+process.stdin.on("data", command => {
+  if (String(command).includes("destroy")) {
+    stream.destroy();
+  } else if (String(command).includes("hangup")) {
+    closeSync(slave);
+  }
+});
+
+say("SLAVE " + slavePath);
+say("READY");

--- a/test/js/node/tty-readstream-nonblocking.fixture.ts
+++ b/test/js/node/tty-readstream-nonblocking.fixture.ts
@@ -4,7 +4,7 @@
 //   "destroy": the fixture calls stream.destroy()
 //   "hangup":  the fixture closes its slave fd. Once the test has closed its own
 //              slave, the master read fails (EIO) or ends.
-import { CString, dlopen } from "bun:ffi";
+import { CString, dlopen, ptr } from "bun:ffi";
 import { closeSync, constants, fstatSync, openSync } from "node:fs";
 import { ReadStream } from "node:tty";
 
@@ -19,6 +19,7 @@ for (const lib of candidates) {
       grantpt: { args: ["int"], returns: "int" },
       unlockpt: { args: ["int"], returns: "int" },
       ptsname: { args: ["int"], returns: "ptr" },
+      ioctl: { args: ["int", "u64", "ptr"], returns: "int" },
     }).symbols;
     break;
   } catch (err) {
@@ -49,6 +50,18 @@ function masterIsOpen() {
   }
 }
 
+// node-pty's pty.resize() is ioctl(master, TIOCSWINSZ, &winsize). It fails with
+// EBADF once the stream has closed the master behind node-pty's back. ioctl is
+// variadic, and Apple's arm64 ABI passes variadic arguments on the stack, so
+// the fixed-arity FFI call is Linux only. macOS falls back to fstat.
+function resize(cols: number, rows: number) {
+  if (process.platform !== "linux") return masterIsOpen();
+  const TIOCSWINSZ = 0x5414n;
+  // struct winsize { unsigned short ws_row, ws_col, ws_xpixel, ws_ypixel; }
+  const winsize = new Uint16Array([rows, cols, 0, 0]);
+  return libc.ioctl(master, TIOCSWINSZ, ptr(winsize)) === 0;
+}
+
 const stream = new ReadStream(master);
 stream.on("error", err => say("ERROR " + err.code));
 stream.on("end", () => say("END"));
@@ -59,6 +72,7 @@ stream.on("close", () => {
 });
 stream.on("data", chunk => {
   say("DATA " + JSON.stringify(chunk.toString()));
+  say("RESIZE " + (resize(120, 40) ? "ok" : "failed"));
   say("READY");
 });
 

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -231,6 +231,8 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
       stderr: "pipe",
     });
 
+    // Drain stderr from the start so a chatty fixture cannot block on it.
+    const stderr = proc.stderr.text();
     const chunks = ["one", "two"];
     const lines: string[] = [];
     let slavePath = "";
@@ -259,7 +261,7 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
       }
     }
 
-    const [, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, exitCode] = await Promise.all([stderr, proc.exited]);
     return { lines, exitCode };
   }
 
@@ -296,28 +298,35 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
       // reporting end of file.
       const holdWriter = openSync(fifo, constants.O_WRONLY);
       const stream = new ReadStream(reader);
-      const events: string[] = [];
-      const closed = Promise.withResolvers<void>();
-      stream.on("error", err => events.push("error " + err.code));
-      stream.on("data", chunk => {
-        events.push("data " + chunk.toString());
-        // The fd is still open: the stream did not close it on EAGAIN.
-        events.push("open " + (fstatSync(reader).isFIFO() ? "yes" : "no"));
-      });
-      stream.on("end", () => events.push("end"));
-      stream.on("close", () => closed.resolve());
+      try {
+        const events: string[] = [];
+        const closed = Promise.withResolvers<void>();
+        stream.on("error", err => events.push("error " + err.code));
+        stream.on("data", chunk => {
+          events.push("data " + chunk.toString());
+          // The fd is still open: the stream did not close it on EAGAIN.
+          events.push("open " + (fstatSync(reader).isFIFO() ? "yes" : "no"));
+        });
+        stream.on("end", () => events.push("end"));
+        stream.on("close", () => closed.resolve());
 
-      // If the stream closed the read side, the writer's open fails with ENXIO
-      // instead of a hang.
-      await writeFromAnotherProcess(fifo, "hello");
-      // The last writer is gone: the reader sees end of file.
-      closeSync(holdWriter);
-      await closed.promise;
+        // If the stream closed the read side, the writer's open fails with ENXIO
+        // instead of a hang.
+        await writeFromAnotherProcess(fifo, "hello");
+        // The last writer is gone: the reader sees end of file.
+        closeSync(holdWriter);
+        await closed.promise;
 
-      expect(events).toEqual(["data hello", "open yes", "end"]);
-      // The stream closed the fd on end. The fd number can already be in use
-      // again by a concurrent test, so do not probe it.
-      expect(stream.fd).toBeNull();
+        expect(events).toEqual(["data hello", "open yes", "end"]);
+        // The stream closed the fd on end. The fd number can already be in use
+        // again by a concurrent test, so do not probe it.
+        expect(stream.fd).toBeNull();
+      } finally {
+        stream.destroy();
+        try {
+          closeSync(holdWriter);
+        } catch {}
+      }
     },
   );
 });

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
-import { WriteStream } from "node:tty";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { closeSync, constants, fstatSync, openSync } from "node:fs";
+import { join } from "node:path";
+import { ReadStream, WriteStream } from "node:tty";
 
 describe("ReadStream.prototype.setRawMode", () => {
   // Regression: on Windows, the `fd === 0` branch returned early on success
@@ -189,6 +191,129 @@ describe("ReadStream.prototype.setRawMode", () => {
       afterStdinCooked: false,
     });
     expect(await proc.exited).toBe(0);
+  });
+});
+
+// node-pty sets O_NONBLOCK on the pty master and wraps it in tty.ReadStream. A
+// read with no data then fails with EAGAIN. The stream must wait for data, as
+// Node's net.Socket based tty.ReadStream does, instead of destroying itself
+// and closing a fd it does not own.
+describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
+  // A separate process opens the path and writes one chunk. The fixture issues
+  // its next read as soon as it says READY, and that read completes long
+  // before a new process can start. So every chunk lands after a read that
+  // found no data, which is the read the bug turned into EAGAIN.
+  async function writeFromAnotherProcess(path: string, chunk: string) {
+    await using writer = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const fs = require("fs");
+         const fd = fs.openSync(process.argv[1], fs.constants.O_WRONLY | fs.constants.O_NOCTTY | fs.constants.O_NONBLOCK);
+         fs.writeSync(fd, process.argv[2]);
+         fs.closeSync(fd);`,
+        path,
+        chunk,
+      ],
+      env: bunEnv,
+    });
+    expect(await writer.exited).toBe(0);
+  }
+
+  // Runs the fixture, writes "one" and "two" to the slave after each READY,
+  // then ends the stream the requested way. Returns the fixture's event log.
+  async function runFixture(end: "destroy" | "hangup") {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "tty-readstream-nonblocking.fixture.ts")],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const chunks = ["one", "two"];
+    const lines: string[] = [];
+    let slavePath = "";
+    let buffered = "";
+    for await (const chunk of proc.stdout) {
+      buffered += Buffer.from(chunk).toString();
+      let newline: number;
+      while ((newline = buffered.indexOf("\n")) !== -1) {
+        const line = buffered.slice(0, newline);
+        buffered = buffered.slice(newline + 1);
+        if (line.startsWith("SLAVE ")) {
+          slavePath = line.slice("SLAVE ".length);
+          continue;
+        }
+        if (line !== "READY") {
+          lines.push(line);
+          continue;
+        }
+        const next = chunks.shift();
+        if (next !== undefined) {
+          await writeFromAnotherProcess(slavePath, next);
+          continue;
+        }
+        proc.stdin.write(end + "\n");
+        proc.stdin.end();
+      }
+    }
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { lines, stderr, exitCode };
+  }
+
+  test.concurrent("delivers data written after the first EAGAIN and destroy() closes the fd", async () => {
+    const { lines, stderr, exitCode } = await runFixture("destroy");
+    expect(stderr).toBe("");
+    expect(lines).toEqual(['DATA "one"', 'DATA "two"', "CLOSE destroyed=true masterOpen=false"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("ends when the slave side hangs up", async () => {
+    const { lines, stderr, exitCode } = await runFixture("hangup");
+    expect(stderr).toBe("");
+    // Linux reports the hangup as EIO, macOS as end of file.
+    expect(["ERROR EIO", "END"]).toContain(lines[2]);
+    expect([...lines.slice(0, 2), ...lines.slice(3)]).toEqual([
+      'DATA "one"',
+      'DATA "two"',
+      "CLOSE destroyed=true masterOpen=false",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a FIFO opened with O_NONBLOCK delivers data and ends when the writer closes", async () => {
+    using dir = tempDir("tty-fifo", {});
+    const fifo = join(String(dir), "pipe.fifo");
+    const mkfifo = Bun.spawnSync({ cmd: ["mkfifo", fifo] });
+    expect(mkfifo.exitCode).toBe(0);
+
+    const reader = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    // With a writer attached and no data, a read fails with EAGAIN instead of
+    // reporting end of file.
+    const holdWriter = openSync(fifo, constants.O_WRONLY);
+    const stream = new ReadStream(reader);
+    const events: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    stream.on("error", err => events.push("error " + err.code));
+    stream.on("data", chunk => {
+      events.push("data " + chunk.toString());
+      // The fd is still open: the stream did not close it on EAGAIN.
+      events.push("open " + (fstatSync(reader).isFIFO() ? "yes" : "no"));
+    });
+    stream.on("end", () => events.push("end"));
+    stream.on("close", () => closed.resolve());
+
+    // If the stream closed the read side, the writer's open fails with ENXIO
+    // instead of a hang.
+    await writeFromAnotherProcess(fifo, "hello");
+    // The last writer is gone: the reader sees end of file.
+    closeSync(holdWriter);
+    await closed.promise;
+
+    expect(events).toEqual(["data hello", "open yes", "end"]);
+    expect(() => fstatSync(reader)).toThrow(expect.objectContaining({ code: "EBADF" }));
   });
 });
 

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -265,19 +265,30 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
     return { lines, exitCode };
   }
 
+  // After each chunk the fixture resizes the pty through the master, as
+  // node-pty's pty.resize() does. That ioctl failed with EBADF when the stream
+  // had closed the fd on the first EAGAIN.
   test.concurrent("delivers data written after the first EAGAIN and destroy() closes the fd", async () => {
     const { lines, exitCode } = await runFixture("destroy");
-    expect(lines).toEqual(['DATA "one"', 'DATA "two"', "CLOSE destroyed=true masterOpen=false"]);
+    expect(lines).toEqual([
+      'DATA "one"',
+      "RESIZE ok",
+      'DATA "two"',
+      "RESIZE ok",
+      "CLOSE destroyed=true masterOpen=false",
+    ]);
     expect(exitCode).toBe(0);
   });
 
   test.concurrent("ends when the slave side hangs up", async () => {
     const { lines, exitCode } = await runFixture("hangup");
     // Linux reports the hangup as EIO, macOS as end of file.
-    expect(["ERROR EIO", "END"]).toContain(lines[2]);
-    expect([...lines.slice(0, 2), ...lines.slice(3)]).toEqual([
+    expect(["ERROR EIO", "END"]).toContain(lines[4]);
+    expect([...lines.slice(0, 4), ...lines.slice(5)]).toEqual([
       'DATA "one"',
+      "RESIZE ok",
       'DATA "two"',
+      "RESIZE ok",
       "CLOSE destroyed=true masterOpen=false",
     ]);
     expect(exitCode).toBe(0);

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -296,7 +296,7 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
       const reader = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
       // With a writer attached and no data, a read fails with EAGAIN instead of
       // reporting end of file.
-      const holdWriter = openSync(fifo, constants.O_WRONLY);
+      let holdWriter: number | null = openSync(fifo, constants.O_WRONLY);
       const stream = new ReadStream(reader);
       try {
         const events: string[] = [];
@@ -315,6 +315,7 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
         await writeFromAnotherProcess(fifo, "hello");
         // The last writer is gone: the reader sees end of file.
         closeSync(holdWriter);
+        holdWriter = null;
         await closed.promise;
 
         expect(events).toEqual(["data hello", "open yes", "end"]);
@@ -323,9 +324,8 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
         expect(stream.fd).toBeNull();
       } finally {
         stream.destroy();
-        try {
-          closeSync(holdWriter);
-        } catch {}
+        // Close once only: the fd number may already belong to another test.
+        if (holdWriter !== null) closeSync(holdWriter);
       }
     },
   );

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { closeSync, constants, fstatSync, openSync } from "node:fs";
 import { join } from "node:path";
 import { ReadStream, WriteStream } from "node:tty";
@@ -259,20 +259,18 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
       }
     }
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { lines, stderr, exitCode };
+    const [, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { lines, exitCode };
   }
 
   test.concurrent("delivers data written after the first EAGAIN and destroy() closes the fd", async () => {
-    const { lines, stderr, exitCode } = await runFixture("destroy");
-    expect(stderr).toBe("");
+    const { lines, exitCode } = await runFixture("destroy");
     expect(lines).toEqual(['DATA "one"', 'DATA "two"', "CLOSE destroyed=true masterOpen=false"]);
     expect(exitCode).toBe(0);
   });
 
   test.concurrent("ends when the slave side hangs up", async () => {
-    const { lines, stderr, exitCode } = await runFixture("hangup");
-    expect(stderr).toBe("");
+    const { lines, exitCode } = await runFixture("hangup");
     // Linux reports the hangup as EIO, macOS as end of file.
     expect(["ERROR EIO", "END"]).toContain(lines[2]);
     expect([...lines.slice(0, 2), ...lines.slice(3)]).toEqual([
@@ -283,38 +281,45 @@ describe.skipIf(isWindows)("ReadStream on a non-blocking fd", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("a FIFO opened with O_NONBLOCK delivers data and ends when the writer closes", async () => {
-    using dir = tempDir("tty-fifo", {});
-    const fifo = join(String(dir), "pipe.fifo");
-    const mkfifo = Bun.spawnSync({ cmd: ["mkfifo", fifo] });
-    expect(mkfifo.exitCode).toBe(0);
+  // Linux only: on macOS, kqueue reports no more events on a non-blocking FIFO
+  // once a writer has closed, so the end of file never arrives there.
+  test.concurrent.skipIf(!isLinux)(
+    "a FIFO opened with O_NONBLOCK delivers data and ends when the writer closes",
+    async () => {
+      using dir = tempDir("tty-fifo", {});
+      const fifo = join(String(dir), "pipe.fifo");
+      const mkfifo = Bun.spawnSync({ cmd: ["mkfifo", fifo] });
+      expect(mkfifo.exitCode).toBe(0);
 
-    const reader = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
-    // With a writer attached and no data, a read fails with EAGAIN instead of
-    // reporting end of file.
-    const holdWriter = openSync(fifo, constants.O_WRONLY);
-    const stream = new ReadStream(reader);
-    const events: string[] = [];
-    const closed = Promise.withResolvers<void>();
-    stream.on("error", err => events.push("error " + err.code));
-    stream.on("data", chunk => {
-      events.push("data " + chunk.toString());
-      // The fd is still open: the stream did not close it on EAGAIN.
-      events.push("open " + (fstatSync(reader).isFIFO() ? "yes" : "no"));
-    });
-    stream.on("end", () => events.push("end"));
-    stream.on("close", () => closed.resolve());
+      const reader = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+      // With a writer attached and no data, a read fails with EAGAIN instead of
+      // reporting end of file.
+      const holdWriter = openSync(fifo, constants.O_WRONLY);
+      const stream = new ReadStream(reader);
+      const events: string[] = [];
+      const closed = Promise.withResolvers<void>();
+      stream.on("error", err => events.push("error " + err.code));
+      stream.on("data", chunk => {
+        events.push("data " + chunk.toString());
+        // The fd is still open: the stream did not close it on EAGAIN.
+        events.push("open " + (fstatSync(reader).isFIFO() ? "yes" : "no"));
+      });
+      stream.on("end", () => events.push("end"));
+      stream.on("close", () => closed.resolve());
 
-    // If the stream closed the read side, the writer's open fails with ENXIO
-    // instead of a hang.
-    await writeFromAnotherProcess(fifo, "hello");
-    // The last writer is gone: the reader sees end of file.
-    closeSync(holdWriter);
-    await closed.promise;
+      // If the stream closed the read side, the writer's open fails with ENXIO
+      // instead of a hang.
+      await writeFromAnotherProcess(fifo, "hello");
+      // The last writer is gone: the reader sees end of file.
+      closeSync(holdWriter);
+      await closed.promise;
 
-    expect(events).toEqual(["data hello", "open yes", "end"]);
-    expect(() => fstatSync(reader)).toThrow(expect.objectContaining({ code: "EBADF" }));
-  });
+      expect(events).toEqual(["data hello", "open yes", "end"]);
+      // The stream closed the fd on end. The fd number can already be in use
+      // again by a concurrent test, so do not probe it.
+      expect(stream.fd).toBeNull();
+    },
+  );
 });
 
 describe("WriteStream.prototype.getColorDepth", () => {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2049,8 +2049,7 @@ describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toMatch(/^first x\nsettled (EIO|done)\n$/);
     expect(exitCode).toBe(0);
   });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -7,9 +7,9 @@ import {
   readableStreamToText,
 } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
-import { createReadStream, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, createReadStream, openSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 it("TransformStream", async () => {
@@ -1944,6 +1944,116 @@ it("Bun.file().stream() read text from large file", async () => {
   } finally {
     unlinkSync(tmpfile);
   }
+});
+
+// A POSIX file is read synchronously inside the stream's pull, so a failing
+// read(2) arrives with no pending read to reject. Windows reads files through
+// libuv, where the error always lands on a pending read.
+describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
+  // read(2) on /proc/self/mem fails with EIO: nothing is mapped at address 0.
+  const eioPath = "/proc/self/mem";
+  const itEIO = isLinux ? it : it.skip;
+
+  async function expectReadError(promise, code) {
+    const err = await promise.then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe(code);
+    return err;
+  }
+
+  itEIO("for await rejects with the read error", async () => {
+    const chunks = [];
+    await expectReadError(
+      (async () => {
+        for await (const chunk of Bun.file(eioPath).stream()) chunks.push(chunk);
+      })(),
+      "EIO",
+    );
+    expect(chunks).toHaveLength(0);
+  });
+
+  itEIO("getReader().read() rejects with the read error", async () => {
+    await expectReadError(Bun.file(eioPath).stream().getReader().read(), "EIO");
+  });
+
+  itEIO("pipeTo() rejects with the read error", async () => {
+    await expectReadError(
+      Bun.file(eioPath)
+        .stream()
+        .pipeTo(new WritableStream({ write() {} })),
+      "EIO",
+    );
+  });
+
+  itEIO("Bun.file().text() reports the same read error", async () => {
+    const err = await expectReadError(Bun.file(eioPath).text(), "EIO");
+    expect(err.syscall).toBe("read");
+  });
+
+  it("a stream over a write-only fd rejects with EBADF", async () => {
+    using dir = tempDir("file-stream-read-error", { "x.bin": "hello" });
+    const fd = openSync(join(String(dir), "x.bin"), "w");
+    try {
+      await expectReadError(Bun.file(fd).stream().getReader().read(), "EBADF");
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  // A pollable fd (here a non-blocking pty master, as node-pty sets it up) is
+  // read when its poll fires. A read error must release that poll, or the
+  // process never exits. The slave hangup fails the master read with EIO on
+  // Linux and ends it on macOS.
+  it("a read error on a pollable fd releases the poll so the process can exit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { CString, dlopen } = require("bun:ffi");
+        const { closeSync, constants, openSync, writeSync } = require("node:fs");
+        const arch = process.arch === "x64" ? "x86_64" : process.arch === "arm64" ? "aarch64" : process.arch;
+        const candidates = process.platform === "darwin" ? ["libSystem.B.dylib"] : ["libc.so.6", "libc.musl-" + arch + ".so.1"];
+        let libc, lastError;
+        for (const lib of candidates) {
+          try {
+            libc = dlopen(lib, {
+              posix_openpt: { args: ["int"], returns: "int" },
+              grantpt: { args: ["int"], returns: "int" },
+              unlockpt: { args: ["int"], returns: "int" },
+              ptsname: { args: ["int"], returns: "ptr" },
+            }).symbols;
+            break;
+          } catch (err) {
+            lastError = err;
+          }
+        }
+        if (!libc) throw lastError;
+        const master = libc.posix_openpt(constants.O_RDWR | constants.O_NOCTTY | constants.O_NONBLOCK);
+        if (master < 0 || libc.grantpt(master) !== 0 || libc.unlockpt(master) !== 0) throw new Error("pty setup failed");
+        const slave = openSync(new CString(libc.ptsname(master)).toString(), constants.O_RDWR | constants.O_NOCTTY);
+        const reader = Bun.file(master).stream().getReader();
+        writeSync(slave, "x");
+        const first = await reader.read();
+        console.log("first", Buffer.from(first.value).toString());
+        // This read finds no data and waits on the poll. The hangup fires it.
+        const pending = reader.read();
+        closeSync(slave);
+        const result = await pending.then(r => (r.done ? "done" : "data"), e => e.code);
+        console.log("settled", result);
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/^first x\nsettled (EIO|done)\n$/);
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("fs.createReadStream(filename) should be able to break inside async loop", async () => {


### PR DESCRIPTION
Fixes #41414, fixes #25822, fixes #27285, fixes #29112. Supersedes #29114. Built on #41420 (the base branch), which it needs: a pty master reports the child's exit as a read error.

This is an interim fix in `tty.ts`. #29140 rewrites `tty.ReadStream` as a `net.Socket` over a native TTY handle, and that deletes this code.

### Problem
- `new tty.ReadStream(fd)` on an `O_NONBLOCK` fd fails at once with `EAGAIN: resource temporarily unavailable, read`, destroys itself and closes the fd. node-pty sets `O_NONBLOCK` on the pty master, so it never gets data and `pty.resize()` fails with `EBADF`.
- `tty.ReadStream` is an `fs.ReadStream` (`src/js/node/tty.ts:25`). Its thread pool reads send every error to `errorOrDestroy` (`src/js/internal/fs/streams.ts:292`). Node's is a `net.Socket` that reads only when the fd is readable.

### Fix
- `tty.ReadStream` gives `fs.ReadStream` a custom `fs.read`. On the first `EAGAIN` it switches to `Bun.file(fd).stream()`, the pollable native reader. A blocking fd keeps the thread pool path (the comment in `tty.ts` says why the check is not up front).
- `destroy()` cancels the native reader, which settles the in-flight read, then closes the fd as before (libuv closes any fd above 2 too, and node-pty relies on it). `ref()` and `unref()` reach the native source.
- Verified: `test/js/node/tty.test.ts` (3 new tests, all fail on 1.4.1). The pty tests also resize the master with `ioctl(TIOCSWINSZ)` after each chunk, the call `pty.resize()` makes. Also the fs, stream, process and spawn suites.

### Background
- `fs.ReadStream` accepts an `fs` option with `read` and `close`. `_destroy` waits for the in-flight read before it closes the fd.
- `Bun.file(fd).stream()` dups the fd. For a non-blocking fd `FileReader` polls it and reads on readiness. `$bunNativePtr` on that stream is the native source, and `updateRef` is what `process.stdin` uses for `ref()` and `unref()`.
- A pty master reports the child's exit as `EIO` on Linux and as end of file on macOS.

<details><summary>Notes</summary>

The review on #29114 (2026-09-01) asked for reads on fd readiness instead of a 10 ms timer, a ref'd pending read, the default `autoClose` with the real `fs.close`, a callback on every exit path, and the test in `test/js/node/tty.test.ts` with the fd asserted closed after `destroy()`. This PR does each of those.

Out of scope: `pty.end()` calls `socket.end()`, which a Readable does not have. That needs the Duplex shape from #29140.

Probes on the fixed build (Linux, pty master with `O_NONBLOCK`): data arrives after the first `EAGAIN`, `ioctl(TIOCSWINSZ)` on the master still succeeds, `destroy()` during a pending read emits `close` and closes the fd, a lone `data` listener keeps the process alive until data arrives, `unref()` before or after the switch lets the process exit, `pause()`/`resume()` deliver every chunk, chunks do not share a backing buffer, a slave hangup emits `error` (`EIO`) then `close` and the process exits. The FIFO repro from the issue prints `DATA: "hello\n"` then `END`.

The tests write each chunk from a second process. The fixture issues its next read as soon as it says READY, and that read completes long before a new process starts, so every chunk lands after a read that found no data. On 1.4.1 the three tests fail the same way on eight runs in a row.

Without #41420 the hangup test hangs: after `EIO` the native reader's poll keeps the fixture alive.

The FIFO test runs on Linux only. On macOS it timed out in CI: once a writer has closed, kqueue reports no more events for the non-blocking FIFO, so the end of file after the last writer closes never arrives. That is the kqueue limitation noted in `src/io/pipes.rs`, and it predates this change. The pty tests pass on macOS.

Pre-existing failures on a debug build, with or without this change: `test/js/node/process/stdin/stdin-fixtures.test.ts` (the runner kills the child after 1 s, a debug child needs 1.1 s).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tty.test.ts

<!-- robobun:evidence:end -->

