### PR TITLE
test(websocket): saturate the socket instead of sending 64 MiB in websocket-buffered-amount.test.ts

### DIFF
--- a/test/js/web/websocket/websocket-buffered-amount.test.ts
+++ b/test/js/web/websocket/websocket-buffered-amount.test.ts
@@ -3,22 +3,29 @@ import { tls } from "harness";
 import crypto from "node:crypto";
 import net from "node:net";
 import nodeTls from "node:tls";
+import { WebSocket as WS } from "ws";
 
 const CHUNK = new Uint8Array(64 * 1024);
-const TOTAL = 1024; // 64 MiB, far past any socket/TLS buffer
-const TOTAL_BYTES = TOTAL * CHUNK.byteLength;
 // Each binary frame is header (10 bytes for a 64 KiB payload) + 4-byte mask + payload.
-const FRAMING_PER_CHUNK = 14;
+const FRAME = CHUNK.byteLength + 14;
+// Upper bound on what the kernel (and any in-process proxy) may absorb before
+// the client has to start queueing. Far above what any platform takes on loopback.
+const MAX_TO_SATURATE = 1024;
+// Frames sent on top of a saturated socket. Every one of them must be counted.
+const EXTRA = 64;
 
 // A raw origin that completes the WebSocket upgrade and then reads only when
 // told to, so the client's send side has to queue. It sees plaintext frames
 // (TLS, when any, terminates here or at the proxy), so the byte count it
-// resolves on is payload plus framing.
+// reports is payload plus framing.
 function rawOrigin(secure: boolean) {
   const { promise: upgraded, resolve: resolveUpgraded } = Promise.withResolvers<net.Socket>();
   let received = 0;
-  const { promise: gotAll, resolve: resolveGotAll } = Promise.withResolvers<void>();
+  let waitingFor = Infinity;
+  let resolveReceived = () => {};
+  const sockets = new Set<net.Socket>();
   function onConnection(sock: net.Socket) {
+    sockets.add(sock);
     sock.once("data", head => {
       const key = /Sec-WebSocket-Key: (.+)\r\n/.exec(head.toString("latin1"))![1].trim();
       const accept = crypto
@@ -32,7 +39,7 @@ function rawOrigin(secure: boolean) {
       sock.pause();
       sock.on("data", (chunk: Buffer) => {
         received += chunk.length;
-        if (received >= TOTAL * (CHUNK.byteLength + FRAMING_PER_CHUNK)) resolveGotAll();
+        if (received >= waitingFor) resolveReceived();
       });
       resolveUpgraded(sock);
     });
@@ -47,8 +54,18 @@ function rawOrigin(secure: boolean) {
         server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
       ),
     upgraded,
-    gotAll,
-    close: () => server.close(),
+    // Resolves with the exact byte count once at least `bytes` have arrived.
+    receive(bytes: number): Promise<number> {
+      waitingFor = bytes;
+      const { promise, resolve } = Promise.withResolvers<void>();
+      resolveReceived = resolve;
+      if (received >= waitingFor) resolve();
+      return promise.then(() => received);
+    },
+    close: () => {
+      for (const sock of sockets) sock.destroy();
+      server.close();
+    },
   };
 }
 
@@ -82,6 +99,29 @@ function open(ws: WebSocket): Promise<void> {
   return new Promise(resolve => (ws.onopen = () => resolve()));
 }
 
+// Sends 64 KiB frames to a peer that is not reading. The kernel absorbs the
+// first few MiB, so bufferedAmount stays 0 until the socket is saturated. From
+// then on nothing drains until the event loop turns, so every further frame
+// must add exactly its framed size. Returns the number of frames sent.
+function sendUntilCounted(ws: { send(data: Uint8Array): void; readonly bufferedAmount: number }): number {
+  expect(ws.bufferedAmount).toBe(0);
+  let sent = 0;
+  while (ws.bufferedAmount === 0 && sent < MAX_TO_SATURATE) {
+    ws.send(CHUNK);
+    sent++;
+  }
+  // At most the frame that did not fit (through a TLS proxy tunnel it is that
+  // frame's ciphertext, a few record headers larger).
+  const saturated = ws.bufferedAmount;
+  expect(saturated).toBeGreaterThan(0);
+  expect(saturated).toBeLessThan(2 * FRAME);
+
+  for (let i = 0; i < EXTRA; i++) ws.send(CHUNK);
+  sent += EXTRA;
+  expect(ws.bufferedAmount).toBe(saturated + EXTRA * FRAME);
+  return sent;
+}
+
 const MODES = [
   { name: "ws", secure: false, proxy: null },
   { name: "wss", secure: true, proxy: null },
@@ -103,29 +143,25 @@ for (const mode of MODES) {
         });
         await open(ws);
         const peer = await origin.upgraded;
-        expect(ws.bufferedAmount).toBe(0);
 
-        for (let i = 0; i < TOTAL; i++) ws.send(CHUNK);
-
-        // The kernel and any proxy absorbed some; the rest is ours to report.
+        const sent = sendUntilCounted(ws);
         const queued = ws.bufferedAmount;
-        expect(queued).toBeGreaterThan(TOTAL_BYTES / 2);
-        expect(queued).toBeLessThanOrEqual(TOTAL * (CHUNK.byteLength + FRAMING_PER_CHUNK));
 
         // Only what the kernel can still absorb drains while the peer isn't reading.
         await new Promise(resolve => setImmediate(resolve));
+        expect(ws.bufferedAmount).toBeGreaterThan(0);
         expect(ws.bufferedAmount).toBeLessThanOrEqual(queued);
-        expect(ws.bufferedAmount).toBeGreaterThan(TOTAL_BYTES / 2);
 
         peer.resume();
-        await origin.gotAll;
+        expect(await origin.receive(sent * FRAME)).toBe(sent * FRAME);
         expect(ws.bufferedAmount).toBe(0);
         ws.close();
+        expect(ws.bufferedAmount).toBe(0);
       } finally {
         proxy?.close();
         origin.close();
       }
-    }, 60_000);
+    });
   });
 }
 
@@ -154,22 +190,19 @@ describe("WebSocket.bufferedAmount", () => {
   });
 
   it("ws package reports the same number", async () => {
-    const { WebSocket: WS } = await import("ws");
     const origin = rawOrigin(false);
     const originPort = await origin.listen();
     try {
       const ws = new WS(`ws://127.0.0.1:${originPort}`);
       await new Promise(resolve => ws.once("open", resolve));
       const peer = await origin.upgraded;
-      expect(ws.bufferedAmount).toBe(0);
-      for (let i = 0; i < TOTAL; i++) ws.send(CHUNK);
-      expect(ws.bufferedAmount).toBeGreaterThan(TOTAL_BYTES / 2);
+      const sent = sendUntilCounted(ws);
       peer.resume();
-      await origin.gotAll;
+      expect(await origin.receive(sent * FRAME)).toBe(sent * FRAME);
       expect(ws.bufferedAmount).toBe(0);
       ws.close();
     } finally {
       origin.close();
     }
-  }, 60_000);
+  });
 });


### PR DESCRIPTION
### Problem
- `test/js/web/websocket/websocket-buffered-amount.test.ts` is in the slowest 5 percent of test files. It takes 13s on the Windows 2019 x64 lane (build 110300) and 8.8s on a local Windows release build.
- Six of its seven tests each send 64 MiB (1024 frames of 64 KiB) to an origin that does not read. That is 384 MiB per run, most of it through TLS and an in-process CONNECT proxy. The two `wss via proxy` modes take 4.1s each on Windows.

### Fix
- `sendUntilCounted` sends frames until `bufferedAmount` first rises above 0 (the kernel is full), then sends 64 more. It asserts that the count grows by exactly `64 * 65550` bytes: once a frame is queued, `send_frame` appends every later frame to `send_buffer` without a write (`src/http_jsc/websocket_client.rs:1257`), so the increment is deterministic.
- The origin now resolves with its exact byte count. The tests assert it equals the framed bytes sent, not `>=`. They also assert `bufferedAmount` is 0 right after `close()`, and that it stays above 0 after one event loop turn while the peer is paused.
- The 60s per-test timeouts are gone. The origin destroys its sockets on close so a paused peer does not outlive the test.
- Verified: Linux debug `bun bd test`: 7.30s before, 3.48s after (1.86s of that is import overhead). Linux release: 589ms before, 152ms after. Windows x64 release: 8.83s before, 190ms after. Five repeat runs on each platform pass.

### Background
- `WebSocket.bufferedAmount` reports the bytes of framed messages the client has not written to the socket yet. Bun counts framing (header and mask), so a 64 KiB binary frame adds 65550 bytes.
- The client writes to the socket on `send()` while nothing is queued. As soon as a write comes back short, it queues the rest and every later frame, and drains on the writable event.
- Through an `https://` proxy the client writes through a TLS tunnel. The first queued bytes are that frame's ciphertext (65660 bytes, record headers included), which is why the first-queued bound is `2 * FRAME` and not `FRAME`.

<details><summary>Notes</summary>

Saturation point, release builds:
- Linux loopback: about 41 frames (2.5 MiB) before the first short write, in every mode. The kernel absorbs nothing more after a tick.
- Windows loopback: 2 to 4 frames. First queued amount is 65550 (the whole frame, the write returns 0), 124 through an `http://` proxy to a `wss` origin, and 65660 through an `https://` proxy.

`it.concurrent` was tried and reverted. The origin, proxy, and client run on one thread, so the file time did not change (3.53s vs 3.48s) and the interleaving adds risk for no gain.

PR #31761 appends new tests to the end of this file and does not touch the code this PR changes.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/websocket/websocket-buffered-amount.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/websocket/websocket-buffered-amount.test.ts
bun test v1.4.3 (e0a2b82fd)

test/js/web/websocket/websocket-buffered-amount.test.ts:
(pass) WebSocket.bufferedAmount (ws) > counts bytes the peer has not accepted and drains to 0 [404.85ms]
(pass) WebSocket.bufferedAmount (wss) > counts bytes the peer has not accepted and drains to 0 [285.45ms]
(pass) WebSocket.bufferedAmount (wss via http:// proxy) > counts bytes the peer has not accepted and drains to 0 [146.04ms]
(pass) WebSocket.bufferedAmount (wss via https:// proxy) > counts bytes the peer has not accepted and drains to 0 [130.23ms]
(pass) WebSocket.bufferedAmount (ws via https:// proxy) > counts bytes the peer has not accepted and drains to 0 [97.97ms]
(pass) WebSocket.bufferedAmount > is 0 once a small message has been written [35.44ms]
(pass) WebSocket.bufferedAmount > ws package reports the same number [112.99ms]

 7 pass
 0 fail
 53 expect() calls
Ran 7 tests across 1 file. [3.49s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../websocket/websocket-buffered-amount.test.ts    | 79 +++++++++++++++-------
 1 file changed, 56 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
test/js/web/websocket/websocket-buffered-amount.test.ts      1      2     10
```

</details>

**root cause** · written by the author bot

The test file was slow because six of its seven tests each pushed a fixed 64 MiB through an in-process origin and proxy, roughly 384 MiB per run with much of it over TLS, far more than needed to observe backpressure. The fix sends frames only until bufferedAmount first rises, then sends a known number more and asserts the exact increment, with the origin reporting its exact byte count for equality checks and a new assertion that bufferedAmount is 0 after close. This cuts Windows wall time from 8.83s to 190ms while replacing loose bounds with deterministic values.

<!-- robobun:evidence:end -->