### PR TITLE
Validate a cached sourcemap section header before use

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -502,11 +502,7 @@ impl Entry {
                 self.metadata.sourcemap_byte_offset,
             )?;
 
-            // A cache hit hands this blob to `SavedSourceMap::put_mappings` and
-            // then `InternalSourceMap::find`, which reads `SyncEntry[]` and the
-            // window streams by the offsets in the blob header. Validate the
-            // header so a damaged entry regenerates instead of reading
-            // out of bounds during stack remapping.
+            // `InternalSourceMap::find` trusts these header offsets.
             if !bun_sourcemap::InternalSourceMap::is_valid_blob(&sourcemap) {
                 return Err(crate::CrateError::InvalidSourceMap);
             }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -496,11 +496,22 @@ impl Entry {
         };
 
         if self.metadata.sourcemap_byte_length > 0 {
-            self.sourcemap = pread_box(
+            let sourcemap = pread_box(
                 file,
                 self.metadata.sourcemap_byte_length as usize,
                 self.metadata.sourcemap_byte_offset,
             )?;
+
+            // A cache hit hands this blob to `SavedSourceMap::put_mappings` and
+            // then `InternalSourceMap::find`, which reads `SyncEntry[]` and the
+            // window streams by the offsets in the blob header. Validate the
+            // header so a damaged entry regenerates instead of reading
+            // out of bounds during stack remapping.
+            if !bun_sourcemap::InternalSourceMap::is_valid_blob(&sourcemap) {
+                return Err(crate::CrateError::InvalidSourceMap);
+            }
+
+            self.sourcemap = sourcemap;
         }
 
         if self.metadata.esm_record_byte_length > 0 {

--- a/src/jsc/error.rs
+++ b/src/jsc/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     MissingData,
     #[error("InvalidHash")]
     InvalidHash,
+    #[error("InvalidSourceMap")]
+    InvalidSourceMap,
     #[error("NotARegularFile")]
     NotARegularFile,
     #[error("CacheDisabled")]
@@ -100,6 +102,7 @@ impl Error {
             Self::WriteFailed => "WriteFailed",
             Self::MissingData => "MissingData",
             Self::InvalidHash => "InvalidHash",
+            Self::InvalidSourceMap => "InvalidSourceMap",
             Self::NotARegularFile => "NotARegularFile",
             Self::CacheDisabled => "CacheDisabled",
             Self::InvalidInputHash => "InvalidInputHash",

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -613,3 +613,80 @@ test("cached module still works", () => {
   expect(third.signalCode).toBeUndefined();
   expect(third.exitCode).toBe(1);
 });
+
+test("rejects a cached entry whose sourcemap section header is corrupt", () => {
+  // A cache hit hands the stored sourcemap section to SavedSourceMap, which
+  // reads it as an InternalSourceMap blob. Stack remapping then walks the
+  // blob's SyncEntry array and window streams by the offsets in its header.
+  // A damaged header (for example an inflated sync_count) must be rejected so
+  // the entry regenerates, not read out of bounds.
+  //
+  // Cache entry layout (src/jsc/RuntimeTranspilerCache.rs, Metadata::encode):
+  //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8,
+  //   then twelve u64 fields; sourcemap_byte_offset @ 54,
+  //   sourcemap_byte_length @ 62, sourcemap_hash @ 70.
+  // InternalSourceMap header (src/sourcemap/InternalSourceMap.rs):
+  //   0: total_len u64, 8: mapping_count u64, 16: input_line_count u64,
+  //   24: sync_count u32, 28: stream_offset u32.
+  const SOURCEMAP_BYTE_OFFSET_AT = 54;
+  const SOURCEMAP_BYTE_LENGTH_AT = 62;
+
+  function corruptSourceMapHeader(file: string): boolean {
+    const data = readFileSync(file);
+    if (data.length < 102) return false;
+    const smOff = Number(data.readBigUInt64LE(SOURCEMAP_BYTE_OFFSET_AT));
+    const smLen = Number(data.readBigUInt64LE(SOURCEMAP_BYTE_LENGTH_AT));
+    if (smLen < 32 || smOff + smLen > data.length) return false;
+    // Inflate sync_count so the SyncEntry array claims far more entries than
+    // the section holds.
+    data.writeUInt32LE(0x0fffffff, smOff + 24);
+    writeFileSync(file, data);
+    return true;
+  }
+
+  // A module large enough for the cache (>= 4 KiB) that throws. Reading the
+  // error's stack forces the runtime to remap the captured frame through the
+  // cached sourcemap while the process still exits 0.
+  const filler = ("// " + "x".repeat(120) + "\n").repeat(120);
+  writeFileSync(
+    join(temp_dir, "boom.ts"),
+    `${filler}
+function boom(): number {
+  throw new Error("boom");
+}
+try {
+  boom();
+} catch (e) {
+  void (e as Error).stack;
+}
+console.log("OK");
+`,
+  );
+
+  const run = () => Bun.spawnSync({ cmd: [bunExe(), "./boom.ts"], cwd: temp_dir, env });
+
+  // First run writes the cache entry. Second run serves the intact entry and
+  // still remaps the stack and prints the marker.
+  const first = run();
+  expect(first.stdout.toString()).toContain("OK");
+  expect(first.exitCode).toBe(0);
+  expect(existsSync(cache_dir)).toBeTrue();
+
+  const second = run();
+  expect(second.stdout.toString()).toContain("OK");
+  expect(second.exitCode).toBe(0);
+
+  // Corrupt the stored sourcemap header.
+  let corrupted = 0;
+  for (const name of readdirSync(cache_dir)) {
+    if (name.endsWith(".pile") && corruptSourceMapHeader(join(cache_dir, name))) corrupted++;
+  }
+  expect(corrupted).toBeGreaterThanOrEqual(1);
+
+  // Third run: the corrupt section is rejected, the entry regenerates, and the
+  // module runs clean with a normal (non-signal) exit.
+  const third = run();
+  expect(third.stdout.toString()).toContain("OK");
+  expect(third.signalCode).toBeUndefined();
+  expect(third.exitCode).toBe(0);
+});

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -647,7 +647,8 @@ test("rejects a cached entry whose sourcemap section header is corrupt", () => {
   // A module large enough for the cache (>= 4 KiB) that throws. Reading the
   // error's stack forces the runtime to remap the captured frame through the
   // cached sourcemap while the process still exits 0.
-  const filler = ("// " + "x".repeat(120) + "\n").repeat(120);
+  const line = `// ${Buffer.alloc(120, "x").toString()}\n`;
+  const filler = Buffer.alloc(120 * line.length, line).toString();
   writeFileSync(
     join(temp_dir, "boom.ts"),
     `${filler}
@@ -669,8 +670,8 @@ console.log("OK");
   // still remaps the stack and prints the marker.
   const first = run();
   expect(first.stdout.toString()).toContain("OK");
-  expect(first.exitCode).toBe(0);
   expect(existsSync(cache_dir)).toBeTrue();
+  expect(first.exitCode).toBe(0);
 
   const second = run();
   expect(second.stdout.toString()).toContain("OK");


### PR DESCRIPTION
### Problem
- A cache hit reads the `.pile` sourcemap section with no hash check and no structural check, then hands the bytes to `SavedSourceMap::put_mappings` (`src/jsc/RuntimeTranspilerCache.rs`, `Entry::load`).
- Stack remapping later reads that blob as an `InternalSourceMap`. `find` walks the `SyncEntry` array and the window streams by the offsets in the blob header. A damaged header reads out of bounds.
- Repro: populate the cache, set the stored sourcemap header `sync_count` to a large value, run again. The cache-hit run crashes (SIGSEGV on release, ASAN abort on a debug build) while it remaps a stack.

### Fix
- After the sourcemap section is read, validate it with `InternalSourceMap::is_valid_blob` before it is stored on the `Entry`.
- On failure `Entry::load` returns the new `InvalidSourceMap` error. The existing unlink guard in `from_file_with_cache_file_path` then removes the entry, so the next run transpiles and writes a correct one.
- Correct because `is_valid_blob` checks the header invariants that `find` trusts: `total_len` equals the section length, and `stream_offset` sits after the `SyncEntry` array and inside the section. The check is a fixed set of header comparisons, so a cache hit pays no cost proportional to the sourcemap size.
- Verified: `test/cli/run/transpiler-cache.test.ts`. The new test crashes on the unfixed build and passes with the fix. All 20 tests in the file pass.

### Background
- The runtime transpiler cache stores the transpiled output, a sourcemap, and an ES module record per source file. `Entry::load` reads each section before the module runs.
- `InternalSourceMap` is Bun's in-process sourcemap format. The blob header holds `total_len`, `sync_count`, and `stream_offset`. `SavedSourceMap` stores the blob and `find` reads it during stack remapping.
- `is_valid_blob` already guards the same format for `--compile` embedded blobs. This change applies it to the disk cache, which an external process or a torn write can damage.

<details><summary>Notes</summary>

This does not restore the full per-section hashing from #39717, which was reverted in #40948 because hashing the whole sourcemap on every cache hit costs time proportional to its size. `is_valid_blob` is an O(1) header check, so it fits the hot path. It catches a corrupt outer header (the repro). It does not walk per-window `SyncEntry.byte_offset` values, so a corruption inside a window can still mislead `find`. That is the same limitation `is_valid_blob` has for `--compile` blobs.

The metadata header offsets used by the test: `sourcemap_byte_offset` at byte 54, `sourcemap_byte_length` at 62 (`Metadata::encode`: `u32` version, two `u8`, then twelve `u64`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->