### PR TITLE
subprocess: surface stdio read and write errors instead of dropping them

### DIFF
--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -256,7 +256,9 @@ function destroy(this: NativeReadable, error: any, cb: () => void) {
     ptr.cancel(error);
   }
   if (cb) {
-    process.nextTick(cb);
+    // `_destroy` reports its error through the callback; dropping it here
+    // turns a read error into a plain 'close' with no 'error' event.
+    process.nextTick(cb, error);
   }
 }
 

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -256,8 +256,7 @@ function destroy(this: NativeReadable, error: any, cb: () => void) {
     ptr.cancel(error);
   }
   if (cb) {
-    // `_destroy` reports its error through the callback; dropping it here
-    // turns a read error into a plain 'close' with no 'error' event.
+    // `_destroy` reports its error through the callback.
     process.nextTick(cb, error);
   }
 }

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -995,6 +995,10 @@ static void rsisAbrupt(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIn
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     op->m_didThrow = true;
+    auto* reader = op->m_reader.get();
+    const bool pumpHoldsLock = !!reader;
+    if (reader)
+        reader->m_pipeOperation.clear();
     op->m_reader.clear();
     auto* result = op->m_result.get();
     JSObject* sink = op->m_didClose ? nullptr : op->m_sink.get();
@@ -1002,13 +1006,17 @@ static void rsisAbrupt(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIn
     JSReadableStream* stream = op->m_stream.get();
     rejectPromise(globalObject, result, error);
     RETURN_IF_EXCEPTION(scope, );
-    rsisFinally(vm, globalObject, op);
-    RETURN_IF_EXCEPTION(scope, );
-    if (stream && !isReadableStreamLocked(stream)) {
+    // The orphaned reader keeps the stream locked, so the lock says nothing about whether the
+    // pump may cancel. Cancel before rsisFinally: it clears the controller slots, and the
+    // source's cancel(reason) (a piped stdin ReadableStream learning of a write error) runs
+    // through the controller.
+    if (stream && (pumpHoldsLock || !isReadableStreamLocked(stream))) {
         auto* cancelPromise = readableStreamCancel(globalObject, stream, error);
         RETURN_IF_EXCEPTION(scope, );
         markPromiseAsHandled(vm, cancelPromise);
     }
+    rsisFinally(vm, globalObject, op);
+    RETURN_IF_EXCEPTION(scope, );
     if (sink)
         RELEASE_AND_RETURN(scope, rsisSinkClose(vm, globalObject, sink, error));
 }

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -1006,10 +1006,8 @@ static void rsisAbrupt(JSC::VM& vm, JSGlobalObject* globalObject, JSReadStreamIn
     JSReadableStream* stream = op->m_stream.get();
     rejectPromise(globalObject, result, error);
     RETURN_IF_EXCEPTION(scope, );
-    // The orphaned reader keeps the stream locked, so the lock says nothing about whether the
-    // pump may cancel. Cancel before rsisFinally: it clears the controller slots, and the
-    // source's cancel(reason) (a piped stdin ReadableStream learning of a write error) runs
-    // through the controller.
+    // The orphaned reader keeps the stream locked. Cancel before rsisFinally clears the
+    // controller slots, so the source's cancel(reason) runs.
     if (stream && (pumpHoldsLock || !isReadableStreamLocked(stream))) {
         auto* cancelPromise = readableStreamCancel(globalObject, stream, error);
         RETURN_IF_EXCEPTION(scope, );

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -484,14 +484,24 @@ impl Subprocess<'_> {
                         unreachable!()
                     };
                     let pipe_state = &mut Readable::pipe_reader_mut(&pipe).state;
-                    if let PipeReader::State::Done(done) = pipe_state {
-                        let taken = core::mem::take(done);
-                        out.set(Readable::Buffer(readable::CowString::init_owned(
-                            taken.into_boxed_slice(),
-                        )));
-                        // pipe.state was emptied via take()
+                    match pipe_state {
+                        PipeReader::State::Done(done) => {
+                            let taken = core::mem::take(done);
+                            out.set(Readable::Buffer(readable::CowString::init_owned(
+                                taken.into_boxed_slice(),
+                            )));
+                            // pipe.state was emptied via take()
+                        }
+                        PipeReader::State::Err(bytes, err) => {
+                            let taken = core::mem::take(bytes);
+                            out.set(Readable::Errored(
+                                readable::CowString::init_owned(taken.into_boxed_slice()),
+                                err.clone(),
+                            ));
+                        }
+                        // *out stays Readable::Ignore (set by replace above).
+                        PipeReader::State::Pending => {}
                     }
-                    // else: *out stays Readable::Ignore (set by replace above).
                 }
             }
         }

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -1,7 +1,7 @@
 use core::mem;
 use core::ptr::NonNull;
 
-use bun_jsc::{JSGlobalObject, JSValue, JsResult, event_loop::EventLoop};
+use bun_jsc::{JSGlobalObject, JSValue, JsResult, SysErrorJsc as _, event_loop::EventLoop};
 use bun_sys::{self, Fd, FdExt as _};
 
 use crate::node::types::FdJsc as _;
@@ -33,6 +33,10 @@ pub enum Readable {
     /// the owning `Readable` will be converted into this variant and the pipe's
     /// buffer will be taken as an owned `CowString`.
     Buffer(CowString),
+    /// A buffered `pipe` whose read failed before JS took the stream: the
+    /// bytes read before the error, then the error, delivered when JS asks
+    /// for the output.
+    Errored(CowString, bun_sys::Error),
 }
 
 impl Readable {
@@ -52,7 +56,7 @@ impl Readable {
     pub(crate) fn memory_cost(&self) -> usize {
         match self {
             Readable::Pipe(pipe) => mem::size_of::<PipeReader>() + pipe.memory_cost(),
-            Readable::Buffer(buffer) => buffer.length(),
+            Readable::Buffer(buffer) | Readable::Errored(buffer, _) => buffer.length(),
             _ => 0,
         }
     }
@@ -237,6 +241,14 @@ impl Readable {
                 let own = buffer.take_slice()?;
                 ReadableStream::from_owned_slice(global, own.into_vec(), 0)
             }
+            Readable::Errored(..) => {
+                let Readable::Errored(mut buffer, err) = mem::replace(self, Readable::Closed)
+                else {
+                    unreachable!()
+                };
+                let own = buffer.take_slice()?;
+                ReadableStream::from_bytes_then_error(global, own.into_vec(), err)
+            }
             _ => Ok(JSValue::UNDEFINED),
         }
     }
@@ -275,6 +287,12 @@ impl Readable {
                 };
 
                 JSValue::create_buffer_from_box(global, own)
+            }
+            Readable::Errored(..) => {
+                let Readable::Errored(_, err) = mem::replace(self, Readable::Closed) else {
+                    unreachable!()
+                };
+                Err(err.throw(global))
             }
             _ => Ok(JSValue::UNDEFINED),
         }

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -33,9 +33,7 @@ pub enum Readable {
     /// the owning `Readable` will be converted into this variant and the pipe's
     /// buffer will be taken as an owned `CowString`.
     Buffer(CowString),
-    /// A buffered `pipe` whose read failed before JS took the stream: the
-    /// bytes read before the error, then the error, delivered when JS asks
-    /// for the output.
+    /// A buffered `pipe` whose read failed: the bytes read before the error, then the error.
     Errored(CowString, bun_sys::Error),
 }
 

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -204,7 +204,7 @@ impl Readable {
                 }
                 Self::pipe_reader_mut(&pipe).process = None;
             }
-            Readable::Buffer(_) => {
+            Readable::Buffer(_) | Readable::Errored(..) => {
                 // Dropping the CowString (via the overwrite) frees the buffer;
                 // finalize is terminal.
                 *self = Readable::Closed;

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -23,7 +23,8 @@ pub enum State {
     #[default]
     Pending,
     Done(Vec<u8>),
-    Err(bun_sys::Error),
+    /// The read failed. The bytes read before the error come first.
+    Err(Vec<u8>, bun_sys::Error),
 }
 
 // Intrusive, single-thread ref-count; `deinit` runs when the last ref drops.
@@ -208,7 +209,7 @@ impl PipeReader {
 
             #[cfg(unix)]
             {
-                if matches!(self.state, State::Err(_)) {
+                if matches!(self.state, State::Err(..)) {
                     // onReaderError already ran; `_guard`'s Drop on return
                     // will drop the last ref and deinit() closes the handle.
                     return;
@@ -317,13 +318,13 @@ impl PipeReader {
                 };
                 ReadableStream::from_owned_slice(global_object, bytes, 0)
             }
-            State::Err(_err) => {
-                let empty = ReadableStream::empty(global_object)?;
-                ReadableStream::cancel(
-                    &ReadableStream::from_js(empty, global_object)?.unwrap(),
-                    global_object,
-                )?;
-                Ok(empty)
+            State::Err(..) => {
+                let State::Err(bytes, err) =
+                    core::mem::replace(&mut self.state, State::Err(Vec::new(), Default::default()))
+                else {
+                    unreachable!()
+                };
+                ReadableStream::from_bytes_then_error(global_object, bytes, err)
             }
         }
     }
@@ -339,8 +340,10 @@ impl PipeReader {
     }
 
     fn on_reader_error(&mut self, err: bun_sys::Error) {
-        // A previous `State::Done` buffer is freed by Drop of the replaced Vec.
-        self.state = State::Err(err);
+        let owned = self.to_owned_slice();
+        // Release the fd now, as EOF does, so a child still writing gets EPIPE.
+        self.reader.deinit();
+        self.state = State::Err(owned, err);
         if let Some(process) = self.process.take() {
             // `process` backref is valid while set; cleared before deref.
             let kind = self.kind(process.get());
@@ -356,7 +359,7 @@ impl PipeReader {
                 self.reader.close();
             }
             State::Done(_) => {}
-            State::Err(_) => {}
+            State::Err(..) => {}
         }
     }
 
@@ -385,7 +388,7 @@ impl PipeReader {
 impl Drop for PipeReader {
     fn drop(&mut self) {
         #[cfg(unix)]
-        debug_assert!(self.reader.is_done() || matches!(self.state, State::Err(_)));
+        debug_assert!(self.reader.is_done() || matches!(self.state, State::Err(..)));
     }
 }
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -803,7 +803,8 @@ impl FileReader {
             }
         }
 
-        if self.reader().is_done() {
+        // A stored error also ends a reader that never started (`from_bytes_then_error`).
+        if self.reader().is_done() || self.read_error.get().is_some() {
             return self.end_of_reader();
         }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -513,8 +513,14 @@ impl FileSink {
                 }
             }
 
+            // A write error closed the writer: the source learns why, so a JS
+            // ReadableStream piped in here sees it as its cancel reason.
+            let err = match (*this).stream_error.get() {
+                Some(streams::StreamError::Error(err)) => Some(err.clone()),
+                _ => None,
+            };
             let mut src = *(*this).source.get();
-            src.close(None);
+            src.close(err);
 
             (*this).settle_stream_done();
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -513,8 +513,7 @@ impl FileSink {
                 }
             }
 
-            // A write error closed the writer: the source learns why, so a JS
-            // ReadableStream piped in here sees it as its cancel reason.
+            // A piped JS ReadableStream sees the write error as its cancel reason.
             let err = match (*this).stream_error.get() {
                 Some(streams::StreamError::Error(err)) => Some(err.clone()),
                 _ => None,

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -604,6 +604,28 @@ impl ReadableStream {
         Ok(stream)
     }
 
+    /// A stream that delivers `bytes`, then errors with `err`: the output of a
+    /// subprocess pipe whose read failed before JS took the stream.
+    pub fn from_bytes_then_error(
+        global_this: &JSGlobalObject,
+        bytes: Vec<u8>,
+        err: syscall::Error,
+    ) -> JsResult<JSValue> {
+        let source = NewSource::<FileReader>::new_mut(NewSource {
+            global_this: Some(bun_ptr::BackRef::new(global_this)),
+            context: FileReader {
+                event_loop: core::cell::Cell::new(jsc::EventLoopHandle::init(
+                    global_this.bun_vm().as_mut().event_loop().cast(),
+                )),
+                buffered: bun_jsc::JsCell::new(bytes),
+                read_error: bun_jsc::JsCell::new(Some(err)),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        source.to_readable_stream(global_this)
+    }
+
     pub fn empty(global_this: &JSGlobalObject) -> JsResult<JSValue> {
         bun_jsc::from_js_host_call(global_this, || {
             // SAFETY: FFI call into JSC bindings; global_this is a valid &JSGlobalObject.

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -618,6 +618,8 @@ impl ReadableStream {
                 )),
                 buffered: bun_jsc::JsCell::new(bytes),
                 read_error: bun_jsc::JsCell::new(Some(err)),
+                // The reader never starts: a sink attached later ends with the error.
+                done: Cell::new(true),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -604,8 +604,7 @@ impl ReadableStream {
         Ok(stream)
     }
 
-    /// A stream that delivers `bytes`, then errors with `err`: the output of a
-    /// subprocess pipe whose read failed before JS took the stream.
+    /// A stream that delivers `bytes`, then errors with `err`.
     pub fn from_bytes_then_error(
         global_this: &JSGlobalObject,
         bytes: Vec<u8>,

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -898,8 +898,13 @@ impl SourceHandle {
                 if global.has_exception() {
                     return;
                 }
+                // The reason reaches the piped ReadableStream's cancel().
+                let reason = match &err {
+                    Some(err) => err.to_js(global),
+                    None => JSValue::UNDEFINED,
+                };
                 crate::dispatch::fold(::bun_jsc::call_check_slow(global, || {
-                    controller_abi::on_close(cpp, JSValue::UNDEFINED)
+                    controller_abi::on_close(cpp, reason)
                 }));
             }
             SourceHandle::ByteStream(p) => p.on_close(err),

--- a/test/js/bun/spawn/spawn-stdio-syscall-error.test.ts
+++ b/test/js/bun/spawn/spawn-stdio-syscall-error.test.ts
@@ -1,0 +1,336 @@
+// A read or write on a subprocess stdio socket can fail with an errno other
+// than EAGAIN/EINTR (ENOBUFS/ENOMEM under memory pressure, EIO, ECONNRESET).
+// The error must reach the handle the caller holds exactly once, and the fd
+// must be released the way EOF releases it, so a child that is still writing
+// gets EPIPE instead of blocking forever.
+//
+// An LD_PRELOAD shim fails the Nth recv()/send() on each AF_UNIX socket (the
+// parent's end of a stdio socketpair) with EIO/ENOBUFS. The children write
+// with write(2), so only bun's side of the pair is affected.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// SPAWN_FAULT_RECV_AT=N  the Nth recv() on each AF_UNIX socket fails with EIO (1-based).
+// SPAWN_FAULT_SEND_AT=N  the Nth send() on each AF_UNIX socket fails with ENOBUFS.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define MAX_FD 65536
+
+static ssize_t (*real_recv)(int, void *, size_t, int);
+static ssize_t (*real_send)(int, const void *, size_t, int);
+static int (*real_close)(int);
+static long (*real_syscall)(long, long, long, long, long, long, long);
+static int fail_recv_at = -1;
+static int fail_send_at = -1;
+static unsigned int recv_count[MAX_FD];
+static unsigned int send_count[MAX_FD];
+
+static void init_modes(void) {
+  const char *s;
+  if (fail_recv_at < 0) {
+    s = getenv("SPAWN_FAULT_RECV_AT");
+    fail_recv_at = s ? atoi(s) : 0;
+  }
+  if (fail_send_at < 0) {
+    s = getenv("SPAWN_FAULT_SEND_AT");
+    fail_send_at = s ? atoi(s) : 0;
+  }
+}
+
+static int is_unix_sock(int fd) {
+  struct stat st;
+  if (fd < 0 || fd >= MAX_FD) return 0;
+  if (fstat(fd, &st) != 0 || !S_ISSOCK(st.st_mode)) return 0;
+  int domain = 0;
+  socklen_t len = sizeof(domain);
+  return getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &domain, &len) == 0 && domain == AF_UNIX;
+}
+
+ssize_t recv(int fd, void *buf, size_t len, int flags) {
+  if (!real_recv) {
+    real_recv = (ssize_t (*)(int, void *, size_t, int))dlsym(RTLD_NEXT, "recv");
+    init_modes();
+  }
+  if (fail_recv_at > 0 && is_unix_sock(fd) && ++recv_count[fd] == (unsigned)fail_recv_at) {
+    errno = EIO;
+    return -1;
+  }
+  return real_recv(fd, buf, len, flags);
+}
+
+ssize_t send(int fd, const void *buf, size_t len, int flags) {
+  if (!real_send) {
+    real_send = (ssize_t (*)(int, const void *, size_t, int))dlsym(RTLD_NEXT, "send");
+    init_modes();
+  }
+  if (fail_send_at > 0 && is_unix_sock(fd) && ++send_count[fd] == (unsigned)fail_send_at) {
+    errno = ENOBUFS;
+    return -1;
+  }
+  return real_send(fd, buf, len, flags);
+}
+
+// Reset the per-fd counters on close so a recycled fd number starts fresh.
+// Bun closes fds through syscall(SYS_close, fd), not the close() wrapper, so
+// both entry points are interposed.
+static void reset_fd(int fd) {
+  if (fd >= 0 && fd < MAX_FD) {
+    recv_count[fd] = 0;
+    send_count[fd] = 0;
+  }
+}
+
+int close(int fd) {
+  if (!real_close) real_close = (int (*)(int))dlsym(RTLD_NEXT, "close");
+  reset_fd(fd);
+  return real_close(fd);
+}
+
+long syscall(long number, ...) {
+  va_list ap;
+  long a, b, c, d, e, f;
+  va_start(ap, number);
+  a = va_arg(ap, long);
+  b = va_arg(ap, long);
+  c = va_arg(ap, long);
+  d = va_arg(ap, long);
+  e = va_arg(ap, long);
+  f = va_arg(ap, long);
+  va_end(ap);
+  if (!real_syscall) {
+    real_syscall = (long (*)(long, long, long, long, long, long, long))dlsym(RTLD_NEXT, "syscall");
+  }
+  if (number == SYS_close) reset_fd((int)a);
+  return real_syscall(number, a, b, c, d, e, f);
+}
+`;
+
+// The child writes 8 MB, far more than the socket buffer holds, so it blocks
+// on write until the parent reads or closes its end. stderr is not a pipe, so
+// the stdout socket is the only AF_UNIX socket the shim sees.
+const WRITER_CMD = ["sh", "-c", "head -c 8000000 /dev/zero"];
+
+// Bun.spawn({stdin: ReadableStream}): the write error is the stream's cancel reason.
+const STDIN_STREAM_FIXTURE = /* js */ `
+const total = 8 << 20;
+let pulled = 0;
+let cancelReason = "not-called";
+const rs = new ReadableStream(
+  {
+    pull(c) {
+      if (pulled >= total) return c.close();
+      c.enqueue(new Uint8Array(65536));
+      pulled += 65536;
+    },
+    cancel(reason) {
+      cancelReason = reason instanceof Error ? reason.code : String(reason);
+    },
+  },
+  { highWaterMark: 0 },
+);
+const p = Bun.spawn(["sh", "-c", "exec wc -c"], { stdin: rs, stdout: "pipe", stderr: "inherit" });
+const childGot = Number((await p.stdout.text()).trim());
+await p.exited;
+console.log(JSON.stringify({ cancelReason, childTruncated: childGot < total, exitCode: p.exitCode }));
+`;
+
+// Bun.spawn stdout: the read rejects with the error and the child's write end
+// sees the close, so exited settles.
+const STDOUT_STREAM_FIXTURE = /* js */ `
+const p = Bun.spawn(${JSON.stringify(WRITER_CMD)}, { stdout: "pipe", stderr: "inherit" });
+let got = 0;
+let code = null;
+try {
+  for await (const chunk of p.stdout) got += chunk.length;
+} catch (e) {
+  code = e.code;
+}
+const exitCode = await p.exited;
+console.log(JSON.stringify({ code, truncated: got < 8000000, exited: typeof exitCode === "number" }));
+`;
+
+// Bun.spawn stdout consumed as a whole: text() rejects instead of hanging.
+const STDOUT_TEXT_FIXTURE = /* js */ `
+const p = Bun.spawn(${JSON.stringify(WRITER_CMD)}, { stdout: "pipe", stderr: "inherit" });
+let code = null;
+try {
+  await p.stdout.text();
+} catch (e) {
+  code = e.code;
+}
+const exitCode = await p.exited;
+console.log(JSON.stringify({ code, exited: typeof exitCode === "number" }));
+`;
+
+// node:child_process: stdout emits 'error' then 'close', and the ChildProcess
+// still emits 'close'.
+const CHILD_PROCESS_FIXTURE = /* js */ `
+import { spawn } from "node:child_process";
+const events = [];
+const child = spawn(${JSON.stringify(WRITER_CMD[0])}, ${JSON.stringify(WRITER_CMD.slice(1))}, { stdio: ["ignore", "pipe", "ignore"] });
+child.stdout.on("data", () => {});
+child.stdout.on("error", e => events.push("stdout.error:" + e.code));
+child.stdout.on("end", () => events.push("stdout.end"));
+child.stdout.on("close", () => events.push("stdout.close"));
+child.on("close", () => {
+  events.push("close");
+  console.log(JSON.stringify({ events }));
+});
+`;
+
+// Bun.spawnSync / child_process.spawnSync / execFileSync: the lost output is an error, not a success.
+const SPAWN_SYNC_FIXTURE = /* js */ `
+import { spawnSync, execFileSync } from "node:child_process";
+const out = {};
+try {
+  const r = Bun.spawnSync(${JSON.stringify(WRITER_CMD)}, { stderr: "inherit" });
+  out.bun = { stdout: r.stdout?.constructor?.name, success: r.success };
+} catch (e) {
+  out.bun = "threw:" + e.code;
+}
+{
+  const r = spawnSync(${JSON.stringify(WRITER_CMD[0])}, ${JSON.stringify(WRITER_CMD.slice(1))}, { stdio: ["ignore", "pipe", "inherit"], maxBuffer: 64 << 20 });
+  out.spawnSync = { stdout: r.stdout, error: r.error?.code };
+}
+try {
+  const r = execFileSync(${JSON.stringify(WRITER_CMD[0])}, ${JSON.stringify(WRITER_CMD.slice(1))}, { stdio: ["ignore", "pipe", "inherit"], maxBuffer: 64 << 20 });
+  out.execFileSync = { returned: r?.constructor?.name };
+} catch (e) {
+  out.execFileSync = "threw:" + e.code;
+}
+console.log(JSON.stringify(out));
+`;
+
+let shimPath: string;
+let dir: ReturnType<typeof tempDir> | undefined;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("spawn-stdio-syscall-error", {
+    "shim.c": SHIM_C,
+    "stdin-stream.mjs": STDIN_STREAM_FIXTURE,
+    "stdout-stream.mjs": STDOUT_STREAM_FIXTURE,
+    "stdout-text.mjs": STDOUT_TEXT_FIXTURE,
+    "child-process.mjs": CHILD_PROCESS_FIXTURE,
+    "spawn-sync.mjs": SPAWN_SYNC_FIXTURE,
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+async function runWithFault(fixture: string, fault: Record<string, string>) {
+  const env: Record<string, string | undefined> = {
+    ...bunEnv,
+    LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
+    SPAWN_FAULT_RECV_AT: undefined,
+    SPAWN_FAULT_SEND_AT: undefined,
+    ...fault,
+  };
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const line = stdout.trim().split("\n").pop() ?? "";
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    parsed = line;
+  }
+  // The child's own "head: error writing" line is the expected EPIPE/ECONNRESET.
+  const unexpectedStderr = stderr
+    .split("\n")
+    .filter(l => l.length > 0 && !l.startsWith("head:") && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  return { parsed, stderr: unexpectedStderr, exitCode };
+}
+
+// The first recv() is the eager read during spawn (the bytes are buffered
+// before JS touches .stdout). A later one is a read the JS consumer drives.
+const RECV_FAULTS = [
+  ["the eager read during spawn", "1"],
+  ["a read after the consumer attached", "3"],
+] as const;
+
+describe.skipIf(!isLinux || !cc)("subprocess stdio syscall errors", () => {
+  describe.each(RECV_FAULTS)("stdout read error on %s", (_label, at) => {
+    test.concurrent("Bun.spawn: the stream read rejects and exited settles", async () => {
+      expect(await runWithFault("stdout-stream.mjs", { SPAWN_FAULT_RECV_AT: at })).toEqual({
+        parsed: { code: "EIO", truncated: true, exited: true },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("Bun.spawn: stdout.text() rejects and exited settles", async () => {
+      expect(await runWithFault("stdout-text.mjs", { SPAWN_FAULT_RECV_AT: at })).toEqual({
+        parsed: { code: "EIO", exited: true },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("node:child_process: stdout emits 'error' before 'close'", async () => {
+      expect(await runWithFault("child-process.mjs", { SPAWN_FAULT_RECV_AT: at })).toEqual({
+        parsed: { events: ["stdout.error:EIO", "stdout.close", "close"] },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("spawnSync: the lost output is reported as an error", async () => {
+      expect(await runWithFault("spawn-sync.mjs", { SPAWN_FAULT_RECV_AT: at })).toEqual({
+        parsed: {
+          bun: "threw:EIO",
+          spawnSync: { stdout: null, error: "EIO" },
+          execFileSync: "threw:EIO",
+        },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
+  describe.each([
+    ["the first write", "1"],
+    ["a later write", "3"],
+  ])("stdin ReadableStream write error on %s", (_label, at) => {
+    test.concurrent("Bun.spawn: the stream is cancelled with the error as the reason", async () => {
+      expect(await runWithFault("stdin-stream.mjs", { SPAWN_FAULT_SEND_AT: at })).toEqual({
+        parsed: { cancelReason: "ENOBUFS", childTruncated: true, exitCode: 0 },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+});

--- a/test/js/bun/spawn/spawn-stdio-syscall-error.test.ts
+++ b/test/js/bun/spawn/spawn-stdio-syscall-error.test.ts
@@ -175,6 +175,19 @@ const exitCode = await p.exited;
 console.log(JSON.stringify({ code, exited: typeof exitCode === "number" }));
 `;
 
+// Bun.spawn stdout piped into a native sink: Bun.write rejects with the read error.
+const STDOUT_WRITE_FIXTURE = /* js */ `
+const p = Bun.spawn(${JSON.stringify(WRITER_CMD)}, { stdout: "pipe", stderr: "inherit" });
+let code = null;
+try {
+  await Bun.write("stdout-write.out", p.stdout);
+} catch (e) {
+  code = e.code;
+}
+const exitCode = await p.exited;
+console.log(JSON.stringify({ code, exited: typeof exitCode === "number" }));
+`;
+
 // node:child_process: stdout emits 'error' then 'close', and the ChildProcess
 // still emits 'close'.
 const CHILD_PROCESS_FIXTURE = /* js */ `
@@ -224,6 +237,7 @@ beforeAll(async () => {
     "stdin-stream.mjs": STDIN_STREAM_FIXTURE,
     "stdout-stream.mjs": STDOUT_STREAM_FIXTURE,
     "stdout-text.mjs": STDOUT_TEXT_FIXTURE,
+    "stdout-write.mjs": STDOUT_WRITE_FIXTURE,
     "child-process.mjs": CHILD_PROCESS_FIXTURE,
     "spawn-sync.mjs": SPAWN_SYNC_FIXTURE,
   });
@@ -294,6 +308,14 @@ describe.skipIf(!isLinux || !cc)("subprocess stdio syscall errors", () => {
 
     test.concurrent("Bun.spawn: stdout.text() rejects and exited settles", async () => {
       expect(await runWithFault("stdout-text.mjs", { SPAWN_FAULT_RECV_AT: at })).toEqual({
+        parsed: { code: "EIO", exited: true },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("Bun.spawn: Bun.write(file, stdout) rejects and exited settles", async () => {
+      expect(await runWithFault("stdout-write.mjs", { SPAWN_FAULT_RECV_AT: at })).toEqual({
         parsed: { code: "EIO", exited: true },
         stderr: "",
         exitCode: 0,


### PR DESCRIPTION
### Problem
- A `recv()` or `send()` on a subprocess stdio socket that fails with an errno other than `EAGAIN`/`EINTR` (`ENOBUFS`, `ENOMEM`, `EIO`, `ECONNRESET`) is lost in four places. `Bun.spawn({stdin: ReadableStream})` truncates the child's input and never calls the stream's `cancel()`. `child.stdout` from `node:child_process` emits `'close'` with no `'error'`. `Bun.spawn` rejects the read with `EIO` but keeps the stdout fd open, so a still-writing child blocks and `proc.exited` never settles. `Bun.spawnSync` returns `{stdout: undefined, success: true}`.
- The common cause is `FileReader::on_reader_error` (`src/runtime/webcore/FileReader.rs`): it only rejects a parked read. With none parked it drops the error, leaves the fd and the poll in place, and the next pull reads on. #41420 (merged) fixes that function for `Bun.file().stream()`. The buffered `SubprocessPipeReader` turns an error into `Readable::Ignore` (`subprocess.rs:on_close_io`), `native-readable.ts` `_destroy` calls its callback without the error, and `FileSink::on_close` hands the piped stream `undefined` as its cancel reason.

### Fix
- On top of #41420's `read_error` slot, now on main: `on_pull` returns a stored error before it consults the reader state, so a reader that never started can end with one.
- `Readable::Errored(bytes, err)` keeps a buffered pipe's partial output and error, and the reader releases its fd at once, the way EOF does, so the child gets `EPIPE`. `.stdout` becomes a stream that delivers the bytes and then errors (`ReadableStream::from_bytes_then_error`). `Bun.spawnSync` throws the error, so `child_process.spawnSync` reports `result.error` and `execFileSync` throws.
- `native-readable.ts` passes the error to the `_destroy` callback, so the node `Readable` emits `'error'` before `'close'`. `FileSink::on_close` passes the recorded write error to the source, and the pump's abrupt path (`rsisAbrupt`) cancels the stream with it even though its own orphaned reader holds the lock.
- Verified: `test/js/bun/spawn/spawn-stdio-syscall-error.test.ts` (12 tests, all fail on 1.4.1; an `LD_PRELOAD` shim fails the Nth `recv`/`send` on the stdio socketpair). Also `test/js/bun/spawn/`, `test/js/node/child_process/`, `test/js/node/stream/`, `test/js/web/streams/`, `test/js/bun/io/bun-write.test.js`, the shell fault tests.

### Background
- `Bun.spawn` reads stdout into a `SubprocessPipeReader` until JS touches `.stdout`. Then the fd and its buffer move into a `FileReader`, the native source behind the JS `ReadableStream`. A JS pull first tries a synchronous read; with no data it registers a poll and parks a `Pending` promise.
- The `BufferedReader` reports `on_read_chunk`, `on_reader_done` (EOF: it closes itself first) or `on_reader_error` (it did not close).
- `node:child_process` wraps the native stream with `native-readable.ts`, a `Readable` whose `_read` calls the native `pull`. A sync throw from `pull` reaches `errorOrDestroy`, which calls `_destroy(err, cb)`. Node's contract is `cb(err)`.
- A `ReadableStream` given as `stdin` is pumped into a `FileSink` by `readStreamIntoSink` (`BunStreamSource.cpp`). A sink write that fails synchronously throws into the pump (`rsisAbrupt`). A write that fails later closes the writer, which calls the pump's `onClose(reason)`.

<details><summary>Notes</summary>

The four faces come from a fault-injection fuzz round (internal ledger entries 20002 to 20005, not GitHub issues): strace injected errnos on the parent's stdio socketpairs. All four pre-date 1.4.

Open question for review: `Bun.spawnSync` has no error channel other than a throw, so the partial output, the exit code and the pid are lost when a stdio read fails. Node's `spawnSync` returns `{error, status, pid, stdout: <partial>}`. A result field on `Bun.spawnSync` (next to `exitedDueToMaxBuffer`) would let `child_process.spawnSync` match Node. That is new API surface, so this PR keeps the throw.

Follow-up candidates, kept out of this PR: the fd release on a read error belongs once in `PosixBufferedReader::on_error` (`src/io/PipeReader.rs`) for every parent, not per parent. The `native-readable.ts` `_destroy` fix also makes a user's `child.stdout.destroy(err)` emit `'error'` before `'close'`.

The strace-based repros from the ledger reproduce with the test's shim (strace is not available in the build container). On 1.4.1:

- stdin stream, `send` #3 fails with `ENOBUFS`: `cancelReason "not-called"`, the child reads 131072 of 8388608 bytes, exit code 0, nothing thrown.
- child_process, `recv` #3 fails with `EIO`: events `["stdout.close", "exit:1:null"]`, 360448 of 8000000 bytes.
- Bun.spawn `for await`, `recv` #3 fails: `rerr "EIO"`, then `exited` does not settle, the child sits in `do_wait`/`sock_alloc_send_pskb`. With `recv` #4 failing instead the error is swallowed and reading continues.
- Bun.spawnSync: `{stdout: undefined, exitCode: 0, success: true}`; `cp.spawnSync` `{stdout: null, status: 0, error: undefined}`; `execFileSync` returns `null`.

`rsisAbrupt` cleared `op->m_reader` and then tested `isReadableStreamLocked(stream)`. The orphaned reader still locks the stream, so that branch never ran and the source's `cancel()` was never called. The old JS pump had the same gap (`stream.cancel(e)` on a locked stream rejects).

The shim interposes `syscall()` for `SYS_close` as well as `close()`: bun closes fds through the raw syscall, so a per-fd counter that only reset in `close()` carried over to a recycled fd number.

Pre-existing on this machine with or without the change (debug ASAN build): `test/js/bun/spawn/spawn-pipe-leak.test.ts` exceeds its 30 s budget (450 ms per iteration), `test/js/web/streams/streams-leak.test.ts` "Absolute memory usage" sits at the 700 MB ASAN bound (692 to 713 MB across runs on both builds), and `child_process.test.ts` "spawn in the default shell" fails on the released bun too.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-stdio-syscall-error.test.ts

<!-- robobun:evidence:end -->
