### PR TITLE
Do not crash when a relative NODE_COMPILE_CACHE path does not fit the path buffer

### DIFF
--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -425,8 +425,6 @@ fn enable_with_dir(dir: &[u8], portable: bool) -> EnableResult {
                 };
             }
         };
-        // `dir` is user input of any length. The checked join returns `None`
-        // instead of writing past `abs_buf`.
         match bun_paths::resolve_path::join_abs_string_buf_checked::<
             bun_paths::resolve_path::platform::Auto,
         >(&cwd_buf[..cwd_len], &mut abs_buf[..], &[dir])

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -400,6 +400,11 @@ fn platform_tmp_dir() -> &'static [u8] {
 
 fn enable_with_dir(dir: &[u8], portable: bool) -> EnableResult {
     let tag = version_tag();
+    let path_too_long = || EnableResult {
+        status: STATUS_FAILED,
+        directory: None,
+        message: Some("Cannot create cache directory: path too long".to_string()),
+    };
 
     // Resolve `dir` to an absolute path against the process cwd.
     let mut abs_buf = PathBuffer::uninit();
@@ -420,19 +425,18 @@ fn enable_with_dir(dir: &[u8], portable: bool) -> EnableResult {
                 };
             }
         };
-        bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::resolve_path::platform::Auto>(
-            &cwd_buf[..cwd_len],
-            &mut abs_buf[..],
-            &[dir],
-        )
-        .as_bytes()
+        // `dir` is user input of any length. The checked join returns `None`
+        // instead of writing past `abs_buf`.
+        match bun_paths::resolve_path::join_abs_string_buf_checked::<
+            bun_paths::resolve_path::platform::Auto,
+        >(&cwd_buf[..cwd_len], &mut abs_buf[..], &[dir])
+        {
+            Some(abs) => abs,
+            None => return path_too_long(),
+        }
     };
     if abs.len() + 1 + tag.len() + 2 > MAX_PATH_BYTES {
-        return EnableResult {
-            status: STATUS_FAILED,
-            directory: None,
-            message: Some("Cannot create cache directory: path too long".to_string()),
-        };
+        return path_too_long();
     }
 
     let mut tagged: Vec<u8> = Vec::with_capacity(abs.len() + 1 + tag.len());

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -190,9 +190,11 @@ describe.concurrent("node-module-module", () => {
   });
 
   // A relative cache dir is joined onto cwd. A value that does not fit the
-  // path buffer after the join used to abort the process. The env var form
-  // stays under the Windows per-variable limit of 32767 characters.
-  test("NODE_COMPILE_CACHE with an over-long relative path does not crash startup", async () => {
+  // path buffer after the join used to abort the process. A Windows
+  // environment variable holds at most 32767 characters, which fits the
+  // Windows path buffer, so the env var form cannot reach the overflow path
+  // there. The API test below covers Windows.
+  test.skipIf(isWindows)("NODE_COMPILE_CACHE with an over-long relative path does not crash startup", async () => {
     using dir = tempDir("compile-cache-long-env", {});
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `console.log("user code ran")`],

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -190,14 +190,13 @@ describe.concurrent("node-module-module", () => {
   });
 
   // A relative cache dir is joined onto cwd. A value that does not fit the
-  // path buffer after the join used to abort the process.
-  const longRelativeDir = Buffer.alloc(8000, "A").toString();
-
+  // path buffer after the join used to abort the process. The env var form
+  // stays under the Windows per-variable limit of 32767 characters.
   test("NODE_COMPILE_CACHE with an over-long relative path does not crash startup", async () => {
     using dir = tempDir("compile-cache-long-env", {});
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `console.log("user code ran")`],
-      env: { ...bunEnv, NODE_COMPILE_CACHE: longRelativeDir },
+      env: { ...bunEnv, NODE_COMPILE_CACHE: Buffer.alloc(8000, "A").toString() },
       cwd: String(dir),
       stderr: "pipe",
     });
@@ -209,9 +208,11 @@ describe.concurrent("node-module-module", () => {
 
   test("module.enableCompileCache reports FAILED for an over-long relative path", async () => {
     using dir = tempDir("compile-cache-long-api", {});
+    // 100000 bytes exceeds the path buffer on every platform (the Windows
+    // buffer holds 32767 * 3 + 1 bytes).
     const code = `
       const Module = require("module");
-      const dir = Buffer.alloc(8000, "A").toString();
+      const dir = Buffer.alloc(100000, "A").toString();
       const r = Module.enableCompileCache(dir);
       console.log(JSON.stringify({ status: r.status, message: r.message }));
     `;
@@ -224,11 +225,7 @@ describe.concurrent("node-module-module", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(JSON.parse(stdout)).toEqual({
       status: Module.constants.compileCacheStatus.FAILED,
-      // The Windows path buffer holds 32767 UTF-16 units, so an 8000 byte
-      // value fits and the failure comes from mkdir with an errno name.
-      message: isWindows
-        ? expect.stringContaining("Cannot create cache directory: ")
-        : "Cannot create cache directory: path too long",
+      message: "Cannot create cache directory: path too long",
     });
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -224,7 +224,11 @@ describe.concurrent("node-module-module", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(JSON.parse(stdout)).toEqual({
       status: Module.constants.compileCacheStatus.FAILED,
-      message: expect.stringContaining("Cannot create cache directory"),
+      // The Windows path buffer holds 32767 UTF-16 units, so an 8000 byte
+      // value fits and the failure comes from mkdir with an errno name.
+      message: isWindows
+        ? expect.stringContaining("Cannot create cache directory: ")
+        : "Cannot create cache directory: path too long",
     });
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -189,6 +189,47 @@ describe.concurrent("node-module-module", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A relative cache dir is joined onto cwd. A value that does not fit the
+  // path buffer after the join used to abort the process.
+  const longRelativeDir = Buffer.alloc(8000, "A").toString();
+
+  test("NODE_COMPILE_CACHE with an over-long relative path does not crash startup", async () => {
+    using dir = tempDir("compile-cache-long-env", {});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log("user code ran")`],
+      env: { ...bunEnv, NODE_COMPILE_CACHE: longRelativeDir },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("user code ran");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("module.enableCompileCache reports FAILED for an over-long relative path", async () => {
+    using dir = tempDir("compile-cache-long-api", {});
+    const code = `
+      const Module = require("module");
+      const dir = Buffer.alloc(8000, "A").toString();
+      const r = Module.enableCompileCache(dir);
+      console.log(JSON.stringify({ status: r.status, message: r.message }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({
+      status: Module.constants.compileCacheStatus.FAILED,
+      message: expect.stringContaining("Cannot create cache directory"),
+    });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test.skipIf(process.platform === "win32")(
     "compile cache persists modules loaded after a non-fatal self-kill",
     async () => {


### PR DESCRIPTION
### Problem
- `NODE_COMPILE_CACHE=<long relative path> bun -e '...'` aborts at startup with `range end index 4109 out of range for slice of length 4095` in `join_abs_string_buf_z`. User code never runs. `module.enableCompileCache(longRelativeDir)` aborts the same way. Node returns `{ status: 0, message: 'Cannot create cache directory: name too long' }`.
- The cause is in `enable_with_dir` (`src/jsc/NodeCompileCache.rs:423`). A relative cache dir is joined onto cwd with the unchecked `join_abs_string_buf_z`. When cwd plus the value exceeds `MAX_PATH_BYTES`, the normalizer slices past the `PathBuffer`. The existing "path too long" check came after the join, so it never ran. An absolute long value already took that check and did not crash.

### Fix
- `enable_with_dir` now uses `join_abs_string_buf_checked`. It returns `None` when the normalized result does not fit the buffer. That case returns the existing `STATUS_FAILED` result with `Cannot create cache directory: path too long`.
- The result is only read as `&[u8]`, so the NUL-terminated variant was not needed.
- Verified: `test/js/node/module/node-module-module.test.js` (two new tests: the env var form and the API form, the API form with a 100000 byte relative dir, which exceeds the path buffer on every platform). Both fail on the released binary and pass with the debug build. Also ran `test/bundler/compile-node-compile-cache.test.ts`.

### Background
- `PathBuffer` is a fixed `[u8; MAX_PATH_BYTES]` (4096 on POSIX). `join_abs_string_buf_z` assumes the joined path fits and writes without a bound check.
- `join_abs_string_buf_checked` is the variant the codebase uses for user-controlled input. It sizes the unnormalized join first and returns `None` when the normalized result is longer than the buffer.
- `enableCompileCache` returns a status object, never throws for a bad directory. `STATUS_FAILED` with a message is the shape Node uses for this case.

<details><summary>Notes</summary>

Repro on main (cwd `/workspace/bun`):

```
NODE_COMPILE_CACHE=$(python3 -c "print('A'*4090)") bun -e 'console.log("user code ran")'
bun -e 'console.log(require("node:module").enableCompileCache("A".repeat(4090)))'
```

Both abort with rc 134. From `/tmp` the 4090 byte value fits exactly (4 + 1 + 4090 = 4095) and does not crash, so the trigger depends on cwd length.

With the fix the second command prints `{ status: 0, message: "Cannot create cache directory: path too long" }`.

The env var form of the test is skipped on Windows. A Windows environment variable holds at most 32767 characters, and the Windows path buffer holds 32767 * 3 + 1 bytes, so an env var value can never reach the overflow check there. On CI an 8000 byte value on Windows reached `make_path`, which spun without returning (the walk defect that #40600 fixes), and the test timed out. That hang is not part of this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->
