### PR TITLE
url: reject punycode labels that decode to another xn-- label

### DIFF
--- a/src/jsc/bindings/ASCIIHostPunycodeCheck.h
+++ b/src/jsc/bindings/ASCIIHostPunycodeCheck.h
@@ -4,7 +4,7 @@
 // "xn--" labels would pass ICU's uidna_nameToASCII(CHECK_BIDI | CHECK_CONTEXTJ | NONTRANSITIONAL_TO_ASCII) with the
 // hyphen and length errors ignored. Mirrors icu::UTS46::processLabel for ACE labels: the label must Punycode-decode
 // (u_strFromPunycode's rules), the decoding must be unchanged by the uts46 normalizer (valid, NFC), must not contain
-// U+FFFD or start with a combining mark. Labels that would then need the BiDi or CONTEXTJ rules are left to ICU.
+// U+FFFD, start with a combining mark, or begin with "xn--" again. Labels that would then need the BiDi or CONTEXTJ rules are left to ICU.
 // Deliberately free of WTF so it can be tested standalone against ICU.
 
 #include <unicode/uchar.h>
@@ -152,6 +152,9 @@ inline ASCIIHostPunycodeVerdict checkLabel(const CharacterType* label, size_t le
         return count == -2 ? ASCIIHostPunycodeVerdict::NeedsFullCheck : ASCIIHostPunycodeVerdict::Invalid;
     if (!count)
         return ASCIIHostPunycodeVerdict::NeedsFullCheck;
+    // UTS #46 4.1 criterion 5 (Unicode 15.1): the decoded label must not begin with "xn--" either.
+    if (count >= 4 && codePoints[0] == 'x' && codePoints[1] == 'n' && codePoints[2] == '-' && codePoints[3] == '-')
+        return ASCIIHostPunycodeVerdict::Invalid;
 
     UChar utf16[maxCodePoints * 2];
     int32_t utf16Length = 0;

--- a/src/jsc/bindings/ASCIIHostPunycodeCheck.h
+++ b/src/jsc/bindings/ASCIIHostPunycodeCheck.h
@@ -152,7 +152,7 @@ inline ASCIIHostPunycodeVerdict checkLabel(const CharacterType* label, size_t le
         return count == -2 ? ASCIIHostPunycodeVerdict::NeedsFullCheck : ASCIIHostPunycodeVerdict::Invalid;
     if (!count)
         return ASCIIHostPunycodeVerdict::NeedsFullCheck;
-    // UTS #46 4.1 criterion 5 (Unicode 15.1): the decoded label must not begin with "xn--" either.
+    // UTS #46 4.1 criterion 4 (Unicode 15.1): the decoded label must not begin with "xn--" either.
     if (count >= 4 && codePoints[0] == 'x' && codePoints[1] == 'n' && codePoints[2] == '-' && codePoints[3] == '-')
         return ASCIIHostPunycodeVerdict::Invalid;
 

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -101,19 +101,16 @@ describe("url.domainToUnicode", () => {
   }
 });
 
-// UTS #46 4.1 criterion 5: a label must not begin with "xn--" once it is Punycode-decoded.
+// UTS #46 4.1 criterion 4: a label must not begin with "xn--" once it is Punycode-decoded.
 // Node rejects the host, so both functions return "". ICU's ToUnicode would otherwise hand back
 // the label with a U+FFFD marker appended.
-const nestedACE = [
-  "xn--xn--zca-hia", // "xn--zca£"
-  "xn--xn---epa", // "xn--é"
-  "a.xn--xn--ab-gva.b", // "xn--abé"
-  "xn--xn--zca-7pj", // "xn--zcaا" (RTL, full ICU check)
-];
 describe("nested xn-- labels", () => {
-  for (const input of nestedACE) {
-    test(`'${input}' is rejected`, () => {
-      expect([url.domainToASCII(input), url.domainToUnicode(input)]).toEqual(["", ""]);
-    });
-  }
+  test.each([
+    ["xn--xn--zca-hia", "xn--zca£"],
+    ["xn--xn---epa", "xn--é"],
+    ["a.xn--xn--ab-gva.b", "xn--abé"],
+    ["xn--xn--zca-7pj", "xn--zcaا (RTL, full ICU check)"],
+  ])("'%s' (decodes to %s) is rejected", input => {
+    expect([url.domainToASCII(input), url.domainToUnicode(input)]).toEqual(["", ""]);
+  });
 });

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -109,7 +109,7 @@ describe("nested xn-- labels", () => {
     ["xn--xn--zca-hia", "xn--zca£"],
     ["xn--xn---epa", "xn--é"],
     ["a.xn--xn--ab-gva.b", "xn--abé"],
-    ["xn--xn--zca-7pj", "xn--zcaا (RTL, full ICU check)"],
+    ["xn--xn--zca-7pj", "xn--zcaا (RTL: rejected before the BiDi rules hand it to ICU)"],
   ])("'%s' (decodes to %s) is rejected", input => {
     expect([url.domainToASCII(input), url.domainToUnicode(input)]).toEqual(["", ""]);
   });

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -100,3 +100,20 @@ describe("url.domainToUnicode", () => {
     });
   }
 });
+
+// UTS #46 4.1 criterion 5: a label must not begin with "xn--" once it is Punycode-decoded.
+// Node rejects the host, so both functions return "". ICU's ToUnicode would otherwise hand back
+// the label with a U+FFFD marker appended.
+const nestedACE = [
+  "xn--xn--zca-hia", // "xn--zca£"
+  "xn--xn---epa", // "xn--é"
+  "a.xn--xn--ab-gva.b", // "xn--abé"
+  "xn--xn--zca-7pj", // "xn--zcaا" (RTL, full ICU check)
+];
+describe("nested xn-- labels", () => {
+  for (const input of nestedACE) {
+    test(`'${input}' is rejected`, () => {
+      expect([url.domainToASCII(input), url.domainToUnicode(input)]).toEqual(["", ""]);
+    });
+  }
+});

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -196,7 +196,7 @@ describe("url", () => {
       ["https://xn--xn--zca-hia.com/", false], // decodes to "xn--zca£": a label must not begin with xn-- after decoding
       ["https://xn--xn---epa/", false], // decodes to "xn--é"
       ["https://a.xn--xn--ab-gva.b/", false], // decodes to "xn--abé"
-      ["https://xn--xn--zca-7pj/", false], // decodes to "xn--zcaا" (RTL, ICU path)
+      ["https://xn--xn--zca-7pj/", false], // decodes to "xn--zcaا" (RTL: rejected before the BiDi rules hand it to ICU)
     ];
     for (const [input, ok] of cases) {
       expect([input, URL.canParse(input)]).toEqual([input, ok]);

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -193,6 +193,10 @@ describe("url", () => {
       ["https://xn--0.com/", false], // truncated delta
       ["https://xn--9999999999999999999999999b/", false], // overflow
       ["https://xn--a-b.com/", false], // "a" + U+0080-ish: disallowed after decoding
+      ["https://xn--xn--zca-hia.com/", false], // decodes to "xn--zca£": a label must not begin with xn-- after decoding
+      ["https://xn--xn---epa/", false], // decodes to "xn--é"
+      ["https://a.xn--xn--ab-gva.b/", false], // decodes to "xn--abé"
+      ["https://xn--xn--zca-7pj/", false], // decodes to "xn--zcaا" (RTL, ICU path)
     ];
     for (const [input, ok] of cases) {
       expect([input, URL.canParse(input)]).toEqual([input, ok]);


### PR DESCRIPTION
### Problem
- `new URL("https://xn--xn--zca-hia.com/")` parses, the `host`/`hostname` setters accept the host, and `url.domainToASCII("xn--xn--zca-hia")` returns it unchanged. `url.domainToUnicode("xn--xn--zca-hia")` returns `"xn--xn--zca-hia\uFFFD"`. Node 26 rejects all of these (`ERR_INVALID_URL`, `""`).
- The cause is the ASCII fast path in `src/jsc/bindings/ASCIIHostPunycodeCheck.h` (`checkLabel`). It decodes the label to `xn--zca£`, finds it normalized and free of U+FFFD, and returns `Valid`. It never applies UTS #46 section 4.1 criterion 4: a label must not begin with `xn--` after Punycode decoding. ICU's full check (the `NeedsFullCheck` path) does apply it, so `xn--xn--zca-7pj` (the same label plus an RTL character) is already rejected.

### Fix
- After `decode`, return `Invalid` when the decoded label begins with `x`, `n`, `-`, `-`. The decoder lowercases ASCII, so one comparison covers `xn--Xn---epa` too.
- This is the same rule ICU 74 applies in `processLabel`, and the rule ada applies in Node. The check sits before the context-rule decision, so a label that decodes to `xn--` plus RTL text is rejected here instead of in ICU. The result is the same.
- `domainToUnicode` needs no change. The host parse now fails first, so ICU's marked output never reaches the caller.
- Verified: `test/js/web/url/url.test.ts` (4 new cases) and `test/js/node/url/url-domain-ascii-unicode.test.js` (new `nested xn-- labels` block). Stock bun 1.4.3 fails both. Also ran `test/js/web/url/`, `test/js/node/url/` and `test/regression/issue/24191.test.ts`.

### Background
- An `xn--` label (an "ACE label") is the Punycode encoding of a Unicode DNS label. UTS #46 ToASCII decodes it and checks the Unicode result against validity criteria. A result that itself begins with `xn--` is invalid. Unicode 15.1 added that criterion.
- WebKit's URL parser does not validate literal `xn--` labels in ASCII hosts. `Bun::hasValidPunycodeHost` (`NodeURL.cpp`) adds that validation for the URL constructor, the setters, and `node:url`. For all-ASCII hosts it runs the fast check in `ASCIIHostPunycodeCheck.h` and only calls ICU when BiDi or CONTEXTJ rules are needed.
- ICU's ToUnicode never fails. It marks a bad ACE label by appending U+FFFD. That is where the `\uFFFD` in the old `domainToUnicode` output came from.

<details><summary>Notes</summary>

Probe (stock bun 1.4.2 and 1.4.3 vs node v26.3.0):

```
"xn--xn--zca-hia"  bun: toUnicode "xn--xn--zca-hia�" toASCII "xn--xn--zca-hia" URL ok   node: "" "" ERR_INVALID_URL
"xn--xn---epa"     bun: toUnicode "xn--xn---epa�"    toASCII "xn--xn---epa"    URL ok   node: "" "" ERR_INVALID_URL
"xn--xn--zca-7pj"  bun: "" "" ERR_INVALID_URL (ICU path)                                node: same
```

`test/js/node/url/url-canParse-whatwg.test.js` times out under the debug ASAN build (1e5 `URL.canParse` calls in about 7 s). That host has no `xn--` label and never reaches the changed code. It is unrelated to this change.

The IPv6 finding from the same fuzz round (`http://[::1:]/` is accepted) is in WebKit's `URLParser`, not in bun's code. It is not part of this PR.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/url/url-domain-ascii-unicode.test.js test/js/web/url/url.test.ts
bun test v1.4.3 (c01965ff7)

test/js/web/url/url.test.ts:
(pass) url > URL throws [10.98ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [9.13ms]
(pass) url > should have correct origin and protocol [10.52ms]
(pass) url > blob urls [7.13ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [6.90ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [4.36ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [19.15ms]
197 |       ["https://xn--xn---epa/", false], // decodes to "xn--é"
198 |       ["https://a.xn--xn--ab-gva.b/", false], // decodes to "xn--abé"
199 |       ["https://xn--xn--zca-7pj/", false], // decodes to "xn--zcaا" (RTL: rejected before the BiDi rules hand it to ICU)
200 |     ];
201 |     for (const [input, ok] of cases) {
202 |       expect([input, URL.canParse(input)]).toEqual([input, ok]);
                                                 ^
error: e
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (c01965ff7)

test/js/web/url/url.test.ts:
(pass) url > URL throws [0.15ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [0.12ms]
(pass) url > should have correct origin and protocol [0.10ms]
(pass) url > blob urls [0.08ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [0.09ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [0.08ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [0.20ms]
197 |       ["https://xn--xn---epa/", false], // decodes to "xn--é"
198 |       ["https://a.xn--xn--ab-gva.b/", false], // decodes to "xn--abé"
199 |       ["https://xn--xn--zca-7pj/", false], // decodes to "xn--zcaا" (RTL: rejected before the BiDi rules hand it to ICU)
200 |     ];
201 |     for (const [input, ok] of cases) {
202 |       expect([input, URL.canParse(input)]).toEqual([input, ok]);
                                                 ^
error: expect(received).toEqual(expected)

  [
    "https://xn--xn--zca-hia.com/",
-   false,
+   true,
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/web/url/url.test.ts:202:4
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/url/url-domain-ascii-unicode.test.js test/js/web/url/url.test.ts
bun test v1.4.3 (c01965ff7)

test/js/web/url/url.test.ts:
(pass) url > URL throws [11.22ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [9.14ms]
(pass) url > should have correct origin and protocol [10.57ms]
(pass) url > blob urls [7.20ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [7.01ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [4.36ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [20.06ms]
(pass) url > judges literal punycode labels like Node (fast path and ICU path) [26.11ms]
(pass) url > resolves against repeated, alternating and invalid string bases consistently [20.19ms]
(pass) url > href, toString and toJSON agree before and after mutation [100.08ms]
(pass) url > prints [99.60ms]
(pass) url > URLContext offsets account for the /. pathname guard [44.26ms]
(pass) url > works [12.29ms]
(pass) url > URL.canParse > URL.canParse(undefined, unde
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 593ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ASCIIHostPunycodeCheck.h         |  5 ++++-
 test/js/node/url/url-domain-ascii-unicode.test.js | 14 ++++++++++++++
 test/js/web/url/url.test.ts                       |  4 ++++
 3 files changed, 22 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/ASCIIHostPunycodeCheck.h              1      3     12
test/js/node/url/url-domain-ascii-unicode.test.js      1      1     10
test/js/web/url/url.test.ts                            1      1      6
```

</details>

<!-- robobun:evidence:end -->