### PR TITLE
fetch: report a handshake cut short as ECONNRESET or ERR_SSL_<REASON>, not as a certificate error

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1273,9 +1273,7 @@ impl<const SSL: bool> Handler<SSL> {
 
                 return client.first_call::<SSL>(socket);
             } else {
-                // The handshake failed: `error_no` is an X509 verdict the
-                // server acted on, or a uSockets transport code (the peer
-                // closed mid-handshake, a fatal TLS protocol error).
+                // `error_no` is an X509 verdict or a uSockets transport code.
                 if client.flags.did_have_handshaking_error {
                     let err = client.handshake_failure_error(&ssl_error);
                     client.close_and_fail::<SSL>(err, socket);

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -5,10 +5,7 @@ use core::ptr::NonNull;
 use crate::Error;
 use crate::http_thread::InitOpts as HTTPThreadInitOpts;
 use crate::ssl_config::{self, SSLConfig};
-use crate::{
-    self as http, AlpnOffer, HTTPCertError, HTTPClient, InitError, ProxyTunnel,
-    get_cert_error_from_no, h2,
-};
+use crate::{self as http, AlpnOffer, HTTPCertError, HTTPClient, InitError, ProxyTunnel, h2};
 use bun_boringssl::ssl_ctx_setup;
 use bun_boringssl_sys::{OwnedSslCtx, SSL_CTX};
 use bun_collections::{HiveArray, TaggedPtrUnion};
@@ -1243,10 +1240,8 @@ impl<const SSL: bool> Handler<SSL> {
                 if client.flags.reject_unauthorized {
                     // only reject the connection if reject_unauthorized == true
                     if client.flags.did_have_handshaking_error {
-                        client.close_and_fail::<SSL>(
-                            get_cert_error_from_no(handshake_error.error_no),
-                            socket,
-                        );
+                        let err = client.handshake_failure_error(&ssl_error);
+                        client.close_and_fail::<SSL>(err, socket);
                         return;
                     }
 
@@ -1278,13 +1273,12 @@ impl<const SSL: bool> Handler<SSL> {
 
                 return client.first_call::<SSL>(socket);
             } else {
-                // if we are here is because server rejected us, and the error_no is the cause of this
-                // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
+                // The handshake failed: `error_no` is an X509 verdict the
+                // server acted on, or a uSockets transport code (the peer
+                // closed mid-handshake, a fatal TLS protocol error).
                 if client.flags.did_have_handshaking_error {
-                    client.close_and_fail::<SSL>(
-                        get_cert_error_from_no(handshake_error.error_no),
-                        socket,
-                    );
+                    let err = client.handshake_failure_error(&ssl_error);
+                    client.close_and_fail::<SSL>(err, socket);
                     return;
                 }
                 // if handshake_success it self is false, this means that the connection was rejected

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -47,6 +47,10 @@ pub struct InternalState<'a> {
     /// the post-redirect target). Captured on the HTTP thread at the failure
     /// so the JS side never dereferences the client's borrowed URL buffers.
     pub(crate) dns_hostname: Option<Box<[u8]>>,
+    /// OpenSSL error string of the fatal TLS protocol error when `fail` is
+    /// `EPROTO`. Copied in the handshake callback: uSockets hands it out as
+    /// a pointer into a stack buffer that dies when the callback returns.
+    pub(crate) tls_handshake_reason: Option<Box<[u8]>>,
     pub(crate) request_stage: HTTPStage,
     pub(crate) response_stage: HTTPStage,
     pub(crate) certificate_info: Option<CertificateInfo>,
@@ -119,6 +123,7 @@ impl Default for InternalState<'_> {
             fail: None,
             dns_error: 0,
             dns_hostname: None,
+            tls_handshake_reason: None,
             request_stage: HTTPStage::Pending,
             response_stage: HTTPStage::Pending,
             certificate_info: None,

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -47,9 +47,8 @@ pub struct InternalState<'a> {
     /// the post-redirect target). Captured on the HTTP thread at the failure
     /// so the JS side never dereferences the client's borrowed URL buffers.
     pub(crate) dns_hostname: Option<Box<[u8]>>,
-    /// OpenSSL error string of the fatal TLS protocol error when `fail` is
-    /// `EPROTO`. Copied in the handshake callback: uSockets hands it out as
-    /// a pointer into a stack buffer that dies when the callback returns.
+    /// OpenSSL reason when `fail` is `EPROTO`. Owned: uSockets' string
+    /// lives in a stack buffer that dies when the handshake callback returns.
     pub(crate) tls_handshake_reason: Option<Box<[u8]>>,
     pub(crate) request_stage: HTTPStage,
     pub(crate) response_stage: HTTPStage,

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -357,7 +357,7 @@ fn on_handshake(
         if this.flags.reject_unauthorized {
             // only reject the connection if reject_unauthorized == true
             if this.flags.did_have_handshaking_error {
-                let err = this.handshake_failure_error(&ssl_error);
+                let err = crate::get_cert_error_from_no(handshake_error.error_no);
                 // SAFETY: `this` dead (NLL); reenter via raw ptr so on_close's
                 // fresh `&mut *ctx` does not alias us.
                 ProxyTunnel::close_from_callback(proxy_nn, err);
@@ -422,7 +422,7 @@ fn on_handshake(
         // if we are here is because server rejected us, and the error_no is the cause of this
         // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
         if this.flags.did_have_handshaking_error && handshake_error.error_no != 0 {
-            let err = this.handshake_failure_error(&ssl_error);
+            let err = crate::get_cert_error_from_no(handshake_error.error_no);
             // SAFETY: `this` dead (NLL); reenter via raw ptr.
             ProxyTunnel::close_from_callback(proxy_nn, err);
             return;

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -357,7 +357,7 @@ fn on_handshake(
         if this.flags.reject_unauthorized {
             // only reject the connection if reject_unauthorized == true
             if this.flags.did_have_handshaking_error {
-                let err = crate::get_cert_error_from_no(handshake_error.error_no);
+                let err = this.handshake_failure_error(&ssl_error);
                 // SAFETY: `this` dead (NLL); reenter via raw ptr so on_close's
                 // fresh `&mut *ctx` does not alias us.
                 ProxyTunnel::close_from_callback(proxy_nn, err);
@@ -422,7 +422,7 @@ fn on_handshake(
         // if we are here is because server rejected us, and the error_no is the cause of this
         // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
         if this.flags.did_have_handshaking_error && handshake_error.error_no != 0 {
-            let err = crate::get_cert_error_from_no(handshake_error.error_no);
+            let err = this.handshake_failure_error(&ssl_error);
             // SAFETY: `this` dead (NLL); reenter via raw ptr.
             ProxyTunnel::close_from_callback(proxy_nn, err);
             return;

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -97,10 +97,8 @@ pub enum Error {
     InvalidCRL,
     #[error("UnsupportedProxyProtocol")]
     UnsupportedProxyProtocol,
-    /// The TLS handshake ended with a fatal protocol error (the peer speaks
-    /// plain HTTP, sent a bad record, or is the client itself after a TCP
-    /// self-connect). Node's code for the same failure. The OpenSSL reason
-    /// travels in `HTTPClientResult::tls_handshake_reason`.
+    /// Fatal TLS protocol error in the handshake (a non-TLS peer, a bad
+    /// record). The OpenSSL reason is `HTTPClientResult::tls_handshake_reason`.
     #[error("EPROTO")]
     EPROTO,
     #[error(transparent)]

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -97,6 +97,12 @@ pub enum Error {
     InvalidCRL,
     #[error("UnsupportedProxyProtocol")]
     UnsupportedProxyProtocol,
+    /// The TLS handshake ended with a fatal protocol error (the peer speaks
+    /// plain HTTP, sent a bad record, or is the client itself after a TCP
+    /// self-connect). Node's code for the same failure. The OpenSSL reason
+    /// travels in `HTTPClientResult::tls_handshake_reason`.
+    #[error("EPROTO")]
+    EPROTO,
     #[error(transparent)]
     Cert(#[from] CertError),
     #[error(transparent)]
@@ -308,6 +314,7 @@ impl Error {
             Self::FailedToOpenSocket => "FailedToOpenSocket",
             Self::InvalidCRL => "InvalidCRL",
             Self::UnsupportedProxyProtocol => "UnsupportedProxyProtocol",
+            Self::EPROTO => "EPROTO",
             Self::Cert(e) => <&'static str>::from(e),
             Self::Alloc(_) => "OutOfMemory",
             Self::Hpack(e) => <&'static str>::from(e),

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -452,6 +452,9 @@ pub struct HTTPClientResult<'a> {
     /// JS side never dereferences the client's borrowed URL buffers, which
     /// the HTTP thread frees after the result callback returns.
     pub dns_hostname: Option<Box<[u8]>>,
+    /// OpenSSL error string when `fail` is `EPROTO` (a fatal TLS protocol
+    /// error in the handshake), for the error message.
+    pub tls_handshake_reason: Option<Box<[u8]>>,
 
     /// Owns the response metadata aka headers, url and status code
     pub metadata: Option<HTTPResponseMetadata>,
@@ -536,6 +539,7 @@ impl<'a> HTTPClientResult<'a> {
             fail: self.fail,
             dns_error: self.dns_error,
             dns_hostname: self.dns_hostname,
+            tls_handshake_reason: self.tls_handshake_reason,
             metadata: self.metadata,
             body_size: self.body_size,
             certificate_info: self.certificate_info,
@@ -1542,6 +1546,32 @@ pub(crate) fn get_cert_error_from_no(error_no: i32) -> crate::Error {
         67 => CertError::NAME_CONSTRAINTS_WITHOUT_SANS,
         _ => CertError::UNKNOWN_CERTIFICATE_VERIFICATION_ERROR,
     })
+}
+
+impl HTTPClient<'_> {
+    /// The error for an `on_handshake` verdict with a non-zero `error_no`.
+    ///
+    /// A non-negative `error_no` is the `X509_V_ERR_*` verdict of the chain
+    /// check. A negative one is a uSockets transport code for a handshake
+    /// that ended before any verdict existed: `ECONNRESET` (the peer closed
+    /// mid-handshake) or `EPROTO` (a fatal TLS protocol error, `reason` is
+    /// the OpenSSL error string). Those are not certificate errors.
+    pub(crate) fn handshake_failure_error(
+        &mut self,
+        ssl_error: &uws::us_bun_verify_error_t,
+    ) -> crate::Error {
+        if ssl_error.error_no >= 0 {
+            return get_cert_error_from_no(ssl_error.error_no);
+        }
+        if ssl_error.code_bytes() == b"ECONNRESET" {
+            return crate::Error::ConnectionClosed;
+        }
+        let reason = ssl_error.reason_bytes();
+        if !reason.is_empty() {
+            self.state.tls_handshake_reason = Some(Box::<[u8]>::from(reason));
+        }
+        crate::Error::EPROTO
+    }
 }
 
 // ── HTTPClient field accessors ──────────────────────────────────────────
@@ -4416,6 +4446,7 @@ impl<'a> HTTPClient<'a> {
                     fail: self.state.fail,
                     dns_error: self.state.dns_error,
                     dns_hostname: self.state.dns_hostname.take(),
+                    tls_handshake_reason: self.state.tls_handshake_reason.take(),
                     has_more: self.state.fail.is_none() && !self.state.is_done(),
                     body_size,
                     certificate_info: None,
@@ -4434,6 +4465,7 @@ impl<'a> HTTPClient<'a> {
             fail: self.state.fail,
             dns_error: self.state.dns_error,
             dns_hostname: self.state.dns_hostname.take(),
+            tls_handshake_reason: self.state.tls_handshake_reason.take(),
             // check if we are reporting cert errors, do not have a fail state and we are not done
             has_more: certificate_info.is_some()
                 || (self.state.fail.is_none() && !self.state.is_done()),

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -452,8 +452,7 @@ pub struct HTTPClientResult<'a> {
     /// JS side never dereferences the client's borrowed URL buffers, which
     /// the HTTP thread frees after the result callback returns.
     pub dns_hostname: Option<Box<[u8]>>,
-    /// OpenSSL error string when `fail` is `EPROTO` (a fatal TLS protocol
-    /// error in the handshake), for the error message.
+    /// OpenSSL reason when `fail` is `EPROTO`.
     pub tls_handshake_reason: Option<Box<[u8]>>,
 
     /// Owns the response metadata aka headers, url and status code
@@ -1549,13 +1548,9 @@ pub(crate) fn get_cert_error_from_no(error_no: i32) -> crate::Error {
 }
 
 impl HTTPClient<'_> {
-    /// The error for an `on_handshake` verdict with a non-zero `error_no`.
-    ///
-    /// A non-negative `error_no` is the `X509_V_ERR_*` verdict of the chain
-    /// check. A negative one is a uSockets transport code for a handshake
-    /// that ended before any verdict existed: `ECONNRESET` (the peer closed
-    /// mid-handshake) or `EPROTO` (a fatal TLS protocol error, `reason` is
-    /// the OpenSSL error string). Those are not certificate errors.
+    /// The error for a non-zero `on_handshake` `error_no`: an `X509_V_ERR_*`
+    /// verdict when non-negative, else a uSockets transport code
+    /// (`ECONNRESET`, or `EPROTO` with the OpenSSL reason).
     pub(crate) fn handshake_failure_error(
         &mut self,
         ssl_error: &uws::us_bun_verify_error_t,

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -4,7 +4,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_boringssl as boringssl;
 use bun_cares_sys::c_ares_draft as c_ares;
-use bun_core::{MutableString, String as BunString};
+use bun_core::{BStr, MutableString, String as BunString};
 use bun_event_loop::{
     ConcurrentTask::{AutoDeinit, ConcurrentTask},
     Task, Taskable,
@@ -1343,6 +1343,13 @@ impl FetchTasklet {
             http::Error::RedirectURLInvalid => {
                 BunString::static_("Redirect URL in Location header is invalid.")
             }
+            http::Error::EPROTO => match self.result.tls_handshake_reason.as_deref() {
+                Some(reason) => BunString::create_format(format_args!(
+                    "TLS handshake failed: {}",
+                    BStr::new(reason)
+                )),
+                None => BunString::static_("TLS handshake failed"),
+            },
 
             http::Error::Cert(http::CertError::UNABLE_TO_GET_ISSUER_CERT) => {
                 BunString::static_("unable to get issuer certificate")

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1323,9 +1323,7 @@ impl FetchTasklet {
 
         let code = match fail {
             http::Error::ConnectionClosed => BunString::static_("ECONNRESET"),
-            // Same shape as node:tls's `tlsHandshakeError` (src/js/node/net.ts):
-            // `ERR_SSL_<REASON>` from the OpenSSL string, `EPROTO` when it
-            // does not parse.
+            // `ERR_SSL_<REASON>` like node:tls's `tlsHandshakeError`; `EPROTO` if unparsed.
             http::Error::EPROTO => match self
                 .result
                 .tls_handshake_reason

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1321,10 +1321,24 @@ impl FetchTasklet {
             }
         }
 
-        let code = if fail == http::Error::ConnectionClosed {
-            BunString::static_("ECONNRESET")
-        } else {
-            BunString::static_(fail.name())
+        let code = match fail {
+            http::Error::ConnectionClosed => BunString::static_("ECONNRESET"),
+            // Same shape as node:tls's `tlsHandshakeError` (src/js/node/net.ts):
+            // `ERR_SSL_<REASON>` from the OpenSSL string, `EPROTO` when it
+            // does not parse.
+            http::Error::EPROTO => match self
+                .result
+                .tls_handshake_reason
+                .as_deref()
+                .and_then(ssl_error_reason)
+            {
+                Some(reason) => BunString::create_format(format_args!(
+                    "ERR_SSL_{}",
+                    BStr::new(reason)
+                )),
+                None => BunString::static_("EPROTO"),
+            },
+            _ => BunString::static_(fail.name()),
         };
 
         let message = match fail {
@@ -1344,10 +1358,7 @@ impl FetchTasklet {
                 BunString::static_("Redirect URL in Location header is invalid.")
             }
             http::Error::EPROTO => match self.result.tls_handshake_reason.as_deref() {
-                Some(reason) => BunString::create_format(format_args!(
-                    "TLS handshake failed: {}",
-                    BStr::new(reason)
-                )),
+                Some(reason) => BunString::clone_utf8(reason),
                 None => BunString::static_("TLS handshake failed"),
             },
 
@@ -2487,6 +2498,23 @@ impl FetchTasklet {
             FetchTasklet::hand_back(task);
         }
     }
+}
+
+/// The `REASON` of an OpenSSL error string
+/// (`error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER`).
+fn ssl_error_reason(error_string: &[u8]) -> Option<&[u8]> {
+    let mut parts = bun_core::strings::split(error_string, b":");
+    if parts.next()? != b"error" {
+        return None;
+    }
+    let hex = parts.next()?;
+    if parts.next()? != b"SSL routines" {
+        return None;
+    }
+    let function = parts.next()?;
+    let start = "error:".len() + hex.len() + ":SSL routines:".len() + function.len() + 1;
+    let reason = error_string.get(start..)?;
+    (!reason.is_empty()).then_some(reason)
 }
 
 fn on_resolve_request_stream(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1332,10 +1332,9 @@ impl FetchTasklet {
                 .as_deref()
                 .and_then(ssl_error_reason)
             {
-                Some(reason) => BunString::create_format(format_args!(
-                    "ERR_SSL_{}",
-                    BStr::new(reason)
-                )),
+                Some(reason) => {
+                    BunString::create_format(format_args!("ERR_SSL_{}", BStr::new(reason)))
+                }
                 None => BunString::static_("EPROTO"),
             },
             _ => BunString::static_(fail.name()),

--- a/test/cli/install/bun-install-stalled-tls.test.ts
+++ b/test/cli/install/bun-install-stalled-tls.test.ts
@@ -74,3 +74,57 @@ test("bun install times out when the registry accepts TCP but never completes th
     await new Promise<void>(resolve => server.close(() => resolve()));
   }
 }, 60_000);
+
+// https://github.com/oven-sh/bun/issues/31949
+//
+// A registry connection that closes during the TLS handshake involves no
+// certificate, so the error must not be UNKNOWN_CERTIFICATE_VERIFICATION_ERROR
+// (the X509 table's fallback, which sent users hunting through CA stores). A
+// FIN after the ClientHello reaches the SSL close path and reports
+// ConnectionClosed; a RST raw-closes the socket and reports the same.
+test("bun install reports a connection error when the registry closes the connection during the TLS handshake", async () => {
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer(socket => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
+    socket.once("data", () => socket.end());
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as net.AddressInfo).port;
+
+  try {
+    using dir = tempDir("install-handshake-close", {
+      "package.json": JSON.stringify({
+        name: "close-repro",
+        version: "1.0.0",
+        dependencies: { lodash: "4.17.21" },
+      }),
+      "bunfig.toml": Bun.TOML.stringify({
+        install: {
+          registry: `https://127.0.0.1:${port}/`,
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_HTTP_RETRY_COUNT: "0",
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const combined = stdout + stderr;
+    expect(combined).toMatch(/error: ConnectionClosed downloading package manifest lodash/);
+    expect(exitCode).not.toBe(0);
+  } finally {
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});

--- a/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
+++ b/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
@@ -27,9 +27,18 @@ const mismatchedTls = {
   key: "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCtOMsk7M5X9jX7\nJp5DjC/CgPxaDmDmv5Thy/9jwiVsKBQySwVxHot3/O7Y7yerFPHb7hqK6rADyTVP\nH3OIFrmd81craTr02Zby4iDJXZfmG/Iv7aeX0w79Ma56bapiHBXN1Uujt2Beuy6m\nCFfsWpfeMmbhLVu/VfJYWXAEdQDyu4v8vZtJhBiwpike+Pwso+SnD42UESH2Cn/A\nJcGxiUyKs8R2x3od+eN+gE3wFbEbzNru3dbiqtjNNv5ixOoZaFJnj20EyPotp9jG\ncPzUZBZ5YnKeCD3RzR0neWNBIi6zn2JmMX/VOns3GduBB1iWaRgYA3fbqI4kLeqZ\nujf7f0RjAgMBAAECggEAI4q+q+Hm6Md9Bf5DhOqTth4PKU8/9LikjLv1t/tTAGEs\n27Dm+fHhfgoo29weUI0onw645X4IBY7YYFa8ttSq20zduuuJjEnFHirlvUt16mIb\njFgABjfpIGx8N2SfDChlFOnJ7lqm7GkNxkV5/OYNuSqwT02mQJka86PORyvWuPcJ\nX6NmhhEJDCnVTL1D7FaEHrRUCC0n4hDMe0LLRNo7JrGljPIqPvpuQXEP52wdbzMC\nYfXJb7NbsiGOKLfrs9RXnR9ztr04gJ7jD5pMoeubbsM/tivRDm2VOY/U3NK2LN2q\ngFJ4hokBbUtIxU46RCTWSyQRRpNzFIBrL5y3a30DOQKBgQDsd/jvDPg55TzCNxFq\n6gLuoemIu4JIkSG4hSn6dtSpE5myQl9HuKvGlIS/kgB44zly8X8havxDuAinpzJc\n+oCnFWOFqi2IOt+OhiqjgeK2p0nsAxFVgWepdnPpv0LZXTj2SR09ZZ74YTh+ZQV8\nBiSuuEKZ064wwAg6esXVEMpkHwKBgQC7h360xoo/+m/ncANtDuA7zuHtE8fdsUaM\nLJ+zqlBsivsmM7ohqKqreIMKdw9b1aW/WrVmJavj9zX8ht/kt8vAYwmjk3lc7wso\nEa7EKF7Qa/IPhDkxQwnn/XTpzFsitItn1JCnnwoQUWcGtH/Su6b2I6T8+WZ8ia4Z\nXFpjyeV3PQKBgFVm2uPTBk86iGAILWU0kMyIc2RrfBkjOU9/4HJRumo55vdnWyv2\n+Srl9q+NVlhSkCwAJg72qZb3f0C1dM35tr8hTWk31evuf1DlCb81qKCY+GyhiwAb\nlUmxuxk/dzAzp9/i9gl3ixtfWVzktT9epJ7pczxFJBL9N7uPHaXew4m3AoGAUwwT\nKb2O9fxTWFv7uG1REktxNAuBhIUAaA1PAELZcOgvhuB7enJ2eo9ZAOZvD81SpKZo\nFP9z2vXcm6OjPWfDvMRfPWiO44AdIbaK/eWe75AOV57HsTAuD+Xnw64zYfAwmF/D\nW+gLjeRuysJepRVjQDfS1hEguOBEEIkconqDu0UCgYAQpb1SRymW/40bD3cTnF41\nDPH6Veqgdzu/6MOlD3oWTugPisH1aPq4UIsK03h+NJlVemQ92fTW47ZUjBuRZojZ\nrxah/Jl1Ta1Ww1q98fpZ2julkm+zEmErTw6plfveSVMC+jmgRjWXGbXYPxfxcUsb\nQlPkp7bJgio6h32XI0nWzA==\n-----END PRIVATE KEY-----\n",
 };
 
+// Dual-stack, because the fetches below dial `localhost` and race ::1 against
+// 127.0.0.1. A leg with no listener can TCP self-connect: when the kernel
+// hands the connecting socket the ephemeral port equal to its destination
+// port, the SYN meets itself (a simultaneous open) and the connect succeeds
+// with the client as its own peer. The TLS handshake then fails with EPROTO
+// (the "server flight" is the client's own ClientHello). With 16384
+// ephemeral ports on macOS and thousands of ::1 legs per run, that hit about
+// one run in four. With a listener on both addresses the kernel never picks
+// the bound port.
 function listen(server: net.Server): Promise<number> {
   return new Promise(resolve => {
-    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port));
+    server.listen(0, () => resolve((server.address() as net.AddressInfo).port));
   });
 }
 

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -460,7 +460,7 @@ describe.concurrent("fetch-tls", () => {
       expect(err.code).toBe("ECONNRESET");
     });
 
-    it(`a peer that does not speak TLS rejects with EPROTO and the OpenSSL reason (rejectUnauthorized: ${rejectUnauthorized})`, async () => {
+    it(`a peer that does not speak TLS rejects with ERR_SSL_WRONG_VERSION_NUMBER (rejectUnauthorized: ${rejectUnauthorized})`, async () => {
       using server = await plainTcpServer(socket => socket.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
       const err = await fetch(`https://127.0.0.1:${server.port}/`, {
         keepalive: false,
@@ -470,8 +470,9 @@ describe.concurrent("fetch-tls", () => {
         e => e,
       );
       expect(err).toBeInstanceOf(Error);
-      expect(err.code).toBe("EPROTO");
-      expect(err.message).toContain("WRONG_VERSION_NUMBER");
+      // The same code and message node:tls gives for this handshake failure.
+      expect(err.code).toBe("ERR_SSL_WRONG_VERSION_NUMBER");
+      expect(err.message).toMatch(/^error:[0-9a-f]+:SSL routines:[^:]*:WRONG_VERSION_NUMBER$/);
     });
   }
 

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows, tmpdirSync } from "harness";
 import { readFileSync } from "node:fs";
+import net from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -425,6 +426,54 @@ describe.concurrent("fetch-tls", () => {
     // The fixture's stalled handshakes wait for the padded 1s idle timer,
     // which the 4s sweep fires at ~4-8s, so this outlives the 5s default.
   }, 30_000);
+
+  // A handshake that ends before any certificate verdict exists (the peer
+  // hangs up, or speaks something other than TLS) is a transport failure.
+  // It used to be reported as UNKNOWN_CERTIFICATE_VERIFICATION_ERROR, the
+  // fallback for an X509 code the client does not know, because uSockets'
+  // ECONNRESET/EPROTO pseudo-codes were fed into the X509 table.
+  async function plainTcpServer(onClientHello: (socket: net.Socket) => void) {
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => onClientHello(socket));
+    });
+    const { promise, resolve } = Promise.withResolvers<void>();
+    server.listen(0, "127.0.0.1", () => resolve());
+    await promise;
+    return {
+      port: (server.address() as net.AddressInfo).port,
+      [Symbol.dispose]: () => void server.close(),
+    };
+  }
+
+  for (const rejectUnauthorized of [true, false]) {
+    it(`a peer that closes during the handshake rejects with ECONNRESET (rejectUnauthorized: ${rejectUnauthorized})`, async () => {
+      using server = await plainTcpServer(socket => socket.end());
+      const err = await fetch(`https://127.0.0.1:${server.port}/`, {
+        keepalive: false,
+        tls: { rejectUnauthorized },
+      }).then(
+        () => expect.unreachable(),
+        e => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe("ECONNRESET");
+    });
+
+    it(`a peer that does not speak TLS rejects with EPROTO and the OpenSSL reason (rejectUnauthorized: ${rejectUnauthorized})`, async () => {
+      using server = await plainTcpServer(socket => socket.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
+      const err = await fetch(`https://127.0.0.1:${server.port}/`, {
+        keepalive: false,
+        tls: { rejectUnauthorized },
+      }).then(
+        () => expect.unreachable(),
+        e => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe("EPROTO");
+      expect(err.message).toContain("WRONG_VERSION_NUMBER");
+    });
+  }
 
   // When checkServerIdentity is provided, the HTTP thread sends an intermediate
   // progress update carrying the server certificate before response headers


### PR DESCRIPTION
Fixes #31949

### Problem
- `fetch()` and `bun install` report every TLS handshake that ends before a certificate verdict as `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`. About 70 darwin CI builds since Aug 26 show this code, and #31949 is a user sent through CA stores by it.
- uSockets reports a handshake cut short with pseudo-codes (`-46` `ECONNRESET`, `-71` `EPROTO`, `openssl.c:1966,2020`). `Handler::on_handshake` fed them into the X509 table (`src/http/lib.rs:1543`), whose fallback is the unknown-certificate code. A plain-HTTP server behind an `https://` URL gets it on every platform.

### Fix
- `HTTPClient::handshake_failure_error`: code `ECONNRESET` becomes `ConnectionClosed` (fetch reports `ECONNRESET`, install `ConnectionClosed`). Any other negative code becomes the new `Error::EPROTO` with the OpenSSL reason copied into `tls_handshake_reason`. Non-negative codes still use the X509 table.
- `fetch()` shapes `EPROTO` like node:tls's `tlsHandshakeError` (`src/js/node/net.ts:376`): the message is the OpenSSL string and the code `ERR_SSL_<REASON>` (`ERR_SSL_WRONG_VERSION_NUMBER`), `EPROTO` only when the string does not parse. One code per wire event across the binary.
- Verified: `test/js/web/fetch/fetch.tls.test.ts` (4 new tests) and `test/cli/install/bun-install-stalled-tls.test.ts` (1 new test). Released bun fails all 5 with `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`. Also the wildcard, backpressure, proxy and serve-ssl suites.
- Supersedes #31950, #34182 and #34921, which fix the same lines with three different codes. The darwin fixture flake that surfaced this is #41455 (test only, also included here).

### Background
- `on_handshake` gets `us_bun_verify_error_t { error_no, code, reason }`. For a finished handshake `error_no` is the `X509_V_ERR_*` verdict (0 to 67). For an unfinished one uSockets substitutes its negative codes and sets `code` to the errno name.
- The reason string points into a uSockets stack buffer that dies when the callback returns, so it is copied at once (the `dns_hostname` pattern).
- The proxy tunnel's inner handshake runs through the Rust `SSLWrapper`, which reports X509 verdicts only, so it is not touched here.

<details><summary>Notes</summary>

Message and code shape before and after on linux with a plain TCP server that answers the ClientHello with HTTP:

```
before: UNKNOWN_CERTIFICATE_VERIFICATION_ERROR "unknown certificate verification error"
after:  ERR_SSL_WRONG_VERSION_NUMBER "error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER"
```

With a server that FINs after the ClientHello: `ECONNRESET` (fetch), `error: ConnectionClosed downloading package manifest lodash` (install). A server that RSTs already reported those (the reset raw-closes the socket before the SSL layer runs).

Sightings: the Buildkite annotations of builds 106090 through 110411 contain `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR` in about 70 builds, all on darwin lanes: `fetch.tls.test.ts` (the churn fixture, `fetch with valid tls should not throw`, `reuses the keep-alive connection ...`), `fetch.tls.wildcard.test.ts` (many rows), `fetch-backpressure.test.ts` (`stalled ... drains the full body`, h1-tls), `fetch-http3-client.test.ts` (the h1 alt-svc fetch), `serve-http3.test.ts`.

The churn-fixture failures are a macOS TCP self-connect on the listener-less `::1` leg of a `localhost` fetch, proven with tcpdump (details in #41455). The 127.0.0.1 sightings have a listener on the dialed address, so they are something else. 300 runs of those files under load on a CI mini did not reproduce them. One candidate, confirmed possible on macOS and impossible on Linux: a dual-stack `[::]:0` listener can land on a port that a v4-only `127.0.0.1` listener in another process already holds (1 in 20000 with 2000 v4-only listeners present), and a `127.0.0.1` connect then reaches the more specific v4-only socket. After this change such a failure reports `ECONNRESET` or `ERR_SSL_<REASON>` instead of a certificate code, which names the actual peer behavior on the next sighting.

The mapping bug dates to #17505 (Feb 2025), which added the `-46` pseudo-code; `-71` came with #31155.

Other suites run on the debug build: `fetch.test.ts` (failures match the released binary: IPv6 localhost, root permissions, internet, GC-heavy timeouts), `fetch-backpressure.test.ts` (only the S3 block fails, egress denied, same on the released binary), `bun-connect-x509.test.ts` (internet). Full list: `fetch.tls.wildcard`, `fetch-backpressure`, `proxy`, `bun-serve-ssl`, `tls-keepalive`, `fetch-abort-ssl-context-eviction`, `proxy-stress-errors`, `proxy-stress-protocol`, `fetch-abort-socket-close-race`.

Self-reviewed: 6 concerns raised, 5 addressed (code shape, dead proxy-tunnel hunks, duplicate PRs, missing issue link, fixture split). Rejected: teaching the proxy tunnel's `SSLWrapper` the same pseudo-codes, which needs its own tunnel test and is a separate change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.tls.test.ts

<!-- robobun:evidence:end -->