### PR TITLE
node:fs: pass the buffer to the read/readv/write/writev callback on error

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -283,12 +283,15 @@ var access = function access(path, mode, callback) {
     callback = wrapFsCallback(callback);
     fs.read(fd, buffer, offset, length, position).then(
       bytesRead => void callback(null, bytesRead, buffer),
-      err => callback(err),
+      err => void callback(err, 0, buffer),
     );
   },
   write = function write(fd, buffer, offsetOrOptions, length, position, callback) {
     function wrapper(bytesWritten) {
       callback(null, bytesWritten, buffer);
+    }
+    function onError(err) {
+      callback(err, 0, buffer);
     }
 
     // $isTypedArrayView excludes DataView, so a DataView would fall through
@@ -305,7 +308,7 @@ var access = function access(path, mode, callback) {
         } = offsetOrOptions ?? {});
       }
 
-      fs.write(fd, buffer, offsetOrOptions, length, position).then(wrapper, callback);
+      fs.write(fd, buffer, offsetOrOptions, length, position).then(wrapper, onError);
       return;
     }
 
@@ -328,7 +331,7 @@ var access = function access(path, mode, callback) {
     callback = position;
     callback = ensureCallback(callback);
 
-    fs.write(fd, buffer, offsetOrOptions, length).then(wrapper, callback);
+    fs.write(fd, buffer, offsetOrOptions, length).then(wrapper, onError);
   },
   readdir = function readdir(path, options, callback) {
     if ($isCallable(options)) {
@@ -593,7 +596,10 @@ var access = function access(path, mode, callback) {
 
     callback = ensureCallback(callback);
 
-    fs.writev(fd, buffers, position).$then(bytesWritten => callback(null, bytesWritten, buffers), callback);
+    fs.writev(fd, buffers, position).$then(
+      bytesWritten => callback(null, bytesWritten, buffers),
+      err => callback(err, 0, buffers),
+    );
   },
   writevSync = fs.writevSync.bind(fs),
   readv = function readv(fd, buffers, position, callback) {
@@ -604,7 +610,10 @@ var access = function access(path, mode, callback) {
 
     callback = ensureCallback(callback);
 
-    fs.readv(fd, buffers, position).$then(bytesRead => callback(null, bytesRead, buffers), callback);
+    fs.readv(fd, buffers, position).$then(
+      bytesRead => callback(null, bytesRead, buffers),
+      err => callback(err, 0, buffers),
+    );
   },
   readvSync = fs.readvSync.bind(fs),
   Dirent = fs.Dirent,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5430,6 +5430,97 @@ describe("fs.write", () => {
   });
 });
 
+// Node's fs.read/readv/write/writev call back with (err, 0, buffer) when the
+// syscall fails, so a caller that resumes after a retryable error still has
+// its buffer. fs.WriteStream's writeAll depends on that after EAGAIN.
+describe("fs.read/readv/write/writev pass the buffer to the callback on error", () => {
+  const closedFd = () => {
+    const fd = fs.openSync(`${tmpdir()}/bun-fs-cb-arity-${Date.now()}-${Math.random()}.txt`, "w+");
+    fs.closeSync(fd);
+    return fd;
+  };
+  const settle = () => Promise.withResolvers<any[]>();
+
+  it("fs.read", async () => {
+    const buffer = Buffer.alloc(8);
+    const { promise, resolve } = settle();
+    fs.read(closedFd(), buffer, 0, 8, null, (...args) => resolve(args));
+    const [err, bytesRead, buf] = await promise;
+    expect(err.code).toBe("EBADF");
+    expect([bytesRead, buf]).toEqual([0, buffer]);
+  });
+
+  it("fs.readv", async () => {
+    const buffers = [Buffer.alloc(4), Buffer.alloc(4)];
+    const { promise, resolve } = settle();
+    fs.readv(closedFd(), buffers, (...args) => resolve(args));
+    const [err, bytesRead, bufs] = await promise;
+    expect(err.code).toBe("EBADF");
+    expect([bytesRead, bufs]).toEqual([0, buffers]);
+  });
+
+  it("fs.write with a buffer", async () => {
+    const buffer = Buffer.from("bun");
+    const { promise, resolve } = settle();
+    fs.write(closedFd(), buffer, 0, 3, null, (...args) => resolve(args));
+    const [err, bytesWritten, buf] = await promise;
+    expect(err.code).toBe("EBADF");
+    expect([bytesWritten, buf]).toEqual([0, buffer]);
+  });
+
+  it("fs.write with a string", async () => {
+    const { promise, resolve } = settle();
+    fs.write(closedFd(), "bun", (...args) => resolve(args));
+    const [err, bytesWritten, str] = await promise;
+    expect(err.code).toBe("EBADF");
+    expect([bytesWritten, str]).toEqual([0, "bun"]);
+  });
+
+  it("fs.writev", async () => {
+    const buffers = [Buffer.from("b"), Buffer.from("un")];
+    const { promise, resolve } = settle();
+    fs.writev(closedFd(), buffers, (...args) => resolve(args));
+    const [err, bytesWritten, bufs] = await promise;
+    expect(err.code).toBe("EBADF");
+    expect([bytesWritten, bufs]).toEqual([0, buffers]);
+  });
+
+  // A pipe that bun has already used through process.stdout is in non-blocking
+  // mode, so a write that lands on a full pipe returns EAGAIN. writeAll retries
+  // with the rest of the buffer it got back from the callback. Without it the
+  // retry read `.slice` off `undefined` and the process died with a TypeError.
+  it.skipIf(isWindows)("fs.WriteStream retries an EAGAIN write on a non-blocking pipe", async () => {
+    const size = 4 * 1024 * 1024;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("node:fs");
+          process.stdout.write("");
+          const ws = fs.createWriteStream(null, { fd: 1, autoClose: false });
+          ws.on("error", err => {
+            console.error("error " + err.code + " " + err.message);
+            process.exit(2);
+          });
+          ws.write(Buffer.alloc(${size}, 0x61), err => {
+            if (err) return;
+            console.error("written " + ws.bytesWritten);
+          });
+          ws.end();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+    expect(stderr.trim()).toBe(`written ${size}`);
+    expect(stdout.byteLength).toBe(size);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("fs.read", () => {
   it("should work with (fd, callback)", done => {
     const path = `${tmpdir()}/bun-fs-read-1-${Date.now()}.txt`;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5447,7 +5447,8 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
     fs.read(closedFd(), buffer, 0, 8, null, (...args) => resolve(args));
     const [err, bytesRead, buf] = await promise;
     expect(err.code).toBe("EBADF");
-    expect([bytesRead, buf]).toEqual([0, buffer]);
+    expect(bytesRead).toBe(0);
+    expect(buf).toBe(buffer);
   });
 
   it("fs.readv", async () => {
@@ -5456,7 +5457,8 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
     fs.readv(closedFd(), buffers, (...args) => resolve(args));
     const [err, bytesRead, bufs] = await promise;
     expect(err.code).toBe("EBADF");
-    expect([bytesRead, bufs]).toEqual([0, buffers]);
+    expect(bytesRead).toBe(0);
+    expect(bufs).toBe(buffers);
   });
 
   it("fs.write with a buffer", async () => {
@@ -5465,7 +5467,8 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
     fs.write(closedFd(), buffer, 0, 3, null, (...args) => resolve(args));
     const [err, bytesWritten, buf] = await promise;
     expect(err.code).toBe("EBADF");
-    expect([bytesWritten, buf]).toEqual([0, buffer]);
+    expect(bytesWritten).toBe(0);
+    expect(buf).toBe(buffer);
   });
 
   it("fs.write with a string", async () => {
@@ -5473,7 +5476,8 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
     fs.write(closedFd(), "bun", (...args) => resolve(args));
     const [err, bytesWritten, str] = await promise;
     expect(err.code).toBe("EBADF");
-    expect([bytesWritten, str]).toEqual([0, "bun"]);
+    expect(bytesWritten).toBe(0);
+    expect(str).toBe("bun");
   });
 
   it("fs.writev", async () => {
@@ -5482,7 +5486,8 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
     fs.writev(closedFd(), buffers, (...args) => resolve(args));
     const [err, bytesWritten, bufs] = await promise;
     expect(err.code).toBe("EBADF");
-    expect([bytesWritten, bufs]).toEqual([0, buffers]);
+    expect(bytesWritten).toBe(0);
+    expect(bufs).toBe(buffers);
   });
 
   // A pipe that bun has already used through process.stdout is in non-blocking

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5494,7 +5494,7 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
   // mode, so a write that lands on a full pipe returns EAGAIN. writeAll retries
   // with the rest of the buffer it got back from the callback. Without it the
   // retry read `.slice` off `undefined` and the process died with a TypeError.
-  // Like Node, writeAll gives up after five EAGAINs in a row with a handled
+  // Like Node, writeAll gives up after five retries (six EAGAINs in a row) with a handled
   // "write failed" error, so a fast reader sees either outcome.
   it.skipIf(isWindows)("fs.WriteStream survives an EAGAIN write on a non-blocking pipe", async () => {
     const size = 4 * 1024 * 1024;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5494,7 +5494,9 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
   // mode, so a write that lands on a full pipe returns EAGAIN. writeAll retries
   // with the rest of the buffer it got back from the callback. Without it the
   // retry read `.slice` off `undefined` and the process died with a TypeError.
-  it.skipIf(isWindows)("fs.WriteStream retries an EAGAIN write on a non-blocking pipe", async () => {
+  // Like Node, writeAll gives up after five EAGAINs in a row with a handled
+  // "write failed" error, so a fast reader sees either outcome.
+  it.skipIf(isWindows)("fs.WriteStream survives an EAGAIN write on a non-blocking pipe", async () => {
     const size = 4 * 1024 * 1024;
     await using proc = Bun.spawn({
       cmd: [
@@ -5504,10 +5506,7 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
           const fs = require("node:fs");
           process.stdout.write("");
           const ws = fs.createWriteStream(null, { fd: 1, autoClose: false });
-          ws.on("error", err => {
-            console.error("error " + err.code + " " + err.message);
-            process.exit(2);
-          });
+          ws.on("error", err => console.error("error " + err.message));
           ws.write(Buffer.alloc(${size}, 0x61), err => {
             if (err) return;
             console.error("written " + ws.bytesWritten);
@@ -5520,8 +5519,13 @@ describe("fs.read/readv/write/writev pass the buffer to the callback on error", 
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
-    expect(stderr.trim()).toBe(`written ${size}`);
-    expect(stdout.byteLength).toBe(size);
+    expect(stderr.trim()).toBeOneOf([`written ${size}`, "error write failed"]);
+    if (stderr.startsWith("written")) {
+      expect(stdout.byteLength).toBe(size);
+    } else {
+      expect(stdout.byteLength).toBeGreaterThan(0);
+      expect(stdout.byteLength).toBeLessThan(size);
+    }
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `fs.createWriteStream(null, { fd: 1 })` on a pipe that `process.stdout` has already touched dies after 64 KiB with `TypeError: undefined is not an object (evaluating 'er')` at `internal:fs/streams` `writeAll`, line `buffer.slice(bytesWritten)`. The pipe is non-blocking, the write returns `EAGAIN`, and the retry has no buffer to slice.
- The cause is in `src/js/node/fs.ts`. On failure, `fs.read`, `fs.readv`, `fs.write` and `fs.writev` called the callback with only the error. Node calls it with `(err, 0, buffer)` (`lib/fs.js`: `callback(err, written || 0, buffer)`), and `writeAll`, a port of Node's, reads the third argument after it clears an `EAGAIN` error.

### Fix
- The four callback wrappers pass `(err, 0, buffer)` and `(err, 0, buffers)` on rejection, as Node does. No other change.
- Correct because the callback shape now matches Node for success and failure. `writeAll`/`writevAll` retry with the same buffer and the stream completes, or fails with Node's `write failed` error after five empty retries. Node has the same two outcomes on this pipe (4 of 5 runs of Node 26.3.0 with a fast reader end in `write failed`).
- Verified: `test/js/node/fs/fs.test.ts`, new block `fs.read/readv/write/writev pass the buffer to the callback on error` (six tests, all six fail on 1.4.1). Full `fs.test.ts` (579 tests) and the `test-fs-read*`, `test-fs-write*`, `test-fs-readv*`, `test-fs-writev*` Node parallel tests pass on the debug build.

### Background
- `fs.write(fd, buffer, ..., cb)` is the callback form of a single `write(2)`. It can write fewer bytes than asked, and on a non-blocking fd it can fail with `EAGAIN`. Node's `fs.WriteStream` owns the retry: `writeAll` treats `EAGAIN` as zero bytes written and calls `fs.write` again with `buffer.slice(bytesWritten)`.
- A pipe becomes non-blocking in bun once `process.stdout.write` runs on it. `O_NONBLOCK` lives on the open file description, so fd 1 itself is affected.
- Refs #7502. The EAGAIN handling in the `Bun.write(file, file)` copy loop (`sendfile`/`splice` rejecting with `EAGAIN` on the same pipe) is already covered by #37128 and is not part of this PR.

<details><summary>Notes</summary>

Repro on 1.4.1, `bun ws.js | slow-reader`:

```js
const fs = require("node:fs");
process.stdout.write("");
const ws = fs.createWriteStream(null, { fd: 1, autoClose: false });
ws.write(Buffer.alloc(1_000_000, "a"), () => console.error("done", ws.bytesWritten));
ws.end();
```

Output: `TypeError: undefined is not an object (evaluating 'er')` at `internal:fs/streams:280`, exit 1, reader receives 262144 bytes. Node v26.3.0 delivers all 1,000,000.

Node callback arity check (closed fd, node v26.3.0): `read`, `readv`, `write` (buffer and string), `writev` each call back with 3 arguments, `0`, and the original buffer(s). The new tests assert the same.

The `fs.WriteStream` test spawns bun with a piped stdout and writes 4 MiB through a WriteStream on fd 1 after `process.stdout.write("")`. It accepts the two outcomes Node has: every byte arrives, or the stream fails with the handled `write failed` error and the process exits 0. The first version of the test required full delivery. It passed on the debug build (20/20) but failed on the release build in CI 3/3 with `write failed`, because a release build runs the five retries in microseconds. On 1.4.1 the test fails 5/5 with the TypeError.

Follow-up, not in this PR: the five immediate retries are Node's behaviour and a poor fit for a pool-thread write. Once #37128 lands its `bun_sys::write_retrying` (poll `POLLOUT` on `EAGAIN`), the async flavour of `fs.write`/`fs.writev` in `node_fs.rs` can use it and the stream would always complete.

Also considered and dropped from this PR: `EINTR`/`EAGAIN` arms in `src/runtime/webcore/blob/copy_file.rs` (`Bun.write(Bun.stdout, Bun.file(src))` rejects with `EAGAIN: sendfile` after 64 KiB on the same non-blocking pipe). #37128 patches the same two sites with shared `bun_sys` retry helpers, and #38498, which did the copy loop alone, was closed in its favour.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->