### PR TITLE
test(node:tls): overlap the OOM child with the syscall fault tests and tighten assertions

### DIFF
--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -1,7 +1,8 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
 import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -9,180 +10,201 @@ const skip = !fault.available() || isWindows;
 
 afterEach(() => fault.clear());
 
-// The loop's shared TLS plaintext buffer is one lazy 512 KiB malloc, and its
-// NULL return used to be ignored: SSL_read then wrote to
-// `NULL + LIBUS_RECV_BUFFER_PADDING`. Runs in a child because the allocation
-// happens once per event loop, on its first TLS socket. No isWindows skip —
-// the unchecked allocation is exactly the one that fails there.
-//
-// Every marker the fixture can print. A crashing debug build symbolizes its
-// backtrace onto stdout, so match the fixture's lines rather than the whole
-// stream; anything past "ARMED" means a TLS socket survived the failed
-// allocation and reached its read loop.
-const OOM_FIXTURE_MARKERS = ["ARMED", "READ DATA", "CLOSED", "CLIENT ERROR"];
-test.skipIf(!fault.available())(
-  "a failed per-loop TLS buffer allocation reports out of memory instead of faulting inside SSL_read",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "tls-loop-buffer-oom-fixture.ts")],
+// The OOM fixture is a separate bun process that aborts on purpose. It is
+// started here, before the first test, so it runs alongside the serial
+// in-process tests below and is only awaited by the last test of the file.
+// It sets no fault in this process.
+let oomChild: { proc: Bun.Subprocess; result: Promise<[string, string, number]> } | null = null;
+
+// One TLS server for every in-process test: the faults are injected into the
+// client side's syscalls, and each test drives exactly one connection at a
+// time, so the listening socket is never affected. Each accepted socket
+// swallows its own error: the process-wide faults hit the server side too.
+let server: tls.Server;
+let port: number;
+
+beforeAll(async () => {
+  if (fault.available()) {
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        // Skip the debug build's symbolized backtrace: it costs seconds and the
+        // assertion only needs the crash reason line.
+        "--debug-crash-handler-use-trace-string",
+        join(import.meta.dir, "tls-loop-buffer-oom-fixture.ts"),
+      ],
       // BUN_CRASH_REPORT_URL="": this OOM is deliberate; uploading it to CI's
       // remap server would pin a spurious "crash reported" error on the next
       // unrelated failing test.
       env: { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" },
+      stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // `CrashReason::OutOfMemory` phrasing varies with SHOW_CRASH_TRACE, so
-    // match the shared substring (see run-crash-handler.test.ts).
-    const outOfMemory = stderr.toLowerCase().includes("out of memory");
-    expect({
-      markers: stdout
-        .split("\n")
-        .map(line => line.trim())
-        .filter(line => OOM_FIXTURE_MARKERS.includes(line)),
-      outOfMemory,
-      // Only populated when the assertion is about to fail, so the diff shows why.
-      stderrTail: outOfMemory ? "" : stderr.slice(-2000),
-    }).toEqual({ markers: ["ARMED"], outOfMemory: true, stderrTail: "" });
-  },
-  // Symbolizing the crash backtrace of a debug/ASAN binary takes several
-  // seconds on its own, well past the default per-test budget.
-  60_000,
-);
-
-async function connectedTLSPair(onServerSocket?: (s: tls.TLSSocket) => void) {
-  const server = tls.createServer({ key: certs.key, cert: certs.cert });
-  server.on("secureConnection", s => {
-    s.on("error", () => {});
-    onServerSocket?.(s);
-  });
+    oomChild = { proc, result: Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]) };
+  }
+  if (skip) return;
+  server = tls.createServer({ key: certs.key, cert: certs.cert });
+  server.on("secureConnection", s => s.on("error", () => {}));
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
-  const port = (server.address() as import("node:net").AddressInfo).port;
+  port = (server.address() as AddressInfo).port;
+});
 
+afterAll(() => {
+  oomChild?.proc.kill();
+  server?.close();
+});
+
+function connect(options: tls.ConnectionOptions = {}) {
+  return tls.connect({ port, host: "127.0.0.1", ca: certs.cert, rejectUnauthorized: true, ...options });
+}
+
+async function connectedTLSPair(onServerSocket?: (s: tls.TLSSocket) => void) {
   // Register the server-side listener before initiating connect so the
   // 'secureConnection' event cannot be missed.
-  const serverSockP = once(server, "secureConnection") as Promise<[tls.TLSSocket]>;
-  const client = tls.connect({ port, host: "127.0.0.1", ca: certs.cert, rejectUnauthorized: true });
-  const [, [serverSock]] = await Promise.all([once(client, "secureConnect"), serverSockP]);
+  const serverSockP = (once(server, "secureConnection") as Promise<[tls.TLSSocket]>).then(([s]) => {
+    onServerSocket?.(s);
+    return s;
+  });
+  const client = connect();
+  const [, serverSock] = await Promise.all([once(client, "secureConnect"), serverSockP]);
 
   return {
-    server,
     client,
     serverSock,
     [Symbol.dispose]() {
       client.destroy();
       serverSock.destroy();
-      server.close();
     },
   };
+}
+
+type ObservedError = { name: string; code?: string; syscall?: string; message: string };
+
+// Records the lifecycle events of a socket in the order they fire. `closed`
+// resolves on 'close' whether or not an 'error' came first (events.once would
+// reject on the error).
+function observe(socket: tls.TLSSocket) {
+  const events: string[] = [];
+  const errors: ObservedError[] = [];
+  const closed = new Promise<void>(resolve => socket.once("close", () => resolve()));
+  socket.on("end", () => events.push("end"));
+  socket.on("error", (e: NodeJS.ErrnoException) => {
+    events.push("error");
+    errors.push({ name: e.name, code: e.code, syscall: e.syscall, message: e.message });
+  });
+  socket.on("close", hadError => events.push(`close(hadError=${hadError})`));
+  return { events, errors, closed };
+}
+
+const CLEAN_CLOSE = ["end", "close(hadError=false)"];
+const RESET_CLOSE = {
+  events: ["error", "close(hadError=true)"],
+  errors: [{ name: "Error", code: "ECONNRESET", syscall: "read", message: "read ECONNRESET" }],
+  destroyed: true,
+};
+
+function collect(socket: tls.TLSSocket) {
+  const chunks: Buffer[] = [];
+  socket.on("data", c => chunks.push(c));
+  return () => Buffer.concat(chunks);
 }
 
 describe.skipIf(skip)("node:tls under injected syscall faults", () => {
   test("recv → ECONNRESET during established session surfaces as 'error'", async () => {
     using p = await connectedTLSPair();
+    const client = observe(p.client);
     fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
-    const errP = once(p.client, "error");
     p.serverSock.write("hello");
-    const [err] = (await errP) as [NodeJS.ErrnoException];
-    // BoringSSL may map a transport reset to ECONNRESET or to an SSL read error;
-    // either is acceptable, but the socket must be destroyed and not hang.
-    expect(err).toBeInstanceOf(Error);
-    expect(err).not.toBeInstanceOf(TypeError);
-    expect(p.client.destroyed).toBe(true);
+    await client.closed;
+    expect({ events: client.events, errors: client.errors, destroyed: p.client.destroyed }).toEqual(RESET_CLOSE);
   });
 
   test("recv → short reads (1 byte) still decrypt complete payload", async () => {
     using p = await connectedTLSPair();
+    const client = observe(p.client);
+    const received = collect(p.client);
     // The TLS record layer must reassemble across many tiny BIO reads.
     fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
-    const chunks: Buffer[] = [];
-    p.client.on("data", c => chunks.push(c));
     const payload = Buffer.alloc(512, "Z");
-    p.serverSock.write(payload);
-    p.serverSock.end();
-    await once(p.client, "end");
-    expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+    p.serverSock.end(payload);
+    await client.closed;
+    expect(received()).toEqual(payload);
+    expect({ events: client.events, errors: client.errors }).toEqual({ events: CLEAN_CLOSE, errors: [] });
   });
 
   test("send → short writes (1 byte) still deliver complete encrypted payload", async () => {
-    let received = Buffer.alloc(0);
+    let received!: () => Buffer;
+    let serverSide!: ReturnType<typeof observe>;
     using p = await connectedTLSPair(s => {
-      s.on("data", c => (received = Buffer.concat([received, c])));
+      received = collect(s);
+      serverSide = observe(s);
     });
     fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
     const payload = Buffer.alloc(512, "Y");
-    p.client.write(payload);
-    p.client.end();
-    await once(p.serverSock, "end");
+    p.client.end(payload);
+    await serverSide.closed;
     fault.clear();
-    expect(received.equals(payload)).toBe(true);
+    expect(received()).toEqual(payload);
+    expect({ events: serverSide.events, errors: serverSide.errors }).toEqual({ events: CLEAN_CLOSE, errors: [] });
   });
 
   test("recv → 0 (peer closed) on established session emits 'end' without 'error'", async () => {
     using p = await connectedTLSPair();
-    let gotError: unknown = null;
-    p.client.on("error", e => (gotError = e));
+    const client = observe(p.client);
+    const received = collect(p.client);
     fault.set({ syscall: "recv", action: "zero", repeat: -1 });
-    const endP = once(p.client, "end");
     p.serverSock.write("hello");
-    await endP;
-    expect(gotError).toBeNull();
+    await client.closed;
+    // The injected EOF lands before the "hello" record is ever read.
+    expect({ events: client.events, errors: client.errors, bytes: received().length }).toEqual({
+      events: CLEAN_CLOSE,
+      errors: [],
+      bytes: 0,
+    });
   });
 
   test("send → short writes during handshake still complete secureConnect", async () => {
-    const server = tls.createServer({ key: certs.key, cert: certs.cert });
-    server.on("secureConnection", s => s.on("error", () => {}));
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const port = (server.address() as import("node:net").AddressInfo).port;
-    try {
-      // Clamp every send to 3 bytes — the ClientHello/ServerHello/Finished
-      // flights are split across hundreds of partial writes.
-      fault.set({ syscall: "send", action: "short", bytes: 3, repeat: -1 });
-      const serverSockP = once(server, "secureConnection") as Promise<[tls.TLSSocket]>;
-      const client = tls.connect({ port, host: "127.0.0.1", ca: certs.cert });
-      const [, [serverSock]] = await Promise.all([once(client, "secureConnect"), serverSockP]);
-      expect(client.authorized).toBe(true);
-      client.destroy();
-      serverSock.destroy();
-    } finally {
-      fault.clear();
-      server.close();
-    }
+    // Clamp every send to 3 bytes — the ClientHello/ServerHello/Finished
+    // flights are split across hundreds of partial writes.
+    fault.set({ syscall: "send", action: "short", bytes: 3, repeat: -1 });
+    using p = await connectedTLSPair();
+    fault.clear();
+    expect({
+      authorized: p.client.authorized,
+      authorizationError: p.client.authorizationError,
+      serverEncrypted: p.serverSock.encrypted,
+    }).toEqual({ authorized: true, authorizationError: null, serverEncrypted: true });
   });
 
   test("recv → short reads at TLS record boundary (5 bytes = header only) still decrypt", async () => {
     using p = await connectedTLSPair();
+    const client = observe(p.client);
+    const received = collect(p.client);
     // 5 bytes is exactly the TLS record header — forces the BIO to assemble
     // header and ciphertext across separate recv calls.
     fault.set({ syscall: "recv", action: "short", bytes: 5, repeat: -1 });
-    const chunks: Buffer[] = [];
-    p.client.on("data", c => chunks.push(c));
     const payload = Buffer.alloc(256, "R");
-    p.serverSock.write(payload);
-    p.serverSock.end();
-    await once(p.client, "end");
-    expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+    p.serverSock.end(payload);
+    await client.closed;
+    expect(received()).toEqual(payload);
+    expect({ events: client.events, errors: client.errors }).toEqual({ events: CLEAN_CLOSE, errors: [] });
   });
 
   test("recv → ECONNRESET mid-handshake fails connect with an error (no hang)", async () => {
-    const server = tls.createServer({ key: certs.key, cert: certs.cert }, s => s.on("error", () => {}));
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const port = (server.address() as import("node:net").AddressInfo).port;
-    try {
-      // Reset the very first wire read of the ServerHello.
-      fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
-      const client = tls.connect({ port, host: "127.0.0.1", ca: certs.cert });
-      const [err] = (await once(client, "error")) as [Error];
-      expect(err).toBeTruthy();
-      client.destroy();
-    } finally {
-      fault.clear();
-      server.close();
-    }
+    // Reset the very first wire read of the ServerHello.
+    fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
+    const c = connect();
+    const client = observe(c);
+    let secureConnect = false;
+    c.on("secureConnect", () => (secureConnect = true));
+    await client.closed;
+    fault.clear();
+    expect({ events: client.events, errors: client.errors, destroyed: c.destroyed, secureConnect }).toEqual({
+      ...RESET_CLOSE,
+      secureConnect: false,
+    });
   });
 });
 
@@ -193,67 +215,72 @@ describe.skipIf(skip)("node:tls close_notify / shutdown under faults", () => {
     // consumer makes the stream's backpressure pause the socket mid-burst.
     // No byte may be lost, and 'end' must come only after all of them.
     const BIG = 192 * 1024;
-    const server = tls.createServer({ key: certs.key, cert: certs.cert });
     const serverClosed = Promise.withResolvers<void>();
-    server.on("secureConnection", s => {
-      s.on("error", () => {});
+    using p = await connectedTLSPair(s => {
       s.on("close", () => serverClosed.resolve());
       s.end(Buffer.alloc(BIG, "Y"));
       s.destroySoon();
     });
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const port = (server.address() as import("node:net").AddressInfo).port;
-    const client = tls.connect({ port, host: "127.0.0.1", ca: certs.cert, rejectUnauthorized: true });
-    client.on("error", () => {});
-    try {
-      await once(client, "secureConnect");
-      client.pause();
-      await serverClosed.promise;
-      fault.set({ syscall: "recv", action: "short", bytes: 65536, repeat: -1 });
-      let bytes = 0;
-      client.on("readable", () => {
-        let chunk;
-        while ((chunk = client.read()) !== null) bytes += chunk.length;
-      });
-      const ended = once(client, "end");
-      client.resume();
-      await ended;
-      fault.clear();
-      expect(bytes).toBe(BIG);
-    } finally {
-      client.destroy();
-      server.close();
-    }
+    const client = observe(p.client);
+    p.client.pause();
+    await serverClosed.promise;
+    fault.set({ syscall: "recv", action: "short", bytes: 65536, repeat: -1 });
+    let bytes = 0;
+    let bytesAtEnd = -1;
+    p.client.on("readable", () => {
+      let chunk;
+      while ((chunk = p.client.read()) !== null) bytes += chunk.length;
+    });
+    p.client.on("end", () => (bytesAtEnd = bytes));
+    p.client.resume();
+    await client.closed;
+    fault.clear();
+    expect({ bytes, bytesAtEnd, events: client.events, errors: client.errors }).toEqual({
+      bytes: BIG,
+      bytesAtEnd: BIG,
+      events: CLEAN_CLOSE,
+      errors: [],
+    });
   });
 
   test("client.end() under 1-byte sends still delivers close_notify and peer sees clean 'end'", async () => {
-    using p = await connectedTLSPair();
-    let serverGotEnd = false;
-    p.serverSock.on("end", () => (serverGotEnd = true));
+    let serverSide!: ReturnType<typeof observe>;
+    using p = await connectedTLSPair(s => (serverSide = observe(s)));
+    const client = observe(p.client);
     fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
     p.client.end();
-    await once(p.serverSock, "close");
+    await Promise.all([serverSide.closed, client.closed]);
     fault.clear();
-    expect(serverGotEnd).toBe(true);
+    expect({
+      server: { events: serverSide.events, errors: serverSide.errors },
+      client: { events: client.events, errors: client.errors },
+    }).toEqual({
+      server: { events: CLEAN_CLOSE, errors: [] },
+      client: { events: CLEAN_CLOSE, errors: [] },
+    });
   });
 
   test("server.end() with recv → 0 immediately after (FIN before close_notify drained) reaches 'close'", async () => {
     // Exercises openssl.c on_end (TCP FIN under TLS): close_notify may not
     // have been read yet when the transport reports EOF.
     using p = await connectedTLSPair();
-    p.client.on("error", () => {});
+    const client = observe(p.client);
     // The client must consume its readable side for the allowHalfOpen:false
     // teardown to run: with "bye" left unread, Node never emits 'end' and never
     // destroys (stream_base_commons.js defers kMaybeDestroy until 'end').
-    p.client.resume();
+    const received = collect(p.client);
     fault.set({ syscall: "recv", action: "zero", after: 1, repeat: -1 });
     p.serverSock.end("bye");
-    await once(p.client, "close");
+    await client.closed;
     fault.clear();
-    // close_notify was truncated by the injected EOF, but the socket must
-    // still reach 'close' without hanging.
-    expect(p.client.destroyed).toBe(true);
+    // close_notify was truncated by the injected EOF, but the data read before
+    // it must be delivered and the socket must still reach 'close'.
+    expect({
+      received: received().toString(),
+      events: client.events,
+      errors: client.errors,
+      destroyed: p.client.destroyed,
+    }).toEqual({ received: "bye", events: CLEAN_CLOSE, errors: [], destroyed: true });
   });
 });
 
@@ -278,26 +305,59 @@ describe.skipIf(skip)("node:tls seeded syscall fuzz", () => {
   test("randomized short-I/O during established echo delivers intact and never crashes", async () => {
     const rand = makePrng(seed);
     for (let i = 0; i < 12; i++) {
-      let echoed = Buffer.alloc(0);
       using p = await connectedTLSPair(s => {
         s.on("data", c => s.write(c));
       });
-      p.client.on("error", () => {});
-      p.client.on("data", c => (echoed = Buffer.concat([echoed, c])));
+      const client = observe(p.client);
+      const echoed = collect(p.client);
 
       const plan = PLANS[Math.floor(rand() * PLANS.length)]!;
       fault.set({ ...plan, after: Math.floor(rand() * 2), repeat: -1 } as any);
 
       const payload = Buffer.alloc(128, i & 0xff);
       p.client.write(payload);
-      while (echoed.length < payload.length) {
+      while (echoed().length < payload.length) {
         await once(p.client, "data");
       }
       fault.clear();
-      expect(echoed.subarray(0, payload.length).equals(payload)).toBe(true);
+      expect(echoed()).toEqual(payload);
       p.client.destroy();
-      await once(p.client, "close").catch(() => {});
-      expect(p.client.destroyed).toBe(true);
+      await client.closed;
+      expect({ lastEvent: client.events.at(-1), errors: client.errors, destroyed: p.client.destroyed }).toEqual({
+        lastEvent: "close(hadError=false)",
+        errors: [],
+        destroyed: true,
+      });
     }
   });
 });
+
+// The loop's shared TLS plaintext buffer is one lazy 512 KiB malloc, and its
+// NULL return used to be ignored: SSL_read then wrote to
+// `NULL + LIBUS_RECV_BUFFER_PADDING`. Runs in a child because the allocation
+// happens once per event loop, on its first TLS socket. No isWindows skip —
+// the unchecked allocation is exactly the one that fails there.
+//
+// Last in the file: the child was started in beforeAll, so by now it has had
+// the whole run of in-process tests to finish.
+test.skipIf(!fault.available())(
+  "a failed per-loop TLS buffer allocation reports out of memory instead of faulting inside SSL_read",
+  async () => {
+    const { proc, result } = oomChild!;
+    const [stdout, stderr, exitCode] = await result;
+    // Anything past "ARMED" on stdout means a TLS socket survived the failed
+    // allocation and reached its read loop (see the fixture's markers).
+    const outOfMemory = stderr.includes("Bun has run out of memory.");
+    expect({
+      stdout,
+      outOfMemory,
+      // Only populated when the assertion is about to fail, so the diff shows why.
+      stderr: outOfMemory ? "" : stderr,
+      signalCode: proc.signalCode,
+    }).toEqual({ stdout: "ARMED\n", outOfMemory: true, stderr: "", signalCode: "SIGABRT" });
+    expect(exitCode).not.toBe(0);
+  },
+  // The child has already run alongside the other tests; this is the budget
+  // for whatever is left of an ASAN child's startup and crash under CI load.
+  15_000,
+);

--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -354,7 +354,13 @@ test.skipIf(!fault.available())(
       // Only populated when the assertion is about to fail, so the diff shows why.
       stderr: outOfMemory ? "" : stderr,
       signalCode: proc.signalCode,
-    }).toEqual({ stdout: "ARMED\n", outOfMemory: true, stderr: "", signalCode: "SIGABRT" });
+    }).toEqual({
+      stdout: "ARMED\n",
+      outOfMemory: true,
+      stderr: "",
+      // The crash handler ends in abort() on POSIX and in ExitProcess(3) on Windows.
+      signalCode: isWindows ? null : "SIGABRT",
+    });
     expect(exitCode).not.toBe(0);
   },
   // The child has already run alongside the other tests; this is the budget


### PR DESCRIPTION
### Problem
- `test/js/node/tls/tls-syscall-fault.test.ts` takes 10s on the debian 13 x64-asan lane. That puts it in the slowest 5 percent of test files.
- The per-loop TLS buffer OOM child is 5.4s of the 9.7s local run. Almost all of that is the debug build symbolizing its crash backtrace. The test then waits for it before any other test starts.
- The in-process cases asserted little: "is an Error", "is truthy", "is destroyed".

### Fix
- The child runs with `--debug-crash-handler-use-trace-string`, the flag the crash handler tests already use. It prints the crash reason line and skips symbolization (5.2s to 2.2s on its own).
- `beforeAll` starts the child and the last test awaits it, so it runs alongside the serial in-process tests. One shared TLS server replaces the per-test servers (about 15ms each in a debug build).
- Each in-process case now asserts the exact error (`code`, `syscall`, `message`), the bytes received, and the event order (`error` before `close`, `close` with `hadError`) with one `toEqual` per case. The child test asserts `stdout === "ARMED\n"`, the exact `Bun has run out of memory.` line, and `SIGABRT`, and checks stdout and stderr before the exit code.
- Verified: `bun bd test test/js/node/tls/tls-syscall-fault.test.ts` 9.73s before, 4.26s after (8 runs, 4.25s to 4.37s). 12 tests pass, 39 `expect()` calls (was 37). Also green with 16 CPU hogs and 3 copies of the file at once (8.4s to 9.3s each).

### Background
- `socketFaultInjection` (`bun:internal-for-testing`) arms process-wide rules in the `bsd_*` syscall wrappers of usockets. It exists only in ASAN builds, so the file skips everywhere else.
- The OOM fixture arms `ssl_loop_buffer`, the one-time 512 KiB plaintext buffer that `us_internal_init_loop_ssl_data` allocates on a loop's first TLS socket. It must run in a child because the allocation happens once per process.
- The faults are process-wide, so the in-process tests stay serial. The shared listening socket is not affected: the rules hit `recv` and `send` on connected sockets only, and each test drives one connection at a time.

<details><summary>Notes</summary>

- The child's remaining 2.2s is mostly the `bun:internal-for-testing` import (1.2s in a debug build) plus the TLS round trip and the crash handler. With the overlap, the last test waits 0.16s to 0.73s for it locally.
- Per-test times after the change: 0.41s, 0.16s, 0.10s, 0.06s, 0.11s, 0.06s, 0.04s, 0.09s, 0.05s, 0.05s, 0.63s (fuzz), 0.16s (OOM child). The rest of the 4.26s is module load.
- The fuzz case asserts `errors: []`, `destroyed: true`, and that the last event is `close(hadError=false)`. Some iterations emit `end` before `close` on `client.destroy()` and some do not, so the full event list is not asserted there.
- Probe output for the exact errors, with the debug build: both ECONNRESET cases produce `{ name: "Error", code: "ECONNRESET", syscall: "read", message: "read ECONNRESET" }` followed by `close(hadError=true)`. The `recv -> 0` cases produce `end`, `close(hadError=false)` with no error.
- Sanity check: with the fixture's `fault.set` commented out, the child test fails and the diff shows `READ DATA` on stdout and `signalCode: null`.
- `USE_SYSTEM_BUN=1 bun test <file>`: 12 skipped, no errors.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/tls-syscall-fault.test.ts

<!-- robobun:evidence:end -->