### PR TITLE
dns: report a temporary getaddrinfo failure as EAI_AGAIN

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1846,7 +1846,8 @@ impl Error {
             "c-ares status {rc} out of range",
         );
         // SAFETY: `n` is in `1..=ARES_ENOSERVER`; `Error` is `#[repr(i32)]` with
-        // contiguous discriminants `1..=ARES_ENOSERVER`.
+        // contiguous discriminants `1..=ARES_ENOSERVER + 1`, so every value in
+        // the asserted range is a valid discriminant.
         Some(unsafe { core::mem::transmute::<i32, Error>(n as i32) })
     }
 }

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1649,10 +1649,8 @@ pub enum Error {
     ECANCELLED = ARES_ECANCELLED,
     ESERVICE = ARES_ESERVICE,
     ENOSERVER = ARES_ENOSERVER,
-    /// getaddrinfo(3) `EAI_AGAIN`: the system resolver failed for now (every
-    /// nameserver timed out or answered SERVFAIL). Not a c-ares status, so
-    /// [`Error::get`] never produces it. Its JS-visible errno is
-    /// [`Error::errno`], not the discriminant.
+    /// getaddrinfo(3) `EAI_AGAIN`. Not a c-ares status: [`Error::get`] never
+    /// produces it, and its errno comes from [`Error::errno`].
     EAI_AGAIN = ARES_ENOSERVER + 1,
 }
 
@@ -1736,8 +1734,7 @@ impl Error {
         }
     }
 
-    /// The raw getaddrinfo(3) status this platform uses for the `EAI_*` code
-    /// named `name`. Lets a test feed `init_eai` without a failing resolver.
+    /// This platform's raw getaddrinfo(3) status for the `EAI_*` code named `name`.
     pub fn eai_raw_by_name(name: &[u8]) -> Option<i32> {
         #[cfg(windows)]
         {
@@ -1760,8 +1757,7 @@ impl Error {
         }
     }
 
-    /// The `errno` a JS error built from this status carries. c-ares statuses
-    /// keep their enum value. `EAI_AGAIN` reports libuv's negative code, like Node.
+    /// The JS-visible `errno` for this status.
     pub fn errno(self) -> i32 {
         match self {
             Error::EAI_AGAIN => UV_EAI_AGAIN,

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1649,7 +1649,15 @@ pub enum Error {
     ECANCELLED = ARES_ECANCELLED,
     ESERVICE = ARES_ESERVICE,
     ENOSERVER = ARES_ENOSERVER,
+    /// getaddrinfo(3) `EAI_AGAIN`: the system resolver failed for now (every
+    /// nameserver timed out or answered SERVFAIL). Not a c-ares status, so
+    /// [`Error::get`] never produces it. Its JS-visible errno is
+    /// [`Error::errno`], not the discriminant.
+    EAI_AGAIN = ARES_ENOSERVER + 1,
 }
+
+/// libuv's `UV_EAI_AGAIN`, the `errno` Node reports for getaddrinfo `EAI_AGAIN`.
+const UV_EAI_AGAIN: i32 = -3001;
 
 impl Error {
     // Deferred / toDeferred / toJSWithSyscall / toJSWithSyscallAndHostname
@@ -1666,7 +1674,7 @@ impl Error {
             // TODO: revisit this
             return match rc {
                 0 => None,
-                libuv::UV_EAI_AGAIN => Some(Error::ETIMEOUT),
+                libuv::UV_EAI_AGAIN => Some(Error::EAI_AGAIN),
                 libuv::UV_EAI_ADDRFAMILY => Some(Error::EBADFAMILY),
                 libuv::UV_EAI_BADFLAGS => Some(Error::EBADFLAGS),
                 libuv::UV_EAI_BADHINTS => Some(Error::EBADHINTS),
@@ -1715,7 +1723,7 @@ impl Error {
             }
             match eai {
                 EAI::ADDRFAMILY => Some(Error::EBADFAMILY),
-                EAI::AGAIN => Some(Error::ETIMEOUT), // transient; matches libuv
+                EAI::AGAIN => Some(Error::EAI_AGAIN),
                 EAI::BADFLAGS => Some(Error::EBADFLAGS), // Invalid hints
                 EAI::FAIL => Some(Error::EBADRESP),
                 EAI::FAMILY => Some(Error::EBADFAMILY),
@@ -1725,6 +1733,39 @@ impl Error {
                 // Any EAI code not mapped above is reported as "not implemented".
                 _ => Some(Error::ENOTIMP),
             }
+        }
+    }
+
+    /// The raw getaddrinfo(3) status this platform uses for the `EAI_*` code
+    /// named `name`. Lets a test feed `init_eai` without a failing resolver.
+    pub fn eai_raw_by_name(name: &[u8]) -> Option<i32> {
+        #[cfg(windows)]
+        {
+            use bun_libuv_sys as libuv;
+            match name {
+                b"EAI_AGAIN" => Some(libuv::UV_EAI_AGAIN),
+                b"EAI_FAIL" => Some(libuv::UV_EAI_FAIL),
+                b"EAI_NONAME" => Some(libuv::UV_EAI_NONAME),
+                _ => None,
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            match name {
+                b"EAI_AGAIN" => Some(EAI::AGAIN.0),
+                b"EAI_FAIL" => Some(EAI::FAIL.0),
+                b"EAI_NONAME" => Some(EAI::NONAME.0),
+                _ => None,
+            }
+        }
+    }
+
+    /// The `errno` a JS error built from this status carries. c-ares statuses
+    /// keep their enum value. `EAI_AGAIN` reports libuv's negative code, like Node.
+    pub fn errno(self) -> i32 {
+        match self {
+            Error::EAI_AGAIN => UV_EAI_AGAIN,
+            _ => self as i32,
         }
     }
 
@@ -1756,6 +1797,7 @@ impl Error {
             Error::ECANCELLED => "DNS_ECANCELLED",
             Error::ESERVICE => "DNS_ESERVICE",
             Error::ENOSERVER => "DNS_ENOSERVER",
+            Error::EAI_AGAIN => "DNS_EAI_AGAIN",
         }
     }
 
@@ -1787,6 +1829,7 @@ impl Error {
             Error::ECANCELLED => "DNS query cancelled",
             Error::ESERVICE => "Service not available",
             Error::ENOSERVER => "No DNS servers were configured",
+            Error::EAI_AGAIN => "Temporary failure in name resolution",
         }
     }
 

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -301,6 +301,7 @@ export function getJS2NativeRust() {
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isLocalhostNameForTesting",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isAllLoopbackOfOneFamilyForTesting",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoErrorForTesting",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -777,6 +777,13 @@ export const dnsIsAllLoopbackOfOneFamily = $newRustFunction(
   1,
 ) as (addresses: string[]) => boolean;
 
+/** The error a getaddrinfo lookup of `hostname` reports when getaddrinfo(3) returns the `EAI_*` status named `code` (`"EAI_AGAIN"`, `"EAI_FAIL"`, `"EAI_NONAME"`). */
+export const dnsGetaddrinfoError = $newRustFunction(
+  "runtime/dns_jsc/dns.rs",
+  "internal.getaddrinfoErrorForTesting",
+  2,
+) as (code: string, hostname: string) => Error & { code: string; errno: number; syscall: string; hostname: string };
+
 export const fetchH2Internals = {
   liveCounts: $newRustFunction("http/H2Client.rs", "TestingAPIs.liveCounts", 0) as () => {
     sessions: number;

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -679,7 +679,7 @@ impl ErrorDeferred {
             ))
         };
         let system_error = SystemError {
-            errno: self.errno as i32,
+            errno: self.errno.errno(),
             code: bstr::String::static_(code),
             message,
             syscall: bstr::String::clone_utf8(self.syscall),
@@ -765,7 +765,7 @@ pub(crate) fn error_to_js_with_syscall(
 ) -> JsResult<JSValue> {
     let code = this.code();
     let instance = SystemError {
-        errno: this as i32,
+        errno: this.errno(),
         code: bstr::String::static_(&code[4..]),
         syscall: bstr::String::static_(syscall),
         message: bstr::String::create_format(format_args!(
@@ -796,7 +796,7 @@ pub(crate) fn system_error_with_syscall_and_hostname(
 ) -> SystemError {
     let code = this.code();
     SystemError {
-        errno: this as i32,
+        errno: this.errno(),
         code: bstr::String::static_(&code[4..]),
         message: bstr::String::create_format(format_args!(
             "{} {} {}",

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2972,10 +2972,8 @@ pub mod internal {
         Ok(out)
     }
 
-    /// `bun:internal-for-testing`: the error a `getaddrinfo` lookup of
-    /// `hostname` reports when getaddrinfo(3) returns the `EAI_*` status named
-    /// `code`, built by the same [`c_ares::Error::init_eai`] mapping the real
-    /// system-backend, `fetch()` and `Bun.connect()` paths use.
+    /// `bun:internal-for-testing`: the error a lookup of `hostname` reports
+    /// when getaddrinfo(3) returns the `EAI_*` status named `code`.
     pub(crate) fn getaddrinfo_error_for_testing(
         global: &JSGlobalObject,
         frame: &CallFrame,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2972,6 +2972,39 @@ pub mod internal {
         Ok(out)
     }
 
+    /// `bun:internal-for-testing`: the error a `getaddrinfo` lookup of
+    /// `hostname` reports when getaddrinfo(3) returns the `EAI_*` status named
+    /// `code`, built by the same [`c_ares::Error::init_eai`] mapping the real
+    /// system-backend, `fetch()` and `Bun.connect()` paths use.
+    pub(crate) fn getaddrinfo_error_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let args = frame.arguments();
+        if args.len() < 2 || !args[0].is_string() || !args[1].is_string() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "expected (code: string, hostname: string)"
+            )));
+        }
+        let code = args[0].to_utf8(global)?;
+        let hostname = args[1].to_utf8(global)?;
+        let Some(rc) = c_ares::Error::eai_raw_by_name(code.slice()) else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "unknown getaddrinfo status name: {}",
+                bstr::BStr::new(code.slice())
+            )));
+        };
+        match c_ares::Error::init_eai(rc) {
+            Some(err) => crate::dns_jsc::cares_jsc::error_to_js_with_syscall_and_hostname(
+                err,
+                global,
+                b"getaddrinfo",
+                hostname.slice(),
+            ),
+            None => Ok(JSValue::UNDEFINED),
+        }
+    }
+
     pub(crate) fn getaddrinfo(
         loop_: *mut Loop,
         host: Option<&ZStr>,
@@ -6083,4 +6116,8 @@ export_host_fn!(
 export_host_fn!(
     internal::is_all_loopback_of_one_family_for_testing,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isAllLoopbackOfOneFamilyForTesting"
+);
+export_host_fn!(
+    internal::getaddrinfo_error_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_getaddrinfoErrorForTesting"
 );

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,3 +1,4 @@
+import { dnsGetaddrinfoError } from "bun:internal-for-testing";
 import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import * as dgram from "node:dgram";
@@ -1059,8 +1060,6 @@ test.concurrent.each(["NAPTR", "naptr"])("resolve(hostname, %p) issues a NAPTR q
 // resolver, so this drives the same mapping the system backend, fetch() and
 // Bun.connect() use with the raw EAI_* status.
 describe("getaddrinfo status mapping", () => {
-  const { dnsGetaddrinfoError } = require("bun:internal-for-testing");
-
   test("EAI_AGAIN is reported as EAI_AGAIN, like Node", () => {
     const err = dnsGetaddrinfoError("EAI_AGAIN", "redis.example");
     expect(err).toBeInstanceOf(Error);

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1051,3 +1051,34 @@ test.concurrent.each(["NAPTR", "naptr"])("resolve(hostname, %p) issues a NAPTR q
     socket.close();
   }
 });
+
+// dns.lookup() is getaddrinfo(3). Node reports a temporary resolver failure
+// (every nameserver timed out or answered SERVFAIL) as `EAI_AGAIN` with
+// libuv's errno, and retry libraries key on that code. Bun used to report it
+// as the c-ares code `ETIMEOUT`. CI cannot point getaddrinfo at a failing
+// resolver, so this drives the same mapping the system backend, fetch() and
+// Bun.connect() use with the raw EAI_* status.
+describe("getaddrinfo status mapping", () => {
+  const { dnsGetaddrinfoError } = require("bun:internal-for-testing");
+
+  test("EAI_AGAIN is reported as EAI_AGAIN, like Node", () => {
+    const err = dnsGetaddrinfoError("EAI_AGAIN", "redis.example");
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toMatchObject({
+      message: "getaddrinfo EAI_AGAIN redis.example",
+      code: "EAI_AGAIN",
+      errno: -3001,
+      syscall: "getaddrinfo",
+      hostname: "redis.example",
+    });
+  });
+
+  test("EAI_NONAME is still reported as ENOTFOUND, like Node", () => {
+    expect(dnsGetaddrinfoError("EAI_NONAME", "redis.example")).toMatchObject({
+      message: "getaddrinfo ENOTFOUND redis.example",
+      code: "ENOTFOUND",
+      syscall: "getaddrinfo",
+      hostname: "redis.example",
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- When every nameserver times out or answers SERVFAIL, getaddrinfo(3) returns `EAI_AGAIN`. Node reports `getaddrinfo EAI_AGAIN <host>` with `code: "EAI_AGAIN"` and `errno: -3001`. Bun reports `getaddrinfo ETIMEOUT <host>` with `code: "ETIMEOUT"` and `errno: 12`. Retry logic that keys on `EAI_AGAIN` (got, superagent, make-fetch-happen, Bun's own build download retry) does not fire. Reported in #31888.
- The cause is `init_eai` in `src/cares_sys/c_ares.rs:1723`. It folds every getaddrinfo status into a c-ares code and maps `EAI_AGAIN` to `ETIMEOUT`. The comment says this matches libuv. It does not: libuv passes `UV_EAI_AGAIN` through and Node prints that name.

### Fix
- Add an `EAI_AGAIN` variant to `c_ares::Error`. Map the POSIX `EAI_AGAIN` and the libuv `UV_EAI_AGAIN` status to it. Its code is `EAI_AGAIN` and its errno is `UV_EAI_AGAIN` (-3001) through a new `Error::errno()`, which the three error builders in `cares_jsc.rs` now use. Every other variant keeps its enum value as errno.
- This reaches `dns.lookup` (the system and libc backends), `fetch()` and `Bun.connect()`, which all report the resolver status through `init_eai`. The c-ares `resolve*` and `reverse` paths are untouched and still report `ETIMEOUT`, as Node does for them. On Windows the change covers the libuv `getaddrinfo` path that `dns.lookup` uses.
- CI cannot point getaddrinfo at a failing resolver, so the test drives the same mapping through a new `bun:internal-for-testing` hook, `dnsGetaddrinfoError(code, hostname)`. It follows the existing `dnsIsLocalhostName` hook pattern.
- Verified: `test/js/node/dns/node-dns.test.js` (two new tests in "getaddrinfo status mapping"). Also the rest of `test/js/node/dns/` and `test/js/bun/dns/`. Manual check against a fake resolver that answers SERVFAIL: Node and this build print the same `code`, `errno`, `syscall` and `hostname` for `dns.lookup`, `dns.promises.lookup` and `fetch()`.

### Background
- `dns.lookup` is the getaddrinfo(3) API. Node runs it on libuv's thread pool and reports libuv's negative `UV_EAI_*` errno and name. `dns.resolve*` is a c-ares query and reports c-ares names such as `ETIMEOUT`.
- `c_ares::Error` is Bun's one DNS error enum. `init_eai` translates a raw getaddrinfo status into it so the system backend can share the c-ares error builders.
- #30987 (open, conflicting) fixes the errno, hostname and name shape of getaddrinfo errors. It keeps `code: "ETIMEOUT"` for `EAI_AGAIN`. When it rebases, its errno table needs an `EAI_AGAIN => UV_EAI_AGAIN` arm and no longer needs `ETIMEOUT => UV_EAI_AGAIN`.

<details><summary>Notes</summary>

Self-reviewed: 4 concerns raised, 2 addressed (errno moved out of the enum discriminant into `Error::errno()`, description corrected for the Windows and c-ares paths). Not addressed: a full getaddrinfo-domain error type that also fixes `EAI_FAIL`, `EAI_FAMILY`, `EAI_SERVICE` and the `ENOTFOUND` errno. That is the right follow-up and is the scope of #30987. This PR fixes the one status users hit in practice.

Manual reproduction: a python UDP server on 127.0.0.1:53 that answers every query with rcode SERVFAIL, `/etc/resolv.conf` set to `nameserver 127.0.0.1`.

Node 26:
```
dns.lookup {"name":"Error","message":"getaddrinfo EAI_AGAIN redis.example","code":"EAI_AGAIN","errno":-3001,"syscall":"getaddrinfo","hostname":"redis.example"}
```
Bun 1.4.3:
```
dns.lookup {"name":"DNSException","message":"getaddrinfo ETIMEOUT redis.example","code":"ETIMEOUT","errno":12,"syscall":"getaddrinfo","hostname":"redis.example"}
```
This branch:
```
dns.lookup {"name":"DNSException","message":"getaddrinfo EAI_AGAIN redis.example","code":"EAI_AGAIN","errno":-3001,"syscall":"getaddrinfo","hostname":"redis.example"}
promises.lookup {"name":"DNSException","message":"getaddrinfo EAI_AGAIN","code":"EAI_AGAIN","errno":-3001,"syscall":"getaddrinfo"}
fetch {"name":"TypeError","message":"getaddrinfo EAI_AGAIN proxy-internal","code":"EAI_AGAIN","errno":-3001,"syscall":"getaddrinfo","hostname":"proxy-internal"}
```
The remaining `name: "DNSException"` and the missing hostname on the promise path are the subject of #30987.

The fuzz round that found this also listed two other faces on the lookup path (name normalisation on input, and c-ares merging hosts-file entries that share an IP). They are not in this PR.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->