### PR TITLE
shell: close un-started stdio pipes on a failed spawn and finish a command from whichever stdio closes last

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -947,8 +947,7 @@ impl Cmd {
         }
     }
 
-    /// Mark the subprocess's buffered stdin as closed; this may be the close
-    /// that finishes the command.
+    /// Mark the subprocess's buffered stdin as closed.
     pub(crate) fn buffered_input_close(&mut self) -> Yield {
         let Exec::Subproc(sub) = &mut self.exec else {
             return Yield::suspended();
@@ -958,8 +957,7 @@ impl Cmd {
     }
 
     /// Mark the subprocess's buffered stdout/stderr as closed (flushing the
-    /// captured bytes into the shell buffers); this may be the close that
-    /// finishes the command.
+    /// captured bytes into the shell buffers).
     pub(crate) fn buffered_output_close(
         &mut self,
         kind: OutKind,
@@ -975,17 +973,15 @@ impl Cmd {
     /// Called by `ShellSubprocess::on_process_exit`.
     pub(crate) fn on_exit(&mut self, exit_code: ExitCode) -> Yield {
         log!("cmd exit code={}", exit_code);
-        // A stdio error already recorded its errno as the exit code
-        // (`buffered_output_close`); the process status does not replace it.
+        // Keep the errno a stdio error already recorded.
         if self.exit_code.is_none() {
             self.exit_code = Some(exit_code);
         }
         self.finish_if_done()
     }
 
-    /// `Done` once the exit code and every piped stdio are in. The caller runs
-    /// the Yield: the four completion events (exit, stdin, stdout, stderr)
-    /// arrive as separate callbacks in no fixed order, so each one ends here.
+    /// `Done` once the exit code and every piped stdio are in; the caller runs
+    /// the Yield.
     fn finish_if_done(&mut self) -> Yield {
         if matches!(self.state, CmdState::Done) || !self.has_finished() {
             return Yield::suspended();
@@ -993,12 +989,10 @@ impl Cmd {
         self.state = CmdState::Done;
         let (interp, this_id) = match &self.exec {
             Exec::Subproc(sub) => (sub.interp, sub.this_id),
-            // Builtins finish through `Builtin::done` → `on_exec_done` instead.
+            // Builtins finish through `Builtin::done`.
             _ => return Yield::suspended(),
         };
-        // `exec.interp` stays null until the spawn returns; a Yield run here
-        // would reach `Cmd::deinit` and free the `ShellSubprocess` still on
-        // the spawn frame. `transition_to_exec` resumes a `Done` command.
+        // Still inside the spawn; `transition_to_exec` resumes from `state`.
         if interp.is_null() {
             return Yield::suspended();
         }

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -892,7 +892,7 @@ impl Cmd {
             core::mem::take(&mut me.exec)
         };
         // `me`'s borrow ended above: the teardown below re-enters this Cmd
-        // via stdin `on_close_io` → `buffered_input_close` (a no-op once
+        // via stdin `on_stdin_writer_close` → `buffered_input_close` (a no-op once
         // `exec` is taken).
         match exec {
             Exec::None => {}
@@ -947,16 +947,19 @@ impl Cmd {
         }
     }
 
-    /// Mark the subprocess's buffered stdin as closed.
-    pub(crate) fn buffered_input_close(&mut self) {
-        if let Exec::Subproc(sub) = &mut self.exec {
-            sub.buffered_closed.close_stdin();
-        }
+    /// Mark the subprocess's buffered stdin as closed; this may be the close
+    /// that finishes the command.
+    pub(crate) fn buffered_input_close(&mut self) -> Yield {
+        let Exec::Subproc(sub) = &mut self.exec else {
+            return Yield::suspended();
+        };
+        sub.buffered_closed.close_stdin();
+        self.finish_if_done()
     }
 
     /// Mark the subprocess's buffered stdout/stderr as closed (flushing the
-    /// captured bytes into the shell buffers); if that makes the command
-    /// finished, transition to `Done` and yield back to the trampoline.
+    /// captured bytes into the shell buffers); this may be the close that
+    /// finishes the command.
     pub(crate) fn buffered_output_close(
         &mut self,
         kind: OutKind,
@@ -966,27 +969,40 @@ impl Cmd {
             OutKind::Stdout => self.buffered_output_close_stdout(err),
             OutKind::Stderr => self.buffered_output_close_stderr(err),
         }
-        if self.has_finished() {
-            // Set `state = Done` and hand the Yield back to the caller
-            // (`PipeReader::run_yield`), which drives the trampoline with the
-            // `*mut Interpreter` it already holds, landing in `Cmd::next` →
-            // `CmdState::Done` → `interp.child_done(...)`.
-            self.state = CmdState::Done;
-            let (interp, this_id) = match &self.exec {
-                Exec::Subproc(sub) => (sub.interp, sub.this_id),
-                // Only the subprocess path calls this; builtin output goes
-                // through `Builtin::done` → `on_exec_done`.
-                _ => return Yield::suspended(),
-            };
-            // Same gate as `on_exit`: `exec.interp` stays null until the spawn
-            // returns, so a Yield run here would reach `Cmd::deinit` and free the
-            // `ShellSubprocess` still on the spawn frame. `transition_to_exec` resumes.
-            if interp.is_null() {
-                return Yield::suspended();
-            }
-            return Yield::Next(this_id);
+        self.finish_if_done()
+    }
+
+    /// Called by `ShellSubprocess::on_process_exit`.
+    pub(crate) fn on_exit(&mut self, exit_code: ExitCode) -> Yield {
+        log!("cmd exit code={}", exit_code);
+        // A stdio error already recorded its errno as the exit code
+        // (`buffered_output_close`); the process status does not replace it.
+        if self.exit_code.is_none() {
+            self.exit_code = Some(exit_code);
         }
-        Yield::suspended()
+        self.finish_if_done()
+    }
+
+    /// `Done` once the exit code and every piped stdio are in. The caller runs
+    /// the Yield: the four completion events (exit, stdin, stdout, stderr)
+    /// arrive as separate callbacks in no fixed order, so each one ends here.
+    fn finish_if_done(&mut self) -> Yield {
+        if matches!(self.state, CmdState::Done) || !self.has_finished() {
+            return Yield::suspended();
+        }
+        self.state = CmdState::Done;
+        let (interp, this_id) = match &self.exec {
+            Exec::Subproc(sub) => (sub.interp, sub.this_id),
+            // Builtins finish through `Builtin::done` → `on_exec_done` instead.
+            _ => return Yield::suspended(),
+        };
+        // `exec.interp` stays null until the spawn returns; a Yield run here
+        // would reach `Cmd::deinit` and free the `ShellSubprocess` still on
+        // the spawn frame. `transition_to_exec` resumes a `Done` command.
+        if interp.is_null() {
+            return Yield::suspended();
+        }
+        Yield::Next(this_id)
     }
 
     fn buffered_output_close_stdout(&mut self, err: Option<bun_sys::SystemError>) {
@@ -1057,31 +1073,6 @@ impl Cmd {
             self.base.shell_mut().buffered_stderr(),
         );
         child.close_io(StdioKind::Stderr);
-    }
-
-    /// Called by `ShellSubprocess::on_process_exit`.
-    pub(crate) fn on_exit(&mut self, exit_code: ExitCode) {
-        self.exit_code = Some(exit_code);
-        let has_finished = self.has_finished();
-        log!("cmd exit code={} has_finished={}", exit_code, has_finished);
-        if has_finished {
-            self.state = CmdState::Done;
-            // `self` lives inside `interp.nodes`, so resume via the stashed
-            // backrefs.
-            let (interp, this_id) = match &self.exec {
-                Exec::Subproc(sub) => (sub.interp, sub.this_id),
-                _ => return,
-            };
-            if interp.is_null() {
-                return;
-            }
-            // SAFETY: `interp` outlives every spawned subprocess (it owns the
-            // arena slot containing `self`). `&mut self` is dead by NLL after
-            // this point so the `&Interpreter` borrow does not alias it.
-            // The caller (`ShellSubprocess::on_process_exit`) does not touch
-            // its `*mut Cmd` again after this returns.
-            Yield::Next(this_id).run(unsafe { &*interp });
-        }
     }
 }
 

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 
 #[cfg(unix)]
 use crate::api::bun::process::SpawnResultExt as _;
-use crate::api::bun::process::{
-    self as bun_process, Process, Rusage, SignalCodeExt, SpawnOptions, Status,
-};
+use crate::api::bun::process::{self as bun_process, Process, SignalCodeExt, SpawnOptions, Status};
 #[cfg(windows)]
 use crate::api::bun::process::{WindowsOptions, WindowsStdioResult};
 use crate::api::bun::subprocess as JscSubprocess;
@@ -225,15 +223,20 @@ impl JscSubprocess::static_pipe_writer::StaticPipeWriterProcess for ShellSubproc
     const POLL_OWNER_TAG: bun_io::PollTag =
         bun_io::posix_event_loop::poll_tag::SHELL_STATIC_PIPE_WRITER;
     unsafe fn on_close_io(this: *mut Self, kind: StdioKind) {
-        // SAFETY: caller (StaticPipeWriter) guarantees `this` is live.
-        unsafe { (*this).on_close_io(kind) }
+        // `Writable::init` only creates the writer for stdin.
+        debug_assert!(matches!(kind, StdioKind::Stdin));
+        // SAFETY: `StaticPipeWriter::on_close` passes its live process backref
+        // and does not touch it afterwards. Forwarded raw, not autoref'd: the
+        // callee may free `*this`.
+        unsafe { Self::on_stdin_writer_close(this) }
     }
 }
 
 bun_spawn::link_impl_ProcessExit! {
     Shell for ShellSubprocess => |this| {
-        on_process_exit(process, status, rusage) =>
-            (*this).on_process_exit(&*process, &status, rusage),
+        // Forwarded raw, not autoref'd: the callee may free `*this`.
+        on_process_exit(_process, status, _rusage) =>
+            ShellSubprocess::on_process_exit(this, &status),
     }
 }
 
@@ -246,15 +249,45 @@ impl ShellSubprocess {
         self.process.as_ref().expect("process closed").process_mut()
     }
 
-    pub(crate) fn on_static_pipe_writer_done(&mut self) {
+    /// The `< ${buffer}` stdin writer closed: release it and let the `Cmd`
+    /// finish. The stdin close can be the last of the four completion events
+    /// (exit, stdin, stdout, stderr), so it runs the same finish check the
+    /// others do.
+    ///
+    /// # Safety
+    /// `this` must be live and unborrowed. `Cmd::deinit`, reached through the
+    /// Yield run here, may free it before this returns, which is why it is raw.
+    unsafe fn on_stdin_writer_close(this: *mut Self) {
+        {
+            // SAFETY: caller contract; the borrow ends with this block, before
+            // the Yield runs.
+            let slot = unsafe { &mut (*this).stdin };
+            match core::mem::replace(slot, Writable::Ignore) {
+                // Dropping the `RefPtr` releases `create()`'s ref; `start()`'s
+                // keeps the writer alive until this callback returns.
+                Writable::Buffer(buffer) => {
+                    // SAFETY: single-threaded; sole borrow of the payload.
+                    unsafe { buffer_mut(&buffer) }.source.detach();
+                }
+                // The writer only exists while the slot holds it.
+                other => {
+                    *slot = other;
+                    return;
+                }
+            }
+        }
+        // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
+        let handle = unsafe { (*this).cmd_parent };
         log!(
-            "Subproc(0x{:x}) onStaticPipeWriterDone(cmd={})",
-            std::ptr::from_mut(self) as usize,
-            self.cmd_parent.id
+            "Subproc(0x{:x}) onStdinWriterClose(cmd={})",
+            this as usize,
+            handle.id
         );
-        // SAFETY: cmd_parent backref resolves to the owning Cmd which outlives
-        // the subprocess (freed only in `Cmd::deinit` after all stdio closes).
-        unsafe { self.cmd_parent.cmd_mut() }.buffered_input_close();
+        // SAFETY: the owning Cmd outlives its subprocess (its `deinit` is what
+        // frees it); the `&mut Cmd` ends before the Yield runs.
+        let y = unsafe { handle.cmd_mut() }.buffered_input_close();
+        // May free `*this`.
+        y.run(&handle.interp);
     }
 
     pub(crate) fn has_exited(&self) -> bool {
@@ -327,56 +360,38 @@ impl ShellSubprocess {
         self.close_io(StdioKind::Stderr);
     }
 
+    /// A stdout/stderr `PipeReader` finished: swap it out of its slot for its
+    /// buffered bytes. Stdin closes through [`Self::on_stdin_writer_close`].
     pub(crate) fn on_close_io(&mut self, kind: StdioKind) {
-        match kind {
-            StdioKind::Stdin => match &mut self.stdin {
-                Writable::Pipe(pipe) => {
-                    pipe.source.with_mut(|s| s.clear());
-                    self.stdin = Writable::Ignore;
+        let out: &mut Readable = match kind {
+            StdioKind::Stdout => &mut self.stdout,
+            StdioKind::Stderr => &mut self.stderr,
+            StdioKind::Stdin => unreachable!("stdin closes through on_stdin_writer_close"),
+        };
+        if let Readable::Pipe(pipe) = core::mem::replace(out, Readable::Ignore) {
+            // The only callers reach here from inside
+            // `PipeReader::on_reader_done`/`on_reader_error`, which still
+            // hold a raw `*mut PipeReader` to this same allocation.
+            // Route every read/write through `Arc::as_ptr` (no `Deref`)
+            // so we never materialise a `&PipeReader` that would alias
+            // those callers' access; see `PipeReader::take_done_buffer`.
+            let pp = Arc::as_ptr(&pipe).cast_mut();
+            // SAFETY: `pp` projects from the Arc allocation's NonNull;
+            // raw place read of the discriminant + raw-ptr write
+            // through `take_done_buffer` (see its doc).
+            let buf = unsafe {
+                if matches!(&(*pp).state, PipeReaderState::Done(_)) {
+                    Some(PipeReader::take_done_buffer(pp))
+                } else {
+                    None
                 }
-                Writable::Buffer(_) => {
-                    self.on_static_pipe_writer_done();
-                    if let Writable::Buffer(buffer) =
-                        core::mem::replace(&mut self.stdin, Writable::Ignore)
-                    {
-                        // SAFETY: single-threaded; sole borrow of the payload.
-                        unsafe { buffer_mut(&buffer) }.source.detach();
-                    }
-                }
-                _ => {}
-            },
-            StdioKind::Stdout | StdioKind::Stderr => {
-                let out: &mut Readable = match kind {
-                    StdioKind::Stdout => &mut self.stdout,
-                    StdioKind::Stderr => &mut self.stderr,
-                    StdioKind::Stdin => unreachable!(),
-                };
-                if let Readable::Pipe(pipe) = core::mem::replace(out, Readable::Ignore) {
-                    // The only callers reach here from inside
-                    // `PipeReader::on_reader_done`/`on_reader_error`, which still
-                    // hold a raw `*mut PipeReader` to this same allocation.
-                    // Route every read/write through `Arc::as_ptr` (no `Deref`)
-                    // so we never materialise a `&PipeReader` that would alias
-                    // those callers' access; see `PipeReader::take_done_buffer`.
-                    let pp = Arc::as_ptr(&pipe).cast_mut();
-                    // SAFETY: `pp` projects from the Arc allocation's NonNull;
-                    // raw place read of the discriminant + raw-ptr write
-                    // through `take_done_buffer` (see its doc).
-                    let buf = unsafe {
-                        if matches!(&(*pp).state, PipeReaderState::Done(_)) {
-                            Some(PipeReader::take_done_buffer(pp))
-                        } else {
-                            None
-                        }
-                    };
-                    if let Some(buf) = buf {
-                        *out = Readable::Buffer(buf);
-                    } else {
-                        *out = Readable::Ignore;
-                    }
-                    drop(pipe); // deref
-                }
+            };
+            if let Some(buf) = buf {
+                *out = Readable::Buffer(buf);
+            } else {
+                *out = Readable::Ignore;
             }
+            drop(pipe); // deref
         }
     }
 
@@ -434,11 +449,11 @@ impl ShellSubprocess {
     /// # Safety
     /// `this` must be the live `heap::alloc`'d subprocess with no outstanding
     /// borrows; single-threaded shell. Raw (not `&mut self`) because the
-    /// stdin close re-enters `on_close_io(&mut Self)` through the writer's
+    /// stdin close re-enters `on_stdin_writer_close` through the writer's
     /// process backref.
     #[cfg(not(windows))]
     pub(crate) unsafe fn deinit_in_flight_io(this: *mut Self) {
-        // Claim `start()`'s +1, `close()` (fires `on_close` → `on_close_io`:
+        // Claim `start()`'s +1, `close()` (fires `on_close` → `on_stdin_writer_close`:
         // slot → `Ignore`, `create()`'s ref released), release the claimed
         // ref — the JS `Subprocess::close_io` stdin shape.
         // SAFETY: caller contract; the `stdin` borrow ends before `close()`.
@@ -894,10 +909,16 @@ impl ShellSubprocess {
         Ok(())
     }
 
-    pub(crate) fn on_process_exit(&mut self, _: &Process, status: &Status, _: &Rusage) {
-        log!("onProcessExit({:x})", std::ptr::from_mut(self) as usize);
-        let interrupted =
-            self.ctrl_c_child.take().is_some() && bun_spawn::ctrl_c::child_died_of_it(status);
+    /// Exit handler (`link_impl_ProcessExit!` above).
+    ///
+    /// # Safety
+    /// Same contract as [`Self::on_stdin_writer_close`]: `this` must be live
+    /// and unborrowed, and may be freed by the time this returns.
+    unsafe fn on_process_exit(this: *mut Self, status: &Status) {
+        log!("onProcessExit({:x})", this as usize);
+        // SAFETY: caller contract; the borrow ends at the `;`.
+        let interrupted = unsafe { (*this).ctrl_c_child.take() }.is_some()
+            && bun_spawn::ctrl_c::child_died_of_it(status);
         let exit_code: Option<u8> = 'brk: {
             if let Status::Exited(exited) = &status {
                 #[cfg(windows)]
@@ -920,17 +941,16 @@ impl ShellSubprocess {
             break 'brk None;
         };
 
-        if let Some(code) = exit_code {
-            let handle = self.cmd_parent;
-            // SAFETY: cmd_parent backref outlives subprocess; resolved
-            // through the node arena so it survives `Vec<Node>` reallocation.
-            // `&mut self` is dead by NLL before `on_exit` re-enters interp.
-            let cmd = unsafe { handle.cmd_mut() };
-            cmd.base.interrupted |= interrupted;
-            if cmd.exit_code.is_none() {
-                cmd.on_exit(code.into());
-            }
-        }
+        let Some(code) = exit_code else { return };
+        // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
+        let handle = unsafe { (*this).cmd_parent };
+        // SAFETY: the owning Cmd outlives its subprocess (its `deinit` is what
+        // frees it); the `&mut Cmd` ends before the Yield runs.
+        let cmd = unsafe { handle.cmd_mut() };
+        cmd.base.interrupted |= interrupted;
+        let y = cmd.on_exit(code.into());
+        // May free `*this`.
+        y.run(&handle.interp);
     }
 }
 
@@ -1121,7 +1141,7 @@ impl Writable {
                 // SAFETY: single-threaded; temporary `&mut` for the call only.
                 unsafe { buffer_mut(&buffer) }.update_ref(false);
                 // `buffer` drops here with the variant already `Ignore`, so a
-                // re-entrant `on_close_io` from the writer's drop is a no-op.
+                // re-entrant `on_stdin_writer_close` from the writer's drop is a no-op.
             }
             Writable::Memfd(fd) => {
                 fd.close();
@@ -1778,8 +1798,10 @@ impl PipeReader {
             return self.reader.start_with_current_pipe();
         }
 
+        // The fd moves into `reader`, which closes it from here on. An
+        // un-started reader still holds it in `stdio_result` (see `Drop`).
         #[cfg(not(windows))]
-        match self.reader.start(self.stdio_result.unwrap(), true) {
+        match self.reader.start(self.stdio_result.take().unwrap(), true) {
             bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
             bun_sys::Result::Ok(()) => {
                 // `reader.start` reports a poll-registration failure through
@@ -2116,6 +2138,11 @@ impl Drop for PipeReader {
         #[cfg(unix)]
         {
             debug_assert!(self.reader.is_done() || matches!(self.state, PipeReaderState::Err(_)));
+            // `start()` never ran (the spawn was aborted first), so the
+            // parent end of the socketpair is still ours to close.
+            if let Some(fd) = self.stdio_result.take() {
+                fd.close();
+            }
         }
 
         #[cfg(windows)]

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -250,26 +250,20 @@ impl ShellSubprocess {
     }
 
     /// The `< ${buffer}` stdin writer closed: release it and let the `Cmd`
-    /// finish. The stdin close can be the last of the four completion events
-    /// (exit, stdin, stdout, stderr), so it runs the same finish check the
-    /// others do.
+    /// finish.
     ///
     /// # Safety
-    /// `this` must be live and unborrowed. `Cmd::deinit`, reached through the
-    /// Yield run here, may free it before this returns, which is why it is raw.
+    /// `this` must be live and unborrowed; the Yield run here may free it.
     unsafe fn on_stdin_writer_close(this: *mut Self) {
         {
-            // SAFETY: caller contract; the borrow ends with this block, before
-            // the Yield runs.
+            // SAFETY: caller contract; the borrow ends before the Yield runs.
             let slot = unsafe { &mut (*this).stdin };
             match core::mem::replace(slot, Writable::Ignore) {
-                // Dropping the `RefPtr` releases `create()`'s ref; `start()`'s
-                // keeps the writer alive until this callback returns.
+                // Drops `create()`'s ref; `start()`'s ref outlives this call.
                 Writable::Buffer(buffer) => {
                     // SAFETY: single-threaded; sole borrow of the payload.
                     unsafe { buffer_mut(&buffer) }.source.detach();
                 }
-                // The writer only exists while the slot holds it.
                 other => {
                     *slot = other;
                     return;
@@ -283,8 +277,8 @@ impl ShellSubprocess {
             this as usize,
             handle.id
         );
-        // SAFETY: the owning Cmd outlives its subprocess (its `deinit` is what
-        // frees it); the `&mut Cmd` ends before the Yield runs.
+        // SAFETY: the owning Cmd outlives its subprocess; the `&mut Cmd` ends
+        // before the Yield runs.
         let y = unsafe { handle.cmd_mut() }.buffered_input_close();
         // May free `*this`.
         y.run(&handle.interp);
@@ -361,7 +355,7 @@ impl ShellSubprocess {
     }
 
     /// A stdout/stderr `PipeReader` finished: swap it out of its slot for its
-    /// buffered bytes. Stdin closes through [`Self::on_stdin_writer_close`].
+    /// buffered bytes.
     pub(crate) fn on_close_io(&mut self, kind: StdioKind) {
         let out: &mut Readable = match kind {
             StdioKind::Stdout => &mut self.stdout,
@@ -909,11 +903,8 @@ impl ShellSubprocess {
         Ok(())
     }
 
-    /// Exit handler (`link_impl_ProcessExit!` above).
-    ///
     /// # Safety
-    /// Same contract as [`Self::on_stdin_writer_close`]: `this` must be live
-    /// and unborrowed, and may be freed by the time this returns.
+    /// `this` must be live and unborrowed; the Yield run here may free it.
     unsafe fn on_process_exit(this: *mut Self, status: &Status) {
         log!("onProcessExit({:x})", this as usize);
         // SAFETY: caller contract; the borrow ends at the `;`.
@@ -944,8 +935,8 @@ impl ShellSubprocess {
         let Some(code) = exit_code else { return };
         // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
         let handle = unsafe { (*this).cmd_parent };
-        // SAFETY: the owning Cmd outlives its subprocess (its `deinit` is what
-        // frees it); the `&mut Cmd` ends before the Yield runs.
+        // SAFETY: the owning Cmd outlives its subprocess; the `&mut Cmd` ends
+        // before the Yield runs.
         let cmd = unsafe { handle.cmd_mut() };
         cmd.base.interrupted |= interrupted;
         let y = cmd.on_exit(code.into());
@@ -1798,8 +1789,7 @@ impl PipeReader {
             return self.reader.start_with_current_pipe();
         }
 
-        // The fd moves into `reader`, which closes it from here on. An
-        // un-started reader still holds it in `stdio_result` (see `Drop`).
+        // `reader` owns the fd from here; `Drop` closes an un-started one.
         #[cfg(not(windows))]
         match self.reader.start(self.stdio_result.take().unwrap(), true) {
             bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
@@ -2138,8 +2128,7 @@ impl Drop for PipeReader {
         #[cfg(unix)]
         {
             debug_assert!(self.reader.is_done() || matches!(self.state, PipeReaderState::Err(_)));
-            // `start()` never ran (the spawn was aborted first), so the
-            // parent end of the socketpair is still ours to close.
+            // Never started: the parent end is still ours to close.
             if let Some(fd) = self.stdio_result.take() {
                 fd.close();
             }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3363,6 +3363,41 @@ describe("stdin redirect from a zero-length buffer delivers EOF to the spawned c
   });
 });
 
+describe.skipIf(isWindows)("stdin redirect whose pipe outlives the command's process", () => {
+  // `< ${input}` is pumped into the child over a pipe. A command finishes once
+  // its exit code and the stdin, stdout and stderr closes are all in, and the
+  // four arrive as separate event-loop callbacks. Here the child hands its
+  // stdin to a background `sleep` and exits without reading the redirect,
+  // which is bigger than the pipe buffer: the exit and the stdout/stderr EOFs
+  // are processed first, and the pending stdin write only fails once `sleep`
+  // lets go of the pipe. That stdin close is what has to finish the command.
+  // Without it the promise never settles.
+  const SIZE = 1 << 20;
+  const script = "exec 3<&0; sleep 1 <&3 >/dev/null 2>&1 & echo out; echo err >&2; exit 3";
+  const redirects: Array<[string, () => Buffer | Blob]> = [
+    ["Buffer", () => Buffer.alloc(SIZE, "a")],
+    ["Blob", () => new Blob([Buffer.alloc(SIZE, "a")])],
+  ];
+
+  test.concurrent.each(redirects)("%s", async (_name, input) => {
+    const r = await $`sh -c ${script} < ${input()}`.quiet().nothrow();
+    expect({ stdout: r.stdout.toString(), stderr: r.stderr.toString(), exitCode: r.exitCode }).toEqual({
+      stdout: "out\n",
+      stderr: "err\n",
+      exitCode: 3,
+    });
+  });
+
+  test.concurrent("inside a pipeline", async () => {
+    const r = await $`sh -c ${script} < ${Buffer.alloc(SIZE, "a")} | cat`.quiet().nothrow();
+    expect({ stdout: r.stdout.toString(), stderr: r.stderr.toString(), exitCode: r.exitCode }).toEqual({
+      stdout: "out\n",
+      stderr: "err\n",
+      exitCode: 0,
+    });
+  });
+});
+
 test("output redirect buffer for an external command stays attached until the command finishes", async () => {
   // `> ${buf}` for an external (non-builtin) command stores the buffer and
   // copies the child's stdout into it as chunks arrive across event-loop

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -12,6 +12,9 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //   SHELL_FAIL_RECV=1        every recv() fails with ENOMEM.
 //   SHELL_FAIL_EPOLL=1       every epoll_ctl ADD/MOD on a pipe-like fd fails
 //                            with ENOMEM.
+//   SHELL_FAIL_EPOLL_IN=1    every epoll_ctl ADD/MOD on an AF_UNIX socket that
+//                            waits for EPOLLIN (a reader) and not EPOLLOUT
+//                            fails with ENOMEM. A stdin writer still registers.
 //   SHELL_FAIL_EPOLL_AFTER=1 the first epoll_ctl ADD on each AF_UNIX socket
 //                            succeeds (so the PipeReader starts and the eager
 //                            read runs); every later ADD/MOD on that fd fails
@@ -60,6 +63,7 @@ static long (*real_syscall)(long, long, long, long, long, long, long);
 static int (*real_close)(int);
 static int fail_recv = -1;
 static int fail_epoll = -1;
+static int fail_epoll_in = -1;
 static int fail_epoll_after = -1;
 static int recv_one_chunk = -1;
 static int recv_eagain_first = -1;
@@ -72,6 +76,7 @@ static unsigned char bulk_count[MAX_FD];
 static void init_modes(void) {
   if (fail_recv < 0) fail_recv = getenv("SHELL_FAIL_RECV") != NULL;
   if (fail_epoll < 0) fail_epoll = getenv("SHELL_FAIL_EPOLL") != NULL;
+  if (fail_epoll_in < 0) fail_epoll_in = getenv("SHELL_FAIL_EPOLL_IN") != NULL;
   if (fail_epoll_after < 0) fail_epoll_after = getenv("SHELL_FAIL_EPOLL_AFTER") != NULL;
   if (recv_one_chunk < 0) recv_one_chunk = getenv("SHELL_RECV_ONE_CHUNK") != NULL;
   if (recv_eagain_first < 0) recv_eagain_first = getenv("SHELL_RECV_EAGAIN_FIRST") != NULL;
@@ -148,8 +153,13 @@ long syscall(long number, ...) {
   if (number == SYS_epoll_ctl) {
     int op = (int)b;
     int target = (int)c;
+    struct epoll_event *ev = (struct epoll_event *)d;
     if (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD) {
       if (fail_epoll && is_pipe_like(target)) {
+        errno = ENOMEM;
+        return -1;
+      }
+      if (fail_epoll_in && ev && (ev->events & EPOLLIN) && !(ev->events & EPOLLOUT) && is_unix_sock(target)) {
         errno = ENOMEM;
         return -1;
       }
@@ -234,6 +244,26 @@ const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.nothrow();
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
+// A 4 MB blob on stdin is larger than the socket buffer, so the stdin writer
+// has to register its poll (the stdout/stderr readers register theirs right
+// after). Runs the command several times and reports the parent's open fd
+// count before and after: a spawn that fails part way through setup must not
+// leave a stdio end open. A command that never finishes shows up as a test
+// timeout. `argv[2]` selects the single-command or the pipeline form.
+const STDIN_BLOB_FIXTURE = /* js */ `
+import { $ } from "bun";
+import { readdirSync } from "node:fs";
+const fds = () => readdirSync("/proc/self/fd").length;
+const blob = new Blob([Buffer.alloc(4 << 20, "a")]);
+const pipeline = process.argv[2] === "pipeline";
+const run = () => (pipeline ? $\`cat < \${blob} | cat\` : $\`cat < \${blob}\`).quiet().nothrow();
+await run();
+const before = fds();
+let last;
+for (let i = 0; i < 5; i++) last = await run();
+console.log(JSON.stringify({ exitCode: last.exitCode, stderr: last.stderr.toString().trim(), fds: fds() - before }));
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -246,6 +276,7 @@ beforeAll(async () => {
     "quiet-chunk.js": QUIET_CHUNK_FIXTURE,
     "poll-chunk.js": POLL_CHUNK_FIXTURE,
     "tee-chunk.js": TEE_CHUNK_FIXTURE,
+    "stdin-blob.js": STDIN_BLOB_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -270,6 +301,7 @@ const ENOMEM = 12;
 const MODES = [
   "SHELL_FAIL_RECV",
   "SHELL_FAIL_EPOLL",
+  "SHELL_FAIL_EPOLL_IN",
   "SHELL_FAIL_EPOLL_AFTER",
   "SHELL_RECV_ONE_CHUNK",
   "SHELL_RECV_EAGAIN_FIRST",
@@ -467,6 +499,70 @@ test.concurrent.skipIf(!isLinux || !cc || !mkfifo || !cat)(
       readerStderr: "",
       exitCode: 0,
       readerExitCode: 0,
+    });
+  },
+);
+
+async function runStdinBlobFixture(modes: (typeof MODES)[number][], form: "single" | "pipeline") {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "stdin-blob.js", form, "--debug-crash-handler-use-trace-string"],
+    cwd: String(dir),
+    env: shimEnv(modes),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const line = stdout.trim().split("\n").pop() ?? "";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    parsed = line;
+  }
+  return { parsed, stderr, exitCode };
+}
+
+// The stdin writer's registration fails, so the spawn is aborted before the
+// stdout and stderr readers start. Each un-started reader still owned the
+// parent end of its socketpair and dropped it without a close: two fds leaked
+// per failed spawn.
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell closes the un-started stdout/stderr pipes when the stdin writer fails to start",
+  async () => {
+    expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL"], "single")).toEqual({
+      parsed: { exitCode: 1, stderr: expect.stringContaining("Cannot allocate memory"), fds: 0 },
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+);
+
+// Only the readers fail to register; the stdin writer is still busy when the
+// reader error records ENOMEM as the exit code. The child then exits (EPIPE on
+// its closed stdout), but the exit handler skipped the command because an exit
+// code was already set, and the stdin close never re-checked either. The
+// command never finished and kept the shell's promise pending forever.
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell finishes a command whose reader failed to register while stdin was still being written",
+  async () => {
+    expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL_IN"], "single")).toEqual({
+      parsed: { exitCode: ENOMEM, stderr: "", fds: 0 },
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+);
+
+// Same fault inside a pipeline: the first stage's stderr reader fails while
+// its stdin is still being written. A stage that never finishes keeps its end
+// of the inter-stage socketpair open, so the second `cat` waits on stdin forever.
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell finishes a pipeline whose first stage's reader failed to register while stdin was still being written",
+  async () => {
+    expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL_IN"], "pipeline")).toEqual({
+      parsed: { exitCode: ENOMEM, stderr: "", fds: 0 },
+      stderr: expect.any(String),
+      exitCode: 0,
     });
   },
 );

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -246,14 +246,18 @@ console.log(JSON.stringify({ exitCode: r.exitCode }));
 
 // A 4 MB blob on stdin is larger than the socket buffer, so the stdin writer
 // has to register its poll (the stdout/stderr readers register theirs right
-// after). Runs the command several times and reports the parent's open fd
-// count before and after: a spawn that fails part way through setup must not
-// leave a stdio end open. A command that never finishes shows up as a test
-// timeout. `argv[2]` selects the single-command or the pipeline form.
+// after). Runs the command several times and lists the parent's fds that were
+// not open before: a spawn that fails part way through setup must not leave a
+// stdio end open. An fd held by a registered poll is closed on the thread pool,
+// so the list is polled until it drains (bounded). A command that never
+// finishes shows up as a test timeout. `argv[2]` selects the single-command or
+// the pipeline form.
 const STDIN_BLOB_FIXTURE = /* js */ `
 import { $ } from "bun";
-import { readdirSync } from "node:fs";
-const fds = () => readdirSync("/proc/self/fd").length;
+import { readdirSync, readlinkSync } from "node:fs";
+const fds = () => new Set(readdirSync("/proc/self/fd").flatMap(fd => {
+  try { return [fd + ":" + readlinkSync("/proc/self/fd/" + fd)]; } catch { return []; }
+}));
 const blob = new Blob([Buffer.alloc(4 << 20, "a")]);
 const pipeline = process.argv[2] === "pipeline";
 const run = () => (pipeline ? $\`cat < \${blob} | cat\` : $\`cat < \${blob}\`).quiet().nothrow();
@@ -261,7 +265,13 @@ await run();
 const before = fds();
 let last;
 for (let i = 0; i < 5; i++) last = await run();
-console.log(JSON.stringify({ exitCode: last.exitCode, stderr: last.stderr.toString().trim(), fds: fds() - before }));
+const deadline = Date.now() + 2000;
+let leaked = [...fds()].filter(fd => !before.has(fd));
+while (leaked.length > 0 && Date.now() < deadline) {
+  await Bun.sleep(10);
+  leaked = [...fds()].filter(fd => !before.has(fd));
+}
+console.log(JSON.stringify({ exitCode: last.exitCode, stderr: last.stderr.toString().trim(), leaked }));
 `;
 
 let shimPath: string;
@@ -530,7 +540,7 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "shell closes the un-started stdout/stderr pipes when the stdin writer fails to start",
   async () => {
     expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL"], "single")).toEqual({
-      parsed: { exitCode: 1, stderr: expect.stringContaining("Cannot allocate memory"), fds: 0 },
+      parsed: { exitCode: 1, stderr: expect.stringContaining("Cannot allocate memory"), leaked: [] },
       stderr: expect.any(String),
       exitCode: 0,
     });
@@ -546,7 +556,7 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "shell finishes a command whose reader failed to register while stdin was still being written",
   async () => {
     expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL_IN"], "single")).toEqual({
-      parsed: { exitCode: ENOMEM, stderr: "", fds: 0 },
+      parsed: { exitCode: ENOMEM, stderr: "", leaked: [] },
       stderr: expect.any(String),
       exitCode: 0,
     });
@@ -560,7 +570,7 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "shell finishes a pipeline whose first stage's reader failed to register while stdin was still being written",
   async () => {
     expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL_IN"], "pipeline")).toEqual({
-      parsed: { exitCode: ENOMEM, stderr: "", fds: 0 },
+      parsed: { exitCode: ENOMEM, stderr: "", leaked: [] },
       stderr: expect.any(String),
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem
- A shell command whose stdin writer fails to start (`cat < ${blob}` when the writer's `epoll_ctl` registration fails) leaks two fds per attempt. `abort_after_failed_start` (`src/runtime/shell/subproc.rs`) drops the stdout and stderr `PipeReader`s before they started, and the parent end of each socketpair is still in `PipeReader::stdio_result`, which nothing closes.
- A command can also never finish. `Cmd::buffered_input_close` (`src/runtime/shell/states/Cmd.rs`) only set a flag, so a stdin close that lands after the exit and the output EOFs completes the command with nothing to move it to `Done`. This reproduces on stock bun with no fault injection: `sh -c 'exec 3<&0; sleep 1 <&3 & exit' < ${Buffer.alloc(1 << 20)}` hangs every time. `on_process_exit` also skipped `Cmd::on_exit` when a reader error had already recorded an errno exit code, so a reader that failed to register while stdin was still being written left the command pending forever (a pipeline then holds its socketpair end open and the next stage blocks on stdin).

### Fix
- `PipeReader::start` takes the fd out of `stdio_result`; `Drop` closes an fd that was never handed to the reader. The reader closes it on every path where it was started, so the two never both close it.
- All four completion events (exit, stdin close, stdout close, stderr close) end in one `Cmd::finish_if_done`, which returns the `Yield` for the caller to run. `on_exit` keeps an exit code a stdio error already recorded instead of being skipped.
- The stdin close and exit callbacks take `*mut ShellSubprocess` (`on_stdin_writer_close`, `on_process_exit`) because running the Yield can free the subprocess. `on_close_io` now serves stdout/stderr only.
- Verified: `test/js/bun/shell/bunshell.test.ts` (3 shim-free tests, hang on 1.4.1), `test/js/bun/shell/shell-pipe-read-fault.test.ts` (3 LD_PRELOAD tests: 10 leaked fds and 2 hangs on 1.4.1). Also 15 shell suites (651 tests), `cargo check` for windows and darwin, clippy.

### Background
- Each piped stdio of a shell subprocess is a socketpair. The parent end is wrapped in a `PipeReader` (stdout/stderr) or a `StaticPipeWriter` (a `< ${buffer}` stdin). Starting a wrapper registers the fd with the event loop. On POSIX a reader reports a registration failure through `on_reader_error`, not its return value, so the writer's `start()` is the only start that aborts the spawn.
- A `Cmd` running a subprocess is finished once it has an exit code and its piped stdin, stdout and stderr are all closed (`has_finished`). The four events arrive as separate event-loop callbacks in no fixed order.
- Shell callbacks return a `Yield` that the caller runs. Running it can complete the parent node and free the `Cmd` and its subprocess, so nothing may still borrow either at that point.

<details><summary>Notes</summary>

- Supersedes #38367 (the reader fd half, same `stdio_result.take()` and `Drop` shape) and #37799 (the stdin-close half, same `finish_if_done` and raw-pointer callbacks). Both no longer merge with main, and #37799's `exit_code.is_some()` early return in `on_process_exit` would keep the reader-error hang.
- Self-reviewed: the first version kept `&mut self` across the freeing Yield and a third hand-rolled `Done` transition in `buffered_output_close`; both were reworked as above, and the shim-free test was added.
- The fault-injection modes live in the existing shim of `shell-pipe-read-fault.test.ts`: `SHELL_FAIL_EPOLL` (stdin writer start fails, counts `/proc/self/fd`) and the new `SHELL_FAIL_EPOLL_IN` (only EPOLLIN registrations fail, so the readers error while the writer runs), single command and pipeline.
- The `matches!(state, Done)` check in `finish_if_done` guards against a second `Yield::Next` for a command that already finished during the spawn (`transition_to_exec` resumes it).
- `leak.test.ts` `memleak_Blob_*` time out on this machine with and without the change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/shell-pipe-read-fault.test.ts, test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->