### PR TITLE
node:fs: write stdio synchronously when the FileSink cannot be opened

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -110,8 +110,9 @@ export function getStdioWriteStream(
   stream._isStdio = true;
   stream.fd = fd;
 
+  // undefined when the FileSink could not be opened (EMFILE at the fd limit);
+  // the stream then writes synchronously through fs.writeSync.
   const underlyingSink = stream[require("internal/fs/streams").kWriteStreamFastPath];
-  $assert(underlyingSink);
   return [stream, underlyingSink];
 }
 

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -110,8 +110,7 @@ export function getStdioWriteStream(
   stream._isStdio = true;
   stream.fd = fd;
 
-  // undefined when the FileSink could not be opened (EMFILE at the fd limit);
-  // the stream then writes synchronously through fs.writeSync.
+  // undefined when the FileSink could not be opened (EMFILE at the fd limit).
   const underlyingSink = stream[require("internal/fs/streams").kWriteStreamFastPath];
   return [stream, underlyingSink];
 }

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -455,16 +455,24 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
   }
 
   // A writer cannot be opened for every fd a caller may hand us -- a read-only
-  // descriptor is the common case, and node's tty.WriteStream accepts one. Fall
-  // back to the general path there, which surfaces the failure at write time the
-  // way node does, rather than throwing from the constructor.
+  // descriptor is the common case, and node's tty.WriteStream accepts one, and
+  // the sink dup()s the fd, which fails with EMFILE at the fd limit. Fall back
+  // to synchronous writes there, like node's SyncWriteStream for stdio: a
+  // failure surfaces at write time rather than from the constructor, and bytes
+  // written right before process.exit() are not left in a thread-pool queue.
   let fastWriter;
   if (fastPath && fd != null) {
     try {
       fastWriter = Bun.file(fd).writer();
     } catch {
       fastPath = false;
+      this._write = underscoreWriteSync;
     }
+    // Already-open fd (stdio): skip the async _construct round-trip so the
+    // stream is born constructed, like node's stdio streams (net.Socket /
+    // tty.WriteStream), which never allocate construct TickObjects. A write
+    // before construction would sit in the buffer until the next tick.
+    this._construct = undefined;
   }
 
   // Enable fast path
@@ -473,12 +481,6 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
     this._write = underscoreWriteFast;
     this._writev = undefined;
     this.write = writeFast as any;
-    if (fd != null) {
-      // Already-open fd (stdio): skip the async _construct round-trip so the
-      // stream is born constructed, like node's stdio streams (net.Socket /
-      // tty.WriteStream), which never allocate construct TickObjects.
-      this._construct = undefined;
-    }
   }
 
   Writable.$call(this, options);
@@ -589,6 +591,31 @@ function _write(data, encoding, cb) {
   }
 }
 writeStreamPrototype._write = _write;
+
+function underscoreWriteSync(this: FSStream, data: Buffer, encoding: any, cb: any) {
+  const length = data.length;
+  let offset = 0;
+  while (offset < length) {
+    let written: number;
+    try {
+      written = fs.writeSync(this.fd, data, offset, length - offset);
+    } catch (err) {
+      if (err?.code !== "EAGAIN") {
+        cb(err);
+        return;
+      }
+      written = 0;
+    }
+    if (written === 0) {
+      // A non-blocking fd with no room. Let the thread pool finish the rest.
+      _write.$call(this, offset === 0 ? data : data.subarray(offset), encoding, cb);
+      return;
+    }
+    this.bytesWritten += written;
+    offset += written;
+  }
+  cb(null);
+}
 
 function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) {
   let fileSink = this[kWriteStreamFastPath];

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -454,9 +454,7 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
     this.pos = start;
   }
 
-  // The sink dup()s the fd. That fails for a read-only fd (node's
-  // tty.WriteStream accepts one) and with EMFILE at the fd limit. Write
-  // synchronously then, like node's SyncWriteStream.
+  // The sink dup()s the fd; on a read-only fd or EMFILE, write synchronously like node's SyncWriteStream.
   let fastWriter;
   if (fastPath && fd != null) {
     try {
@@ -465,8 +463,7 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
       fastPath = false;
       this._write = underscoreWriteSync;
     }
-    // An already-open fd (stdio) is born constructed, like node's net.Socket.
-    // A deferred _construct would hold a write until the next tick.
+    // Born constructed, like node's stdio: a deferred _construct holds a write until the next tick.
     this._construct = undefined;
   }
 

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -596,12 +596,9 @@ function underscoreWriteSync(this: FSStream, data: Buffer, encoding: any, cb: an
         cb(err);
         return;
       }
-      written = 0;
-    }
-    if (written === 0) {
-      // A non-blocking fd with no room. Let the thread pool finish the rest.
-      _write.$call(this, offset === 0 ? data : data.subarray(offset), encoding, cb);
-      return;
+      // A non-blocking fd with no room: wait for the reader, as a blocking write would.
+      Bun.sleepSync(1);
+      continue;
     }
     this.bytesWritten += written;
     offset += written;

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -454,12 +454,9 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
     this.pos = start;
   }
 
-  // A writer cannot be opened for every fd a caller may hand us: node's
-  // tty.WriteStream accepts a read-only descriptor, and the sink dup()s the fd,
-  // which fails with EMFILE at the fd limit. Fall back to synchronous writes
-  // there, like node's SyncWriteStream for stdio: a failure surfaces at write
-  // time rather than from the constructor, and bytes written right before
-  // process.exit() are not left in a thread-pool queue.
+  // The sink dup()s the fd. That fails for a read-only fd (node's
+  // tty.WriteStream accepts one) and with EMFILE at the fd limit. Write
+  // synchronously then, like node's SyncWriteStream.
   let fastWriter;
   if (fastPath && fd != null) {
     try {
@@ -468,10 +465,8 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
       fastPath = false;
       this._write = underscoreWriteSync;
     }
-    // Already-open fd (stdio): skip the async _construct round-trip so the
-    // stream is born constructed, like node's stdio streams (net.Socket /
-    // tty.WriteStream), which never allocate construct TickObjects. A write
-    // before construction would sit in the buffer until the next tick.
+    // An already-open fd (stdio) is born constructed, like node's net.Socket.
+    // A deferred _construct would hold a write until the next tick.
     this._construct = undefined;
   }
 

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -454,12 +454,12 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
     this.pos = start;
   }
 
-  // A writer cannot be opened for every fd a caller may hand us -- a read-only
-  // descriptor is the common case, and node's tty.WriteStream accepts one, and
-  // the sink dup()s the fd, which fails with EMFILE at the fd limit. Fall back
-  // to synchronous writes there, like node's SyncWriteStream for stdio: a
-  // failure surfaces at write time rather than from the constructor, and bytes
-  // written right before process.exit() are not left in a thread-pool queue.
+  // A writer cannot be opened for every fd a caller may hand us: node's
+  // tty.WriteStream accepts a read-only descriptor, and the sink dup()s the fd,
+  // which fails with EMFILE at the fd limit. Fall back to synchronous writes
+  // there, like node's SyncWriteStream for stdio: a failure surfaces at write
+  // time rather than from the constructor, and bytes written right before
+  // process.exit() are not left in a thread-pool queue.
   let fastWriter;
   if (fastPath && fd != null) {
     try {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -216,19 +216,20 @@ describe.concurrent("process-stdio", () => {
     test("non-blocking pipe: a write larger than the pipe waits for the reader", async () => {
       const size = 1 << 20;
       // `Bun.file(1).writer()` puts O_NONBLOCK on the stdout description, so the
-      // fallback meets EAGAIN once the pipe is full. The parent starts reading
-      // only after the child has begun its write.
+      // fallback meets EAGAIN once the pipe is full. The writer stays open: its
+      // end() closes the dup on another thread, which would free an fd slot.
+      // The parent starts reading only after the child has begun its write.
       const nonblockingScript = /* js */ `
         const fs = require("fs");
         new fs.WriteStream(null, { fd: 1, autoClose: false });
-        Bun.file(1).writer().end();
+        const writer = Bun.file(1).writer();
         const held = [];
         try {
           for (;;) held.push(fs.openSync("/dev/null", "r"));
         } catch {}
         fs.writeSync(2, "writing\\n");
         process.stdout.write(Buffer.alloc(${size}, "x"));
-        process.exit(0);
+        process.exit(writer ? 0 : 1);
       `;
       await using proc = spawn({
         cmd: ["/bin/sh", "-c", `ulimit -n 32 && exec "$1" -e "$2"`, "sh", bunExe(), nonblockingScript],

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -157,5 +157,54 @@ describe.concurrent("process-stdio", () => {
     expect(stdout?.toString()).toBe(
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
+  });
+
+  // `ulimit -n` caps the fd table of the child. The script then opens /dev/null
+  // until EMFILE, so the first touch of process.stdout / process.stderr cannot
+  // dup() its fd for the FileSink fast path. The stream must still deliver the
+  // bytes before process.exit(), the way node's synchronous stdio does.
+  describe.skipIf(isWindows)("stdio writes at the fd limit", () => {
+    const script = /* js */ `
+      const fs = require("fs");
+      // A debug build reads internal modules from disk on first use. Load the
+      // stream module while an fd is still free.
+      new fs.WriteStream(null, { fd: 1, autoClose: false });
+      const held = [];
+      try {
+        for (;;) held.push(fs.openSync("/dev/null", "r"));
+      } catch {}
+      const ok = process.stderr.write("E1 diagnostic on stderr\\n");
+      process.stdout.write("O1 line on stdout\\n");
+      process.exit(ok ? 0 : 1);
+    `;
+
+    test("pipe: bytes written before process.exit() reach the reader", async () => {
+      await using proc = spawn({
+        cmd: ["/bin/sh", "-c", `ulimit -n 32 && exec "$1" -e "$2"`, "sh", bunExe(), script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("O1 line on stdout\n");
+      expect(stderr).toBe("E1 diagnostic on stderr\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("file: bytes written before process.exit() reach the file", async () => {
+      using dir = tempDir("stdio-fd-limit", {});
+      const out = path.join(String(dir), "out.txt");
+      const err = path.join(String(dir), "err.txt");
+      await using proc = spawn({
+        cmd: ["/bin/sh", "-c", `ulimit -n 32 && exec "$1" -e "$2" >"$3" 2>"$4"`, "sh", bunExe(), script, out, err],
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      const exitCode = await proc.exited;
+      expect(await Bun.file(out).text()).toBe("O1 line on stdout\n");
+      expect(await Bun.file(err).text()).toBe("E1 diagnostic on stderr\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -212,5 +212,40 @@ describe.concurrent("process-stdio", () => {
       expect(await Bun.file(err).text()).toBe("E1 diagnostic on stderr\n");
       expect(exitCode).toBe(0);
     });
+
+    test("non-blocking pipe: a write larger than the pipe waits for the reader", async () => {
+      const size = 1 << 20;
+      // `Bun.file(1).writer()` puts O_NONBLOCK on the stdout description, so the
+      // fallback meets EAGAIN once the pipe is full. The parent starts reading
+      // only after the child has begun its write.
+      const nonblockingScript = /* js */ `
+        const fs = require("fs");
+        new fs.WriteStream(null, { fd: 1, autoClose: false });
+        Bun.file(1).writer().end();
+        const held = [];
+        try {
+          for (;;) held.push(fs.openSync("/dev/null", "r"));
+        } catch {}
+        fs.writeSync(2, "writing\\n");
+        process.stdout.write(Buffer.alloc(${size}, "x"));
+        process.exit(0);
+      `;
+      await using proc = spawn({
+        cmd: ["/bin/sh", "-c", `ulimit -n 32 && exec "$1" -e "$2"`, "sh", bunExe(), nonblockingScript],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      let stderr = "";
+      for await (const chunk of proc.stderr) {
+        stderr += Buffer.from(chunk).toString();
+        if (stderr.includes("writing\n")) break;
+      }
+      const [stdout, exitCode] = await Promise.all([proc.stdout.bytes(), proc.exited]);
+      expect(stderr).toBe("writing\n");
+      expect(stdout.length).toBe(size);
+      expect(stdout.every(b => b === 0x78)).toBe(true);
+      expect(exitCode).toBe(0);
+    });
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -177,11 +177,17 @@ describe.concurrent("process-stdio", () => {
       process.stdout.write("O1 line on stdout\\n");
       process.exit(ok ? 0 : 1);
     `;
+    // detect_leaks=0: LeakSanitizer needs an fd for /proc/<pid>/task at exit
+    // and prints its own failure on stderr when the table is full.
+    const env = {
+      ...bunEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    };
 
     test("pipe: bytes written before process.exit() reach the reader", async () => {
       await using proc = spawn({
         cmd: ["/bin/sh", "-c", `ulimit -n 32 && exec "$1" -e "$2"`, "sh", bunExe(), script],
-        env: bunEnv,
+        env,
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -197,7 +203,7 @@ describe.concurrent("process-stdio", () => {
       const err = path.join(String(dir), "err.txt");
       await using proc = spawn({
         cmd: ["/bin/sh", "-c", `ulimit -n 32 && exec "$1" -e "$2" >"$3" 2>"$4"`, "sh", bunExe(), script, out, err],
-        env: bunEnv,
+        env,
         stdout: "ignore",
         stderr: "ignore",
       });


### PR DESCRIPTION
### Problem
- `process.stdout.write()` and `process.stderr.write()` return `true` and print nothing when the stream is first touched at the fd limit and `process.exit()` follows. A server that hits EMFILE cannot print its own diagnostic. Bun 1.3.14 threw `EMFILE fcntl` at the same spot. Node prints both lines.
- The stdio stream opens a `FileSink` on first touch. The sink dup()s the fd (`src/io/openForWriting.rs:34`), and the dup fails with EMFILE. `src/js/internal/fs/streams.ts:465` catches that and falls back to the async thread-pool `WriteStream`. Its `_construct` is deferred to the next tick, so the write sits in the buffer, and `process.exit()` discards it.

### Fix
- When the sink cannot be opened, the stream writes with `fs.writeSync` (`underscoreWriteSync`). This is the shape of node's `SyncWriteStream`, which node uses for file stdio and, on POSIX, for pipes and TTYs.
- The fallback also skips the deferred `_construct` step, the same as the fast path already did. A write before the next tick goes to the fd at once.
- A partial write loops. EAGAIN hands the rest to the existing async path. Any other error reaches the write callback and the `error` event, as before (no throw from `write()`).
- Verified: `test/js/node/process/process-stdio.test.ts` (two new tests, pipe and file, both fail on bun 1.4.1). Also `test-fs-write-stream*.js`, `test-fs-syncwritestream.js`, `test-util-styletext.js`, `test-console-{sync,async}-write-error.js`, `test-child-process-stdout-flush*.js`, and `process-stdout-write-after-end.test.ts`.

### Background
- `process.stdout` is a `fs.WriteStream` built with the internal `$fastPath` option. The fast path replaces `_write` with a call into a native `FileSink` (`Bun.file(fd).writer()`), which writes to the fd at once and buffers only on EAGAIN.
- `FileSink` owns its fd and closes it on `end()`. So it dup()s a caller-provided fd instead of taking it. The dup needs a free slot in the fd table.
- The `$assert(underlyingSink)` in `getStdioWriteStream` is removed. The native consumer (`Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio`) already returns early when the value is not a `FileSink`.

<details><summary>Notes</summary>

Repro (any fd limit works, the script exhausts the table itself):

```
bash -c 'ulimit -n 16; bun r.js'; echo rc=$?
```

```js
const fs = require("fs"); const held = [];
try { for (;;) held.push(fs.openSync("/dev/null", "r")); } catch {}
const ok = process.stderr.write("E1 diagnostic on stderr\n");
process.stdout.write("O1 line on stdout\n");
process.exit(ok ? 0 : 1);
```

Before: nothing printed, rc=0. After: both lines, rc=0.

The first attempt only swapped `_write` and still printed nothing. The cause was the deferred `_construct`: `Writable` buffers every write until `_construct` completes on the next tick. Moving `this._construct = undefined` out of the fast-path branch fixed it.

The test fixture constructs a `fs.WriteStream` on fd 1 before it exhausts the fd table. A debug build reads internal modules from disk on first use and needs an fd for that. The stream is never written to.

Error path check at the fd limit with a read-only fd (`new tty.WriteStream(fd)`): `write()` returns false, the callback gets EBADF, the `error` event fires with EBADF, nothing throws.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process-stdio.test.ts

<!-- robobun:evidence:end -->