### PR TITLE
install: default to symlink backend on Android

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -258,6 +258,8 @@ impl Step {
 // so `Relaxed` adds no contention).
 pub(crate) static SUPPORTED_METHOD: AtomicU8 = AtomicU8::new(if cfg!(target_os = "macos") {
     Method::Clonefile as u8
+} else if cfg!(target_os = "android") {
+    Method::Symlink as u8
 } else {
     Method::Hardlink as u8
 });


### PR DESCRIPTION
### Summary

Android environments (such as Termux) run under specific filesystem permission models and SELinux contexts where hardlinks or clonefile operations typically fail across storage boundaries. Defaulting to `Method::Symlink` prevents installation failures on Android targets.

Fixes #42223

### Test Plan

Built and verified package installation behavior on an Android target.