### PR TITLE
tls: report a fatal post-handshake SSL error instead of a clean close

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1921,6 +1921,26 @@ struct us_bun_verify_error_t us_internal_ssl_verify_error(struct us_socket_t *s)
 
 /* ── Handshake state machine ─────────────────────────────────────────────── */
 
+/* Drain the thread's error queue and return the entry that names the failure
+ * the way node reports it: the OLDEST entry is the root cause
+ * (https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L860),
+ * except that BoringSSL queues a lower layer's entry first for some failures
+ * (a record that fails to authenticate is "Cipher functions:BAD_DECRYPT"
+ * under "SSL routines:DECRYPTION_FAILED_OR_BAD_RECORD_MAC") where OpenSSL
+ * queues only the SSL one. The oldest SSL-library entry wins, then the oldest
+ * overall. 0 when nothing was queued. */
+static unsigned long ssl_take_root_cause_error(void) {
+  unsigned long root = 0;
+  unsigned long ssl_queue_err;
+  while ((ssl_queue_err = ERR_get_error()) != 0) {
+    if (root == 0 || (ERR_GET_LIB(root) != ERR_LIB_SSL &&
+                      ERR_GET_LIB(ssl_queue_err) == ERR_LIB_SSL)) {
+      root = ssl_queue_err;
+    }
+  }
+  return root;
+}
+
 /* Park the fatal OpenSSL reason behind a failed SSL_* call where the
  * handshake-failure dispatch can find it, then drain the queue and mark the
  * socket fatal. Only parks while the handshake is unfinished: that dispatch is
@@ -1930,10 +1950,7 @@ static void ssl_park_fatal_reason(struct us_socket_t *s) {
   struct loop_ssl_data *loop_ssl_data =
       (struct loop_ssl_data *) s->group->loop->data.ssl_data;
   if (loop_ssl_data && s->ssl_handshake_state != HANDSHAKE_COMPLETED) {
-    /* The OLDEST queued entry is the root cause and is what node reports
-     * (https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L860);
-     * later entries wrap it or belong to another socket on this thread. */
-    unsigned long ssl_queue_err = ERR_peek_error();
+    unsigned long ssl_queue_err = ssl_take_root_cause_error();
     if (ssl_queue_err != 0) {
       ERR_error_string_n(ssl_queue_err, loop_ssl_data->ssl_last_fatal_error,
                          sizeof(loop_ssl_data->ssl_last_fatal_error));
@@ -1942,6 +1959,24 @@ static void ssl_park_fatal_reason(struct us_socket_t *s) {
   }
   ERR_clear_error();
   s->ssl_fatal_error = 1;
+}
+
+/* The post-handshake counterpart of ssl_park_fatal_reason: the handshake
+ * dispatch that would consume a parked reason has already run, so the reason
+ * travels with the close instead (on_close's `reason`, which node surfaces
+ * as the socket's ERR_SSL_* 'error' before 'close'). Copies the root-cause
+ * reason into `out` and returns 1, or returns 0 with nothing queued (a
+ * renegotiation-limit close, a BIO write that failed with no SSL error).
+ * Drains the queue and marks the socket fatal either way. */
+static int ssl_take_fatal_reason(struct us_socket_t *s, char *out, size_t out_len) {
+  int taken = 0;
+  unsigned long ssl_queue_err = ssl_take_root_cause_error();
+  if (ssl_queue_err != 0) {
+    ERR_error_string_n(ssl_queue_err, out, out_len);
+    taken = 1;
+  }
+  s->ssl_fatal_error = 1;
+  return taken;
 }
 
 /* The on_handshake callback runs JS which may us_socket_close(s) — that frees
@@ -2619,7 +2654,19 @@ restart:
         }
 
         if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
-          ssl_park_fatal_reason(s);
+          if (s->ssl_handshake_state == HANDSHAKE_COMPLETED) {
+            /* A bad record, a peer alert, an unexpected message after the
+             * handshake: BoringSSL already sealed the fatal alert into the
+             * wire via the BIO. Close with the reason so the owner reports
+             * it, instead of a clean EOF that hides the protocol failure. */
+            char reason[US_SSL_FATAL_ERROR_REASON_MAX];
+            if (ssl_take_fatal_reason(s, reason, sizeof(reason))) {
+              ssl_close(s, 0, reason);
+              return NULL;
+            }
+          } else {
+            ssl_park_fatal_reason(s);
+          }
         }
         ssl_close(s, 0, NULL);
         loop_ssl_data->ssl_last_fatal_error[0] = 0;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -401,10 +401,8 @@ function tlsHandshakeError(verifyError) {
   return new ConnResetException("socket hang up");
 }
 
-// A fatal TLS protocol error after the handshake (EPROTO carrying the OpenSSL
-// reason, see NewSocket::on_close). Node destroys the socket with the
-// ERR_SSL_* error, listener or not. A write parked on the native drain can
-// never complete: fail it with the same error, like the native error dispatch.
+// Fatal post-handshake TLS error (EPROTO with the OpenSSL reason): fail the
+// parked write and destroy with the ERR_SSL_* error, like the native dispatch.
 function destroyWithTLSError(self, err) {
   const error = tlsHandshakeError(err);
   const pendingWrite = self[kwriteCallback];

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -644,10 +644,8 @@ function SocketEmitEndNT(self, _err?) {
   // merely called): a peer reset while queued data is still unflushed is the
   // peer aborting mid-transfer and must surface (test-net-error-twice).
   const teardownNoise = self[kended] && self.writableFinished;
-  // A fatal TLS protocol error after the handshake (a bad record, a peer
-  // alert) arrives as EPROTO carrying the OpenSSL reason. Node's TLSWrap
-  // reports it as the socket's ERR_SSL_<REASON> 'error' whether or not a
-  // listener exists, so it is never downgraded to a silent EOF below.
+  // Fatal post-handshake TLS error (EPROTO with the OpenSSL reason): node
+  // destroys the socket with the ERR_SSL_* error, listener or not.
   if (_err && _err.code === "EPROTO" && !self.destroyed && !self._hadError) {
     self.destroy(tlsHandshakeError(_err));
     return;
@@ -1336,8 +1334,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     if (err) $debug(err);
     if (self[kclosed]) return;
     self[kclosed] = true;
-    // A fatal TLS protocol error after the handshake (see SocketEmitEndNT):
-    // node reports it as the ERR_SSL_<REASON> 'error' even with no listener.
+    // Fatal post-handshake TLS error: same as SocketEmitEndNT.
     if (err && err.code === "EPROTO" && !self.destroyed && !self._hadError && socket === self._handle) {
       self.destroy(tlsHandshakeError(err));
       return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -401,6 +401,20 @@ function tlsHandshakeError(verifyError) {
   return new ConnResetException("socket hang up");
 }
 
+// A fatal TLS protocol error after the handshake (EPROTO carrying the OpenSSL
+// reason, see NewSocket::on_close). Node destroys the socket with the
+// ERR_SSL_* error, listener or not. A write parked on the native drain can
+// never complete: fail it with the same error, like the native error dispatch.
+function destroyWithTLSError(self, err) {
+  const error = tlsHandshakeError(err);
+  const pendingWrite = self[kwriteCallback];
+  if (pendingWrite) {
+    self[kwriteCallback] = null;
+    pendingWrite(error);
+  }
+  self.destroy(error);
+}
+
 const SocketHandlers: SocketHandler = {
   close(socket, err) {
     const self = socket.data;
@@ -644,10 +658,8 @@ function SocketEmitEndNT(self, _err?) {
   // merely called): a peer reset while queued data is still unflushed is the
   // peer aborting mid-transfer and must surface (test-net-error-twice).
   const teardownNoise = self[kended] && self.writableFinished;
-  // Fatal post-handshake TLS error (EPROTO with the OpenSSL reason): node
-  // destroys the socket with the ERR_SSL_* error, listener or not.
   if (_err && _err.code === "EPROTO" && !self.destroyed && !self._hadError) {
-    self.destroy(tlsHandshakeError(_err));
+    destroyWithTLSError(self, _err);
     return;
   }
   // _hadError: the failure already reached JS through the error dispatch
@@ -1334,9 +1346,8 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     if (err) $debug(err);
     if (self[kclosed]) return;
     self[kclosed] = true;
-    // Fatal post-handshake TLS error: same as SocketEmitEndNT.
     if (err && err.code === "EPROTO" && !self.destroyed && !self._hadError && socket === self._handle) {
-      self.destroy(tlsHandshakeError(err));
+      destroyWithTLSError(self, err);
       return;
     }
     // A received RST surfacing as ECONNRESET with the close is not a clean

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -644,6 +644,14 @@ function SocketEmitEndNT(self, _err?) {
   // merely called): a peer reset while queued data is still unflushed is the
   // peer aborting mid-transfer and must surface (test-net-error-twice).
   const teardownNoise = self[kended] && self.writableFinished;
+  // A fatal TLS protocol error after the handshake (a bad record, a peer
+  // alert) arrives as EPROTO carrying the OpenSSL reason. Node's TLSWrap
+  // reports it as the socket's ERR_SSL_<REASON> 'error' whether or not a
+  // listener exists, so it is never downgraded to a silent EOF below.
+  if (_err && _err.code === "EPROTO" && !self.destroyed && !self._hadError) {
+    self.destroy(tlsHandshakeError(_err));
+    return;
+  }
   // _hadError: the failure already reached JS through the error dispatch
   // (native on_error / a fatal write); node emits a socket error exactly
   // once, so the close that follows it is delivered plain.
@@ -1328,6 +1336,12 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     if (err) $debug(err);
     if (self[kclosed]) return;
     self[kclosed] = true;
+    // A fatal TLS protocol error after the handshake (see SocketEmitEndNT):
+    // node reports it as the ERR_SSL_<REASON> 'error' even with no listener.
+    if (err && err.code === "EPROTO" && !self.destroyed && !self._hadError && socket === self._handle) {
+      self.destroy(tlsHandshakeError(err));
+      return;
+    }
     // A received RST surfacing as ECONNRESET with the close is not a clean
     // EOF - Node destroys the socket with "read ECONNRESET" instead of a
     // graceful 'end'. Only surface it when the closing handle is still the

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -81,6 +81,24 @@ fn read_error_from_close_code(code: c_int) -> sys::Error {
     }
 }
 
+/// The OpenSSL reason string uSockets attaches to the close of a TLS socket
+/// that hit a fatal SSL error after its handshake (`us_internal_ssl_on_data`).
+/// Only the SSL data path ever passes a close reason, and it is a stack
+/// buffer that lives for the duration of the close dispatch.
+fn tls_close_reason<'a, const SSL: bool>(reason: Option<*mut c_void>) -> Option<&'a [u8]> {
+    if !SSL {
+        return None;
+    }
+    let ptr = reason?.cast::<core::ffi::c_char>();
+    if ptr.is_null() {
+        return None;
+    }
+    // SAFETY: the caller (uSockets) passes a NUL-terminated C string that
+    // outlives this close dispatch.
+    let bytes = unsafe { core::ffi::CStr::from_ptr(ptr) }.to_bytes();
+    (!bytes.is_empty()).then_some(bytes)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Re-exports
 // ──────────────────────────────────────────────────────────────────────────
@@ -2124,8 +2142,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             // hand over the raw pointer rather than letting `RefPtr::drop`
             // release it a second time. This frame is the twin's trampoline for
             // the event, so what its handlers left pending is folded here and
-            // this socket's own close proceeds regardless.
-            crate::dispatch::fold(Self::on_close(raw.into_this_ptr(), socket, err, reason));
+            // this socket's own close proceeds regardless. A TLS reason is the
+            // encrypted half's to report: the raw half sees a plain close.
+            crate::dispatch::fold(Self::on_close(raw.into_this_ptr(), socket, err, None));
         }
         let cleanup = CloseTeardown {
             socket: this,
@@ -2177,6 +2196,19 @@ impl<const SSL: bool> NewSocket<SSL> {
         if err > 2 {
             js_error =
                 <sys::Error as jsc::SysErrorJsc>::to_js(&read_error_from_close_code(err), &global);
+        } else if let Some(reason) = tls_close_reason::<SSL>(reason) {
+            // uSockets closed a TLS socket on a fatal post-handshake SSL
+            // error (bad record, peer alert) and passed the OpenSSL reason
+            // string. Same shape as the handshake-failure EPROTO verdict, so
+            // node:tls decomposes both into ERR_SSL_<REASON> the same way.
+            js_error = SystemError {
+                errno: -(sys::SystemErrno::EPROTO as c_int),
+                code: BunString::static_("EPROTO"),
+                message: BunString::clone_utf8(reason),
+                syscall: BunString::static_("read"),
+                ..Default::default()
+            }
+            .to_error_instance(&global);
         }
 
         if let Err(e) = callback.call(&global, this_value, &[this_value, js_error]) {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -81,10 +81,8 @@ fn read_error_from_close_code(code: c_int) -> sys::Error {
     }
 }
 
-/// The OpenSSL reason string uSockets attaches to the close of a TLS socket
-/// that hit a fatal SSL error after its handshake (`us_internal_ssl_on_data`).
-/// Only the SSL data path ever passes a close reason, and it is a stack
-/// buffer that lives for the duration of the close dispatch.
+/// The OpenSSL reason `us_internal_ssl_on_data` attaches to the close of a TLS
+/// socket whose `SSL_read` failed after the handshake. Valid for the dispatch.
 fn tls_close_reason<'a, const SSL: bool>(reason: Option<*mut c_void>) -> Option<&'a [u8]> {
     if !SSL {
         return None;
@@ -2142,8 +2140,8 @@ impl<const SSL: bool> NewSocket<SSL> {
             // hand over the raw pointer rather than letting `RefPtr::drop`
             // release it a second time. This frame is the twin's trampoline for
             // the event, so what its handlers left pending is folded here and
-            // this socket's own close proceeds regardless. A TLS reason is the
-            // encrypted half's to report: the raw half sees a plain close.
+            // this socket's own close proceeds regardless. The TLS reason is
+            // the encrypted half's to report.
             crate::dispatch::fold(Self::on_close(raw.into_this_ptr(), socket, err, None));
         }
         let cleanup = CloseTeardown {
@@ -2197,10 +2195,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             js_error =
                 <sys::Error as jsc::SysErrorJsc>::to_js(&read_error_from_close_code(err), &global);
         } else if let Some(reason) = tls_close_reason::<SSL>(reason) {
-            // uSockets closed a TLS socket on a fatal post-handshake SSL
-            // error (bad record, peer alert) and passed the OpenSSL reason
-            // string. Same shape as the handshake-failure EPROTO verdict, so
-            // node:tls decomposes both into ERR_SSL_<REASON> the same way.
+            // Same shape as the handshake-failure EPROTO verdict.
             js_error = SystemError {
                 errno: -(sys::SystemErrno::EPROTO as c_int),
                 code: BunString::static_("EPROTO"),

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4742,10 +4742,11 @@ it("a TLS record that fails to decrypt after the handshake closes both peers wit
     c.on("error", () => {});
     upstream.on("error", () => {});
   });
+  using _proxy = { [Symbol.dispose]: () => proxy.close() };
   proxy.listen(0, "127.0.0.1");
   await new Promise<void>(resolve => proxy.once("listening", resolve));
 
-  const client = await Bun.connect({
+  using client = await Bun.connect({
     hostname: "127.0.0.1",
     port: (proxy.address() as net.AddressInfo).port,
     tls: { rejectUnauthorized: false },
@@ -4774,7 +4775,4 @@ it("a TLS record that fails to decrypt after the handshake closes both peers wit
     code: "EPROTO",
     message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:SSLV3_ALERT_BAD_RECORD_MAC$/),
   });
-
-  client.end();
-  proxy.close();
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4706,3 +4706,75 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
 
   await Promise.all([serverClosed.promise, clientClosed.promise]);
 });
+
+it("a TLS record that fails to decrypt after the handshake closes both peers with an EPROTO error", async () => {
+  // A TCP proxy between client and server injects an application_data
+  // record that cannot authenticate once the server has completed its
+  // handshake. The server's SSL_read fails, it sends a bad_record_mac alert,
+  // and both peers close with the OpenSSL reason (node: ERR_SSL_*) instead
+  // of a clean EOF.
+  const badRecord = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
+  const { promise: serverClosed, resolve: resolveServerClosed } = Promise.withResolvers<Error | undefined>();
+  const { promise: clientClosed, resolve: resolveClientClosed } = Promise.withResolvers<Error | undefined>();
+  const { promise: serverOpen, resolve: resolveServerOpen } = Promise.withResolvers<void>();
+
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    tls,
+    socket: {
+      open() {
+        resolveServerOpen();
+      },
+      data() {},
+      close(_socket, err) {
+        resolveServerClosed(err);
+      },
+      error() {},
+    },
+  });
+
+  let upstream: net.Socket | undefined;
+  const proxy = net.createServer(c => {
+    upstream = net.connect(server.port, "127.0.0.1");
+    c.pipe(upstream);
+    upstream.pipe(c);
+    c.on("error", () => {});
+    upstream.on("error", () => {});
+  });
+  proxy.listen(0, "127.0.0.1");
+  await new Promise<void>(resolve => proxy.once("listening", resolve));
+
+  const client = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: (proxy.address() as net.AddressInfo).port,
+    tls: { rejectUnauthorized: false },
+    socket: {
+      open() {},
+      data() {},
+      close(_socket, err) {
+        resolveClientClosed(err);
+      },
+      error() {},
+    },
+  });
+  await serverOpen;
+
+  upstream!.write(badRecord);
+
+  const serverErr = await serverClosed;
+  expect(serverErr).toMatchObject({
+    code: "EPROTO",
+    syscall: "read",
+    message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:DECRYPTION_FAILED_OR_BAD_RECORD_MAC$/),
+  });
+
+  const clientErr = await clientClosed;
+  expect(clientErr).toMatchObject({
+    code: "EPROTO",
+    message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:SSLV3_ALERT_BAD_RECORD_MAC$/),
+  });
+
+  client.end();
+  proxy.close();
+});

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2717,6 +2717,15 @@ it("a bad record after the handshake surfaces as ERR_SSL_* on both peers", async
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
   const { proxy, inject } = injectingProxy((server.address() as AddressInfo).port);
+  try {
+    await runBadRecordExchange(server, proxy, inject);
+  } finally {
+    proxy.close();
+    server.close();
+  }
+});
+
+async function runBadRecordExchange(server: Server, proxy: net.Server, inject: (bytes: Buffer) => void) {
   proxy.listen(0, "127.0.0.1");
   await once(proxy, "listening");
 
@@ -2743,8 +2752,4 @@ it("a bad record after the handshake surfaces as ERR_SSL_* on both peers", async
   const [clientErr] = await clientError;
   expect(clientErr.code).toBe("ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC");
   expect(await clientClose).toBe(true);
-
-  proxy.close();
-  server.close();
-  await once(server, "close");
-});
+}

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2741,7 +2741,11 @@ async function runBadRecordExchange(server: Server, proxy: net.Server, inject: (
 
   inject(BAD_RECORD);
 
-  const [err] = await serverError;
+  // A regression closes without an error: fail on the close, not the timeout.
+  const closedWithoutError = (close: Promise<boolean>) =>
+    close.then(hadError => Promise.reject(new Error(`closed without an error (hadError=${hadError})`)));
+
+  const [err] = await Promise.race([serverError, closedWithoutError(serverClose)]);
   expect(err.code).toBe("ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC");
   expect(err.library).toBe("SSL routines");
   expect(err.reason).toBe("DECRYPTION_FAILED_OR_BAD_RECORD_MAC");
@@ -2749,7 +2753,7 @@ async function runBadRecordExchange(server: Server, proxy: net.Server, inject: (
   expect(await serverClose).toBe(true);
 
   // The server's fatal alert reaches the client as its own SSL error.
-  const [clientErr] = await clientError;
+  const [clientErr] = await Promise.race([clientError, closedWithoutError(clientClose)]);
   expect(clientErr.code).toBe("ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC");
   expect(await clientClose).toBe(true);
 }

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2685,3 +2685,66 @@ describe("pauseOnConnect", () => {
     }
   });
 });
+
+// A TLS record that fails to decrypt after the handshake is a fatal protocol
+// error. Node surfaces it as the socket's ERR_SSL_<REASON> 'error' (and the
+// peer, which receives the fatal alert, gets its own), then 'close' with
+// hadError. A TCP proxy between client and server injects the record once the
+// server has completed its handshake, so the bytes land in a known state.
+function injectingProxy(upstreamPort: number) {
+  let upstream: net.Socket | undefined;
+  const proxy = net.createServer(c => {
+    upstream = net.connect(upstreamPort, "127.0.0.1");
+    c.pipe(upstream);
+    upstream.pipe(c);
+    c.on("error", () => {});
+    upstream.on("error", () => {});
+  });
+  return {
+    proxy,
+    inject(bytes: Buffer) {
+      upstream!.write(bytes);
+    },
+  };
+}
+
+// application_data, legacy version TLS 1.2, 32 bytes of ciphertext that cannot
+// authenticate: the server fails the AEAD open and alerts bad_record_mac.
+const BAD_RECORD = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
+
+it("a bad record after the handshake surfaces as ERR_SSL_* on both peers", async () => {
+  const server: Server = createServer(COMMON_CERT);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { proxy, inject } = injectingProxy((server.address() as AddressInfo).port);
+  proxy.listen(0, "127.0.0.1");
+  await once(proxy, "listening");
+
+  const serverSocket = new Promise<TLSSocket>(resolve => server.once("secureConnection", resolve));
+  const client = connect({ port: (proxy.address() as AddressInfo).port, host: "127.0.0.1", rejectUnauthorized: false });
+  const clientError = once(client, "error");
+  await once(client, "secureConnect");
+  const socket = await serverSocket;
+  const serverError = once(socket, "error");
+  // Not events.once: it rejects when 'error' fires first, and here it must.
+  const serverClose = new Promise<boolean>(resolve => socket.once("close", resolve));
+  const clientClose = new Promise<boolean>(resolve => client.once("close", resolve));
+
+  inject(BAD_RECORD);
+
+  const [err] = await serverError;
+  expect(err.code).toBe("ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC");
+  expect(err.library).toBe("SSL routines");
+  expect(err.reason).toBe("DECRYPTION_FAILED_OR_BAD_RECORD_MAC");
+  expect(err.message).toMatch(/^error:[0-9a-f]+:SSL routines:[^:]*:DECRYPTION_FAILED_OR_BAD_RECORD_MAC$/);
+  expect(await serverClose).toBe(true);
+
+  // The server's fatal alert reaches the client as its own SSL error.
+  const [clientErr] = await clientError;
+  expect(clientErr.code).toBe("ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC");
+  expect(await clientClose).toBe(true);
+
+  proxy.close();
+  server.close();
+  await once(server, "close");
+});


### PR DESCRIPTION
### Problem
- A TLS record that fails after the handshake (a bad MAC, a wrong version, a peer's fatal alert) makes `SSL_read` fail with `SSL_ERROR_SSL`. uSockets dropped the OpenSSL reason and closed the socket with code 0. node:tls emitted `'end'` then `'close'` with `hadError` false. `Bun.listen` / `Bun.connect` got a `close` with no error. Node reports the socket's `ERR_SSL_<REASON>` `'error'` (for example `ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`), then `'close'` with `hadError` true.
- The cause is the fatal branch of `us_internal_ssl_on_data` (`packages/bun-usockets/src/crypto/openssl.c:2656`). `ssl_park_fatal_reason` only parks a reason while the handshake is unfinished, because the handshake-failure dispatch is its only consumer. After the handshake the reason went nowhere and the close looked clean.

### Fix
- `us_internal_ssl_on_data` closes with the reason string (`ssl_close(s, 0, reason)`) once the handshake has completed. The alert BoringSSL sealed on the failure still goes out first, so the peer gets its own `ERR_SSL_*ALERT_*` error.
- `NewSocket::on_close` turns a non-null close reason into the same `EPROTO` `SystemError` the handshake-failure path already uses (`code: "EPROTO"`, `syscall: "read"`, message is the `error:...:SSL routines:...` string). The raw half of an `upgradeTLS` pair keeps its plain close.
- node:net decomposes that error with the existing `tlsHandshakeError` into `library` / `function` / `reason` and `ERR_SSL_<REASON>`, and destroys the socket with it, listener or not, like node's `TLSWrap` `onerror`.
- The root-cause picker now takes the oldest SSL-library entry from the error queue. BoringSSL queues `Cipher functions:BAD_DECRYPT` ahead of `SSL routines:DECRYPTION_FAILED_OR_BAD_RECORD_MAC`, where OpenSSL queues only the SSL entry. This applies to the handshake path too.
- Verified: `test/js/node/tls/node-tls-server.test.ts` ("a bad record after the handshake surfaces as ERR_SSL_* on both peers") and `test/js/bun/net/socket.test.ts` ("a TLS record that fails to decrypt after the handshake closes both peers with an EPROTO error"). Both fail on 1.4.3-canary (the server sees a clean `end`). Also `test/js/node/tls/`, `test/js/node/http2/`, `test/js/node/https/`, `test/js/bun/net/`, and the node `test-tls-*` / `test-https-*` parallel files.

### Background
- uSockets TLS: `loop.c` routes readable events for a socket with `s->ssl` to `us_internal_ssl_on_data`, which runs `SSL_read` and dispatches plaintext. A fatal `SSL_read` sends the alert through the write BIO and the function closes the socket.
- Close reason: `us_socket_close(s, code, reason)` carries an opaque `reason` pointer to the group's `on_close`. Nothing in bun passed a non-null one before. It is now the OpenSSL reason string (a stack buffer that lives for the close dispatch).
- Parked reason: `ssl_park_fatal_reason` stores the OpenSSL error string per loop for a failure before the handshake is reported. `ssl_dispatch_parked_reason` turns it into the `EPROTO` handshake verdict that node:tls already maps to `ERR_SSL_*`.
- Error queue: OpenSSL keeps a per-thread error queue. Node reports the oldest entry (crypto_tls.cc). BoringSSL's layering can put a lower-layer entry first.

<details><summary>Notes</summary>

- Repro: a TCP proxy between a `tls.connect` client and a `tls.createServer` server. Once the server emits `secureConnection`, the proxy writes an application_data record (`17 03 03 00 20` plus 32 bytes of `0x42`) toward the server. node v26.3.0 server: `ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`, client: `ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC`. bun 1.4.2 and canary: `end`, `close false` on both sides.
- BoringSSL names differ from OpenSSL for alerts: bun's client reports `ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC`. The handshake path already has the same naming difference.
- A 5-byte record body gives `BAD_PACKET_LENGTH` under BoringSSL (too short for an AEAD tag), so the test uses a 32-byte body to exercise the AEAD open.
- Accepted `tls.Server` sockets keep an internal `'error'` listener (`onSocketTLSError`, added in #35006) after control is released, so in bun such an error is not uncaught when the user attached no listener. Node throws there. That is pre-existing and not changed here.
- #38176 covers the write-side counterpart (a fatal post-handshake `SSL_write`). This PR covers the read side.
- The SSLWrapper path in `src/uws/lib.rs` (node:tls over a generic Duplex, Windows named pipes) is a separate `SSL_read` driver. #32929 adds its handshake-time reason. Its post-handshake counterpart is tracked as a follow-up on top of #32929.
- Unrelated failures in this container: `SNICallback runs even when the requested servername matches the bind hostname` (localhost dual-stack, fails without the change), `should not call drain before handshake` (needs www.example.com).

</details>

