### PR TITLE
test: run the WPT url-constructor fixture one test per section

### DIFF
--- a/test/js/web/url/url-wpt-constructor.test.ts
+++ b/test/js/web/url/url-wpt-constructor.test.ts
@@ -42,13 +42,14 @@ for (const item of JSON.parse(readFileSync(fixture, "utf8")) as (Entry | string)
 }
 
 // url.origin for these does not match the spec yet (parsing does); tracked separately from the parser.
-// The test asserts that each one still deviates, so a fix shows up here and the input gets removed from the list.
-const knownOriginDeviations = new Set([
-  "ftps:/example.com/",
-  "ftps:example.com/",
-  "blob:ftp://host/path",
-  "blob:ws://example.org/",
-  "blob:wss://example.org/",
+// The value is the origin bun returns today. The test asserts it, so a fix (or a different wrong value) shows up
+// here and the input gets removed from the list.
+const knownOriginDeviations = new Map([
+  ["ftps:/example.com/", "ftps:"],
+  ["ftps:example.com/", "ftps:"],
+  ["blob:ftp://host/path", "ftp://host"],
+  ["blob:ws://example.org/", "ws://example.org"],
+  ["blob:wss://example.org/", "wss://example.org"],
 ]);
 
 const componentKeys = [
@@ -115,13 +116,8 @@ function check(entry: Entry): Mismatch | null {
     actual.searchParams = url.searchParams.toString();
   }
   if (entry.origin !== undefined) {
-    if (knownOriginDeviations.has(entry.input)) {
-      expected.originStillDeviates = true;
-      actual.originStillDeviates = url.origin !== entry.origin;
-    } else {
-      expected.origin = entry.origin;
-      actual.origin = url.origin;
-    }
+    expected.origin = knownOriginDeviations.get(entry.input) ?? entry.origin;
+    actual.origin = url.origin;
   }
 
   return Bun.deepEquals(actual, expected) ? null : mismatch(expected, actual);

--- a/test/js/web/url/url-wpt-constructor.test.ts
+++ b/test/js/web/url/url-wpt-constructor.test.ts
@@ -1,5 +1,9 @@
 // WPT url/url-constructor.any.js over the vendored urltestdata.json: every non-failure entry must produce the expected
-// href and components, every failure entry must throw.
+// href and components, every failure entry must throw and fail URL.canParse().
+//
+// The fixture is a flat array. A string entry is a section label, the objects after it belong to that section.
+// One bun:test test runs per section (one test per entry spent most of the wall time in runner overhead).
+// A failing test lists every mismatching entry of its section, with the input and base, so nothing is hidden.
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -19,14 +23,26 @@ type Entry = {
   pathname?: string;
   search?: string;
   hash?: string;
+  searchParams?: string;
 };
 
+type Section = { label: string; entries: Entry[] };
+
 const fixture = join(import.meta.dir, "../../node/test/fixtures/wpt/url/resources/urltestdata.json");
-const entries = (JSON.parse(readFileSync(fixture, "utf8")) as (Entry | string)[]).filter(
-  (entry): entry is Entry => typeof entry === "object",
-);
+const sections: Section[] = [];
+let entryCount = 0;
+for (const item of JSON.parse(readFileSync(fixture, "utf8")) as (Entry | string)[]) {
+  if (typeof item === "string") {
+    sections.push({ label: item, entries: [] });
+    continue;
+  }
+  if (sections.length === 0) sections.push({ label: "(no section)", entries: [] });
+  sections[sections.length - 1].entries.push(item);
+  entryCount++;
+}
 
 // url.origin for these does not match the spec yet (parsing does); tracked separately from the parser.
+// The test asserts that each one still deviates, so a fix shows up here and the input gets removed from the list.
 const knownOriginDeviations = new Set([
   "ftps:/example.com/",
   "ftps:example.com/",
@@ -35,31 +51,97 @@ const knownOriginDeviations = new Set([
   "blob:wss://example.org/",
 ]);
 
-describe("WPT url-constructor", () => {
-  test("fixture is present", () => {
-    expect(entries.length).toBeGreaterThan(800);
+const componentKeys = [
+  "href",
+  "protocol",
+  "username",
+  "password",
+  "host",
+  "hostname",
+  "port",
+  "pathname",
+  "search",
+  "hash",
+] as const;
+
+function construct(entry: Entry) {
+  return entry.base != null ? new URL(entry.input, entry.base) : new URL(entry.input);
+}
+
+function canParse(entry: Entry) {
+  return entry.base != null ? URL.canParse(entry.input, entry.base) : URL.canParse(entry.input);
+}
+
+type Mismatch = { input: string; base: string | null; expected: unknown; actual: unknown };
+
+// Returns the mismatch for one entry, or null when the entry matches the fixture.
+function check(entry: Entry): Mismatch | null {
+  const mismatch = (expected: unknown, actual: unknown): Mismatch => ({
+    input: entry.input,
+    base: entry.base ?? null,
+    expected,
+    actual,
   });
 
-  for (const entry of entries) {
-    const name = `${JSON.stringify(entry.input)}${entry.base != null ? ` against ${JSON.stringify(entry.base)}` : ""}`;
-    test(name, () => {
-      const construct = () => (entry.base != null ? new URL(entry.input, entry.base) : new URL(entry.input));
-      if (entry.failure) {
-        expect(construct).toThrow(TypeError);
-        return;
+  if (entry.failure) {
+    let thrown: unknown = null;
+    try {
+      construct(entry);
+    } catch (error) {
+      thrown = error;
+    }
+    const expected = { throws: "TypeError", canParse: false };
+    const actual = { throws: thrown instanceof TypeError ? "TypeError" : String(thrown), canParse: canParse(entry) };
+    return Bun.deepEquals(actual, expected) ? null : mismatch(expected, actual);
+  }
+
+  let url: URL;
+  try {
+    url = construct(entry);
+  } catch (error) {
+    return mismatch({ href: entry.href }, { throws: String(error) });
+  }
+
+  const expected: Record<string, string | boolean> = {};
+  const actual: Record<string, string | boolean> = {};
+  for (const key of componentKeys) {
+    expected[key] = entry[key]!;
+    actual[key] = url[key];
+  }
+  expected.canParse = true;
+  actual.canParse = canParse(entry);
+  if (entry.searchParams !== undefined) {
+    expected.searchParams = entry.searchParams;
+    actual.searchParams = url.searchParams.toString();
+  }
+  if (entry.origin !== undefined) {
+    if (knownOriginDeviations.has(entry.input)) {
+      expected.originStillDeviates = true;
+      actual.originStillDeviates = url.origin !== entry.origin;
+    } else {
+      expected.origin = entry.origin;
+      actual.origin = url.origin;
+    }
+  }
+
+  return Bun.deepEquals(actual, expected) ? null : mismatch(expected, actual);
+}
+
+describe("WPT url-constructor", () => {
+  test("fixture is present", () => {
+    expect(entryCount).toBeGreaterThan(800);
+    expect(sections.length).toBeGreaterThan(100);
+  });
+
+  for (const [index, section] of sections.entries()) {
+    if (section.entries.length === 0) continue;
+    test(`section ${index}: ${section.label} (${section.entries.length} entries)`, () => {
+      const mismatches: Mismatch[] = [];
+      for (const entry of section.entries) {
+        const mismatch = check(entry);
+        if (mismatch) mismatches.push(mismatch);
       }
-      const url = construct();
-      expect(url.href).toBe(entry.href);
-      if (entry.origin !== undefined && !knownOriginDeviations.has(entry.input)) expect(url.origin).toBe(entry.origin);
-      expect(url.protocol).toBe(entry.protocol);
-      expect(url.username).toBe(entry.username);
-      expect(url.password).toBe(entry.password);
-      expect(url.host).toBe(entry.host);
-      expect(url.hostname).toBe(entry.hostname);
-      expect(url.port).toBe(entry.port);
-      expect(url.pathname).toBe(entry.pathname);
-      expect(url.search).toBe(entry.search);
-      expect(url.hash).toBe(entry.hash);
+      expect(mismatches).toEqual([]);
     });
   }
 });


### PR DESCRIPTION
### Problem
- `test/js/web/url/url-wpt-constructor.test.ts` took 12.5 s on the darwin x64 lane (build 110300). It is in the slowest 5 percent of test files.
- The file registered one `test()` per fixture entry, 870 tests. The URL work itself is small. The time goes to per-test runner overhead: registration, timing, and reporting.

### Fix
- Group the entries by the fixture's section labels (the string items in `urltestdata.json`). Run one test per section, 111 tests. Each test checks every entry of its section and collects the mismatches. `expect(mismatches).toEqual([])` then prints every broken entry with its input and base.
- Compare the full component set per entry in one object: href, protocol, username, password, host, hostname, port, pathname, search, hash, canParse, origin, and searchParams when the fixture gives it. A failure prints the whole diff.
- For a `failure: true` entry, assert that `new URL()` throws a `TypeError` and that `URL.canParse()` returns false. Before, the test only checked the throw.
- The five known `origin` deviations are now asserted to still deviate. When a fix lands, this test reports it and the input comes off the list.

### Timing
- Debug build, local linux x64, CI flags (`--dots --reporter=junit`): 3.4 s before, 2.65 s after. The rest is process startup (1.6 s for an empty file) plus fixture parse and URL work (about 0.6 s).
- Release build, same machine: about 70 ms both before and after. I cannot measure the darwin lane here.

### Background
- The fixture is the WPT `urltestdata.json`, vendored for the Node tests. It is a flat array. A string item labels a section. The objects after it belong to that section. The fixture is not changed.
- `URL.canParse()` is the constructor without the throw. The WPT suite checks it in `url-statics-canparse`. This file now covers it with the same data.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 3 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/url/url-wpt-constructor.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/url/url-wpt-constructor.test.ts
bun test v1.4.3 (e0a2b82fd)

test/js/web/url/url-wpt-constructor.test.ts:
(pass) WPT url-constructor > fixture is present [4.43ms]
(pass) WPT url-constructor > section 0: See ../README.md for a description of the format. (110 entries) [98.27ms]
(pass) WPT url-constructor > section 1: # Based on https://felixfbecker.github.io/whatwg-url-custom-host-repro/ (1 entries) [1.61ms]
(pass) WPT url-constructor > section 2: # Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/file.html (24 entries) [10.92ms]
(pass) WPT url-constructor > section 3: # Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/script-tests/path.js (36 entries) [18.14ms]
(pass) WPT url-constructor > section 4: # Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/script-tests/relative.js (52 entries) [26.48ms]
(pass) WPT url-constructor > section 5: # Based on http://trac.webkit.org/browser/trunk/LayoutTests/fast/url/segments-userinfo-vs-host.html (28 entries) [11.55ms]
(pass) WPT url-constructor > section 6: # Others (17 entries) [8.67ms]
(pass) WPT url-constructor > section 8: Basic canonicalization, uppercase should be converted to lowercase (5 entries) [2.03ms]
(pass) WPT url-constructor > section 9: U+3000 is mapped to U+0020 (space) which is disallowed (1 entries) [0.71ms]
(pass) WPT url-constructor > section 10: Other types of space (no-break, zero-width, zero-width-no-break) are name-prepped away to nothing. U+200B, U+2060, and U+FEFF, are ignored (1 entries) [1.01ms]
(pass) WPT url-constructor > section 11: Leading and trailing C0 control or space (9 entries) [4.42ms]
(pass) WPT url-constructor > section 12: Ideographic full stop (full-width period for Chinese, etc.) should be treated as a dot. U+3002 is mapped to U+002E (dot) (1 entries) [0.70ms]
(pass) WPT url-constructor > section 13: Invalid unicode characters sh
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/url/url-wpt-constructor.test.ts | 138 ++++++++++++++++++++++------
 1 file changed, 108 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
test/js/web/url/url-wpt-constructor.test.ts      4      6     15
```

</details>

**root cause** · written by the author bot

The slowness had nothing to do with URL parsing: the file registered one bun:test case per WPT fixture entry, so roughly 870 tiny tests paid the runner's per-test registration, timing, and reporting cost, which dominated the 13s wall time. The fix groups entries by the fixture's section-label strings and runs one test per section, looping over entries inside and collecting every mismatch (with input, base, expected, and actual) into an array asserted against an empty list, so each broken input is still named on failure. While restructuring, the assertions were tightened to compare the full …

<!-- robobun:evidence:end -->