### PR TITLE
install: replace an empty directory in an isolated link slot with the link

### DIFF
--- a/src/install/isolated_install/Symlinker.rs
+++ b/src/install/isolated_install/Symlinker.rs
@@ -75,10 +75,7 @@ impl Symlinker {
                                         _ => Err(symlink_err),
                                     },
                                 },
-                                // dest exists but isn't a symlink. A real directory
-                                // with a package.json is the `bun patch <pkg>`
-                                // workspace the user is editing before `--commit`:
-                                // keep it. Anything else is replaced.
+                                // A real directory with a package.json is a `bun patch` workspace: keep it.
                                 _ => {
                                     #[cfg(windows)]
                                     let is_dir = if let Some(a) =

--- a/src/install/isolated_install/Symlinker.rs
+++ b/src/install/isolated_install/Symlinker.rs
@@ -77,11 +77,14 @@ impl Symlinker {
                                 },
                                 // readlink failed for a reason other than NOENT —
                                 // dest exists but isn't a symlink. If it's a real
-                                // directory, leave it: this is the `bun patch <pkg>`
-                                // workspace (a detached copy the user is editing
-                                // before `--commit`), and `deleteTree` here would
-                                // silently destroy their in-progress edits. If it's
-                                // a regular file, replace it.
+                                // directory with a package.json, leave it: this is
+                                // the `bun patch <pkg>` workspace (a detached copy
+                                // the user is editing before `--commit`), and
+                                // `deleteTree` here would silently destroy their
+                                // in-progress edits. A directory without a
+                                // package.json is not a package (an empty leftover
+                                // from a failed install or a manual `rm`), and a
+                                // regular file is never one: replace both.
                                 _ => {
                                     #[cfg(windows)]
                                     let is_dir = if let Some(a) =
@@ -100,9 +103,18 @@ impl Symlinker {
                                         false
                                     };
                                     if is_dir {
-                                        return Ok(false);
+                                        let has_package_json = {
+                                            let mut dest = self.dest.save();
+                                            let _ = dest.append(b"package.json");
+                                            bun_sys::exists_z(dest.slice_z())
+                                        };
+                                        if has_package_json {
+                                            return Ok(false);
+                                        }
+                                        let _ = Fd::cwd().delete_tree(self.dest.slice_z());
+                                    } else {
+                                        let _ = bun_sys::unlink(self.dest.slice_z());
                                     }
-                                    let _ = bun_sys::unlink(self.dest.slice_z());
                                     return self.symlink().map(|()| true);
                                 }
                             };

--- a/src/install/isolated_install/Symlinker.rs
+++ b/src/install/isolated_install/Symlinker.rs
@@ -75,16 +75,10 @@ impl Symlinker {
                                         _ => Err(symlink_err),
                                     },
                                 },
-                                // readlink failed for a reason other than NOENT —
-                                // dest exists but isn't a symlink. If it's a real
-                                // directory with a package.json, leave it: this is
-                                // the `bun patch <pkg>` workspace (a detached copy
-                                // the user is editing before `--commit`), and
-                                // `deleteTree` here would silently destroy their
-                                // in-progress edits. A directory without a
-                                // package.json is not a package (an empty leftover
-                                // from a failed install or a manual `rm`), and a
-                                // regular file is never one: replace both.
+                                // dest exists but isn't a symlink. A real directory
+                                // with a package.json is the `bun patch <pkg>`
+                                // workspace the user is editing before `--commit`:
+                                // keep it. Anything else is replaced.
                                 _ => {
                                     #[cfg(windows)]
                                     let is_dir = if let Some(a) =

--- a/src/install/isolated_install/Symlinker.rs
+++ b/src/install/isolated_install/Symlinker.rs
@@ -77,35 +77,15 @@ impl Symlinker {
                                 },
                                 // A real directory with a package.json is a `bun patch` workspace: keep it.
                                 _ => {
-                                    #[cfg(windows)]
-                                    let is_dir = if let Some(a) =
-                                        bun_sys::get_file_attributes(self.dest.slice_z())
-                                    {
-                                        a.is_directory && !a.is_reparse_point
-                                    } else {
-                                        false
+                                    let has_package_json = {
+                                        let mut dest = self.dest.save();
+                                        let _ = dest.append(b"package.json");
+                                        bun_sys::exists_z(dest.slice_z())
                                     };
-                                    #[cfg(not(windows))]
-                                    let is_dir = if let Ok(st) = bun_sys::lstat(self.dest.slice_z())
-                                    {
-                                        // `mode_t` is `u16` on darwin/freebsd/android, `u32` on linux.
-                                        bun_sys::posix::s_isdir(st.st_mode as u32)
-                                    } else {
-                                        false
-                                    };
-                                    if is_dir {
-                                        let has_package_json = {
-                                            let mut dest = self.dest.save();
-                                            let _ = dest.append(b"package.json");
-                                            bun_sys::exists_z(dest.slice_z())
-                                        };
-                                        if has_package_json {
-                                            return Ok(false);
-                                        }
-                                        let _ = Fd::cwd().delete_tree(self.dest.slice_z());
-                                    } else {
-                                        let _ = bun_sys::unlink(self.dest.slice_z());
+                                    if has_package_json {
+                                        return Ok(false);
                                     }
+                                    let _ = Fd::cwd().delete_tree(self.dest.slice_z());
                                     return self.symlink().map(|()| true);
                                 }
                             };

--- a/test/cli/install/isolated-relink.test.ts
+++ b/test/cli/install/isolated-relink.test.ts
@@ -170,6 +170,42 @@ test.concurrent(
   },
 );
 
+test.concurrent("an empty real directory in a root dependency's slot is replaced with the link", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(packageJson, oneRangeDep());
+  await installOk(packageDir);
+  const link = join(packageDir, "node_modules", "one-range-dep");
+  expect((await lstat(link)).isSymbolicLink()).toBeTrue();
+
+  await unlink(link);
+  await mkdir(link);
+  expect(existsSync(join(link, "package.json"))).toBeFalse();
+
+  // Root links are not counted in the summary, so only the tree is checked here.
+  await installOk(packageDir);
+  expect((await lstat(link)).isSymbolicLink()).toBeTrue();
+  expect(await file(join(link, "package.json")).json()).toMatchObject({ name: "one-range-dep", version: "1.0.0" });
+});
+
+test.concurrent("an empty real directory in a store entry's dependency slot is replaced with the link", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(packageJson, oneRangeDep());
+  await installOk(packageDir);
+  const link = await nestedNoDeps(packageDir);
+
+  await unlink(link);
+  await mkdir(link);
+
+  const out = await installOk(packageDir);
+  expect(out).not.toContain("(no changes)");
+  expect((await lstat(link)).isSymbolicLink()).toBeTrue();
+  expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.1.0" });
+
+  expect(await installOk(packageDir)).toContain("(no changes)");
+});
+
 test.concurrent.skipIf(!isWindows)("junction-mode warm install reports no changes", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
   const env = { BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS: "1" };

--- a/test/cli/install/isolated-relink.test.ts
+++ b/test/cli/install/isolated-relink.test.ts
@@ -1,7 +1,7 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "fs";
-import { lstat, mkdir, realpath, unlink } from "fs/promises";
+import { lstat, mkdir, readlink, realpath, unlink } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import { dirname, join } from "path";
 
@@ -204,6 +204,93 @@ test.concurrent("an empty real directory in a store entry's dependency slot is r
   expect(await nestedNoDepsPackageJson(link)).toStrictEqual({ name: "no-deps", version: "1.1.0" });
 
   expect(await installOk(packageDir)).toContain("(no changes)");
+});
+
+test.concurrent("a regular file in a root dependency's slot is replaced with the link", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(packageJson, oneRangeDep());
+  await installOk(packageDir);
+  const link = join(packageDir, "node_modules", "one-range-dep");
+
+  await unlink(link);
+  await write(link, "not a package");
+
+  await installOk(packageDir);
+  expect((await lstat(link)).isSymbolicLink()).toBeTrue();
+  expect(await file(join(link, "package.json")).json()).toMatchObject({ name: "one-range-dep", version: "1.0.0" });
+});
+
+// ninja creates the directory of every declared output before it runs the command, so bun's own build
+// runs `bun install` with an empty `node_modules/<new dep>/` already in place.
+test.concurrent("a new dependency is linked over an empty directory created before the install", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(packageJson, oneRangeDep());
+  await installOk(packageDir);
+
+  const nm = join(packageDir, "node_modules");
+  await write(
+    packageJson,
+    JSON.stringify({ name: "foo", dependencies: { "one-range-dep": "1.0.0", "what-bin": "1.0.0" } }),
+  );
+  await mkdir(join(nm, "what-bin"));
+
+  const out = await installOk(packageDir);
+  expect(out).toContain("what-bin@1.0.0");
+  expect((await lstat(join(nm, "what-bin"))).isSymbolicLink()).toBeTrue();
+  expect(await file(join(nm, "what-bin", "package.json")).json()).toMatchObject({ name: "what-bin", version: "1.0.0" });
+  expect(binFiles(nm, "what-bin").map(bin => existsSync(bin))).toStrictEqual(binFiles(nm, "what-bin").map(() => true));
+  expect(await binTargetContents(nm, "what-bin")).toContain("what-bin@1.0.0");
+});
+
+test.concurrent("empty directories in the .bun/node_modules and scoped slots are replaced with links", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(
+    packageJson,
+    JSON.stringify({ name: "foo", dependencies: { "no-deps": "1.0.0", "@types/is-number": "1.0.0" } }),
+  );
+  await installOk(packageDir);
+
+  const nm = join(packageDir, "node_modules");
+  const links = [
+    join(nm, "no-deps"),
+    join(nm, "@types", "is-number"),
+    join(nm, ".bun", "node_modules", "no-deps"),
+    join(nm, ".bun", "node_modules", "@types", "is-number"),
+  ];
+  const expected = await Promise.all(links.map(link => readlink(link)));
+  for (const link of links) {
+    await unlink(link);
+    await mkdir(link);
+  }
+
+  await installOk(packageDir);
+  expect(await Promise.all(links.map(link => readlink(link)))).toStrictEqual(expected);
+});
+
+test.concurrent("an empty directory in a workspace package's dependency slot is replaced with the link", async () => {
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({ name: "foo", workspaces: ["packages/*"] }),
+      "packages/pkg-1/package.json": JSON.stringify({
+        name: "pkg-1",
+        version: "1.0.0",
+        dependencies: { "a-dep": "1.0.1" },
+      }),
+    },
+  });
+  await installOk(packageDir);
+
+  const link = join(packageDir, "packages", "pkg-1", "node_modules", "a-dep");
+  const expected = await readlink(link);
+  await unlink(link);
+  await mkdir(link);
+
+  await installOk(packageDir);
+  expect(await readlink(link)).toBe(expected);
 });
 
 test.concurrent.skipIf(!isWindows)("junction-mode warm install reports no changes", async () => {


### PR DESCRIPTION
### Problem
- With `linker = "isolated"`, when `node_modules/<pkg>` is an empty real directory instead of the symlink into `node_modules/.bun/<pkg>@<ver>/`, `bun install` and `bun install --frozen-lockfile` report `(no changes)` and leave it as is. `node_modules/<pkg>/package.json` never exists. Deleting the link, or deleting the store entry, is repaired. Only the "empty directory in the link's place" case is missed.
- Cause: `Symlinker::ensure_symlink` (`src/install/isolated_install/Symlinker.rs:102`) keeps any real directory found at a link path. #29489 added that to protect a `bun patch <pkg>` workspace, which is a real directory at the same path. An empty directory matches the same check.

### Fix
- When `readlink` says the link path is not a symlink, probe `<dest>/package.json` with one syscall. If it exists, keep the directory (the patch workspace). If not, `delete_tree` removes whatever is there (a directory or a regular file) and the link is written. The separate `lstat` that classified the path is gone.
- Correct because a `bun patch` workspace is a copy of the package, so it always has a `package.json`. A directory without one is not a package. The hoisted linker uses the same signal (`PackageInstall::verify_package_json_name_and_version`) to decide whether an install is present.
- The same function writes the dependency links inside a store entry and the `.bun/node_modules/<pkg>` links, so those slots heal too.
- Verified: six new tests in `test/cli/install/isolated-relink.test.ts`. Five fail on the current release and pass with this change (the root slot, a store entry slot, the `.bun/node_modules` and scoped slots, a workspace package slot, and a new dependency whose directory exists before the install). The sixth pins that a regular file in the slot is replaced. `isolated-install.test.ts`, `isolated-relink.test.ts`, and the isolated tests in `bun-install-patch.test.ts` pass with a debug build.

### Background
- Isolated linker: each package is unpacked once into `node_modules/.bun/<pkg>@<ver>/node_modules/<pkg>`. `node_modules/<pkg>` at the project root, and each dependency slot inside a store entry, is a symlink into that store.
- `ensure_symlink` with `Strategy::ExpectExisting` reads the link at the destination. Right target: nothing to do. Nothing there: create it. Anything else is in the way. Only the "a directory is in the way" arm changes here.
- `bun patch <pkg>` replaces `node_modules/<pkg>` with a real directory that holds a copy of the package for the user to edit until `bun patch --commit`. Install must not delete it.

Supersedes #37757, which removes the directory with `rmdir` (so only an empty one). This change also repairs a leftover directory that has stray contents but no `package.json`. The tests from #37757 (the `.bun/node_modules` and scoped slots, a workspace package slot, and the `bun bd` case where ninja creates `node_modules/<new dep>/` before `bun install` runs) are folded into this branch. The summary line still says `(no changes)` when only a root link is rewritten. That is pre-existing: root and workspace entries are always counted as skipped in `Installer::on_task_complete`, also when the root link was deleted outright.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-relink.test.ts

<!-- robobun:evidence:end -->

