### PR TITLE
test: run the issue 13696 http.request regression test in-process

### DIFF
--- a/test/regression/issue/13696.test.ts
+++ b/test/regression/issue/13696.test.ts
@@ -36,6 +36,7 @@ for (const socketMode of ["tcp", "unix"] as const) {
       using dir = tempDir("issue-13696", {});
       const socketPath = socketMode === "unix" ? join(String(dir), "docker.sock") : undefined;
       const payload = JSON.stringify({ Detach: false, Tty: true });
+      const chunkedFrame = `${payload.length.toString(16)}\r\n${payload}\r\n`;
 
       const events: string[] = [];
       let request = "";
@@ -44,7 +45,7 @@ for (const socketMode of ["tcp", "unix"] as const) {
       await using server = net.createServer(async sock => {
         // The single write() must dispatch the headers and the body chunk
         // without req.end().
-        request = await readUntil(sock, payload);
+        request = await readUntil(sock, chunkedFrame);
         events.push("request-seen");
 
         // Docker's exec response has no Content-Length and no chunked encoding;
@@ -115,7 +116,7 @@ for (const socketMode of ["tcp", "unix"] as const) {
         });
         expect(request).toStartWith("POST /exec/abc/start HTTP/1.1\r\n");
         expect(request.toLowerCase()).toContain("transfer-encoding: chunked\r\n");
-        expect(request).toEndWith(`${payload.length.toString(16)}\r\n${payload}\r\n`);
+        expect(request).toEndWith(chunkedFrame);
       } finally {
         req.destroy();
       }

--- a/test/regression/issue/13696.test.ts
+++ b/test/regression/issue/13696.test.ts
@@ -5,145 +5,138 @@
 // is why testcontainers' default HostPortWaitStrategy hung until timeout.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { tempDir } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
 import { join } from "node:path";
 
-// Runs a fixture that simulates docker-modem's chunked POST with an open
-// request body, against a raw TCP server that responds before the request is
-// finished. Prints "recv:<text>" for each response chunk as it arrives, and
-// "request-seen" once the server has received the headers.
-const fixture = (socketPath: string | undefined) => `
-const net = require("net");
-const http = require("http");
-
-const socketPath = ${JSON.stringify(socketPath)};
-
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const server = net.createServer((sock) => {
-  let buf = "";
-  let responded = false;
-  sock.on("data", async (d) => {
-    buf += d.toString("latin1");
-    if (responded || !buf.includes("\\r\\n\\r\\n")) return;
-    responded = true;
-    console.log("request-seen");
-    // Docker's exec response has no Content-Length and no chunked encoding;
-    // it just writes raw frames until the connection closes.
-    sock.write(
-      "HTTP/1.1 200 OK\\r\\n" +
-      "Content-Type: application/vnd.docker.raw-stream\\r\\n" +
-      "\\r\\n",
-    );
-    for (let i = 0; i < 3; i++) {
-      sock.write("chunk-" + i + "\\n");
-      await wait(50);
-    }
-    sock.end();
+// Resolves with everything the socket has received once `marker` appears in it.
+function readUntil(sock: net.Socket, marker: string): Promise<string> {
+  return new Promise(resolve => {
+    let buf = "";
+    const onData = (d: Buffer) => {
+      buf += d.toString("latin1");
+      if (!buf.includes(marker)) return;
+      sock.off("data", onData);
+      resolve(buf);
+    };
+    sock.on("data", onData);
   });
-});
+}
 
-const listenArgs = socketPath ? [socketPath] : [0, "127.0.0.1"];
-
-server.listen(...listenArgs, () => {
-  const requestOpts = socketPath
-    ? { socketPath, path: "/exec/abc/start" }
-    : { host: "127.0.0.1", port: server.address().port, path: "/exec/abc/start" };
-
-  // docker-modem passes an empty callback here and attaches 'response'
-  // separately via req.on('response', ...).
-  const req = http.request(
-    {
-      ...requestOpts,
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Transfer-Encoding": "chunked",
-      },
-    },
-    function () {},
-  );
-
-  req.on("response", (res) => {
-    console.log("response-status:" + res.statusCode);
-    res.setEncoding("utf8");
-    res.on("data", (chunk) => {
-      for (const line of chunk.split("\\n")) {
-        if (line) console.log("recv:" + line);
-      }
-    });
-    res.on("end", () => {
-      console.log("response-end");
-      server.close();
-      // The request body stream is still open; end it now so the process
-      // can exit cleanly.
-      req.end();
-    });
-  });
-
-  req.on("error", (err) => {
-    console.error("request-error:" + err.message);
-    process.exit(1);
-  });
-
-  // Single write, no req.end(). docker-modem does exactly this for
-  // openStdin: true.
-  req.write(JSON.stringify({ Detach: false, Tty: true }));
-});
-
-// Exit with whatever we've collected so far if the response never arrives,
-// so the parent test gets a clean assertion failure instead of a timeout.
-setTimeout(() => process.exit(0), 3000).unref();
-`;
-
+// Simulates docker-modem's chunked POST with an open request body, against a
+// raw TCP server that responds before the request is finished. The server
+// writes the next body chunk only after the client has observed the previous
+// one, so every chunk is proven to stream while the request body is open.
 for (const socketMode of ["tcp", "unix"] as const) {
-  test(`http.request delivers response while request body stream is still open (${socketMode})`, async () => {
-    using dir = tempDir("issue-13696", {});
-    const socketPath = socketMode === "unix" ? join(String(dir), "docker.sock") : undefined;
+  test.concurrent(
+    `http.request delivers response while request body stream is still open (${socketMode})`,
+    async () => {
+      using dir = tempDir("issue-13696", {});
+      const socketPath = socketMode === "unix" ? join(String(dir), "docker.sock") : undefined;
+      const payload = JSON.stringify({ Detach: false, Tty: true });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture(socketPath)],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      const events: string[] = [];
+      let request = "";
+      let chunkReceived = Promise.withResolvers<void>();
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      await using server = net.createServer(async sock => {
+        // The single write() must dispatch the headers and the body chunk
+        // without req.end().
+        request = await readUntil(sock, payload);
+        events.push("request-seen");
 
-    const lines = stdout.trim().split("\n");
-    // The server must have received the request (a single write() dispatches
-    // it), the response must be emitted with status 200, every body chunk must
-    // be delivered, and the response must end cleanly.
-    expect({ lines, stderr }).toEqual({
-      lines: ["request-seen", "response-status:200", "recv:chunk-0", "recv:chunk-1", "recv:chunk-2", "response-end"],
-      stderr: expect.not.stringContaining("request-error"),
-    });
-    expect(exitCode).toBe(0);
-  });
+        // Docker's exec response has no Content-Length and no chunked encoding;
+        // it just writes raw frames until the connection closes.
+        sock.write("HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.raw-stream\r\n\r\n");
+        for (let i = 0; i < 3; i++) {
+          chunkReceived = Promise.withResolvers<void>();
+          sock.write(`chunk-${i}\n`);
+          await chunkReceived.promise;
+        }
+        sock.end();
+      });
+      server.listen(...(socketPath ? [socketPath] : [0, "127.0.0.1"]));
+      await once(server, "listening");
+
+      const requestOpts = socketPath
+        ? { socketPath, path: "/exec/abc/start" }
+        : { host: "127.0.0.1", port: (server.address() as net.AddressInfo).port, path: "/exec/abc/start" };
+
+      // docker-modem passes an empty callback here and attaches 'response'
+      // separately via req.on('response', ...).
+      const req = http.request(
+        {
+          ...requestOpts,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Transfer-Encoding": "chunked",
+          },
+        },
+        function () {},
+      );
+      try {
+        const responseEnd = new Promise<void>((resolve, reject) => {
+          req.on("error", reject);
+          req.on("response", res => {
+            events.push(`response-status:${res.statusCode}`);
+            res.setEncoding("utf8");
+            res.on("data", (chunk: string) => {
+              for (const line of chunk.split("\n")) {
+                if (line) events.push(`recv:${line}`);
+              }
+              chunkReceived.resolve();
+            });
+            res.on("end", () => {
+              events.push("response-end");
+              resolve();
+            });
+          });
+        });
+
+        // Single write, no req.end(). docker-modem does exactly this for
+        // openStdin: true.
+        req.write(payload);
+        await responseEnd;
+
+        // The whole response arrived while the request body stream is still open.
+        expect({ events, writableEnded: req.writableEnded }).toEqual({
+          events: [
+            "request-seen",
+            "response-status:200",
+            "recv:chunk-0",
+            "recv:chunk-1",
+            "recv:chunk-2",
+            "response-end",
+          ],
+          writableEnded: false,
+        });
+        expect(request).toStartWith("POST /exec/abc/start HTTP/1.1\r\n");
+        expect(request.toLowerCase()).toContain("transfer-encoding: chunked\r\n");
+        expect(request).toEndWith(`${payload.length.toString(16)}\r\n${payload}\r\n`);
+      } finally {
+        req.destroy();
+      }
+    },
+  );
 }
 
 // Also cover the case where flushHeaders() is called explicitly (which already
 // started the fetch in duplex mode) but the response was still being held back
 // until req.end().
-test("http.request emits 'response' in duplex mode after flushHeaders() without end()", async () => {
-  const src = `
-const net = require("net");
-const http = require("http");
-
-const server = net.createServer((sock) => {
-  let buf = "";
-  let responded = false;
-  sock.on("data", (d) => {
-    buf += d.toString("latin1");
-    if (responded || !buf.includes("\\r\\n\\r\\n")) return;
-    responded = true;
-    sock.write("HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\n\\r\\nhello");
+test.concurrent("http.request emits 'response' in duplex mode after flushHeaders() without end()", async () => {
+  let request = "";
+  await using server = net.createServer(async sock => {
+    request = await readUntil(sock, "\r\n\r\n");
+    sock.write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello");
     sock.end();
   });
-});
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
 
-server.listen(0, "127.0.0.1", () => {
-  const { port } = server.address();
   const req = http.request({
     host: "127.0.0.1",
     port,
@@ -151,39 +144,22 @@ server.listen(0, "127.0.0.1", () => {
     method: "POST",
     headers: { "Transfer-Encoding": "chunked" },
   });
-  req.on("response", (res) => {
-    let body = "";
-    res.setEncoding("utf8");
-    res.on("data", (c) => (body += c));
-    res.on("end", () => {
-      console.log("body:" + body);
-      server.close();
-      req.end();
+  try {
+    const body = new Promise<string>((resolve, reject) => {
+      req.on("error", reject);
+      req.on("response", res => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (c: string) => (body += c));
+        res.on("end", () => resolve(body));
+      });
     });
-  });
-  req.on("error", (err) => {
-    console.error("request-error:" + err.message);
-    process.exit(1);
-  });
-  req.flushHeaders();
-  req.write("payload");
-});
+    req.flushHeaders();
+    req.write("payload");
 
-setTimeout(() => process.exit(0), 3000).unref();
-`;
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect({ stdout: stdout.trim(), stderr }).toEqual({
-    stdout: "body:hello",
-    stderr: expect.not.stringContaining("request-error"),
-  });
-  expect(exitCode).toBe(0);
+    expect({ body: await body, writableEnded: req.writableEnded }).toEqual({ body: "hello", writableEnded: false });
+    expect(request).toStartWith("POST / HTTP/1.1\r\n");
+  } finally {
+    req.destroy();
+  }
 });

--- a/test/regression/issue/13696.test.ts
+++ b/test/regression/issue/13696.test.ts
@@ -43,6 +43,8 @@ for (const socketMode of ["tcp", "unix"] as const) {
       let chunkReceived = Promise.withResolvers<void>();
 
       await using server = net.createServer(async sock => {
+        // req.destroy() at the end of the test may reset the connection.
+        sock.on("error", () => {});
         // The single write() must dispatch the headers and the body chunk
         // without req.end().
         request = await readUntil(sock, chunkedFrame);
@@ -58,7 +60,11 @@ for (const socketMode of ["tcp", "unix"] as const) {
         }
         sock.end();
       });
-      server.listen(...(socketPath ? [socketPath] : [0, "127.0.0.1"]));
+      if (socketPath) {
+        server.listen(socketPath);
+      } else {
+        server.listen(0, "127.0.0.1");
+      }
       await once(server, "listening");
 
       const requestOpts = socketPath
@@ -84,11 +90,17 @@ for (const socketMode of ["tcp", "unix"] as const) {
           req.on("response", res => {
             events.push(`response-status:${res.statusCode}`);
             res.setEncoding("utf8");
+            // Only a complete line counts as a received chunk: a data event
+            // can carry part of a line.
+            let pending = "";
             res.on("data", (chunk: string) => {
-              for (const line of chunk.split("\n")) {
-                if (line) events.push(`recv:${line}`);
+              pending += chunk;
+              const lines = pending.split("\n");
+              pending = lines.pop()!;
+              for (const line of lines) {
+                events.push(`recv:${line}`);
+                chunkReceived.resolve();
               }
-              chunkReceived.resolve();
             });
             res.on("end", () => {
               events.push("response-end");
@@ -130,6 +142,7 @@ for (const socketMode of ["tcp", "unix"] as const) {
 test.concurrent("http.request emits 'response' in duplex mode after flushHeaders() without end()", async () => {
   let request = "";
   await using server = net.createServer(async sock => {
+    sock.on("error", () => {});
     request = await readUntil(sock, "\r\n\r\n");
     sock.write("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nhello");
     sock.end();


### PR DESCRIPTION
### Problem
- `test/regression/issue/13696.test.ts` takes 13s on the debian 13 x64-asan lane (build 110300). Locally with a debug build it took 9.11s, about 2.2s per test.
- Each of the three tests spawned a bun child. The child loaded `node:http` and `node:net`, which takes about 2s in a debug build. The tests ran one after another, and the fixture paced its body chunks with a fixed 50ms sleep.

### Fix
- The raw `net` server and the `http.request` client now run inside the test process. The three tests run with `test.concurrent`, each on its own `port: 0` listener or unix socket.
- The server writes the next body chunk only after the client has observed the previous one. No sleep and no exit timeout remain. A hang in either direction fails on the test timeout, as before.
- Stronger assertions: the raw request line, the `Transfer-Encoding: chunked` header, and the chunked frame of the single `write()` are checked on the server side. After the response ends, `req.writableEnded` must still be `false`, which proves the response arrived while the request body was open.
- Verified: `bun bd test test/regression/issue/13696.test.ts` goes from 9.11s to 3.5s locally (10 runs, all green). The tests themselves take about 1s. The rest is runner startup. Also green under `USE_SYSTEM_BUN=1`.

### Background
- Issue #13696: a `ClientRequest` with one `write()` and no `end()` never sent the request. In duplex mode the `response` event was held back until `end()`. docker-modem does a write-once-keep-open POST for `container.exec` stdin, so testcontainers hung. #30377 fixed it.
- Docker's exec response has no `Content-Length` and no chunked encoding. The server writes raw frames and closes the connection, so the client `end` event depends on the server's `sock.end()`.

<details><summary>Notes</summary>

- Before: 2444ms, 2220ms, 2073ms per test, 9.11s for the file. `bun-debug -e 'require("http"); require("net")'` alone takes 2.0s, against 0.3s for an empty script. That is the whole cost of the old subprocess design.
- After: 962ms (tcp), 496ms (unix), 393ms (flushHeaders), all concurrent, 3.5s for the file.
- The `expect()` calls run in the test body, not inside the server callback, so a failed assertion reports against the test instead of surfacing as an unhandled rejection.
- #33704 is an older, conflicting bulk PR that only adds `test.concurrent` to this file. This change keeps that and removes the subprocesses too.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/13696.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/13696.test.ts"
bun test v1.4.3 (e0a2b82fd)

test/regression/issue/13696.test.ts:
(pass) http.request emits 'response' in duplex mode after flushHeaders() without end() [385.23ms]
(pass) http.request delivers response while request body stream is still open (tcp) [954.82ms]
(pass) http.request delivers response while request body stream is still open (unix) [486.72ms]

 3 pass
 0 fail
 10 expect() calls
Ran 3 tests across 1 file. [3.43s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/13696.test.ts | 308 +++++++++++++++++-------------------
 1 file changed, 149 insertions(+), 159 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/regression/issue/13696.test.ts      3     13     12
```

</details>

<!-- robobun:evidence:end -->