### PR TITLE
completions(bash): prevent empty regex match in script completion

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -57,7 +57,7 @@ _read_scripts_in_package_json() {
     local re_prev_script="(^| )${prev}($| )";
     [[
         ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
-            ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
+            ( -n "${re_comp_word_script}" && "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
     ]] && {
         local filtered_reply=();
         local reply_word script_name keep;


### PR DESCRIPTION
### Summary
Prevents Bash completion from evaluating an empty regex when `re_comp_word_script` is unset. In Bash, `[[ string =~ "" ]]` evaluates to true, which caused the script completion block to trigger erroneously when no script name was present.

### Test Plan
Sourced `completions/bun.bash` and tested tab completion when typing arguments without matching scripts.
