### PR TITLE
WebKit preview-pr-567: idle wasm compiler threads release the memory they freed (#41438)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-567-e62d118e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -1,0 +1,90 @@
+// Compile one control-flow-heavy wasm module many times, drop every Module,
+// then watch RSS. Prints one JSON line: how far above the pre-compile
+// baseline RSS settled, and how long that took.
+//
+// The module is F functions, each `(local.get 0)` followed by OPS copies of
+// `(block (br_if 0 (local.get 0)))`. Blocks and branches are what make the
+// compiler threads allocate (control stack, IPInt metadata); straight-line
+// arithmetic of the same byte size retains almost nothing.
+const F = 1500;
+const OPS = 600;
+const COMPILES = 20;
+const SETTLED_MIB = +process.env.SETTLED_MIB;
+const DEADLINE_MS = +process.env.DEADLINE_MS;
+
+function leb(n) {
+  const out = [];
+  do {
+    let byte = n & 0x7f;
+    n >>>= 7;
+    if (n) byte |= 0x80;
+    out.push(byte);
+  } while (n);
+  return out;
+}
+
+const bodyLen = 3 + OPS * 7 + 1;
+const fnHeader = leb(bodyLen);
+const codeCount = leb(F);
+const codeLen = codeCount.length + F * (fnHeader.length + bodyLen);
+const typeSec = [1, 0x60, 1, 0x7f, 1, 0x7f];
+const funcSec = [...leb(F), ...new Array(F).fill(0)];
+const sizeOf = sec => 1 + leb(sec.length).length + sec.length;
+const total = 8 + sizeOf(typeSec) + sizeOf(funcSec) + 1 + leb(codeLen).length + codeLen;
+
+// Write straight into one Uint8Array so the baseline is not inflated by
+// megabytes of number arrays waiting to be collected.
+const bytes = new Uint8Array(total);
+let p = 0;
+const put = arr => {
+  for (const x of arr) bytes[p++] = x;
+};
+put([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+put([1, ...leb(typeSec.length), ...typeSec]);
+put([3, ...leb(funcSec.length), ...funcSec]);
+put([10, ...leb(codeLen), ...codeCount]);
+for (let f = 0; f < F; f++) {
+  put(fnHeader);
+  put([0x00, 0x20, 0x00]);
+  for (let i = 0; i < OPS; i++) put([0x02, 0x40, 0x20, 0x00, 0x0d, 0x00, 0x0b]);
+  bytes[p++] = 0x0b;
+}
+if (p !== total) throw new Error(`module size mismatch: wrote ${p}, expected ${total}`);
+
+const rssMiB = () => process.memoryUsage().rss / 1048576;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+Bun.gc(true);
+await sleep(300);
+Bun.gc(true);
+const base = rssMiB();
+
+for (let i = 0; i < COMPILES; i++) {
+  let mod = await WebAssembly.compile(bytes);
+  mod = null;
+}
+Bun.gc(true);
+const peak = rssMiB() - base;
+
+const start = performance.now();
+let delta = peak;
+let settledAfterMs = -1;
+while (performance.now() - start < DEADLINE_MS) {
+  await sleep(250);
+  Bun.gc(true);
+  delta = rssMiB() - base;
+  if (delta <= SETTLED_MIB) {
+    settledAfterMs = Math.round(performance.now() - start);
+    break;
+  }
+}
+
+console.log(
+  JSON.stringify({
+    moduleBytes: bytes.length,
+    baseMiB: Math.round(base),
+    peakMiB: Math.round(peak),
+    deltaMiB: Math.round(delta),
+    settledAfterMs,
+  }),
+);

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -51,7 +51,13 @@ for (let f = 0; f < F; f++) {
 }
 if (p !== total) throw new Error(`module size mismatch: wrote ${p}, expected ${total}`);
 
-const rssMiB = () => process.memoryUsage().rss / 1048576;
+// On macOS mimalloc returns memory with MADV_FREE_REUSABLE, which leaves RSS
+// untouched until the kernel needs the pages. phys_footprint drops at once.
+const footprint =
+  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
+    ? Bun.unsafe.memoryFootprint
+    : () => process.memoryUsage().rss;
+const rssMiB = () => footprint() / 1048576;
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 Bun.gc(true);

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -53,10 +53,9 @@ if (p !== total) throw new Error(`module size mismatch: wrote ${p}, expected ${t
 
 // On macOS mimalloc returns memory with MADV_FREE_REUSABLE, which leaves RSS
 // untouched until the kernel needs the pages. phys_footprint drops at once.
-const footprint =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : () => process.memoryUsage().rss;
+// memoryFootprint() is undefined when task_info fails, so fall back to RSS.
+const footprint = () =>
+  (process.platform === "darwin" ? Bun.unsafe.memoryFootprint?.() : undefined) ?? process.memoryUsage().rss;
 const rssMiB = () => footprint() / 1048576;
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 

--- a/test/js/bun/wasm/compile-rss-fixture.mjs
+++ b/test/js/bun/wasm/compile-rss-fixture.mjs
@@ -60,6 +60,9 @@ const footprint =
 const rssMiB = () => footprint() / 1048576;
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
+// Startup garbage is freed by the first collection, but mimalloc hands the
+// emptied pages back on its purge delay, not at free time. There is no event
+// for that, so give it a moment before the baseline read.
 Bun.gc(true);
 await sleep(300);
 Bun.gc(true);

--- a/test/js/bun/wasm/compile-rss.test.ts
+++ b/test/js/bun/wasm/compile-rss.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { join } from "node:path";
 
 // JSC compiles wasm on a pool of AutomaticThreads, one per core. Each thread
@@ -12,35 +12,40 @@ import { join } from "node:path";
 //
 // ASAN builds link JSC against the sanitizer allocator, not mimalloc. The
 // release path does not exist there, and ASAN's own per-thread caches hold
-// hundreds of MB per compile on their own.
-test.skipIf(isASAN)("idle wasm compiler threads release the memory they freed (oven-sh/bun#41438)", async () => {
-  // A fixed thread count keeps the number stable across hosts. With 16
-  // threads the unfixed build sits 100 to 115 MiB above the baseline for
-  // the full 10 s on a 16-core Linux x64 box. The fixed build settles at
-  // 4 to 6 MiB there and about 15 MiB on Linux aarch64 CI, within 1 s.
-  const settledMiB = 30;
-  // Far under the 10 s AutomaticThread timeout, so an unfixed build cannot
-  // pass by outliving its compiler threads.
-  const deadlineMs = 3000;
+// hundreds of MB per compile on their own. A debug JSC compiles the 6.3 MB
+// module many times slower than release, so 20 compiles do not fit the 5 s
+// test budget. CI runs release and ASAN lanes, so release is where this runs.
+test.skipIf(isASAN || isDebug)(
+  "idle wasm compiler threads release the memory they freed (oven-sh/bun#41438)",
+  async () => {
+    // A fixed thread count keeps the number stable across hosts. With 16
+    // threads the unfixed build sits 100 to 115 MiB above the baseline for
+    // the full 10 s on a 16-core Linux x64 box. The fixed build settles at
+    // 4 to 6 MiB there and about 15 MiB on Linux aarch64 CI, within 1 s.
+    const settledMiB = 30;
+    // Far under the 10 s AutomaticThread timeout, so an unfixed build cannot
+    // pass by outliving its compiler threads.
+    const deadlineMs = 3000;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "compile-rss-fixture.mjs")],
-    env: {
-      ...bunEnv,
-      BUN_JSC_numberOfWasmCompilerThreads: "16",
-      SETTLED_MIB: String(settledMiB),
-      DEADLINE_MS: String(deadlineMs),
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const result = JSON.parse(stdout.trim().split("\n").at(-1)!);
-  // The whole measurement is in the object so a failure prints it.
-  expect({ ...result, settled: result.settledAfterMs >= 0 && result.deltaMiB <= settledMiB }).toMatchObject({
-    moduleBytes: expect.any(Number),
-    settled: true,
-  });
-  expect(exitCode).toBe(0);
-});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "compile-rss-fixture.mjs")],
+      env: {
+        ...bunEnv,
+        BUN_JSC_numberOfWasmCompilerThreads: "16",
+        SETTLED_MIB: String(settledMiB),
+        DEADLINE_MS: String(deadlineMs),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim().split("\n").at(-1)!);
+    // The whole measurement is in the object so a failure prints it.
+    expect({ ...result, settled: result.settledAfterMs >= 0 && result.deltaMiB <= settledMiB }).toMatchObject({
+      moduleBytes: expect.any(Number),
+      settled: true,
+    });
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/wasm/compile-rss.test.ts
+++ b/test/js/bun/wasm/compile-rss.test.ts
@@ -14,10 +14,11 @@ import { join } from "node:path";
 // release path does not exist there, and ASAN's own per-thread caches hold
 // hundreds of MB per compile on their own.
 test.skipIf(isASAN)("idle wasm compiler threads release the memory they freed (oven-sh/bun#41438)", async () => {
-  // Eight compiler threads keep the number stable across hosts. On a
-  // 16-core Linux box the unfixed build sits 25 to 45 MiB above the
-  // baseline for the full 10 s, the fixed one 1 to 4 MiB above within 1 s.
-  const settledMiB = 10;
+  // A fixed thread count keeps the number stable across hosts. With 16
+  // threads the unfixed build sits 100 to 115 MiB above the baseline for
+  // the full 10 s on a 16-core Linux x64 box. The fixed build settles at
+  // 4 to 6 MiB there and about 15 MiB on Linux aarch64 CI, within 1 s.
+  const settledMiB = 30;
   // Far under the 10 s AutomaticThread timeout, so an unfixed build cannot
   // pass by outliving its compiler threads.
   const deadlineMs = 3000;
@@ -26,7 +27,7 @@ test.skipIf(isASAN)("idle wasm compiler threads release the memory they freed (o
     cmd: [bunExe(), join(import.meta.dir, "compile-rss-fixture.mjs")],
     env: {
       ...bunEnv,
-      BUN_JSC_numberOfWasmCompilerThreads: "8",
+      BUN_JSC_numberOfWasmCompilerThreads: "16",
       SETTLED_MIB: String(settledMiB),
       DEADLINE_MS: String(deadlineMs),
     },

--- a/test/js/bun/wasm/compile-rss.test.ts
+++ b/test/js/bun/wasm/compile-rss.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+import { join } from "node:path";
+
+// JSC compiles wasm on a pool of AutomaticThreads, one per core. Each thread
+// has its own mimalloc heap, and only the owner can return that heap's freed
+// pages to the OS. Before oven-sh/WebKit#567 an idle compiler thread kept
+// everything it had freed until it exited after 10 s without work, so RSS
+// after `WebAssembly.compile` grew with the core count and not with the live
+// modules (oven-sh/bun#41438). The threads now release their heap after
+// 100 ms idle.
+//
+// ASAN builds link JSC against the sanitizer allocator, not mimalloc. The
+// release path does not exist there, and ASAN's own per-thread caches hold
+// hundreds of MB per compile on their own.
+test.skipIf(isASAN)("idle wasm compiler threads release the memory they freed (oven-sh/bun#41438)", async () => {
+  // Eight compiler threads keep the number stable across hosts. On a
+  // 16-core Linux box the unfixed build sits 25 to 45 MiB above the
+  // baseline for the full 10 s, the fixed one 1 to 4 MiB above within 1 s.
+  const settledMiB = 10;
+  // Far under the 10 s AutomaticThread timeout, so an unfixed build cannot
+  // pass by outliving its compiler threads.
+  const deadlineMs = 3000;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "compile-rss-fixture.mjs")],
+    env: {
+      ...bunEnv,
+      BUN_JSC_numberOfWasmCompilerThreads: "8",
+      SETTLED_MIB: String(settledMiB),
+      DEADLINE_MS: String(deadlineMs),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim().split("\n").at(-1)!);
+  // The whole measurement is in the object so a failure prints it.
+  expect({ ...result, settled: result.settledAfterMs >= 0 && result.deltaMiB <= settledMiB }).toMatchObject({
+    moduleBytes: expect.any(Number),
+    settled: true,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `WebAssembly.compile` leaves about 4 to 10 MB of RSS per wasm compiler thread behind, and the memory does not come back when the `WebAssembly.Module` is collected. The amount scales with the core count, not with the live modules: +124 MB on a 16-core Linux box with the default thread count, +340 MB on the reporter's 32 cores (#41438). It all returns at the 10 s mark, when the idle compiler threads exit.
- Only the owning thread can collect its mimalloc thread-local heap. A JSC `AutomaticThread` that finishes a compile and waits on its condition keeps every page it freed until it exits or works again.

### Fix
- Pins WebKit to the preview build of oven-sh/WebKit#567. An `AutomaticThread` that has waited 100 ms without a notify now releases its thread-local heap (`mi_on_thread_idle()`, the same hook Bun's event loop and thread pool call when idle), then waits out the rest of its timeout. A thread that gets work within 100 ms pays nothing.
- The preview tag is one commit on top of the current WebKit main. The pin also picks up oven-sh/WebKit#566 (CodeBlock aging refreshes its execution-counter snapshot on every look), the only other commit past the current pin `2e2aa2290fac`. Move the pin to the merge commit once #567 merges.
- Verified: `test/js/bun/wasm/compile-rss.test.ts` compiles a 6.3 MB control-flow-heavy module 20 times with 16 compiler threads and polls RSS (phys_footprint on macOS, where `MADV_FREE_REUSABLE` leaves RSS untouched) for 3 s against a 30 MiB bound. Fixed release build: +4 to +6 MiB within 1 s, 3 of 3 runs. Unfixed main release build: +102 and +103 MiB, never settles. Also `test/js/bun/wasm/`, `test/js/web/fetch/wasm-streaming.test.ts`, `test/js/bun/jsc/`, `test/js/bun/jsc-stress/` on the release build, and the ASAN debug build links and skips the new test.

### Background
- `AutomaticThread` is WTF's worker thread with a lifetime. It polls for work under a shared lock, waits on a condition when there is none, and exits after 10 s of silence. The wasm `Worklist`, the DFG/FTL `JITWorklist`, the GC helpers and the collector thread are all `AutomaticThread`s.
- mimalloc gives each thread its own heap. A block freed by another thread goes on the page's `thread_free` list, and a page emptied by its owner is retired rather than unmapped. Both wait for the owner to run a collect.
- The test skips under ASAN. Those builds link JSC against the sanitizer allocator, not mimalloc, so the release path does not exist there.

<details><summary>Notes</summary>

Probe on this 16-core Linux box, clean baseline (module bytes written straight into one `Uint8Array`), 8 compiler threads, 20 compiles of the 6.3 MB module, `Bun.gc(true)` before each read:

```
unfixed main (WebKit 2e2aa2290fac)     fixed (preview-pr-567-e62d118e)
after compiles: +287 MB                after compiles: +265 MB
idle 1s:  +55 MB                       idle 1s:  +32 MB
idle 2s:  +29 MB                       idle 2s:   +5 MB
idle 9s:  +27 MB                       idle 9s:   +5 MB
idle 11s:  -2 MB  (threads exit)       idle 11s:  +4 MB
```

Default thread count (15 here): unfixed +124 MB until the threads exit, fixed +5 MB.

Shape matters. The module is 1500 functions of 600 `(block (br_if 0 (local.get 0)))` each. A module of the same byte size made of straight-line `i32.const/add/shl` retains almost nothing, which matches tree-sitter grammars (large switch and `br_table` lexers) being the real-world trigger.

The test uses a fixture file, not `-e`, because the module generator is 40 lines. The per-test budget is the default 5 s: the fixed run takes about 1 s, the unfixed run 4 s (3 s poll deadline plus the compiles).

First CI run, with 8 threads and a 10 MiB bound: Linux aarch64 lanes settled at 11 to 15 MiB, and both macOS lanes never moved off the peak (613 and 486 MiB) because RSS does not reflect `MADV_FREE_REUSABLE`. The fixture now reads `Bun.unsafe.memoryFootprint()` on macOS, the same idiom as `test/js/bun/shell/leak.test.ts`, and uses 16 threads so the unfixed build sits at 100 to 115 MiB against a 30 MiB bound.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 2 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/wasm/compile-rss.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/wasm/compile-rss.test.ts
bun test v1.4.3 (e0a2b82fd)

test/js/bun/wasm/compile-rss.test.ts:
(skip) idle wasm compiler threads release the memory they freed (oven-sh/bun#41438)

 0 pass
 1 skip
 0 fail
Ran 1 test across 1 file. [1.84s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts             |  2 +-
 test/js/bun/wasm/compile-rss-fixture.mjs | 98 ++++++++++++++++++++++++++++++++
 test/js/bun/wasm/compile-rss.test.ts     | 51 +++++++++++++++++
 3 files changed, 150 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
scripts/build/deps/webkit.ts                  1      0     14
test/js/bun/wasm/compile-rss-fixture.mjs      1      2     17
test/js/bun/wasm/compile-rss.test.ts          3      5     14
```

</details>

**root cause** · written by the author bot

Allocations made and freed on JSC's WebAssembly compiler worker threads during `WebAssembly.compile` remained in each thread's allocator-local heap, and since JSC keeps roughly one worker per core alive for about ten seconds after the last plan, tens of megabytes per thread stayed resident even after every Module was dropped and collected. The fix pins Bun to a WebKit build that makes idle compiler worker threads release their thread-local heap after a short idle interval instead of waiting for thread exit, so RSS settles within seconds and no longer scales with core count. A regression tes…

<!-- robobun:evidence:end -->