### PR TITLE
Take path scratch buffers from the pool instead of uninitialized stack arrays

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2842,6 +2842,7 @@ pub mod asan {
         safe fn __asan_describe_address(ptr: *const c_void);
         safe fn __lsan_register_root_region(ptr: *const c_void, size: usize);
         safe fn __lsan_unregister_root_region(ptr: *const c_void, size: usize);
+        safe fn __lsan_ignore_object(ptr: *const c_void);
     }
 
     #[inline]
@@ -2886,6 +2887,14 @@ pub mod asan {
         __lsan_unregister_root_region(ptr, size);
         #[cfg(not(bun_asan))]
         let _ = (ptr, size);
+    }
+    /// Exclude the allocation at `ptr` from leak reports.
+    #[inline]
+    pub fn ignore_object(ptr: *const c_void) {
+        #[cfg(bun_asan)]
+        __lsan_ignore_object(ptr);
+        #[cfg(not(bun_asan))]
+        let _ = ptr;
     }
 }
 

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -19,7 +19,6 @@ pub mod atomic_cell;
 pub mod comptime_string_map;
 pub mod error;
 pub mod hint;
-pub mod path_buffer_pool;
 pub mod result;
 pub mod thread_id;
 pub mod tty;

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -19,6 +19,7 @@ pub mod atomic_cell;
 pub mod comptime_string_map;
 pub mod error;
 pub mod hint;
+pub mod path_buffer_pool;
 pub mod result;
 pub mod thread_id;
 pub mod tty;

--- a/src/bun_core/path_buffer_pool.rs
+++ b/src/bun_core/path_buffer_pool.rs
@@ -4,6 +4,12 @@
 //! make the stack memory usage more predictable. We keep up to 4 path buffers
 //! alive per thread at a time.
 //!
+//! It is also the only sound way to hand out scratch path storage without a
+//! per-call zero-fill. A `[u8; N]` value must be initialized, so a by-value
+//! stack `PathBuffer` whose bytes were never written is UB even though every
+//! bit pattern is a valid `u8`. The pool zeroes a buffer once on allocation
+//! and reuses it afterwards.
+//!
 //! Implemented over `thread_local!` + `RefCell<Vec<Box<T>>>` (per-thread, so no
 //! lock needed): at most 4 buffers cached per thread; excess `put`s drop. An
 //! RAII guard replaces manual `get`/`put` pairing.
@@ -17,7 +23,7 @@ use crate::{PathBuffer, WPathBuffer};
 const POOL_CAP: usize = 4;
 
 /// Per-thread pool of reusable path buffers.
-pub struct PathBufferPoolT<T: 'static + Default>(PhantomData<T>);
+pub struct PathBufferPoolT<T: 'static>(PhantomData<T>);
 
 // One thread-local Vec per buffer type: per-thread storage means mimalloc
 // frees the buffers on thread deinit and no lock is needed.
@@ -28,8 +34,11 @@ thread_local! {
     static U16_POOL: RefCell<Vec<Box<WPathBuffer>>> = const { RefCell::new(Vec::new()) };
 }
 
-pub trait PoolStorage: Sized + Default + 'static {
-    fn with_pool<R>(f: impl FnOnce(&RefCell<Vec<Box<Self>>>) -> R) -> R;
+pub trait PoolStorage: Sized + 'static {
+    /// `None` when the thread-local pool is not accessible: during or after
+    /// this thread's TLS destructors (a `Drop` that runs at thread exit can
+    /// still need a path buffer). The caller falls back to the heap.
+    fn with_pool<R>(f: impl FnOnce(&RefCell<Vec<Box<Self>>>) -> R) -> Option<R>;
     /// Allocate a fresh boxed buffer. Implemented per concrete type so the
     /// `assume_init` SAFETY obligation is discharged monomorphically (the
     /// generic site cannot soundly assert "every bit-pattern is valid" for an
@@ -37,8 +46,8 @@ pub trait PoolStorage: Sized + Default + 'static {
     fn new_boxed() -> Box<Self>;
 }
 impl PoolStorage for PathBuffer {
-    fn with_pool<R>(f: impl FnOnce(&RefCell<Vec<Box<Self>>>) -> R) -> R {
-        U8_POOL.with(f)
+    fn with_pool<R>(f: impl FnOnce(&RefCell<Vec<Box<Self>>>) -> R) -> Option<R> {
+        U8_POOL.try_with(f).ok()
     }
     #[inline]
     fn new_boxed() -> Box<Self> {
@@ -54,8 +63,8 @@ impl PoolStorage for PathBuffer {
     }
 }
 impl PoolStorage for WPathBuffer {
-    fn with_pool<R>(f: impl FnOnce(&RefCell<Vec<Box<Self>>>) -> R) -> R {
-        U16_POOL.with(f)
+    fn with_pool<R>(f: impl FnOnce(&RefCell<Vec<Box<Self>>>) -> R) -> Option<R> {
+        U16_POOL.try_with(f).ok()
     }
     #[inline]
     fn new_boxed() -> Box<Self> {
@@ -70,22 +79,26 @@ impl PoolStorage for WPathBuffer {
 impl<T: PoolStorage> PathBufferPoolT<T> {
     /// Returns an RAII guard that derefs to `&mut T` and returns the buffer to
     /// the pool on `Drop`. Replaces manual `get`/`put` pairing.
+    #[inline]
     pub fn get() -> PoolGuard<T> {
         // Zero-allocate on the (rare) cache-miss path — see
         // `PoolStorage::new_boxed` for the soundness/perf justification.
-        let buf = T::with_pool(|p| p.borrow_mut().pop()).unwrap_or_else(T::new_boxed);
+        let buf = T::with_pool(|p| p.borrow_mut().pop())
+            .flatten()
+            .unwrap_or_else(T::new_boxed);
         PoolGuard { buf: Some(buf) }
     }
 
     /// Manual return path. Prefer dropping
     /// the `PoolGuard` instead.
-    pub(crate) fn put(buf: Box<T>) {
-        T::with_pool(|p| {
+    pub fn put(buf: Box<T>) {
+        // A buffer the pool does not take (cap reached, or TLS already torn
+        // down) is dropped here — mimalloc frees it.
+        let _ = T::with_pool(|p| {
             let mut p = p.borrow_mut();
             if p.len() < POOL_CAP {
                 p.push(buf);
             }
-            // else: drop — mimalloc frees it.
         });
     }
 }
@@ -119,6 +132,16 @@ impl<T: PoolStorage> Drop for PoolGuard<T> {
     }
 }
 
+impl<T: PoolStorage> PoolGuard<T> {
+    /// Extract the `Box` without returning it to the pool (for `ManuallyDrop`
+    /// owners that will `put` explicitly later). `Drop` is a no-op once `buf`
+    /// is `None`, so no leak.
+    #[inline]
+    pub fn into_box(mut self) -> Box<T> {
+        self.buf.take().unwrap()
+    }
+}
+
 #[allow(non_camel_case_types)]
 pub type path_buffer_pool = PathBufferPoolT<PathBuffer>;
 #[allow(non_camel_case_types)]
@@ -133,18 +156,8 @@ pub fn get() -> PoolGuard<PathBuffer> {
     PathBufferPoolT::<PathBuffer>::get()
 }
 #[inline]
-pub(crate) fn put(buf: Box<PathBuffer>) {
+pub fn put(buf: Box<PathBuffer>) {
     PathBufferPoolT::<PathBuffer>::put(buf)
-}
-
-impl<T: PoolStorage> PoolGuard<T> {
-    /// Extract the `Box` without returning it to the pool (for `ManuallyDrop`
-    /// owners that will `put` explicitly later). `Drop` is a no-op once `buf`
-    /// is `None`, so no leak.
-    #[inline]
-    pub(crate) fn into_box(mut self) -> Box<T> {
-        self.buf.take().unwrap()
-    }
 }
 
 #[cfg(windows)]
@@ -153,3 +166,53 @@ pub type os_path_buffer_pool = w_path_buffer_pool;
 #[cfg(not(windows))]
 #[allow(non_camel_case_types)]
 pub type os_path_buffer_pool = path_buffer_pool;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_buffers_are_initialized_and_returned_to_the_pool() {
+        // Drain whatever an earlier test left so every `get` below allocates.
+        let drained: Vec<Box<PathBuffer>> = U8_POOL.with(|p| core::mem::take(&mut *p.borrow_mut()));
+        drop(drained);
+
+        let mut a = get();
+        let mut b = get();
+        // A never-written `[u8; N]` is UB to read; the pool hands out zeroed
+        // memory, so every byte is readable before the caller writes it.
+        assert!(a.iter().all(|&byte| byte == 0));
+        assert!(b.iter().all(|&byte| byte == 0));
+        a[0] = b'a';
+        b[0] = b'b';
+        let a_ptr: *const PathBuffer = &*a;
+        let b_ptr: *const PathBuffer = &*b;
+        drop(b);
+        drop(a);
+
+        // LIFO reuse: the last buffer returned is the next one handed out, and
+        // it carries the previous caller's bytes (callers track their own length).
+        let c = get();
+        assert_eq!(&*c as *const PathBuffer, a_ptr);
+        assert_eq!(c[0], b'a');
+        let d = get();
+        assert_eq!(&*d as *const PathBuffer, b_ptr);
+        assert_eq!(d[0], b'b');
+    }
+
+    #[test]
+    fn pool_caps_the_cached_buffers() {
+        U8_POOL.with(|p| p.borrow_mut().clear());
+        let guards: Vec<Guard> = (0..POOL_CAP + 2).map(|_| get()).collect();
+        drop(guards);
+        assert_eq!(U8_POOL.with(|p| p.borrow().len()), POOL_CAP);
+    }
+
+    #[test]
+    fn wide_pool_is_separate_and_zeroed() {
+        U16_POOL.with(|p| p.borrow_mut().clear());
+        let w = w_path_buffer_pool::get();
+        assert!(w.iter().all(|&unit| unit == 0));
+        assert_eq!(w.len(), crate::PATH_MAX_WIDE);
+    }
+}

--- a/src/bun_core/path_buffer_pool.rs
+++ b/src/bun_core/path_buffer_pool.rs
@@ -71,10 +71,8 @@ impl PoolStorage for WPathBuffer {
     }
 }
 
-/// A pooled buffer lives as long as its guard or its thread's pool. A guard
-/// that is still live when the process calls `exit` has no drop, and in an
-/// optimized build its stack slot can be dead by then, so LeakSanitizer would
-/// report the buffer. Scratch storage is never a leak worth reporting.
+/// A guard still live at `exit` never drops, and an optimized build may have
+/// discarded its stack slot, so LeakSanitizer would report the buffer.
 #[inline]
 fn lsan_ignore<T>(buf: Box<T>) -> Box<T> {
     crate::asan::ignore_object((&raw const *buf).cast());

--- a/src/bun_core/path_buffer_pool.rs
+++ b/src/bun_core/path_buffer_pool.rs
@@ -54,7 +54,7 @@ impl PoolStorage for PathBuffer {
         // on pool cache miss (≤ once per slot per thread); `alloc_zeroed` for a
         // 64 KB heap block is typically satisfied by fresh OS-zeroed pages, so
         // there is no hot-path memset cost.
-        unsafe { Box::<Self>::new_zeroed().assume_init() }
+        lsan_ignore(unsafe { Box::<Self>::new_zeroed().assume_init() })
     }
 }
 impl PoolStorage for WPathBuffer {
@@ -67,8 +67,18 @@ impl PoolStorage for WPathBuffer {
         // `new_zeroed` writes every byte to `0`, which is a valid `u16`, so the
         // value is fully initialized before `assume_init`. See `PathBuffer`
         // impl above for rationale re: `new_uninit` UB and perf.
-        unsafe { Box::<Self>::new_zeroed().assume_init() }
+        lsan_ignore(unsafe { Box::<Self>::new_zeroed().assume_init() })
     }
+}
+
+/// A pooled buffer lives as long as its guard or its thread's pool. A guard
+/// that is still live when the process calls `exit` has no drop, and in an
+/// optimized build its stack slot can be dead by then, so LeakSanitizer would
+/// report the buffer. Scratch storage is never a leak worth reporting.
+#[inline]
+fn lsan_ignore<T>(buf: Box<T>) -> Box<T> {
+    crate::asan::ignore_object((&raw const *buf).cast());
+    buf
 }
 
 impl<T: PoolStorage> PathBufferPoolT<T> {

--- a/src/bun_core/path_buffer_pool.rs
+++ b/src/bun_core/path_buffer_pool.rs
@@ -124,6 +124,15 @@ impl<T: PoolStorage> DerefMut for PoolGuard<T> {
     }
 }
 
+/// `Default` takes a buffer from the pool, so a struct that embeds a `Guard`
+/// can `#[derive(Default)]`.
+impl<T: PoolStorage> Default for PoolGuard<T> {
+    #[inline]
+    fn default() -> Self {
+        PathBufferPoolT::<T>::get()
+    }
+}
+
 impl<T: PoolStorage> Drop for PoolGuard<T> {
     fn drop(&mut self) {
         if let Some(buf) = self.buf.take() {

--- a/src/bun_core/path_buffer_pool.rs
+++ b/src/bun_core/path_buffer_pool.rs
@@ -4,11 +4,8 @@
 //! make the stack memory usage more predictable. We keep up to 4 path buffers
 //! alive per thread at a time.
 //!
-//! It is also the only sound way to hand out scratch path storage without a
-//! per-call zero-fill. A `[u8; N]` value must be initialized, so a by-value
-//! stack `PathBuffer` whose bytes were never written is UB even though every
-//! bit pattern is a valid `u8`. The pool zeroes a buffer once on allocation
-//! and reuses it afterwards.
+//! A pooled buffer is zeroed once on allocation and then reused, which is how
+//! scratch storage avoids both a per-call zero-fill and uninitialized `[u8; N]`.
 //!
 //! Implemented over `thread_local!` + `RefCell<Vec<Box<T>>>` (per-thread, so no
 //! lock needed): at most 4 buffers cached per thread; excess `put`s drop. An
@@ -35,9 +32,7 @@ thread_local! {
 }
 
 pub trait PoolStorage: Sized + 'static {
-    /// `None` when the thread-local pool is not accessible: during or after
-    /// this thread's TLS destructors (a `Drop` that runs at thread exit can
-    /// still need a path buffer). The caller falls back to the heap.
+    /// `None` while this thread's TLS destructors run. The caller uses the heap.
     fn with_pool<R>(f: impl FnOnce(&RefCell<Vec<Box<Self>>>) -> R) -> Option<R>;
     /// Allocate a fresh boxed buffer. Implemented per concrete type so the
     /// `assume_init` SAFETY obligation is discharged monomorphically (the
@@ -81,8 +76,6 @@ impl<T: PoolStorage> PathBufferPoolT<T> {
     /// the pool on `Drop`. Replaces manual `get`/`put` pairing.
     #[inline]
     pub fn get() -> PoolGuard<T> {
-        // Zero-allocate on the (rare) cache-miss path — see
-        // `PoolStorage::new_boxed` for the soundness/perf justification.
         let buf = T::with_pool(|p| p.borrow_mut().pop())
             .flatten()
             .unwrap_or_else(T::new_boxed);
@@ -92,8 +85,7 @@ impl<T: PoolStorage> PathBufferPoolT<T> {
     /// Manual return path. Prefer dropping
     /// the `PoolGuard` instead.
     pub fn put(buf: Box<T>) {
-        // A buffer the pool does not take (cap reached, or TLS already torn
-        // down) is dropped here — mimalloc frees it.
+        // Dropped when the pool is full or TLS is gone.
         let _ = T::with_pool(|p| {
             let mut p = p.borrow_mut();
             if p.len() < POOL_CAP {
@@ -124,8 +116,7 @@ impl<T: PoolStorage> DerefMut for PoolGuard<T> {
     }
 }
 
-/// `Default` takes a buffer from the pool, so a struct that embeds a `Guard`
-/// can `#[derive(Default)]`.
+/// Lets a struct that embeds a `Guard` `#[derive(Default)]`.
 impl<T: PoolStorage> Default for PoolGuard<T> {
     #[inline]
     fn default() -> Self {
@@ -142,9 +133,7 @@ impl<T: PoolStorage> Drop for PoolGuard<T> {
 }
 
 impl<T: PoolStorage> PoolGuard<T> {
-    /// Extract the `Box` without returning it to the pool (for `ManuallyDrop`
-    /// owners that will `put` explicitly later). `Drop` is a no-op once `buf`
-    /// is `None`, so no leak.
+    /// Extract the `Box` without returning it to the pool; the owner `put`s it later.
     #[inline]
     pub fn into_box(mut self) -> Box<T> {
         self.buf.take().unwrap()
@@ -182,14 +171,11 @@ mod tests {
 
     #[test]
     fn fresh_buffers_are_initialized_and_returned_to_the_pool() {
-        // Drain whatever an earlier test left so every `get` below allocates.
         let drained: Vec<Box<PathBuffer>> = U8_POOL.with(|p| core::mem::take(&mut *p.borrow_mut()));
         drop(drained);
 
         let mut a = get();
         let mut b = get();
-        // A never-written `[u8; N]` is UB to read; the pool hands out zeroed
-        // memory, so every byte is readable before the caller writes it.
         assert!(a.iter().all(|&byte| byte == 0));
         assert!(b.iter().all(|&byte| byte == 0));
         a[0] = b'a';
@@ -199,8 +185,7 @@ mod tests {
         drop(b);
         drop(a);
 
-        // LIFO reuse: the last buffer returned is the next one handed out, and
-        // it carries the previous caller's bytes (callers track their own length).
+        // LIFO reuse, previous contents kept.
         let c = get();
         assert_eq!(&*c as *const PathBuffer, a_ptr);
         assert_eq!(c[0], b'a');

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -701,13 +701,8 @@ pub use bun_alloc::SEP;
 /// crates share ONE nominal type and callers can pass a `bun_paths` buffer to
 /// `bun_core::getcwd`/`which` without a pointer cast.
 ///
-/// Scratch instances come from [`crate::path_buffer_pool::get`], which zeroes
-/// a buffer once on allocation and then reuses it. On Windows `MAX_PATH_BYTES`
-/// is 98 302 (vs 4 096 Linux / 1 024 macOS), so a by-value `ZEROED` at every
-/// call site would be a ~100 KB `memset` per call, and a by-value buffer whose
-/// bytes are never written is UB (a `u8` must be initialized; "every bit
-/// pattern is valid" does not cover uninitialized memory). `ZEROED` / `Default`
-/// are for long-lived struct fields.
+/// Scratch instances come from [`crate::path_buffer_pool::get`]. `ZEROED` /
+/// `Default` are for long-lived struct fields: on Windows this is 98 KB.
 ///
 /// NOTE on alignment: `os_path_kernel32` (Windows) reinterprets a
 /// `&mut PathBuffer` as `&mut [u16]` via [`bytes_as_slice_mut`]. The language
@@ -752,9 +747,7 @@ impl core::ops::DerefMut for PathBuffer {
 }
 
 /// `[u16; PATH_MAX_WIDE]` wide path buffer. Same newtype shape as [`PathBuffer`].
-/// Scratch instances come from `bun_paths::w_path_buffer_pool::get()`: 32 767
-/// `u16`s (~64 KB) per Windows syscall for UTF-8→UTF-16 path conversion, so a
-/// by-value zero-fill would dominate the hot path.
+/// Scratch instances come from `bun_paths::w_path_buffer_pool::get()`.
 #[repr(transparent)]
 pub struct WPathBuffer(pub [u16; PATH_MAX_WIDE]);
 impl WPathBuffer {

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -695,11 +695,19 @@ pub type OSPathSlice<'a> = &'a [OSPathChar];
 
 pub use bun_alloc::SEP;
 
-/// `[u8; MAX_PATH_BYTES]` stack buffer for path syscalls.
+/// `[u8; MAX_PATH_BYTES]` scratch buffer for path syscalls.
 ///
 /// Canonical definition; `bun_paths::PathBuffer` re-exports this so the two
 /// crates share ONE nominal type and callers can pass a `bun_paths` buffer to
 /// `bun_core::getcwd`/`which` without a pointer cast.
+///
+/// Scratch instances come from [`crate::path_buffer_pool::get`], which zeroes
+/// a buffer once on allocation and then reuses it. On Windows `MAX_PATH_BYTES`
+/// is 98 302 (vs 4 096 Linux / 1 024 macOS), so a by-value `ZEROED` at every
+/// call site would be a ~100 KB `memset` per call, and a by-value buffer whose
+/// bytes are never written is UB (a `u8` must be initialized; "every bit
+/// pattern is valid" does not cover uninitialized memory). `ZEROED` / `Default`
+/// are for long-lived struct fields.
 ///
 /// NOTE on alignment: `os_path_kernel32` (Windows) reinterprets a
 /// `&mut PathBuffer` as `&mut [u16]` via [`bytes_as_slice_mut`]. The language
@@ -714,23 +722,6 @@ pub use bun_alloc::SEP;
 pub struct PathBuffer(pub [u8; MAX_PATH_BYTES]);
 impl PathBuffer {
     pub const ZEROED: Self = Self([0; MAX_PATH_BYTES]);
-    /// The bytes are immediately overwritten by the syscall
-    /// that fills it, so the initial contents are never observed.
-    ///
-    /// On Windows `MAX_PATH_BYTES` is 98 302 (vs 4 096 Linux / 1 024 macOS), so
-    /// the previous `Self::ZEROED` body here was a ~100 KB `memset` at every
-    /// one of the ~400 call sites — turning hot loops (glob scan, module load,
-    /// stack-trace formatting) into multi-GB zero-fill workloads and timing out
-    /// the leak/stress tests. Leave the bytes uninit.
-    #[inline]
-    #[allow(invalid_value, clippy::uninit_assumed_init)]
-    pub fn uninit() -> Self {
-        // SAFETY: `PathBuffer` is `repr(transparent)` over `[u8; N]`; every bit
-        // pattern is a valid `u8`, and callers treat this as a write-only
-        // scratch buffer (length-tracked). No byte is read before being
-        // written by the consuming syscall / encoder.
-        unsafe { core::mem::MaybeUninit::uninit().assume_init() }
-    }
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.0
@@ -743,7 +734,7 @@ impl PathBuffer {
 impl Default for PathBuffer {
     #[inline]
     fn default() -> Self {
-        Self::uninit()
+        Self::ZEROED
     }
 }
 impl core::ops::Deref for PathBuffer {
@@ -761,22 +752,13 @@ impl core::ops::DerefMut for PathBuffer {
 }
 
 /// `[u16; PATH_MAX_WIDE]` wide path buffer. Same newtype shape as [`PathBuffer`].
+/// Scratch instances come from `bun_paths::w_path_buffer_pool::get()`: 32 767
+/// `u16`s (~64 KB) per Windows syscall for UTF-8→UTF-16 path conversion, so a
+/// by-value zero-fill would dominate the hot path.
 #[repr(transparent)]
 pub struct WPathBuffer(pub [u16; PATH_MAX_WIDE]);
 impl WPathBuffer {
     pub const ZEROED: Self = Self([0; PATH_MAX_WIDE]);
-    /// See [`PathBuffer::uninit`] — `PATH_MAX_WIDE` is
-    /// 32 767 `u16`s (~64 KB), and these are allocated per Windows syscall
-    /// for UTF-8→UTF-16 path conversion, so zero-initialising dominated the
-    /// hot path on Windows.
-    #[inline]
-    #[allow(invalid_value, clippy::uninit_assumed_init)]
-    pub fn uninit() -> Self {
-        // SAFETY: `repr(transparent)` over `[u16; N]`; every bit pattern is a
-        // valid `u16`. Callers treat this as a write-only scratch buffer and
-        // track the written length out-of-band.
-        unsafe { core::mem::MaybeUninit::uninit().assume_init() }
-    }
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u16] {
         &mut self.0
@@ -785,7 +767,7 @@ impl WPathBuffer {
 impl Default for WPathBuffer {
     #[inline]
     fn default() -> Self {
-        Self::uninit()
+        Self::ZEROED
     }
 }
 impl core::ops::Deref for WPathBuffer {
@@ -4655,7 +4637,7 @@ fn spawn_sync_inherit_impl(
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         let pid: libc::pid_t = {
             let arg0 = argv[0].as_ref();
-            let mut pathbuf = PathBuffer::uninit();
+            let mut pathbuf = crate::path_buffer_pool::get();
             let exe: *const core::ffi::c_char = if crate::strings::contains_char(arg0, b'/') {
                 // Contains a separator → use as-is (execve resolves relative
                 // to cwd, matching posix_spawnp semantics for non-bare names).

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -701,8 +701,8 @@ pub use bun_alloc::SEP;
 /// crates share ONE nominal type and callers can pass a `bun_paths` buffer to
 /// `bun_core::getcwd`/`which` without a pointer cast.
 ///
-/// Scratch instances come from [`crate::path_buffer_pool::get`]. `ZEROED` /
-/// `Default` are for long-lived struct fields: on Windows this is 98 KB.
+/// Scratch instances come from `bun_paths::path_buffer_pool::get()`. `ZEROED`
+/// is for long-lived struct fields: on Windows it is a 98 KB memset.
 ///
 /// NOTE on alignment: `os_path_kernel32` (Windows) reinterprets a
 /// `&mut PathBuffer` as `&mut [u16]` via [`bytes_as_slice_mut`]. The language
@@ -724,12 +724,6 @@ impl PathBuffer {
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
         &self.0
-    }
-}
-impl Default for PathBuffer {
-    #[inline]
-    fn default() -> Self {
-        Self::ZEROED
     }
 }
 impl core::ops::Deref for PathBuffer {
@@ -755,12 +749,6 @@ impl WPathBuffer {
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u16] {
         &mut self.0
-    }
-}
-impl Default for WPathBuffer {
-    #[inline]
-    fn default() -> Self {
-        Self::ZEROED
     }
 }
 impl core::ops::Deref for WPathBuffer {
@@ -4630,7 +4618,7 @@ fn spawn_sync_inherit_impl(
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         let pid: libc::pid_t = {
             let arg0 = argv[0].as_ref();
-            let mut pathbuf = crate::path_buffer_pool::get();
+            let mut pathbuf = PathBuffer::ZEROED;
             let exe: *const core::ffi::c_char = if crate::strings::contains_char(arg0, b'/') {
                 // Contains a separator → use as-is (execve resolves relative
                 // to cwd, matching posix_spawnp semantics for non-bare names).

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -6,7 +6,6 @@ use crate::options::Loader;
 use crate::Error;
 use crate::options::{OutputKind, Side};
 use bun_core::String as BunString;
-use bun_paths::PathBuffer;
 use bun_paths::fs;
 use bun_paths::resolve_path::{self, platform};
 use bun_sys::Fd;
@@ -232,7 +231,7 @@ impl OutputFile {
                     bun_sys::Dir::borrow(&root_dir).make_path(parent)?;
                 }
 
-                let mut path_buf = PathBuffer::uninit();
+                let mut path_buf = bun_paths::path_buffer_pool::get();
                 let _ = bun_sys::write_file_with_path_buffer(
                     &mut path_buf,
                     &bun_sys::WriteFileArgs {
@@ -252,14 +251,14 @@ impl OutputFile {
     }
 
     pub(crate) fn copy_to(&self, rel_path: &[u8], dir: Fd) -> Result<(), Error> {
-        let mut out_buf = PathBuffer::uninit();
+        let mut out_buf = bun_paths::path_buffer_pool::get();
         let fd_out = bun_sys::openat(
             dir,
             resolve_path::z(rel_path, &mut out_buf),
             bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
             0o644,
         )?;
-        let mut in_buf = PathBuffer::uninit();
+        let mut in_buf = bun_paths::path_buffer_pool::get();
         let fd_in = bun_sys::openat(
             Fd::cwd(),
             resolve_path::z(self.src_path.text, &mut in_buf),

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -4,7 +4,7 @@ use core::sync::atomic::AtomicUsize;
 use bun_alloc::Arena; // bumpalo::Bump re-export
 use bun_collections::{ArrayHashMap, AutoBitSet, VecExt, index_sort};
 use bun_core::strings;
-use bun_paths::{PathBuffer, resolve_path};
+use bun_paths::resolve_path;
 use bun_sourcemap::SourceMapPieces;
 use bun_wyhash::{self, Wyhash};
 
@@ -693,7 +693,7 @@ pub(crate) fn compute_chunks(
             } else {
                 b"."
             };
-            let mut real_path_buf = PathBuffer::uninit();
+            let mut real_path_buf = bun_paths::path_buffer_pool::get();
             let dir: &[u8] = 'dir: {
                 let Ok(dir_file) = bun_sys::File::openat(
                     bun_sys::Fd::cwd(),

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1069,7 +1069,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     if matches!(chunk.content, crate::chunk::Content::Javascript(_))
                         && loader.is_javascript_like()
                     {
-                        let mut fdpath = bun_paths::PathBuffer::uninit();
+                        let mut fdpath = bun_paths::path_buffer_pool::get();
                         // For --compile builds, the bytecode URL must match the module name
                         // that will be used at runtime. The module name is:
                         //   public_path + final_rel_path (e.g., "/$bunfs/root/app.js")

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -6,7 +6,7 @@ use bun_alloc::MaxHeapAllocator;
 use bun_ast::Loc;
 use bun_core::fmt::quote;
 use bun_core::{String as BunString, strings};
-use bun_paths::{self as paths, PathBuffer};
+use bun_paths as paths;
 use bun_wyhash::hash;
 
 use crate::LinkerContext;
@@ -74,7 +74,7 @@ pub(crate) fn write_output_files_to_disk(
     let mut _max_heap_allocator_source_map = MaxHeapAllocator::init();
     let mut _max_heap_allocator_inline_source_map = MaxHeapAllocator::init();
 
-    let mut pathbuf = PathBuffer::uninit();
+    let mut pathbuf = bun_paths::path_buffer_pool::get();
     // SAFETY: c points to LinkerContext which is the `linker` field of BundleV2.
     let bv2: &mut BundleV2 =
         unsafe { &mut *LinkerContext::bundle_v2_ptr(std::ptr::from_mut::<LinkerContext>(c)) };
@@ -394,7 +394,7 @@ pub(crate) fn write_output_files_to_disk(
                 };
 
                 if loader.is_javascript_like() {
-                    let mut fdpath = PathBuffer::uninit();
+                    let mut fdpath = bun_paths::path_buffer_pool::get();
                     let source_provider_url = BunString::create_format(format_args!(
                         "{}{}",
                         bstr::BStr::new(&chunk.final_rel_path),

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1931,7 +1931,7 @@ impl<'a> BundleOptions<'a> {
             let handle = open_output_dir(&opts.output_dir)?;
             // The inline `bun_resolver::fs::FileSystem` does
             // not yet expose `get_fd_path`, so resolve via `bun_sys` and box.
-            let mut buf = bun_paths::PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let dir = bun_sys::get_fd_path(handle.fd(), &mut buf).map_err(crate::Error::from)?;
             opts.output_dir = Box::from(&dir[..]);
             opts.output_dir_handle = Some(handle);
@@ -2006,7 +2006,7 @@ pub(crate) fn open_output_dir(output_dir: &[u8]) -> Result<Dir, crate::Error> {
             // Single-level mkdir
             // (fails ENOENT if parent missing). Do NOT use `make_path` (the
             // recursive `mkdir -p` variant) here.
-            let mut buf = bun_paths::PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let len = output_dir.len().min(buf.0.len() - 1);
             buf.0[..len].copy_from_slice(&output_dir[..len]);
             buf.0[len] = 0;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -466,7 +466,7 @@ impl<'a> Transpiler<'a> {
         match self._resolve_entry_point(entry_point) {
             Ok(r) => self.reject_unbundleable_entry_point(r, entry_point),
             Err(err) => {
-                let mut cache_bust_buf = bun_paths::PathBuffer::uninit();
+                let mut cache_bust_buf = bun_paths::path_buffer_pool::get();
 
                 // Bust directory cache and try again
                 // reshaped for borrowck — a single labelled block would
@@ -1763,7 +1763,7 @@ impl<'a> Transpiler<'a> {
                                     // No shared const for the bytecode extension
                                     // in `bun_core` yet, so inline the literal.
                                     const BYTECODE_EXT: &[u8] = b".jsc";
-                                    let mut path_buf2 = bun_paths::PathBuffer::uninit();
+                                    let mut path_buf2 = bun_paths::path_buffer_pool::get();
                                     let n = path.text.len();
                                     let total = n + BYTECODE_EXT.len();
                                     // `ZStr::from_buf` needs `buf[total] == 0`

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -86,7 +86,7 @@ fn load_global_bunfig(cmd: CommandTag, ctx: Context<'_>) -> Result<(), crate::Er
     }
     ctx.has_loaded_global_config = true;
 
-    let mut config_buf = PathBuffer::uninit();
+    let mut config_buf = bun_paths::path_buffer_pool::get();
     if let Some(path) = get_home_config_path(&mut config_buf) {
         load_bunfig(cmd, true, path, ctx)?;
     }
@@ -150,7 +150,7 @@ pub fn load_config(
         }
     }
 
-    let mut config_buf = PathBuffer::uninit();
+    let mut config_buf = bun_paths::path_buffer_pool::get();
     if cmd.read_global_config() {
         if !ctx.has_loaded_global_config {
             ctx.has_loaded_global_config = true;
@@ -200,7 +200,7 @@ pub fn load_config(
         config_path_len = config_path_.len();
     } else {
         if ctx.args.absolute_working_dir.is_none() {
-            let mut secondbuf = PathBuffer::uninit();
+            let mut secondbuf = bun_paths::path_buffer_pool::get();
             let cwd_len = match bun_sys::getcwd(&mut *secondbuf) {
                 Ok(n) => n,
                 Err(_) => return Ok(()),

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2860,8 +2860,8 @@ mod draft {
             target_os = "freebsd"
         ))]
         {
-            let mut buf = bun_core::PathBuffer::default();
-            let mut buf2 = bun_core::PathBuffer::default();
+            let mut buf = bun_core::PathBuffer::ZEROED;
+            let mut buf2 = bun_core::PathBuffer::ZEROED;
             let Some(path_env) = env_var::PATH::get() else {
                 return;
             };

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -456,7 +456,7 @@ impl Loader {
     fn load_ccache_path_impl(&mut self, fs: &bun_paths::fs::FileSystem) -> Result<(), AllocError> {
         // if they have ccache installed, put it in env variable `CMAKE_CXX_COMPILER_LAUNCHER` so
         // cmake can use it to hopefully speed things up
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let path = match self.get(b"PATH") {
             Some(p) => p,
             None => return Ok(()),
@@ -496,7 +496,7 @@ impl Loader {
         fs: &bun_paths::fs::FileSystem,
         override_node: &[u8],
     ) -> crate::Result<bool> {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
 
         let node_path_to_use: Box<[u8]> = if !override_node.is_empty() {
             Box::from(override_node)

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -144,7 +144,7 @@ pub fn init_global(
         // Dupe to keep Box<[u8]> ownership uniform.
         global.top_level_dir = Box::<[u8]>::from(dir);
     } else if global.top_level_dir.is_empty() {
-        let mut buf = bun_paths::PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         match sys::getcwd(&mut buf[..]) {
             Ok(len) => {
                 global.top_level_dir = Box::<[u8]>::from(&buf[..len]);

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -48,8 +48,7 @@ pub(crate) fn statat_windows(fd: Fd, path: &ZStr) -> Maybe<Stat> {
     // so we need two buffers — but on Windows `PathBuffer` is ~96 KB,
     // and this is called from deep inside `Iterator::next()` (via `lstatat`
     // for `FileKind::Unknown`), so two stack `PathBuffer`s (~192 KB) risk
-    // overflowing the smaller worker-thread stacks. Draw both from the
-    // per-thread heap pool instead (RAII-returned) — zero stack footprint.
+    // overflowing the smaller worker-thread stacks.
     let mut dir_buf = bun_paths::path_buffer_pool::get();
     let dir = Syscall::get_fd_path(fd, &mut dir_buf)?;
     let parts: &[&[u8]] = &[&dir[..], path.as_bytes()];

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -47,10 +47,9 @@ pub(crate) fn statat_windows(fd: Fd, path: &ZStr) -> Maybe<Stat> {
     // passing the same buffer as both `join_z_buf`'s output and an input part,
     // so we need two buffers — but on Windows `PathBuffer` is ~96 KB,
     // and this is called from deep inside `Iterator::next()` (via `lstatat`
-    // for `FileKind::Unknown`), so two stack `PathBuffer`s (~192 KB, zero-
-    // initialized by `PathBuffer::uninit()`) risk overflowing the smaller
-    // worker-thread stacks. Draw both from the per-thread heap pool instead
-    // (uninit, RAII-returned) — zero stack footprint, no zero-fill.
+    // for `FileKind::Unknown`), so two stack `PathBuffer`s (~192 KB) risk
+    // overflowing the smaller worker-thread stacks. Draw both from the
+    // per-thread heap pool instead (RAII-returned) — zero stack footprint.
     let mut dir_buf = bun_paths::path_buffer_pool::get();
     let dir = Syscall::get_fd_path(fd, &mut dir_buf)?;
     let parts: &[&[u8]] = &[&dir[..], path.as_bytes()];
@@ -256,7 +255,7 @@ pub struct GlobWalker<A: Accessor, const SENTINEL: bool> {
     pub(crate) error_on_broken_symlinks: bool,
     pub(crate) only_files: bool,
 
-    pub(crate) path_buf: Box<PathBuffer>,
+    pub(crate) path_buf: bun_paths::path_buffer_pool::Guard,
     // iteration state
     pub(crate) workbuf: Vec<WorkItem<A>>,
 
@@ -319,7 +318,7 @@ pub enum IterState<A: Accessor> {
 pub struct Directory<A: Accessor> {
     pub(crate) fd: A::Handle,
     pub(crate) iter: A::DirIter,
-    pub(crate) path: Box<PathBuffer>,
+    pub(crate) path: bun_paths::path_buffer_pool::Guard,
     // The dir path is a prefix of `path` (self-referential).
     // Store the length and reconstruct on demand.
     pub(crate) dir_path_len: usize,
@@ -555,7 +554,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
         log!("transition => {}", bstr::BStr::new(work_item_path));
         // Build the Directory in a local and assign at the end (borrowck:
         // mutating `iter_state` in place would overlap the `self.walker` borrow).
-        let mut dir_path_buf = Box::new(PathBuffer::uninit());
+        let mut dir_path_buf = bun_paths::path_buffer_pool::get();
         let mut dir_path_len: usize = 'dir_path: {
             if ROOT {
                 if !self.walker.absolute {
@@ -1450,7 +1449,7 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             end_byte_of_basename_excluding_special_syntax: 0,
             pattern_components: Vec::new(),
             matched_paths: MatchedMap::default(),
-            path_buf: Box::new(PathBuffer::uninit()),
+            path_buf: bun_paths::path_buffer_pool::get(),
             workbuf: Vec::new(),
             followed_links: Vec::new(),
             is_ignored: ignore_filter_fn.unwrap_or(dummy_filter_false),

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -5,7 +5,7 @@ use bun_core::Progress::Progress;
 use bun_core::{Global, Output};
 use bun_core::{MutableString, ZStr};
 use bun_paths::strings;
-use bun_paths::{self as path, OSPathChar, OSPathSlice, PathBuffer, SEP, SEP_STR};
+use bun_paths::{self as path, OSPathChar, OSPathSlice, SEP, SEP_STR};
 use bun_semver::String as SemverString;
 #[cfg(not(windows))]
 use bun_sys::OpenDirOptions;
@@ -1732,7 +1732,7 @@ impl<'a> PackageInstall<'a> {
         };
 
         #[cfg(not(windows))]
-        let mut buf2 = PathBuffer::uninit();
+        let mut buf2 = bun_paths::path_buffer_pool::get();
         #[cfg(not(windows))]
         let to_copy_buf2_offset: usize;
         #[cfg(unix)]
@@ -2053,10 +2053,10 @@ impl<'a> PackageInstall<'a> {
             && dirname_slice != dest_path.as_bytes())
         .then_some(dirname_slice);
 
-        let mut dest_buf = PathBuffer::uninit();
+        let mut dest_buf = bun_paths::path_buffer_pool::get();
         // cache_dir_subpath in here is actually the full path to the symlink pointing to the linked package
         let symlinked_path = self.cache_dir_subpath;
-        let mut to_buf = PathBuffer::uninit();
+        let mut to_buf = bun_paths::path_buffer_pool::get();
         // Open the target relative to cache_dir, then resolve its canonical path.
         // Returning a borrow of `to_buf` from an `FnMut` closure is rejected by
         // borrowck, so inline the open/getFdPath/close.
@@ -2105,7 +2105,7 @@ impl<'a> PackageInstall<'a> {
         #[cfg(windows)]
         {
             use bun_sys::windows;
-            let mut wbuf = bun_paths::WPathBuffer::uninit();
+            let mut wbuf = bun_paths::w_path_buffer_pool::get();
             // SAFETY: FFI — destination_dir.fd() is an open handle; wbuf is a valid writable
             // WPathBuffer of the passed length.
             let dest_path_length = unsafe {
@@ -2210,7 +2210,7 @@ impl<'a> PackageInstall<'a> {
             let target = path::resolve_path::relative(dest_dir_path, to_path);
             // `symlinkat` takes `&ZStr` for both target and dest; build NUL-terminated
             // copies in stack buffers.
-            let mut target_buf = PathBuffer::uninit();
+            let mut target_buf = bun_paths::path_buffer_pool::get();
             target_buf[..target.len()].copy_from_slice(target);
             target_buf[target.len()] = 0;
             // SAFETY: NUL written above.

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -130,7 +130,7 @@ impl NodeModulesFolder {
         root_node_modules_dir: &Dir,
         file_path: &ZStr,
     ) -> bool {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let parts: [&[u8]; 2] = [self.path.as_slice(), file_path.as_bytes()];
         bun_sys::directory_exists_at(
             root_node_modules_dir.fd(),
@@ -163,7 +163,7 @@ impl NodeModulesFolder {
         root_node_modules_dir: &Dir,
         file_path: &ZStr,
     ) -> bun_sys::Result<bun_sys::File> {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let parts: [&[u8]; 2] = [self.path.as_slice(), file_path.as_bytes()];
         root_node_modules_dir.open_file(
             join_z_buf::<platform::Auto>(path_buf.as_mut_slice(), &parts),
@@ -220,7 +220,7 @@ impl NodeModulesFolder {
         #[cfg(unix)]
         {
             // Copy into a NUL-terminated PathBuffer.
-            let mut path_buf = PathBuffer::uninit();
+            let mut path_buf = bun_paths::path_buffer_pool::get();
             let path_z = bun_paths::resolve_path::z(self.path.as_slice(), &mut path_buf);
             return root
                 .open_at_with(path_z.as_bytes(), 0)
@@ -345,7 +345,7 @@ fn abs_node_modules_path(
     string_buf: &[u8],
     tree_id: lockfile::tree::Id,
 ) -> AbsPath {
-    let mut rel_buf = PathBuffer::uninit();
+    let mut rel_buf = bun_paths::path_buffer_pool::get();
     rel_buf[..b"node_modules".len()].copy_from_slice(b"node_modules");
     let mut depth_buf = lockfile::tree::depth_buf_uninit();
     let (rel, _) = lockfile::tree::relative_path_and_depth::<
@@ -503,9 +503,9 @@ impl<'a> PackageInstaller<'a> {
         if self.trees[tree_id as usize].binaries.count() > 0 {
             self.seen_bin_links.clear();
 
-            let mut link_target_buf = PathBuffer::uninit();
-            let mut link_dest_buf = PathBuffer::uninit();
-            let mut link_rel_buf = PathBuffer::uninit();
+            let mut link_target_buf = bun_paths::path_buffer_pool::get();
+            let mut link_dest_buf = bun_paths::path_buffer_pool::get();
+            let mut link_rel_buf = bun_paths::path_buffer_pool::get();
             // reshaped for borrowck — pass tree_id, re-borrow tree inside.
             self.link_tree_bins(
                 tree_id,
@@ -735,12 +735,12 @@ impl<'a> PackageInstaller<'a> {
 
     pub(crate) fn link_remaining_bins(&mut self, log_level: Options::LogLevel) {
         let mut depth_buf = lockfile::tree::depth_buf_uninit();
-        let mut node_modules_rel_path_buf = PathBuffer::uninit();
+        let mut node_modules_rel_path_buf = bun_paths::path_buffer_pool::get();
         node_modules_rel_path_buf[..b"node_modules".len()].copy_from_slice(b"node_modules");
 
-        let mut link_target_buf = PathBuffer::uninit();
-        let mut link_dest_buf = PathBuffer::uninit();
-        let mut link_rel_buf = PathBuffer::uninit();
+        let mut link_target_buf = bun_paths::path_buffer_pool::get();
+        let mut link_dest_buf = bun_paths::path_buffer_pool::get();
+        let mut link_rel_buf = bun_paths::path_buffer_pool::get();
 
         let trees_len = self.trees.len();
         for tree_id in 0..trees_len {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1121,7 +1121,7 @@ fn configure_env_for_scripts_run(
     }
 
     {
-        let mut node_path = PathBuffer::uninit();
+        let mut node_path = bun_paths::path_buffer_pool::get();
         if let Some(node_path_z) = this.env_mut().get_node_path(paths_fs, &mut node_path) {
             let _ = this
                 .env_mut()
@@ -1154,7 +1154,7 @@ fn ensure_temp_node_gyp_script_run(manager: &mut PackageManager) -> Result<(), E
     }
 
     let tempdir = get_temporary_directory(manager);
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     let node_gyp_tempdir_name =
         fs::FileSystem::tmpname(b"node-gyp", &mut path_buf.0, bun_core::fast_random())?;
 
@@ -1583,7 +1583,7 @@ pub fn init(
             let need_write = subcommand != Subcommand::Install || cli.positionals.len() > 1;
 
             loop {
-                let mut package_json_path_buf = PathBuffer::uninit();
+                let mut package_json_path_buf = bun_paths::path_buffer_pool::get();
                 package_json_path_buf[..this_cwd.len()].copy_from_slice(this_cwd);
                 package_json_path_buf[this_cwd.len()..this_cwd.len() + b"/package.json".len()]
                     .copy_from_slice(b"/package.json");
@@ -1681,7 +1681,7 @@ pub fn init(
             if !created_package_json && !no_project {
                 while let Some(parent) = bun_core::dirname(this_cwd) {
                     let parent_without_trailing_slash = strings::without_trailing_slash(parent);
-                    let mut parent_path_buf = PathBuffer::uninit();
+                    let mut parent_path_buf = bun_paths::path_buffer_pool::get();
                     parent_path_buf[..parent_without_trailing_slash.len()]
                         .copy_from_slice(parent_without_trailing_slash);
                     parent_path_buf[parent_without_trailing_slash.len()
@@ -1929,7 +1929,7 @@ pub fn init(
         let mut install = Api::BunInstall::default();
         let npmrc_local = ZBox::from_bytes(b".npmrc");
 
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let parts = [b"./.npmrc" as &[u8]];
 
         // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
@@ -2183,7 +2183,7 @@ pub fn init(
         // a stack buffer and convert separators in place.
         // SAFETY: ROOT_PACKAGE_JSON_PATH set above on the main thread.
         let raw: &[u8] = unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_ref();
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         buf[..raw.len()].copy_from_slice(raw);
         let normalized = &mut buf[..raw.len()];
         resolve_path::dangerously_convert_path_to_posix_in_place::<u8>(normalized);
@@ -2302,7 +2302,7 @@ pub fn init(
             if bun_paths::is_absolute(options.ca_file_name) {
                 abs_ca_file_name = ZBox::from_bytes(options.ca_file_name);
             } else {
-                let mut path_buf = PathBuffer::uninit();
+                let mut path_buf = bun_paths::path_buffer_pool::get();
                 abs_ca_file_name =
                     ZBox::from_bytes(resolve_path::join_abs_string_buf::<platform::Auto>(
                         &original_cwd_clone,

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -17,7 +17,7 @@ use bun_clap as clap;
 use bun_core::strings;
 use bun_core::{Global, Output};
 use bun_install::npm as Npm;
-use bun_paths::{self as Path, PathBuffer};
+use bun_paths as Path;
 
 use std::sync::OnceLock;
 
@@ -1605,8 +1605,8 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         }
 
         if let Some(cwd_) = args.option(b"--cwd") {
-            let mut buf = PathBuffer::uninit();
-            let mut buf2 = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
+            let mut buf2 = bun_paths::path_buffer_pool::get();
 
             let final_path: &mut bun_core::ZStr = if !cwd_.is_empty() && cwd_[0] == b'.' {
                 let cwd_len = bun_sys::getcwd(&mut buf[..])?;

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -180,7 +180,7 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
             }
         };
 
-    let mut tmpbuf = PathBuffer::uninit();
+    let mut tmpbuf = bun_paths::path_buffer_pool::get();
     let tmpname =
         FileSystem::tmpname(b"hm", &mut tmpbuf, bun_core::fast_random()).expect("unreachable");
 
@@ -280,7 +280,7 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
     if let Some(timer) = timer.as_mut() {
         let elapsed = timer.read();
         if elapsed > bun_core::time::NS_PER_MS * 100 {
-            let mut path_buf = PathBuffer::uninit();
+            let mut path_buf = bun_paths::path_buffer_pool::get();
             let cache_dir_path: &[u8] = match sys::get_fd_path(cache_directory_fd, &mut path_buf) {
                 Ok(p) => &p[..],
                 Err(_) => b"it",
@@ -293,7 +293,7 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
     }
 
     #[cfg(windows)]
-    let mut buf = PathBuffer::uninit();
+    let mut buf = bun_paths::path_buffer_pool::get();
     #[cfg(windows)]
     let temp_dir_path = match sys::get_fd_path_z(Fd::from_std_dir(&tempdir), &mut buf) {
         Ok(p) => p,
@@ -762,7 +762,7 @@ pub fn is_package_in_cache_at(cache_dir: Fd, folder_path: &ZStr, tag: Resolution
         ResolutionTag::Git => b".bun-tag",
         _ => return sys::directory_exists_at(cache_dir, folder_path).unwrap_or(false),
     };
-    let mut buf = PathBuffer::uninit();
+    let mut buf = bun_paths::path_buffer_pool::get();
     let marker_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
         &mut buf.0,
         &[folder_path.as_bytes(), marker],
@@ -782,7 +782,7 @@ pub fn is_package_in_cache(
 
 pub fn setup_global_dir(manager: &mut PackageManager, ctx: &Command::Context) -> Result<(), Error> {
     manager.options.global_bin_dir = options::open_global_bin_dir(ctx.install.as_deref())?;
-    let mut out_buffer = PathBuffer::uninit();
+    let mut out_buffer = bun_paths::path_buffer_pool::get();
     let result = sys::get_fd_path_z(manager.options.global_bin_dir, &mut out_buffer)?;
     let path = FileSystem::instance()
         .dirname_store()
@@ -830,7 +830,7 @@ pub fn global_link_dir(this: &mut PackageManager) -> Fd {
     let link_fd = link_dir.fd();
     this.global_dir = Some(global_dir);
     this.global_link_dir = Some(link_dir);
-    let mut buf = PathBuffer::uninit();
+    let mut buf = bun_paths::path_buffer_pool::get();
     let path_ = match sys::get_fd_path(link_fd, &mut buf) {
         Ok(p) => p,
         Err(err) => {
@@ -861,7 +861,7 @@ pub fn path_for_cached_npm_path<'a>(
     package_name: &[u8],
     version: Semver::Version,
 ) -> Result<&'a mut [u8], Error> {
-    let mut cache_path_buf = PathBuffer::uninit();
+    let mut cache_path_buf = bun_paths::path_buffer_pool::get();
 
     let cache_path = cached_npm_package_folder_name_print(
         this,
@@ -882,7 +882,7 @@ pub fn path_for_cached_npm_path<'a>(
     #[cfg(windows)]
     {
         let _ = cache_dir;
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let cache_path = ZStr::from_buf(&cache_path_buf, cache_path_len);
         let joined = path::resolve_path::join_abs_string_buf_z::<path::platform::Windows>(
             &this.cache_directory_path,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -7,7 +7,7 @@ use core::sync::atomic::Ordering;
 use crate::bun_fs::FileSystem;
 use bun_core::{Output, UnwrapOrOom, fmt as bun_fmt};
 use bun_core::{StringOrTinyString, strings};
-use bun_paths::{self as Path, PathBuffer};
+use bun_paths as Path;
 use bun_semver::{self as Semver, String as SemverString};
 use bun_sys::Fd;
 use bun_threading::thread_pool as ThreadPool;
@@ -2127,7 +2127,7 @@ fn enqueue_local_tarball(
     // can be reallocated concurrently by the main thread while processing
     // other dependencies (e.g. `appendPackage` / `StringBuilder.allocate`
     // in `Package.fromNPM`).
-    let mut abs_buf = PathBuffer::uninit();
+    let mut abs_buf = bun_paths::path_buffer_pool::get();
     let (tarball_path, normalize): (&[u8], bool) =
         match local_tarball_base_dir(&this.lockfile, dependency_id, path) {
             None => (path, true),
@@ -2883,7 +2883,7 @@ fn get_or_put_resolved_package(
                     // SAFETY: `get_or_put` copies `folder_path_abs` into the
                     // lockfile string buffer before any other mutation.
                     let folder_path = this.lockfile.str_detached(&folder);
-                    let mut buf2 = PathBuffer::uninit();
+                    let mut buf2 = bun_paths::path_buffer_pool::get();
                     let folder_path_abs = if bun_paths::is_absolute(folder_path) {
                         folder_path
                     } else {
@@ -2997,7 +2997,7 @@ fn get_or_put_resolved_package(
             // SAFETY: `get_or_put` copies `workspace_path_u8` into the
             // lockfile string buffer before any other mutation.
             let workspace_path = this.lockfile.str_detached(&workspace_path_raw);
-            let mut buf2 = PathBuffer::uninit();
+            let mut buf2 = bun_paths::path_buffer_pool::get();
             let workspace_path_u8 = if bun_paths::is_absolute(workspace_path) {
                 workspace_path
             } else {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -1,7 +1,6 @@
 use crate::bun_schema::api as Api;
 use bun_core::ZStr;
 use bun_core::{Output, env_var};
-use bun_paths::PathBuffer;
 
 use super::Subcommand;
 use super::command_line_arguments::{self, CommandLineArguments};
@@ -336,7 +335,7 @@ pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd>
     }
 
     if let Some(home_dir) = env_var::BUN_INSTALL.get() {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let parts: [&[u8]; 2] = [b"install", b"global"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
         return Dir::cwd()
@@ -349,7 +348,7 @@ pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd>
         .get()
         .or_else(|| env_var::HOME.get())
     {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let parts: [&[u8]; 3] = [b".bun", b"install", b"global"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
         return Dir::cwd()
@@ -384,7 +383,7 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
     }
 
     if let Some(home_dir) = env_var::BUN_INSTALL.get() {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let parts: [&[u8]; 1] = [b"bin"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
         return Dir::cwd()
@@ -397,7 +396,7 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
         .get()
         .or_else(|| env_var::HOME.get())
     {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let parts: [&[u8]; 2] = [b".bun", b"bin"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
         return Dir::cwd()

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -4,7 +4,6 @@ use core::mem::ManuallyDrop;
 use bun_collections::index_sort;
 use bun_core::Output;
 use bun_core::strings;
-use bun_paths::PathBuffer;
 use bun_semver as semver;
 use bun_semver::{SlicedString, String as SemverString};
 
@@ -196,7 +195,7 @@ impl PackageManager {
                 self.lockfile.buffers.string_bytes.as_slice(),
                 tags_buf.as_slice(),
             ) {
-                let mut buf = PathBuffer::uninit();
+                let mut buf = bun_paths::path_buffer_pool::get();
                 let npm_package_path = match super::path_for_cached_npm_path(
                     self,
                     &mut buf,

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -13,8 +13,6 @@ use crate::bun_json::Expr;
 // `bun_js_printer::PrintJsonOptions` see no mismatch.
 use bun_ast::Indentation;
 use bun_ast::{Log, Source};
-#[cfg(windows)]
-use bun_paths::PathBuffer;
 use bun_paths::is_absolute;
 
 use crate::bun_json as json;
@@ -142,7 +140,7 @@ impl WorkspacePackageJSONCache {
         debug_assert!(is_absolute(abs_package_json_path));
 
         #[cfg(windows)]
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         #[cfg(not(windows))]
         let path: &[u8] = abs_package_json_path;
         #[cfg(windows)]

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -63,7 +63,7 @@ pub fn do_patch_commit(
     pathbuf: &mut PathBuffer,
     log_level: LogLevel,
 ) -> Result<Option<PatchCommitResult>, crate::Error> {
-    let mut folder_path_buf = PathBuffer::uninit();
+    let mut folder_path_buf = bun_paths::path_buffer_pool::get();
     let mut lockfile: Box<Lockfile> = Box::default();
     let log = manager.log_mut();
     match lockfile.load_from_cwd::<true>(Some(manager), log) {
@@ -290,8 +290,8 @@ pub fn do_patch_commit(
 
     let patchfile_contents: Vec<u8> = 'brk: {
         let new_folder = changes_dir;
-        let mut buf2 = PathBuffer::uninit();
-        let mut buf3 = PathBuffer::uninit();
+        let mut buf2 = bun_paths::path_buffer_pool::get();
+        let mut buf3 = bun_paths::path_buffer_pool::get();
         let old_folder: &[u8] = 'old_folder: {
             let cache_dir_path = match sys::get_fd_path(cache_dir, &mut buf2) {
                 Ok(s) => s,
@@ -451,7 +451,7 @@ pub fn do_patch_commit(
             }
         }
 
-        let mut cwdbuf = PathBuffer::uninit();
+        let mut cwdbuf = bun_paths::path_buffer_pool::get();
         let cwd = match sys::getcwd_z(&mut cwdbuf) {
             Ok(fd) => fd,
             Err(e) => {
@@ -459,7 +459,7 @@ pub fn do_patch_commit(
                 Global::crash();
             }
         };
-        let mut gitbuf = PathBuffer::uninit();
+        let mut gitbuf = bun_paths::path_buffer_pool::get();
         let git = match bun_which::which(
             &mut gitbuf,
             bun_core::env_var::PATH.get().unwrap_or(b""),
@@ -702,10 +702,10 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
 
     let arg_kind: PatchArgKind = PatchArgKind::from_arg(argument);
 
-    let mut folder_path_buf = PathBuffer::uninit();
+    let mut folder_path_buf = bun_paths::path_buffer_pool::get();
 
     #[cfg(windows)]
-    let mut win_normalizer = PathBuffer::uninit();
+    let mut win_normalizer = bun_paths::path_buffer_pool::get();
 
     let workspace_name_hash = manager.workspace_name_hash;
     let workspace_package_id = manager
@@ -967,7 +967,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     }
 
     if not_in_workspace_root {
-        let mut bufn = PathBuffer::uninit();
+        let mut bufn = bun_paths::path_buffer_pool::get();
         bun_core::pretty!(
             "\nTo patch <b>{}<r>, edit the following folder:\n\n  <cyan>{}<r>\n",
             bstr::BStr::new(pkg_name),
@@ -1006,7 +1006,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
 
 fn is_real_dir_not_symlink(path: &[u8]) -> bool {
     #[cfg(windows)]
-    let mut native_buf = PathBuffer::uninit();
+    let mut native_buf = bun_paths::path_buffer_pool::get();
     #[cfg(windows)]
     let native: &[u8] = {
         if path.len() > native_buf.len() {
@@ -1046,7 +1046,7 @@ fn detach_module_folder_from_shared_store(module_folder: &[u8]) {
     // platform separator so `undo()`/`basename()` walk the path correctly on
     // Windows and the lstat/getFileAttributes calls below see a native path.
     #[cfg(windows)]
-    let mut native_buf = PathBuffer::uninit();
+    let mut native_buf = bun_paths::path_buffer_pool::get();
     #[cfg(windows)]
     let native: &[u8] = {
         native_buf[0..module_folder.len()].copy_from_slice(module_folder);
@@ -1164,7 +1164,7 @@ fn overwrite_package_in_node_modules_folder(
     > = 'src_path: {
         #[cfg(windows)]
         {
-            let mut path_buf = bun_paths::WPathBuffer::uninit();
+            let mut path_buf = bun_paths::w_path_buffer_pool::get();
             let abs_path = sys::get_fd_path_w(cache_dir, &mut path_buf)?;
 
             let mut sp = bun_paths::AbsPath::<

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -11,7 +11,6 @@ use crate::bun_fs::FileSystem;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
 use bun_js_printer as js_printer;
-use bun_paths::{self, PathBuffer};
 use bun_sys::{self, Fd, File};
 
 use super::add_catalog;
@@ -426,7 +425,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         }
         _ => {
             if matches!(manager.options.patch_features, PatchFeatures::Commit { .. }) {
-                let mut pathbuf = PathBuffer::uninit();
+                let mut pathbuf = bun_paths::path_buffer_pool::get();
                 if let Some(stuff) =
                     patch_package::do_patch_commit(manager, &mut pathbuf, log_level)?
                 {
@@ -518,7 +517,7 @@ fn update_package_json_and_install_with_manager_with_updates(
     let top_level_dir_without_trailing_slash =
         strings::without_trailing_slash(FileSystem::instance().top_level_dir());
 
-    let mut root_package_json_path_buf = PathBuffer::uninit();
+    let mut root_package_json_path_buf = bun_paths::path_buffer_pool::get();
     let root_package_json_path: &ZStr = 'root_package_json_path: {
         root_package_json_path_buf[..top_level_dir_without_trailing_slash.len()]
             .copy_from_slice(top_level_dir_without_trailing_slash);
@@ -724,7 +723,7 @@ pub(super) fn remove_leftover_node_modules(
     updates: &[UpdateRequest],
 ) {
     let cwd = bun_sys::Dir::cwd();
-    let mut node_modules_buf = PathBuffer::uninit();
+    let mut node_modules_buf = bun_paths::path_buffer_pool::get();
     node_modules_buf[..b"node_modules".len()].copy_from_slice(b"node_modules");
     node_modules_buf[b"node_modules".len()] = bun_paths::SEP;
     let name_hashes = manager.lockfile.packages.items_name_hash();
@@ -869,7 +868,7 @@ pub fn update_package_json_and_install_and_cli(
         if manager.options.global {
             if !manager.options.bin_path.is_empty() {
                 if let TrackInstalledBin::Basename(basename) = &manager.track_installed_bin {
-                    let mut path_buf = PathBuffer::uninit();
+                    let mut path_buf = bun_paths::path_buffer_pool::get();
                     let needs_to_print = if let Some(path_env) = bun_core::env_var::PATH.get() {
                         // This is not perfect
                         //

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -28,7 +28,7 @@ use bun_core::strings;
 use bun_core::{self, Output, ZBox, env_var, fmt as bun_fmt};
 use bun_libarchive::lib;
 use bun_paths::resolve_path::{self, platform};
-use bun_paths::{self, OSPathBuffer, OSPathChar, OSPathSliceZ, PathBuffer};
+use bun_paths::{self, OSPathChar, OSPathSliceZ};
 #[cfg(not(windows))]
 use bun_sys::FdDirExt;
 use bun_sys::{self, Dir, Fd, FdExt, FileKind, Mode, O};
@@ -708,7 +708,7 @@ impl TarballStream {
                 self.invalid_name = true;
                 return Err(crate::Error::InstallFailed);
             };
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let tmpname = FileSystem::tmpname(tmpname_suffix, &mut buf[..], bun_core::fast_random())?;
         // allocator.dupeZ → owned NUL-terminated copy.
         self.tmpname = ZBox::from_bytes(tmpname.as_bytes());
@@ -805,7 +805,7 @@ impl TarballStream {
         // `OSPathSliceZ` suffix view here.
         let rest: &[OSPathChar] = tokenize_rest_after_first(&pathname[..]);
 
-        let mut norm_buf = OSPathBuffer::uninit();
+        let mut norm_buf = bun_paths::os_path_buffer_pool::get();
         if rest.len() >= norm_buf.len() {
             bun_core::warn!(
                 "Skipping entry with a path longer than the maximum path length: {}\n",

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -12,7 +12,7 @@ use bun_paths::MAX_PATH_BYTES;
 use bun_paths::platform::Auto as PlatformAuto;
 use bun_paths::resolve_path;
 use bun_paths::strings;
-use bun_paths::{self as path, AbsPath, PathBuffer, SEP};
+use bun_paths::{self as path, AbsPath, SEP};
 use bun_semver::{ExternalString, String};
 #[cfg(not(windows))]
 use bun_sys::Mode;
@@ -597,7 +597,7 @@ pub(crate) struct NamesIterator<'a> {
     /// caller owns the underlying `Dir`. Default is `Fd::INVALID`, which
     /// `next_in_dir()` never reaches.
     pub(crate) destination_node_modules: Fd,
-    pub(crate) buf: PathBuffer,
+    pub(crate) buf: bun_paths::path_buffer_pool::Guard,
     pub(crate) string_buffer: &'a [u8],
     pub(crate) extern_string_buf: &'a [ExternalString],
 }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -9,8 +9,6 @@ use bun_core::ZStr;
 use bun_core::w;
 #[cfg(not(windows))]
 use bun_paths::MAX_PATH_BYTES;
-#[cfg(windows)]
-use bun_paths::WPathBuffer;
 use bun_paths::platform::Auto as PlatformAuto;
 use bun_paths::resolve_path;
 use bun_paths::strings;
@@ -860,7 +858,7 @@ impl<'a> Linker<'a> {
 
         #[cfg(windows)]
         {
-            let mut dest_buf = WPathBuffer::uninit();
+            let mut dest_buf = bun_paths::w_path_buffer_pool::get();
             let abs_dest_w = strings::convert_utf8_to_utf16_in_buffer(
                 dest_buf.as_mut_slice(),
                 abs_dest.as_bytes(),
@@ -1122,8 +1120,8 @@ impl<'a> Linker<'a> {
         let mut shim_buf = ShimBuf([0u8; 65536]);
         let shim_buf = &mut shim_buf.0;
         let mut read_in_buf = [0u8; WinShimShebang::MAX_SHEBANG_INPUT_LENGTH];
-        let mut dest_buf = WPathBuffer::uninit();
-        let mut target_buf = WPathBuffer::uninit();
+        let mut dest_buf = bun_paths::w_path_buffer_pool::get();
+        let mut target_buf = bun_paths::w_path_buffer_pool::get();
 
         let abs_dest_w =
             strings::convert_utf8_to_utf16_in_buffer(dest_buf.as_mut_slice(), abs_dest.as_bytes());

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -4,8 +4,6 @@ use core::fmt;
 use bun_core::fmt::s;
 use bun_core::{Output, fmt as bun_fmt};
 use bun_core::{StringOrTinyString, ZStr};
-#[cfg(windows)]
-use bun_paths::WPathBuffer;
 use bun_paths::strings;
 use bun_paths::{self as path, PathBuffer};
 use bun_semver::Version;
@@ -236,7 +234,7 @@ impl ExtractTarball {
         let tmpdir = Dir::borrow(&self.temp_dir);
         // UTF-8 on every platform; the Windows tmpdir path is converted to
         // wide at the `open_dir_at_windows_a` boundary, not here.
-        let mut tmpname_buf = PathBuffer::uninit();
+        let mut tmpname_buf = bun_paths::path_buffer_pool::get();
         let (name, basename) = self.name_and_basename();
         let truncated_basename = &basename[0..basename.len().min(32)];
         let tmpname_suffix: &[u8] =
@@ -541,7 +539,7 @@ impl ExtractTarball {
                 // handle to the destination. Back off briefly between retries.
                 const MAX_RETRIES: u32 = 4;
                 let mut retries: u32 = 0;
-                let mut path2_buf = WPathBuffer::uninit();
+                let mut path2_buf = bun_paths::w_path_buffer_pool::get();
                 let path2 = strings::to_wpath_normalized(&mut path2_buf, folder_name);
                 if create_subdir {
                     if let Some(folder) = bun_paths::Dirname::dirname_u16(path2) {
@@ -601,14 +599,14 @@ impl ExtractTarball {
                                         // we rename it back into the temp dir
                                         // and then delete that temp dir
                                         // The goal is to make it more difficult for an application to reach this folder
-                                        let mut tempdest_buf = PathBuffer::uninit();
+                                        let mut tempdest_buf = bun_paths::path_buffer_pool::get();
                                         tempdest_buf[0..tmpname.len()]
                                             .copy_from_slice(tmpname.as_bytes());
                                         tempdest_buf[tmpname.len()..][0..4]
                                             .copy_from_slice(&[b't', b'm', b'p', 0]);
                                         let tempdest =
                                             ZStr::from_buf(&tempdest_buf, tmpname.len() + 3);
-                                        let mut folder_name_z_buf = PathBuffer::uninit();
+                                        let mut folder_name_z_buf = bun_paths::path_buffer_pool::get();
                                         folder_name_z_buf[0..folder_name.len()]
                                             .copy_from_slice(folder_name);
                                         folder_name_z_buf[folder_name.len()] = 0;
@@ -828,7 +826,7 @@ impl ExtractTarball {
                                 break 'create_index;
                             }
 
-                            let mut dest_buf = PathBuffer::uninit();
+                            let mut dest_buf = bun_paths::path_buffer_pool::get();
                             let dest_path = path::resolve_path::join_abs_string_buf_z::<
                                 path::platform::Windows,
                             >(
@@ -858,7 +856,7 @@ impl ExtractTarball {
                                 break 'create_index;
                             };
 
-                            let mut dest_buf = PathBuffer::uninit();
+                            let mut dest_buf = bun_paths::path_buffer_pool::get();
                             dest_buf[..dest_name.len()].copy_from_slice(dest_name);
                             dest_buf[dest_name.len()] = 0;
                             let dest_z = ZStr::from_buf(&dest_buf, dest_name.len());

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -403,8 +403,8 @@ pub(crate) fn install_hoisted_packages(
                 },
                 trusted_dependencies_from_update_requests: trusted_deps,
                 seen_bin_links: StringHashMap::<()>::default(),
-                destination_dir_subpath_buf: bun_paths::PathBuffer::uninit(),
-                folder_path_buf: bun_paths::PathBuffer::uninit(),
+                destination_dir_subpath_buf: bun_paths::PathBuffer::ZEROED,
+                folder_path_buf: bun_paths::PathBuffer::ZEROED,
                 current_tree_id: tree::INVALID_ID,
                 pending_lifecycle_scripts: Vec::new(),
                 copy_trees: {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -34,7 +34,7 @@ use bun_collections::{
 };
 use bun_core::{Environment, Global, Output, fast_random, fmt as bun_fmt};
 use bun_paths::path_options::AssumeOk as _;
-use bun_paths::{self as paths, AutoAbsPath as AbsPath, AutoRelPath, PathBuffer};
+use bun_paths::{self as paths, AutoAbsPath as AbsPath, AutoRelPath};
 use bun_semver as semver;
 use bun_sys::{self as sys, Fd};
 use bun_wyhash::{Wyhash, Wyhash11};
@@ -1237,7 +1237,7 @@ pub(crate) fn install_isolated_packages(
                                 // shared global copy would either diverge from the
                                 // patch or be mutated underneath other projects.
                                 if lockfile.patched_dependencies.count() > 0 {
-                                    let mut name_version_buf = PathBuffer::uninit();
+                                    let mut name_version_buf = bun_paths::path_buffer_pool::get();
                                     let mut cursor =
                                         std::io::Cursor::new(&mut name_version_buf.0[..]);
                                     let name_version: &[u8] = match write!(
@@ -1802,7 +1802,7 @@ pub(crate) fn install_isolated_packages(
                     // 3. rename temp into 'node_modules/.old_modules-{hex}'
                     // 4. attempt renaming 'node_modules/.old_modules-{hex}/.cache' to 'node_modules/.cache'
                     // 5. rename each workspace 'node_modules' into 'node_modules/.old_modules-{hex}/old_{basename}_modules'
-                    let mut temp_node_modules_buf = PathBuffer::uninit();
+                    let mut temp_node_modules_buf = bun_paths::path_buffer_pool::get();
                     let temp_node_modules = paths::fs::FileSystem::tmpname(
                         b"tmp_modules",
                         &mut temp_node_modules_buf.0,

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -478,7 +478,7 @@ impl RunCommand {
         static ONCE: std::sync::OnceLock<Option<Vec<u8>>> = std::sync::OnceLock::new();
 
         ONCE.get_or_init(|| {
-            let mut scratch = bun_paths::PathBuffer::uninit();
+            let mut scratch = bun_paths::path_buffer_pool::get();
             let found = Self::find_shell_impl(&mut scratch, path, cwd)?;
             // Includes trailing NUL so the caller may treat it as `[:0]const u8`.
             Some(found.as_bytes_with_nul().to_vec())
@@ -615,7 +615,7 @@ impl RunCommand {
                             // would make every `--bun` child of the SECOND
                             // binary silently exec the FIRST. Verify the target
                             // before reusing; replace it once if stale.
-                            let mut buf = bun_paths::PathBuffer::uninit();
+                            let mut buf = bun_paths::path_buffer_pool::get();
                             let matches = bun_sys::readlink(dest, &mut buf)
                                 .map(|n| &buf[..n] == argv0_z.as_bytes())
                                 .unwrap_or(false);
@@ -647,7 +647,7 @@ impl RunCommand {
             use bun_core::strings;
             use bun_sys::windows as win;
 
-            let mut target_path_buffer = bun_paths::WPathBuffer::default();
+            let mut target_path_buffer = bun_paths::w_path_buffer_pool::get();
             let prefix: &[u16] = strings::w!("\\??\\");
 
             // SAFETY: GetTempPathW writes at most `nBufferLength` WCHARs (incl.

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -12,7 +12,7 @@ use bun_collections::{
 };
 use bun_core::fmt::PathSep;
 use bun_core::{Global, Output};
-use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR, platform, resolve_path};
+use bun_paths::{MAX_PATH_BYTES, SEP, SEP_STR, platform, resolve_path};
 // `bun_install` sits above `bun_resolver` in the crate graph (no cycle), so use
 // the real resolver `FileSystem` directly — same as `PackageManager.rs`.
 use crate::bun_json as JSON;
@@ -1605,8 +1605,8 @@ impl<'a> Printer<'a> {
         // We truncate longer than allowed paths. We should probably throw an error instead.
         let path = &input_lockfile_path[..input_lockfile_path.len().min(MAX_PATH_BYTES)];
 
-        let mut lockfile_path_buf1 = PathBuffer::uninit();
-        let mut lockfile_path_buf2 = PathBuffer::uninit();
+        let mut lockfile_path_buf1 = bun_paths::path_buffer_pool::get();
+        let mut lockfile_path_buf2 = bun_paths::path_buffer_pool::get();
 
         let mut lockfile_path: &ZStr = ZStr::EMPTY;
         // Track which buffer backs `lockfile_path` so the chdir NUL-terminate
@@ -2823,7 +2823,7 @@ impl Lockfile {
 
         let mut sort_buf: Vec<PathToId> = Vec::with_capacity(l_len + r_len);
 
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let mut depth_buf: tree::DepthBuf = tree::depth_buf_uninit();
 
         // Track owned tree-path allocations so they outlive the sort and are freed at scope end.

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -4,7 +4,7 @@ use core::mem;
 use bun_collections::{ArrayHashMap, ArrayIdentityContext, MultiArrayList, StringSet, index_sort};
 use bun_core::strings;
 use bun_core::{Global, Output};
-use bun_paths::{self as path, AutoAbsPath, MAX_PATH_BYTES, PathBuffer, resolve_path};
+use bun_paths::{self as path, AutoAbsPath, MAX_PATH_BYTES, resolve_path};
 use bun_resolver::fs::FileSystem;
 use bun_semver::semver_query::Wildcard;
 use bun_semver::version::VersionInt;
@@ -1863,7 +1863,7 @@ impl Package<u64> {
         match dependency_version.tag {
             dependency::version::Tag::Folder => {
                 let folder = *dependency_version.folder();
-                let mut folder_buf = PathBuffer::uninit();
+                let mut folder_buf = bun_paths::path_buffer_pool::get();
                 let Some(joined) = resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
                     FileSystem::instance().top_level_dir(),
                     &mut folder_buf.0,
@@ -1982,7 +1982,7 @@ impl Package<u64> {
                             b"*"
                         } else {
                             'brk: {
-                                let mut buf2 = PathBuffer::uninit();
+                                let mut buf2 = bun_paths::path_buffer_pool::get();
                                 let rel =
                                     resolve_path::relative_platform::<path::platform::Auto, false>(
                                         FileSystem::instance().top_level_dir(),
@@ -2816,7 +2816,7 @@ impl Package<u64> {
                         // this path does alot of extra work to format the error message
                         // but this is ok because the install is going to fail anyways, so this
                         // has zero effect on the happy path.
-                        let mut cwd_buf = PathBuffer::uninit();
+                        let mut cwd_buf = bun_paths::path_buffer_pool::get();
                         // `bun_sys::getcwd` returns the byte length — slice
                         // the buffer ourselves.
                         let cwd_len = bun_sys::getcwd(&mut cwd_buf.0[..])?;

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -211,7 +211,7 @@ impl Scripts {
             self.get_script_entries(lockfile_buf, resolution_tag, add_node_gyp_rebuild_script);
         if first_index != -1 {
             #[cfg(windows)]
-            let mut cwd_buf = bun_paths::PathBuffer::uninit();
+            let mut cwd_buf = bun_paths::path_buffer_pool::get();
 
             #[cfg(not(windows))]
             let cwd: &[u8] = cwd_.slice();

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -6,7 +6,7 @@ use bun_core::strings;
 use bun_glob as glob;
 use bun_paths as path;
 use bun_paths::resolve_path;
-use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP_STR};
+use bun_paths::{MAX_PATH_BYTES, SEP_STR};
 
 use crate::lockfile_real::{Lockfile, StringBuilder, pruned_workspaces};
 use crate::package_manager::workspace_package_json_cache::{
@@ -266,8 +266,7 @@ impl WorkspaceMap {
         let orig_msgs_len = log.msgs.len();
 
         let mut workspace_globs: Vec<Box<[u8]>> = Vec::new();
-        let mut filepath_buf_os: Box<PathBuffer> = Box::new(PathBuffer::uninit());
-        // Boxed to avoid a large stack frame.
+        let mut filepath_buf_os = path::path_buffer_pool::get();
         let filepath_buf: &mut [u8] = &mut filepath_buf_os.0[..];
         let mut rel_path_buf = path::path_buffer_pool::get();
         let root_dir: &[u8] = source.path.name().dir;

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -224,7 +224,7 @@ impl<'a, const PATH_STYLE: IteratorPathStyle> Iterator<'a, PATH_STYLE> {
             hoisted_dependencies,
             dependencies,
             string_bytes,
-            path_buf: PathBuffer::uninit(),
+            path_buf: PathBuffer::ZEROED,
             depth_stack: depth_buf_uninit(),
         };
         if PATH_STYLE == IteratorPathStyle::NodeModules {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -7,7 +7,6 @@ use bun_ast::{Expr, expr::Data as ExprData};
 use bun_collections::{HashContext, HashMap, StringHashMap, index_sort};
 use bun_core::strings;
 use bun_core::{self};
-use bun_paths::PathBuffer;
 use bun_semver::semver_string::{
     Buf as StringBuf, Builder as StringBuilder, JsonFormatterOptions as JsonOpts,
 };
@@ -344,7 +343,7 @@ impl Stringifier {
             buf,
         );
 
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
 
         // if we loaded from a binary lockfile or pnpm-lock.yaml and we're migrating it to a text lockfile, ensure
         // peer dependencies have resolutions, and mark them optional if they don't
@@ -3112,7 +3111,7 @@ pub(crate) fn parse_into_binary_lockfile(
             }
         }
 
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
 
         if lockfile_version != Version::V0 {
             // then workspace dependencies are resolved
@@ -3492,7 +3491,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
     }
 
     let mut path_buf = if CHECK_FOR_BUNDLED {
-        Some(PathBuffer::uninit())
+        Some(bun_paths::path_buffer_pool::get())
     } else {
         None
     };

--- a/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
+++ b/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
@@ -1,6 +1,5 @@
 use crate::lockfile::package::PackageColumns as _;
 use bun_core::fmt as bun_fmt;
-use bun_paths::PathBuffer;
 use bun_semver::ExternalString;
 use bun_semver::string::JsonFormatterOptions;
 
@@ -230,7 +229,7 @@ where
         let hoisted_deps = this.buffers.hoisted_dependencies.as_slice();
         let resolutions = this.buffers.resolutions.as_slice();
         let mut depth_buf = tree::depth_buf_uninit();
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         path_buf[..b"node_modules".len()].copy_from_slice(b"node_modules");
 
         for tree_id in 0..this.buffers.trees.as_slice().len() {

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -778,7 +778,7 @@ where
                     package_name: dependency.name,
                     // Never read on the .map/.file/.named_file paths this arm covers.
                     destination_node_modules: Fd::INVALID,
-                    buf: bun_paths::PathBuffer::uninit(),
+                    buf: bun_paths::PathBuffer::ZEROED,
                     string_buffer: string_buf,
                     extern_string_buf: this.lockfile.buffers.extern_strings.as_slice(),
                 };

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -778,7 +778,7 @@ where
                     package_name: dependency.name,
                     // Never read on the .map/.file/.named_file paths this arm covers.
                     destination_node_modules: Fd::INVALID,
-                    buf: bun_paths::PathBuffer::ZEROED,
+                    buf: bun_paths::path_buffer_pool::get(),
                     string_buffer: string_buf,
                     extern_string_buf: this.lockfile.buffers.extern_strings.as_slice(),
                 };

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -2,7 +2,6 @@ use crate::Error;
 use bun_ast::{E, ExprData};
 use bun_core::strings;
 use bun_core::{Output, zstr};
-use bun_paths::PathBuffer;
 use bun_semver as Semver;
 use bun_semver::query::token::Wildcard;
 use bun_sys::{self, Fd, File, O};
@@ -42,7 +41,7 @@ pub fn detect_and_load_other_lockfile<'a>(
             break 'npm;
         };
         // file closes on Drop
-        let mut lockfile_path_buf = PathBuffer::uninit();
+        let mut lockfile_path_buf = bun_paths::path_buffer_pool::get();
         let Ok(lockfile_path) = bun_sys::get_fd_path(lockfile.handle(), &mut lockfile_path_buf)
         else {
             break 'npm;

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1075,7 +1075,7 @@ pub mod package_manifest {
             // GetFinalPathnameByHandle is very expensive if called many times
             // We skip calling it when we are giving an absolute file path.
             // This needs many more call sites, doesn't have much impact on this location.
-            let mut realpath_buf = bun_paths::PathBuffer::uninit();
+            let mut realpath_buf = bun_paths::path_buffer_pool::get();
             // SAFETY: `crate::package_manager::get()` returns the live
             // singleton; `get_temporary_directory` only mutates its
             // lazy-init state and is called from the install thread.
@@ -1155,7 +1155,7 @@ pub mod package_manifest {
 
             #[cfg(windows)]
             {
-                let mut realpath2_buf = bun_paths::PathBuffer::uninit();
+                let mut realpath2_buf = bun_paths::path_buffer_pool::get();
                 let cache_dir_abs = &PackageManager::get().cache_directory_path;
                 let cache_path_abs =
                     bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Auto>(

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -6,7 +6,7 @@ use bun_ast::{Loc, Log};
 use bun_core::ZBox;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
-use bun_paths::{self as path, PathBuffer};
+use bun_paths as path;
 use bun_resolver::fs::FileSystem;
 use bun_semver::String as SemverString;
 use bun_sys::{self as sys, Fd, FdExt};
@@ -393,7 +393,7 @@ impl PatchTask {
         let dir = self.project_dir;
         let patchfile_path = &patch.patchfilepath;
 
-        let mut absolute_patchfile_path_buf = PathBuffer::uninit();
+        let mut absolute_patchfile_path_buf = bun_paths::path_buffer_pool::get();
         // 1. Parse the patch file
         let absolute_patchfile_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
             &mut absolute_patchfile_path_buf.0,
@@ -567,7 +567,7 @@ impl PatchTask {
         }
 
         // 6. rename to cache dir
-        let mut path_in_tmpdir_buf = PathBuffer::uninit();
+        let mut path_in_tmpdir_buf = bun_paths::path_buffer_pool::get();
         let path_in_tmpdir = path::resolve_path::join_z_buf::<path::platform::Auto>(
             &mut path_in_tmpdir_buf.0,
             &[
@@ -608,7 +608,7 @@ impl PatchTask {
         let dir = self.project_dir;
         let patchfile_path = &calc_hash.patchfile_path;
 
-        let mut absolute_patchfile_path_buf = PathBuffer::uninit();
+        let mut absolute_patchfile_path_buf = bun_paths::path_buffer_pool::get();
         // parse the patch file
         let absolute_patchfile_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
             &mut absolute_patchfile_path_buf.0,
@@ -766,7 +766,7 @@ impl PatchTask {
         let resolution_clone: Resolution =
             pkg_manager.lockfile.packages.items_resolution()[pkg_id as usize];
 
-        let mut folder_path_buf = PathBuffer::uninit();
+        let mut folder_path_buf = bun_paths::path_buffer_pool::get();
         let stuff = package_manager::compute_cache_dir_and_subpath(
             pkg_manager,
             &pkg_name_slice,

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -5,7 +5,6 @@ use bstr::BStr;
 use bun_alloc::AllocError;
 use bun_core::ZBox;
 use bun_core::strings;
-use bun_paths::PathBuffer;
 use bun_semver::string::Buf as StringBuf;
 
 use crate::dependency as Dependency;
@@ -32,7 +31,7 @@ impl SloppyGlobalGitConfig {
             return SloppyGlobalGitConfig::default();
         };
 
-        let mut config_file_path_buf = PathBuffer::uninit();
+        let mut config_file_path_buf = bun_paths::path_buffer_pool::get();
         let config_file_path = bun_paths::resolve_path::join_abs_string_buf_z::<
             bun_paths::platform::Auto,
         >(home_dir, &mut config_file_path_buf, &[b".gitconfig"]);

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -196,7 +196,7 @@ fn normalize_package_json_path<'a>(
     const PACKAGE_JSON_LEN: usize = "/package.json".len();
 
     let rel: &[u8] = if strings::starts_with_char(normalized, b'.') {
-        let mut tempcat = PathBuffer::uninit();
+        let mut tempcat = bun_paths::path_buffer_pool::get();
 
         tempcat[..normalized.len()].copy_from_slice(normalized);
         tempcat[normalized.len()] = SEP;
@@ -381,9 +381,9 @@ pub(crate) fn get_or_put(
     non_normalized_path: &[u8],
     manager: &mut PackageManager,
 ) -> FolderResolution {
-    let mut joined = PathBuffer::uninit();
+    let mut joined = bun_paths::path_buffer_pool::get();
     #[cfg(windows)]
-    let mut rel_buf = PathBuffer::uninit();
+    let mut rel_buf = bun_paths::path_buffer_pool::get();
     let paths = normalize_package_json_path(global_or_relative, &mut joined, non_normalized_path);
 
     #[cfg(not(windows))]
@@ -433,7 +433,7 @@ pub(crate) fn get_or_put(
 
     let result: crate::Result<LockfilePackage> = match global_or_relative {
         GlobalOrRelative::Global(_) => 'global: {
-            let mut path = PathBuffer::uninit();
+            let mut path = bun_paths::path_buffer_pool::get();
             path[..non_normalized_path.len()].copy_from_slice(non_normalized_path);
             let mut resolver: SymlinkResolver = NewResolver {
                 folder_path: &path[0..non_normalized_path.len()],

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -29,7 +29,6 @@ use crate::repository::Repository;
 use crate::resolution_real::{Resolution, Tag as ResolutionTag, TaggedValue as ResolutionValue};
 use crate::versioned_url::VersionedURL;
 use bun_core::strings;
-use bun_paths::PathBuffer;
 use bun_semver::{self as Semver, SlicedString, String as SemverString};
 use bun_sys::Fd;
 
@@ -640,7 +639,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
     };
 
     // `package_json_source.path` borrows this buffer (lifetime-erased); keep it alive until the overrides are parsed below.
-    let mut package_json_path_buf = PathBuffer::uninit();
+    let mut package_json_path_buf = bun_paths::path_buffer_pool::get();
     let package_json_source = {
         let Ok(package_json_path) =
             bun_sys::get_fd_path(package_json_fd.handle(), &mut package_json_path_buf)

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -3,8 +3,6 @@ use std::io::Write as _;
 
 use crate::VM;
 use bun_core::String as BunString;
-#[cfg(windows)]
-use bun_paths::OSPathBuffer;
 use bun_paths::{AutoAbsPathChecked, PathBuffer};
 use bun_sys::{self, Errno, Fd, FdDirExt as _};
 
@@ -95,7 +93,7 @@ fn write_profile_to_file(
 
     // Convert to OS-specific path (UTF-16 on Windows, UTF-8 elsewhere)
     #[cfg(windows)]
-    let mut path_buf_os = OSPathBuffer::uninit();
+    let mut path_buf_os = bun_paths::os_path_buffer_pool::get();
     #[cfg(windows)]
     let output_path_os =
         bun_core::strings::convert_utf8_to_utf16_in_buffer_z(&mut path_buf_os, path_buf.slice_z());
@@ -137,7 +135,7 @@ fn build_output_path(
     is_md_format: bool,
 ) -> Result<(), ProfilerError> {
     // Generate filename
-    let mut filename_buf = PathBuffer::uninit();
+    let mut filename_buf = bun_paths::path_buffer_pool::get();
 
     // If both formats are being written and a custom name was specified,
     // we need to add the appropriate extension to disambiguate

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -47,7 +47,7 @@ pub(crate) fn generate_and_write_profile(
 
     // Convert to OS-specific path (UTF-16 on Windows, UTF-8 elsewhere)
     #[cfg(windows)]
-    let mut path_buf_os = bun_paths::OSPathBuffer::uninit();
+    let mut path_buf_os = bun_paths::os_path_buffer_pool::get();
     #[cfg(windows)]
     let output_path_os: &bun_core::WStr = bun_core::strings::convert_utf8_to_utf16_in_buffer_z(
         &mut path_buf_os,
@@ -104,7 +104,7 @@ fn build_output_path(
     config: &HeapProfilerConfig,
 ) -> Result<(), Error> {
     // Generate filename
-    let mut filename_buf = PathBuffer::uninit();
+    let mut filename_buf = bun_paths::path_buffer_pool::get();
     let filename: &[u8] = if !config.name.is_empty() {
         config.name
     } else {

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -10,7 +10,7 @@ use bun_collections::{HashMap, IdentityContext};
 use bun_core::String as BunString;
 use bun_core::{Mutex, ZStr, env_var};
 use bun_options_types::Format;
-use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
+use bun_paths::{MAX_PATH_BYTES, SEP};
 use bun_sys::{self as sys, Fd, O};
 
 pub const STATUS_FAILED: i32 = 0;
@@ -402,8 +402,8 @@ fn enable_with_dir(dir: &[u8], portable: bool) -> EnableResult {
     let tag = version_tag();
 
     // Resolve `dir` to an absolute path against the process cwd.
-    let mut abs_buf = PathBuffer::uninit();
-    let mut cwd_buf = PathBuffer::uninit();
+    let mut abs_buf = bun_paths::path_buffer_pool::get();
+    let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let abs: &[u8] = if bun_paths::is_absolute(dir) {
         dir
     } else {
@@ -512,8 +512,8 @@ fn enable_with_dir(dir: &[u8], portable: bool) -> EnableResult {
         if portable {
             // Resolve symlinks (e.g. macOS /var -> /private/var) so relative
             // keys match Bun's realpath'd module paths.
-            let mut z_buf = bun_core::PathBuffer::uninit();
-            let mut real_buf = bun_core::PathBuffer::uninit();
+            let mut z_buf = bun_paths::path_buffer_pool::get();
+            let mut real_buf = bun_paths::path_buffer_pool::get();
             let tagged_z = bun_paths::resolve_path::z(&tagged, &mut z_buf);
             if let Ok(real) = sys::realpath(tagged_z, &mut real_buf) {
                 tagged = real.to_vec();
@@ -1021,7 +1021,7 @@ fn write_persist_job_locked(
     let cache_hash = sha256(blob);
 
     let basename = cache_basename(job.key);
-    let mut tmpname_buf = PathBuffer::uninit();
+    let mut tmpname_buf = bun_paths::path_buffer_pool::get();
     let tmpname_zstr: &ZStr =
         match bun_resolver::fs::FileSystem::tmpname(&basename, &mut tmpname_buf[..], job.key) {
             Ok(z) => z,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -247,7 +247,7 @@ impl Entry {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.save");
 
         // atomically write to a tmpfile and then move it to the final destination
-        let mut tmpname_buf = PathBuffer::uninit();
+        let mut tmpname_buf = bun_paths::path_buffer_pool::get();
         let tmpfilename = FileSystem::tmpname(
             paths::extension(destination_path.as_bytes()),
             &mut tmpname_buf[..],
@@ -710,7 +710,7 @@ impl RuntimeTranspilerCache {
     ) -> crate::CrateResult<Entry> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.fromFile");
 
-        let mut cache_file_path_buf = PathBuffer::uninit();
+        let mut cache_file_path_buf = bun_paths::path_buffer_pool::get();
         let cache_file_path = Self::get_cache_file_path(&mut cache_file_path_buf, input_hash)?;
         debug_assert!(!cache_file_path.is_empty());
         Self::from_file_with_cache_file_path(
@@ -784,7 +784,7 @@ impl RuntimeTranspilerCache {
     ) -> crate::CrateResult<()> {
         let _tracer = bun_core::perf::trace("RuntimeTranspilerCache.toFile");
 
-        let mut cache_file_path_buf = PathBuffer::uninit();
+        let mut cache_file_path_buf = bun_paths::path_buffer_pool::get();
         let cache_file_path = Self::get_cache_file_path(&mut cache_file_path_buf, input_hash)?;
         bun_core::scoped_log!(
             cache,

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -93,7 +93,7 @@ fn dump_source_string_failiable(
 
     let mut holder = BUN_DEBUG_HOLDER.lock();
 
-    let mut path_buf = bun_paths::PathBuffer::default();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
 
     if holder.is_none() {
         let base_name: &[u8] = if cfg!(windows) {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5079,11 +5079,11 @@ impl VirtualMachine {
     pub fn set_process_cwd(&mut self, to: &bun_core::ZStr) -> bun_sys::Result<()> {
         let fs = self.transpiler.fs_mut();
         bun_sys::chdir(to)?;
-        let mut buf = bun_paths::PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let into_cwd_len = match bun_sys::getcwd(&mut buf[..]) {
             bun_sys::Result::Ok(r) => r,
             bun_sys::Result::Err(err) => {
-                let mut rollback = bun_paths::PathBuffer::uninit();
+                let mut rollback = bun_paths::path_buffer_pool::get();
                 let _ = bun_sys::chdir(bun_paths::resolve_path::z(fs.top_level_dir, &mut rollback));
                 return bun_sys::Result::Err(err);
             }
@@ -5123,7 +5123,7 @@ impl VirtualMachine {
         Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(self.global());
 
         if let Some(cwd) = self.test_isolation_state.saved_cwd.take() {
-            let mut buf = bun_paths::PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let z = bun_paths::resolve_path::z(&cwd, &mut buf);
             let _ = self.set_process_cwd(z);
         }

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -9,7 +9,6 @@ use bun_core::ZStr;
 #[cfg(not(windows))]
 use bun_paths::SEP;
 use bun_paths::strings;
-use bun_paths::{self, PathBuffer};
 #[cfg(not(windows))]
 use bun_resolver::fs::PathName;
 use bun_resolver::fs::{self as Fs, FileSystem};
@@ -864,7 +863,7 @@ where
         let rfs: &mut Fs::file_system::RealFS = &mut fs.fs;
         #[cfg(windows)]
         let _ = (changed_files, parents, file_descriptors, rfs);
-        let mut _on_file_update_path_buf = PathBuffer::uninit();
+        let mut _on_file_update_path_buf = bun_paths::path_buffer_pool::get();
 
         for event in events.iter() {
             // Stale udata: kevent.udata can outlive a swapRemove in flushEvictions.
@@ -1021,7 +1020,7 @@ where
                                             // bun_sys::access takes a &ZStr; build one on the
                                             // stack from the &[u8] watch-list slice.
                                             let was_deleted = {
-                                                let mut zbuf = PathBuffer::uninit();
+                                                let mut zbuf = bun_paths::path_buffer_pool::get();
                                                 if affected_path.len() >= zbuf.len() {
                                                     false
                                                 } else {
@@ -1099,7 +1098,7 @@ where
                                     continue;
                                 }
                                 let main_exists = {
-                                    let mut zbuf = PathBuffer::uninit();
+                                    let mut zbuf = bun_paths::path_buffer_pool::get();
                                     if self.main.file.len() >= zbuf.len() {
                                         false
                                     } else {

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -13,7 +13,7 @@ use bun_core::{MutableString, slice_to_nul, strings};
 use bun_core::{Output, ZStr, slice_as_bytes};
 #[cfg(unix)]
 use bun_paths::PathBuffer;
-use bun_paths::{OSPathBuffer, OSPathChar, SEP, SEP_STR};
+use bun_paths::{OSPathChar, SEP, SEP_STR};
 use bun_sys::{self, Fd, FdExt};
 use bun_wyhash::hash;
 
@@ -1263,7 +1263,7 @@ impl Archiver {
         // a directory HANDLE on Windows. Mirrors the guard pattern in extract_to_disk.
         let _close_dir_guard = scopeguard::guard(dir, |d| d.close());
 
-        let mut normalized_buf = bun_paths::PathBuffer::uninit();
+        let mut normalized_buf = bun_paths::path_buffer_pool::get();
 
         'loop_: loop {
             // SAFETY: archive valid for stream lifetime
@@ -1406,7 +1406,7 @@ impl Archiver {
         #[cfg(unix)]
         let mut deferred_symlinks: Vec<DeferredSymlink> = Vec::new();
 
-        let mut normalized_buf = OSPathBuffer::uninit();
+        let mut normalized_buf = bun_paths::os_path_buffer_pool::get();
         let mut use_pwrite = cfg!(unix);
         let mut use_lseek = true;
 

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -2702,7 +2702,7 @@ fn resolve_local_image_path(src: &[u8], base_dir: Option<&[u8]>) -> Option<Box<[
     // Prefer the markdown file's directory when provided; otherwise fall
     // back to cwd so `Bun.markdown.ansi()` callers without a source path
     // still work.
-    let mut cwd_buf = bun_paths::PathBuffer::uninit();
+    let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let base: &[u8] = if let Some(d) = base_dir {
         d
     } else {
@@ -2719,7 +2719,7 @@ fn resolve_local_image_path(src: &[u8], base_dir: Option<&[u8]>) -> Option<Box<[
     // for any entry, including directories — and emitKittyImageFile sets
     // q=2 so the terminal silently drops directory paths without falling
     // through to alt text.
-    let mut zbuf = bun_paths::PathBuffer::uninit();
+    let mut zbuf = bun_paths::path_buffer_pool::get();
     let abs_z = bun_paths::resolve_path::z(&abs, &mut zbuf);
     match bun_sys::stat(abs_z) {
         Ok(s) => {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -53,7 +53,7 @@ struct ApplyState {
 impl ApplyState {
     fn new() -> Self {
         Self {
-            pathbuf: PathBuffer::uninit(),
+            pathbuf: PathBuffer::ZEROED,
             patch_dir_abs_path: None,
         }
     }
@@ -228,7 +228,7 @@ impl<'a> PatchFile<'a> {
                             sys::Result::Ok(p) => p,
                             sys::Result::Err(e) => return Some(e.without_path()),
                         };
-                        let mut buf = PathBuffer::uninit();
+                        let mut buf = bun_paths::path_buffer_pool::get();
                         let joined_absfilepath =
                             paths::resolve_path::join_z_buf::<paths::platform::Auto>(
                                 &mut buf[..],
@@ -1758,7 +1758,7 @@ pub fn git_diff_internal(
 
     // `bun_spawn::sync` execs argv[0] verbatim (execve, no PATH search), so
     // resolve `git` here — same as `patchCommit`'s `bun.which` call.
-    let mut gitbuf = PathBuffer::uninit();
+    let mut gitbuf = bun_paths::path_buffer_pool::get();
     let git = bun_which::which(
         &mut gitbuf,
         bun_core::env_var::PATH.get().unwrap_or(b""),

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -10,7 +10,7 @@ pub mod error;
 pub use error::{Error, Result};
 
 // `bun.w_path_buffer_pool` — u16 sibling. Backed by the same generic
-// thread-local pool as the u8 one (`bun_core::path_buffer_pool` handles both
+// thread-local pool as the u8 one (path_buffer_pool.rs already handles both
 // via `PoolStorage`).
 pub mod w_path_buffer_pool {
     use super::WPathBuffer;
@@ -325,8 +325,7 @@ pub type OSPathBuffer = WPathBuffer;
 #[cfg(not(windows))]
 pub type OSPathBuffer = PathBuffer;
 
-// Defined in `bun_core` so `bun_core` can use it too.
-pub use bun_core::path_buffer_pool;
+pub mod path_buffer_pool;
 
 // resolve_path: enum const-generics lowered to sealed `PlatformT` trait + ZSTs
 // (done). 46× E0106 remain — TLS-buf-returning wrappers need `'static` lifetime

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -325,8 +325,7 @@ pub type OSPathBuffer = WPathBuffer;
 #[cfg(not(windows))]
 pub type OSPathBuffer = PathBuffer;
 
-// The pool lives in `bun_core` so `bun_core` itself and every crate that only
-// depends on `bun_core` can use it. Re-exported here as the canonical path.
+// Defined in `bun_core` so `bun_core` can use it too.
 pub use bun_core::path_buffer_pool;
 
 // resolve_path: enum const-generics lowered to sealed `PlatformT` trait + ZSTs

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -10,7 +10,7 @@ pub mod error;
 pub use error::{Error, Result};
 
 // `bun.w_path_buffer_pool` — u16 sibling. Backed by the same generic
-// thread-local pool as the u8 one (path_buffer_pool.rs already handles both
+// thread-local pool as the u8 one (`bun_core::path_buffer_pool` handles both
 // via `PoolStorage`).
 pub mod w_path_buffer_pool {
     use super::WPathBuffer;
@@ -21,7 +21,7 @@ pub mod w_path_buffer_pool {
         PathBufferPoolT::<WPathBuffer>::get()
     }
     #[inline]
-    pub(crate) fn put(buf: Box<WPathBuffer>) {
+    pub fn put(buf: Box<WPathBuffer>) {
         PathBufferPoolT::<WPathBuffer>::put(buf)
     }
 }
@@ -325,7 +325,9 @@ pub type OSPathBuffer = WPathBuffer;
 #[cfg(not(windows))]
 pub type OSPathBuffer = PathBuffer;
 
-pub mod path_buffer_pool;
+// The pool lives in `bun_core` so `bun_core` itself and every crate that only
+// depends on `bun_core` can use it. Re-exported here as the canonical path.
+pub use bun_core::path_buffer_pool;
 
 // resolve_path: enum const-generics lowered to sealed `PlatformT` trait + ZSTs
 // (done). 46× E0106 remain — TLS-buf-returning wrappers need `'static` lifetime

--- a/src/paths/path_buffer_pool.rs
+++ b/src/paths/path_buffer_pool.rs
@@ -15,7 +15,7 @@ use core::cell::RefCell;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 
-use crate::{PathBuffer, WPathBuffer};
+use bun_core::{PathBuffer, WPathBuffer};
 
 const POOL_CAP: usize = 4;
 
@@ -75,7 +75,7 @@ impl PoolStorage for WPathBuffer {
 /// discarded its stack slot, so LeakSanitizer would report the buffer.
 #[inline]
 fn lsan_ignore<T>(buf: Box<T>) -> Box<T> {
-    crate::asan::ignore_object((&raw const *buf).cast());
+    bun_core::asan::ignore_object((&raw const *buf).cast());
     buf
 }
 
@@ -215,6 +215,6 @@ mod tests {
         U16_POOL.with(|p| p.borrow_mut().clear());
         let w = w_path_buffer_pool::get();
         assert!(w.iter().all(|&unit| unit == 0));
-        assert_eq!(w.len(), crate::PATH_MAX_WIDE);
+        assert_eq!(w.len(), bun_core::PATH_MAX_WIDE);
     }
 }

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -2156,8 +2156,7 @@ fn last_index_of_sep_t<T: PathChar>(path: &[T]) -> Option<usize> {
 /// ```
 ///
 /// This API does nothing on Linux (it has a size of zero). On Windows it
-/// holds a pooled path buffer, so construction is a pool pop, not a 98 KB
-/// zero-fill.
+/// holds a pooled path buffer.
 #[derive(Default)]
 pub struct PosixToWinNormalizer {
     #[cfg(windows)]

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -2155,11 +2155,13 @@ fn last_index_of_sep_t<T: PathChar>(path: &[T]) -> Option<usize> {
 /// let result = normalizer.resolve_cwd(b"/dev/bun/test/etc.js");
 /// ```
 ///
-/// This API does nothing on Linux (it has a size of zero)
+/// This API does nothing on Linux (it has a size of zero). On Windows it
+/// holds a pooled path buffer, so construction is a pool pop, not a 98 KB
+/// zero-fill.
 #[derive(Default)]
 pub struct PosixToWinNormalizer {
     #[cfg(windows)]
-    _raw_bytes: PathBuffer,
+    _raw_bytes: crate::path_buffer_pool::Guard,
     #[cfg(not(windows))]
     _raw_bytes: (),
 }
@@ -2170,8 +2172,6 @@ type PosixToWinBuf = PathBuffer;
 type PosixToWinBuf = ();
 
 impl PosixToWinNormalizer {
-    // methods on PosixToWinNormalizer, to be minimal yet stack allocate the PathBuffer
-    // these do not force inline of much code
     #[inline]
     pub fn resolve<'a>(&'a mut self, source_dir: &[u8], maybe_posix_path: &'a [u8]) -> &'a [u8] {
         Self::resolve_with_external_buf(&mut self._raw_bytes, source_dir, maybe_posix_path)

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -6,8 +6,8 @@ use bun_alloc::{AllocError, allocators};
 use bun_collections::VecExt as _;
 use bun_core::Generation;
 use bun_core::MutableString;
+use bun_paths::MAX_PATH_BYTES;
 use bun_paths::strings;
-use bun_paths::{MAX_PATH_BYTES, PathBuffer};
 use bun_ptr::Interned;
 use bun_sys::{self, Fd};
 use bun_threading::Mutex;
@@ -442,7 +442,7 @@ impl DirEntry {
         // case (matches `DirEntry::get`); only a basename longer than
         // `MAX_PATH_BYTES` — which `getdents`/`FindNextFile` can't produce —
         // would touch the heap.
-        let mut name_lc_buf = PathBuffer::uninit();
+        let mut name_lc_buf = bun_paths::path_buffer_pool::get();
         let name_lc_heap: Option<bun_collections::StringHashMapContext::PrehashedCaseInsensitive> =
             if name_slice.len() <= MAX_PATH_BYTES {
                 None
@@ -603,7 +603,7 @@ impl DirEntry {
         if query_.is_empty() || query_.len() > MAX_PATH_BYTES {
             return None;
         }
-        let mut scratch_lookup_buffer = PathBuffer::uninit();
+        let mut scratch_lookup_buffer = bun_paths::path_buffer_pool::get();
 
         let query = strings::copy_lowercase_if_needed(query_, &mut scratch_lookup_buffer[..]);
         let &result_ptr = self.data.get(query)?;

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -292,7 +292,7 @@ pub mod fs {
                 // (the singleton outlives every caller).
                 Some(d) => DirnameStore::instance().append_slice(d)?,
                 None => {
-                    let mut buf = bun_paths::PathBuffer::default();
+                    let mut buf = bun_paths::path_buffer_pool::get();
                     DirnameStore::instance().append_slice(bun_core::getcwd(&mut buf)?.as_bytes())?
                 }
             };
@@ -310,7 +310,7 @@ pub mod fs {
             unsafe {
                 (*INSTANCE.get()).write(FileSystem {
                     top_level_dir: cwd,
-                    top_level_dir_buf: bun_paths::PathBuffer::uninit(),
+                    top_level_dir_buf: bun_paths::PathBuffer::ZEROED,
                     fs: Implementation::init(cwd),
                     dirname_store: DirnameStore::instance(),
                     filename_store: FilenameStore::instance(),
@@ -830,7 +830,7 @@ pub mod fs {
                     | bun_sys::O::TRUNC
                     | bun_sys::O::CLOEXEC;
                 self.fd = bun_sys::openat(tmp_dir, name, flags, 0)?;
-                let mut buf = bun_paths::PathBuffer::uninit();
+                let mut buf = bun_paths::path_buffer_pool::get();
                 let existing_path = bun_sys::get_fd_path(self.fd, &mut buf)?;
                 self.existing_path = Box::<[u8]>::from(&*existing_path);
                 Ok(())
@@ -858,8 +858,8 @@ pub mod fs {
             {
                 use bun_sys::windows as w;
                 let _ = from_name;
-                let mut existing_buf = bun_paths::WPathBuffer::uninit();
-                let mut new_buf = bun_paths::WPathBuffer::uninit();
+                let mut existing_buf = bun_paths::w_path_buffer_pool::get();
+                let mut new_buf = bun_paths::w_path_buffer_pool::get();
                 self.close();
                 let existing = bun_paths::strings::paths::to_extended_path_normalized(
                     &mut new_buf.0[..],
@@ -1380,7 +1380,7 @@ pub mod fs {
             };
 
             let combo: [&[u8]; 2] = [dir_, base];
-            let mut outpath = bun_paths::PathBuffer::uninit();
+            let mut outpath = bun_paths::path_buffer_pool::get();
             let join_capacity = outpath.len() - 2;
             let Some(entry_path) = join_abs_string_buf_checked::<platform::Auto>(
                 self.cwd,
@@ -1681,14 +1681,14 @@ pub mod fs {
                             return out;
                         }
                         if let Some(profile) = env_var::HOME.get() {
-                            let mut buf = bun_paths::PathBuffer::uninit();
+                            let mut buf = bun_paths::path_buffer_pool::get();
                             let parts: [&[u8]; 1] = [b"AppData\\Local\\Temp"];
                             let out = bun_paths::resolve_path::join_abs_string_buf::<
                                 bun_paths::resolve_path::platform::Loose,
                             >(profile, &mut buf[..], &parts);
                             return out.to_vec();
                         }
-                        let mut tmp_buf = bun_paths::PathBuffer::uninit();
+                        let mut tmp_buf = bun_paths::path_buffer_pool::get();
                         let cwd = match bun_sys::getcwd(&mut tmp_buf[..]) {
                             Ok(len) => &tmp_buf[..len],
                             Err(_) => panic!("Failed to get cwd for platformTempDir"),
@@ -1814,7 +1814,7 @@ pub mod dir_entry_accessor {
     use crate::fs::{DirEntry, EntriesOption, Entry, EntryKind, FileSystem as FS, Implementation};
     use bun_core::ZStr;
     use bun_glob::walk::{Accessor, AccessorDirEntry, AccessorDirIter, AccessorHandle};
-    use bun_paths::{PathBuffer, Platform, resolve_path};
+    use bun_paths::{Platform, resolve_path};
     use bun_sys::{self as Syscall, Error as SysError, Result as Maybe, Stat};
 
     pub struct DirEntryAccessor;
@@ -1962,7 +1962,7 @@ pub mod dir_entry_accessor {
         type DirIter = DirEntryDirIter;
 
         fn statat(handle: DirEntryHandle, path_: &ZStr) -> Maybe<Stat> {
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let path: &ZStr = if !Platform::AUTO.is_absolute(path_.as_bytes()) {
                 if let Some(entry) = handle.value {
                     let slice = resolve_path::join_string_buf::<bun_paths::platform::Auto>(
@@ -1984,7 +1984,7 @@ pub mod dir_entry_accessor {
 
         /// Like statat but does not follow symlinks.
         fn lstatat(handle: DirEntryHandle, path_: &ZStr) -> Maybe<Stat> {
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             if let Some(entry) = handle.value {
                 return Syscall::lstatat(entry.fd, path_);
             }
@@ -2016,7 +2016,7 @@ pub mod dir_entry_accessor {
             handle: DirEntryHandle,
             path_: &ZStr,
         ) -> Result<Maybe<DirEntryHandle>, bun_core::Error> {
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let mut path: &[u8] = path_.as_bytes();
 
             if !Platform::AUTO.is_absolute(path) {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -413,15 +413,14 @@ fn bufs_storage_get() -> *mut Bufs {
 
 #[cold]
 fn bufs_storage_init() -> *mut Bufs {
-    // SAFETY: every field of `Bufs` is a byte/integer array
-    // (`PathBuffer` = `[u8; N]`, `[FD; 256]` where `Fd` is a
-    // `#[repr(C)]` integer newtype, `[MaybeUninit<_>; 256]` which has
-    // no validity requirement, `()`), so EVERY bit-pattern — not just
-    // all-zero — is a valid `Bufs`. Each
-    // field is scratch (write-then-read within a single resolve call,
-    // including `open_dirs` which is bounded by `open_dir_count`), so
-    // there is no need to pay for zero-filling ~100 KiB on first use.
-    let p: *mut Bufs = Box::leak(unsafe { Box::<Bufs>::new_uninit().assume_init() });
+    // SAFETY: every field of `Bufs` is a byte/integer array (`PathBuffer` =
+    // `[u8; N]`, `[u8; 512]`, `[FD; 256]` where `Fd` is a `#[repr(transparent)]`
+    // integer newtype with no niche) or `[MaybeUninit<_>; 256]`, so the
+    // all-zero bit-pattern is a valid `Bufs`. `new_zeroed` (not `new_uninit`)
+    // because integers must be initialized: a never-written `[u8; N]` is UB
+    // even though every bit pattern is a valid `u8`. Runs once per thread;
+    // `alloc_zeroed` of ~100 KiB is usually fresh OS-zeroed pages.
+    let p: *mut Bufs = Box::leak(unsafe { Box::<Bufs>::new_zeroed().assume_init() });
     BUFS_PTR.with(|s| s.0.set(p));
     p
 }
@@ -1602,7 +1601,7 @@ impl<'a> Resolver<'a> {
                 } else if !dir.abs_real_path.is_empty() {
                     // When the directory is a symlink, we don't need to call getFdPath.
                     let parts = [dir.abs_real_path, query.entry().base()];
-                    let mut buf = bun_paths::PathBuffer::uninit();
+                    let mut buf = bun_paths::path_buffer_pool::get();
 
                     // NOTE: `abs_buf` returns a borrow of `buf`; capture only the
                     // length so `buf` can be re-borrowed for null-termination below.

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1338,7 +1338,7 @@ fn extract_to_disk_filtered(
         let raw_pathname_z = raw_pathname_zbox.as_zstr();
         let raw_pathname = raw_pathname_z.as_bytes();
 
-        let mut normalized_buf = bun_paths::PathBuffer::uninit();
+        let mut normalized_buf = bun_paths::path_buffer_pool::get();
         if raw_pathname.len() >= normalized_buf.len() {
             continue;
         }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -76,10 +76,6 @@ use crate::cli::open::Editor;
 use bun_core::{EncodedSlice, String as BunString, strings};
 use bun_jsc::virtual_machine::{ResolveMode, VirtualMachine};
 use bun_paths::MAX_PATH_BYTES;
-#[cfg(not(windows))]
-use bun_paths::PathBuffer;
-#[cfg(windows)]
-use bun_paths::WPathBuffer;
 use bun_shell_parser::braces as Braces;
 use bun_sys::{self as sys, Fd, FdExt as _};
 use bun_zlib as zlib;
@@ -822,7 +818,7 @@ pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
             let _close = scopeguard::guard(fd, |fd: Fd| fd.close());
             #[cfg(windows)]
             {
-                let mut wpath = WPathBuffer::uninit();
+                let mut wpath = bun_paths::w_path_buffer_pool::get();
                 let Ok(fdpath) = bun_sys::get_fd_path_w(fd, &mut wpath) else {
                     break 'use_resolved_path;
                 };
@@ -830,7 +826,7 @@ pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
             }
             #[cfg(not(windows))]
             {
-                let mut path = PathBuffer::uninit();
+                let mut path = bun_paths::path_buffer_pool::get();
                 let Ok(fdpath) = bun_sys::get_fd_path(fd, &mut path) else {
                     break 'use_resolved_path;
                 };
@@ -1575,7 +1571,7 @@ fn mmap_file(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JS
         let vm = global_this.bun_vm();
         let mut args = ArgumentsSlice::init(vm, callframe.arguments());
 
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let path = 'brk: {
             if let Some(path) = args.next_eat() {
                 if path.is_string() {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -957,7 +957,7 @@ pub mod js_bundler {
                 };
                 let _close = scopeguard::guard(dir, |d| d.close());
 
-                let mut rootdir_buf = bun_paths::PathBuffer::uninit();
+                let mut rootdir_buf = bun_paths::path_buffer_pool::get();
                 let rootdir = match bun_sys::get_fd_path(*_close, &mut rootdir_buf) {
                     Ok(p) => p,
                     Err(err) => {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -105,9 +105,7 @@ fn get_argv0(
             )
             .throw());
     }
-    // Heap allocate it to ensure we don't run out of stack space.
-    let mut path_buf: Box<bun_core::PathBuffer> = Box::default();
-    // drops at scope exit (was `defer bun.default_allocator.destroy(path_buf)`).
+    let mut path_buf = bun_paths::path_buffer_pool::get();
 
     let argv0_to_use: &[u8] = arg0.slice();
 

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -27,9 +27,7 @@ use bun_jsc::{
     self as jsc, CallFrame, EncodedSliceJsc as _, EventLoopHandle, GlobalRef, JSFunction,
     JSGlobalObject, JSObject, JSValue, JsCell, JsRef, JsResult,
 };
-#[cfg(not(target_os = "macos"))]
-use bun_paths::PathBuffer;
-use bun_paths::{self as path};
+use bun_paths as path;
 use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_resolver::fs::FileSystem;
 #[cfg(not(target_os = "macos"))]
@@ -2003,7 +2001,7 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
     // Hoisted to function scope: `resolved_argv0` borrows into this buffer on
     // Windows and must outlive the spawn below.
     #[cfg(windows)]
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     #[cfg(windows)]
     {
         // Resolve the executable via bun.which, matching Bun.spawn's behavior.
@@ -2189,7 +2187,7 @@ fn find_crontab() -> Option<ZString> {
     #[cfg(not(windows))]
     {
         let path_env = env_var::PATH.get().unwrap_or(b"/usr/bin:/bin");
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let found = bun_which::which(&mut buf, path_env, b"", b"crontab")?;
         Some(ZString::from_bytes(found.as_bytes()))
     }
@@ -2224,7 +2222,7 @@ fn alloc_print_z(args: core::fmt::Arguments<'_>) -> Result<ZString, bun_alloc::A
 /// Create a temp file path with a random suffix to avoid TOCTOU/symlink attacks.
 #[cfg(not(target_os = "macos"))]
 fn make_temp_path(prefix: &'static str) -> Result<ZString, bun_alloc::AllocError> {
-    let mut name_buf = PathBuffer::uninit();
+    let mut name_buf = bun_paths::path_buffer_pool::get();
     let mut full_prefix = Vec::with_capacity(prefix.len() + 3);
     full_prefix.extend_from_slice(prefix.as_bytes());
     full_prefix.extend_from_slice(b"tmp");

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -10,7 +10,7 @@ use bun_jsc::{
     JsResult, JsThread, StringJsc as _, SysErrorJsc as _,
 };
 use bun_paths::resolve_path::join_string_buf;
-use bun_paths::{self as resolve_path, MAX_PATH_BYTES, PathBuffer, platform};
+use bun_paths::{self as resolve_path, MAX_PATH_BYTES, platform};
 use bun_sys as syscall;
 
 // Codegen hooks (JSGlob): toJS / fromJS / fromJSDirect are provided by the
@@ -68,7 +68,7 @@ impl ScanOpts {
             }
 
             // Convert to an absolute path
-            let mut path_buf = PathBuffer::uninit();
+            let mut path_buf = bun_paths::path_buffer_pool::get();
             let cwd_len = match bun_sys::getcwd(&mut path_buf[..]) {
                 bun_sys::Result::Ok(len) => len,
                 bun_sys::Result::Err(err) => {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -28,7 +28,7 @@ use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue, LogJsc as _};
 use bun_options_types::WindowsOptions;
 use bun_options_types::schema::api;
 use bun_paths::resolve_path::{join_abs_string, join_abs_string_buf, platform};
-use bun_paths::{self as paths, PathBuffer, SEP};
+use bun_paths::{self as paths, SEP};
 use bun_ptr::{BackRef, RefCount, RefPtr};
 use bun_standalone_graph::StandaloneModuleGraph::{
     CompileErrorReason, CompileResult, Flags as StandaloneFlags, target_base_public_path,
@@ -483,7 +483,7 @@ impl JSBundleCompletionTask {
                     };
 
                     // Write the sourcemap file to disk next to the executable
-                    let mut pathbuf = PathBuffer::uninit();
+                    let mut pathbuf = bun_paths::path_buffer_pool::get();
                     let write_path: &[u8] = if cfg!(windows) {
                         &sourcemap_full_path
                     } else {

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -15,7 +15,7 @@ use bun_jsc::bun_string_jsc;
 use bun_jsc::{
     CallFrame, JSGlobalObject, JSValue, JsClass, JsResult, StringJsc, Strong, StrongOptional,
 };
-use bun_paths::{self as paths, MAX_PATH_BYTES, PathBuffer};
+use bun_paths::{self as paths, MAX_PATH_BYTES};
 use bun_resolver::{DirInfo, Resolver};
 
 use bun_wyhash;
@@ -1581,7 +1581,7 @@ impl FrameworkRouter {
                             }
                         }
 
-                        let mut rel_path_buf = PathBuffer::uninit();
+                        let mut rel_path_buf = bun_paths::path_buffer_pool::get();
                         let full_rel_path_len = {
                             let full_rel_path = paths::resolve_path::relative_normalized_buf::<
                                 paths::platform::Auto,

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -30,7 +30,6 @@ use bun_jsc::{
     self as jsc, AnyPromise, JSGlobalObject, JSModuleLoader, JSPromise, JSValue, JsResult,
     StringJsc as _,
 };
-use bun_paths::PathBuffer;
 use bun_paths::resolve_path::{self, platform};
 use bun_resolver as resolver;
 
@@ -84,7 +83,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
         Global::crash();
     }
 
-    let mut cwd_buf = PathBuffer::uninit();
+    let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let cwd = match bun_core::getcwd(&mut cwd_buf) {
         Ok(cwd) => cwd.as_bytes(),
         Err(err) => {
@@ -527,7 +526,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // trailing slash
     let public_path: &[u8] = b"/";
 
-    let mut root_dir_buf = PathBuffer::uninit();
+    let mut root_dir_buf = bun_paths::path_buffer_pool::get();
     let root_dir_path =
         resolve_path::join_abs_string_buf::<platform::Auto>(cwd, &mut root_dir_buf.0, &[b"dist"]);
     // Note: reshaped for borrowck — copy out so root_dir_buf can drop.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -19,8 +19,8 @@ use bun_jsc::regular_expression::Flags as RegexFlags;
 use bun_options_types::code_coverage_options::Reporters as CoverageReporters;
 use bun_options_types::context::{Debugger, DebuggerEnable, HotReload, MacroOptions, Shard};
 use bun_options_types::schema::api;
+use bun_paths::platform;
 use bun_paths::resolve_path;
-use bun_paths::{PathBuffer, platform};
 
 use crate::cli;
 use crate::cli::colon_list_type::ColonListType;
@@ -825,7 +825,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     // `api::TransformOptions.absolute_working_dir` is `Option<Box<[u8]>>`,
     // so we dupe into a plain `Box<[u8]>`.
     let cwd: Box<[u8]> = if let Some(cwd_arg) = args.option(b"--cwd") {
-        let mut outbuf = PathBuffer::uninit();
+        let mut outbuf = bun_paths::path_buffer_pool::get();
         // An absolute --cwd needs no base; a relative one still requires a
         // live cwd (an exe-dir base would silently chdir somewhere else).
         let base: &[u8] = if bun_paths::is_absolute(cwd_arg) {
@@ -849,7 +849,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         }
         // Store the post-chdir physical path (mirrors process.chdir) so
         // process.cwd(), path.resolve, and the resolver agree on one form.
-        let mut phys = PathBuffer::uninit();
+        let mut phys = bun_paths::path_buffer_pool::get();
         match bun_core::getcwd(&mut phys) {
             Ok(p) => Box::<[u8]>::from(p.as_bytes()),
             Err(_) => Box::<[u8]>::from(out_z.as_bytes()),
@@ -860,12 +860,12 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     ) {
         // A deleted cwd must not abort the runtime (Node boots and lets
         // `process.cwd()` throw later); fall back to the executable's dir.
-        let mut temp = PathBuffer::uninit();
+        let mut temp = bun_paths::path_buffer_pool::get();
         Box::<[u8]>::from(bun_core::getcwd_or_exe_dir(&mut temp).as_bytes())
     } else {
         // Everything else (install/test/build/...) must not silently act on
         // whatever project happens to live above the executable.
-        let mut temp = PathBuffer::uninit();
+        let mut temp = bun_paths::path_buffer_pool::get();
         Box::<[u8]>::from(bun_core::getcwd(&mut temp)?.as_bytes())
     };
 

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -136,7 +136,7 @@ impl AuditCommand {
             Ok(v) => v,
             Err(err) => {
                 if err == bun_install::Error::MissingPackageJSON {
-                    let mut cwd_buf = bun_paths::PathBuffer::uninit();
+                    let mut cwd_buf = bun_paths::path_buffer_pool::get();
                     if let Ok(cwd) = bun_core::getcwd(&mut cwd_buf) {
                         Output::err_generic(
                             "No package.json was found for directory \"{s}\"",

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -11,7 +11,7 @@ use bun_core::{Global, Output, fmt as bun_fmt};
 use bun_js_parser::parser::Runtime;
 use bun_options_types::context::MacroOptions;
 use bun_options_types::schema::api;
-use bun_paths::{PathBuffer, resolve_path};
+use bun_paths::resolve_path;
 use bun_sys::{self, Fd, FdExt as _};
 
 extern crate bun_standalone_graph as bun_standalone_module_graph;
@@ -394,7 +394,7 @@ impl BuildCommand {
             }
         }
 
-        let mut src_root_dir_buf = PathBuffer::uninit();
+        let mut src_root_dir_buf = bun_paths::path_buffer_pool::get();
         let src_root_dir: &[u8] = 'brk1: {
             let path: &[u8] = 'brk2: {
                 if !ctx.bundler_options.root_dir.is_empty() {
@@ -889,7 +889,7 @@ impl BuildCommand {
                     outfile = &outfile_owned;
                 } else if was_renamed_from_index && outfile != b"index" {
                     // If we're going to fail due to EISDIR, we should instead pick a different name.
-                    let mut zbuf = PathBuffer::uninit();
+                    let mut zbuf = bun_paths::path_buffer_pool::get();
                     let n = outfile.len().min(zbuf.0.len() - 1);
                     zbuf.0[..n].copy_from_slice(&outfile[..n]);
                     zbuf.0[n] = 0;
@@ -996,7 +996,7 @@ impl BuildCommand {
                             // root_dir already points to the outfile's parent directory,
                             // so use map_basename (not a path with directory components)
                             // to avoid writing to a doubled directory path.
-                            let mut pathbuf = PathBuffer::uninit();
+                            let mut pathbuf = bun_paths::path_buffer_pool::get();
                             match bun_sys::write_file_with_path_buffer(
                                 &mut pathbuf,
                                 &bun_sys::WriteFileArgs {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -18,7 +18,7 @@ use bun_core::{ZStr, strings};
 use bun_install::dependency::VersionTag;
 use bun_install::update_request::{self, UpdateRequest};
 use bun_parsers::json;
-use bun_paths::{self, DELIMITER, PathBuffer};
+use bun_paths::{self, DELIMITER};
 use bun_resolver::fs::RealFS;
 #[cfg(windows)]
 use bun_sys::FdExt as _;
@@ -372,7 +372,7 @@ impl BunxCommand {
         dir_fd: Fd,
         package_name: &[u8],
     ) -> crate::Result<Box<[u8]>> {
-        let mut subpath = PathBuffer::uninit();
+        let mut subpath = bun_paths::path_buffer_pool::get();
         let len = {
             let total = subpath.len();
             let mut cursor: &mut [u8] = &mut subpath[..];
@@ -400,7 +400,7 @@ impl BunxCommand {
         package_name: &[u8],
         with_stale_check: bool,
     ) -> crate::Result<Box<[u8]>> {
-        let mut subpath = PathBuffer::uninit();
+        let mut subpath = bun_paths::path_buffer_pool::get();
         if with_stale_check {
             let len = {
                 let total = subpath.len();
@@ -568,7 +568,7 @@ impl BunxCommand {
 
     #[cfg(unix)]
     fn is_trusted_cache_root(cache_root: &[u8], temp_dir_len: usize, uid: libc::uid_t) -> bool {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         if cache_root.len() >= buf.len() || temp_dir_len >= cache_root.len() {
             return false;
         }
@@ -627,7 +627,7 @@ impl BunxCommand {
             Ok(st) if dir_ok(&st) => st,
             _ => return false,
         };
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         if cache_dir.len() >= buf.len() {
             return false;
         }
@@ -980,10 +980,10 @@ impl BunxCommand {
 
         // `path_buf` is a stack local so
         // `bun_which::which`'s returned slice can borrow it for the rest of exec().
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let top_level_dir: &[u8] = fs.top_level_dir;
 
-        let mut absolute_in_cache_dir_buf = PathBuffer::uninit();
+        let mut absolute_in_cache_dir_buf = bun_paths::path_buffer_pool::get();
         let buf_total = absolute_in_cache_dir_buf.len();
         let mut absolute_in_cache_dir: &[u8] = {
             let mut cursor: &mut [u8] = &mut absolute_in_cache_dir_buf[..];

--- a/src/runtime/cli/create/SourceFileProjectGenerator.rs
+++ b/src/runtime/cli/create/SourceFileProjectGenerator.rs
@@ -247,7 +247,7 @@ pub(crate) fn generate_files(
     }
 
     // Normalize file paths
-    let mut normalized_buf = bun_paths::PathBuffer::uninit();
+    let mut normalized_buf = bun_paths::path_buffer_pool::get();
     let mut normalized_name: &[u8] = if bun_paths::is_absolute(entry_point) {
         resolve_path::relative_normalized_buf::<path::platform::Loose, true>(
             &mut normalized_buf,
@@ -612,7 +612,7 @@ fn get_shadcn_components(
 // Local wrapper for `bun.sys.exists([]const u8)` — bun_sys currently exposes
 // only `exists_z(&ZStr)`, so NUL-terminate via `resolve_path::z`.
 fn exists(path: &[u8]) -> bool {
-    let mut buf = bun_paths::PathBuffer::uninit();
+    let mut buf = bun_paths::path_buffer_pool::get();
     bun_sys::exists_z(resolve_path::z(path, &mut buf))
 }
 

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -614,7 +614,7 @@ impl CreateCommand {
                 };
 
                 #[cfg(windows)]
-                let mut destination_buf: bun_paths::WPathBuffer = bun_paths::WPathBuffer::uninit();
+                let mut destination_buf = bun_paths::w_path_buffer_pool::get();
                 #[cfg(windows)]
                 let dst_without_trailing_slash: &[u8] =
                     strings::without_trailing_slash(destination);
@@ -625,8 +625,7 @@ impl CreateCommand {
                 }
 
                 #[cfg(windows)]
-                let mut template_path_buf: bun_paths::WPathBuffer =
-                    bun_paths::WPathBuffer::uninit();
+                let mut template_path_buf = bun_paths::w_path_buffer_pool::get();
                 #[cfg(windows)]
                 let src_without_trailing_slash: &[u8] =
                     strings::without_trailing_slash(abs_template_path);

--- a/src/runtime/cli/exec_command.rs
+++ b/src/runtime/cli/exec_command.rs
@@ -5,7 +5,6 @@ use bun_core::{Global, Output};
 use bun_options_types::schema::api;
 
 use crate::shell::Interpreter;
-use bun_paths::{self, PathBuffer};
 use bun_sys;
 
 use crate::command::Context;
@@ -52,7 +51,7 @@ impl ExecCommand {
         // Read the field before the `&mut` method call (borrowck).
         let disable_default_env_files = bundle.options.env.disable_default_env_files;
         bundle.run_env_loader(disable_default_env_files)?;
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let cwd: &[u8] = match bun_sys::getcwd(&mut *buf) {
             Ok(n) => &buf[..n],
             Err(e) => {

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -63,7 +63,7 @@ fn get_candidate_package_patterns<'a>(
     // `break` → `break 'walk`.
     'walk: loop {
         'body: {
-            let mut name_buf = PathBuffer::uninit();
+            let mut name_buf = bun_paths::path_buffer_pool::get();
             let json_path: &ZStr = resolve_path::join_abs_string_buf_z::<platform::Auto>(
                 workdir,
                 &mut name_buf[..],
@@ -166,7 +166,7 @@ pub(crate) fn select_packages(
     };
 
     let mut glob_patterns: Vec<Box<[u8]>> = Vec::new();
-    let mut root_buf = PathBuffer::uninit();
+    let mut root_buf = bun_paths::path_buffer_pool::get();
     let root_dir: Box<[u8]> = get_candidate_package_patterns(
         // SAFETY: `ctx.log` is the process-static `Cli::LOG_`; CLI dispatch is single-threaded and no other `&mut Log` is live.
         unsafe { ctx.log_mut() },

--- a/src/runtime/cli/install_completions_command.rs
+++ b/src/runtime/cli/install_completions_command.rs
@@ -3,9 +3,6 @@ use bun_core::strings;
 use bun_core::{Global, Output, env_var};
 #[cfg(not(windows))]
 use bun_core::{note, print_errorln};
-use bun_paths::PathBuffer;
-#[cfg(windows)]
-use bun_paths::WPathBuffer;
 #[cfg(not(windows))]
 use bun_paths::{platform, resolve_path};
 use bun_sys::{self, E, File};
@@ -24,7 +21,7 @@ impl InstallCompletionsCommand {
 
     #[cfg(not(windows))]
     fn install_bunx_symlink_posix(cwd: &[u8]) -> Result<(), crate::Error> {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
 
         // don't install it if it's already there
         if bun_which::which(
@@ -40,7 +37,7 @@ impl InstallCompletionsCommand {
 
         // first try installing the symlink into the same directory as the bun executable
         let exe = bun_core::self_exe_path()?;
-        let mut link_buf = PathBuffer::uninit();
+        let mut link_buf = bun_paths::path_buffer_pool::get();
         let link_path = buf_print_z(
             &mut link_buf,
             format_args!(
@@ -115,7 +112,7 @@ impl InstallCompletionsCommand {
             strings::last_index_of_char_t(image_path, u16::from(b'\\')).expect("unreachable");
         let image_dirname = &image_path[..last_sep + 1];
 
-        let mut bunx_path_buf = WPathBuffer::uninit();
+        let mut bunx_path_buf = bun_paths::w_path_buffer_pool::get();
 
         let cmd_suffix: &[u16] = if bun_core::env::IS_DEBUG {
             w!("bunx-debug.cmd")
@@ -189,7 +186,7 @@ impl InstallCompletionsCommand {
 
         const CONTENT: &[u8] = include_bytes!("uninstall.ps1");
 
-        let mut bunx_path_buf = WPathBuffer::uninit();
+        let mut bunx_path_buf = bun_paths::w_path_buffer_pool::get();
         let uninstaller_path = strings::concat_buf_t::<u16>(
             &mut bunx_path_buf,
             &[
@@ -220,7 +217,7 @@ impl InstallCompletionsCommand {
             0
         };
 
-        let mut cwd_buf = PathBuffer::uninit();
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
 
         let stdout = File::stdout();
 
@@ -556,12 +553,12 @@ impl InstallCompletionsCommand {
 
             // Check if they need to load the zsh completions file into their .zshrc
             if shell == Shell::Zsh {
-                let mut completions_path_buf = PathBuffer::uninit();
+                let mut completions_path_buf = bun_paths::path_buffer_pool::get();
                 let completions_path: &[u8] = resolve_path::join_string_buf::<platform::Auto>(
                     &mut completions_path_buf,
                     &[completions_dir, filename],
                 );
-                let mut zshrc_filepath = PathBuffer::uninit();
+                let mut zshrc_filepath = bun_paths::path_buffer_pool::get();
                 let needs_to_tell_them_to_add_completions_file: bool = 'brk: {
                     let dot_zshrc: File = 'zshrc: {
                         'first: {

--- a/src/runtime/cli/link_command.rs
+++ b/src/runtime/cli/link_command.rs
@@ -2,7 +2,7 @@ use bstr::BStr;
 
 use bun_core::strings;
 use bun_core::{Global, Output};
-use bun_paths::{AbsPath, PathBuffer};
+use bun_paths::AbsPath;
 use bun_resolver::fs::FileSystem;
 use bun_sys::{Dir, Fd, FdDirExt};
 
@@ -172,7 +172,7 @@ fn link(ctx: command::Context) -> crate::Result<()> {
                 use bun_paths::{platform, resolve_path};
                 // create the junction
                 let top_level = FileSystem::instance().top_level_dir_without_trailing_slash();
-                let mut link_path_buf = PathBuffer::uninit();
+                let mut link_path_buf = bun_paths::path_buffer_pool::get();
                 link_path_buf.0[..top_level.len()].copy_from_slice(top_level);
                 link_path_buf.0[top_level.len()] = 0;
                 // SAFETY: NUL written at link_path_buf[top_level.len()] above.
@@ -217,9 +217,9 @@ fn link(ctx: command::Context) -> crate::Result<()> {
 
         // Step 3b. Link any global bins
         if package.bin.tag != bin::Tag::None {
-            let mut link_target_buf = PathBuffer::uninit();
-            let mut link_dest_buf = PathBuffer::uninit();
-            let mut link_rel_buf = PathBuffer::uninit();
+            let mut link_target_buf = bun_paths::path_buffer_pool::get();
+            let mut link_dest_buf = bun_paths::path_buffer_pool::get();
+            let mut link_rel_buf = bun_paths::path_buffer_pool::get();
 
             // `target_node_modules_path` (`&`) and `node_modules_path` (`&mut`)
             // cannot alias the same value, so resolve the fd path twice (cheap:

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1895,7 +1895,7 @@ To create a project with the official Next.js scaffolding tool, run\n\
 
         for arg in bun::argv() {
             if arg == b"--hash" {
-                let mut path_buf = bun_paths::PathBuffer::uninit();
+                let mut path_buf = bun_paths::path_buffer_pool::get();
                 let entry = &ctx.args.entry_points[0];
                 path_buf[..entry.len()].copy_from_slice(entry);
                 path_buf[entry.len()] = 0;

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -464,12 +464,12 @@ impl EditorContext {
     }
 
     pub(crate) fn detect_editor(&mut self, env: &mut dot_env::Loader) {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         // Note: borrowck — `by_path_for_editor`/`by_fallback` tie `out`'s lifetime
         // to `&'a mut buf`. On the `false` path NLL conservatively keeps `buf` borrowed
         // (Polonius case). Re-borrow through a raw pointer at each call site; on a hit
         // we return immediately so only one `&mut` is ever live.
-        let buf_ptr: *mut PathBuffer = &raw mut buf;
+        let buf_ptr: *mut PathBuffer = &raw mut *buf;
         let mut out: &[u8] = b"";
 
         // first: choose from user preference

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -20,7 +20,7 @@ use bun_parsers::json as JSON;
 use bun_ast::{E, Expr, ExprData};
 use bun_js_printer as js_printer;
 use bun_libarchive::lib::{Archive, Entry as ArchiveEntry, Result as ArchiveStatus};
-use bun_paths::{self as path, PathBuffer, SEP_STR};
+use bun_paths::{self as path, SEP_STR};
 // `bun.ptr.CowString = CowSlice(u8)` — the lifetime-free struct port (init_owned/
 // borrow_subslice/length live on `cow_slice::CowSliceZ`).
 use bun_ptr::cow_slice::CowSlice;
@@ -1459,7 +1459,7 @@ pub(crate) struct BinInfo {
 fn get_package_bins(json: &Expr) -> Result<Vec<BinInfo>, AllocError> {
     let mut bins: Vec<BinInfo> = Vec::new();
 
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
 
     if let Some(bin) = json.as_property(b"bin") {
         if let Some(bin_str) = bin.expr.as_string(pack_bump()) {
@@ -1941,7 +1941,7 @@ pub(crate) fn published_files(
                     let mut includes: Vec<Pattern> = Vec::new();
                     let mut excludes: Vec<Pattern> = Vec::new();
 
-                    let mut path_buf = PathBuffer::uninit();
+                    let mut path_buf = bun_paths::path_buffer_pool::get();
                     while let Some(files_entry) = files_array.next() {
                         if let Some(file_entry_str) = files_entry.as_string(bump) {
                             let normalized = resolve_path::normalize_buf::<
@@ -2254,7 +2254,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         // On Windows, the cache key is stored with POSIX path separators,
         // so we need to convert the path before removing.
         #[cfg(windows)]
-        let mut cache_key_buf = PathBuffer::uninit();
+        let mut cache_key_buf = bun_paths::path_buffer_pool::get();
         #[cfg(windows)]
         let cache_key: &[u8] = {
             let len = abs_package_json_path.as_bytes().len();
@@ -2335,7 +2335,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     let edited_package_json = edit_root_package_json(ctx.lockfile, json)?;
 
     let root_dir: Dir = 'root_dir: {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         path_buf[..abs_workspace_path.len()].copy_from_slice(abs_workspace_path);
         path_buf[abs_workspace_path.len()] = 0;
         // SAFETY: NUL written above
@@ -2412,7 +2412,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     log_level,
                 );
             } else {
-                let mut dest_buf = PathBuffer::uninit();
+                let mut dest_buf = bun_paths::path_buffer_pool::get();
                 let (abs_tarball_dest, _) = tarball_destination(
                     opt_pack_destination(ctx.manager),
                     opt_pack_filename(ctx.manager),
@@ -2442,7 +2442,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         }
 
         if FOR_PUBLISH {
-            let mut dest_buf = PathBuffer::uninit();
+            let mut dest_buf = bun_paths::path_buffer_pool::get();
             let (abs_tarball_dest, _) = tarball_destination(
                 opt_pack_destination(ctx.manager),
                 opt_pack_filename(ctx.manager),
@@ -2542,7 +2542,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         _ => {}
     }
 
-    let mut dest_buf = PathBuffer::uninit();
+    let mut dest_buf = bun_paths::path_buffer_pool::get();
     let (abs_tarball_dest, abs_tarball_dest_dir_end) = tarball_destination(
         opt_pack_destination(ctx.manager),
         opt_pack_filename(ctx.manager),
@@ -3658,7 +3658,7 @@ impl IgnorePatterns {
         reason: IgnoreFileFailReason,
         err: crate::Error,
     ) -> ! {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let dir_path: &[u8] = match bun_sys::get_fd_path(Fd::from_std_dir(dir), &mut buf) {
             Ok(p) => &*p,
             Err(_) => b"",

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -13,7 +13,7 @@ use bun_install::package_manager_real::{
     package_manager_options::LogLevel, setup_global_dir,
 };
 use bun_install::{DependencyID, PackageID, PackageManager, migration};
-use bun_paths::{self as Path, PathBuffer};
+use bun_paths as Path;
 use bun_resolver::fs as Fs;
 use bun_sys::{self, Dir, Fd, File};
 
@@ -265,7 +265,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             Ok(v) => v,
             Err(err) => {
                 if err == bun_install::Error::MissingPackageJSON {
-                    let mut cwd_buf = PathBuffer::uninit();
+                    let mut cwd_buf = bun_paths::path_buffer_pool::get();
                     match bun_sys::getcwd(&mut cwd_buf[..]) {
                         Ok(len) => {
                             Output::err_generic(
@@ -440,7 +440,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
                 let cache_dir = fetch_cache_directory_path(&mut process_env, None);
-                let mut rm_buf = PathBuffer::uninit();
+                let mut rm_buf = bun_paths::path_buffer_pool::get();
                 let rm_dir = match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
                     Ok(d) => d,
                     Err(err) => {
@@ -532,7 +532,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 Global::exit(if had_err { 1 } else { 0 });
             }
 
-            let mut dir = PathBuffer::uninit();
+            let mut dir = bun_paths::path_buffer_pool::get();
             let fd = get_cache_directory(pm);
             let outpath = match bun_sys::get_fd_path(fd, &mut dir) {
                 Ok(p) => &p[..],
@@ -619,7 +619,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                     )?;
                 }
             } else {
-                let mut cwd_buf = PathBuffer::uninit();
+                let mut cwd_buf = bun_paths::path_buffer_pool::get();
                 let path = match bun_sys::getcwd(&mut cwd_buf[..]) {
                     Ok(len) => &cwd_buf[..len],
                     Err(_) => {
@@ -855,7 +855,7 @@ fn print_node_modules_folder_structure(
                 );
             }
         } else {
-            let mut cwd_buf = PathBuffer::uninit();
+            let mut cwd_buf = bun_paths::path_buffer_pool::get();
             let path = match bun_sys::getcwd(&mut cwd_buf[..]) {
                 Ok(len) => &cwd_buf[..len],
                 Err(_) => {
@@ -982,7 +982,7 @@ fn print_trusted_dependencies_flat(
     directories: &[NodeModulesFolder],
     lockfile: &Lockfile,
 ) {
-    let mut cwd_buf = PathBuffer::uninit();
+    let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let path = match bun_sys::getcwd(&mut cwd_buf[..]) {
         Ok(len) => &cwd_buf[..len],
         Err(_) => {

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -17,7 +17,6 @@ use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::npm::{self, PackageManifest};
 use bun_install::{PackageManager, resolution};
 use bun_libarchive::lib::{ArchiveIterator, IteratorResult as ArchiveIterResult};
-use bun_paths::PathBuffer;
 use bun_semver as Semver;
 use bun_sys::{Fd, FdExt as _, dir_iterator as DirIterator};
 use bun_url::URL;
@@ -704,12 +703,12 @@ fn fetch_registry_tree(
     let bump = Bump::new();
     let scope = pm.scope_for_package_name(name);
 
-    let mut url_buf = PathBuffer::uninit();
+    let mut url_buf = bun_paths::path_buffer_pool::get();
     let encoded_name = buf_print(
         url_buf.0.as_mut_slice(),
         format_args!("{}", bun_fmt::dependency_url(name)),
     );
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     let manifest_url = buf_print(
         path_buf.0.as_mut_slice(),
         format_args!(

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -10,7 +10,7 @@ use bun_core::{Global, Output};
 use bun_install::PackageManager;
 use bun_js_printer as js_printer;
 use bun_parsers::json;
-use bun_paths::{self as path, PathBuffer};
+use bun_paths as path;
 use bun_sys;
 
 pub(crate) struct PmPkgCommand;
@@ -118,7 +118,7 @@ impl PmPkgCommand {
     }
 
     fn find_package_json(cwd: &[u8]) -> Result<Box<[u8]>, Error> {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let mut current_dir = cwd;
 
         loop {
@@ -412,7 +412,7 @@ impl PmPkgCommand {
                         if pkg_dir.is_empty() {
                             pkg_dir = cwd;
                         }
-                        let mut buf = PathBuffer::uninit();
+                        let mut buf = bun_paths::path_buffer_pool::get();
                         let full_path = path::resolve_path::join_abs_string_buf_z::<
                             path::platform::Auto,
                         >(pkg_dir, &mut buf, &[bin_path]);

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -16,7 +16,7 @@ use bun_install::LogLevel;
 use bun_install::PackageManager;
 use bun_js_printer as JSPrinter;
 use bun_parsers::json as JSON;
-use bun_paths::{PathBuffer, resolve_path as path, resolve_path::platform as path_platform};
+use bun_paths::{resolve_path as path, resolve_path::platform as path_platform};
 use bun_semver as Semver;
 use bun_sys::{self, Fd};
 use bun_which::which;
@@ -84,7 +84,7 @@ impl PmVersionCommand {
 
         Self::verify_git(&package_json_dir, pm)?;
 
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let package_json_path = path::join_abs_string_buf_z::<path_platform::Auto>(
             &package_json_dir,
             &mut path_buf.0,
@@ -275,7 +275,7 @@ impl PmVersionCommand {
     }
 
     fn find_package_dir(start_dir: &[u8]) -> Result<Vec<u8>, AllocError> {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let mut current_dir = start_dir;
 
         loop {
@@ -303,7 +303,7 @@ impl PmVersionCommand {
             return Ok(());
         }
 
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let git_dir_path =
             path::join_abs_string_buf_z::<path_platform::Auto>(cwd, &mut path_buf.0, &[b".git"]);
         if !matches!(
@@ -340,7 +340,7 @@ impl PmVersionCommand {
 
     fn get_current_version(ctx: &command::ContextData, cwd: &[u8]) -> Option<Vec<u8>> {
         // Returns an owned Vec<u8> (no borrow of the package.json bytes).
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let package_json_path = path::join_abs_string_buf_z::<path_platform::Auto>(
             cwd,
             &mut path_buf.0,
@@ -680,7 +680,7 @@ impl PmVersionCommand {
     }
 
     fn is_git_clean(cwd: &[u8]) -> Result<bool, AllocError> {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let Some(git_path) = which(
             &mut path_buf,
             env_var::PATH.get().unwrap_or(b""),
@@ -722,7 +722,7 @@ impl PmVersionCommand {
     }
 
     fn get_version_from_git(cwd: &[u8]) -> Result<Vec<u8>, AllocError> {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let Some(git_path) = which(
             &mut path_buf,
             env_var::PATH.get().unwrap_or(b""),
@@ -784,7 +784,7 @@ impl PmVersionCommand {
         custom_message: Option<&[u8]>,
         cwd: &[u8],
     ) -> Result<(), AllocError> {
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let Some(git_path) = which(
             &mut path_buf,
             env_var::PATH.get().unwrap_or(b""),

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -12,7 +12,6 @@ use bun_install::npm::{self, PackageManifest};
 use bun_js_parser as ast;
 use bun_js_printer as JSPrinter;
 use bun_parsers::json as JSON;
-use bun_paths::PathBuffer;
 use bun_semver as Semver;
 use bun_url::URL; // bumpalo::Bump re-export
 
@@ -79,12 +78,12 @@ pub(crate) fn view(
 
     let scope = manager.scope_for_package_name(name);
 
-    let mut url_buf = PathBuffer::uninit();
+    let mut url_buf = bun_paths::path_buffer_pool::get();
     let encoded_name = buf_print(
         url_buf.0.as_mut_slice(),
         format_args!("{}", bun_fmt::dependency_url(name)),
     );
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     // Always fetch the full registry manifest, not a specific version
     let url_slice = buf_print(
         path_buf.0.as_mut_slice(),

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -15,8 +15,8 @@ use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::{self as install, Lockfile, Npm, PackageManager, Subcommand};
 use bun_libarchive::lib::{Archive, ArchiveIterator, IteratorResult as ArchiveIterResult};
 use bun_parsers::json as json_mod;
+use bun_paths as path;
 use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf, normalize_buf_z};
-use bun_paths::{self as path, PathBuffer};
 use bun_resolver::fs::FileSystem;
 use bun_sha_hmac as sha;
 use bun_simdutf_sys::simdutf;
@@ -140,7 +140,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         manager: &'a mut PackageManager,
         tarball_path: &[u8],
     ) -> Result<Context<'a, DIRECTORY_PUBLISH>, FromTarballError> {
-        let mut abs_buf = PathBuffer::uninit();
+        let mut abs_buf = bun_paths::path_buffer_pool::get();
         let abs_tarball_path = join_abs_string_buf_z::<path::platform::Auto>(
             FileSystem::instance().top_level_dir,
             &mut abs_buf,
@@ -1603,7 +1603,7 @@ impl PublishCommand {
                 crate::cli::cli_dupe($v) as &'static [u8]
             };
         }
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         if let Some(bin_query) = json.as_property(b"bin") {
             match &bin_query.expr.data {
                 ExprData::EString(bin_str) => {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -25,7 +25,7 @@ use bun_core::{Environment, Output, env_var, fmt, identifier};
 use bun_jsc::js_promise::Status as PromiseStatus;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, ProtectedJSValue};
-use bun_paths::{self as path, PathBuffer};
+use bun_paths as path;
 use bun_sys::{self as sys, Fd};
 
 // ============================================================================
@@ -198,7 +198,7 @@ impl History {
             return Ok(());
         }
 
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let path = path::resolve_path::join_z_buf::<path::platform::Auto>(
             &mut path_buf,
             &[home_path, HISTORY_FILENAME],
@@ -730,7 +730,7 @@ fn cmd_load(repl: &mut Repl, args: &[u8]) -> ReplResult {
         return ReplResult::SkipEval;
     }
 
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     let path_z = path::resolve_path::z(filename, &mut path_buf);
     let content: Box<[u8]> = match sys::File::read_from(Fd::cwd(), path_z) {
         sys::Result::Ok(bytes) => bytes.into(),

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3342,11 +3342,8 @@ impl RunCommand {
     }
 
     fn render_markdown_file_and_exit(path: &[u8]) -> ! {
-        // The render body returns so that its locals (pooled path buffers,
-        // the file contents, the rendered output) are dropped before
-        // `exit`. A heap allocation that is still owned by a live local at
-        // `exit` is a leak to LeakSanitizer once the optimizer has reused
-        // the local's stack slot.
+        // Render in a function that returns so its pooled buffers are dropped
+        // before `exit`; LeakSanitizer reports them otherwise.
         let code = Self::render_markdown_file(path);
         Global::exit(code);
     }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3342,15 +3342,23 @@ impl RunCommand {
     }
 
     fn render_markdown_file_and_exit(path: &[u8]) -> ! {
-        // No explicit free() on contents / rendered below: every path out
-        // of this function calls Global::exit() or bun.outOfMemory() (both
-        // noreturn), so the OS reclaims the allocations on process exit.
+        // The render body returns so that its locals (pooled path buffers,
+        // the file contents, the rendered output) are dropped before
+        // `exit`. A heap allocation that is still owned by a live local at
+        // `exit` is a leak to LeakSanitizer once the optimizer has reused
+        // the local's stack slot.
+        let code = Self::render_markdown_file(path);
+        Global::exit(code);
+    }
+
+    /// Renders `path` to stdout. Returns the process exit code.
+    fn render_markdown_file(path: &[u8]) -> u32 {
         let contents = match sys::File::read_from(Fd::cwd(), path) {
             Ok(bytes) => bytes,
             Err(err) => {
                 pretty_errorln!("<r><red>error<r>: {}", err);
                 Output::flush();
-                Global::exit(1);
+                return 1;
             }
         };
 
@@ -3462,12 +3470,12 @@ impl RunCommand {
                     "<r><red>error<r>: markdown rendering exceeded the stack — input is too deeply nested",
                 );
                 Output::flush();
-                Global::exit(1);
+                return 1;
             }
             Err(_) | Ok(None) => {
                 pretty_errorln!("<r><red>error<r>: failed to render markdown");
                 Output::flush();
-                Global::exit(1);
+                return 1;
             }
             Ok(Some(r)) => r,
         };
@@ -3482,7 +3490,7 @@ impl RunCommand {
         // silently (q=2 suppresses the error). System tmp cleanup
         // (systemd-tmpfiles, /tmp reboot wipe) eventually removes the
         // bun-md-*.png files, which are small (~100KB each) and rare.
-        Global::exit(0);
+        0
     }
 
     /// Shell-completion entries for `bun run`. Called from

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -911,7 +911,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         mini.top_level_dir = Box::<[u8]>::from(top_level_dir);
 
         // `initAndRunFromFile`: read source then hand off to the interpreter.
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         path_buf[..entry_path.len()].copy_from_slice(entry_path);
         path_buf[entry_path.len()] = 0;
         // SAFETY: NUL-terminated above; `path_buf` outlives the call.
@@ -1029,7 +1029,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 runner_arena().alloc_slice_copy(cron_script.as_bytes());
 
             // entry_path must end with /[eval] for the transpiler to use eval_source
-            let mut cwd_buf = PathBuffer::uninit();
+            let mut cwd_buf = bun_paths::path_buffer_pool::get();
             let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
             let cwd_bytes = cwd.as_bytes();
             let mut eval_path: Vec<u8> = Vec::with_capacity(cwd_bytes.len() + EVAL_TRIGGER.len());
@@ -1758,8 +1758,8 @@ impl RunCommand {
         }
         #[cfg(windows)]
         {
-            let mut temp_path_buffer = WPathBuffer::uninit();
-            let mut target_path_buffer = PathBuffer::uninit();
+            let mut temp_path_buffer = bun_paths::w_path_buffer_pool::get();
+            let mut target_path_buffer = bun_paths::path_buffer_pool::get();
             // SAFETY: FFI Win32 `GetTempPathW`. `temp_path_buffer` is a valid
             // writable WCHAR[MAX_PATH+] buffer and `nBufferLength` is its
             // capacity in WCHARs; the call writes at most that many wide chars.
@@ -2633,7 +2633,7 @@ impl RunCommand {
             }
 
             if !path_for_which.is_empty() {
-                let mut path_buf = PathBuffer::uninit();
+                let mut path_buf = bun_paths::path_buffer_pool::get();
                 if let Some(destination) =
                     which(&mut path_buf, path_for_which, top_level_dir, target_name)
                 {
@@ -2717,7 +2717,7 @@ impl RunCommand {
         // absolute path via `get_fd_path` before booting. The
         // get_fd_path step matters: it resolves symlinks so module-relative
         // resolution sees the real location.
-        let mut script_name_buf = PathBuffer::uninit();
+        let mut script_name_buf = bun_paths::path_buffer_pool::get();
 
         // Build a NUL-terminated path to open (branching for
         // absolute vs. simple-relative vs. `..`/`~`-prefixed).
@@ -2748,7 +2748,7 @@ impl RunCommand {
             target.len()
         } else {
             // `..foo` / `~foo` — resolve against cwd via joinAbsStringBuf.
-            let mut cwd_buf = PathBuffer::uninit();
+            let mut cwd_buf = bun_paths::path_buffer_pool::get();
             let Ok(cwd) = bun_core::getcwd(&mut cwd_buf) else {
                 return false;
             };
@@ -2838,7 +2838,7 @@ impl RunCommand {
         const STDIN_TRIGGER: &[u8] = b"/[stdin]";
 
         let mut entry_point_buf = [0u8; MAX_PATH_BYTES + STDIN_TRIGGER.len()];
-        let mut cwd_buf = PathBuffer::uninit();
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
         let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
         let cwd_bytes = cwd.as_bytes();
         let cwd_len = cwd_bytes.len();
@@ -2900,7 +2900,7 @@ impl RunCommand {
         }
 
         let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
-        let mut cwd_buf = PathBuffer::uninit();
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
         let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
         let cwd_bytes = cwd.as_bytes();
         let cwd_len = cwd_bytes.len();
@@ -2935,7 +2935,7 @@ impl RunCommand {
         if !ctx.runtime_options.eval.script.is_empty() {
             // synthetic `[eval]` path under cwd
             let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
-            let mut cwd_buf = PathBuffer::uninit();
+            let mut cwd_buf = bun_paths::path_buffer_pool::get();
             let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
             let cwd_bytes = cwd.as_bytes();
             let cwd_len = cwd_bytes.len();
@@ -2969,11 +2969,11 @@ impl RunCommand {
             // `cwd_buf[cwd_len] = b'/'` (always `/`, NOT the
             // platform separator) and then run the result through
             // `join_abs_string_buf::<Loose>` to collapse `.`/`..`.
-            let mut cwd_buf = PathBuffer::uninit();
+            let mut cwd_buf = bun_paths::path_buffer_pool::get();
             let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
             let cwd_len = cwd.as_bytes().len();
             cwd_buf[cwd_len] = b'/';
-            let mut out_buf = PathBuffer::uninit();
+            let mut out_buf = bun_paths::path_buffer_pool::get();
             let joined = paths::resolve_path::join_abs_string_buf::<paths::platform::Loose>(
                 &cwd_buf[..cwd_len + 1],
                 &mut out_buf.0,
@@ -3419,8 +3419,8 @@ impl RunCommand {
         // `bun ./docs/README.md` from `/home/user` can't find `./img.png`
         // that sits next to README.md. Resolve to an absolute dir first
         // so joinAbsString downstream doesn't double-apply cwd.
-        let mut base_buf = PathBuffer::uninit();
-        let mut cwd_buf = PathBuffer::uninit();
+        let mut base_buf = bun_paths::path_buffer_pool::get();
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
         let abs_md_path: &[u8] = 'blk: {
             if paths::is_absolute(path) {
                 break 'blk path;
@@ -3576,7 +3576,7 @@ impl RunCommand {
                             .fs
                             .entries_mutex
                             .lock_guard();
-                        let mut path_buf = PathBuffer::uninit();
+                        let mut path_buf = bun_paths::path_buffer_pool::get();
                         let mut iter = entries.data.iter();
                         let mut has_copied = false;
                         let mut dir_slice_len: usize = 0;

--- a/src/runtime/cli/test/ChangedFilesFilter.rs
+++ b/src/runtime/cli/test/ChangedFilesFilter.rs
@@ -31,7 +31,7 @@ use bun_jsc::EventLoopHandle;
 use bun_jsc::virtual_machine::VirtualMachine;
 #[cfg(not(windows))]
 use bun_paths::SEP;
-use bun_paths::{self, PathBuffer, platform, resolve_path};
+use bun_paths::{self, platform, resolve_path};
 use bun_ptr::Interned;
 #[cfg(not(windows))]
 use bun_resolver::fs::RealFS;
@@ -634,7 +634,7 @@ fn run_git(git_path: &[u8], cwd: &[u8], args: &[&[u8]]) -> GitResult {
 /// Parse newline-delimited repo-relative paths from git output, join each
 /// with the repository root, and insert existing files into `set`.
 fn append_paths(set: &mut StringSet, git_root: &[u8], stdout: &[u8]) {
-    let mut buf = PathBuffer::uninit();
+    let mut buf = bun_paths::path_buffer_pool::get();
     for line in strings::tokenize_any(stdout, b"\r\n") {
         let rel = strings::trim(line, b" \t");
         if rel.is_empty() {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -85,7 +85,7 @@ impl<'a> Scanner<'a> {
             options: &transpiler.options,
             fs: transpiler.fs,
             test_files: results,
-            open_dir_buf: PathBuffer::uninit(),
+            open_dir_buf: PathBuffer::ZEROED,
             has_iterated: false,
             search_count: 0,
             current_dir: None,
@@ -126,7 +126,7 @@ impl<'a> Scanner<'a> {
     }
 
     pub(crate) fn scan(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
-        let mut scan_dir_buf = PathBuffer::uninit();
+        let mut scan_dir_buf = bun_paths::path_buffer_pool::get();
         let parts: [&[u8]; 2] = [self.top_level_dir(), path_literal];
         let Some(path) = Self::abs_buf_projected(self.top_level_dir(), &parts, &mut scan_dir_buf)
         else {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -13,9 +13,9 @@ use bun_dotenv as DotEnv;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{self as jsc};
 use bun_options_types::code_coverage_options::CodeCoverageOptions;
+use bun_paths as bun_path;
 use bun_paths::resolve_path;
 use bun_paths::string_paths::without_leading_path_separator;
-use bun_paths::{self as bun_path, PathBuffer};
 use bun_ptr::Interned;
 use bun_resolver::fs::FileSystem;
 use bun_sys::{self, Fd, File};
@@ -895,7 +895,7 @@ impl JunitReporter {
             self.contents.extend_from_slice(b"</testsuites>\n");
         }
 
-        let mut junit_path_buf = PathBuffer::uninit();
+        let mut junit_path_buf = bun_paths::path_buffer_pool::get();
 
         junit_path_buf[..path.len()].copy_from_slice(path);
         junit_path_buf[path.len()] = 0;
@@ -1653,7 +1653,7 @@ fn write_lcov_report(
         ".lcov.info.{}.tmp",
         bun_core::fmt::hex_lower(&rand)
     );
-    let mut buf = PathBuffer::uninit();
+    let mut buf = bun_paths::path_buffer_pool::get();
     let tmp_path = resolve_path::join_abs_string_buf_z::<bun_path::platform::Auto>(
         relative_dir,
         &mut buf,

--- a/src/runtime/cli/unlink_command.rs
+++ b/src/runtime/cli/unlink_command.rs
@@ -2,7 +2,7 @@ use bstr::BStr;
 
 use bun_core::strings;
 use bun_core::{Global, Output};
-use bun_paths::{AbsPath, PathBuffer, platform, resolve_path};
+use bun_paths::{AbsPath, platform, resolve_path};
 use bun_sys::{self as sys, Dir, Fd, FdDirExt};
 
 use bun_install::Features;
@@ -168,9 +168,9 @@ fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
 
         // Step 3b. Link any global bins
         if package.bin.tag != stub_bin::Tag::None {
-            let mut link_target_buf = PathBuffer::uninit();
-            let mut link_dest_buf = PathBuffer::uninit();
-            let mut link_rel_buf = PathBuffer::uninit();
+            let mut link_target_buf = bun_paths::path_buffer_pool::get();
+            let mut link_dest_buf = bun_paths::path_buffer_pool::get();
+            let mut link_rel_buf = bun_paths::path_buffer_pool::get();
 
             // `target_node_modules_path` (`&`) and `node_modules_path` (`&mut`)
             // cannot alias the same value, so resolve the fd path twice

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -227,7 +227,7 @@ impl UpdateInteractiveCommand {
         // Write the updated package.json
         // Routes through `bun_sys::File::write_file` (cwd-relative
         // open + write + close) per src/CLAUDE.md.
-        let mut path_zbuf = PathBuffer::uninit();
+        let mut path_zbuf = bun_paths::path_buffer_pool::get();
         let path_z = path::resolve_path::z(package_json_path, &mut path_zbuf);
         if let Err(err) =
             bun_sys::File::write_file(bun_sys::Fd::cwd(), path_z, &new_package_json_source)
@@ -330,7 +330,7 @@ impl UpdateInteractiveCommand {
             // Build the package.json path for this workspace
             // SAFETY: `FileSystem::init` ran during `PackageManager::init`.
             let root_dir = FileSystem::get().top_level_dir;
-            let mut path_buf = PathBuffer::uninit();
+            let mut path_buf = bun_paths::path_buffer_pool::get();
             let package_json_path =
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);
 
@@ -460,7 +460,7 @@ impl UpdateInteractiveCommand {
             // Build the package.json path for this workspace
             // SAFETY: `FileSystem::init` ran during `PackageManager::init`.
             let root_dir = FileSystem::get().top_level_dir;
-            let mut path_buf = PathBuffer::uninit();
+            let mut path_buf = bun_paths::path_buffer_pool::get();
             let package_json_path =
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);
 

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -13,7 +13,7 @@ use bun_http::{self as HTTP, headers};
 use bun_install::integrity::{Integrity, Tag as IntegrityTag};
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_parsers::json as JSON;
-use bun_paths::{self, PathBuffer, SEP_STR};
+use bun_paths::{self, SEP_STR};
 use bun_resolver::fs;
 use bun_sys as sys;
 use bun_url::URL;
@@ -756,7 +756,7 @@ impl UpgradeCommand {
             let save_dir: sys::Dir = save_dir_it;
 
             // Reshaped for borrowck — use a stack-local PathBuffer instead of thread_local
-            let mut tmpdir_path_buf = PathBuffer::uninit();
+            let mut tmpdir_path_buf = bun_paths::path_buffer_pool::get();
             let tmpdir_path = match sys::get_fd_path(save_dir.fd(), &mut tmpdir_path_buf) {
                 Ok(p) => p,
                 Err(err) => {
@@ -816,7 +816,7 @@ impl UpgradeCommand {
 
                 #[cfg(unix)]
                 {
-                    let mut unzip_path_buf = PathBuffer::uninit();
+                    let mut unzip_path_buf = bun_paths::path_buffer_pool::get();
                     let Some(unzip_exe) = which(
                         &mut unzip_path_buf,
                         env_loader.map.get(b"PATH").unwrap_or(b""),
@@ -896,10 +896,10 @@ impl UpgradeCommand {
                     )
                     .expect("oom");
 
-                    let mut buf = PathBuffer::uninit();
+                    let mut buf = bun_paths::path_buffer_pool::get();
                     // Separate fallback buffer — borrowck holds `buf` for the lifetime
                     // of `which`'s returned `Option<&ZStr>` even across the `None` arm.
-                    let mut buf2 = PathBuffer::uninit();
+                    let mut buf2 = bun_paths::path_buffer_pool::get();
                     let powershell_path: &ZStr = match which(
                         &mut buf,
                         bun_core::env_var::PATH.get().unwrap_or(b""),
@@ -1093,7 +1093,7 @@ impl UpgradeCommand {
             // or `&mut [u8]` over the *whole* array, retagging it and
             // invalidating the raw-pointer-derived `&ZStr` views below. The
             // single `buf_ptr` is the shared provenance root.
-            let mut current_executable_buf = PathBuffer::uninit();
+            let mut current_executable_buf = bun_paths::path_buffer_pool::get();
             let buf_ptr: *mut u8 = current_executable_buf.as_mut_ptr();
             // SAFETY: `buf_ptr` covers `MAX_PATH_BYTES`; `destination_executable`
             // came from `self_exe_path()` which is bounded by that.
@@ -1145,7 +1145,7 @@ impl UpgradeCommand {
 
             // `move_file_z` wants `&ZStr`; pre-compute a NUL-terminated
             // copy of `exe`.
-            let mut exe_z_buf = PathBuffer::uninit();
+            let mut exe_z_buf = bun_paths::path_buffer_pool::get();
             exe_z_buf[..exe.len()].copy_from_slice(exe);
             exe_z_buf[exe.len()] = 0;
             // SAFETY: NUL written above.
@@ -1436,9 +1436,9 @@ pub(crate) mod upgrade_js_bindings {
         {
             use sys::windows as w;
 
-            let mut buf = bun_paths::WPathBuffer::uninit();
+            let mut buf = bun_paths::w_path_buffer_pool::get();
             let tmpdir_path = fs::RealFS::get_default_temp_dir();
-            let mut wtmp = bun_paths::WPathBuffer::uninit();
+            let mut wtmp = bun_paths::w_path_buffer_pool::get();
             let tmpdir_w = bun_core::convert_utf8_to_utf16_in_buffer(&mut wtmp[..], tmpdir_path);
             let path = match sys::normalize_path_windows(sys::Fd::INVALID, tmpdir_w, &mut buf[..]) {
                 sys::Result::Err(_) => return Ok(JSValue::UNDEFINED),

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -27,7 +27,6 @@ use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromiseStrong, JSValue, JsCell, JsResult,
     SystemError, host_fn,
 };
-use bun_paths::PathBuffer;
 use bun_ptr::RefPtr;
 #[cfg(windows)]
 use bun_sys::windows::libuv;
@@ -258,7 +257,7 @@ pub(crate) mod lib_uv_backend {
         // SAFETY: port_buf[port_len] == 0 written above
         let port_z = ZStr::from_buf(&port_buf[..], port_len);
 
-        let mut hostname = PathBuffer::uninit();
+        let mut hostname = bun_paths::path_buffer_pool::get();
         // Reserve the last byte for the NUL terminator so the index below can never
         // exceed the buffer even if the upstream length guard in `doLookup` is bypassed.
         let cap = hostname.len() - 1;
@@ -1054,7 +1053,7 @@ pub mod get_addr_info_request {
             // SAFETY: NUL written at port_buf[port_len]
             let port_z = ZStr::from_buf(&port_buf[..], port_len);
 
-            let mut hostname = PathBuffer::uninit();
+            let mut hostname = bun_paths::path_buffer_pool::get();
             // Reserve the last byte for the NUL terminator so the index below
             // can never exceed the buffer even if the upstream length guard in
             // `doLookup` is bypassed.

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -19,7 +19,6 @@ use bun_jsc::{
 };
 #[cfg(target_os = "macos")]
 use bun_paths as path;
-use bun_paths::PathBuffer;
 use bun_resolver::fs as Fs;
 use bun_sys;
 
@@ -661,7 +660,7 @@ impl CompileC {
 
         #[cfg(target_os = "macos")]
         {
-            let mut pathbuf = PathBuffer::uninit();
+            let mut pathbuf = bun_paths::path_buffer_pool::get();
             'add_system_include_dir: {
                 let dirs_to_try: [&[u8]; 2] = [
                     env_var::SDKROOT.get().unwrap_or(b""),
@@ -2330,7 +2329,7 @@ impl CompilerRT {
     fn fresh_compiler_rt_dir_name() -> Option<ZBox> {
         #[cfg(unix)]
         {
-            let mut name_buf = PathBuffer::uninit();
+            let mut name_buf = bun_paths::path_buffer_pool::get();
             let name = Fs::FileSystem::tmpname(b"bun-cc", &mut name_buf.0, bun_core::fast_random())
                 .ok()?;
             Some(ZBox::from_bytes(name.as_bytes()))
@@ -2368,7 +2367,7 @@ impl CompilerRT {
             }
         }
 
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let Ok(path) = bun_sys::get_fd_path(bun_cc.fd(), &mut path_buf) else {
             return false;
         };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1332,7 +1332,7 @@ unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
         None
     };
     bun_core::heap::into_raw(Box::new(NodeFS {
-        sync_error_buf: bun_paths::PathBuffer::ZEROED,
+        sync_error_buf: bun_paths::path_buffer_pool::get(),
         vm: vm_field,
     }))
     .cast::<c_void>()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1332,7 +1332,7 @@ unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
         None
     };
     bun_core::heap::into_raw(Box::new(NodeFS {
-        sync_error_buf: bun_paths::PathBuffer::uninit(),
+        sync_error_buf: bun_paths::PathBuffer::ZEROED,
         vm: vm_field,
     }))
     .cast::<c_void>()

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1768,8 +1768,8 @@ mod _async_tasks {
             let this = unsafe { &**_done };
 
             let args = &this.args;
-            let mut src_buf = OSPathBuffer::uninit();
-            let mut dest_buf = OSPathBuffer::uninit();
+            let mut src_buf = bun_paths::os_path_buffer_pool::get();
+            let mut dest_buf = bun_paths::os_path_buffer_pool::get();
             let name_too_long = |path: &PathLike| sys::Error {
                 errno: E::ENAMETOOLONG as _,
                 syscall: sys::Tag::copyfile,
@@ -1973,7 +1973,7 @@ mod _async_tasks {
             let _close = scopeguard::guard(fd, |fd| fd.close());
 
             #[cfg(windows)]
-            let mut buf = OSPathBuffer::uninit();
+            let mut buf = bun_paths::os_path_buffer_pool::get();
             #[cfg(windows)]
             let normdest: &OSPathSliceZ = match sys::normalize_path_windows_opts(
                 FD::INVALID,
@@ -2176,7 +2176,7 @@ mod _async_tasks {
             done: bun_jsc::Completion<Self>,
         ) -> Option<bun_jsc::Completion<Self>> {
             this.done = Some(done);
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let root_path_z = {
                 let bytes: &'static [u8] =
                     // SAFETY: `root_path` is a NUL-terminated `Box<[u8]>` fixed for the
@@ -2283,7 +2283,7 @@ mod _async_tasks {
             // SAFETY: `enqueue()` built `basename` with a trailing NUL at
             // `[len]`, so `ZStr::from_buf` is valid.
             let basename_z = ZStr::from_buf(&basename, basename.len() - 1);
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             // SAFETY: readdir_task (ParentRef) outlives subtask via subtask_count
             // refcount. `from_raw_mut` was used at enqueue, so write provenance is
             // present; this work-pool callback is the sole holder of `&mut` to the
@@ -4421,7 +4421,7 @@ pub struct NodeFS {
 impl Default for NodeFS {
     fn default() -> Self {
         Self {
-            sync_error_buf: PathBuffer::uninit(),
+            sync_error_buf: PathBuffer::ZEROED,
             vm: None,
         }
     }
@@ -4708,8 +4708,8 @@ impl NodeFS {
         // TODO: do we need to fchown?
         #[cfg(target_os = "macos")]
         {
-            let mut src_buf = PathBuffer::uninit();
-            let mut dest_buf = PathBuffer::uninit();
+            let mut src_buf = bun_paths::path_buffer_pool::get();
+            let mut dest_buf = bun_paths::path_buffer_pool::get();
             let src = args.src.slice_z(&mut src_buf);
             let dest = args.dest.slice_z(&mut dest_buf);
 
@@ -4808,8 +4808,8 @@ impl NodeFS {
 
         #[cfg(target_os = "freebsd")]
         {
-            let mut src_buf = PathBuffer::uninit();
-            let mut dest_buf = PathBuffer::uninit();
+            let mut src_buf = bun_paths::path_buffer_pool::get();
+            let mut dest_buf = bun_paths::path_buffer_pool::get();
             let src = args.src.slice_z(&mut src_buf);
             let dest = args.dest.slice_z(&mut dest_buf);
 
@@ -4920,8 +4920,8 @@ impl NodeFS {
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            let mut src_buf = PathBuffer::uninit();
-            let mut dest_buf = PathBuffer::uninit();
+            let mut src_buf = bun_paths::path_buffer_pool::get();
+            let mut dest_buf = bun_paths::path_buffer_pool::get();
             let src = args.src.slice_z(&mut src_buf);
             let dest = args.dest.slice_z(&mut dest_buf);
 
@@ -5339,7 +5339,7 @@ impl NodeFS {
     }
 
     pub(crate) fn link(&mut self, args: &args::Link, _: Flavor) -> Maybe<ret::Link> {
-        let mut to_buf = PathBuffer::uninit();
+        let mut to_buf = bun_paths::path_buffer_pool::get();
         let from = args.old_path.slice_z(&mut self.sync_error_buf);
         let to = args.new_path.slice_z(&mut to_buf);
         #[cfg(windows)]
@@ -6617,7 +6617,7 @@ impl NodeFS {
         }
 
         if recursive && flavor == Flavor::Sync {
-            let mut buf_to_pass = PathBuffer::uninit();
+            let mut buf_to_pass = bun_paths::path_buffer_pool::get();
             let mut entries: Vec<T> = Vec::new();
             return Self::readdir_with_entries_recursive_sync::<T>(
                 &mut buf_to_pass,
@@ -7286,7 +7286,7 @@ impl NodeFS {
     }
 
     pub(crate) fn readlink(&mut self, args: &args::Readlink, _: Flavor) -> Maybe<ret::Readlink> {
-        let mut outbuf = PathBuffer::uninit();
+        let mut outbuf = bun_paths::path_buffer_pool::get();
         let inbuf = &mut self.sync_error_buf;
         let path = args.path.slice_z(inbuf);
         // PORT: `Syscall` (= `sys_uv` on Windows) returns the link slice
@@ -7394,7 +7394,7 @@ impl NodeFS {
 
         #[cfg(not(windows))]
         {
-            let mut outbuf = PathBuffer::uninit();
+            let mut outbuf = bun_paths::path_buffer_pool::get();
             let inbuf = &mut self.sync_error_buf;
             // SAFETY: single-threaded init flag (resolver/fs.rs).
             debug_assert!(
@@ -7448,7 +7448,7 @@ impl NodeFS {
 
     pub(crate) fn rename(&mut self, args: &args::Rename, _: Flavor) -> Maybe<ret::Rename> {
         let from_buf = &mut self.sync_error_buf;
-        let mut to_buf = PathBuffer::uninit();
+        let mut to_buf = bun_paths::path_buffer_pool::get();
         let from = args.old_path.slice_z(from_buf);
         let to = args.new_path.slice_z(&mut to_buf);
         match Syscall::rename(from, to) {
@@ -7594,7 +7594,7 @@ impl NodeFS {
     }
 
     pub(crate) fn symlink(&mut self, args: &args::Symlink, _: Flavor) -> Maybe<ret::Symlink> {
-        let mut to_buf = PathBuffer::uninit();
+        let mut to_buf = bun_paths::path_buffer_pool::get();
         #[cfg(windows)]
         {
             const UV_FS_SYMLINK_DIR: c_int = 0x0001;
@@ -7890,8 +7890,8 @@ impl NodeFS {
     /// This function is `cpSync`, but only if you pass `{ recursive: ..., force: ..., errorOnExist: ..., mode: ... }'
     /// The other options like `filter` use a JS fallback, see `src/js/internal/fs/cp.ts`
     pub(crate) fn cp(&mut self, args: &args::Cp, _: Flavor) -> Maybe<ret::Cp> {
-        let mut src_buf = OSPathBuffer::uninit();
-        let mut dest_buf = OSPathBuffer::uninit();
+        let mut src_buf = bun_paths::os_path_buffer_pool::get();
+        let mut dest_buf = bun_paths::os_path_buffer_pool::get();
         let name_too_long = |path: &PathLike| sys::Error {
             errno: E::ENAMETOOLONG as _,
             syscall: sys::Tag::copyfile,
@@ -8169,7 +8169,7 @@ impl NodeFS {
         if e.get_errno() != E::BUSY {
             return result;
         }
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let Ok(statbuf) = Syscall::stat(src.slice_z(&mut buf)) else {
             return result;
         };
@@ -8184,7 +8184,7 @@ impl NodeFS {
 
     #[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
     fn cp_symlink(&mut self, src: &ZStr, dest: &ZStr) -> Maybe<ret::CopyFile> {
-        let mut target_buf = PathBuffer::uninit();
+        let mut target_buf = bun_paths::path_buffer_pool::get();
         // `bun_sys::readlink` returns the byte length on every
         // platform (the `Syscall` alias = `sys_uv` on Windows would return the
         // slice itself); reconstruct the NUL-terminated view from `target_buf`.
@@ -8201,8 +8201,8 @@ impl NodeFS {
         if paths::is_absolute(link_target.as_bytes()) {
             return Syscall::symlink(link_target, dest);
         }
-        let mut cwd_buf = PathBuffer::uninit();
-        let mut resolved_buf = PathBuffer::uninit();
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
+        let mut resolved_buf = bun_paths::path_buffer_pool::get();
         let src_dir = paths::resolve_path::dirname::<paths::platform::Posix>(src.as_bytes());
         let Ok(cwd_len) = sys::getcwd(&mut cwd_buf[..]) else {
             // If we can't resolve cwd, preserve the link target as-is rather
@@ -9339,7 +9339,7 @@ fn dt_err(errno: E) -> crate::Error {
 
 #[inline]
 fn dt_open_dir(parent: &sys::Dir, name: &[u8]) -> Result<sys::Dir, E> {
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     let len = name.len().min(path_buf.len() - 1);
     path_buf[..len].copy_from_slice(&name[..len]);
     path_buf[len] = 0;
@@ -9358,7 +9358,7 @@ fn dt_open_dir(parent: &sys::Dir, name: &[u8]) -> Result<sys::Dir, E> {
 
 #[inline]
 fn dt_delete_file(parent: &sys::Dir, name: &[u8]) -> Result<(), E> {
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     let len = name.len().min(path_buf.len() - 1);
     path_buf[..len].copy_from_slice(&name[..len]);
     path_buf[len] = 0;
@@ -9398,7 +9398,7 @@ fn dt_delete_file(parent: &sys::Dir, name: &[u8]) -> Result<(), E> {
 
 #[inline]
 fn dt_delete_dir(parent: &sys::Dir, name: &[u8]) -> Result<(), E> {
-    let mut path_buf = PathBuffer::uninit();
+    let mut path_buf = bun_paths::path_buffer_pool::get();
     let len = name.len().min(path_buf.len() - 1);
     path_buf[..len].copy_from_slice(&name[..len]);
     path_buf[len] = 0;
@@ -9710,7 +9710,7 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
         // Valid use of MAX_PATH_BYTES because dir_name_buf will only
         // ever store a single path component that was returned from the
         // filesystem.
-        let mut dir_name_buf = PathBuffer::uninit();
+        let mut dir_name_buf = bun_paths::path_buffer_pool::get();
         let mut dir_name_len = sub_path.len().min(dir_name_buf.len());
         dir_name_buf[..dir_name_len].copy_from_slice(&sub_path[..dir_name_len]);
         // `dir_name` conceptually aliases either `sub_path` or `dir_name_buf`;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4401,27 +4401,16 @@ pub mod ret {
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/fs.d.ts
 // ──────────────────────────────────────────────────────────────────────────
 
-// `#[repr(C)]` pins `sync_error_buf` (a `[u8; N]`, nominal align = 1) at
-// offset 0. The struct's overall alignment is ≥ `align_of::<*const ()>()`
-// (from the `vm` field), so the buffer's address inherits that alignment.
-// This is load-bearing on Windows where `sync_error_buf` is reinterpreted as
-// `&mut [u16]` / `&mut WPathBuffer` (see `mkdir_recursive_os_path_impl` and
-// the `os_path_kernel32` callers); a misaligned `&mut [u16]` is instant UB.
-#[repr(C)]
 pub struct NodeFS {
-    /// Buffer to store a temporary file path that might appear in a returned error message.
-    ///
-    /// We want to avoid allocating a new path buffer for every error message so that jsc can clone + GC it.
-    /// That means a stack-allocated buffer won't suffice. Instead, we re-use
-    /// the heap allocated buffer on the NodeFS struct
-    pub(crate) sync_error_buf: PathBuffer, // must be align_of::<u16>()-aligned — enforced via #[repr(C)] + field order, see above
+    /// Scratch for a temporary file path that might appear in a returned error message.
+    pub(crate) sync_error_buf: bun_paths::path_buffer_pool::Guard,
     pub(crate) vm: Option<NonNull<VirtualMachine>>,
 }
 
 impl Default for NodeFS {
     fn default() -> Self {
         Self {
-            sync_error_buf: PathBuffer::ZEROED,
+            sync_error_buf: bun_paths::path_buffer_pool::get(),
             vm: None,
         }
     }
@@ -5531,8 +5520,8 @@ impl NodeFS {
             }
         }
 
-        // SAFETY: `NodeFS` is `#[repr(C)]` with `sync_error_buf` at offset 0 and
-        // struct alignment ≥ pointer-align (from `vm`), so this address is
+        // SAFETY: `sync_error_buf` is a pooled heap allocation, and every
+        // supported allocator aligns it to at least 8 bytes, so this address is
         // ≥ `align_of::<OSPathChar>()`-aligned. On Windows
         // `OSPathBuffer = [u16; PATH_MAX_WIDE]` (65 534 B) which fits inside
         // `PathBuffer` (`MAX_PATH_BYTES` = 98 302 B); on POSIX it is the same
@@ -5541,7 +5530,7 @@ impl NodeFS {
         // `&mut PathBuffer` without reborrowing `&mut self` (which would alias
         // `working_mem` under stacked borrows). On every such path `working_mem` is
         // not used afterward, so the re-derive is sound.
-        let sync_error_buf_ptr: *mut PathBuffer = &raw mut self.sync_error_buf;
+        let sync_error_buf_ptr: *mut PathBuffer = &raw mut *self.sync_error_buf;
         assert!(
             sync_error_buf_ptr.cast::<OSPathChar>().is_aligned(),
             "NodeFS.sync_error_buf misaligned for OSPathChar",

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -37,8 +37,7 @@ mod _impl {
     use bun_core::strings;
     use bun_core::{env_var, fmt as bun_fmt};
     use bun_jsc::{CallFrame, JSArray, StringJsc as _, SysErrorJsc as _, SystemError};
-    #[cfg(windows)]
-    use bun_paths::PathBuffer;
+
     #[cfg(windows)]
     use bun_sys::ReturnCodeExt as _;
     #[cfg(not(windows))]
@@ -659,7 +658,7 @@ mod _impl {
         // In Node.js, this is a wrapper around uv_os_homedir.
         #[cfg(windows)]
         {
-            let mut out = PathBuffer::uninit();
+            let mut out = bun_paths::path_buffer_pool::get();
             let mut size: usize = out.len();
             // SAFETY: valid buffer + size out-param
             if let Some(err) = unsafe { libuv::uv_os_homedir(out.as_mut_ptr(), &mut size) }

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -167,7 +167,6 @@ mod _impl {
     use bun_jsc::{
         EncodedSliceJsc as _, JSGlobalObject, JSValue, JsResult, StringJsc, SysErrorJsc, WebWorker,
     };
-    use bun_paths::PathBuffer;
 
     #[cfg(windows)]
     unsafe extern "C" {
@@ -443,7 +442,7 @@ mod _impl {
     fn get_cwd(global_object: &JSGlobalObject) -> JsResult<JSValue> {
         // Real syscall (not the resolver's cached top_level_dir): Node's
         // process.cwd() calls uv_cwd() so a deleted cwd must surface here.
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         match bun_sys::getcwd(&mut buf[..]) {
             bun_sys::Result::Ok(len) => {
                 bun_string_jsc::create_utf8_for_js(global_object, &buf[..len])
@@ -494,7 +493,7 @@ mod _impl {
         // the process-lifetime singleton (centralised single-unsafe deref).
         let fs = vm.transpiler.fs_mut();
 
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let Ok(slice) = to.slice_z_buf(&mut buf) else {
             return Err(global_object.throw(format_args!("Invalid path")));
         };

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -2950,7 +2950,7 @@ fn resolve_windows_t<'a, T: PathCharCwd>(
             //   path = process.env[`=${resolvedDevice}`] || process.cwd();
             #[cfg(windows)]
             {
-                let mut u16_buf = bun_paths::WPathBuffer::uninit();
+                let mut u16_buf = bun_paths::w_path_buffer_pool::get();
                 // Storage for the `=X:` fast-path key. Declared here (not inside the
                 // `'brk:` block) so the slice it backs stays live across `getenv_w`.
                 // 4 elements (not 3) so the wchar immediately following the 3-char
@@ -3001,9 +3001,8 @@ fn resolve_windows_t<'a, T: PathCharCwd>(
                     // T == u8 when !IS_U16; bytemuck statically checks the layout.
                     let key8: &[u8] = bytemuck::cast_slice::<T, u8>(&buf2[..buf_size]);
                     // Write the NUL after widening so the LPCWSTR is properly
-                    // terminated regardless of `WPathBuffer::uninit()`'s init
-                    // state — don't rely on `uninit()` happening to zero-fill
-                    // today.
+                    // terminated; a pooled buffer carries a previous caller's
+                    // bytes.
                     let n = strings::convert_utf8_to_utf16_in_buffer(&mut u16_buf[..], key8).len();
                     u16_buf[n] = 0;
                     &u16_buf[..=n]

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3000,9 +3000,7 @@ fn resolve_windows_t<'a, T: PathCharCwd>(
                     }
                     // T == u8 when !IS_U16; bytemuck statically checks the layout.
                     let key8: &[u8] = bytemuck::cast_slice::<T, u8>(&buf2[..buf_size]);
-                    // Write the NUL after widening so the LPCWSTR is properly
-                    // terminated; a pooled buffer carries a previous caller's
-                    // bytes.
+                    // Write the NUL after widening; a pooled buffer is not zeroed.
                     let n = strings::convert_utf8_to_utf16_in_buffer(&mut u16_buf[..], key8).len();
                     u16_buf[n] = 0;
                     &u16_buf[..=n]

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -40,8 +40,6 @@ use bun_core::strings;
 use bun_core::{Output, zstr};
 use bun_core::{ZStr, handle_oom};
 use bun_paths as path;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use bun_paths::PathBuffer;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use bun_paths::platform;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
@@ -901,7 +899,7 @@ impl Linux {
                 b.assume_init()
             }
         };
-        let mut path_buf = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
         let mut rel_spill: Vec<u8> = Vec::new();
 
         while running.load(Ordering::Acquire) {

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -10,7 +10,6 @@ use bun_collections::{ArrayHashMap, StringArrayHashMap};
 use bun_core::{String as BunString, ZStr};
 use bun_jsc as jsc;
 use bun_jsc::JsCell;
-use bun_paths::PathBuffer;
 use bun_sys as sys;
 use bun_sys::ReturnCodeExt as _;
 use bun_sys::windows::libuv as uv;
@@ -339,7 +338,7 @@ impl PathWatcher {
         path: &ZStr,
         recursive: bool,
     ) -> sys::Result<*mut PathWatcher> {
-        let mut outbuf = PathBuffer::uninit();
+        let mut outbuf = bun_paths::path_buffer_pool::get();
         // Windows `sys::readlink` returns the byte length; the link target is
         // written into `outbuf[..len]` with `outbuf[len] == 0` (sys_uv NUL-terminates). Reconstruct
         // the NUL-terminated string via `ZStr::from_buf`.

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -260,7 +260,7 @@ impl FileRoute {
         let fd_result: bun_sys::Result<Fd> = {
             #[cfg(windows)]
             {
-                let mut path_buffer = bun_paths::PathBuffer::uninit();
+                let mut path_buffer = bun_paths::path_buffer_pool::get();
                 path_buffer[..path.len()].copy_from_slice(path);
                 path_buffer[path.len()] = 0;
                 bun_sys::open(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -240,7 +240,6 @@ use bun_core::Output;
 use bun_core::strings;
 use bun_http_types as HTTP;
 use bun_http_types::MimeType::MimeType;
-use bun_paths::PathBuffer;
 use std::io::Write as _;
 #[allow(non_snake_case)]
 mod NativePromiseContext {
@@ -1786,7 +1785,7 @@ where
         let crate::webcore::blob::store::Data::File(file) = &blob_ref.store().unwrap().data else {
             unreachable!("do_sendfile called with non-file blob");
         };
-        let mut file_buf = PathBuffer::uninit();
+        let mut file_buf = bun_paths::path_buffer_pool::get();
         let auto_close = !matches!(
             file.pathlike,
             crate::webcore::node_types::PathOrFileDescriptor::Fd(_)

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -710,7 +710,7 @@ impl AnyRoute {
                     // NOTE: `sys::exists_at_type` takes `&ZStr`; the store
                     // path is a borrowed byte slice. NUL-terminate into a path
                     // buffer for the syscall.
-                    let mut buf = bun_paths::PathBuffer::default();
+                    let mut buf = bun_paths::path_buffer_pool::get();
                     let zpath = bun_paths::resolve_path::z(store_path, &mut buf);
                     match sys::exists_at_type(sys::Fd::cwd(), zpath) {
                         Ok(sys::ExistsAtType::Directory) => {

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -468,8 +468,8 @@ impl ShellCpTask {
         }
         #[cfg(windows)]
         {
-            let mut buf = bun_paths::PathBuffer::uninit();
-            let mut buf2 = bun_paths::PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
+            let mut buf2 = bun_paths::path_buffer_pool::get();
             let src8 = bun_paths::strings::from_wpath(&mut buf, src);
             let dest8 = bun_paths::strings::from_wpath(&mut buf2, dest);
             self.on_copy_impl(src8, dest8);
@@ -607,8 +607,8 @@ impl ShellCpTask {
     ) -> Option<ShellErr> {
         use resolve_path::{Platform, platform};
 
-        let mut buf2 = bun_paths::PathBuffer::uninit();
-        let mut buf3 = bun_paths::PathBuffer::uninit();
+        let mut buf2 = bun_paths::path_buffer_pool::get();
+        let mut buf3 = bun_paths::path_buffer_pool::get();
         // We have to give an absolute path to our cp implementation for it to
         // work with cwd.
         let src: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.src) {

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -403,7 +403,7 @@ impl MkdirCtx for MkdirVerboseVTable {
         let out = unsafe { &mut *self.inner };
         #[cfg(windows)]
         {
-            let mut buf = bun_paths::PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             let str = bun_paths::strings::from_wpath(buf.as_mut(), dirpath.as_slice());
             out.extend_from_slice(str.as_bytes());
             out.push(b'\n');

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -454,7 +454,7 @@ impl ShellMvBatchedTask {
         }
         // Moving one entry into a directory.
         if let Some(dir) = this.target_fd {
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             if let Err(e) = Self::move_in_dir(
                 this.cwd,
                 dir,
@@ -651,7 +651,7 @@ impl ShellMvBatchedTask {
     }
 
     fn move_multiple_into_dir(&mut self) {
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         // `target_fd` is always Some when sources.len() > 1 — `next` rejected
         // the multi-source-into-non-directory case before scheduling.
         let dir = self.target_fd.expect("target_fd set for multi-source mv");

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -934,7 +934,7 @@ impl ShellRmTask {
     /// dereferences `dir_task` to find out.
     fn remove_entry(&self, dir_task: *mut DirTask, is_absolute: bool) -> bun_sys::Maybe<bool> {
         let mut waiting = false;
-        let mut buf = bun_paths::PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         // SAFETY: `dir_task` is live; this thread owns it. `kind_hint` /
         // `path` are read-only after construction.
         let (kind_hint, path) = unsafe { ((*dir_task).kind_hint, (*dir_task).path.as_zstr()) };
@@ -1199,7 +1199,7 @@ impl ShellRmTask {
                     },
                 }
             } else {
-                let mut buf = bun_paths::PathBuffer::uninit();
+                let mut buf = bun_paths::path_buffer_pool::get();
                 self.remove_entry_file(dir_task, path, is_abs, &mut buf, &mut state)?;
                 if state.enqueued {
                     return Ok(false);

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -40,8 +40,6 @@ use bun_jsc::GlobalRef;
 #[cfg(windows)]
 use bun_libuv_sys::UvHandle as _;
 #[cfg(windows)]
-use bun_paths::PathBuffer;
-#[cfg(windows)]
 use bun_sys::windows::libuv as uv;
 
 bun_output::define_scoped_log!(log, Listener, visible);
@@ -208,14 +206,14 @@ impl Listener {
         #[cfg(windows)]
         if port.is_none() {
             // we check if the path is a named pipe otherwise we try to connect using AF_UNIX
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             if let Some(pipe_name) =
                 normalize_pipe_name(socket_config.hostname_or_unix.slice(), buf.as_mut_slice())
             {
                 // Note: reshaped — `pipe_name` borrows `buf`; copy to an owned
                 // buffer so the borrow ends before we `mem::take` from
                 // `socket_config` below.
-                let mut pipe_buf = PathBuffer::uninit();
+                let mut pipe_buf = bun_paths::path_buffer_pool::get();
                 let pipe_len = pipe_name.len();
                 pipe_buf[..pipe_len].copy_from_slice(pipe_name);
 
@@ -1172,7 +1170,7 @@ impl Listener {
             use crate::socket::windows_named_pipe_context::SocketType as PipeSocketType;
             use bun_sys::FdExt as _;
 
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             // Note: reshaped for borrowck — `normalize_pipe_name` borrows
             // `buf` for the returned slice; store length and re-borrow after the
             // `connection` match drops.
@@ -1908,7 +1906,7 @@ impl WindowsNamedPipeListeningContext {
                 )
             }
         } else {
-            let mut path_buf = PathBuffer::uninit();
+            let mut path_buf = bun_paths::path_buffer_pool::get();
             // we need to null terminate the path
             let len = path.len().min(path_buf.len() - 1);
             path_buf[..len].copy_from_slice(&path[..len]);

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -12,7 +12,6 @@ use bun_core::ZStr;
 use bun_event_loop::Task;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{GlobalRef, JSGlobalObject, SysErrorJsc};
-use bun_paths::PathBuffer;
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
 use bun_sys::{self, Error as SysError, Fd, SystemErrno};
@@ -493,7 +492,7 @@ impl WindowsNamedPipeContext {
             let slice_z = ZStr::from_slice_with_nul(path);
             named_pipe.connect(slice_z, ssl_config, owned_ctx)?;
         } else {
-            let mut path_buf = PathBuffer::uninit();
+            let mut path_buf = bun_paths::path_buffer_pool::get();
             // we need to null terminate the path
             let len = path.len().min(path_buf.len() - 1);
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -9,7 +9,6 @@ use crate::Error;
 use bun_core::{ZStr, strings};
 use bun_js_parser::{self as js_parser, lexer as js_lexer};
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_paths::{self, PathBuffer};
 use bun_sys::{self};
 use bun_wyhash::hash;
 
@@ -253,7 +252,7 @@ impl Snapshots {
         let test_filename = name.filename;
         let dir_path = name.dir_with_trailing_slash();
 
-        let mut snapshot_file_path_buf = PathBuffer::uninit();
+        let mut snapshot_file_path_buf = bun_paths::path_buffer_pool::get();
         let buf = snapshot_file_path_buf.0.as_mut_slice();
         let mut pos = 0usize;
         buf[pos..pos + dir_path.len()].copy_from_slice(dir_path);
@@ -845,7 +844,7 @@ impl Snapshots {
             let test_filename = name.filename;
             let dir_path = name.dir_with_trailing_slash();
 
-            let mut snapshot_file_path_buf = PathBuffer::uninit();
+            let mut snapshot_file_path_buf = bun_paths::path_buffer_pool::get();
             let buf = snapshot_file_path_buf.0.as_mut_slice();
             let mut pos = 0usize;
             buf[pos..pos + dir_path.len()].copy_from_slice(dir_path);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1445,7 +1445,7 @@ impl BlobExt for Blob {
                 let fd: Fd = if let PathOrFileDescriptor::Fd(fd) = pathlike {
                     *fd
                 } else {
-                    let mut file_path = bun_paths::PathBuffer::uninit();
+                    let mut file_path = bun_paths::path_buffer_pool::get();
                     let path = pathlike.path().slice_z(&mut file_path);
                     let flags = bun_sys::O::WRONLY
                         | bun_sys::O::CREAT
@@ -1765,7 +1765,7 @@ impl BlobExt for Blob {
             let fd: Fd = match pathlike {
                 PathOrFileDescriptor::Fd(fd) => *fd,
                 PathOrFileDescriptor::Path(p) => {
-                    let mut file_path = bun_paths::PathBuffer::uninit();
+                    let mut file_path = bun_paths::path_buffer_pool::get();
                     match bun_sys::open(
                         p.slice_z(&mut file_path),
                         bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
@@ -4314,7 +4314,7 @@ fn write_file_with_empty_source_to_destination(
                                 }
 
                                 // SAFETY: we check if `file.pathlike` is an fd above, returning if it is.
-                                let mut buf = bun_paths::PathBuffer::uninit();
+                                let mut buf = bun_paths::path_buffer_pool::get();
                                 let mode: bun_sys::Mode =
                                     options.mode.unwrap_or(node::fs::DEFAULT_PERMISSION);
                                 match bun_sys::File::open(
@@ -5267,7 +5267,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
     } else {
-        let mut file_path = bun_paths::PathBuffer::uninit();
+        let mut file_path = bun_paths::path_buffer_pool::get();
         match bun_sys::open(
             pathlike.path().slice_z(&mut file_path),
             // we deliberately don't use O_TRUNC here
@@ -5351,7 +5351,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     let fd: Fd = if !NEEDS_OPEN {
         pathlike.fd()
     } else {
-        let mut file_path = bun_paths::PathBuffer::uninit();
+        let mut file_path = bun_paths::path_buffer_pool::get();
         let flags = if cfg!(not(windows)) {
             bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK
         } else {
@@ -6011,7 +6011,7 @@ fn resolve_file_stat(store: &RefPtr<Store>) {
     let file = Store::data_mut(store).as_file_mut();
     match &file.pathlike {
         PathOrFileDescriptor::Path(path) => {
-            let mut buffer = bun_paths::PathBuffer::uninit();
+            let mut buffer = bun_paths::path_buffer_pool::get();
             match bun_sys::stat(path.slice_z(&mut buffer)) {
                 bun_sys::Result::Ok(stat) => {
                     file.max_size = if bun_sys::S::ISREG(stat.st_mode as _) || stat.st_size > 0 {
@@ -6684,7 +6684,7 @@ pub trait FileOpener: Sized {
     fn open_callback(&self) -> fn(&mut Self, Fd);
 
     fn get_fd_by_opening(&mut self, callback: fn(&mut Self, Fd)) {
-        let mut buf = bun_paths::PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let path_string = match self.pathlike() {
             PathOrFileDescriptor::Path(p) => p.clone(),
             PathOrFileDescriptor::Fd(_) => unreachable!(),

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -128,7 +128,7 @@ impl Lazy {
             fd: Fd::INVALID,
             ..Default::default()
         };
-        let mut file_buf = bun_paths::PathBuffer::uninit();
+        let mut file_buf = bun_paths::path_buffer_pool::get();
         #[cfg(unix)]
         let mut is_nonblocking = false;
 

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -9,7 +9,6 @@ use crate::webcore::node_types::PathOrFileDescriptor;
 #[cfg(windows)]
 use bun_io as aio;
 use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue};
-use bun_paths::PathBuffer;
 use bun_ptr::RefPtr;
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
@@ -216,7 +215,7 @@ impl CopyFile {
 
     #[cfg(not(windows))]
     pub(crate) fn do_open_file<const WHICH: IOWhich>(&mut self) -> Result<(), crate::Error> {
-        let mut path_buf1 = PathBuffer::uninit();
+        let mut path_buf1 = bun_paths::path_buffer_pool::get();
         // open source file first
         // if it fails, we don't want the extra destination file hanging out
         if matches!(WHICH, IOWhich::Both | IOWhich::Source) {
@@ -572,8 +571,8 @@ impl CopyFile {
 
     #[cfg(target_os = "macos")]
     pub(crate) fn do_clonefile(&mut self) -> Result<(), crate::Error> {
-        let mut source_buf = PathBuffer::uninit();
-        let mut dest_buf = PathBuffer::uninit();
+        let mut source_buf = bun_paths::path_buffer_pool::get();
+        let mut dest_buf = bun_paths::path_buffer_pool::get();
 
         loop {
             // reshaped for borrowck — `slice_z(&'a self, &'a mut buf)`
@@ -650,7 +649,7 @@ impl CopyFile {
                         )
                     {
                         'do_clonefile: {
-                            let mut path_buf = PathBuffer::uninit();
+                            let mut path_buf = bun_paths::path_buffer_pool::get();
 
                             // stat the output file, make sure it:
                             // 1. Exists
@@ -1482,8 +1481,8 @@ impl<'a> CopyFileWindows<'a> {
             return;
         }
 
-        let mut pathbuf1 = PathBuffer::uninit();
-        let mut pathbuf2 = PathBuffer::uninit();
+        let mut pathbuf1 = bun_paths::path_buffer_pool::get();
+        let mut pathbuf2 = bun_paths::path_buffer_pool::get();
         // capture the raw `self` pointer before borrowing the file
         // stores. `slice_z` ties the returned `&ZStr` lifetime to `&self`, so
         // `new_path`/`old_path` keep `self.{destination,source}_file_store`
@@ -1650,7 +1649,7 @@ impl<'a> CopyFileWindows<'a> {
                 PathOrFileDescriptor::Path(_)
             ) {
                 self.written_bytes = written;
-                let mut pathbuf = PathBuffer::uninit();
+                let mut pathbuf = bun_paths::path_buffer_pool::get();
                 // Borrowck: `slice_z` ties the returned `&ZStr` to
                 // `&self.destination_file_store`, which would conflict with the
                 // `core::ptr::from_mut(self)` below. Capture the raw C pointer now —

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -46,7 +46,6 @@ use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
 use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _, URLJsc as _};
-use bun_paths::{self, PathBuffer};
 use bun_sys::FdExt as _;
 // `FromJsEnum for FetchRedirect` lives in bun_http_jsc; importing the impl crate
 // brings the trait impl into scope for `JSValue::get_optional_enum::<FetchRedirect>`.
@@ -1227,8 +1226,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // We don't pass along headers, we ignore method, we ignore status code...
     // But it's better than status quo.
     if url_type != URLType::Remote {
-        let mut path_buf = PathBuffer::uninit();
-        let mut path_buf2 = PathBuffer::uninit();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
+        let mut path_buf2 = bun_paths::path_buffer_pool::get();
         let decoded_len = match PercentEncoding::decode_into(
             &mut path_buf2[..],
             match url_type {
@@ -1307,7 +1306,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 }
 
                 #[cfg(windows)]
-                let mut cwd_buf = PathBuffer::uninit();
+                let mut cwd_buf = bun_paths::path_buffer_pool::get();
                 #[cfg(windows)]
                 // `bun_sys::getcwd` returns the byte length written into
                 // `cwd_buf`; slice it here.
@@ -1479,7 +1478,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // A local `PathBuffer` serves as NUL-termination scratch for
             // `path.slice_z()` (the `vm.node_fs()` accessor is gated behind a
             // jsc↔runtime cycle).
-            let mut open_path_buf = PathBuffer::uninit();
+            let mut open_path_buf = bun_paths::path_buffer_pool::get();
             let opened_fd_res: bun_sys::Result<bun_sys::Fd> = {
                 let store = body.store().expect("needs_to_read_file implies store");
                 match &store.data.as_file().pathlike {

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -1,6 +1,6 @@
 use bun_ast::{Loc, Source};
 use bun_core::{MutableString, strings};
-use bun_paths::{PathBuffer, fs::FileSystem};
+use bun_paths::fs::FileSystem;
 use bun_ptr::RawSlice;
 
 use crate::{
@@ -75,7 +75,7 @@ fn print_source_map_contents_json<const ASCII_ONLY: bool>(
     include_sources_contents: bool,
     mappings: &[u8],
 ) -> Result<(), crate::Error> {
-    let mut filename_buf = PathBuffer::uninit();
+    let mut filename_buf = bun_paths::path_buffer_pool::get();
     let mut filename: &[u8] = source.path.text;
     let top_level_dir: &[u8] =
         strings::without_trailing_slash(FileSystem::instance().top_level_dir());

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -391,7 +391,7 @@ impl Lookup {
 
             let name: &[u8] = &source_map.external_source_names[index];
 
-            let mut buf = bun_paths::PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             // `platform::Auto` is
             // cfg-selected (Posix on unix, Windows on windows).
             let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(base_filename);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -18,8 +18,6 @@ use bun_options_types::bundle_enums::{Format, WindowsOptions};
 use bun_paths::SEP_STR;
 use bun_paths::fs as bun_fs;
 use bun_paths::{self as path, PathBuffer, strings};
-#[cfg(windows)]
-use bun_paths::{OSPathBuffer, WPathBuffer};
 use bun_sourcemap as SourceMap;
 use bun_sys::{self as Syscall, E, Fd, FdExt as _, Stat};
 
@@ -175,7 +173,7 @@ impl StandaloneModuleGraph {
     fn lookup_file(&self, name: &[u8]) -> Option<&File> {
         #[cfg(windows)]
         {
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             return self.files.get(normalize_file_key(name, &mut buf));
         }
         #[cfg(not(windows))]
@@ -222,7 +220,7 @@ impl StandaloneModuleGraph {
         if !is_bun_standalone_file_path(name) {
             return false;
         }
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let name = Self::normalize_dir_path(name, &mut buf);
         self.dirs.contains_key(name)
     }
@@ -233,7 +231,7 @@ impl StandaloneModuleGraph {
         if !is_bun_standalone_file_path(name) {
             return Err(E::ENOENT);
         }
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let name = Self::normalize_dir_path(name, &mut buf);
         if let Some(index) = self.dirs.get_index(name) {
             return Ok(&self.dirs.keys()[index]);
@@ -250,7 +248,7 @@ impl StandaloneModuleGraph {
         if !is_bun_standalone_file_path(name) {
             return None;
         }
-        let mut buf = PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let name = Self::normalize_dir_path(name, &mut buf);
         if !self.dirs.contains_key(name) {
             return None;
@@ -290,7 +288,7 @@ impl StandaloneModuleGraph {
     pub fn find_assume_standalone_path(&mut self, name: &[u8]) -> Option<&mut File> {
         #[cfg(windows)]
         {
-            let mut buf = PathBuffer::uninit();
+            let mut buf = bun_paths::path_buffer_pool::get();
             return self.files.get_mut(normalize_file_key(name, &mut buf));
         }
         #[cfg(not(windows))]
@@ -1748,7 +1746,7 @@ pub(crate) fn inject<'a>(
             return None;
         }
     };
-    let mut buf = PathBuffer::uninit();
+    let mut buf = bun_paths::path_buffer_pool::get();
     // Note: `tmpname` borrows `buf` mutably for the &ZStr it returns. The
     // tmpdir-fallback retry below may need to repoint `zname` at a heap-owned
     // buffer instead, so hoist that owner here so it outlives the loop.
@@ -1789,10 +1787,10 @@ pub(crate) fn inject<'a>(
         {
             // copy self and then open it for writing
 
-            let mut in_buf = WPathBuffer::uninit();
+            let mut in_buf = bun_paths::w_path_buffer_pool::get();
             strings::copy_u8_into_u16(&mut in_buf, self_exe.as_bytes());
             in_buf[self_exe.len()] = 0;
-            let mut out_buf = WPathBuffer::uninit();
+            let mut out_buf = bun_paths::w_path_buffer_pool::get();
             strings::copy_u8_into_u16(&mut out_buf, zname.as_bytes());
             out_buf[zname.len()] = 0;
 
@@ -2429,7 +2427,7 @@ pub fn target_executable(
             }
         }
     } else {
-        let mut exe_path_buf = PathBuffer::uninit();
+        let mut exe_path_buf = bun_paths::path_buffer_pool::get();
         let mut version_str: Vec<u8> = Vec::new();
         let _ = write!(&mut version_str, "{}", target);
         version_str.push(0);
@@ -2579,7 +2577,7 @@ pub fn to_executable(
         // Build the absolute destination path
         // On Windows, we need an absolute path for MoveFileExW
         // Get the current working directory and join with outfile
-        let mut cwd_buf = PathBuffer::uninit();
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
         let cwd_path: &[u8] = match bun_sys::getcwd(&mut cwd_buf) {
             Ok(len) => &cwd_buf[..len],
             Err(e) => {
@@ -2597,8 +2595,8 @@ pub fn to_executable(
         };
 
         // Convert paths to Windows UTF-16
-        let mut temp_buf_w = OSPathBuffer::uninit();
-        let mut dest_buf_w = OSPathBuffer::uninit();
+        let mut temp_buf_w = bun_paths::os_path_buffer_pool::get();
+        let mut dest_buf_w = bun_paths::os_path_buffer_pool::get();
         let temp_w_len = strings::paths::to_w_path_normalized(&mut temp_buf_w, temp_path).len();
         let dest_w_len = strings::paths::to_w_path_normalized(&mut dest_buf_w, dest_path).len();
 
@@ -2676,7 +2674,7 @@ pub fn to_executable(
     {
         let temp_posix = injected.temp_path;
         let outfile_basename = bun_paths::basename(outfile);
-        let mut outfile_posix_buf = PathBuffer::uninit();
+        let mut outfile_posix_buf = bun_paths::path_buffer_pool::get();
         let outfile_posix = path::resolve_path::z(outfile_basename, &mut outfile_posix_buf);
 
         if let Err(e) =

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -296,7 +296,7 @@ pub fn rmdirat(dirfd: impl AsFd, path: &ZStr) -> Maybe<()> {
 
 /// `unlinkat` taking a non-sentinel slice (NUL-terminates into a path buffer).
 fn unlinkat_a(dirfd: Fd, path: &[u8], flags: i32) -> Maybe<()> {
-    let mut buf = bun_paths::PathBuffer::default();
+    let mut buf = bun_paths::path_buffer_pool::get();
     let len = path.len().min(buf.0.len() - 1);
     buf.0[..len].copy_from_slice(&path[..len]);
     buf.0[len] = 0;
@@ -319,7 +319,7 @@ impl Dir {
     /// this dir. Unlike `make_path`, does NOT create intermediate directories
     /// and surfaces `EEXIST` for callers to branch on.
     pub fn make_dir(&self, sub_path: &[u8]) -> core::result::Result<(), bun_errno::SystemErrno> {
-        let mut buf = bun_paths::PathBuffer::default();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let len = sub_path.len().min(buf.0.len() - 1);
         buf.0[..len].copy_from_slice(&sub_path[..len]);
         buf.0[len] = 0;
@@ -337,14 +337,14 @@ impl Dir {
     /// on Windows it selects junction vs. file-symlink and
     /// callers route through `sys_uv::symlink_uv` instead.
     pub fn sym_link(&self, target: &[u8], link_name: &[u8], _is_directory: bool) -> Maybe<()> {
-        let mut tbuf = bun_paths::PathBuffer::default();
+        let mut tbuf = bun_paths::path_buffer_pool::get();
         let tlen = target.len().min(tbuf.0.len() - 1);
         tbuf.0[..tlen].copy_from_slice(&target[..tlen]);
         tbuf.0[tlen] = 0;
         // SAFETY: NUL-terminated above.
         let tz = ZStr::from_buf(&tbuf.0[..], tlen);
 
-        let mut lbuf = bun_paths::PathBuffer::default();
+        let mut lbuf = bun_paths::path_buffer_pool::get();
         let llen = link_name.len().min(lbuf.0.len() - 1);
         lbuf.0[..llen].copy_from_slice(&link_name[..llen]);
         lbuf.0[llen] = 0;

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -370,7 +370,7 @@ impl File {
         input_path: &[u8],
     ) -> Maybe<Vec<u8>> {
         let dir = dir.as_fd();
-        let mut buf = bun_paths::PathBuffer::default();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let normalized = bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Loose>(
             top_level_dir,
             &mut buf.0,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -803,7 +803,7 @@ pub mod dir_iterator {
 pub fn open_dir_for_iteration_os_path(dir: Fd, path: &bun_paths::OSPathSlice) -> Result<Fd> {
     #[cfg(not(windows))]
     {
-        let mut buf = bun_paths::PathBuffer::default();
+        let mut buf = bun_paths::path_buffer_pool::get();
         // ENAMETOOLONG on
         // overflow, never silently truncate (would open the wrong directory).
         if path.len() >= buf.len() {
@@ -3533,7 +3533,6 @@ mod windows_impl {
     use super::windows as w;
     use super::windows::libuv as uv;
     use super::*;
-    use bun_paths::WPathBuffer;
 
     // ── libuv-backed ─────────────────────────────────────────────────────
     pub fn open(path: &ZStr, flags: i32, mode: Mode) -> Maybe<Fd> {
@@ -3913,7 +3912,7 @@ mod windows_impl {
     }
     pub fn getcwd(buf: &mut [u8]) -> Maybe<usize> {
         // GetCurrentDirectoryW + WTF16→UTF8.
-        let mut wbuf = WPathBuffer::default();
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let len =
             unsafe { w::kernel32::GetCurrentDirectoryW(wbuf.len() as u32, wbuf.as_mut_ptr()) };
         if len == 0 {
@@ -3933,7 +3932,7 @@ mod windows_impl {
         let dir = dir.as_fd();
         // Open with `op = OnlyCreate`, then close the resulting handle on
         // success.
-        let mut wbuf = WPathBuffer::default();
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let wpath = bun_paths::string_paths::to_nt_path(&mut wbuf, path.as_bytes());
         let made = super::open_dir_at_windows_nt_path(
             dir,
@@ -3951,8 +3950,8 @@ mod windows_impl {
     pub fn renameat(from_dir: impl AsFd, from: &ZStr, to_dir: impl AsFd, to: &ZStr) -> Maybe<()> {
         let from_dir = from_dir.as_fd();
         let to_dir = to_dir.as_fd();
-        let mut wf = WPathBuffer::default();
-        let mut wt = WPathBuffer::default();
+        let mut wf = bun_paths::w_path_buffer_pool::get();
+        let mut wt = bun_paths::w_path_buffer_pool::get();
         let from_w = bun_paths::string_paths::to_nt_path(&mut wf, from.as_bytes());
         let to_w = bun_paths::string_paths::to_nt_path(&mut wt, to.as_bytes());
         super::windows::rename_at_w(from_dir, from_w, to_dir, to_w, true)
@@ -3974,7 +3973,7 @@ mod windows_impl {
         // `remove_dir = flags & AT_REMOVEDIR != 0`.
         // AT_REMOVEDIR on Windows = 0x200.
         const AT_REMOVEDIR: i32 = 0x200;
-        let mut wbuf = WPathBuffer::default();
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let wpath = bun_paths::string_paths::to_nt_path(&mut wbuf, path.as_bytes());
         super::windows::DeleteFileBun(
             wpath,
@@ -4031,7 +4030,7 @@ mod windows_impl {
         if sub.is_empty() || sub == b"." {
             return Ok(());
         }
-        let mut buf = bun_core::PathBuffer::default();
+        let mut buf = bun_paths::path_buffer_pool::get();
         if sub.len() >= buf.0.len() {
             return Err(Error::new(E::ENAMETOOLONG, Tag::mkdir));
         }
@@ -4106,7 +4105,7 @@ mod windows_impl {
         // makePath (NtCreateFile rejects them anyway).
         let it = ComponentIterator::init(&buf.0[..w], PathFormat::Windows)
             .map_err(|_| Error::new(E::EINVAL, Tag::mkdir))?;
-        let mut z = bun_core::PathBuffer::default();
+        let mut z = bun_paths::path_buffer_pool::get();
         bun_paths::make_path_with(it, |p| {
             z.0[..p.len()].copy_from_slice(p);
             z.0[p.len()] = 0;
@@ -4121,9 +4120,9 @@ mod windows_impl {
     pub fn symlinkat(target: &ZStr, dirfd: impl AsFd, dest: &ZStr) -> Maybe<()> {
         let dirfd = dirfd.as_fd();
         // Resolve `dest` against `dirfd`, then symlink via libuv.
-        let mut db = bun_core::PathBuffer::default();
+        let mut db = bun_paths::path_buffer_pool::get();
         let d = super::get_fd_path(dirfd, &mut db)?;
-        let mut dj = bun_core::PathBuffer::default();
+        let mut dj = bun_paths::path_buffer_pool::get();
         let d_abs = bun_paths::resolve_path::join_string_buf_z::<bun_paths::platform::Windows>(
             &mut dj.0,
             &[d, dest.as_bytes()],
@@ -4133,9 +4132,9 @@ mod windows_impl {
     pub fn readlinkat(fd: impl AsFd, path: &ZStr, buf: &mut [u8]) -> Maybe<usize> {
         let fd = fd.as_fd();
         // No `readlinkat` on Windows — resolve and call `readlink`.
-        let mut db = bun_core::PathBuffer::default();
+        let mut db = bun_paths::path_buffer_pool::get();
         let d = super::get_fd_path(fd, &mut db)?;
-        let mut dj = bun_core::PathBuffer::default();
+        let mut dj = bun_paths::path_buffer_pool::get();
         let abs = bun_paths::resolve_path::join_string_buf_z::<bun_paths::platform::Windows>(
             &mut dj.0,
             &[d, path.as_bytes()],
@@ -4170,7 +4169,7 @@ mod windows_impl {
         ) {
             return Err(Error::new(E::ENAMETOOLONG, Tag::access).with_path(path.as_bytes()));
         }
-        let mut wbuf = WPathBuffer::default();
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let wpath = bun_paths::string_paths::to_kernel32_path(&mut wbuf, path.as_bytes());
         let attrs = unsafe { w::kernel32::GetFileAttributesW(wpath.as_ptr()) };
         if attrs == w::INVALID_FILE_ATTRIBUTES {
@@ -4241,7 +4240,7 @@ mod windows_impl {
         // system security policy and recognizes `.js/.lnk/.pif/.pl/.shs/.url/
         // .vbs/...` in addition to `.exe/.cmd/.bat/.com` . Do NOT hand-roll an extension whitelist —
         // PORTING.md §Forbidden bars re-implementing linked OS API surface.
-        let mut wbuf = WPathBuffer::default();
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let wpath = bun_paths::string_paths::to_w_path(&mut wbuf, path.as_bytes());
         // `bFromShellExecute = FALSE` so `.exe` files are included
         // (https://learn.microsoft.com/en-us/windows/win32/api/winsafer/nf-winsafer-saferiisexecutablefiletype).
@@ -4313,7 +4312,7 @@ mod windows_impl {
         // `SetCurrentDirectoryW(toWDirPath(..))`.
         // `toWDirPath` appends a trailing backslash so e.g. `"C:"` is treated
         // as the drive root, not the drive's saved cwd.
-        let mut wbuf = WPathBuffer::default();
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let wpath = bun_paths::string_paths::to_w_dir_path(&mut wbuf, path.as_bytes());
         if unsafe { w::SetCurrentDirectoryW(wpath.as_ptr()) } == 0 {
             return Err(
@@ -4323,9 +4322,9 @@ mod windows_impl {
         Ok(())
     }
     pub fn fchdir(fd: Fd) -> Maybe<()> {
-        let mut buf = bun_core::PathBuffer::default();
+        let mut buf = bun_paths::path_buffer_pool::get();
         let p = super::get_fd_path(fd, &mut buf)?;
-        let mut zb = bun_core::PathBuffer::default();
+        let mut zb = bun_paths::path_buffer_pool::get();
         zb.0[..p.len()].copy_from_slice(p);
         zb.0[p.len()] = 0;
         // SAFETY: NUL-terminated above.
@@ -5952,7 +5951,7 @@ unsafe impl Sync for DynLib {}
 impl DynLib {
     /// `dlopen(path, RTLD_LAZY)` / `LoadLibraryW(path)`.
     pub fn open(path: &[u8]) -> core::result::Result<Self, bun_errno::SystemErrno> {
-        let mut buf = bun_paths::PathBuffer::default();
+        let mut buf = bun_paths::path_buffer_pool::get();
         // `std.DynLib.open` returns `error.NameTooLong`; never truncate (could
         // dlopen a different library whose path is a prefix of the requested one).
         if path.len() >= buf.0.len() {
@@ -6106,7 +6105,7 @@ pub fn open_a(path: &[u8], flags: i32, perm: Mode) -> Maybe<Fd> {
 /// `openatA` — like `openat` but takes a non-NUL-terminated slice.
 pub fn openat_a(dir: impl AsFd, path: &[u8], flags: i32, perm: Mode) -> Maybe<Fd> {
     let dir = dir.as_fd();
-    let mut buf = bun_paths::PathBuffer::default();
+    let mut buf = bun_paths::path_buffer_pool::get();
     if path.len() >= buf.0.len() {
         return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::open).with_path(path));
     }
@@ -7747,7 +7746,7 @@ pub fn mkdir_recursive(sub_path: &[u8]) -> Maybe<()> {
 /// to UTF-8 and delegates to `mkdir_recursive_at`.
 pub(crate) fn make_path_w(dir: Fd, sub_path: &[u16]) -> Maybe<()> {
     // Transcode UTF-16 → UTF-8, then call `makePath` (`mkdir_recursive_at`).
-    let mut buf = bun_paths::PathBuffer::default();
+    let mut buf = bun_paths::path_buffer_pool::get();
     let utf8 = bun_paths::strings::from_w_path(&mut buf.0[..], sub_path);
     mkdir_recursive_at(dir, utf8.as_bytes())
 }
@@ -8846,14 +8845,14 @@ pub fn renameat_concurrently_a(
     opts: RenameatConcurrentlyOptions,
 ) -> Maybe<()> {
     // Z-terminate both paths into stack buffers.
-    let mut from_buf = bun_paths::PathBuffer::default();
+    let mut from_buf = bun_paths::path_buffer_pool::get();
     let from_len = from.len().min(from_buf.0.len() - 1);
     from_buf.0[..from_len].copy_from_slice(&from[..from_len]);
     from_buf.0[from_len] = 0;
     // SAFETY: NUL-terminated above.
     let from_z = ZStr::from_buf(&from_buf.0[..], from_len);
 
-    let mut to_buf = bun_paths::PathBuffer::default();
+    let mut to_buf = bun_paths::path_buffer_pool::get();
     let to_len = to.len().min(to_buf.0.len() - 1);
     to_buf.0[..to_len].copy_from_slice(&to[..to_len]);
     to_buf.0[to_len] = 0;
@@ -8871,7 +8870,7 @@ pub fn iterate_dir(dir: Fd) -> dir_iterator::WrappedIterator {
 /// [`exists_z`]: copies into a stack `PathBuffer`, NUL-terminates, then
 /// `access(path, F_OK)` (POSIX) / `GetFileAttributesW` (Windows).
 pub fn exists(path: &[u8]) -> bool {
-    let mut buf = bun_paths::PathBuffer::default();
+    let mut buf = bun_paths::path_buffer_pool::get();
     if path.len() >= buf.0.len() {
         return false;
     }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1347,7 +1347,7 @@ pub mod rescle {
         // Allocate UTF-16 strings (global mimalloc; allocator param dropped)
 
         // Icon is a path, so use toWPathNormalized with proper buffer handling
-        let mut icon_buf = bun_paths::WPathBuffer::uninit();
+        let mut icon_buf = bun_paths::w_path_buffer_pool::get();
         let icon_w: Option<&bun_core::WStr> = if let Some(i) = icon {
             let path_w = bun_paths::string_paths::to_w_path_normalized(&mut icon_buf, i);
             // toWPathNormalized returns a slice into icon_buf, need to null-terminate it
@@ -1649,7 +1649,7 @@ pub(crate) fn spawn_watcher_child(
     let flags: DWORD = CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT;
 
     let image_path = exe_path_w();
-    let mut wbuf = bun_paths::WPathBuffer::uninit();
+    let mut wbuf = bun_paths::w_path_buffer_pool::get();
     wbuf.as_mut_slice()[0..image_path.len()].copy_from_slice(image_path.as_slice());
     wbuf.as_mut_slice()[image_path.len()] = 0;
 
@@ -1758,7 +1758,7 @@ pub(crate) extern "C" fn Bun__LoadLibraryBunString(str_: &bun_core::String) -> *
         compile_error!("unreachable");
     }
 
-    let mut buf = bun_paths::WPathBuffer::uninit();
+    let mut buf = bun_paths::w_path_buffer_pool::get();
     // The path is JS-supplied; over-length input must surface as the same
     // `null + GetLastError()` shape `LoadLibraryExW` itself would yield, not
     // a Rust panic unwinding across the `extern "C"` boundary.

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -826,7 +826,7 @@ impl Watcher {
         // Only open fd if we might need it
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
         let fd: Fd = {
-            let mut path_z = bun_paths::PathBuffer::uninit();
+            let mut path_z = bun_paths::path_buffer_pool::get();
             if file_path.len() >= path_z.len() {
                 return false;
             }

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -5,8 +5,8 @@ use core::ptr;
 
 use crate::watcher_impl::{Op, WatchEvent, WatchItemColumns, WatchItemIndex, Watcher};
 use bun_core::strings;
+use bun_paths::PathBuffer;
 use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
-use bun_paths::{PathBuffer, WPathBuffer};
 use bun_ptr::{BackRef, RawSlice};
 
 use bun_collections::index_sort;
@@ -33,7 +33,7 @@ impl Default for WindowsWatcher {
                 buf: [0u8; 64 * 1024],
                 dir_handle: w::INVALID_HANDLE_VALUE,
             },
-            buf: PathBuffer::uninit(),
+            buf: PathBuffer::ZEROED,
             base_idx: 0,
         }
     }
@@ -216,7 +216,7 @@ impl WindowsWatcher {
 
     fn init(&mut self, root: &[u8]) -> Result<(), crate::Error> {
         use bun_paths::string_paths as paths;
-        let mut pathbuf = WPathBuffer::uninit();
+        let mut pathbuf = bun_paths::w_path_buffer_pool::get();
         let wpath = paths::to_nt_path(&mut pathbuf, root);
         let path_len_bytes: u16 = (wpath.len() * 2) as u16;
         let mut nt_name = w::UNICODE_STRING {

--- a/test/internal/source-lints/uninit-assumed-init.test.ts
+++ b/test/internal/source-lints/uninit-assumed-init.test.ts
@@ -18,12 +18,10 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `[MaybeUninit<T>; N]` instead, written with `write_copy_of_slice` / `write`
 // and read back through `assume_init_ref` on the written prefix. See
 // `bun_url::URL::join_normalize` and `bun_paths::resolve_path::join_string_buf_t`.
-//
-// `PathBuffer::uninit` and `WPathBuffer::uninit` in `src/bun_core/util.rs`
-// still use the pattern. Their ~400 call sites need an initialized-prefix API
-// (or the path buffer pool) before they can change. This lint keeps that set
-// from growing; remove the entry when those two are fixed.
-const KNOWN_SITES = ["src/bun_core/util.rs"];
+// Scratch path storage comes from `bun_core::path_buffer_pool`, which zeroes
+// a buffer once on allocation and reuses it (issue #41437 covers the old
+// `PathBuffer::uninit` / `WPathBuffer::uninit` constructors).
+const KNOWN_SITES: string[] = [];
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));

--- a/test/internal/source-lints/uninit-assumed-init.test.ts
+++ b/test/internal/source-lints/uninit-assumed-init.test.ts
@@ -18,7 +18,7 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `[MaybeUninit<T>; N]` instead, written with `write_copy_of_slice` / `write`
 // and read back through `assume_init_ref` on the written prefix. See
 // `bun_url::URL::join_normalize` and `bun_paths::resolve_path::join_string_buf_t`.
-// Scratch path storage comes from `bun_core::path_buffer_pool`, which zeroes
+// Scratch path storage comes from `bun_paths::path_buffer_pool`, which zeroes
 // a buffer once on allocation and reuses it (issue #41437 covers the old
 // `PathBuffer::uninit` / `WPathBuffer::uninit` constructors).
 const KNOWN_SITES: string[] = [];


### PR DESCRIPTION
### Problem
- `PathBuffer::uninit()` and `WPathBuffer::uninit()` (`src/bun_core/util.rs`) return a `[u8; N]` / `[u16; N]` built with `MaybeUninit::uninit().assume_init()`. An integer must be initialized, so this is undefined behavior at the constructor, before any byte is read. Miri: `constructing invalid value of type bun_core::PathBuffer: at .0[0], encountered uninitialized memory, but expected an integer` (`cargo miri test -p bun_sys dir::tests::borrow_does_not_close`).
- `bufs_storage_init` (`src/resolver/resolver.rs`) does the same with `Box::<Bufs>::new_uninit().assume_init()`. Both sites silenced the `invalid_value` and `clippy::uninit_assumed_init` lints that catch this.

### Fix
- Remove both constructors and `impl Default` for both types. Every scratch call site (about 440, mechanical one-line edits) takes a buffer from `bun_paths::path_buffer_pool::get()` or its `w_` / `os_` siblings. The pool zeroes a buffer once on allocation and reuses it, so there is no per-call memset and no 98 KB stack frame on Windows. Structs built per item (`NodeFS`, `bin::NamesIterator`, `PosixToWinNormalizer`) hold a pool guard. Long-lived struct fields use an explicit `ZEROED`.
- The pool gains: a `try_with` fallback to the heap while TLS destructors run, `Default` for `PoolGuard` so structs can derive it, and `__lsan_ignore_object` on each allocation. The last one matters because a guard live at `Global::exit` never drops, and in an optimized build its stack slot is dead, so LeakSanitizer reported the buffer and the ASAN lane aborted every `bun <file.md>` run.
- The resolver's `Bufs` uses `Box::new_zeroed()` (once per thread).
- Verified: `test/internal/source-lints/uninit-assumed-init.test.ts` (its known-site list is now empty, so it fails on main), new pool unit tests under Miri (`cargo miri test -p bun_paths`, 29 pass), a release ASAN build with the CI `ASAN_OPTIONS` on the markdown, `bun exec` and `bunx` paths, `cargo check` for linux, macOS, FreeBSD, Windows x64 and arm64, clippy, and the fs, shell, spawn, path, resolve and `bun add` suites.

### Background
- `PathBuffer` is a `[u8; MAX_PATH_BYTES]` newtype used as write-then-read scratch around path syscalls. `MAX_PATH_BYTES` is 4 096 on Linux, 1 024 on macOS and 98 302 on Windows. `WPathBuffer` is the `[u16; 32767]` sibling for Windows wide paths.
- "Every bit pattern is a valid `u8`" is true, but uninitialized memory is not a bit pattern. The Rust reference lists an integer read from uninitialized memory as undefined behavior.
- `bun_paths::path_buffer_pool` is a per-thread LIFO of up to four boxed buffers with an RAII guard. It already existed with about 180 callers. A cache miss allocates with `alloc_zeroed`, which is usually fresh OS-zeroed pages.

<details><summary>Notes</summary>

Why not `ZEROED` at the call sites: on Windows that is a 98 KB memset per call at about 440 sites. A previous attempt did exactly that and the leak and stress tests timed out, which is why `uninit()` was introduced. #31258 proposes `ZEROED` again and has the same cost.

Why not `[MaybeUninit<u8>; N]` inside `PathBuffer`: every syscall wrapper in `bun_sys` takes `&mut [u8]`, so an initialized-prefix API would change the whole syscall surface. The pool gives the same result with no API change.

Why `impl Default` is gone: `Default` has to return a by-value buffer, so it can only be `ZEROED`. With it, `#[derive(Default)]` on a struct that embeds a `PathBuffer` silently picked up a 98 KB memset per construction on Windows (`PosixToWinNormalizer`, built per resolved import). Every zero-fill is now a visible `ZEROED` at its site: the crash handler (must not allocate), `bun_core::spawn_sync` (cold, linux/freebsd), and once-per-task fields in `PackageInstaller`, `extract_tarball`, the test `Scanner`, `Tree` iterators, `PatchFile`, `WindowsWatcher` and the resolver's `top_level_dir_buf`.

Overlap with #40680: that PR moves `NodeFS::sync_error_buf` to a pool guard and the `fetch_impl` locals to the pool for Windows stack depth. This PR contains the same source changes (the `fetch_impl` locals were part of the sweep). #40680's test is not included here.

LeakSanitizer and `Global::exit`: reproduced with `bun run build:asan` and `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1`. `render_markdown_file_and_exit` held two guards at `exit`, and LSan reported the 4 KB buffer allocated at `path_buffer_pool::get` (`run_command.rs:3423`). `new_boxed` now calls `__lsan_ignore_object` on each buffer (under `cfg(bun_asan)`), which fixes every such site. The markdown body was also split into a function that returns the exit code. Verified both ways: with the original `-> !` shape plus only the LSan call, the test passes.

Perf check (debug builds, main vs this branch, three runs each): `Glob("**/*.rs").scan` over `src/` 457/475/459 ms vs 478/453/452 ms, 20 000 `statSync` + `realpathSync` 2663/2674/2663 ms vs 2663/2717/2683 ms, 2 000 `readdirSync` 617/618/617 vs 617/628/626 ms, 4 000 `Bun.resolveSync` 261/262/262 vs 263/266/265 ms. No difference outside noise. No Windows measurement. Windows has the most to gain (no 98 KB stack frames) and nothing in the hot paths zero-fills per call.

`bun_sys` cannot join `MIRI_CRATES` in `scripts/rust-miri.ts`: after this change Miri gets past the constructor and stops at `can't call foreign function openat64`, which it has no shim for. The pool and its unit tests stay in `bun_paths`, which is in `MIRI_CRATES`.

`test/js/bun/glob/scan.test.ts` times out in this container on main and on this branch alike: it scans the whole checkout, which holds 685 000 files of build output here.

Test suites run with the debug build: `test/js/node/fs/fs.test.ts` (565 pass), `test/js/node/fs/fs-mkdir.test.ts`, `test/js/bun/shell/bunshell.test.ts` (431 pass), `test/js/bun/spawn/spawn.test.ts` (148 tests), `test/js/node/path/path.test.js`, `test/js/bun/resolve/` (390 pass, one 5 s timeout that also fails on main here), `test/cli/install/bun-add.test.ts` (71 pass), `test/cli/run/markdown-entrypoint.test.ts`. With the release ASAN build and the CI leak settings: `test/cli/run/` (1177 pass, 4 environment failures: FUSE, uid/gid, a 60 s timeout) and `test/js/bun/shell/exec.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 129 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/internal/source-lints/uninit-assumed-init.test.ts
bun test v1.4.3 (e0a2b82fd)

test/internal/source-lints/uninit-assumed-init.test.ts:
(pass) scans a non-empty set of tracked Rust sources [1.99ms]
68 | });
69 | 
70 | test("no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)]", () => {
71 |   // `[^)]*` spans the multi-line form of the attribute; lint paths never
72 |   // contain `)`.
73 |   expect(scan(/#!?\[(?:allow|expect)\([^)]*\b(?:invalid_value|clippy::uninit_assumed_init)\b/)).toEqual(KNOWN_SITES);
                                                                                                     ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/bun_core/util.rs",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/uninit-assumed-init.test.ts:73:97)
(fail) no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)] [126.91ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [23.59s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (1491acd76)

test/internal/source-lints/uninit-assumed-init.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.11ms]
68 | });
69 | 
70 | test("no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)]", () => {
71 |   // `[^)]*` spans the multi-line form of the attribute; lint paths never
72 |   // contain `)`.
73 |   expect(scan(/#!?\[(?:allow|expect)\([^)]*\b(?:invalid_value|clippy::uninit_assumed_init)\b/)).toEqual(KNOWN_SITES);
                                                                                                     ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/bun_core/util.rs",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/uninit-assumed-init.test.ts:73:97)
(fail) no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)] [12.05ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [561.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/internal/source-lints/uninit-assumed-init.test.ts
bun test v1.4.3 (e0a2b82fd)

test/internal/source-lints/uninit-assumed-init.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.21ms]
(pass) no new #[allow(invalid_value)] or #[allow(clippy::uninit_assumed_init)] [122.33ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [24.05s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 575ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_brotli_sys v0.0.0 (/workspace/bun/src/brotli_sys)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/lib.rs                                |   9 ++
 src/bun_core/util.rs                               |  49 ++-------
 src/bundler/OutputFile.rs                          |   7 +-
 src/bundler/linker_context/computeChunks.rs        |   4 +-
 .../linker_context/generateChunksInParallel.rs     |   2 +-
 .../linker_context/writeOutputFilesToDisk.rs       |   6 +-
 src/bundler/options.rs                             |   4 +-
 src/bundler/transpiler.rs                          |   4 +-
 src/bunfig/arguments.rs                            |   6 +-
 src/crash_handler/lib.rs                           |   4 +-
 src/dotenv/env_loader.rs                           |   4 +-
 src/event_loop/MiniEventLoop.rs                    |   2 +-
 src/glob/GlobWalker.rs                             |  14 ++-
 src/install/PackageInstall.rs                      |  12 +--
 src/install/PackageInstaller.rs                    |  22 ++--
 src/install/PackageManager.rs                      |  14 +--
 src/install/PackageManager/CommandLineArguments.rs |   6 +-
 .../PackageManager/PackageManagerDirectories.rs    |  16 +--
 .../PackageManager/PackageManagerEnqueue.rs        |   8 +-
 .../PackageManager/PackageManagerOptions.rs        |   9 +-
 .../PackageManager/PackageManagerResolution.rs     |   3 +-
 .../PackageManager/WorkspacePackageJSONCache.rs    |   4 +-
 src/install/PackageManager/patchPackage.rs         |  22 ++--
 .../PackageManager/updatePackageJSONAndInstall.rs  |   9 +-
 src/install/TarballStream.rs                       |   6 +-
 src/install/bin.rs                                 |  12 +--
 src/install/extract_tarball.rs                     |  14 ++-
 src/install/hoisted_install.rs                     |   4 +-
 src/install/isolated_install.rs                    |   6 +-
 src/install/lib.rs                                 |   6 +-
 src/install/lockfile.rs                            |   8 +-
 src/install/lockfile/Package.rs                    |   8 +-
 src/install/loc
... (truncated)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bun_core/lib.rs                                         1      2     11
src/bun_core/util.rs                                        1      3     14
src/bundler/OutputFile.rs                                   0      0      9
src/bundler/linker_context/computeChunks.rs                 0      0      9
src/bundler/linker_context/generateChunksInParallel.rs      0      0      9
src/bundler/linker_context/writeOutputFilesToDisk.rs        0      0      9
src/bundler/options.rs                                      0      0      9
src/bundler/transpiler.rs                                   0      0      9
src/bunfig/arguments.rs                                     0      0      9
src/crash_handler/lib.rs                                    0      0      9
src/dotenv/env_loader.rs                                    0      0      9
src/event_loop/MiniEventLoop.rs                             0      0      9
src/glob/GlobWalker.rs                                      0      0     11
src/install/PackageInstall.rs                               0      0      9
src/install/PackageInstaller.rs                             0      0      9
src/install/PackageManager.rs                               0      0      9
(+ 113 more files)
```

</details>

**root cause** · written by the author bot

`PathBuffer::uninit`, `WPathBuffer::uninit`, and the resolver's `bufs_storage_init` materialized `[u8; N]` and `[u16; N]` values from `MaybeUninit::uninit().assume_init()`, which is undefined behavior because integer types require initialized memory regardless of whether the bytes are later read, and the `invalid_value` and `uninit_assumed_init` lints that diagnose this were suppressed at those sites. The fix removes those constructors and migrates their call sites to the existing `path_buffer_pool`, which produces buffers through `Box::new_zeroed().assume_init()` so every byte is written b…

<!-- robobun:evidence:end -->