### PR TITLE
test(bake): speed up dev-and-prod.test.ts and tighten its assertions

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -848,6 +848,8 @@ export class Client extends EventEmitter {
   webSocketMessagesAllowed = true;
   /** Every `received-hmr-event` ack so far, counted before any listener runs. */
   acksReceived = 0;
+  /** The page this client shows. */
+  url: string;
 
   constructor(
     url: string,
@@ -855,6 +857,7 @@ export class Client extends EventEmitter {
   ) {
     super();
     activeClient = this;
+    this.url = url;
     const proc = Bun.spawn({
       cmd: [
         node,
@@ -903,20 +906,32 @@ export class Client extends EventEmitter {
     proc.exited.then(exitCode => (this.output.exitCode = exitCode));
   }
 
-  hardReload(options: { errors?: ErrorSpec[] } = {}) {
+  /**
+   * Reloads the page. With `url`, the client loads that page of the same
+   * server instead, as a browser does on navigation: the old window is
+   * closed, its HMR socket with it, and a new window loads the page.
+   */
+  hardReload(options: { errors?: ErrorSpec[]; url?: string } = {}) {
     return withAnnotatedStack(snapshotCallerLocation(), async () => {
       await maybeWaitInteractive("hard-reload");
       if (this.exited) throw new Error("Client is not running.");
+      if (options.url) this.url = new URL(options.url, this.url).href;
+      const message = { type: "hard-reload", args: [this.url] };
       if (!this.hmr) {
-        this.#proc.send({ type: "hard-reload" });
+        this.#proc.send(message);
         return;
       }
       await this.drainAcks();
       const loaded = this.waitForPageLoad();
-      this.#proc.send({ type: "hard-reload" });
+      this.#proc.send(message);
       await loaded;
       await this.expectErrorOverlay(options.errors ?? []);
     });
+  }
+
+  /** Loads another page of the same server in this client. See `hardReload`. */
+  navigate(url: string, options: { errors?: ErrorSpec[] } = {}) {
+    return this.hardReload({ ...options, url });
   }
 
   /**

--- a/test/bake/client-fixture.mjs
+++ b/test/bake/client-fixture.mjs
@@ -453,6 +453,8 @@ process.on("message", async message => {
     });
   }
   if (message.type === "hard-reload") {
+    // The harness sends the page to load: the current one, or another page on a navigation.
+    url = new URL(message.args[0]);
     expectingReload = true;
     await handleReload();
   }

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -1,6 +1,11 @@
 // Tests which apply to both dev and prod. They are run twice.
+//
+// Every case boots a server (a dev server, then a production build) and waits
+// for it to exit. That is most of a case's time, so pages that only differ in
+// their HTML live in one project, one route each.
+import { expect } from "bun:test";
 import { writeFileSync } from "node:fs";
-import { devAndProductionTest, devTest, emptyHtmlFile, WAIT_MULTIPLIER } from "./bake-harness";
+import { Dev, devAndProductionTest, devTest, emptyHtmlFile, WAIT_MULTIPLIER } from "./bake-harness";
 
 const hmrSelfAcceptingModule = (label: string) => `
   console.log(${JSON.stringify(label)});
@@ -9,30 +14,56 @@ const hmrSelfAcceptingModule = (label: string) => `
   }
 `;
 
-devAndProductionTest("define config via bunfig.toml", {
+/**
+ * Fetches a page and splits off the tags the bundler injects in place of the
+ * page's own `<script>` and `<link rel="stylesheet">` tags: one `<link>` per
+ * stylesheet, the page's bundle as one module script and, in development, the
+ * dev server's inline snippet. `html` keeps a marker where they were, with the
+ * whitespace between tags collapsed so the expected document fits on one line.
+ */
+async function fetchPage(dev: Dev, url: string) {
+  const res = await dev.fetch(url);
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toBe("text/html;charset=utf-8");
+  const html = await res.text();
+  const injected = html.match(
+    /((?:<link rel="stylesheet" (?:crossorigin )?href="[^"]+">)*)<script type="module" crossorigin src="([^"]+)"(?: data-bun-dev-server-script)?><\/script>(?:<script>[^<]*<\/script>)?/,
+  );
+  if (!injected) throw new Error("The bundler did not inject its script tag:\n" + html);
+  return {
+    html: html.replace(injected[0], "<!--injected-->").replace(/\s+/g, " ").replaceAll("> <", "><").trim(),
+    styles: Array.from(injected[1].matchAll(/href="([^"]+)"/g), m => m[1]),
+    script: injected[2],
+  };
+}
+
+/** The dev server's "Bundled page" lines so far, without colors and timings. */
+function bundledPages(dev: Dev) {
+  return dev.output.lines
+    .map(line => line.replace(/\x1b\[\d+m/g, "").replaceAll("\\", "/"))
+    .filter(line => line.startsWith("Bundled page"))
+    .map(line => line.replace(/ in \d+ms/, ""));
+}
+
+devAndProductionTest("html entry points of every shape", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      console.log("a=" + DEFINE);
-    `,
     "bunfig.toml": `
       [serve.static]
       define = {
         "DEFINE" = "\\"HELLO\\""
       }
     `,
-  },
-  async test(dev) {
-    const c = await dev.client("/");
-    await c.expectMessage("a=HELLO");
-  },
-});
-devAndProductionTest("invalid html does not crash 1", {
-  files: {
-    "public/index.html": `
+    // define config via bunfig.toml
+    "define/index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["../src/define.ts"],
+    }),
+    "src/define.ts": `
+      console.log("a=" + DEFINE);
+    `,
+    // invalid html does not crash: a self-closing <script /> swallows the rest
+    // of the document as script text.
+    "invalid/index.html": `
       <!DOCTYPE html>
       <html>
         <head>
@@ -45,24 +76,8 @@ devAndProductionTest("invalid html does not crash 1", {
         </body>
       </html>
     `,
-    "src/app/index.tsx": `
-      console.log("hello");
-    `,
-    "src/app/styles.css": `
-      body {
-        background-color: red;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("hello");
-    await c.style("body").backgroundColor.expect.toBe("red");
-  },
-});
-devAndProductionTest("missing head end tag works fine", {
-  files: {
-    "public/index.html": `
+    // missing head end tag works fine
+    "no-head-end/index.html": `
       <!DOCTYPE html>
       <html>
         <head>
@@ -74,49 +89,16 @@ devAndProductionTest("missing head end tag works fine", {
         </body>
       </html>
     `,
-    "src/app/index.tsx": `
-      console.log("hello");
-    `,
-    "src/app/styles.css": `
-      body {
-        background-color: red;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("hello");
-    await c.style("body").backgroundColor.expect.toBe("red");
-  },
-});
-devAndProductionTest("missing all meta tags works fine", {
-  files: {
-    "public/index.html": `
+    // missing all meta tags works fine
+    "no-meta/index.html": `
       <title>Dashboard</title>
       <link rel="stylesheet" href="../src/app/styles.css"></link>
 
       <div id="root" />
       <script type="module" src="../src/app/index.tsx"></script>
     `,
-    "src/app/index.tsx": `
-      console.log("hello");
-    `,
-    "src/app/styles.css": `
-      body {
-        background-color: red;
-      }
-    `,
-  },
-  async test(dev) {
-    await dev.fetch("/").expect.toInclude("root");
-    await using c = await dev.client("/");
-    await c.expectMessage("hello");
-    await c.style("body").backgroundColor.expect.toBe("red");
-  },
-});
-devAndProductionTest("inline script and styles appear", {
-  files: {
-    "public/index.html": `
+    // inline script and styles appear
+    "inline/index.html": `
       <!DOCTYPE html>
       <html>
         <head>
@@ -128,13 +110,99 @@ devAndProductionTest("inline script and styles appear", {
         </body>
       </html>
     `,
+    "src/app/index.tsx": `
+      console.log("hello");
+    `,
+    "src/app/styles.css": `
+      body {
+        background-color: red;
+      }
+    `,
   },
   async test(dev) {
-    await dev.fetch("/").expect.toInclude("hello");
-    await dev.fetch("/").expect.not.toInclude("hello 3"); // TODO:
-    await using c = await dev.client("/");
+    const isDev = dev.nodeEnv === "development";
+    const script = expect.stringMatching(
+      isDev ? /^\/_bun\/client\/index-[0-9a-f]{16}\.js$/ : /^\/chunk-[a-z0-9]+\.js$/,
+    );
+    const style = expect.stringMatching(isDev ? /^\/_bun\/asset\/[0-9a-f]{16}\.css$/ : /^\/chunk-[a-z0-9]+\.css$/);
+
+    // define config via bunfig.toml
+    expect(await fetchPage(dev, "/define")).toEqual({
+      html: "<!DOCTYPE html><html><head><!--injected--></head><body></body></html>",
+      styles: [],
+      script,
+    });
+    // One client visits every page, as a browser that navigates between them.
+    await using c = await dev.client("/define");
+    await c.expectMessage("a=HELLO");
+
+    // invalid html does not crash 1
+    const invalid = await fetchPage(dev, "/invalid");
+    expect(invalid).toEqual({
+      html: '<!DOCTYPE html><html><head><title>Dashboard</title><!--injected--></head><body><div id="root" />',
+      styles: [style],
+      script,
+    });
+    await c.navigate("/invalid");
+    await c.expectMessage("hello");
+    await c.style("body").backgroundColor.expect.toBe("red");
+
+    // missing head end tag works fine
+    const noHeadEnd = await fetchPage(dev, "/no-head-end");
+    expect(noHeadEnd).toEqual({
+      html: isDev
+        ? '<!DOCTYPE html><html><head><title>Dashboard</title></link><body><div id="root" /></body><!--injected--></html>'
+        : '<!DOCTYPE html><html><head><title>Dashboard</title></link><body><div id="root" /><!--injected--></body></html>',
+      styles: [style],
+      script,
+    });
+    await c.navigate("/no-head-end");
+    await c.expectMessage("hello");
+    await c.style("body").backgroundColor.expect.toBe("red");
+
+    // missing all meta tags works fine
+    const noMeta = await fetchPage(dev, "/no-meta");
+    expect(noMeta).toEqual({
+      html: '<title>Dashboard</title></link><div id="root" /><!--injected-->',
+      styles: [style],
+      script,
+    });
+    await c.navigate("/no-meta");
+    await c.expectMessage("hello");
+    await c.style("body").backgroundColor.expect.toBe("red");
+
+    // The three pages import the same stylesheet, so they share one URL.
+    expect(noHeadEnd.styles).toEqual(invalid.styles);
+    expect(noMeta.styles).toEqual(invalid.styles);
+    const css = await dev.fetch(invalid.styles[0]);
+    expect(css.status).toBe(200);
+    expect(css.headers.get("content-type")).toBe("text/css;charset=utf-8");
+    expect(await css.text()).toBe(
+      isDev ? "/* src/app/styles.css */\nbody {\n  background-color: red;\n}\n" : "body{background-color:red}\n",
+    );
+
+    // inline script and styles appear, untouched by the bundler
+    expect(await fetchPage(dev, "/inline")).toEqual({
+      html: '<!DOCTYPE html><html><head><title>Dashboard</title><style> body { background-color: red; } </style><!--injected--></head><body><script> console.log("hello " + (1 + 2)); </script></body></html>',
+      styles: [],
+      script,
+    });
+    await c.navigate("/inline");
     await c.expectMessage("hello 3");
     await c.style("body").backgroundColor.expect.toBe("red");
+
+    if (isDev) {
+      // Each page is bundled once, on its first request. The page loads above
+      // are served from that bundle.
+      await dev.output.waitForLine(/Bundled page .*inline[\\/]index\.html/);
+      expect(bundledPages(dev)).toEqual([
+        "Bundled page: define/index.html",
+        "Bundled page: invalid/index.html",
+        "Bundled page: no-head-end/index.html",
+        "Bundled page: no-meta/index.html",
+        "Bundled page: inline/index.html",
+      ]);
+    }
   },
 });
 // TODO: revive production


### PR DESCRIPTION
### Problem
- `test/bake/dev-and-prod.test.ts` takes 12s on the darwin aarch64 lane (build 110300). Its five `devAndProductionTest` cases each boot a dev server, a production build, and a happy-dom client per mode. That is 10 servers and 10 clients for five pages that only differ in their HTML.
- The cases asserted one console message and one computed style. None checked the served document, the injected URLs, the stylesheet body, or the dev server's log.

### Fix
- The five cases are one project with one route per page. One client per mode visits every page through the new `Client.navigate(url)`. The two `devTest` cases are unchanged. 12 tests become 4, with the same writes, messages and style checks.
- Each page now asserts its exact served document (with the injected tags split off), the shape of the bundle and stylesheet URLs, that the three stylesheet pages share one URL, the stylesheet's status, content type and body, and in development the exact list of "Bundled page" lines (each page once). `expect()` calls: 27 to 62.
- Harness (small, general): `Client` keeps its `url`, `hardReload` accepts a `url` and `navigate(url)` wraps it. The fixture's `hard-reload` message carries the page to load. Existing `hardReload` callers send their own URL, so they are unchanged in behavior.
- Verified: `bun bd test test/bake/dev-and-prod.test.ts` debug+ASAN, before 26.2s, after 11.5s to 12.0s (4 runs). Release (system bun): 4.8s before, 2.0s after. Also `dev/hot.test.ts`, `dev/css.test.ts`, `dev/react-spa.test.ts`, `dev/html.test.ts` (the other `hardReload` users): 43 pass.

### Background
- `devAndProductionTest` (`test/bake/bake-harness.ts`) runs a case twice: `NODE_ENV=development` with a dev server and HMR, then `NODE_ENV=production` with a build at server start. With several HTML files the harness maps `x/index.html` to the route `/x`.
- `dev.client(route)` spawns a node process that loads the page in happy-dom, reports its `console.log` output over IPC and, in development, acks each page load once its stylesheets settled. `hardReload` closes the window and loads the page again in the same process.
- The bundler drops a page's own `<script>` and `<link rel="stylesheet">` tags and injects its own: a `<link>` per stylesheet, one module script and, in development, an inline snippet. Where it injects depends on the page: before `</head>`, before `</body>` or `</html>`, or at the end of a page without those tags.

<details><summary>Notes</summary>

**Per-test timing, debug+ASAN, local.** Before: dev 1.8s to 2.2s per case, prod 1.8s to 1.9s per case, 12 tests, 26.2s. After: the merged case 2.7s (dev) and 2.1s (prod), the two `devTest` cases 1.9s and 2.1s, 11.5s to 12.0s over 4 runs. An intermediate shape with one client per page on the shared server measured 13.8s to 14.4s, so the client spawn is the second cost after the server.

**Release, system bun 1.4.1.** Before 4.75s and 4.78s, after 2.00s and 2.03s. A release server costs little, so the client spawns set the time there. The darwin lane is a release build.

**What each page asserts now.**
- `/define` (define config via bunfig.toml): the document, no stylesheet, the bundle URL, the client logs `a=HELLO`.
- `/invalid` (invalid html does not crash): the self-closing `<script />` swallows the rest of the document as script text, so the served document ends after `<div id="root" />`. Both modes serve the same document. The client still logs `hello` and the body is red.
- `/no-head-end` (missing head end tag): the stray `</link>` stays, the dev server injects before `</html>` and the production build before `</body>`. The assertion is per mode.
- `/no-meta` (missing all meta tags): the tags are appended at the end.
- `/inline`: the `<style>` and the inline `<script>` are served verbatim. This replaces the old `not.toInclude("hello 3")` check.
- The stylesheet: `text/css;charset=utf-8`, `/* src/app/styles.css */` plus the rule in development, `body{background-color:red}` in production.
- Development only: the `Bundled page` lines are exactly one per page, in request order, after `waitForLine` on the last one. The client loads are served from the cached bundle.

**The production runtime import case** stays a `devTest`. A probe that served the same page in production logged nothing and timed out, which matches the `TODO: revive production` above it. The block and "hmr handles rapid consecutive edits" are untouched, so #35662 still applies.

**Related PRs.** #40337 and #41032 merge cases in `dev/css.test.ts` and `dev/html.test.ts` with file-local helpers and no harness change. #40541 adds a `concurrent` option to `devTest`. None of them adds navigation, and this PR does not touch the code they change. #40357 edits the same fixture in `createWindow` and `loadPage`, not the message handler.

**Not changed.** `test/expected-durations.json` is regenerated from CI.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev-and-prod.test.ts

<!-- robobun:evidence:end -->