### PR TITLE
fetch: drain all decoded zstd output before waiting for more input

### DIFF
--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -577,10 +577,13 @@ impl StreamingDecoder {
         }
 
         let mut total_in = 0usize;
+        // zstd may hold decoded bytes it could not fit into the last output
+        // window. Call it again with no input until it leaves the window short.
+        let mut output_full = false;
         while matches!(self.state, State::Uninitialized | State::Inflating) {
             let next_in = &input[total_in..];
 
-            if next_in.is_empty() {
+            if next_in.is_empty() && !output_full {
                 if is_done {
                     if self.state == State::Inflating {
                         self.state = State::Error;
@@ -628,6 +631,7 @@ impl StreamingDecoder {
 
             let bytes_written = out_buf.pos;
             let bytes_read = in_buf.pos;
+            output_full = bytes_written == out_buf.size;
             // SAFETY: zstd wrote exactly `bytes_written` initialized bytes into
             // the spare capacity starting at the previous len.
             unsafe { bun_core::vec::commit_spare(out, bytes_written) };
@@ -651,7 +655,7 @@ impl StreamingDecoder {
             self.state = State::Inflating;
 
             if bytes_read == next_in.len() {
-                if bytes_written > 0 {
+                if output_full {
                     continue;
                 }
                 if is_done {

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -1466,3 +1466,64 @@ test.concurrent(
     expect(exitCode).toBe(0);
   },
 );
+
+// https://github.com/oven-sh/bun/issues/41439
+// A flushed zstd chunk that decodes to more than 4096 bytes must reach the
+// reader in full. The decoder used to hand over 4096 bytes and keep the rest
+// until the next compressed chunk arrived.
+test("fetch zstd streaming body delivers the whole flushed chunk at once", async () => {
+  const firstLine = Buffer.alloc(20000, "x").toString() + "\n";
+  const secondLine = "done\n";
+
+  // Compress the two lines as one zstd stream, with a flush after the first
+  // line, so the server can send each compressed part on its own.
+  const compressor = zlib.createZstdCompress();
+  const compressed: Buffer[] = [];
+  compressor.on("data", chunk => compressed.push(chunk));
+  await new Promise<void>(resolve => {
+    compressor.write(firstLine);
+    compressor.flush(resolve);
+  });
+  const firstPart = Buffer.concat(compressed.splice(0));
+  const ended = new Promise<void>(resolve => compressor.once("end", resolve));
+  compressor.end(secondLine);
+  await ended;
+  const restPart = Buffer.concat(compressed.splice(0));
+  expect(firstPart.byteLength).toBeGreaterThan(0);
+  expect(restPart.byteLength).toBeGreaterThan(0);
+
+  const { promise: sendRest, resolve: releaseRest } = Promise.withResolvers<void>();
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            controller.enqueue(firstPart);
+            await sendRest;
+            controller.enqueue(restPart);
+            controller.close();
+          },
+        }),
+        { headers: { "Content-Encoding": "zstd", "Content-Type": "application/x-ndjson" } },
+      );
+    },
+  });
+
+  const response = await fetch(server.url, { headers: { "Accept-Encoding": "zstd" } });
+  const reader = response.body!.getReader();
+
+  const first = await reader.read();
+  expect(first.done).toBe(false);
+  expect(first.value!.byteLength).toBe(firstLine.length);
+  expect(Buffer.from(first.value!).toString()).toBe(firstLine);
+
+  releaseRest();
+  let rest = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    rest += Buffer.from(value).toString();
+  }
+  expect(rest).toBe(secondLine);
+});


### PR DESCRIPTION
### Problem
- A streamed `fetch()` response with `Content-Encoding: zstd` reaches the reader in 4096-byte pieces. After the server flushes a frame that decodes to 60001 bytes, the first `reader.read()` returns 4096 bytes. The rest arrives only with the next compressed chunk. gzip, deflate, and Node deliver the whole flushed chunk at once. Reported in #41439 (the brotli half is #41441).
- The cause is in `StreamingDecoder::decompress` (`src/zstd/lib.rs:569`). Each step offers zstd a 4096-byte output window. When a step fills the window and consumes all input, the loop runs again, finds the input empty, and returns. zstd still holds the rest of the decoded bytes and hands them over on the next call, seconds later.

### Fix
- Track `output_full` per step (`bytes_written == out_buf.size`). When the input is empty and the last step filled the window, call `ZSTD_decompressStream` again with no input. Stop on the first step that leaves the window short, or on frame end.
- This is the documented zstd streaming contract: a return value above zero after a full output buffer means "call again to flush". The window is never zero bytes, so a full window always means progress. The loop cannot spin.
- `DecompressionStream("zstd")` in `src/runtime/webcore/CompressionStreamCoder.rs:687` already checks the window this way. Only the HTTP client path was missing it.
- Verified: `test/js/web/fetch/fetch.stream.test.ts` (new test, stock bun gets 4096 bytes instead of 20001). Also the zstd cases of `fetch.stream.test.ts`, `test/js/bun/util/zstd.test.ts`, `fetch-compress.test.ts`, and the repro from the issue.

### Background
- `bun_zstd::StreamingDecoder` is the zstd path of `src/http/Decompressor.rs`. The HTTP client calls `decompress` once per body chunk it receives from the socket, and appends the output to the decoded body buffer. A `ShortRead` or `Ok` return means "wait for the next chunk".
- `ZSTD_decompressStream` writes as much as fits in the caller's output buffer. Its return value is 0 when a frame is complete. Any other value is a hint for more input, but when the output buffer is full it also means decoded bytes are still buffered inside zstd.

<details><summary>Notes</summary>

The issue's repro (Node `createZstdCompress` server with `flush()` after a 60001-byte line, Bun client):

```
before: chunk 4096 at 12ms, chunk 55910 at 511ms, chunk 5 at 1012ms
after:  chunk 60001 at 766ms, chunk 5 at 1161ms, chunk 5 at 1657ms
```

The new test compresses a 20001-byte line and a 5-byte line as one zstd stream with a flush between them, and serves the two parts from a `Bun.serve` `ReadableStream`. The second part is held back until the client has read the first. The first `read()` must return the whole first line.

The old `bytes_written > 0` guard also made a final chunk (`is_done`) that decodes to more than one window report a decompression error: the loop continued, found the input empty, and hit the `is_done` error branch before zstd could report frame end. The new loop drains first, so the frame end is seen.

`fetch.stream.test.ts` "Content-Length response works (multiple parts)" variants for identity, gzip, and deflate sit at the 5 s timeout under the ASAN debug build in this container. They do not use zstd, the zstd and br variants pass, and #41441 saw the same.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.stream.test.ts

<!-- robobun:evidence:end -->