### PR TITLE
fix(image): apply embedded CMYK JPEG ICC profiles

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -40,6 +40,7 @@ Bun statically links these libraries:
 | [`libuv`](https://github.com/libuv/libuv) (on Windows) | MIT |
 | [`libdeflate`](https://github.com/ebiggers/libdeflate) | MIT |
 | [`libjpeg-turbo`](https://github.com/libjpeg-turbo/libjpeg-turbo) | [BSD 3-Clause / IJG / zlib](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/LICENSE.md) |
+| [`Little CMS`](https://github.com/mm2/Little-CMS) | [MIT](https://github.com/mm2/Little-CMS/blob/master/LICENSE) |
 | [`libspng`](https://github.com/randy408/libspng) | BSD 2-Clause |
 | [`libwebp`](https://github.com/webmproject/libwebp) | BSD 3-Clause |
 | [`highway`](https://github.com/google/highway) | Apache 2.0 |

--- a/scripts/build/deps/index.ts
+++ b/scripts/build/deps/index.ts
@@ -16,6 +16,7 @@ import { brotli } from "./brotli.ts";
 import { cares } from "./cares.ts";
 import { hdrhistogram } from "./hdrhistogram.ts";
 import { highway } from "./highway.ts";
+import { lcms2 } from "./lcms2.ts";
 import { libarchive } from "./libarchive.ts";
 import { libdeflate } from "./libdeflate.ts";
 import { libjpegTurbo } from "./libjpeg-turbo.ts";
@@ -57,6 +58,7 @@ export const allDeps: readonly Dependency[] = [
   libjpegTurbo,
   libspng,
   libwebp,
+  lcms2,
   cares,
   hdrhistogram,
   highway,
@@ -85,6 +87,7 @@ export {
   cares,
   hdrhistogram,
   highway,
+  lcms2,
   libarchive,
   libdeflate,
   libjpegTurbo,

--- a/scripts/build/deps/lcms2.ts
+++ b/scripts/build/deps/lcms2.ts
@@ -1,0 +1,45 @@
+import type { Dependency } from "../source.ts";
+
+const LCMS2_COMMIT = "21c582a594fe5279f90c0b93437c398f93bf62b0"; // 2.19.1
+
+export const lcms2: Dependency = {
+  name: "lcms2",
+  source: () => ({
+    kind: "github-archive",
+    repo: "mm2/Little-CMS",
+    commit: LCMS2_COMMIT,
+  }),
+  build: () => ({
+    kind: "direct",
+    sources: [
+      "cmscnvrt",
+      "cmserr",
+      "cmsgamma",
+      "cmsgmt",
+      "cmsintrp",
+      "cmsio0",
+      "cmsio1",
+      "cmslut",
+      "cmsplugin",
+      "cmssm",
+      "cmsmd5",
+      "cmsmtrx",
+      "cmspack",
+      "cmspcs",
+      "cmswtpnt",
+      "cmsxform",
+      "cmssamp",
+      "cmsnamed",
+      "cmscam02",
+      "cmsvirt",
+      "cmstypes",
+      "cmscgats",
+      "cmsps2",
+      "cmsopt",
+      "cmshalf",
+      "cmsalpha",
+    ].map(name => `src/${name}.c`),
+    includes: ["include"],
+  }),
+  provides: () => ({ libs: [], includes: ["include"] }),
+};

--- a/src/runtime/image/codec_jpeg.rs
+++ b/src/runtime/image/codec_jpeg.rs
@@ -263,9 +263,6 @@ pub(crate) fn decode(
     }
     // SAFETY: rc 0 (no warning) with unchanged dims means all `ht` rows of `w` pixels were written.
     unsafe { bun_core::vec::commit_spare(&mut out, out_len) };
-    if cmyk {
-        codecs::cmyk_to_rgba(&mut out);
-    }
 
     // Extract the APP2 ICC profile (if the source carried one). The marker
     // parser ran during tj3DecompressHeader, so this is a copy-out of
@@ -279,16 +276,10 @@ pub(crate) fn decode(
     // exact bug #30197 is about.
     let mut icc_ptr: *mut u8 = core::ptr::null_mut();
     let mut icc_size: usize = 0;
+    let mut cmyk_converted = false;
     let icc: Option<Vec<u8>> = 'blk: {
-        // A CMYK profile describes ink channels, not the RGBA produced above.
-        if cmyk {
-            break 'blk None;
-        }
         // SAFETY: `h` is live; out-params are valid `&mut` locals.
-        if unsafe { tj3GetICCProfile(h, &raw mut icc_ptr, &raw mut icc_size) } != 0 || icc_size == 0
-        {
-            break 'blk None;
-        }
+        let result = unsafe { tj3GetICCProfile(h, &raw mut icc_ptr, &raw mut icc_size) };
         let _free = scopeguard::guard(icc_ptr, |p| {
             if !p.is_null() {
                 // SAFETY: `p` was allocated by libjpeg-turbo via tj3GetICCProfile;
@@ -296,13 +287,21 @@ pub(crate) fn decode(
                 unsafe { tj3Free(p.cast()) };
             }
         });
-        if icc_ptr.is_null() {
+        if result != 0 || icc_size == 0 || icc_ptr.is_null() {
             break 'blk None;
         }
         // SAFETY: tj3GetICCProfile wrote `icc_size` bytes at `icc_ptr`.
         let src = unsafe { core::slice::from_raw_parts(icc_ptr, icc_size) };
-        break 'blk Some(src.to_vec());
+        if cmyk {
+            cmyk_converted = super::color_management::cmyk_to_srgb(src, &mut out)?;
+        } else {
+            break 'blk Some(src.to_vec());
+        }
+        break 'blk None;
     };
+    if cmyk && !cmyk_converted {
+        codecs::cmyk_to_rgba(&mut out);
+    }
     Ok(codecs::Decoded {
         rgba: out,
         width: w,

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -215,10 +215,10 @@ pub struct Decoded {
     /// ICC color profile bytes pulled from the source container (JPEG APP2,
     /// PNG iCCP, WebP ICCP), global-allocator-owned. `None` when the
     /// source didn't carry one or the decode path doesn't extract it —
-    /// BMP/GIF (no ICC chunk) and system backends (which already colour-
-    /// manage into sRGB during decode, so the profile is no longer
-    /// needed). The image pipeline hands this straight to the matching
-    /// encoder — the RGBA buffer is NOT converted to sRGB, so the bytes
+    /// BMP/GIF (no ICC chunk), CMYK JPEGs and system backends (which
+    /// already colour-manage into sRGB during decode, so the source
+    /// profile is no longer needed). Otherwise the image pipeline hands
+    /// this straight to the matching encoder without converting to sRGB, so the bytes
     /// only have their intended colour meaning when the profile travels
     /// with them. Dropping it on a Display-P3 / Adobe RGB / XYB source
     /// would reinterpret the values as sRGB and visibly shift the

--- a/src/runtime/image/color_management.rs
+++ b/src/runtime/image/color_management.rs
@@ -1,0 +1,116 @@
+//! ICC-aware CMYK JPEG conversion through Little CMS.
+
+use core::ffi::{c_int, c_void};
+use core::ptr::NonNull;
+
+use super::codecs;
+
+type Context = *mut c_void;
+type Profile = *mut c_void;
+type Transform = *mut c_void;
+
+// lcms2.h: COLORSPACE_SH(s) = s << 16, CHANNELS_SH(c) = c << 3,
+// BYTES_SH(b) = b, EXTRA_SH(e) = e << 7, FLAVOR_SH(f) = f << 13.
+const TYPE_CMYK_8_REV: u32 = (6 << 16) | (4 << 3) | 1 | (1 << 13);
+const TYPE_RGBA_8: u32 = (4 << 16) | (3 << 3) | 1 | (1 << 7);
+const CMYK_SIGNATURE: u32 = u32::from_be_bytes(*b"CMYK");
+const INTENT_PERCEPTUAL: u32 = 0;
+const LCMS_USED_AS_INPUT: u32 = 0;
+const FLAGS_NOCACHE: u32 = 0x0040;
+
+unsafe extern "C" {
+    fn cmsCreateContext(plugin: *mut c_void, user_data: *mut c_void) -> Context;
+    fn cmsDeleteContext(context: Context);
+    fn cmsOpenProfileFromMemTHR(context: Context, bytes: *const c_void, size: u32) -> Profile;
+    fn cmsCreate_sRGBProfileTHR(context: Context) -> Profile;
+    fn cmsCloseProfile(profile: Profile) -> c_int;
+    fn cmsGetColorSpace(profile: Profile) -> u32;
+    fn cmsGetDeviceClass(profile: Profile) -> u32;
+    fn cmsIsIntentSupported(profile: Profile, intent: u32, direction: u32) -> c_int;
+    fn cmsCreateTransformTHR(
+        context: Context,
+        input: Profile,
+        input_format: u32,
+        output: Profile,
+        output_format: u32,
+        intent: u32,
+        flags: u32,
+    ) -> Transform;
+    fn cmsDeleteTransform(transform: Transform);
+    fn cmsDoTransform(transform: Transform, input: *const c_void, output: *mut c_void, count: u32);
+}
+
+pub(super) fn cmyk_to_srgb(profile: &[u8], pixels: &mut [u8]) -> Result<bool, codecs::Error> {
+    debug_assert_eq!(pixels.len() % 4, 0);
+    let size = u32::try_from(profile.len()).map_err(|_| codecs::Error::DecodeFailed)?;
+    // SAFETY: null plugin/user_data requests an independent default context.
+    let context =
+        NonNull::new(unsafe { cmsCreateContext(core::ptr::null_mut(), core::ptr::null_mut()) })
+            .ok_or(codecs::Error::OutOfMemory)?;
+    let context = scopeguard::guard(context, |c| {
+        // SAFETY: all profiles/transforms drop before their owning context.
+        unsafe { cmsDeleteContext(c.as_ptr()) };
+    });
+    // SAFETY: `profile` stays alive until the profile handle is closed.
+    let Some(input) = NonNull::new(unsafe {
+        cmsOpenProfileFromMemTHR(context.as_ptr(), profile.as_ptr().cast(), size)
+    }) else {
+        return Ok(false);
+    };
+    let input = scopeguard::guard(input, |p| {
+        // SAFETY: the live profile is closed once, after its transform is deleted.
+        unsafe { cmsCloseProfile(p.as_ptr()) };
+    });
+    // SAFETY: input is a live profile. Device links cannot describe source pixels.
+    if unsafe {
+        cmsGetColorSpace(input.as_ptr()) != CMYK_SIGNATURE
+            || cmsGetDeviceClass(input.as_ptr()) == u32::from_be_bytes(*b"link")
+            || cmsIsIntentSupported(input.as_ptr(), INTENT_PERCEPTUAL, LCMS_USED_AS_INPUT) == 0
+    } {
+        return Ok(false);
+    }
+    // SAFETY: context remains live until the output profile is closed.
+    let output = NonNull::new(unsafe { cmsCreate_sRGBProfileTHR(context.as_ptr()) })
+        .ok_or(codecs::Error::OutOfMemory)?;
+    let output = scopeguard::guard(output, |p| {
+        // SAFETY: the live profile is closed once, after its transform is deleted.
+        unsafe { cmsCloseProfile(p.as_ptr()) };
+    });
+    // SAFETY: both live profiles belong to this context and match their pixel formats.
+    let transform = NonNull::new(unsafe {
+        cmsCreateTransformTHR(
+            context.as_ptr(),
+            input.as_ptr(),
+            TYPE_CMYK_8_REV,
+            output.as_ptr(),
+            TYPE_RGBA_8,
+            INTENT_PERCEPTUAL,
+            FLAGS_NOCACHE,
+        )
+    })
+    .ok_or(codecs::Error::DecodeFailed)?;
+    let transform = scopeguard::guard(transform, |t| {
+        // SAFETY: the transform is deleted once, before either profile or context.
+        unsafe { cmsDeleteTransform(t.as_ptr()) };
+    });
+
+    // Small batches bound the u32 pixel count and keep later alpha writes cache-local.
+    for chunk in pixels.chunks_mut(4096 * 4) {
+        let ptr = chunk.as_mut_ptr();
+        // SAFETY: LCMS supports in-place transforms; both formats occupy 4 bytes per pixel.
+        // The input formatter reads all four ink channels before the output formatter writes RGB.
+        unsafe {
+            cmsDoTransform(
+                transform.as_ptr(),
+                ptr.cast(),
+                ptr.cast(),
+                (chunk.len() / 4) as u32,
+            )
+        };
+        for pixel in chunk.as_chunks_mut::<4>().0 {
+            // LCMS leaves the extra channel untouched; the original K byte is not alpha.
+            pixel[3] = 255;
+        }
+    }
+    Ok(true)
+}

--- a/src/runtime/image/mod.rs
+++ b/src/runtime/image/mod.rs
@@ -17,6 +17,8 @@
 #[path = "codecs.rs"]
 pub mod codecs;
 
+mod color_management;
+
 #[path = "codec_jpeg.rs"]
 pub mod codec_jpeg;
 

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -793,6 +793,113 @@ describe("Bun.Image", () => {
       expect(extractWebpIccp(lossless)).toBeNull();
     });
 
+    // CC0 synthetic v4.3 CMYK-to-Lab profile, generated with Little CMS 2.19.1.
+    // A 5-point-per-axis CLUT samples sRGB ((1-C)*(1-K))^0.6,
+    // ((1-M)*(1-K))^0.7, ((1-Y)*(1-K))^0.8 into D50 Lab.
+    // Unlike an identity profile, its mixed-ink pixels detect ignored ICC data.
+    const cmykProfile = zlib.inflateSync(
+      Buffer.from(
+        "eJyV13dU09ceAPCroqC1Sl/taRW0AVGwCiICgigyxMUW2TOEEEISCJkkBAgJK0DYQQIJK4QdhixBGbIEcYCjtDhardSqKA6sghbegfvrez3vvJ53Xv5Ifrmf3y+5ub/7HQFA9RMRQ6Iq6QNAptAo1vaetnboQJTyM7AWrAbrgA4AaAyVbOnkZAf+9vH792DF0ust3aXP+vvz/utDmUkj0wAAPwAANgUSlo+nl46DsFQMgB9MxpApNABWkAEA5pYGVvoArGgEYKOdpYHVvr8cG/x57OHphfrPuf177N8PEpGOQQ6XzlqPDXN1AQCcAQCoAytAB2EABaiABcIADYQALKABPMAAFLAG9sAT2AIUoAAswC0/UwEV4EH48jW05fc0gAJkQAHhIBjgARFg/+b7NJe/zxpYA32AAvuA3vKrKwgDeMAAWEABVIAGRABIllbLv0Fp1dLzRvW//JQAAACKjKag/zWyAoD/9/3q1atX/3V9VgIAFhe5XC53YnPcb/HmlcX8kKRCws34nwSvAFga/yOV7S++cmdXNEq8pcKMu+4sh7CGr5TzA9SPdfT4llO3FCy3+ntynWifyjeh2Dh+0edQ50kUg2uPbyoYnf3XywlRnPYB/BtuaOUM1LmfyE0PrG4a0znjjeWfsfn9q/E1sR2NgVB/8T6rQ97YPSfaxuDntmVLOfP+2Iy1fDWoP3tkjgo+XizM3JP6JmdNhrbQw48i1BJ6Q32gktosf9o5nGZS9jKrPS2gaND3XGpBvi7Ue9HJ+n2YDqGA1XkoczyF0Ojjq50SKdsM9e7VxLzv3c7PJ+8a3ZzpLcB1vfIZF1xSaEIdSm9U+K+p6K6pCrGN65JlRMydflFgwVGG2nepBsNykF2WD8d8E1tRosNrch7KxyZmQO0Zk9vmkUvZpRN5mjFKUlzuvNPdvJ+z3kDtmijtaX1V/Lz4q4ZXnMeF1Cqqk4HoknQe6sXZkm+vPy7Wk/YNvOY4FYR1mDoOi9bXfAm19v7oVoexzCO9r7w6yJ+1bsIRj2vIf6Nvh1qpNEjEf50WczGeLCWFN81HnrI5X24Qi9xB2YHewcQFgfD8U0EAwb+BmnrgaF7ZaGoT1BJZF7faMknQ5iePw79WyEsirQdKL+VfhVrMurAwopooatXq1cQb1rW0plpblH5TEQ61QPkB3rqf2z7e7rwLo9av7J982KwxKdwYaq7xj2LfEc6Bax+Cn/p/6A0i+5klNWxifYSacfZOTdRMpPzKs9j3vqzuI3zJwZ2KXxI1oKYRbz4pfsLQHe6XFnp3XGwvQJnuUKzMRUFN+TheOlRDB5fPd3/jdfPCs+ZUE34dtSwe6odz1C+iXo7F0Z9wUaUvWabx/8CRo22TDkP9fSvhvcjyOoPsLlIpodOP5ywE50dtydKHOqsVbNswdXWK8LjmebEzZWt5Nnaa5VzIhvrmTiBmZHR0IuR6L6ooJfyXlkIsJXKFnI/okQDJJH/UA3fmukuRVlhnryZ2B1O3Xg/qpKuAG+rWdj95NgIt7Ev2iCzwQiVRY29ChbHZ4sxfk3gz9XX8d8l/eG5J0E7ZAvW2NKq7xPacV4yJdDoliXu5IMnjJN9GtBLqzVkmrUu7aQ17sjVLIIzxq8O6n4v7ueRbRJejrzGYdWjorWBDtHonwf0Md6GGC/XCRtkN93IJu9gQ3c5SEU8RiXa0HHUmkhna7kq+iBgV64t1meGMVlFN9GbbPZlXeZFQm/NEtenzeSW5xhmptEfZezMiT+1IfyREYr8pMEurfib3YWZDdR+1OKNRduIkTkgv2A+1EZuxbvh97ob0uZ4Wyly6f8vEiVdpaRWdUCVzvQM22/mftVef3h30XqETcOyIavF0OBIpZ907avzXxdSd24obRj+vtiDPHSZKB9glULN/aq7nXI0yUrC4LP8Y+SL/8aHNhe8Tkb2RMd6ALk6MHK/RkK71HZWViZPMNAqKcn6Bmh6m8L0Uy6yviulI9nlehm5UO5go7i0dg5p0f4Jz4CFZPMo8Vu4q7Kp2a99/rI4VchkqjALC50Nvve84KzojcXv37a5ppwZAZT+7ej9sIjizfw8tyyGlfYxtuZdSbR7Lgcq4P+Kbo4kJ7aVkZ9g5tT7M2qqnV7Vd2A0V7nP0rz3qbVm22i2Tdaa6/pUkyVGor+ewR5mtV4LxVI6DRBoWx+3DHKdrxNdAnTnquzJrw7BF4EzW4UJV/A+ZbYFoSlx6BdQXBm7utTeGCnxrK83Ed4O/KMWg68he4lVQn487tw3OD8Z4frqoEKtgME1F6F1hfbK9iBo6np1YPfDBw2T0u3wJ+o+u4IAJUk+dKtTx++x3Qa8bDKPuEeOTtKJRtFBX5ZhPnCKo13ERwzFjdZG08rjXCXrMhfhrLs84monPoY52hRoVvKvxDjsn3s6voA7khbkos/qzfoU6Mht097x21YtQVtMmXj65syrtdBBzUYrMakQ7EH3NvMoyhNT3jrchHNW26PwH434lcm3DS5HAiZYdme3jfYzMSJ8KfmGzkHKbegvJsUdTu0JJ6TdSasn3SPcFNGbiUWHSnRhXJMcu100Ym4TxpeppjU1wEExChZVR8DGWLBMu18f1Vhl8bJ4LVFj7YPThq2M7GtFWKjwdmSFU4VCrqpkRnaVYe9LFM0r21mPMuDD/VmgisuvUavvPpJFPyNv9eK4/FvXgzQwrRa/o66EuV6h5olrxacbc6ekCC47K/o05DC6ykjGrpcG583iDAkHOLViJ9j3OSk+PgwqrDO5qvsa5U46XRZ/VfLlPO9NJUgyVtm2M+t1Dv+lBFbM1xxLOq9jd09lQpYZmQA19POJq9at7ew/O0dSS1qLkU77DTv6A0AYV1gIYBcsV4YDmgmyGWQAVZnt7h7buBHWY8zWsyiISkOiG+RzucxN+HaUsHqVVyshFvndaz32etnFws+/xyLmzLzGj0bf9ecRyHrLOT30ciEJC36RrrXA6z97vhPC6XyaenXYG6pP9xyRVRy9960gpXyFa6zlQlO47Fnw3rw/qVJ+lZl9lzzvbDR3y3N1uyfXvfI8FPSlF+pypreaSW3M9oSdmhoNyOs/c6fzdZwZTWbMN6hUS0S1Avyo0LCpEP25vRCC5zMmR3s+SIx1FD9qUvUrOxZZHi2K/IqyMW+GoRtnJR7qC/t/cJ/MOyA77GedORJOxVdnNDjvDN6d/QvoN4Kze3FDa4vG9QpnjgO6WK9vTiVcKCFAv7bB/O2JV8tHNsMcjqsO/unnSfg3BTh6B7MkbiT4npwTH4ymuLiEsXj166MhonHX4XaTu17DaMRUJJmxMaDc2OyqCYmWuG23IdkIy8HIm4SlFpPK+xxxbyieHHrAUCci14nvBX5QGxo6HPpLWomuXMobZc8ab7FioMBvEDOESW/0DJki9dapmp+k7ipHViF1VtXZffMj2klkLkYOSeI+zs+5s5u6gKajMtYX7Tn2FfpRX56pzsjDrPNphd3bquz87CjIzfSr4pU9P2kfS3uXIvb2rMHkn+wNU2NPCugljU2dnwqbkeqiw84S1D0af9gHeQt4jqP5gZEz9sW1995ierdHAObzlqNpWGdcDqYOnzXpvGJRZZrRnWZTpJSm2Ohl9rVbCCAyDCqPDBNModmuGMfJlnrSMVAkVdkSwFsAoUF0smI1CejPYt8B8Dvf5xqD8uynIvvpti315RNQlCxcKIy3Xz0scddbHOciVi2SkKQOrlyk/dr88NZ7Ky647Y5aa6+0SIEhBOuRH7w9ukvd2aVk3lMqzfBxmJRgvga9n7m2oD6P2j/faXnhlLm4nZdJtNeueer73eltsgvTeY/rPxm9c8D+kMeSdsXhyW8dXnlJPXBUF6uDmAIrPoAyH2RH0iZMZ3E9qtDMl7mcikQJnW+LuIWO7s939FmLWnZrB5cR5Qe22OXEke0T6zlGSVRYp9nDJGDz5BJObRkJ6YBsL5UayxP3Eu+pFZpCLV5nFSZ2AmLNIxwjnU5hrU3GxlDHkVNvkd6LJL1JmA7XoNEvfZg3PknnNaSBwLaPHt/CgEYNGtEL25ADe3S8neiL0SbCS3yRpO+l3Eyy5mYHsSbi2cLY+TksrbPyCwOAh/yaWVy+QOe2aJ1bxSl5aQ6NJ3IH010hHsbw+cD6ekqVVMtoT5CQ5DpVqUzi5a9B3u2iVqZv1olB06sIOeoKxvxuyJ2dSPrfkunYkmtsbmit4tl66mtwYYzySzQLXMbp9JY5sBjWo9KARg0q0Qq1ifk37ESrcCXBt4Wy3aZBzeClQ4f2C6wPno/6UCDJboNo2Dm5QVTHd1qmlMaO1X/GDsdp6huSaI3L34fiu9qav9Ue+Cax4YhmrfDun0gO5g/B8OA6vUtqX0o8phQpH4PlwfEVhPImiA/V/Pf+//3X/CXfMOCU=",
+        "base64",
+      ),
+    );
+
+    function jpegWithCmykProfile(jpeg: Uint8Array, profile: Uint8Array, multipart = false) {
+      const split = multipart ? Math.floor(profile.length / 2) : profile.length;
+      const parts = multipart ? [profile.subarray(0, split), profile.subarray(split)] : [profile];
+      const segments = parts.map((part, i) => {
+        const header = Buffer.alloc(18);
+        header.set([0xff, 0xe2]);
+        header.writeUInt16BE(part.length + 16, 2);
+        header.write("ICC_PROFILE\0", 4, "ascii");
+        header[16] = i + 1;
+        header[17] = parts.length;
+        return Buffer.concat([header, part]);
+      });
+      // JPEG ICC chunks are identified by sequence number, not file order.
+      return Buffer.concat([jpeg.subarray(0, 2), ...segments.reverse(), jpeg.subarray(2)]);
+    }
+
+    describe.each([
+      ["CMYK", cmykJpeg],
+      ["YCCK", ycckJpeg],
+    ] as const)("%s ICC conversion", (_name, fixture) => {
+      test.each([64, 32, 8, 128])("applies the profile before encoding a %i-pixel PNG", async size => {
+        const input = jpegWithCmykProfile(fixture, cmykProfile);
+        const original = Buffer.from(input);
+        const png = await new Bun.Image(input).resize(size, size).png().bytes();
+        const { w, h, data } = decodePngRaw(png);
+        expect([w, h]).toEqual([size, size]);
+        // Independent reference: sharp 0.35.3 toColorspace('srgb'), raw RGB.
+        const expected = [
+          [0, 255, 255],
+          [255, 0, 255],
+          [140, 170, 202],
+          [0, 0, 0],
+        ];
+        for (const [i, [x, y]] of [
+          [1, 1],
+          [3, 1],
+          [1, 3],
+          [3, 3],
+        ].entries()) {
+          const pixel = rgbaAt(data, w, (x * size) / 4, (y * size) / 4);
+          for (let channel = 0; channel < 3; channel++) {
+            expect(Math.abs(pixel[channel] - expected[i][channel])).toBeLessThanOrEqual(4);
+          }
+          expect(pixel[3]).toBe(255);
+        }
+        expect(extractPngIccp(png)).toBeNull();
+        expect(input).toEqual(original);
+      });
+
+      test("reassembles out-of-order ICC chunks", async () => {
+        const single = jpegWithCmykProfile(fixture, cmykProfile);
+        const multipart = jpegWithCmykProfile(fixture, cmykProfile, true);
+        expect(await new Bun.Image(multipart).png().bytes()).toEqual(await new Bun.Image(single).png().bytes());
+      });
+
+      test("parallel decodes own independent color transforms", async () => {
+        const input = jpegWithCmykProfile(fixture, cmykProfile);
+        const expected = await new Bun.Image(input).png().bytes();
+        const results = await Promise.all(Array.from({ length: 16 }, () => new Bun.Image(input).png().bytes()));
+        for (const result of results) expect(result).toEqual(expected);
+      });
+
+      test("does not attach the consumed CMYK profile to RGB JPEG or WebP", async () => {
+        const input = jpegWithCmykProfile(fixture, cmykProfile);
+        const jpeg = await new Bun.Image(input).jpeg({ quality: 100 }).bytes();
+        const webp = await new Bun.Image(input).webp({ lossless: true }).bytes();
+        expect(extractJpegIcc(jpeg)).toBeNull();
+        expect(extractWebpIccp(webp)).toBeNull();
+        for (const output of [jpeg, webp]) {
+          const { w, data } = decodePngRaw(await new Bun.Image(output).png().bytes());
+          const pixel = rgbaAt(data, w, 16, 48);
+          for (const [channel, value] of [140, 170, 202].entries()) {
+            expect(Math.abs(pixel[channel] - value)).toBeLessThanOrEqual(4);
+          }
+          expect(pixel[3]).toBe(255);
+        }
+      });
+
+      test("invalid and mismatched profiles retain the unprofiled fallback", async () => {
+        const mismatched = Buffer.from(cmykProfile);
+        mismatched.write("RGB ", 16, "ascii");
+        const deviceLink = Buffer.from(cmykProfile);
+        deviceLink.write("link", 12, "ascii");
+        const reference = await new Bun.Image(fixture).png().bytes();
+        for (const profile of [
+          Buffer.from("not an ICC profile"),
+          cmykProfile.subarray(0, 100),
+          mismatched,
+          deviceLink,
+        ]) {
+          const input = jpegWithCmykProfile(fixture, profile);
+          expect(await new Bun.Image(input).png().bytes()).toEqual(reference);
+        }
+      });
+    });
+
     test("CMYK JPEG's ink-channel ICC profile is dropped on re-encode", async () => {
       expect(extractJpegIcc(cmykIccJpeg)).not.toBeNull();
       const jpg = await new Bun.Image(cmykIccJpeg).jpeg({ quality: 90 }).bytes();


### PR DESCRIPTION
### What does this PR do?

Fixes #37059.

CMYK/YCCK JPEGs currently decode with the inverted-CMYK multiplication fallback even when they contain an ICC profile. Dropping that profile does not apply its color transform, so profiled artwork can render with substantially different colors.

This adds a pinned, statically linked Little CMS 2.19.1 dependency and transforms decoded inverted CMYK pixels into sRGB using the embedded profile and perceptual rendering intent. The transform runs in place before the rest of the image pipeline. Each decode owns its context, profiles, and transform, with scoped cleanup; the resulting RGB pixels are opaque and do not retain the consumed CMYK profile.

Unprofiled JPEGs and profiles rejected by the source-profile checks retain the existing CMYK fallback. RGB ICC transport is unchanged. This does not introduce a default CMYK profile for unprofiled images or attempt general RGB color management.

### How did you verify your code works?

- Added 16 tests to the existing image suite using a self-contained, CC0 synthetic CMYK LUT profile and the existing true CMYK/YCCK JPEG fixtures. Coverage includes full-size decode, down/upscaling, PNG/JPEG/WebP output, opaque alpha, unchanged input bytes, out-of-order ICC chunks, invalid/mismatched profiles, and parallel decodes.
- Before: the color assertions fail on Bun 1.4.2, with a 45-level channel error on the synthetic mixed-ink quadrant.
- After: `bun bd test test/js/bun/image/` passes **249 tests, 0 failures**, including the adversarial, kernel, and Sharp-reference suites, on macOS arm64 with AddressSanitizer.
- Separately compared direct Bun decoding against Sharp 0.35.3 CMYK-to-sRGB normalization followed by the same Bun resize pipeline. Profiled solid-color fixtures match exactly at full size and at 2, 8, and 32 pixels; final flattened JPEG output also matches exactly at qualities 70, 80, and 99. Unprofiled input intentionally retains Bun's existing behavior, which differs from Sharp's default CMYK interpretation.
- Formatted changed TypeScript/Rust files and ran `git diff --check`.

Linux and Windows build/runtime validation remains for CI; it has not been run locally.
