### PR TITLE
runner: dump the process tree and stacks of a stalled parallel batch before killing it

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1645,7 +1645,9 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
   // gdb is a sibling of the batch. Fall back to passwordless sudo when the
   // agent has it.
   let prefix = [];
-  const denied = lines => lines.some(line => /^(ptrace:|Could not attach)/.test(line));
+  // A permission failure is the same for every process. Any other attach
+  // failure (the process exited after `ps`, for one) is local to this pid.
+  const denied = lines => lines.some(line => /Operation not permitted|^Could not attach/.test(line));
   const backtrace = pid => {
     const [command, ...argv] = [...prefix, "gdb", "-p", String(pid), "-batch", "-ex", "thread apply all bt 16"];
     // spawnSync treats timeout 0 as "none", so never let it reach 0.
@@ -1654,11 +1656,13 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
       timeout: Math.max(1, Math.min(20_000, remaining())),
       stdio: ["ignore", "pipe", "pipe"],
     });
-    if (gdb.error) return { error: gdb.error.message, lines: [] };
-    const lines = `${gdb.stdout}\n${gdb.stderr}`
+    // A timeout still returns what gdb printed so far. Only a spawn failure
+    // (no gdb on this agent) has no output and ends the search.
+    const missing = gdb.error && gdb.error.code !== "ETIMEDOUT" ? gdb.error.message : undefined;
+    const lines = `${gdb.stdout ?? ""}\n${gdb.stderr ?? ""}`
       .split("\n")
       .filter(line => /^(Thread \d+|#\d+|ptrace:|warning: .*ptrace|Could not attach)/.test(line));
-    return { status: gdb.status, lines };
+    return { status: gdb.status, timedOut: gdb.error?.code === "ETIMEDOUT", missing, lines };
   };
   for (const { pid, args } of targets) {
     if (remaining() < 5_000) {
@@ -1677,12 +1681,12 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
       prefix = ["sudo", "-n"];
       result = backtrace(pid);
     }
-    if (result.error) {
-      out += `gdb failed: ${result.error}\n`;
+    if (result.missing) {
+      out += `gdb failed: ${result.missing}\n`;
       break;
     }
     out += result.lines.length ? `${result.lines.join("\n")}\n` : `no backtrace (exit ${result.status})\n`;
-    // Not allowed to attach: the same answer for every other process.
+    if (result.timedOut) out += `(gdb timed out, output above is partial)\n`;
     if (denied(result.lines)) break;
   }
   return out;

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1560,16 +1560,23 @@ async function runTests() {
  * every thread in each bun process. The output goes to the job log so a stall
  * that never reproduces locally still names the blocked process and its stack.
  *
- * Everything here is bounded: one `ps`, a few /proc reads, and at most
- * `maxBacktraces` gdb attaches of 20s each.
+ * The whole report has to finish within `budgetMs` of wall-clock time. It runs
+ * synchronously, so the caller's kill waits for it: one `ps`, a few /proc
+ * reads, then gdb attaches only while time remains.
  * @param {number} rootPid
  * @param {string} execPath the bun binary under test
+ * @param {number} [budgetMs]
  * @returns {string}
  */
-function describeStalledProcessTree(rootPid, execPath) {
+function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
   if (isWindows) return "";
+  const deadline = Date.now() + budgetMs;
+  const remaining = () => deadline - Date.now();
   let out = `\n======== process tree under ${rootPid} at the stall ========\n`;
-  const ps = spawnSync("ps", ["-eo", "pid=,ppid=,stat=,etime=,args="], { encoding: "utf-8", timeout: 10_000 });
+  const ps = spawnSync("ps", ["-eo", "pid=,ppid=,stat=,etime=,args="], {
+    encoding: "utf-8",
+    timeout: Math.min(10_000, budgetMs),
+  });
   if (ps.status !== 0 || !ps.stdout) {
     return `${out}ps failed: ${ps.error?.message ?? ps.stderr ?? `code ${ps.status}`}\n`;
   }
@@ -1630,7 +1637,11 @@ function describeStalledProcessTree(rootPid, execPath) {
   const denied = lines => lines.some(line => /^(ptrace:|Could not attach)/.test(line));
   const backtrace = pid => {
     const [command, ...argv] = [...prefix, "gdb", "-p", String(pid), "-batch", "-ex", "thread apply all bt 16"];
-    const gdb = spawnSync(command, argv, { encoding: "utf-8", timeout: 20_000, stdio: ["ignore", "pipe", "pipe"] });
+    const gdb = spawnSync(command, argv, {
+      encoding: "utf-8",
+      timeout: Math.min(20_000, remaining()),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     if (gdb.error) return { error: gdb.error.message, lines: [] };
     const lines = `${gdb.stdout}\n${gdb.stderr}`
       .split("\n")
@@ -1638,18 +1649,23 @@ function describeStalledProcessTree(rootPid, execPath) {
     return { status: gdb.status, lines };
   };
   for (const { pid, args } of targets) {
+    if (remaining() < 5_000) {
+      out += `\nno time left in the ${budgetMs / 1000}s report budget for more backtraces\n`;
+      break;
+    }
     out += `\n======== gdb ${pid}: ${args.length > 120 ? `${args.slice(0, 117)}...` : args} ========\n`;
     let result = backtrace(pid);
     if (
       denied(result.lines) &&
       prefix.length === 0 &&
+      remaining() >= 5_000 &&
       spawnSync("sudo", ["-n", "true"], { stdio: "ignore", timeout: 5_000 }).status === 0
     ) {
       prefix = ["sudo", "-n"];
       result = backtrace(pid);
     }
     if (result.error) {
-      out += `gdb did not run: ${result.error}\n`;
+      out += `gdb failed: ${result.error}\n`;
       break;
     }
     out += result.lines.length ? `${result.lines.join("\n")}\n` : `no backtrace (exit ${result.status})\n`;
@@ -1757,7 +1773,8 @@ async function spawnSafe(options) {
           clearTimeout(idleTimer);
           if (options.gracefulTimeout && !isWindows) {
             // The batch is about to be killed for a stall. Record who was
-            // blocked, and where, while the processes are still alive.
+            // blocked, and where, while the processes are still alive. The
+            // report is synchronous and holds the kill for at most its budget.
             const elapsed = ((Date.now() - timestamp) / 1000).toFixed(0);
             const reason = idledOut ? `no output for ${options.idleTimeout / 1000}s` : `timeout after ${elapsed}s`;
             let report = `\n${reason}, killing the batch.`;

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1554,6 +1554,112 @@ async function runTests() {
  */
 
 /**
+ * Describe the live descendants of `rootPid` at the moment a run stalls or
+ * times out: the process tree from `ps`, each process's kernel state and
+ * signal masks from /proc, and, where ptrace is allowed, a gdb backtrace of
+ * every thread in each bun process. The output goes to the job log so a stall
+ * that never reproduces locally still names the blocked process and its stack.
+ *
+ * Everything here is bounded: one `ps`, a few /proc reads, and at most
+ * `maxBacktraces` gdb attaches of 20s each.
+ * @param {number} rootPid
+ * @param {string} execPath the bun binary under test
+ * @returns {string}
+ */
+function describeStalledProcessTree(rootPid, execPath) {
+  if (isWindows) return "";
+  let out = `\n======== process tree under ${rootPid} at the stall ========\n`;
+  const ps = spawnSync("ps", ["-eo", "pid=,ppid=,stat=,etime=,args="], { encoding: "utf-8", timeout: 10_000 });
+  if (ps.status !== 0 || !ps.stdout) {
+    return `${out}ps failed: ${ps.error?.message ?? ps.stderr ?? `code ${ps.status}`}\n`;
+  }
+  const children = new Map();
+  let root;
+  for (const line of ps.stdout.split("\n")) {
+    const row = /^\s*(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(.*)$/.exec(line);
+    if (!row) continue;
+    const [, pid, ppid, stat, etime, args] = row;
+    const proc = { pid: parseInt(pid, 10), stat, etime, args };
+    if (proc.pid === rootPid) root = proc;
+    if (!children.has(ppid)) children.set(ppid, []);
+    children.get(ppid).push(proc);
+  }
+  if (!root) {
+    return `${out}${rootPid} is not running\n`;
+  }
+  const tree = [{ ...root, depth: 0 }];
+  const walk = (pid, depth) => {
+    for (const proc of children.get(String(pid)) ?? []) {
+      tree.push({ ...proc, depth });
+      walk(proc.pid, depth + 1);
+    }
+  };
+  walk(rootPid, 1);
+  const bunName = basename(execPath);
+  const isBun = args => {
+    const argv0 = args.split(" ", 1)[0];
+    return argv0 === execPath || basename(argv0) === bunName;
+  };
+  for (const { pid, stat, etime, args, depth } of tree) {
+    out += `${"  ".repeat(depth)}${pid} ${stat} ${etime} ${args.length > 200 ? `${args.slice(0, 197)}...` : args}\n`;
+    if (!isLinux) continue;
+    // State names a zombie (Z), a stopped (T) or an uninterruptible (D) process.
+    // SigBlk/SigPnd together show a signal that was sent and never delivered.
+    try {
+      const status = readFileSync(`/proc/${pid}/status`, "utf-8")
+        .split("\n")
+        .filter(line => /^(State|Threads|SigPnd|ShdPnd|SigBlk|SigIgn|SigCgt):/.test(line))
+        .map(line => line.replace(/\s+/g, " "))
+        .join(", ");
+      let wchan = "";
+      try {
+        wchan = readFileSync(`/proc/${pid}/wchan`, "utf-8").trim();
+      } catch {}
+      out += `${"  ".repeat(depth)}  ${status}${wchan ? `, wchan: ${wchan}` : ""}\n`;
+    } catch (error) {
+      out += `${"  ".repeat(depth)}  /proc/${pid}/status: ${error?.message ?? error}\n`;
+    }
+  }
+  if (!isLinux) return out;
+  const maxBacktraces = 8;
+  const targets = tree.filter(({ args, stat }) => isBun(args) && !stat.startsWith("Z")).slice(0, maxBacktraces);
+  // Yama ptrace_scope 1 (Ubuntu's default) only lets an ancestor attach, and
+  // gdb is a sibling of the batch. Fall back to passwordless sudo when the
+  // agent has it.
+  let prefix = [];
+  const denied = lines => lines.some(line => /^(ptrace:|Could not attach)/.test(line));
+  const backtrace = pid => {
+    const [command, ...argv] = [...prefix, "gdb", "-p", String(pid), "-batch", "-ex", "thread apply all bt 16"];
+    const gdb = spawnSync(command, argv, { encoding: "utf-8", timeout: 20_000, stdio: ["ignore", "pipe", "pipe"] });
+    if (gdb.error) return { error: gdb.error.message, lines: [] };
+    const lines = `${gdb.stdout}\n${gdb.stderr}`
+      .split("\n")
+      .filter(line => /^(Thread \d+|#\d+|ptrace:|warning: .*ptrace|Could not attach)/.test(line));
+    return { status: gdb.status, lines };
+  };
+  for (const { pid, args } of targets) {
+    out += `\n======== gdb ${pid}: ${args.length > 120 ? `${args.slice(0, 117)}...` : args} ========\n`;
+    let result = backtrace(pid);
+    if (
+      denied(result.lines) &&
+      prefix.length === 0 &&
+      spawnSync("sudo", ["-n", "true"], { stdio: "ignore", timeout: 5_000 }).status === 0
+    ) {
+      prefix = ["sudo", "-n"];
+      result = backtrace(pid);
+    }
+    if (result.error) {
+      out += `gdb did not run: ${result.error}\n`;
+      break;
+    }
+    out += result.lines.length ? `${result.lines.join("\n")}\n` : `no backtrace (exit ${result.status})\n`;
+    // Not allowed to attach: the same answer for every other process.
+    if (denied(result.lines)) break;
+  }
+  return out;
+}
+
+/**
  * @typedef {object} SpawnResult
  * @property {boolean} ok
  * @property {string} [error]
@@ -1650,6 +1756,17 @@ async function spawnSafe(options) {
           timedOut = true;
           clearTimeout(idleTimer);
           if (options.gracefulTimeout && !isWindows) {
+            // The batch is about to be killed for a stall. Record who was
+            // blocked, and where, while the processes are still alive.
+            const elapsed = ((Date.now() - timestamp) / 1000).toFixed(0);
+            const reason = idledOut ? `no output for ${options.idleTimeout / 1000}s` : `timeout after ${elapsed}s`;
+            let report = `\n${reason}, killing the batch.`;
+            try {
+              report += describeStalledProcessTree(subprocess.pid, command);
+            } catch (error) {
+              report += `\nprocess tree unavailable: ${error?.message ?? error}\n`;
+            }
+            stderr?.(report);
             subprocess.kill("SIGTERM");
             timer = setTimeout(() => {
               subprocess.kill(9);

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1594,23 +1594,30 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
   if (!root) {
     return `${out}${rootPid} is not running\n`;
   }
-  const tree = [{ ...root, depth: 0 }];
-  const walk = (pid, depth) => {
-    for (const proc of children.get(String(pid)) ?? []) {
-      tree.push({ ...proc, depth });
-      walk(proc.pid, depth + 1);
+  // A runaway fork storm could list thousands of processes. The first few dozen
+  // are the coordinator, its workers and their children, which is what matters.
+  const maxListed = 64;
+  const tree = [];
+  let truncated = false;
+  // Depth-first, in ps order, without recursion: a deep chain must not
+  // overflow the stack while we are trying to report a stall.
+  const pending = [{ ...root, depth: 0 }];
+  while (pending.length) {
+    if (tree.length === maxListed) {
+      truncated = true;
+      break;
     }
-  };
-  walk(rootPid, 1);
+    const proc = pending.pop();
+    tree.push(proc);
+    const kids = children.get(String(proc.pid)) ?? [];
+    for (let k = kids.length - 1; k >= 0; k--) pending.push({ ...kids[k], depth: proc.depth + 1 });
+  }
   const bunName = basename(execPath);
   const isBun = args => {
     const argv0 = args.split(" ", 1)[0];
     return argv0 === execPath || basename(argv0) === bunName;
   };
-  // A runaway fork storm could list thousands of processes. The first few dozen
-  // are the coordinator, its workers and their children, which is what matters.
-  const maxListed = 64;
-  for (const { pid, stat, etime, args, depth } of tree.slice(0, maxListed)) {
+  for (const { pid, stat, etime, args, depth } of tree) {
     out += `${"  ".repeat(depth)}${pid} ${stat} ${etime} ${args.length > 200 ? `${args.slice(0, 197)}...` : args}\n`;
     if (!isLinux) continue;
     // State names a zombie (Z), a stopped (T) or an uninterruptible (D) process.
@@ -1630,7 +1637,7 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
       out += `${"  ".repeat(depth)}  /proc/${pid}/status: ${error?.message ?? error}\n`;
     }
   }
-  if (tree.length > maxListed) out += `... and ${tree.length - maxListed} more\n`;
+  if (truncated) out += `... list capped at ${maxListed} processes\n`;
   if (!isLinux) return out;
   const maxBacktraces = 8;
   const targets = tree.filter(({ args, stat }) => isBun(args) && !stat.startsWith("Z")).slice(0, maxBacktraces);

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1603,14 +1603,16 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
   // overflow the stack while we are trying to report a stall.
   const pending = [{ ...root, depth: 0 }];
   while (pending.length) {
-    if (tree.length === maxListed) {
-      truncated = true;
-      break;
-    }
     const proc = pending.pop();
     tree.push(proc);
+    // Queue only the children that can still be listed, so the queue itself
+    // never grows past the cap.
     const kids = children.get(String(proc.pid)) ?? [];
-    for (let k = kids.length - 1; k >= 0; k--) pending.push({ ...kids[k], depth: proc.depth + 1 });
+    const room = Math.max(0, maxListed - tree.length - pending.length);
+    if (kids.length > room) truncated = true;
+    for (let k = Math.min(kids.length, room) - 1; k >= 0; k--) {
+      pending.push({ ...kids[k], depth: proc.depth + 1 });
+    }
   }
   const bunName = basename(execPath);
   const isBun = args => {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1607,7 +1607,10 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
     const argv0 = args.split(" ", 1)[0];
     return argv0 === execPath || basename(argv0) === bunName;
   };
-  for (const { pid, stat, etime, args, depth } of tree) {
+  // A runaway fork storm could list thousands of processes. The first few dozen
+  // are the coordinator, its workers and their children, which is what matters.
+  const maxListed = 64;
+  for (const { pid, stat, etime, args, depth } of tree.slice(0, maxListed)) {
     out += `${"  ".repeat(depth)}${pid} ${stat} ${etime} ${args.length > 200 ? `${args.slice(0, 197)}...` : args}\n`;
     if (!isLinux) continue;
     // State names a zombie (Z), a stopped (T) or an uninterruptible (D) process.
@@ -1627,6 +1630,7 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
       out += `${"  ".repeat(depth)}  /proc/${pid}/status: ${error?.message ?? error}\n`;
     }
   }
+  if (tree.length > maxListed) out += `... and ${tree.length - maxListed} more\n`;
   if (!isLinux) return out;
   const maxBacktraces = 8;
   const targets = tree.filter(({ args, stat }) => isBun(args) && !stat.startsWith("Z")).slice(0, maxBacktraces);
@@ -1637,9 +1641,10 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
   const denied = lines => lines.some(line => /^(ptrace:|Could not attach)/.test(line));
   const backtrace = pid => {
     const [command, ...argv] = [...prefix, "gdb", "-p", String(pid), "-batch", "-ex", "thread apply all bt 16"];
+    // spawnSync treats timeout 0 as "none", so never let it reach 0.
     const gdb = spawnSync(command, argv, {
       encoding: "utf-8",
-      timeout: Math.min(20_000, remaining()),
+      timeout: Math.max(1, Math.min(20_000, remaining())),
       stdio: ["ignore", "pipe", "pipe"],
     });
     if (gdb.error) return { error: gdb.error.message, lines: [] };
@@ -1658,8 +1663,9 @@ function describeStalledProcessTree(rootPid, execPath, budgetMs = 60_000) {
     if (
       denied(result.lines) &&
       prefix.length === 0 &&
-      remaining() >= 5_000 &&
-      spawnSync("sudo", ["-n", "true"], { stdio: "ignore", timeout: 5_000 }).status === 0
+      remaining() >= 10_000 &&
+      spawnSync("sudo", ["-n", "true"], { stdio: "ignore", timeout: 5_000 }).status === 0 &&
+      remaining() >= 5_000
     ) {
       prefix = ["sudo", "-n"];
       result = backtrace(pid);
@@ -1769,8 +1775,12 @@ async function spawnSafe(options) {
       subprocess.on("spawn", () => {
         timestamp = Date.now();
         const expire = () => {
+          // The idle timer and the total timer both call this. The second
+          // call would write a second report and arm a second kill timer.
+          if (timedOut) return;
           timedOut = true;
           clearTimeout(idleTimer);
+          clearTimeout(timer);
           if (options.gracefulTimeout && !isWindows) {
             // The batch is about to be killed for a stall. Record who was
             // blocked, and where, while the processes are still alive. The


### PR DESCRIPTION
### Problem
- `test/napi/node-napi-tests/test/js-native-api/test_object/do.test.ts` stalls in the parallel batch in about 12% of CI builds (47 of the last 400, all on Debian 13 x64 and Ubuntu 25.04 x64). The annotation says only `stalled in the parallel batch` and `worker process crashed before reporting results`. The file passes alone every time.
- The stall was hidden until #41204 removed the blanket retry. Before that it was a `flaky` warning (9 of 300 builds from 09-01 to 09-03).
- The job log cannot say what was blocked. The other 76 files finish in 12s, then there is no output for 240s, then the idle kill. The worker output is buffered until the file completes, so nothing from the file reaches the log. About 2000 local runs of the child scripts and 21 local runs of the same 77-file batch did not reproduce it.

### Fix
- When the batch idles out or times out, `spawnSafe` now writes a report to the log before it sends SIGTERM: the process tree under the coordinator from `ps`, each process's `State`, `Threads`, `SigPnd`, `SigBlk`, `SigIgn`, `SigCgt` and `wchan` from `/proc`, and a `gdb -p` backtrace of every thread in each bun process.
- The report is synchronous and holds the SIGTERM for at most a 60s wall-clock budget: one `ps`, a few `/proc` reads, then gdb attaches (20s each, at most 8) only while time remains. When gdb is missing or ptrace is denied (Yama `ptrace_scope` 1, the Ubuntu default) it tries `sudo -n gdb` once, then stops. The `/proc` fields alone tell a zombie child from a blocked worker from a child that holds a pending signal.
- No test output parsing changes. The report goes through the batch's `stderr` callback, not into the parsed buffer, and it precedes the coordinator's `Interrupted while still running` list.
- Verified: ran the runner on `test/js/bun/util/` with an extra file that blocks in `spawnSync` and `BUN_RUNNER_BATCH_IDLE_MS=8000`. The report listed the coordinator, the four workers, the blocking `sleep` child with `wchan: hrtimer_nanosleep`, and the worker waiting in `ep_poll`. Also a standalone check of the function against `bun test --parallel=2`.

### Background
- The CI runner (`scripts/runner.node.mjs`) runs allowlisted files as one `bun test --parallel` batch per shard. The coordinator spawns `--test-worker --isolate` workers and buffers each worker's output until that file finishes.
- The runner kills the batch after 4 minutes with no output (`idleTimeout`), SIGTERM first and SIGKILL 15s later. Until now the only record of such a kill was the coordinator's list of files still running.
- In `do.test.ts` each child script runs through `spawnSync` with `stdin` and `stderr` inherited. `spawnSync` waits on an isolated event loop. The bun test timeout fires inside that loop and SIGTERMs the child, then the wait continues until the child's exit arrives. So the stall is either a child that survives SIGTERM or an exit event that never reaches the isolated loop. The report distinguishes these cases.

<details><summary>Notes</summary>

- Hit list: builds 109731 through 110461, first seen 2026-09-03T10Z. Builds 108xxx to 109700 (600 builds, 2026-08-29 to 2026-09-03T02Z) have no error annotation for this file but 9 `flaky` warnings with the same `(worker crashed)` body.
- Lane split over 51 annotations: Debian 13 x64 23, Ubuntu 25.04 x64 25, Ubuntu 25.04 aarch64 2, Debian 13 aarch64 1. None on Alpine x64 or on the ASAN lane.
- Buildkite line timestamps for build 110461: the batch starts at t=0, the last output is at t=12s, the interrupt is at t=253s. The coordinator names only `test_object/do.test.ts` (242s).
- Local attempts: `bun run` of `test.js`, `test_exceptions.js`, `test_null.js` 900 times serially (release), 720 times 4-wide (debug), 480 times 4-wide with the CI env (`BUN_GARBAGE_COLLECTOR_LEVEL=1`, `BUN_JSC_randomIntegrityAuditRate=1.0`), and 1200 more with the release build. 21 runs of the same 77-file `--parallel=3` batch, 8 of them pinned to 4 CPUs. No stall.
- In this container ptrace is denied even as root, so the gdb path was exercised only as far as the `ptrace: Operation not permitted.` line and the sudo fallback.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->