### PR TITLE
bun test: report directories the scanner cannot read, scan each directory once

### DIFF
--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::rc::Rc;
 
 use bun_alloc::AllocError;
@@ -32,6 +32,12 @@ pub struct Scanner<'a> {
     pub(crate) options: &'a BundleOptions<'a>,
     pub(crate) has_iterated: bool,
     pub(crate) search_count: usize,
+    /// Directories that could not be opened or read. Each one is reported as
+    /// it happens; the count makes the run exit non-zero.
+    pub(crate) unreadable_dirs: usize,
+    /// `(st_dev, st_ino)` of every directory scanned so far. A symlink that
+    /// points back into the tree is skipped instead of walked again.
+    visited_dirs: HashSet<(u64, u64)>,
     /// The directory being iterated; its fd closes once every child `ScanEntry` has been opened.
     current_dir: Option<Rc<Dir>>,
 }
@@ -88,8 +94,30 @@ impl<'a> Scanner<'a> {
             open_dir_buf: PathBuffer::uninit(),
             has_iterated: false,
             search_count: 0,
+            unreadable_dirs: 0,
+            visited_dirs: HashSet::new(),
             current_dir: None,
         })
+    }
+
+    fn report_unreadable_dir(&mut self, path: &[u8], err: &bun_sys::Error) {
+        self.unreadable_dirs += 1;
+        bun_core::pretty_errorln!(
+            "<r><red>error<r>: could not scan {} for tests\n{}",
+            bun_core::fmt::quote(path),
+            err.with_path(path)
+        );
+    }
+
+    /// Records `fd`'s directory identity. Returns `false` when that directory
+    /// was scanned before (reached again through a symlink).
+    fn mark_visited(&mut self, fd: Fd) -> bool {
+        match bun_sys::fstat(fd) {
+            Ok(st) => self
+                .visited_dirs
+                .insert((st.st_dev as u64, st.st_ino as u64)),
+            Err(_) => true,
+        }
     }
 
     #[inline]
@@ -158,6 +186,18 @@ impl<'a> Scanner<'a> {
                     bstr::BStr::new(path),
                     root_err.original_err.name()
                 );
+                if let bun_resolver::Error::Sys(errno) = e {
+                    self.report_unreadable_dir(
+                        path,
+                        &bun_sys::Error::from_code(errno, bun_sys::Tag::open),
+                    );
+                }
+            }
+        } else {
+            let zpath = bun_core::ZBox::from_bytes(path);
+            if let Ok(st) = bun_sys::fstatat(Fd::cwd(), &zpath) {
+                self.visited_dirs
+                    .insert((st.st_dev as u64, st.st_ino as u64));
             }
         }
 
@@ -204,10 +244,17 @@ impl<'a> Scanner<'a> {
             let opened = bun_sys::open_dir_no_renaming_or_deleting_windows(parent, rel_path);
             // Dropping `entry` releases the parent fd once its last child is opened.
             drop(entry);
-            let Ok(child_fd) = opened else {
-                continue;
+            let child_fd = match opened {
+                Ok(fd) => fd,
+                Err(err) => {
+                    self.report_unreadable_dir(path2, &err);
+                    continue;
+                }
             };
             let child_dir = Rc::new(Dir::from_fd(child_fd));
+            if !self.mark_visited(child_dir.fd) {
+                continue;
+            }
             let path2 = self
                 .fs()
                 .dirname_store
@@ -216,7 +263,14 @@ impl<'a> Scanner<'a> {
             self.current_dir = Some(Rc::clone(&child_dir));
             let result = self.read_dir_with_name(path2, Some(child_dir.fd));
             self.current_dir = None;
-            result.map_err(|_| ScanError::OutOfMemory)?;
+            if let EntriesOption::Err(dir_err) = result.map_err(|_| ScanError::OutOfMemory)? {
+                if let bun_resolver::Error::Sys(errno) = dir_err.original_err {
+                    self.report_unreadable_dir(
+                        path2,
+                        &bun_sys::Error::from_code(errno, bun_sys::Tag::scandir),
+                    );
+                }
+            }
         }
 
         Ok(())

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -98,7 +98,12 @@ impl<'a> Scanner<'a> {
         })
     }
 
+    /// A directory that vanished between readdir and open (or a dangling link
+    /// to one) is not an error; anything else is reported and fails the run.
     fn report_unreadable_dir(&mut self, path: &[u8], err: &bun_sys::Error) {
+        if err.get_errno() == bun_sys::E::ENOENT {
+            return;
+        }
         self.unreadable_dirs += 1;
         bun_core::pretty_errorln!(
             "<r><red>error<r>: could not scan {} for tests\n{}",
@@ -107,13 +112,31 @@ impl<'a> Scanner<'a> {
         );
     }
 
-    /// Returns `false` when `fd`'s directory was scanned before.
+    fn report_dir_read_error(&mut self, path: &[u8], err: bun_resolver::Error, tag: bun_sys::Tag) {
+        match err {
+            bun_resolver::Error::Sys(errno) => self.report_unreadable_dir(
+                path,
+                &bun_sys::Error::from_code_int(errno as core::ffi::c_int, tag),
+            ),
+            other => {
+                self.unreadable_dirs += 1;
+                bun_core::pretty_errorln!(
+                    "<r><red>error<r>: could not scan {} for tests\n{}",
+                    bun_core::fmt::quote(path),
+                    other
+                );
+            }
+        }
+    }
+
+    /// Returns `false` when `fd`'s directory was scanned before. A filesystem
+    /// that reports no inode number (`st_ino == 0`) gets no deduplication.
     fn mark_visited(&mut self, fd: Fd) -> bool {
         match bun_sys::fstat(fd) {
-            Ok(st) => self
+            Ok(st) if st.st_ino != 0 => self
                 .visited_dirs
                 .insert((st.st_dev as u64, st.st_ino as u64)),
-            Err(_) => true,
+            _ => true,
         }
     }
 
@@ -183,15 +206,7 @@ impl<'a> Scanner<'a> {
                     bstr::BStr::new(path),
                     root_err.original_err.name()
                 );
-                if let bun_resolver::Error::Sys(errno) = e {
-                    self.report_unreadable_dir(
-                        path,
-                        &bun_sys::Error::from_code_int(
-                            errno as core::ffi::c_int,
-                            bun_sys::Tag::open,
-                        ),
-                    );
-                }
+                self.report_dir_read_error(path, e, bun_sys::Tag::open);
             }
         } else {
             let zpath = bun_core::ZBox::from_bytes(path);
@@ -264,15 +279,7 @@ impl<'a> Scanner<'a> {
             let result = self.read_dir_with_name(path2, Some(child_dir.fd));
             self.current_dir = None;
             if let EntriesOption::Err(dir_err) = result.map_err(|_| ScanError::OutOfMemory)? {
-                if let bun_resolver::Error::Sys(errno) = dir_err.original_err {
-                    self.report_unreadable_dir(
-                        path2,
-                        &bun_sys::Error::from_code_int(
-                            errno as core::ffi::c_int,
-                            bun_sys::Tag::scandir,
-                        ),
-                    );
-                }
+                self.report_dir_read_error(path2, dir_err.original_err, bun_sys::Tag::scandir);
             }
         }
 

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -189,7 +189,10 @@ impl<'a> Scanner<'a> {
                 if let bun_resolver::Error::Sys(errno) = e {
                     self.report_unreadable_dir(
                         path,
-                        &bun_sys::Error::from_code(errno, bun_sys::Tag::open),
+                        &bun_sys::Error::from_code_int(
+                            errno as core::ffi::c_int,
+                            bun_sys::Tag::open,
+                        ),
                     );
                 }
             }
@@ -267,7 +270,10 @@ impl<'a> Scanner<'a> {
                 if let bun_resolver::Error::Sys(errno) = dir_err.original_err {
                     self.report_unreadable_dir(
                         path2,
-                        &bun_sys::Error::from_code(errno, bun_sys::Tag::scandir),
+                        &bun_sys::Error::from_code_int(
+                            errno as core::ffi::c_int,
+                            bun_sys::Tag::scandir,
+                        ),
                     );
                 }
             }

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -32,11 +32,9 @@ pub struct Scanner<'a> {
     pub(crate) options: &'a BundleOptions<'a>,
     pub(crate) has_iterated: bool,
     pub(crate) search_count: usize,
-    /// Directories that could not be opened or read. Each one is reported as
-    /// it happens; the count makes the run exit non-zero.
+    /// Directories that could not be opened or read; non-zero fails the run.
     pub(crate) unreadable_dirs: usize,
-    /// `(st_dev, st_ino)` of every directory scanned so far. A symlink that
-    /// points back into the tree is skipped instead of walked again.
+    /// `(st_dev, st_ino)` of every directory scanned so far.
     visited_dirs: HashSet<(u64, u64)>,
     /// The directory being iterated; its fd closes once every child `ScanEntry` has been opened.
     current_dir: Option<Rc<Dir>>,
@@ -109,8 +107,7 @@ impl<'a> Scanner<'a> {
         );
     }
 
-    /// Records `fd`'s directory identity. Returns `false` when that directory
-    /// was scanned before (reached again through a symlink).
+    /// Returns `false` when `fd`'s directory was scanned before.
     fn mark_visited(&mut self, fd: Fd) -> bool {
         match bun_sys::fstat(fd) {
             Ok(st) => self

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::rc::Rc;
 
 use bun_alloc::AllocError;
@@ -35,10 +35,12 @@ pub struct Scanner<'a> {
     /// Directories that could not be opened or read; non-zero fails the run.
     pub(crate) unreadable_dirs: usize,
     /// `(st_dev, st_ino)` of every directory scanned so far.
-    visited_dirs: HashSet<(u64, u64)>,
+    visited_dirs: VisitedDirs,
     /// The directory being iterated; its fd closes once every child `ScanEntry` has been opened.
     current_dir: Option<Rc<Dir>>,
 }
+
+type VisitedDirs = bun_collections::hashbrown::HashSet<(u64, u64), bun_wyhash::BuildHasher>;
 
 // FIFO queue of scan entries (pop_front / push_back).
 pub(crate) type Fifo = VecDeque<ScanEntry>;
@@ -93,7 +95,7 @@ impl<'a> Scanner<'a> {
             has_iterated: false,
             search_count: 0,
             unreadable_dirs: 0,
-            visited_dirs: HashSet::new(),
+            visited_dirs: VisitedDirs::default(),
             current_dir: None,
         })
     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2167,6 +2167,7 @@ impl TestCommand {
         // so the watcher-enable check below can read it without reborrowing.
         let all_test_files_count = all_test_files.len();
         let search_count = scanner.search_count;
+        let unreadable_dirs = scanner.unreadable_dirs;
         drop(scanner);
 
         // When --changed or --shard filters the discovered test files
@@ -2642,6 +2643,13 @@ impl TestCommand {
             }
         }
 
+        if unreadable_dirs > 0 {
+            pretty_error!(
+                "<r><red>error<r>: {} director{} could not be scanned for tests\n",
+                unreadable_dirs,
+                if unreadable_dirs == 1 { "y" } else { "ies" }
+            );
+        }
         pretty_error!("\n");
         Output::flush();
 
@@ -2668,6 +2676,7 @@ impl TestCommand {
                 && coverage_options.fail_on_low_coverage)
             || !write_snapshots_success
             || reporter.jest.unhandled_errors_between_tests > 0
+            || unreadable_dirs > 0
         {
             vm.exit_handler.exit_code = 1;
         }

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -2118,12 +2118,19 @@ describe.concurrent("test file discovery (scanner)", () => {
 
   // root bypasses permission checks, so the unreadable directory is only
   // unreadable for a different user.
+  function hasNobodyUser(): boolean {
+    try {
+      return /^nobody:/m.test(readFileSync("/etc/passwd", "utf8"));
+    } catch {
+      return false;
+    }
+  }
   const canUseRunuser =
     isLinux &&
     typeof process.getuid === "function" &&
     process.getuid() === 0 &&
     !!Bun.which("runuser") &&
-    /^nobody:/m.test(readFileSync("/etc/passwd", "utf8"));
+    hasNobodyUser();
 
   test.skipIf(!canUseRunuser)("a directory that cannot be read is reported and fails the run", async () => {
     using dir = tempDir("scanner-unreadable", {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 
 describe("bun test", () => {
@@ -2090,5 +2090,71 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(Number(stdout.match(/OPEN_FDS=(\d+)/)?.[1])).toBeLessThan(N);
     expect(stderr).toContain(" 1 pass");
     expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("a symlink that points back into the tree is scanned once", async () => {
+    using dir = tempDir("scanner-symlink-loop", {
+      "sub/a.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a"); });`,
+      "sub/deeper/b.test.ts": `import { test } from "bun:test"; test("b", () => { console.log("RAN b"); });`,
+    });
+    // sub/loop -> the scan root, sub/deeper/self -> sub/deeper
+    symlinkSync("..", join(String(dir), "sub", "loop"));
+    symlinkSync(".", join(String(dir), "sub", "deeper", "self"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.match(/RAN a/g)).toHaveLength(1);
+    expect(stdout.match(/RAN b/g)).toHaveLength(1);
+    expect(stderr).toContain("Ran 2 tests across 2 files.");
+    expect(exitCode).toBe(0);
+  });
+
+  // root bypasses permission checks, so the unreadable directory is only
+  // unreadable for a different user.
+  const canUseRunuser =
+    isLinux &&
+    typeof process.getuid === "function" &&
+    process.getuid() === 0 &&
+    !!Bun.which("runuser") &&
+    /^nobody:/m.test(readFileSync("/etc/passwd", "utf8"));
+
+  test.skipIf(!canUseRunuser)("a directory that cannot be read is reported and fails the run", async () => {
+    using dir = tempDir("scanner-unreadable", {
+      "ok/a.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a"); });`,
+      "locked/b.test.ts": `import { test } from "bun:test"; test("b", () => { console.log("RAN b"); });`,
+    });
+    const root = String(dir);
+    chmodSync(root, 0o755);
+    chmodSync(join(root, "ok"), 0o755);
+    chmodSync(join(root, "ok", "a.test.ts"), 0o644);
+    chmodSync(join(root, "locked"), 0o000);
+
+    try {
+      await using proc = Bun.spawn({
+        cmd: ["runuser", "-m", "-u", "nobody", "--", bunExe(), "test"],
+        env: bunEnv,
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // The readable part of the tree still runs.
+      expect(stdout).toContain("RAN a");
+      expect(stderr).toContain(" 1 pass");
+      expect(stderr).toContain(`could not scan "${join(root, "locked")}" for tests`);
+      expect(stderr).toContain("EACCES");
+      expect(stderr).toContain("1 directory could not be scanned for tests");
+      expect(exitCode).toBe(1);
+    } finally {
+      chmodSync(join(root, "locked"), 0o755);
+    }
   });
 });


### PR DESCRIPTION
### Problem
- `bun test` skips a directory it cannot open without a message, and the run exits 0. A suite under a `chmod 000` directory is absent from the run and nothing says so. The cause is `let Ok(child_fd) = opened else { continue }` in `src/runtime/cli/test/Scanner.rs:207`.
- The scanner follows a symlink that points back into the tree until the path no longer fits a `PathBuffer`. `sub/loop -> ..` plus `sub/deeper/self -> .` gives `Ran 2 tests across 902 files.` The scanner has no record of which directories it has seen.

### Fix
- A directory that fails to open or read is reported at once: `error: could not scan "<path>" for tests` plus the errno line. The count is printed again before the summary, and the exit code is 1. The readable part of the tree still runs.
- Every directory the scanner opens is recorded as `(st_dev, st_ino)` from `fstat`. A directory seen before is skipped. The scan root is recorded too, by `fstatat`, so a symlink to the root is skipped as well.
- Correct because the exit status now covers discovery errors the same way it covers test failures, and a directory runs once whatever path leads to it. A first `fstat` per directory is the only added cost. A directory that is gone by the time it is opened (ENOENT, a dangling link) is skipped without a report.
- The exit code is a policy choice. `node --test`, Jest and vitest skip an unreadable directory and exit 0. Self-review raised this. The error line and the summary count stand on their own; drop `|| unreadable_dirs > 0` in `test_command.rs` if the run should stay green.
- Verified: `test/cli/test/bun-test.test.ts` (two new cases in the scanner block, 1.4.3 fails both). Also `pass-with-no-tests`, `test-shard`, `path-ignore-patterns`, `test-changed`.

### Background
- The scanner walks from the root with a FIFO of directories. It opens each child with `openat` on the parent fd and hands the fd to the resolver, which lists the directory and calls `Scanner::next` per entry.
- `EntriesOption::Err` is the resolver's directory-read failure. Its `original_err` is a `bun_resolver::Error`, with `Sys(errno)` for an OS error.
- The unreadable-directory test needs a user that permission checks apply to. It runs only as root on Linux with `runuser` and a `nobody` user, the same guard `test/cli/run/env.test.ts` uses.

<details><summary>Notes</summary>

Probe on bun 1.4.3, as a non-root user, with `ok/a.test.ts` readable and `locked/b.test.ts` under a `chmod 000` directory:

```
$ bun test; echo rc=$?
ok/a.test.ts:
(pass) a
 1 pass
 0 fail
Ran 1 test across 1 file.
rc=0
```

Symlink loop probe on 1.4.3: `sub/a.test.ts`, `sub/deeper/b.test.ts`, `sub/loop -> ..`, `sub/deeper/self -> .` gives `Ran 2 tests across 902 files.` Each path is a new cache key for the resolver, so the same file is loaded again and again; the module cache keeps the tests from registering twice, but the file count and the wall time grow with the path limit.

Root errors other than ENOENT and ENOTDIR were already logged under `BUN_DEBUG_jest`. They are now also reported to the user and counted.

On Windows `fstat` on a directory handle fills `st_dev` from the volume serial number and `st_ino` from the NTFS file index, so the visited set works there too. A filesystem that reports `st_ino == 0` (FAT, exFAT, some SMB redirectors) gets no deduplication. If `fstat` fails the directory is scanned as before.

Self-reviewed: 5 concerns raised, 4 addressed (Windows compile of the errno conversion, `st_ino == 0`, ENOENT on a dangling junction, non-errno resolver errors). The fifth is the exit-code policy above, left for a maintainer.

Suites run with the debug build: `test/cli/test/bun-test.test.ts`, `pass-with-no-tests.test.ts`, `test-shard.test.ts`, `path-ignore-patterns.test.ts`, `test-changed.test.ts` (164 pass, 0 fail).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->