### PR TITLE
test(timers): run timer-heap-race fixtures concurrently and bound the atomics fixture by iterations

### DIFF
--- a/test/js/web/timers/timer-heap-atomics-fixture.ts
+++ b/test/js/web/timers/timer-heap-atomics-fixture.ts
@@ -1,15 +1,21 @@
+// Each worker runs PUMPS rounds of: arm a batch of short Atomics.waitAsync
+// timeouts, queue a few setTimeouts, notify. The main thread spins
+// Atomics.notify against the same address the whole time, so every worker's
+// RunLoop timers are re-armed from a foreign thread while the worker's own
+// loop drains them. The loop is bounded by iterations, not by the clock, so a
+// slow build gets the same number of cross-thread collisions as a fast one.
 declare var self: Worker;
 
-const DURATION_MS = Number(process.argv[2] ?? 3000);
+const PUMPS = Number(process.argv[2] ?? 100);
 const WORKERS = Number(process.argv[3] ?? 3);
 
 function noop() {}
 
 if (!Bun.isMainThread) {
   self.onmessage = (e: MessageEvent) => {
-    const { sab, durationMs } = e.data as { sab: SharedArrayBuffer; durationMs: number };
+    const { sab, pumps: total } = e.data as { sab: SharedArrayBuffer; pumps: number };
     const i32 = new Int32Array(sab);
-    const deadline = Date.now() + durationMs;
+    let pumps = 0;
 
     function pump() {
       for (let i = 0; i < 48; i++) {
@@ -18,10 +24,10 @@ if (!Bun.isMainThread) {
       }
       for (let i = 0; i < 8; i++) setTimeout(noop, i % 4);
       Atomics.notify(i32, 0, 8);
-      if (Date.now() < deadline) {
+      if (++pumps < total) {
         setTimeout(pump, 0);
       } else {
-        postMessage("done");
+        postMessage(pumps);
       }
     }
     pump();
@@ -31,13 +37,15 @@ if (!Bun.isMainThread) {
   const i32 = new Int32Array(sab);
   const workers: Worker[] = [];
   let done = 0;
+  let pumps = 0;
 
   for (let w = 0; w < WORKERS; w++) {
     const worker = new Worker(import.meta.url);
-    worker.onmessage = () => {
+    worker.onmessage = (e: MessageEvent) => {
+      pumps += e.data as number;
       if (++done === WORKERS) {
         for (const other of workers) other.terminate();
-        console.log("OK");
+        console.log(`OK ${done} workers ${pumps} pumps`);
         process.exit(0);
       }
     };
@@ -45,11 +53,10 @@ if (!Bun.isMainThread) {
       console.error("worker error:", e.message);
       process.exit(3);
     };
-    worker.postMessage({ sab, durationMs: DURATION_MS });
+    worker.postMessage({ sab, pumps: PUMPS });
     workers.push(worker);
   }
 
-  const deadline = Date.now() + DURATION_MS + 1000;
   function hammer() {
     for (let i = 0; i < 24; i++) {
       const w = Atomics.waitAsync(i32, 0, 0, 1 + (i % 5));
@@ -62,7 +69,7 @@ if (!Bun.isMainThread) {
       Atomics.notify(i32, 0, 2);
     }
     for (let i = 0; i < 4; i++) setTimeout(noop, i % 3);
-    if (Date.now() < deadline && done < WORKERS) setTimeout(hammer, 0);
+    if (done < WORKERS) setTimeout(hammer, 0);
   }
   hammer();
 }

--- a/test/js/web/timers/timer-heap-gc-fixture.ts
+++ b/test/js/web/timers/timer-heap-gc-fixture.ts
@@ -1,4 +1,4 @@
-const TICKS = 30;
+const TICKS = Number(process.argv[2] ?? 30);
 
 let garbage: unknown[] = [];
 let ticks = 0;

--- a/test/js/web/timers/timer-heap-race.test.ts
+++ b/test/js/web/timers/timer-heap-race.test.ts
@@ -2,9 +2,17 @@ import { expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import path from "node:path";
 
-async function runFixture(fixture: string, env: Record<string, string | undefined> = {}) {
+// Rounds of cross-thread timer churn per worker, and the number of workers.
+// About 3s on a debug ASAN build, well under 1s on a release build.
+const ATOMICS_PUMPS = 100;
+const ATOMICS_WORKERS = 3;
+// Full GCs driven from a setTimeout loop, so the per-VM RunLoop timer is
+// re-armed and popped next to the regular timer heap.
+const GC_TICKS = 30;
+
+async function runFixture(fixture: string, args: string[] = [], env: Record<string, string | undefined> = {}) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, fixture)],
+    cmd: [bunExe(), path.join(import.meta.dir, fixture), ...args],
     env: {
       ...bunEnv,
       // These make the debug build an order of magnitude slower; the fixtures need real wall time.
@@ -21,20 +29,26 @@ async function runFixture(fixture: string, env: Record<string, string | undefine
   return { stdout, stderr, signal: proc.signalCode, exitCode };
 }
 
-it("timer heap survives cross-thread Atomics.waitAsync timeout cancellation", async () => {
-  expect(await runFixture("timer-heap-atomics-fixture.ts")).toEqual({
-    stdout: "OK\n",
-    stderr: expect.any(String),
-    signal: null,
-    exitCode: 0,
-  });
-}, 20_000);
+it.concurrent(
+  "timer heap survives cross-thread Atomics.waitAsync timeout cancellation",
+  async () => {
+    expect(await runFixture("timer-heap-atomics-fixture.ts", [String(ATOMICS_PUMPS), String(ATOMICS_WORKERS)])).toEqual(
+      {
+        stdout: `OK ${ATOMICS_WORKERS} workers ${ATOMICS_WORKERS * ATOMICS_PUMPS} pumps\n`,
+        stderr: expect.any(String),
+        signal: null,
+        exitCode: 0,
+      },
+    );
+  },
+  20_000,
+);
 
-it.skipIf(!isDebug)(
+it.concurrent.skipIf(!isDebug)(
   "timer heap stays consistent while GC re-arms the RunLoop timer",
   async () => {
-    expect(await runFixture("timer-heap-gc-fixture.ts")).toEqual({
-      stdout: "ok 30\n",
+    expect(await runFixture("timer-heap-gc-fixture.ts", [String(GC_TICKS)])).toEqual({
+      stdout: `ok ${GC_TICKS}\n`,
       stderr: expect.any(String),
       signal: null,
       exitCode: 0,
@@ -43,10 +57,10 @@ it.skipIf(!isDebug)(
   20_000,
 );
 
-it.skipIf(!isASAN)(
+it.concurrent.skipIf(!isASAN)(
   "terminating a worker with pending Atomics.waitAsync tickets does not leak deferred-work tasks",
   async () => {
-    const { stdout, stderr, signal, exitCode } = await runFixture("timer-heap-atomics-teardown-fixture.ts", {
+    const { stdout, stderr, signal, exitCode } = await runFixture("timer-heap-atomics-teardown-fixture.ts", [], {
       BUN_DESTRUCT_VM_ON_EXIT: "1",
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
       LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${path.join(import.meta.dir, "..", "..", "..", "leaksan.supp")}`,


### PR DESCRIPTION
### Problem
- `test/js/web/timers/timer-heap-race.test.ts` is in the slowest 5 percent of test files in CI: 12s on debian 13 x64-asan (build 110300). Locally on the debug ASAN build it takes 11.3s.
- The three tests run serially (3.5s + 2.1s + 3.7s) although each one spawns one independent child. The atomics fixture runs for a fixed 3s of wall time, so a release build does 25x more rounds than a debug build for the same 3s.

### Fix
- The three tests run with `it.concurrent`. The file takes as long as its slowest child.
- `timer-heap-atomics-fixture.ts` runs a fixed number of pump rounds per worker instead of a clock deadline. The test passes the count (100 rounds, 3 workers). 100 rounds is what the old 3s gave on the debug ASAN build, the lane where the heap assertion lives, so that lane keeps the same number of cross-thread collisions. The main thread hammers until every worker reports done.
- Assertions: the atomics fixture reports `OK 3 workers 300 pumps` and the test asserts the exact line from the shared constants. The GC fixture takes its tick count from the test (`GC_TICKS = 30`) and the test asserts `ok 30` from the same constant. The LeakSanitizer stderr check on the teardown test is unchanged.
- Verified: `bun bd test test/js/web/timers/timer-heap-race.test.ts` went from 11.28s to 5.6s (three runs: 5.63s, 5.55s, 5.56s). `USE_SYSTEM_BUN=1 bun test` on the same file went from 3.2s to 0.2s. Also ran `test/js/web/timers/setTimeout.test.js` and `timer-gc-roots.test.ts`: the same four pre-existing debug ASAN failures as on main (the three RSS leak tests and one 5s timeout), none in files this PR touches.

### Background
- The atomics fixture guards #33131. `Atomics.waitAsync` timeouts are `WTF::RunLoop` timers that Bun keeps in its own heap (`All.wtf_timers` in `src/runtime/timer/mod.rs`). Other threads can touch that heap, so it has its own mutex, separate from the `setTimeout` heap.
- The teardown fixture guards #34293: a worker terminated with live `waitAsync` tickets must drop its deferred-work tasks, not enqueue them into the dead loop. It runs only under ASAN with `detect_leaks=1`.
- The 20s ceilings stay. Each fixture still runs for seconds on a debug build and the default is 5s.

<details><summary>Notes</summary>

- About 3s of the teardown test is LeakSanitizer's exit scan. A trivial `bun -e 'console.log(1)'` with `ASAN_OPTIONS=detect_leaks=1` takes 3.3s on the debug build. The fixture itself is 0.5s. That cost is not reachable from the test and is now overlapped with the other two tests.
- I tried to calibrate the round count against the original race by building a debug binary with the `wtf_timers` pop moved outside its lock. The fixture ran 30s without tripping. The vendored JSC no longer stops a `waitAsync` timer from the notifying thread (`Waiter::clearTimer` in `WaiterListManager.h` only drops its reference), and `DeferredWorkTimer::scheduleWorkSoonIfActive` goes through Bun's `onScheduleWorkSoon` hook instead of a RunLoop timer. So the cross-thread cancel the fixture was written against does not exist in this tree, and the count cannot be proven against it. The count keeps the debug ASAN lane at its previous iteration budget.
- Release builds did about 2500 rounds per worker in the old 3s. They now do 100. The release binary compiles out the heap assertion, so the debug lane is the one that detects a heap corruption.
- GC fixture per-tick cost on the debug build is dominated by `Bun.gc(true)`, not by the 16ms delay, so the delay is unchanged.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/timers/timer-heap-race.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/timers/timer-heap-race.test.ts
bun test v1.4.3 (e0a2b82fd)

test/js/web/timers/timer-heap-race.test.ts:
(pass) timer heap stays consistent while GC re-arms the RunLoop timer [1945.78ms]
(pass) timer heap survives cross-thread Atomics.waitAsync timeout cancellation [3519.14ms]
(pass) terminating a worker with pending Atomics.waitAsync tickets does not leak deferred-work tasks [3624.34ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [5.55s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/timers/timer-heap-atomics-fixture.ts | 27 +++++++++------
 test/js/web/timers/timer-heap-gc-fixture.ts      |  2 +-
 test/js/web/timers/timer-heap-race.test.ts       | 44 ++++++++++++++++--------
 3 files changed, 47 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
test/js/web/timers/timer-heap-atomics-fixture.ts      1      2     10
test/js/web/timers/timer-heap-gc-fixture.ts           1      2      7
test/js/web/timers/timer-heap-race.test.ts            1      2      6
```

</details>

**root cause** · written by the author bot

The file was slow because its three independent subprocess tests ran serially and the atomics fixture spun against a fixed wall-clock deadline rather than stopping once it had done a bounded amount of race-provoking work, so every run paid the full sleep regardless of how quickly the race reproduced. The fix switches the tests to it.concurrent so the file's wall time collapses to the slowest single fixture, and replaces the clock-based loop with a fixed per-worker pump budget that each worker reports back, calibrated to match the previous duration on the debug ASAN lane where the heap asser…

<!-- robobun:evidence:end -->