### PR TITLE
watch: reload when a missing import appears, keep scanning after a resolve error

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5465,9 +5465,8 @@ pub mod bv2_impl {
             }
         }
 
-        /// `bun build --watch` watches every file it parses, so a file whose
-        /// import failed to resolve still schedules its other imports. The dev
-        /// server links failed files and tracks the failure itself.
+        /// Under `bun build --watch` the imports that did resolve are still
+        /// parsed, so they are watched. The dev server tracks failures itself.
         fn keeps_scanning_after_resolve_error(&self) -> bool {
             self.bun_watcher.is_some() && self.dev_server.is_none()
         }
@@ -6118,10 +6117,6 @@ pub mod bv2_impl {
 
             if let Some(err) = resolve_result.last_error {
                 bun_core::scoped_log!(Bundle, "failed with error: {}", err.name());
-                // Under `bun build --watch` the imports that did resolve are
-                // still parsed, so an edit to any of them rebuilds while the
-                // failed one is missing. The build aborts before link time
-                // either way (`transpiler.log.errors > 0`).
                 if !this.keeps_scanning_after_resolve_error() {
                     resolve_result.resolve_queue.clear();
                 }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5465,6 +5465,13 @@ pub mod bv2_impl {
             }
         }
 
+        /// `bun build --watch` watches every file it parses, so a file whose
+        /// import failed to resolve still schedules its other imports. The dev
+        /// server links failed files and tracks the failure itself.
+        fn keeps_scanning_after_resolve_error(&self) -> bool {
+            self.bun_watcher.is_some() && self.dev_server.is_none()
+        }
+
         /// Dev Server uses this instead to run a subset of the transpiler, and to run it asynchronously.
         pub fn start_from_bake_dev_server(
             &mut self,
@@ -6111,7 +6118,13 @@ pub mod bv2_impl {
 
             if let Some(err) = resolve_result.last_error {
                 bun_core::scoped_log!(Bundle, "failed with error: {}", err.name());
-                resolve_result.resolve_queue.clear();
+                // Under `bun build --watch` the imports that did resolve are
+                // still parsed, so an edit to any of them rebuilds while the
+                // failed one is missing. The build aborts before link time
+                // either way (`transpiler.log.errors > 0`).
+                if !this.keeps_scanning_after_resolve_error() {
+                    resolve_result.resolve_queue.clear();
+                }
 
                 // Preserve the parsed import_records on the graph so any plugin
                 // onResolve tasks already dispatched for *other* records in this
@@ -6650,7 +6663,7 @@ pub mod bv2_impl {
                 };
                 let mut resolve_result = resolve_result;
                 // if there were errors, lets go ahead and collect them all
-                if last_error.is_some() {
+                if last_error.is_some() && !self.keeps_scanning_after_resolve_error() {
                     continue;
                 }
 
@@ -7613,6 +7626,14 @@ pub mod bv2_impl {
                         debug_assert!(
                             this.graph.ast.items_parts()[err.source_index.get() as usize].len()
                                 == 0
+                        );
+                    }
+
+                    if !resolve_queue.is_empty() {
+                        diff += this.process_resolve_queue(
+                            &resolve_queue,
+                            err.target,
+                            err.source_index.get(),
                         );
                     }
                 }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5465,8 +5465,7 @@ pub mod bv2_impl {
             }
         }
 
-        /// Under `bun build --watch` the imports that did resolve are still
-        /// parsed, so they are watched. The dev server tracks failures itself.
+        /// `bun build --watch` still parses (and so watches) the imports that did resolve.
         fn keeps_scanning_after_resolve_error(&self) -> bool {
             self.bun_watcher.is_some() && self.dev_server.is_none()
         }

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -947,8 +947,8 @@ where
                 bun_watcher::Kind::Directory => {
                     // A file the resolver could not find is not in the watchlist, so
                     // its creation only shows up as an event on the directory the
-                    // resolver searched. The Windows watcher does not pass entry
-                    // names, so a new entry in that directory has to do.
+                    // resolver searched. The Windows watcher passes no entry name, so
+                    // the watcher lists the directory instead.
                     #[cfg(windows)]
                     {
                         // on windows we receive file events for all items affected by a directory change
@@ -1087,20 +1087,26 @@ where
 
                         // A file the resolver could not find is not in the watchlist,
                         // so its creation only shows up as an event on the directory
-                        // the resolver searched. kqueue reports a directory write
-                        // with no entry name; inotify names each entry.
+                        // the resolver searched. A kqueue directory write means an
+                        // entry was added, removed, or renamed, with no name; inotify
+                        // names each entry and tells a create from a write.
                         let satisfies_unresolved_import = if IS_KQUEUE {
-                            // SAFETY: the Watcher outlives this call (it owns the
-                            // Reloader that calls us); the borrow is scoped to this call.
-                            unsafe { (*ctx).unresolved_import_matches(file_path, None) }
+                            event.op.contains(WatchOp::WRITE)
+                                // SAFETY: the Watcher outlives this call (it owns the
+                                // Reloader that calls us); the borrow is scoped to this call.
+                                && unsafe { (*ctx).unresolved_import_matches(file_path, None) }
                         } else {
-                            affected_inotify.iter().any(|name| match name {
-                                // SAFETY: see the kqueue arm above.
-                                Some(z) => unsafe {
-                                    (*ctx).unresolved_import_matches(file_path, Some(z.as_bytes()))
-                                },
-                                None => false,
-                            })
+                            event.op.intersects(WatchOp::CREATE | WatchOp::MOVE_TO)
+                                && affected_inotify.iter().any(|name| match name {
+                                    // SAFETY: see the kqueue arm above.
+                                    Some(z) => unsafe {
+                                        (*ctx).unresolved_import_matches(
+                                            file_path,
+                                            Some(z.as_bytes()),
+                                        )
+                                    },
+                                    None => false,
+                                })
                         };
                         if satisfies_unresolved_import {
                             current_task.append(current_hash);

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -945,10 +945,6 @@ where
                     }
                 }
                 bun_watcher::Kind::Directory => {
-                    // A file the resolver could not find is not in the watchlist, so
-                    // its creation only shows up as an event on the directory the
-                    // resolver searched. The Windows watcher passes no entry name, so
-                    // the watcher lists the directory instead.
                     #[cfg(windows)]
                     {
                         // on windows we receive file events for all items affected by a directory change
@@ -1085,11 +1081,8 @@ where
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );
 
-                        // A file the resolver could not find is not in the watchlist,
-                        // so its creation only shows up as an event on the directory
-                        // the resolver searched. A kqueue directory write means an
-                        // entry was added, removed, or renamed, with no name; inotify
-                        // names each entry and tells a create from a write.
+                        // A missing import is not in the watchlist. Its creation is
+                        // only visible as an event on the directory it belongs in.
                         let satisfies_unresolved_import = if IS_KQUEUE {
                             event.op.contains(WatchOp::WRITE)
                                 // SAFETY: the Watcher outlives this call (it owns the

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -579,7 +579,10 @@ where
         while self.pending_count().swap(0, Ordering::Relaxed) > 0 {
             let ctx = self.ctx_ptr();
             // SAFETY: ctx outlives reloader (BACKREF).
-            unsafe { (*ctx).reload(self) };
+            unsafe {
+                (*ctx).bun_watcher_mut().clear_unresolved_imports();
+                (*ctx).reload(self);
+            }
         }
     }
 
@@ -942,6 +945,10 @@ where
                     }
                 }
                 bun_watcher::Kind::Directory => {
+                    // A file the resolver could not find is not in the watchlist, so
+                    // its creation only shows up as an event on the directory the
+                    // resolver searched. The Windows watcher does not pass entry
+                    // names, so a new entry in that directory has to do.
                     #[cfg(windows)]
                     {
                         // on windows we receive file events for all items affected by a directory change
@@ -950,6 +957,13 @@ where
                         let _ = self.ctx_mut().bust_dir_cache(
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );
+                        if event.op.intersects(WatchOp::CREATE | WatchOp::MOVE_TO)
+                            // SAFETY: the Watcher outlives this call (it owns the
+                            // Reloader that calls us); the borrow is scoped to this call.
+                            && unsafe { (*ctx).unresolved_import_matches(file_path, None) }
+                        {
+                            current_task.append(current_hash);
+                        }
                         continue;
                     }
                     #[cfg(not(windows))]
@@ -1070,6 +1084,27 @@ where
                         let _ = self.ctx_mut().bust_dir_cache(
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );
+
+                        // A file the resolver could not find is not in the watchlist,
+                        // so its creation only shows up as an event on the directory
+                        // the resolver searched. kqueue reports a directory write
+                        // with no entry name; inotify names each entry.
+                        let satisfies_unresolved_import = if IS_KQUEUE {
+                            // SAFETY: the Watcher outlives this call (it owns the
+                            // Reloader that calls us); the borrow is scoped to this call.
+                            unsafe { (*ctx).unresolved_import_matches(file_path, None) }
+                        } else {
+                            affected_inotify.iter().any(|name| match name {
+                                // SAFETY: see the kqueue arm above.
+                                Some(z) => unsafe {
+                                    (*ctx).unresolved_import_matches(file_path, Some(z.as_bytes()))
+                                },
+                                None => false,
+                            })
+                        };
+                        if satisfies_unresolved_import {
+                            current_task.append(current_hash);
+                        }
 
                         // The watched entrypoint has a per-file inotify watch on its inode.
                         // An atomic rename (`rename(tmp, entrypoint)`) or a rm+recreate over

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1081,8 +1081,7 @@ where
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );
 
-                        // A missing import is not in the watchlist. Its creation is
-                        // only visible as an event on the directory it belongs in.
+                        // A missing import is only visible as an event on its directory.
                         let satisfies_unresolved_import = if IS_KQUEUE {
                             event.op.contains(WatchOp::WRITE)
                                 // SAFETY: the Watcher outlives this call (it owns the

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -760,6 +760,8 @@ where
 
         // SAFETY: see above.
         let watcher_ptr = unsafe { (*this).install_bun_watcher(watcher, RELOAD_IMMEDIATELY) };
+        // SAFETY: `watcher_ptr` was just installed into the ctx and is live.
+        unsafe { (*watcher_ptr).enable_unresolved_import_tracking() };
 
         // SAFETY: single-threaded init; watcher thread not yet started.
         CLEAR_SCREEN.store(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2157,6 +2157,12 @@ impl<'a> Resolver<'a> {
                 ..Default::default()
             })
         } else {
+            if FeatureFlags::WATCH_DIRECTORIES
+                && let Some(watcher) = self.watcher.as_ref()
+                && let Some(dir) = bun_paths::dirname(abs_path)
+            {
+                watcher.unresolved(dir, bun_paths::basename(abs_path));
+            }
             ResultUnion::NotFound
         };
         self.extension_order = prev_extension_order;
@@ -5972,7 +5978,7 @@ impl<'a> Resolver<'a> {
             // Start watching it automatically,
             if let Some(watcher) = self.watcher.as_ref() {
                 if let Some((dir, fd)) = dir_entry.get().dir_and_fd() {
-                    watcher.watch(dir, fd, base);
+                    watcher.watch(dir, fd);
                 }
             }
         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5972,7 +5972,7 @@ impl<'a> Resolver<'a> {
             // Start watching it automatically,
             if let Some(watcher) = self.watcher.as_ref() {
                 if let Some((dir, fd)) = dir_entry.get().dir_and_fd() {
-                    watcher.watch(dir, fd);
+                    watcher.watch(dir, fd, base);
                 }
             }
         }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -87,8 +87,7 @@ impl AnyResolveWatcher {
     }
 }
 
-/// An import the resolver could not find: the directory it searched and the
-/// stem of the name it tried (`a` for `a.js`).
+/// An import the resolver could not find: the directory and the name stem (`a` for `a.js`).
 struct UnresolvedImport {
     dir_hash: HashType,
     stem: Box<[u8]>,
@@ -1037,9 +1036,7 @@ impl Watcher {
         Self::get_hash(strings::without_trailing_slash(dir_path))
     }
 
-    /// Whether an entry in `dir_path` can satisfy a recorded unresolved import.
-    /// `None` lists the directory (kqueue and Windows report no entry name).
-    /// The caller must hold `mutex`.
+    /// `name: None` lists the directory (kqueue and Windows report no entry name). Caller holds `mutex`.
     pub fn unresolved_import_matches(&self, dir_path: &[u8], name: Option<&[u8]>) -> bool {
         debug_assert!(self.mutex.is_held_by_current_thread());
         let dir_hash = Self::unresolved_dir_hash(dir_path);

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -175,6 +175,8 @@ pub struct Watcher {
 
     /// Imports the resolver could not find. Guarded by `mutex`.
     unresolved_imports: Vec<UnresolvedImport>,
+    /// Set by the hot reloader, the only consumer of `unresolved_imports`.
+    track_unresolved_imports: bool,
 
     /// Scratch snapshot of `watchlist.eventlist_index` used by
     /// `watch_loop_cycle`; owned by the watcher thread.
@@ -256,6 +258,7 @@ impl Watcher {
             evict_list: [0; MAX_EVICTION_COUNT],
             evict_list_i: 0,
             unresolved_imports: Vec::new(),
+            track_unresolved_imports: false,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index_scratch: Vec::new(),
             thread_lock: ThreadLock::init_unlocked(),
@@ -1026,8 +1029,12 @@ impl Watcher {
     }
 
     /// Called once the whole resolution missed, not on every `load_as_file` miss.
+    pub fn enable_unresolved_import_tracking(&mut self) {
+        self.track_unresolved_imports = true;
+    }
+
     pub(crate) fn on_unresolved_import(&mut self, dir_path: &[u8], base: &[u8]) {
-        if !self.is_watchable_directory(dir_path) {
+        if !self.track_unresolved_imports || !self.is_watchable_directory(dir_path) {
             return;
         }
         let stem = UnresolvedImport::stem_of(base);

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -70,15 +70,22 @@ pub struct AnyResolveWatcher {
     // receives exactly the `context` it was paired with at construction (a
     // closure-style invariant upheld by this struct), and the body discharges
     // its own type-recovery `unsafe` internally.
-    pub(crate) callback: fn(*mut (), dir_path: &[u8], dir_fd: Fd, base: &[u8]),
+    pub(crate) callback: fn(*mut (), dir_path: &[u8], dir_fd: Fd),
+    pub(crate) on_unresolved: fn(*mut (), dir_path: &[u8], base: &[u8]),
 }
 
 impl AnyResolveWatcher {
-    /// The resolver looked for `base` (the basename it tried, before any
-    /// extension probing) in `dir_path` and did not find it.
     #[inline]
-    pub fn watch(self, dir_path: &[u8], dir_fd: Fd, base: &[u8]) {
-        (self.callback)(self.context, dir_path, dir_fd, base)
+    pub fn watch(self, dir_path: &[u8], dir_fd: Fd) {
+        (self.callback)(self.context, dir_path, dir_fd)
+    }
+
+    /// A relative or absolute import resolved to nothing: the resolver looked
+    /// for `base` in `dir_path`, with every extension and index probe, and
+    /// found no file and no directory.
+    #[inline]
+    pub fn unresolved(self, dir_path: &[u8], base: &[u8]) {
+        (self.on_unresolved)(self.context, dir_path, base)
     }
 }
 
@@ -975,48 +982,61 @@ impl Watcher {
     }
 
     pub fn get_resolve_watcher(&mut self) -> AnyResolveWatcher {
-        fn wrap(ctx: *mut (), dir_path: &[u8], dir_fd: Fd, base: &[u8]) {
+        fn wrap(ctx: *mut (), dir_path: &[u8], dir_fd: Fd) {
             // SAFETY: ctx was stored from *mut Watcher in get_resolve_watcher()
             // and `AnyResolveWatcher::watch` only ever feeds back the paired
             // `context`; the resolver holds it for the Watcher's lifetime. The
             // `&mut Watcher` is scoped to this call.
-            unsafe { (*ctx.cast::<Watcher>()).on_maybe_watch_directory(dir_path, dir_fd, base) }
+            unsafe { (*ctx.cast::<Watcher>()).on_maybe_watch_directory(dir_path, dir_fd) }
+        }
+        fn wrap_unresolved(ctx: *mut (), dir_path: &[u8], base: &[u8]) {
+            // SAFETY: see `wrap`.
+            unsafe { (*ctx.cast::<Watcher>()).on_unresolved_import(dir_path, base) }
         }
         AnyResolveWatcher {
             context: std::ptr::from_mut::<Self>(self).cast::<()>(),
             callback: wrap,
+            on_unresolved: wrap_unresolved,
         }
     }
 
-    pub(crate) fn on_maybe_watch_directory(&mut self, file_path: &[u8], dir_fd: Fd, base: &[u8]) {
+    #[inline]
+    fn is_watchable_directory(&self, dir_path: &[u8]) -> bool {
         // We don't want to watch:
         // - Directories outside the root directory
         // - Directories inside node_modules
-        if !strings::contains(file_path, b"node_modules")
-            && strings::contains(file_path, self.top_level_dir())
+        !strings::contains(dir_path, b"node_modules")
+            && strings::contains(dir_path, self.top_level_dir())
+    }
+
+    pub(crate) fn on_maybe_watch_directory(&mut self, file_path: &[u8], dir_fd: Fd) {
+        if self.is_watchable_directory(file_path) {
+            let _ = self.add_directory::<false>(dir_fd, file_path, Self::get_hash(file_path));
+        }
+    }
+
+    /// The directory watch itself comes from `on_maybe_watch_directory`, which
+    /// `load_as_file` calls for every miss, including the misses that go on to
+    /// resolve as a directory. Only a miss of the whole resolution is recorded.
+    pub(crate) fn on_unresolved_import(&mut self, dir_path: &[u8], base: &[u8]) {
+        if !self.is_watchable_directory(dir_path) {
+            return;
+        }
+        let stem = UnresolvedImport::stem_of(base);
+        if stem.is_empty() {
+            return;
+        }
+        let dir_hash = Self::unresolved_dir_hash(dir_path);
+        let _guard = self.mutex.lock_guard();
+        if !self
+            .unresolved_imports
+            .iter()
+            .any(|u| u.dir_hash == dir_hash && &*u.stem == stem)
         {
-            if self
-                .add_directory::<false>(dir_fd, file_path, Self::get_hash(file_path))
-                .is_err()
-            {
-                return;
-            }
-            let stem = UnresolvedImport::stem_of(base);
-            if stem.is_empty() {
-                return;
-            }
-            let dir_hash = Self::unresolved_dir_hash(file_path);
-            let _guard = self.mutex.lock_guard();
-            if !self
-                .unresolved_imports
-                .iter()
-                .any(|u| u.dir_hash == dir_hash && &*u.stem == stem)
-            {
-                self.unresolved_imports.push(UnresolvedImport {
-                    dir_hash,
-                    stem: stem.into(),
-                });
-            }
+            self.unresolved_imports.push(UnresolvedImport {
+                dir_hash,
+                stem: stem.into(),
+            });
         }
     }
 
@@ -1028,20 +1048,38 @@ impl Watcher {
         Self::get_hash(strings::without_trailing_slash(dir_path))
     }
 
-    /// Whether an entry named `name` that appeared in `dir_path` can satisfy
-    /// an import the resolver failed to find since the last
-    /// `clear_unresolved_imports`. `None` (the platform reports no entry
-    /// name) matches any unresolved import in that directory. The caller must
-    /// hold `mutex` (the platform watcher holds it around `on_file_update`).
+    /// Whether an entry that appeared in `dir_path` can satisfy an import the
+    /// resolver failed to find since the last `clear_unresolved_imports`.
+    /// With `Some(name)` the entry name from the event is checked. With
+    /// `None` (kqueue and Windows report no entry name) the directory is
+    /// listed and every entry is checked. The caller must hold `mutex` (the
+    /// platform watcher holds it around `on_file_update`).
     pub fn unresolved_import_matches(&self, dir_path: &[u8], name: Option<&[u8]>) -> bool {
         debug_assert!(self.mutex.is_held_by_current_thread());
-        if self.unresolved_imports.is_empty() {
+        let dir_hash = Self::unresolved_dir_hash(dir_path);
+        let mut candidates = self
+            .unresolved_imports
+            .iter()
+            .filter(|u| u.dir_hash == dir_hash)
+            .peekable();
+        if candidates.peek().is_none() {
             return false;
         }
-        let dir_hash = Self::unresolved_dir_hash(dir_path);
-        self.unresolved_imports
-            .iter()
-            .any(|u| u.dir_hash == dir_hash && name.is_none_or(|n| u.matches(n)))
+        if let Some(name) = name {
+            return candidates.any(|u| u.matches(name));
+        }
+        let candidates: Vec<&UnresolvedImport> = candidates.collect();
+        let Ok(dir) = sys::Dir::open(strings::without_trailing_slash(dir_path)) else {
+            return false;
+        };
+        let mut iter = sys::iterate_dir(dir.fd());
+        while let Ok(Some(entry)) = iter.next() {
+            let entry_name = entry.name.slice_u8();
+            if candidates.iter().any(|u| u.matches(entry_name)) {
+                return true;
+            }
+        }
+        false
     }
 
     /// A reload re-runs every resolution, so the record of failed ones starts over.

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -70,13 +70,43 @@ pub struct AnyResolveWatcher {
     // receives exactly the `context` it was paired with at construction (a
     // closure-style invariant upheld by this struct), and the body discharges
     // its own type-recovery `unsafe` internally.
-    pub(crate) callback: fn(*mut (), dir_path: &[u8], dir_fd: Fd),
+    pub(crate) callback: fn(*mut (), dir_path: &[u8], dir_fd: Fd, base: &[u8]),
 }
 
 impl AnyResolveWatcher {
+    /// The resolver looked for `base` (the basename it tried, before any
+    /// extension probing) in `dir_path` and did not find it.
     #[inline]
-    pub fn watch(self, dir_path: &[u8], dir_fd: Fd) {
-        (self.callback)(self.context, dir_path, dir_fd)
+    pub fn watch(self, dir_path: &[u8], dir_fd: Fd, base: &[u8]) {
+        (self.callback)(self.context, dir_path, dir_fd, base)
+    }
+}
+
+/// One import the resolver could not find: the directory it searched and the
+/// stem of the basename it tried. A new entry in that directory whose name is
+/// the stem, or starts with the stem followed by a dot, can satisfy the import
+/// (`a`, `a.js`, `a.ts`, `a.js.ts`, or a directory `a`).
+struct UnresolvedImport {
+    dir_hash: HashType,
+    stem: Box<[u8]>,
+}
+
+impl UnresolvedImport {
+    fn stem_of(base: &[u8]) -> &[u8] {
+        if base.len() < 2 {
+            return base;
+        }
+        // Skip a leading dot so `.env` keeps its name.
+        match strings::index_of_char_usize(&base[1..], b'.') {
+            Some(i) => &base[..i + 1],
+            None => base,
+        }
+    }
+
+    fn matches(&self, name: &[u8]) -> bool {
+        let stem: &[u8] = &self.stem;
+        name == stem
+            || (name.len() > stem.len() && name.starts_with(stem) && name[stem.len()] == b'.')
     }
 }
 
@@ -123,6 +153,11 @@ pub struct Watcher {
 
     pub(crate) evict_list: [WatchItemIndex; MAX_EVICTION_COUNT],
     pub(crate) evict_list_i: WatchItemIndex,
+
+    /// Imports the resolver could not find. A file that appears for one of
+    /// them must trigger a reload even though the file itself is not in the
+    /// watchlist. Guarded by `mutex`.
+    unresolved_imports: Vec<UnresolvedImport>,
 
     /// Scratch snapshot of `watchlist.eventlist_index` used by
     /// `watch_loop_cycle`; owned by the watcher thread.
@@ -203,6 +238,7 @@ impl Watcher {
             close_descriptors: bun_core::AtomicCell::new(false),
             evict_list: [0; MAX_EVICTION_COUNT],
             evict_list_i: 0,
+            unresolved_imports: Vec::new(),
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index_scratch: Vec::new(),
             thread_lock: ThreadLock::init_unlocked(),
@@ -939,12 +975,12 @@ impl Watcher {
     }
 
     pub fn get_resolve_watcher(&mut self) -> AnyResolveWatcher {
-        fn wrap(ctx: *mut (), dir_path: &[u8], dir_fd: Fd) {
+        fn wrap(ctx: *mut (), dir_path: &[u8], dir_fd: Fd, base: &[u8]) {
             // SAFETY: ctx was stored from *mut Watcher in get_resolve_watcher()
             // and `AnyResolveWatcher::watch` only ever feeds back the paired
             // `context`; the resolver holds it for the Watcher's lifetime. The
             // `&mut Watcher` is scoped to this call.
-            unsafe { (*ctx.cast::<Watcher>()).on_maybe_watch_directory(dir_path, dir_fd) }
+            unsafe { (*ctx.cast::<Watcher>()).on_maybe_watch_directory(dir_path, dir_fd, base) }
         }
         AnyResolveWatcher {
             context: std::ptr::from_mut::<Self>(self).cast::<()>(),
@@ -952,15 +988,66 @@ impl Watcher {
         }
     }
 
-    pub(crate) fn on_maybe_watch_directory(&mut self, file_path: &[u8], dir_fd: Fd) {
+    pub(crate) fn on_maybe_watch_directory(&mut self, file_path: &[u8], dir_fd: Fd, base: &[u8]) {
         // We don't want to watch:
         // - Directories outside the root directory
         // - Directories inside node_modules
         if !strings::contains(file_path, b"node_modules")
             && strings::contains(file_path, self.top_level_dir())
         {
-            let _ = self.add_directory::<false>(dir_fd, file_path, Self::get_hash(file_path));
+            if self
+                .add_directory::<false>(dir_fd, file_path, Self::get_hash(file_path))
+                .is_err()
+            {
+                return;
+            }
+            let stem = UnresolvedImport::stem_of(base);
+            if stem.is_empty() {
+                return;
+            }
+            let dir_hash = Self::unresolved_dir_hash(file_path);
+            let _guard = self.mutex.lock_guard();
+            if !self
+                .unresolved_imports
+                .iter()
+                .any(|u| u.dir_hash == dir_hash && &*u.stem == stem)
+            {
+                self.unresolved_imports.push(UnresolvedImport {
+                    dir_hash,
+                    stem: stem.into(),
+                });
+            }
         }
+    }
+
+    /// The resolver and the parent-directory autowatch spell the same directory
+    /// with and without a trailing slash, so `unresolved_imports` keys on the
+    /// stripped form.
+    #[inline]
+    fn unresolved_dir_hash(dir_path: &[u8]) -> HashType {
+        Self::get_hash(strings::without_trailing_slash(dir_path))
+    }
+
+    /// Whether an entry named `name` that appeared in `dir_path` can satisfy
+    /// an import the resolver failed to find since the last
+    /// `clear_unresolved_imports`. `None` (the platform reports no entry
+    /// name) matches any unresolved import in that directory. The caller must
+    /// hold `mutex` (the platform watcher holds it around `on_file_update`).
+    pub fn unresolved_import_matches(&self, dir_path: &[u8], name: Option<&[u8]>) -> bool {
+        debug_assert!(self.mutex.is_held_by_current_thread());
+        if self.unresolved_imports.is_empty() {
+            return false;
+        }
+        let dir_hash = Self::unresolved_dir_hash(dir_path);
+        self.unresolved_imports
+            .iter()
+            .any(|u| u.dir_hash == dir_hash && name.is_none_or(|n| u.matches(n)))
+    }
+
+    /// A reload re-runs every resolution, so the record of failed ones starts over.
+    pub fn clear_unresolved_imports(&mut self) {
+        let _guard = self.mutex.lock_guard();
+        self.unresolved_imports.clear();
     }
 }
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -80,19 +80,15 @@ impl AnyResolveWatcher {
         (self.callback)(self.context, dir_path, dir_fd)
     }
 
-    /// A relative or absolute import resolved to nothing: the resolver looked
-    /// for `base` in `dir_path`, with every extension and index probe, and
-    /// found no file and no directory.
+    /// A relative or absolute import of `base` in `dir_path` resolved to nothing.
     #[inline]
     pub fn unresolved(self, dir_path: &[u8], base: &[u8]) {
         (self.on_unresolved)(self.context, dir_path, base)
     }
 }
 
-/// One import the resolver could not find: the directory it searched and the
-/// stem of the basename it tried. A new entry in that directory whose name is
-/// the stem, or starts with the stem followed by a dot, can satisfy the import
-/// (`a`, `a.js`, `a.ts`, `a.js.ts`, or a directory `a`).
+/// An import the resolver could not find: the directory it searched and the
+/// stem of the name it tried (`a` for `a.js`).
 struct UnresolvedImport {
     dir_hash: HashType,
     stem: Box<[u8]>,
@@ -103,7 +99,6 @@ impl UnresolvedImport {
         if base.len() < 2 {
             return base;
         }
-        // Skip a leading dot so `.env` keeps its name.
         match strings::index_of_char_usize(&base[1..], b'.') {
             Some(i) => &base[..i + 1],
             None => base,
@@ -161,9 +156,7 @@ pub struct Watcher {
     pub(crate) evict_list: [WatchItemIndex; MAX_EVICTION_COUNT],
     pub(crate) evict_list_i: WatchItemIndex,
 
-    /// Imports the resolver could not find. A file that appears for one of
-    /// them must trigger a reload even though the file itself is not in the
-    /// watchlist. Guarded by `mutex`.
+    /// Imports the resolver could not find. Guarded by `mutex`.
     unresolved_imports: Vec<UnresolvedImport>,
 
     /// Scratch snapshot of `watchlist.eventlist_index` used by
@@ -1015,9 +1008,7 @@ impl Watcher {
         }
     }
 
-    /// The directory watch itself comes from `on_maybe_watch_directory`, which
-    /// `load_as_file` calls for every miss, including the misses that go on to
-    /// resolve as a directory. Only a miss of the whole resolution is recorded.
+    /// Called once the whole resolution missed, not on every `load_as_file` miss.
     pub(crate) fn on_unresolved_import(&mut self, dir_path: &[u8], base: &[u8]) {
         if !self.is_watchable_directory(dir_path) {
             return;
@@ -1040,20 +1031,15 @@ impl Watcher {
         }
     }
 
-    /// The resolver and the parent-directory autowatch spell the same directory
-    /// with and without a trailing slash, so `unresolved_imports` keys on the
-    /// stripped form.
+    /// Callers spell the same directory with and without a trailing slash.
     #[inline]
     fn unresolved_dir_hash(dir_path: &[u8]) -> HashType {
         Self::get_hash(strings::without_trailing_slash(dir_path))
     }
 
-    /// Whether an entry that appeared in `dir_path` can satisfy an import the
-    /// resolver failed to find since the last `clear_unresolved_imports`.
-    /// With `Some(name)` the entry name from the event is checked. With
-    /// `None` (kqueue and Windows report no entry name) the directory is
-    /// listed and every entry is checked. The caller must hold `mutex` (the
-    /// platform watcher holds it around `on_file_update`).
+    /// Whether an entry in `dir_path` can satisfy a recorded unresolved import.
+    /// `None` lists the directory (kqueue and Windows report no entry name).
+    /// The caller must hold `mutex`.
     pub fn unresolved_import_matches(&self, dir_path: &[u8], name: Option<&[u8]>) -> bool {
         debug_assert!(self.mutex.is_held_by_current_thread());
         let dir_hash = Self::unresolved_dir_hash(dir_path);

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -91,6 +91,8 @@ impl AnyResolveWatcher {
 struct UnresolvedImport {
     dir_hash: HashType,
     stem: Box<[u8]>,
+    /// Entries that matched the stem when the import failed. They cannot satisfy it.
+    present: Vec<Box<[u8]>>,
 }
 
 impl UnresolvedImport {
@@ -104,11 +106,27 @@ impl UnresolvedImport {
         }
     }
 
-    fn matches(&self, name: &[u8]) -> bool {
-        let stem: &[u8] = &self.stem;
+    fn stem_matches(stem: &[u8], name: &[u8]) -> bool {
         name == stem
             || (name.len() > stem.len() && name.starts_with(stem) && name[stem.len()] == b'.')
     }
+
+    fn matches(&self, name: &[u8]) -> bool {
+        Self::stem_matches(&self.stem, name) && !self.present.iter().any(|p| &**p == name)
+    }
+}
+
+fn for_each_dir_entry(dir_path: &[u8], mut f: impl FnMut(&[u8]) -> bool) -> bool {
+    let Ok(dir) = sys::Dir::open(strings::without_trailing_slash(dir_path)) else {
+        return false;
+    };
+    let mut iter = sys::iterate_dir(dir.fd());
+    while let Ok(Some(entry)) = iter.next() {
+        if f(entry.name.slice_u8()) {
+            return true;
+        }
+    }
+    false
 }
 
 // TODO: some platform-specific behavior is implemented in
@@ -1017,17 +1035,29 @@ impl Watcher {
             return;
         }
         let dir_hash = Self::unresolved_dir_hash(dir_path);
-        let _guard = self.mutex.lock_guard();
-        if !self
-            .unresolved_imports
-            .iter()
-            .any(|u| u.dir_hash == dir_hash && &*u.stem == stem)
         {
-            self.unresolved_imports.push(UnresolvedImport {
-                dir_hash,
-                stem: stem.into(),
-            });
+            let _guard = self.mutex.lock_guard();
+            if self
+                .unresolved_imports
+                .iter()
+                .any(|u| u.dir_hash == dir_hash && &*u.stem == stem)
+            {
+                return;
+            }
         }
+        let mut present: Vec<Box<[u8]>> = Vec::new();
+        for_each_dir_entry(dir_path, |name| {
+            if UnresolvedImport::stem_matches(stem, name) {
+                present.push(name.into());
+            }
+            false
+        });
+        let _guard = self.mutex.lock_guard();
+        self.unresolved_imports.push(UnresolvedImport {
+            dir_hash,
+            stem: stem.into(),
+            present,
+        });
     }
 
     /// Callers spell the same directory with and without a trailing slash.
@@ -1052,17 +1082,9 @@ impl Watcher {
             return candidates.any(|u| u.matches(name));
         }
         let candidates: Vec<&UnresolvedImport> = candidates.collect();
-        let Ok(dir) = sys::Dir::open(strings::without_trailing_slash(dir_path)) else {
-            return false;
-        };
-        let mut iter = sys::iterate_dir(dir.fd());
-        while let Ok(Some(entry)) = iter.next() {
-            let entry_name = entry.name.slice_u8();
-            if candidates.iter().any(|u| u.matches(entry_name)) {
-                return true;
-            }
-        }
-        false
+        for_each_dir_entry(dir_path, |entry_name| {
+            candidates.iter().any(|u| u.matches(entry_name))
+        })
     }
 
     /// A reload re-runs every resolution, so the record of failed ones starts over.

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -539,6 +539,12 @@ fn create_watch_event(event: &FileEvent, index: WatchItemIndex) -> WatchEvent {
     if event.action == Action::Modified {
         op |= Op::WRITE;
     }
+    if event.action == Action::Added {
+        op |= Op::CREATE;
+    }
+    if event.action == Action::RenamedNew {
+        op |= Op::MOVE_TO;
+    }
     WatchEvent {
         op,
         index,

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, forEachLine, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -775,4 +775,40 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+it(
+  "--hot reloads when a missing import is created",
+  async () => {
+    writeFileSync(join(cwd, "missing-entry.js"), `import { a } from "./missing-dep.js"; console.log("RUN", a);`);
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "--no-clear-screen", "missing-entry.js"],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const stdout = forEachLine(runner.stdout);
+    const stderr = forEachLine(runner.stderr);
+    const until = async (lines: AsyncIterator<string>, predicate: (line: string) => boolean) => {
+      while (true) {
+        const { value, done } = await lines.next();
+        if (done) throw new Error("stream ended before the expected line");
+        if (predicate(value)) return value;
+      }
+    };
+
+    await until(stderr, line => line.includes("Cannot find module"));
+
+    writeFileSync(join(cwd, "missing-dep.js"), "export const a = 10;");
+    expect(await until(stdout, line => line.startsWith("RUN"))).toBe("RUN 10");
+
+    writeFileSync(join(cwd, "missing-dep.js"), "export const a = 20;");
+    expect(await until(stdout, line => line.startsWith("RUN"))).toBe("RUN 20");
+
+    runner.kill();
+    await runner.exited;
+  },
+  timeout,
 );

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -55,13 +55,15 @@ class LineReader {
   constructor(stream: ReadableStream<Uint8Array>) {
     this.#lines = forEachLine(stream);
   }
+  /** The read in flight. It stays in flight across a timed-out `within` so no line is lost. */
   #next(): Promise<IteratorResult<string>> {
-    this.#pending ??= this.#lines.next().finally(() => (this.#pending = undefined));
+    this.#pending ??= this.#lines.next();
     return this.#pending;
   }
   async until(predicate: (line: string) => boolean): Promise<string> {
     while (true) {
       const { value, done } = await this.#next();
+      this.#pending = undefined;
       if (done) throw new Error("stream ended before the expected line");
       if (predicate(value)) return value;
     }
@@ -74,7 +76,9 @@ class LineReader {
       const left = deadline - Date.now();
       if (left <= 0) return out;
       const result = await Promise.race([this.#next(), Bun.sleep(left).then(() => undefined)]);
-      if (result === undefined || result.done) return out;
+      if (result === undefined) return out;
+      this.#pending = undefined;
+      if (result.done) return out;
       out.push(result.value);
     }
   }

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -49,11 +49,34 @@ describe.todoIf(isBroken && isWindows)("--watch works", async () => {
   }
 });
 
-async function readUntil(lines: AsyncIterator<string>, predicate: (line: string) => boolean): Promise<string> {
-  while (true) {
-    const { value, done } = await lines.next();
-    if (done) throw new Error("stream ended before the expected line");
-    if (predicate(value)) return value;
+class LineReader {
+  #lines: AsyncIterator<string>;
+  #pending: Promise<IteratorResult<string>> | undefined;
+  constructor(stream: ReadableStream<Uint8Array>) {
+    this.#lines = forEachLine(stream);
+  }
+  #next(): Promise<IteratorResult<string>> {
+    this.#pending ??= this.#lines.next().finally(() => (this.#pending = undefined));
+    return this.#pending;
+  }
+  async until(predicate: (line: string) => boolean): Promise<string> {
+    while (true) {
+      const { value, done } = await this.#next();
+      if (done) throw new Error("stream ended before the expected line");
+      if (predicate(value)) return value;
+    }
+  }
+  /** The lines that arrive within `ms`. A line that arrives later stays queued for the next read. */
+  async within(ms: number): Promise<string[]> {
+    const out: string[] = [];
+    const deadline = Date.now() + ms;
+    while (true) {
+      const left = deadline - Date.now();
+      if (left <= 0) return out;
+      const result = await Promise.race([this.#next(), Bun.sleep(left).then(() => undefined)]);
+      if (result === undefined || result.done) return out;
+      out.push(result.value);
+    }
   }
 }
 
@@ -68,16 +91,16 @@ describe.todoIf(isBroken && isWindows)("--watch recovers from a missing import",
       env: bunEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const stdout = forEachLine(proc.stdout);
-    const stderr = forEachLine(proc.stderr);
+    const stdout = new LineReader(proc.stdout);
+    const stderr = new LineReader(proc.stderr);
 
-    await readUntil(stderr, line => line.includes("Cannot find module"));
+    await stderr.until(line => line.includes("Cannot find module"));
 
     await writeFile(join(String(dir), "a.js"), "export const a = 10;");
-    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 10");
+    expect(await stdout.until(line => line.startsWith("RUN"))).toBe("RUN 10");
 
     await writeFile(join(String(dir), "a.js"), "export const a = 20;");
-    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 20");
+    expect(await stdout.until(line => line.startsWith("RUN"))).toBe("RUN 20");
 
     proc.kill("SIGKILL");
     await proc.exited;
@@ -101,13 +124,16 @@ describe.todoIf(isBroken && isWindows)("--watch recovers from a missing import",
       env: bunEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const stdout = forEachLine(proc.stdout);
+    const stdout = new LineReader(proc.stdout);
 
-    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 1");
+    expect(await stdout.until(line => line.startsWith("RUN"))).toBe("RUN 1");
 
-    // The next run must come from this edit, not from the lib.log write.
+    // A rerun from the lib.log write would land well inside this window. A
+    // correct build prints nothing here, so the window cannot make it flake.
+    expect(await stdout.within(2000)).toEqual([]);
+
     await writeFile(join(String(dir), "lib", "index.js"), "export const v = 2;");
-    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 2");
+    expect(await stdout.until(line => line.startsWith("RUN"))).toBe("RUN 2");
 
     proc.kill("SIGKILL");
     await proc.exited;
@@ -124,20 +150,20 @@ describe.todoIf(isBroken && isWindows)("--watch recovers from a missing import",
       env: bunEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const stdout = forEachLine(proc.stdout);
-    const stderr = forEachLine(proc.stderr);
+    const stdout = new LineReader(proc.stdout);
+    const stderr = new LineReader(proc.stderr);
     const isResolveError = (line: string) => line.includes('Could not resolve: "./a.js"');
 
-    await readUntil(stderr, isResolveError);
+    await stderr.until(isResolveError);
 
     // An edit to an import that did resolve rebuilds while a.js is missing.
     await writeFile(join(String(dir), "b.js"), "export const b = 30;");
-    await readUntil(stderr, isResolveError);
+    await stderr.until(isResolveError);
 
     // Creating the missing file rebuilds with both edits.
     await writeFile(join(String(dir), "a.js"), "export const a = 10;");
     // The per-file row is printed after the file is written.
-    await readUntil(stdout, line => line.includes("entry.js") && line.includes("(entry point)"));
+    await stdout.until(line => line.includes("entry.js") && line.includes("(entry point)"));
     const bundle = await Bun.file(join(String(dir), "out", "entry.js")).text();
     expect(bundle).toContain("var a = 10");
     expect(bundle).toContain("var b = 30");

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -83,6 +83,36 @@ describe.todoIf(isBroken && isWindows)("--watch recovers from a missing import",
     await proc.exited;
   });
 
+  test("a directory import that resolves does not rerun on a sibling file", async () => {
+    // `./lib` misses as a file before it resolves as `lib/index.js`. A file the
+    // program writes next to it must not count as the missing file appearing.
+    await using dir = tempDir("watch-dir-import", {
+      "entry.js": `
+        import { writeFileSync } from "node:fs";
+        import { v } from "./lib";
+        console.log("RUN", v);
+        writeFileSync("lib.log", String(Date.now()));
+      `,
+      "lib/index.js": "export const v = 1;",
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "--watch", "--no-clear-screen", "entry.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout = forEachLine(proc.stdout);
+
+    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 1");
+
+    // The next run must come from this edit, not from the lib.log write.
+    await writeFile(join(String(dir), "lib", "index.js"), "export const v = 2;");
+    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 2");
+
+    proc.kill("SIGKILL");
+    await proc.exited;
+  });
+
   test("bun build --watch keeps rebuilding and recovers", async () => {
     await using dir = tempDir("build-watch-missing-import", {
       "entry.js": `import { a } from "./a.js"; import { b } from "./b.js"; console.log(a + b);`,

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -48,3 +48,71 @@ describe.todoIf(isBroken && isWindows)("--watch works", async () => {
     });
   }
 });
+
+async function readUntil(lines: AsyncIterator<string>, predicate: (line: string) => boolean): Promise<string> {
+  while (true) {
+    const { value, done } = await lines.next();
+    if (done) throw new Error("stream ended before the expected line");
+    if (predicate(value)) return value;
+  }
+}
+
+describe.todoIf(isBroken && isWindows)("--watch recovers from a missing import", () => {
+  test("bun --watch reruns when the missing file is created", async () => {
+    await using dir = tempDir("watch-missing-import", {
+      "entry.js": `import { a } from "./a.js"; console.log("RUN", a);`,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "--watch", "--no-clear-screen", "entry.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout = forEachLine(proc.stdout);
+    const stderr = forEachLine(proc.stderr);
+
+    await readUntil(stderr, line => line.includes("Cannot find module"));
+
+    await writeFile(join(String(dir), "a.js"), "export const a = 10;");
+    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 10");
+
+    await writeFile(join(String(dir), "a.js"), "export const a = 20;");
+    expect(await readUntil(stdout, line => line.startsWith("RUN"))).toBe("RUN 20");
+
+    proc.kill("SIGKILL");
+    await proc.exited;
+  });
+
+  test("bun build --watch keeps rebuilding and recovers", async () => {
+    await using dir = tempDir("build-watch-missing-import", {
+      "entry.js": `import { a } from "./a.js"; import { b } from "./b.js"; console.log(a + b);`,
+      "b.js": "export const b = 2;",
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "build", "entry.js", "--outdir", "out", "--watch", "--no-clear-screen"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout = forEachLine(proc.stdout);
+    const stderr = forEachLine(proc.stderr);
+    const isResolveError = (line: string) => line.includes('Could not resolve: "./a.js"');
+
+    await readUntil(stderr, isResolveError);
+
+    // An edit to an import that did resolve rebuilds while a.js is missing.
+    await writeFile(join(String(dir), "b.js"), "export const b = 30;");
+    await readUntil(stderr, isResolveError);
+
+    // Creating the missing file rebuilds with both edits.
+    await writeFile(join(String(dir), "a.js"), "export const a = 10;");
+    // The per-file row is printed after the file is written.
+    await readUntil(stdout, line => line.includes("entry.js") && line.includes("(entry point)"));
+    const bundle = await Bun.file(join(String(dir), "out", "entry.js")).text();
+    expect(bundle).toContain("var a = 10");
+    expect(bundle).toContain("var b = 30");
+
+    proc.kill("SIGKILL");
+    await proc.exited;
+  });
+});


### PR DESCRIPTION
### Problem
- `bun build --watch` stops rebuilding after `error: Could not resolve: "./a.js"`. Creating `a.js`, or editing any other import, triggers nothing. Only an edit to the entry file recovers. `bun --watch` and `bun --hot` have the same gap for a missing import. esbuild `--watch` rebuilds as soon as the file appears.
- Two causes. The resolver already watches the directory it searched (`src/resolver/resolver.rs`, `load_as_file`), but the directory arm of `on_file_update` (`src/jsc/hot_reloader.rs`) only reloads for entries that are in the watchlist, and a file that never resolved is not. In the bundler, the first failed import clears the resolve queue of the importing file (`src/bundler/bundle_v2.rs`, `run_resolution_for_parse_task`), so its other imports are never parsed or watched.

### Fix
- When a relative or absolute import misses as both a file and a directory, the resolver tells the watcher. The watcher records `(directory, name stem)`, for example `(src, a)` for `./a.js`, plus the entries that already match the stem (they cannot satisfy the import). A create or move-in event on that directory for a new entry named `a` or `a.<anything>` enqueues a reload. inotify reports the entry name. kqueue and Windows do not, so there the watcher lists the directory. The Windows watcher now maps `FILE_ACTION_ADDED` to `Op::CREATE` and `FILE_ACTION_RENAMED_NEW_NAME` to `Op::MOVE_TO`.
- Only the hot reloader turns the recording on. The dev server shares the resolver callback but keeps its own failure tracking. `--hot` clears the record before each reload. `--watch` re-execs, so the record dies with the process.
- Under `bun build --watch` (a watcher and no dev server) a resolve error no longer clears the resolve queue, and the error arm of `on_parse_task_complete` schedules it. The other imports are parsed and watched. The build still aborts before link time on `log.errors > 0`.
- Verified: `test/cli/hot/watch.test.ts` (three new tests) and `test/cli/hot/hot.test.ts` (one new `--hot` test). The recovery tests fail on 1.4.3. Also `test/cli/hot/`, `test/bake/dev/bundle.test.ts`, `test/bake/dev/esm.test.ts`, and `cargo check` for the windows-msvc and apple-darwin targets.

### Background
- `bun build --watch` and `bun --watch` use `NewHotReloader<_, _, true>`: the watcher thread calls `execve` on the first change. `--hot` uses `RELOAD_IMMEDIATELY = false` and reloads the module graph in place through `Task::run`.
- The watchlist holds the files the build parsed plus their parent directories. `load_as_file` adds a directory watch when it finds nothing in a directory. That watch had no effect on reloads until now.
- The stem match is wider than the exact candidates the resolver tries, so `a.ts` for `./a.js` and a directory `a` count. A false match costs one rebuild while the build is already failing.

<details><summary>Notes</summary>

- The record is written only when the whole resolution misses, not on every `load_as_file` miss. `import "./lib"` misses as a file before it resolves as `lib/index.js`, and must leave no record. The third watch test covers that with a bounded no-output window.
- The reload is gated on a create or move-in (inotify, Windows) or a directory write (kqueue, which fires for an entry add, remove, or rename). A write to an existing file in that directory does not reload. An entry that was present when the import failed (`util.test.ts` next to a missing `./util`) never matches.
- Not recovered by this change: a bare specifier (node_modules), a missing `dir/index.*` (`load_as_index` registers no watch), and a miss under tsconfig `paths`.
- Prior art is esbuild `--watch`. Node `--watch` does not restart in this case.
- #33073 handles the narrower case of a watched file that is deleted and recreated under `--hot`, by remembering evicted watch entries. This change covers a file that never existed, and the bundler. The two do not conflict.
- Self-reviewed: the review asked for the recording to stay out of the dev server (done), for exact resolver candidates instead of a stem (kept the stem plus the present-entry exclusion, because the candidates miss the `.js` to `.ts` rewrite and a directory), and for the bundler half as a separate PR (kept in one PR, the report is one bug with two faces).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/watch.test.ts, test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->