### PR TITLE
Bump WebKit (oven-sh/WebKit#567 preview): idle JSC worker threads release their mimalloc heap

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-567-e62d118e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -92,6 +92,7 @@ function makeModule({ functionCount = 35, opsPerFunction = 1400, giantOps = 3000
 }
 
 const targetMiB = Number(process.argv[2]);
+if (!Number.isFinite(targetMiB)) throw new Error(`expected the target in MiB as argv[2], got ${process.argv[2]}`);
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 const bytes = makeModule();
 Bun.gc(true);

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -93,35 +93,50 @@ function makeModule({ functionCount = 35, opsPerFunction = 1400, giantOps = 3000
 
 const targetMiB = Number(process.argv[2]);
 if (!Number.isFinite(targetMiB)) throw new Error(`expected the target in MiB as argv[2], got ${process.argv[2]}`);
+// On Darwin mimalloc returns memory with MADV_FREE_REUSABLE, which the kernel keeps counted in RSS
+// until it reuses the pages. phys_footprint drops at once, so measure that there.
+const rss =
+  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
+    ? Bun.unsafe.memoryFootprint
+    : process.memoryUsage.rss;
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 const bytes = makeModule();
-Bun.gc(true);
-await sleep(50);
-Bun.gc(true);
 
-const base = process.memoryUsage().rss;
+// Building the module leaves garbage behind. Wait until RSS stops falling before taking the
+// baseline: mimalloc hands freed memory back on its own schedule, and there is no signal for it.
+let base = Infinity;
+for (const deadline = performance.now() + 2000; performance.now() < deadline; ) {
+  Bun.gc(true);
+  await sleep(50);
+  const now = rss();
+  if (now >= base - 1048576) break;
+  base = now;
+}
 for (let i = 0; i < 3; i++) {
   let mod = await WebAssembly.compile(bytes);
   mod = null;
 }
+// Read before anything is freed: the test checks that the compiles grew RSS at all.
+const peak = rss() - base;
 // Free the modules. The main thread frees their metadata into the compiler threads' pages, and only
 // those threads can hand that memory back. They do so once they have worked and gone idle again, so
 // give each of them one trivial function to compile after the modules are gone.
 Bun.gc(true);
 await WebAssembly.compile(makeModule({ functionCount: 16, opsPerFunction: 1, giantOps: 1 }));
 Bun.gc(true);
-const afterCompiles = process.memoryUsage().rss - base;
+const afterCompiles = rss() - base;
 
 const deadline = performance.now() + 3000;
 let min = Infinity;
 while (performance.now() < deadline && min / 1048576 >= targetMiB) {
   await sleep(100);
   Bun.gc(true);
-  min = Math.min(min, process.memoryUsage().rss - base);
+  min = Math.min(min, rss() - base);
 }
 console.log(
   JSON.stringify({
     moduleMiB: bytes.length / 1048576,
+    peakDeltaMiB: peak / 1048576,
     afterCompilesDeltaMiB: afterCompiles / 1048576,
     idleDeltaMiB: min / 1048576,
   }),

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -1,0 +1,127 @@
+// Fixture for compile-rss.test.ts. Compiles a generated wasm module 3 times, discards each result,
+// then polls RSS until it falls below the target (argv[2], MiB) or the deadline passes. The idle
+// compiler threads exit after 10 s and release everything then, so the deadline stays well below
+// that. Prints one JSON line with the lowest RSS growth seen, relative to the RSS before the first
+// compile.
+
+class Bytes {
+  constructor() {
+    this.buf = new Uint8Array(1 << 20);
+    this.len = 0;
+  }
+  push(...bytes) {
+    for (const b of bytes) this.byte(b);
+  }
+  byte(b) {
+    if (this.len === this.buf.length) {
+      const next = new Uint8Array(this.buf.length * 2);
+      next.set(this.buf);
+      this.buf = next;
+    }
+    this.buf[this.len++] = b;
+  }
+  leb(n) {
+    do {
+      let b = n & 0x7f;
+      n >>>= 7;
+      if (n !== 0) b |= 0x80;
+      this.byte(b);
+    } while (n !== 0);
+  }
+  append(other) {
+    for (let i = 0; i < other.len; i++) this.byte(other.buf[i]);
+  }
+  section(id, payload) {
+    this.byte(id);
+    this.leb(payload.len);
+    this.append(payload);
+  }
+  bytes() {
+    return this.buf.subarray(0, this.len);
+  }
+}
+
+// A module shaped like a tree-sitter parser: a few dozen functions of 20 to 30 KB of control-flow
+// heavy code, plus one giant function. Compiling it makes each wasm compiler thread allocate and
+// free tens of MB of temporaries. Uniform modules of many small functions do not show the
+// retention: their pages end up fully free and mimalloc's scavenger purges them on its own.
+function makeModule({ functionCount = 35, opsPerFunction = 1400, giantOps = 30000 } = {}) {
+  const out = new Bytes();
+  out.push(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
+
+  // type 0: (i32, i32) -> i32
+  const types = new Bytes();
+  types.push(1, 0x60, 2, 0x7f, 0x7f, 1, 0x7f);
+  out.section(1, types);
+
+  const funcs = new Bytes();
+  funcs.leb(functionCount);
+  for (let f = 0; f < functionCount; f++) funcs.byte(0);
+  out.section(3, funcs);
+
+  const exports = new Bytes();
+  exports.push(1, 1, 0x66, 0x00, 0); // export "f" = func 0
+  out.section(7, exports);
+
+  const code = new Bytes();
+  code.leb(functionCount);
+  for (let f = 0; f < functionCount; f++) {
+    const ops = f === 0 ? giantOps : opsPerFunction + ((f * 7919) % 400);
+    const body = new Bytes();
+    body.push(1, 1, 0x7f); // one local group: 1 x i32
+    body.push(0x20, 0); // local.get 0
+    for (let i = 0; i < ops; i++) {
+      // block
+      //   local.get 1; i32.const k; i32.add; local.tee 2
+      //   br_table {0,0,0,0} 0
+      //   local.get 2; local.get 0; call g; drop
+      // end
+      // local.get 2; i32.xor
+      body.push(0x02, 0x40, 0x20, 1, 0x41);
+      body.leb((f * 31 + i * 7) & 0x3f);
+      body.push(0x6a, 0x22, 2, 0x0e, 4, 0, 0, 0, 0, 0, 0x20, 2, 0x20, 0, 0x10);
+      body.leb((f + 1) % functionCount);
+      body.push(0x1a, 0x0b, 0x20, 2, 0x73);
+    }
+    body.byte(0x0b); // end
+    code.leb(body.len);
+    code.append(body);
+  }
+  out.section(10, code);
+  return out.bytes();
+}
+
+const targetMiB = Number(process.argv[2]);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const bytes = makeModule();
+Bun.gc(true);
+await sleep(50);
+Bun.gc(true);
+
+const base = process.memoryUsage().rss;
+for (let i = 0; i < 3; i++) {
+  let mod = await WebAssembly.compile(bytes);
+  mod = null;
+}
+// Free the modules. The main thread frees their metadata into the compiler threads' pages, and only
+// those threads can hand that memory back. They do so once they have worked and gone idle again, so
+// give each of them one trivial function to compile after the modules are gone.
+Bun.gc(true);
+await WebAssembly.compile(makeModule({ functionCount: 16, opsPerFunction: 1, giantOps: 1 }));
+Bun.gc(true);
+const afterCompiles = process.memoryUsage().rss - base;
+
+const deadline = performance.now() + 3000;
+let min = Infinity;
+while (performance.now() < deadline && min / 1048576 >= targetMiB) {
+  await sleep(100);
+  Bun.gc(true);
+  min = Math.min(min, process.memoryUsage().rss - base);
+}
+console.log(
+  JSON.stringify({
+    moduleMiB: bytes.length / 1048576,
+    afterCompilesDeltaMiB: afterCompiles / 1048576,
+    idleDeltaMiB: min / 1048576,
+  }),
+);

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -1,4 +1,4 @@
-// Fixture for compile-rss.test.ts. Compiles a generated wasm module 3 times, discards each result,
+// Fixture for compile-rss.test.ts. Compiles a generated wasm module 6 times, discards each result,
 // then polls RSS until it falls below the target (argv[2], MiB) or the deadline passes. The idle
 // compiler threads exit after 10 s and release everything then, so the deadline stays well below
 // that. Prints one JSON line with the lowest RSS growth seen, relative to the RSS before the first
@@ -94,11 +94,10 @@ function makeModule({ functionCount = 35, opsPerFunction = 1400, giantOps = 3000
 const targetMiB = Number(process.argv[2]);
 if (!Number.isFinite(targetMiB)) throw new Error(`expected the target in MiB as argv[2], got ${process.argv[2]}`);
 // On Darwin mimalloc returns memory with MADV_FREE_REUSABLE, which the kernel keeps counted in RSS
-// until it reuses the pages. phys_footprint drops at once, so measure that there.
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+// until it reuses the pages. phys_footprint drops at once, so measure that there. memoryFootprint()
+// returns undefined when task_info fails, so fall back to RSS.
+const rss = () =>
+  (process.platform === "darwin" ? Bun.unsafe.memoryFootprint?.() : undefined) ?? process.memoryUsage.rss();
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 const bytes = makeModule();
 
@@ -112,7 +111,9 @@ for (const deadline = performance.now() + 2000; performance.now() < deadline; ) 
   if (now >= base - 1048576) break;
   base = now;
 }
-for (let i = 0; i < 3; i++) {
+// Each compile adds to what the unfixed threads keep (8 threads: 18 to 27 MiB after 3 compiles,
+// 35 to 39 MiB after 6) and costs about 20 ms. The fixed build returns to the baseline either way.
+for (let i = 0; i < 6; i++) {
   let mod = await WebAssembly.compile(bytes);
   mod = null;
 }

--- a/test/js/bun/wasm/compile-rss.test.ts
+++ b/test/js/bun/wasm/compile-rss.test.ts
@@ -26,6 +26,8 @@ test.skipIf(isDebug || isASAN)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const result = JSON.parse(stdout.trim().split("\n").at(-1)!);
+    // The compiles have to grow RSS well past the target first, or the check below means nothing.
+    expect(result.peakDeltaMiB).toBeGreaterThan(idleTargetMiB * 2);
     expect(result.idleDeltaMiB).toBeLessThan(idleTargetMiB);
     expect(exitCode).toBe(0);
   },

--- a/test/js/bun/wasm/compile-rss.test.ts
+++ b/test/js/bun/wasm/compile-rss.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import path from "node:path";
+
+// Unfixed, the 8 idle wasm compiler threads keep 17 to 25 MB of freed compile temporaries until
+// they exit after 10 s. Fixed, they release it about 100 ms after the last compile and RSS returns
+// to where it started.
+const idleTargetMiB = 10;
+
+// Debug and ASAN builds link a JavaScriptCore that does not allocate through mimalloc, so the
+// per-thread retention this test checks for does not exist there.
+test.skipIf(isDebug || isASAN)(
+  "WebAssembly.compile does not retain memory in idle compiler threads (#41438)",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "compile-rss-fixture.mjs"), String(idleTargetMiB)],
+      env: {
+        ...bunEnv,
+        // The retained amount scales with the compiler thread count. Pin it so the test does not
+        // depend on the core count of the machine.
+        BUN_JSC_numberOfWasmCompilerThreads: "8",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim().split("\n").at(-1)!);
+    expect(result.idleDeltaMiB).toBeLessThan(idleTargetMiB);
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/wasm/compile-rss.test.ts
+++ b/test/js/bun/wasm/compile-rss.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import path from "node:path";
 
-// Unfixed, the 8 idle wasm compiler threads keep 17 to 25 MB of freed compile temporaries until
+// Unfixed, the 8 idle wasm compiler threads keep 35 to 39 MiB of freed compile temporaries until
 // they exit after 10 s. Fixed, they release it about 100 ms after the last compile and RSS returns
 // to where it started.
 const idleTargetMiB = 10;
@@ -26,9 +26,13 @@ test.skipIf(isDebug || isASAN)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const result = JSON.parse(stdout.trim().split("\n").at(-1)!);
-    // The compiles have to grow RSS well past the target first, or the check below means nothing.
-    expect(result.peakDeltaMiB).toBeGreaterThan(idleTargetMiB * 2);
-    expect(result.idleDeltaMiB).toBeLessThan(idleTargetMiB);
+    // The whole measurement is in the object so a failure prints it. The compiles have to grow RSS
+    // well past the target first, or the idle check means nothing.
+    expect({
+      ...result,
+      grew: result.peakDeltaMiB > idleTargetMiB * 2,
+      released: result.idleDeltaMiB < idleTargetMiB,
+    }).toMatchObject({ grew: true, released: true });
     expect(exitCode).toBe(0);
   },
 );


### PR DESCRIPTION
### Problem
- `WebAssembly.compile` of a 4 MB module leaves about 10 MB of RSS per wasm compiler thread behind, and the memory does not come back when the `WebAssembly.Module` is collected. The issue's script ends at +150 MB on 16 cores and +340 MB on 32 cores (#41438). It all returns at the 10 s mark, when the idle threads time out and exit.
- Only the owning thread can collect its mimalloc thread-local heap. A JSC `AutomaticThread` that finishes a compile and waits on its condition keeps every page it freed until it exits or works again. The wasm compiler threads, the DFG/FTL worklist threads and the GC helpers all wait this way.

### Fix
- oven-sh/WebKit#567: when an `AutomaticThread` has waited 100 ms without a notify, it releases its thread-local heap (`mi_on_thread_idle()`, the same hook Bun's event loop and thread pool call) with the worklist lock dropped, then waits out the rest of its timeout. A thread notified within 100 ms pays nothing.
- This PR pins `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-567-e62d118e`) so CI runs Bun against it. The tag is two commits past the current `2e2aa2290fac` pin: oven-sh/WebKit#566 (CodeBlock aging refreshes its execution-counter snapshot on every look) and the #567 commit. Before landing, oven-sh/WebKit#567 has to merge and the pin has to move to the resulting main sha.
- Test: `test/js/bun/wasm/compile-rss.test.ts` spawns `compile-rss-fixture.mjs` with 8 compiler threads. The fixture compiles a tree-sitter shaped module (35 functions, one giant, 2.2 MB) 6 times, drops the modules, then polls RSS for up to 3 s against a 10 MiB bound. Unfixed it stays at +35 to +39 MiB. Fixed it returns to the starting RSS within a few hundred ms, and the whole test takes about 0.7 s. Skipped on debug and ASAN builds: their JSC prebuilts do not allocate through mimalloc.
- Supersedes #41452, which pinned the same tag with a heavier test (16 threads, a 6.3 MB module compiled 20 times, about 700 MiB peak RSS). Its `memoryFootprint()` fallback and its failure output that prints every number are folded in here.
- Verified: the test fails on bun 1.4.1 and on a release build of main (idle +30 MiB), and passes 3 of 3 runs on a release build of this branch. The issue's script on the same build: +12 MB after 30 compiles, was +150 MB. Also green on the fixed build: `test/js/bun/wasm/`, `test/js/bun/jsc/`, `jsc-stress.test.ts`, `test/js/web/workers/`. Self-reviewed: 1 concern raised (the jsc shell could not link the new symbol), addressed in the WebKit PR.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit. `scripts/build/deps/webkit.ts` pins which build. An engine fix lands as a WebKit PR plus a pin bump here, and `autobuild-preview-pr-*` tags let the bump PR run Bun's suite against the WebKit PR before it merges.
- mimalloc gives each thread its own heap. A block freed by another thread goes on the page's `thread_free` list, and a page emptied by its owner is retired rather than unmapped. Both wait for the owner to run a collect. mimalloc's scavenger thread purges memory that is already free at the arena level, but it cannot walk another thread's heap while that thread may allocate.
- `AutomaticThread` is WTF's worker thread with a lifetime: it polls for work under a shared lock, waits on a condition when there is none, and exits after 10 s of silence.

<details><summary>Notes</summary>

Repro on Linux x64, 16 cores, bun 1.4.1 (the issue's script, 30 compiles of `tree-sitter-cpp.wasm`):

```
after 30 compiles: +150 MB rss
idle 9s: +146 MB rss
idle 10s: +3 MB rss      <- the compiler threads exit here
```

Scaling with `BUN_JSC_numberOfWasmCompilerThreads`: 15 threads +132 MB, 8 +105 MB, 4 +66 MB, 2 +31 MB, 1 +18 MB. `MIMALLOC_PURGE_DELAY=0` gives +29 MB, which points at the allocator and not at the compiled code.

Why the fixture's module is shaped like a tree-sitter parser: a uniform module of thousands of small functions does not show the retention. Its compile temporaries end up in fully free pages, which mimalloc's scavenger purges on its own. Large control-flow heavy functions leave pages that are partly used or that hold blocks the main thread frees later, and those need the owner.

Why the fixture compiles a trivial 16-function module after dropping the real ones: the main thread frees the dead modules' metadata into the compiler threads' pages. A thread hands that back the next time it works and goes idle. Without this step the fixed build kept 2 to 10 MB of late cross-thread frees, which made the threshold fragile.

The second preview build of the WebKit PR crashed Bun at 110 ms of idle: the first version re-polled after the release, and `JITWorklistThread::poll` counts one deactivation per Wait, so the extra poll tripped `RELEASE_ASSERT(m_numberOfActiveThreads)`. The thread now stays in the waiting state through the release and polls again only if a notify arrived.

Margin probe on Linux x64, 8 compiler threads, release builds, 3 s poll, lowest idle delta seen (MiB):

```
compiles   unfixed main        fixed (preview-pr-567)
3          17, 21, 19          0, -3, -8
6          35, 38, 39          0, -3, -1
10         50, 41, 45          -9, -11, -6
```

Each compile adds about 20 ms. The test uses 6.
</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 3 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/wasm/compile-rss.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/wasm/compile-rss.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/wasm/compile-rss.test.ts:
(skip) WebAssembly.compile does not retain memory in idle compiler threads (#41438)

 0 pass
 1 skip
 0 fail
Ran 1 test across 1 file. [2.06s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts             |   2 +-
 test/js/bun/wasm/compile-rss-fixture.mjs | 144 +++++++++++++++++++++++++++++++
 test/js/bun/wasm/compile-rss.test.ts     |  38 ++++++++
 3 files changed, 183 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
scripts/build/deps/webkit.ts                  0      0     16
test/js/bun/wasm/compile-rss-fixture.mjs      1      2     34
test/js/bun/wasm/compile-rss.test.ts          0      2     15
```

</details>

<!-- robobun:evidence:end -->
