### PR TITLE
fetch: drain all decoded brotli output before waiting for more input

### DIFF
--- a/src/brotli/lib.rs
+++ b/src/brotli/lib.rs
@@ -173,6 +173,13 @@ impl StreamingDecoder {
                 }
                 c::BrotliDecoderResult::needs_more_input => {
                     self.state = ReaderState::Inflating;
+                    // Input ran out with the output buffer full. Brotli keeps
+                    // the rest of the decoded bytes in its ring buffer and
+                    // still reports `needs_more_input`. Loop to drain them
+                    // before we stop for this chunk.
+                    if bytes_written > 0 && BrotliDecoder::has_more_output(self.brotli_mut()) {
+                        continue;
+                    }
                     if is_done {
                         self.state = ReaderState::Error;
                         return Err(crate::Error::BrotliDecompressionError);

--- a/src/brotli/lib.rs
+++ b/src/brotli/lib.rs
@@ -173,10 +173,7 @@ impl StreamingDecoder {
                 }
                 c::BrotliDecoderResult::needs_more_input => {
                     self.state = ReaderState::Inflating;
-                    // Input ran out with the output buffer full. Brotli keeps
-                    // the rest of the decoded bytes in its ring buffer and
-                    // still reports `needs_more_input`. Loop to drain them
-                    // before we stop for this chunk.
+                    // Brotli reports `needs_more_input` even with output left in its ring buffer.
                     if bytes_written > 0 && BrotliDecoder::has_more_output(self.brotli_mut()) {
                         continue;
                     }

--- a/src/brotli_sys/brotli_c.rs
+++ b/src/brotli_sys/brotli_c.rs
@@ -48,6 +48,7 @@ unsafe extern "C" {
     // `!Freeze` (UnsafeCell) so internal C mutation through `&` is sound.
     pub safe fn BrotliDecoderGetErrorCode(state: &BrotliDecoder) -> BrotliDecoderErrorCode2;
     pub safe fn BrotliDecoderErrorString(c: BrotliDecoderErrorCode) -> *const c_char;
+    pub safe fn BrotliDecoderHasMoreOutput(state: &BrotliDecoder) -> c_int;
 }
 
 bun_opaque::opaque_ffi! {
@@ -104,6 +105,13 @@ impl BrotliDecoder {
                     .unwrap_or(core::ptr::null_mut()),
             )
         }
+    }
+
+    /// True when decoded bytes are still held in the decoder's ring buffer.
+    /// `decompress_stream` can return `needs_more_input` with output pending
+    /// when the caller's output buffer filled up.
+    pub fn has_more_output(state: &BrotliDecoder) -> bool {
+        BrotliDecoderHasMoreOutput(state) != 0
     }
 
     pub fn initialize_brotli() -> bool {

--- a/src/brotli_sys/brotli_c.rs
+++ b/src/brotli_sys/brotli_c.rs
@@ -108,8 +108,6 @@ impl BrotliDecoder {
     }
 
     /// True when decoded bytes are still held in the decoder's ring buffer.
-    /// `decompress_stream` can return `needs_more_input` with output pending
-    /// when the caller's output buffer filled up.
     pub fn has_more_output(state: &BrotliDecoder) -> bool {
         BrotliDecoderHasMoreOutput(state) != 0
     }

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -555,8 +555,7 @@ impl CompressionStreamCoder {
                             return Ok(Progress::Done);
                         }
                         brotli::BrotliDecoderResult::needs_more_input => {
-                            // The output buffer filled before the ring buffer
-                            // drained. Brotli reports `needs_more_input` anyway.
+                            // Brotli reports `needs_more_input` even with output left in its ring buffer.
                             // SAFETY: `p` is a live decoder.
                             if written > 0
                                 && brotli::BrotliDecoder::has_more_output(unsafe { &*p.as_ptr() })

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -557,9 +557,8 @@ impl CompressionStreamCoder {
                         brotli::BrotliDecoderResult::needs_more_input => {
                             // Brotli reports `needs_more_input` even with output left in its ring buffer.
                             // SAFETY: `p` is a live decoder.
-                            if written > 0
-                                && brotli::BrotliDecoder::has_more_output(unsafe { &*p.as_ptr() })
-                            {
+                            let decoder = unsafe { &*p.as_ptr() };
+                            if written > 0 && brotli::BrotliDecoder::has_more_output(decoder) {
                                 continue;
                             }
                             if finish {

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -555,6 +555,14 @@ impl CompressionStreamCoder {
                             return Ok(Progress::Done);
                         }
                         brotli::BrotliDecoderResult::needs_more_input => {
+                            // The output buffer filled before the ring buffer
+                            // drained. Brotli reports `needs_more_input` anyway.
+                            // SAFETY: `p` is a live decoder.
+                            if written > 0
+                                && brotli::BrotliDecoder::has_more_output(unsafe { &*p.as_ptr() })
+                            {
+                                continue;
+                            }
                             if finish {
                                 return Err(CodecError::Message("unexpected end of file"));
                             }

--- a/test/js/web/fetch/fetch.brotli.test.ts
+++ b/test/js/web/fetch/fetch.brotli.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { once } from "node:events";
+import { createBrotliCompress } from "node:zlib";
 
 import brotliFile from "./fetch.brotli.test.ts.br" with { type: "file" };
 import gzipFile from "./fetch.brotli.test.ts.gzip" with { type: "file" };
@@ -52,4 +54,64 @@ test("fetch brotli response works", async () => {
 
   expect(firstText).toBe(secondText);
   expect(headers.get("Content-Encoding")).toBe("br");
+});
+
+// https://github.com/oven-sh/bun/issues/41439
+// A flushed brotli chunk that decodes to more than 4096 bytes must reach the
+// reader in full. The decoder used to hand over 4096 bytes and keep the rest
+// until the next compressed chunk arrived.
+test("fetch brotli streaming body delivers the whole flushed chunk at once", async () => {
+  const firstLine = Buffer.alloc(8000, "x").toString() + "\n";
+  const secondLine = "done\n";
+
+  // Compress the two lines as one brotli stream, with a flush after the first
+  // line, so the server can send each compressed part on its own.
+  const compressor = createBrotliCompress();
+  const compressed: Buffer[] = [];
+  compressor.on("data", chunk => compressed.push(chunk));
+  await new Promise<void>(resolve => {
+    compressor.write(firstLine);
+    compressor.flush(resolve);
+  });
+  const firstPart = Buffer.concat(compressed.splice(0));
+  compressor.end(secondLine);
+  await once(compressor, "end");
+  const restPart = Buffer.concat(compressed.splice(0));
+  expect(firstPart.byteLength).toBeGreaterThan(0);
+  expect(restPart.byteLength).toBeGreaterThan(0);
+
+  const { promise: sendRest, resolve: releaseRest } = Promise.withResolvers<void>();
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            controller.enqueue(firstPart);
+            await sendRest;
+            controller.enqueue(restPart);
+            controller.close();
+          },
+        }),
+        { headers: { "Content-Encoding": "br", "Content-Type": "application/x-ndjson" } },
+      );
+    },
+  });
+
+  const response = await fetch(server.url, { headers: { "Accept-Encoding": "br" } });
+  const reader = response.body!.getReader();
+
+  const first = await reader.read();
+  expect(first.done).toBe(false);
+  expect(first.value!.byteLength).toBe(firstLine.length);
+  expect(Buffer.from(first.value!).toString()).toBe(firstLine);
+
+  releaseRest();
+  let rest = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    rest += Buffer.from(value).toString();
+  }
+  expect(rest).toBe(secondLine);
 });

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
+import { once } from "node:events";
 import { addAbortSignal } from "node:stream";
 import zlib from "node:zlib";
 
@@ -126,6 +127,50 @@ describe("CompressionStream and DecompressionStream", () => {
         const output = decoder.decode(decompressed);
         expect(output).toBe(input);
       }
+    });
+
+    // https://github.com/oven-sh/bun/issues/41439
+    // A flushed brotli chunk must come out in full once its write settles. The
+    // decoder used to stop after one 16 KiB output buffer and keep the rest
+    // until the next compressed chunk was written.
+    test("DecompressionStream delivers the whole flushed chunk before the next write", async () => {
+      const firstLine = Buffer.alloc(40000, "x").toString() + "\n";
+      const secondLine = "done\n";
+
+      const compressor = zlib.createBrotliCompress();
+      const compressed: Buffer[] = [];
+      compressor.on("data", chunk => compressed.push(chunk));
+      await new Promise<void>(resolve => {
+        compressor.write(firstLine);
+        compressor.flush(resolve);
+      });
+      const firstPart = Buffer.concat(compressed.splice(0));
+      compressor.end(secondLine);
+      await once(compressor, "end");
+      const restPart = Buffer.concat(compressed.splice(0));
+
+      const ds = new DecompressionStream("brotli");
+      const writer = ds.writable.getWriter();
+      const reader = ds.readable.getReader();
+      let received = 0;
+      const readAll = (async () => {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          received += value.byteLength;
+        }
+      })();
+
+      // The write settles only once every output step of the chunk is done.
+      await writer.write(firstPart);
+      // Let the pending reads above settle before we count.
+      await new Promise(resolve => setImmediate(resolve));
+      expect(received).toBe(firstLine.length);
+
+      await writer.write(restPart);
+      await writer.close();
+      await readAll;
+      expect(received).toBe(firstLine.length + secondLine.length);
     });
   });
 


### PR DESCRIPTION
### Problem
- A streamed `fetch()` response with `Content-Encoding: br` reaches the reader in 4096-byte pieces. After the server flushes a chunk that decodes to 7.8 KB, the first `reader.read()` returns 4096 bytes. The rest arrives only with the next compressed chunk, seconds later. gzip, zstd, and Node deliver the whole flushed chunk at once.
- The cause is in `StreamingDecoder::decompress` (`src/brotli/lib.rs:174`). The loop reserves 4096 bytes of output and calls `BrotliDecoderDecompressStream`. When the input runs out, brotli pushes as much output as fits, keeps the rest in its ring buffer, and still returns `NEEDS_MORE_INPUT` (`vendor/brotli/c/dec/decode.c:2335`). The loop treated that result as "output drained" and returned `ShortRead`.

### Fix
- Bind `BrotliDecoderHasMoreOutput` in `src/brotli_sys/brotli_c.rs`. It reports whether decoded bytes are still held in the ring buffer.
- On `needs_more_input`, loop again while brotli wrote bytes in this step and `has_more_output` is true. Each extra step reserves another 4096 bytes and drains the ring buffer with no new input. The loop stops on the first step that finds the ring buffer empty.
- The `bytes_written > 0` guard means the loop cannot spin on a step that makes no progress.
- Verified: `test/js/web/fetch/fetch.brotli.test.ts` (new test, stock bun gets 4096 bytes instead of 8001). Also `fetch-compress.test.ts`, `fetch-gzip.test.ts`, `fetch.stream.test.ts`, `encoding.test.ts`, and the repro from the issue.

### Background
- `bun_brotli::StreamingDecoder` is the brotli path of `src/http/Decompressor.rs`. The HTTP client calls `decompress` once per body chunk it receives from the socket, and appends the output to the decoded body buffer.
- Brotli decodes into an internal ring buffer and copies from it into the caller's output buffer. `BrotliDecoderDecompressStream` returns `NEEDS_MORE_OUTPUT` only in the middle of a metablock. When the input runs out first, it returns `NEEDS_MORE_INPUT` whether or not the copy finished.
- The zstd decoder in `src/zstd/lib.rs` already loops while the last step wrote bytes, so it does not have this problem.

<details><summary>Notes</summary>

The issue's own repro (Node server with `BROTLI_OPERATION_FLUSH` after each write, Bun client):

```
before: chunk of 4096 bytes at 16 ms, chunk of 3809 bytes at 2007 ms
after:  chunk of 7872 bytes at 42 ms, chunk of 34 bytes at 2018 ms
```

The new test builds one brotli stream with `createBrotliCompress`, flushes after an 8001-byte line, and serves the two compressed parts from a `Bun.serve` `ReadableStream`. The second part is held back until the client has read the first. The first `read()` must return all 8001 bytes.

`fetch.stream.test.ts` "Content-Length response works (multiple parts)" variants for gzip, deflate, and identity hit the 5 s timeout when the four fetch files run together under the ASAN debug build. They pass when the file runs alone, and they do not use brotli.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/fetch.brotli.test.ts test/js/web/streams/compression.test.ts
bun test v1.4.3 (e0a2b82fd)

test/js/web/fetch/fetch.brotli.test.ts:
(pass) fetch brotli response works [81.74ms]
101 |   const response = await fetch(server.url, { headers: { "Accept-Encoding": "br" } });
102 |   const reader = response.body!.getReader();
103 | 
104 |   const first = await reader.read();
105 |   expect(first.done).toBe(false);
106 |   expect(first.value!.byteLength).toBe(firstLine.length);
                                        ^
error: expect(received).toBe(expected)

Expected: 8001
Received: 4096

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch.brotli.test.ts:106:35)
(fail) fetch brotli streaming body delivers the whole flushed chunk at once [295.17ms]

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [7.59ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.49ms]
(pass) TransformStream.prototype getters reject native tra
... (truncated)

release without fix: 1 skipped
bun test v1.4.3-canary.1 (edda85964)

test/js/web/fetch/fetch.brotli.test.ts:
(pass) fetch brotli response works [4.32ms]
(pass) fetch brotli streaming body delivers the whole flushed chunk at once [14.74ms]

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [0.37ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [0.08ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [0.04ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [0.06ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [1.31ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [1.15ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [2.81ms]
(pass) CompressionStream and DecompressionStream > brotli > DecompressionStream delivers the whole flushed chunk before the next write [8.64ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [0.42ms]
(pass) CompressionStream and DecompressionStre
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/fetch.brotli.test.ts test/js/web/streams/compression.test.ts
bun test v1.4.3 (e0a2b82fd)

test/js/web/fetch/fetch.brotli.test.ts:
(pass) fetch brotli response works [93.45ms]
(pass) fetch brotli streaming body delivers the whole flushed chunk at once [278.63ms]

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [8.13ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.49ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [2.59ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.45ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [14.46ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [22.51ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [48.85ms]
(pass) CompressionStream and DecompressionStream > brotli > DecompressionStr
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 842ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_brotli_sys v0.0.0 (/workspace/bun/src/brotli_sys)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/brotli/lib.rs                             |  4 ++
 src/brotli_sys/brotli_c.rs                    |  6 +++
 src/runtime/webcore/CompressionStreamCoder.rs |  6 +++
 test/js/web/fetch/fetch.brotli.test.ts        | 62 +++++++++++++++++++++++++++
 test/js/web/streams/compression.test.ts       | 45 +++++++++++++++++++
 5 files changed, 123 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/brotli/lib.rs                                  2      4     13
src/brotli_sys/brotli_c.rs                         2      3     12
src/runtime/webcore/CompressionStreamCoder.rs      3      4     12
test/js/web/fetch/fetch.brotli.test.ts             1      2      6
test/js/web/streams/compression.test.ts            1      3      9
```

</details>

**root cause** · written by the author bot

The streaming Brotli decoder stopped as soon as the underlying decoder reported that it needed more input, even though that status is also returned when decoded bytes remain buffered internally after a single 4096-byte output buffer has been filled, so the reader got one buffer's worth of a flushed write and the remainder sat in the decoder until the next compressed chunk arrived. The fix drains the decoder's pending output whenever it signals needs_more_input, repeatedly pulling decoded bytes until nothing is left to emit before actually waiting for more input. This makes a flushed Brotli …

<!-- robobun:evidence:end -->