### PR TITLE
test: run 27890 custom lookup TLS test in-process and assert SNI

### DIFF
--- a/test/regression/issue/27890.test.ts
+++ b/test/regression/issue/27890.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
-import { bunEnv, bunExe } from "harness";
-import { join } from "path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import dns from "node:dns";
+import { readFileSync } from "node:fs";
+import https from "node:https";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+import type { TLSSocket } from "node:tls";
 
 // Self-signed cert with ONLY DNS:localhost in SANs (no IP SANs).
 // Valid from 2025-01-01 to 2035-01-01 to avoid CI clock skew issues.
@@ -15,183 +18,99 @@ const localhostOnlyTls = {
   key: readFileSync(join(import.meta.dir, "27890-localhost-only.key"), "utf8"),
 };
 
-// Uses a local HTTPS server with self-signed certs to avoid CI environments
-// lacking system CA certificates (Windows, Alpine).
-describe("custom lookup with HTTPS", () => {
-  test("https.request with custom lookup should not break TLS", async () => {
-    using server = Bun.serve({
-      tls: localhostOnlyTls,
-      port: 0,
-      fetch() {
-        return new Response("OK");
-      },
-    });
+type Result = {
+  status: number | undefined;
+  body: string;
+  // SNI hostname the server saw in the ClientHello (req.socket.servername),
+  // echoed back in the x-servername response header. "false" when none was sent.
+  servername: string;
+};
 
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-const https = require("https");
-const port = ${server.port};
-const ca = ${JSON.stringify(localhostOnlyTls.cert)};
-
-function customLookup(hostname, options, callback) {
-  // Resolve "localhost" to 127.0.0.1 — simulates the real-world scenario
-  // where a custom lookup returns an IP address for a hostname.
-  if (options && options.all) {
-    callback(null, [{ address: "127.0.0.1", family: 4 }]);
-  } else {
-    callback(null, "127.0.0.1", 4);
-  }
+function request(options: https.RequestOptions): Promise<Result> {
+  const { promise, resolve, reject } = Promise.withResolvers<Result>();
+  const req = https.request({ ...options, ca: localhostOnlyTls.cert }, res => {
+    let body = "";
+    res.setEncoding("utf8");
+    res.on("data", chunk => (body += chunk));
+    res.on("end", () => resolve({ status: res.statusCode, body, servername: res.headers["x-servername"] as string }));
+  });
+  req.on("error", reject);
+  req.end();
+  return promise;
 }
 
-const req = https.request("https://localhost:" + port, {
-  lookup: customLookup,
-  ca,
-}, (res) => {
-  let data = "";
-  res.on("data", (chunk) => data += chunk);
-  res.on("end", () => {
-    console.log("status:" + res.statusCode + " body:" + data);
-  });
-});
-req.on("error", (e) => {
-  console.error("error:" + e.message + " " + (e.code || ""));
-  process.exitCode = 1;
-});
-req.end();
-`,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
+// Uses a local HTTPS server with a self-signed cert to avoid CI environments
+// lacking system CA certificates (Windows, Alpine).
+describe.concurrent("custom lookup with HTTPS", () => {
+  let server: https.Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = https.createServer(localhostOnlyTls, (req, res) => {
+      res.setHeader("x-servername", String((req.socket as TLSSocket).servername));
+      res.end("OK");
     });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    port = (server.address() as AddressInfo).port;
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  afterAll(() => {
+    server.close();
+  });
 
-    expect(stderr).not.toContain("certificate");
-    expect(stderr).not.toContain("CERT_ALTNAME");
-    expect(stdout).toContain("status:200");
-    expect(stdout).toContain("body:OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+  test("https.request with custom lookup should not break TLS", async () => {
+    const lookedUp: string[] = [];
+    // Resolve "localhost" to 127.0.0.1. Simulates the real-world scenario
+    // where a custom lookup returns an IP address for a hostname.
+    function customLookup(hostname: string, options: dns.LookupOptions, callback: Function) {
+      lookedUp.push(hostname);
+      if (options?.all) {
+        callback(null, [{ address: "127.0.0.1", family: 4 }]);
+      } else {
+        callback(null, "127.0.0.1", 4);
+      }
+    }
+
+    const result = await request({ host: "localhost", port, lookup: customLookup });
+    expect(result).toEqual({ status: 200, body: "OK", servername: "localhost" });
+    expect(lookedUp).toEqual(["localhost"]);
+  });
 
   test("https.request without custom lookup should still work", async () => {
-    using server = Bun.serve({
-      tls: localhostOnlyTls,
-      port: 0,
-      fetch() {
-        return new Response("OK");
-      },
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-const https = require("https");
-const port = ${server.port};
-const ca = ${JSON.stringify(localhostOnlyTls.cert)};
-
-const req = https.request("https://localhost:" + port, { ca }, (res) => {
-  let data = "";
-  res.on("data", (chunk) => data += chunk);
-  res.on("end", () => {
-    console.log("status:" + res.statusCode + " body:" + data);
+    const result = await request({ host: "localhost", port });
+    expect(result).toEqual({ status: 200, body: "OK", servername: "localhost" });
   });
-});
-req.on("error", (e) => {
-  console.error("error:" + e.message + " " + (e.code || ""));
-  process.exitCode = 1;
-});
-req.end();
-`,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).not.toContain("certificate");
-    expect(stdout).toContain("status:200");
-    expect(stdout).toContain("body:OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
 
   test("custom lookup via dns.lookup should preserve hostname for TLS SNI", async () => {
-    // This test verifies the specific scenario from issue #27890:
-    // A custom lookup that resolves hostname to IP should not break TLS.
-    // The lookup uses dns.lookup (which checks /etc/hosts) to resolve
-    // "localhost" to an IP, but the original hostname must be preserved
-    // for SNI and certificate SAN matching.
-    // The cert only has DNS:localhost (no IP SANs), so if SNI is broken
-    // and the IP is used for cert verification, it WILL fail.
-    using server = Bun.serve({
-      tls: localhostOnlyTls,
-      port: 0,
-      fetch() {
-        return new Response("OK");
-      },
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-const https = require("https");
-const dns = require("dns");
-const port = ${server.port};
-const ca = ${JSON.stringify(localhostOnlyTls.cert)};
-
-// Custom lookup using dns.lookup — exercises the real resolution path
-// (including /etc/hosts) where hostname is resolved to IP, reproducing
-// the exact issue #27890 scenario. Forces IPv4 to avoid inconsistent
-// results on dual-stack hosts.
-function customLookup(hostname, options, callback) {
-  dns.lookup(hostname, { all: true, family: 4 }, (err, addresses) => {
-    if (err) { callback(err); return; }
-    if (options && options.all) {
-      callback(null, addresses);
-    } else {
-      const first = addresses[0];
-      callback(null, first.address, first.family);
+    // This is the exact scenario from issue #27890: a custom lookup that uses
+    // dns.lookup (which checks /etc/hosts) to resolve "localhost" to an IP.
+    // The original hostname must still be used for SNI and certificate SAN
+    // matching. Forces IPv4 to avoid inconsistent results on dual-stack hosts.
+    const resolved: { hostname: string; addresses: string[] }[] = [];
+    function customLookup(hostname: string, options: dns.LookupOptions, callback: Function) {
+      dns.lookup(hostname, { all: true, family: 4 }, (err, addresses) => {
+        if (err) return callback(err);
+        // dns.lookup may list the same hosts-file entry more than once.
+        resolved.push({ hostname, addresses: [...new Set(addresses.map(a => `${a.address}/${a.family}`))] });
+        if (options?.all) {
+          callback(null, addresses);
+        } else {
+          callback(null, addresses[0].address, addresses[0].family);
+        }
+      });
     }
-  });
-}
 
-const req = https.request("https://localhost:" + port, {
-  lookup: customLookup,
-  ca,
-}, (res) => {
-  let data = "";
-  res.on("data", (chunk) => data += chunk);
-  res.on("end", () => {
-    console.log("status:" + res.statusCode + " body:" + data);
+    const result = await request({ host: "localhost", port, lookup: customLookup });
+    expect(result).toEqual({ status: 200, body: "OK", servername: "localhost" });
+    expect(resolved).toEqual([{ hostname: "localhost", addresses: ["127.0.0.1/4"] }]);
   });
-});
-req.on("error", (e) => {
-  console.error("error:" + e.message + " " + (e.code || ""));
-  process.exitCode = 1;
-});
-req.end();
-`,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
+
+  test("connecting by IP fails certificate verification (cert has no IP SAN)", async () => {
+    // Proves the cert cannot be matched by IP. If the custom lookup tests
+    // above leaked the resolved IP into SNI or hostname verification, they
+    // would fail with this same error.
+    await expect(request({ host: "127.0.0.1", port })).rejects.toMatchObject({
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
     });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).not.toContain("certificate");
-    expect(stderr).not.toContain("CERT_ALTNAME");
-    expect(stdout).toContain("status:200");
-    expect(stdout).toContain("body:OK");
-    expect(exitCode).toBe(0);
-  }, 30_000);
+  });
 });


### PR DESCRIPTION
### Problem
- `test/regression/issue/27890.test.ts` takes 12s in CI (debian 13 x64-asan, build 110300). It is in the slowest 5 percent of test files.
- Each of its 3 tests spawns a bun child that runs an https.request against a TLS server in the parent. Under ASAN each child costs about 2.4s of startup plus a TLS handshake, and the tests run serially.
- The assertions are loose: `toContain("status:200")`, `not.toContain("certificate")` on stderr, and a bare exit code check. None of them check the SNI the client sent.

### Fix
- Run the https.request in the test process. The custom `lookup` is a plain function, so a child is not needed to observe it. One `node:https` server on port 0 starts in `beforeAll` and echoes `req.socket.servername` in an `x-servername` header. The 3 tests run under `describe.concurrent`.
- Each test asserts one parsed result object: `{ status: 200, body: "OK", servername: "localhost" }`. The custom lookup tests also assert the hostname the lookup was called with, and the dns.lookup test asserts it resolved to `127.0.0.1` family 4.
- A fourth test connects by `127.0.0.1` and asserts `ERR_TLS_CERT_ALTNAME_INVALID`. This proves the cert has no IP SAN, so the other tests can only pass when the hostname is kept for SNI and certificate matching.
- Verified: `bun bd test test/regression/issue/27890.test.ts` goes from 9.30s to 3.92s locally (debug, ASAN). Also passes under `USE_SYSTEM_BUN=1` (107ms).

### Background
- Issue #27890: `https.request` with a custom `lookup` option replaced the hostname with the resolved IP for TLS. SNI and certificate verification then used the IP, and a cert with only `DNS:localhost` failed. #27891 fixed it in `src/http.zig` (`getTlsHostname`).
- The fixture cert `27890-localhost-only.crt` has only `DNS:localhost` in its SANs on purpose. An IP SAN would let the tests pass even with the bug.
- `req.socket.servername` on a server-side TLS socket is the SNI name from the ClientHello, or `false` when none was sent.

<details><summary>Notes</summary>

- `dns.lookup("localhost", { all: true, family: 4 })` returns `127.0.0.1` twice on the CI image (one `/etc/hosts` line). The test dedupes the addresses before it compares them, so it does not depend on that behavior. Open PR #32923 touches hosts-file handling in dns.lookup and mentions this test. This diff does not change what the test asks of dns.lookup.
- #33704 adds `describe.concurrent` to this file as part of a 53-file pass. This PR supersedes that one-line change for this file.
- Per-test timings under debug ASAN before: 2480ms, 2409ms, 2456ms (serial). After: 1176ms, 729ms, 670ms, 256ms (concurrent), 3.9s wall including startup.
- The 30s per-test timeouts are gone.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/27890.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/27890.test.ts"
bun test v1.4.3 (e0a2b82fd)

test/regression/issue/27890.test.ts:
(pass) custom lookup with HTTPS > connecting by IP fails certificate verification (cert has no IP SAN) [262.62ms]
(pass) custom lookup with HTTPS > https.request with custom lookup should not break TLS [1198.10ms]
(pass) custom lookup with HTTPS > https.request without custom lookup should still work [745.36ms]
(pass) custom lookup with HTTPS > custom lookup via dns.lookup should preserve hostname for TLS SNI [685.46ms]

 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [4.04s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/27890.test.ts | 255 ++++++++++++------------------------
 1 file changed, 87 insertions(+), 168 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/regression/issue/27890.test.ts      3      6      9
```

</details>

**root cause** · written by the author bot

The test was slow because each of its three cases spawned a separate Bun child process that paid full interpreter startup under ASAN plus its own TLS handshake, and the three ran serially. The fix moves the https server and the request into the test process itself, sharing a single node:https server on port 0 across the cases and running them with describe.concurrent, which cut local wall time from about 9.3s to 3.9s. While in there the bare exit-code checks were replaced with assertions on one parsed result object covering status, body, server-side SNI servername, the hostname passed to th…

<!-- robobun:evidence:end -->