### PR TITLE
bun test --parallel: exit 128 + signal, kill what a crashed worker spawned

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -219,12 +219,7 @@ impl<'a> Coordinator<'a> {
         for w in self.workers[..self.spawned_count as usize].iter_mut() {
             if let Some(p) = &w.process {
                 #[cfg(unix)]
-                {
-                    // SAFETY: FFI call; -pid targets the worker's process group.
-                    unsafe {
-                        let _ = libc::kill(-(p.pid as libc::pid_t), libc::SIGTERM);
-                    }
-                }
+                terminate_process_group(p.pid);
                 #[cfg(not(unix))]
                 {
                     // SIGKILL → TerminateProcess; libuv-win ENOSYSes signals
@@ -233,7 +228,11 @@ impl<'a> Coordinator<'a> {
                 }
             }
         }
-        self.aborted = Some(128 + signal as u32);
+        self.aborted = Some(u32::from(
+            bun_sys::SignalCode(signal as u8)
+                .to_exit_code()
+                .unwrap_or(130),
+        ));
     }
 
     fn spawn_worker(&mut self) -> bool {
@@ -603,10 +602,7 @@ impl<'a> Coordinator<'a> {
             // test spawned; it led its own process group, so kill(-pid) does it.
             #[cfg(unix)]
             if let Some(p) = &w.process {
-                // SAFETY: FFI call; -pid targets the worker's process group.
-                unsafe {
-                    let _ = libc::kill(-(p.pid as libc::pid_t), libc::SIGTERM);
-                }
+                terminate_process_group(p.pid);
             }
             self.break_dots();
             self.ensure_header(idx);
@@ -839,12 +835,7 @@ impl<'a> Coordinator<'a> {
             // through *mut forms no `&mut Worker` aliasing the caller's `w`.
             if let Some(p) = unsafe { &(*other).process } {
                 #[cfg(unix)]
-                {
-                    // SAFETY: FFI call; -pid targets the worker's process group.
-                    unsafe {
-                        let _ = libc::kill(-(p.pid as libc::pid_t), libc::SIGTERM);
-                    }
-                }
+                terminate_process_group(p.pid);
                 #[cfg(not(unix))]
                 {
                     // SIGKILL → TerminateProcess (libuv-win ENOSYSes most
@@ -930,6 +921,17 @@ impl<'a> Coordinator<'a> {
             }
             Some(job)
         }
+    }
+}
+
+/// SIGTERM to the process group a worker leads: the worker and everything it
+/// spawned. Safe after the worker exited: the pid stays reserved while any
+/// member of the group lives, and an empty group gives ESRCH.
+#[cfg(unix)]
+fn terminate_process_group(pid: libc::pid_t) {
+    // SAFETY: FFI call; -pid targets the worker's process group.
+    unsafe {
+        let _ = libc::kill(-pid, libc::SIGTERM);
     }
 }
 

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -181,8 +181,7 @@ impl<'a> Coordinator<'a> {
     /// the coordinator can't run this (SIGKILL): PDEATHSIG on Linux,
     /// kill-on-close Job Object on Windows. macOS has neither; the process
     /// group kill here plus stdin EOF in the worker loop is the best effort.
-    /// Exits with 128 + the signal number, the status a shell reports for a
-    /// process that the same signal killed.
+    /// Exits with 128 + `signal`, the status a shell reports for a signal death.
     fn abort_all(&mut self, signal: i32) {
         abort_handler::uninstall();
         let now = bun_core::time::milli_timestamp();
@@ -600,11 +599,8 @@ impl<'a> Coordinator<'a> {
         let startup_failure = w.inflight.is_none() && !w.reached_ready;
         let worker_idx = w.idx;
         if let Some(idx) = w.inflight {
-            // A worker that dies mid-file never reaches the `--isolate`
-            // cleanup between files that kills the processes its tests
-            // spawned. It is its own process group leader, so kill(-pid)
-            // reaches them. The pid stays reserved while any group member
-            // lives, so it cannot name an unrelated process here.
+            // The dead worker skipped the between-files cleanup of what its
+            // test spawned; it led its own process group, so kill(-pid) does it.
             #[cfg(unix)]
             if let Some(p) = &w.process {
                 // SAFETY: FFI call; -pid targets the worker's process group.
@@ -1048,8 +1044,7 @@ fn describe_status<'b>(buf: &'b mut [u8; 32], status: &SpawnStatus) -> &'b [u8] 
 pub(crate) mod abort_handler {
     use super::*;
 
-    /// The signal that asked for the abort (SIGINT or SIGTERM), or 0 when none
-    /// arrived. On Windows a console control event is reported as SIGINT.
+    /// The signal that asked for the abort, or 0. Windows console events count as SIGINT.
     pub(crate) static ABORT_SIGNAL: AtomicI32 = AtomicI32::new(0);
 
     // PORTING.md §Global mutable state: written once in `install()` (single

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -7,7 +7,7 @@
 use core::ffi::c_void;
 #[cfg(unix)]
 use core::mem::MaybeUninit;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicI32, Ordering};
 use std::io::Write as _;
 
 use bun_core::strings;
@@ -141,8 +141,9 @@ impl<'a> Coordinator<'a> {
         let _ = self.spawn_worker();
         self.run_pending_reaps();
         while !self.is_done() {
-            if abort_handler::SHOULD_ABORT.load(Ordering::Acquire) {
-                self.abort_all();
+            let signal = abort_handler::ABORT_SIGNAL.load(Ordering::Acquire);
+            if signal != 0 {
+                self.abort_all(signal);
                 return;
             }
             self.vm.event_loop_ref().tick();
@@ -180,7 +181,9 @@ impl<'a> Coordinator<'a> {
     /// the coordinator can't run this (SIGKILL): PDEATHSIG on Linux,
     /// kill-on-close Job Object on Windows. macOS has neither; the process
     /// group kill here plus stdin EOF in the worker loop is the best effort.
-    fn abort_all(&mut self) {
+    /// Exits with 128 + the signal number, the status a shell reports for a
+    /// process that the same signal killed.
+    fn abort_all(&mut self, signal: i32) {
         abort_handler::uninstall();
         let now = bun_core::time::milli_timestamp();
         let workers = &self.workers[..self.spawned_count as usize];
@@ -231,7 +234,7 @@ impl<'a> Coordinator<'a> {
                 }
             }
         }
-        self.aborted = Some(130);
+        self.aborted = Some(128 + signal as u32);
     }
 
     fn spawn_worker(&mut self) -> bool {
@@ -597,6 +600,18 @@ impl<'a> Coordinator<'a> {
         let startup_failure = w.inflight.is_none() && !w.reached_ready;
         let worker_idx = w.idx;
         if let Some(idx) = w.inflight {
+            // A worker that dies mid-file never reaches the `--isolate`
+            // cleanup between files that kills the processes its tests
+            // spawned. It is its own process group leader, so kill(-pid)
+            // reaches them. The pid stays reserved while any group member
+            // lives, so it cannot name an unrelated process here.
+            #[cfg(unix)]
+            if let Some(p) = &w.process {
+                // SAFETY: FFI call; -pid targets the worker's process group.
+                unsafe {
+                    let _ = libc::kill(-(p.pid as libc::pid_t), libc::SIGTERM);
+                }
+            }
             self.break_dots();
             self.ensure_header(idx);
             // A worker dying mid-file is never silently retried. If a test
@@ -1033,7 +1048,9 @@ fn describe_status<'b>(buf: &'b mut [u8; 32], status: &SpawnStatus) -> &'b [u8] 
 pub(crate) mod abort_handler {
     use super::*;
 
-    pub(crate) static SHOULD_ABORT: AtomicBool = AtomicBool::new(false);
+    /// The signal that asked for the abort (SIGINT or SIGTERM), or 0 when none
+    /// arrived. On Windows a console control event is reported as SIGINT.
+    pub(crate) static ABORT_SIGNAL: AtomicI32 = AtomicI32::new(0);
 
     // PORTING.md §Global mutable state: written once in `install()` (single
     // call site), read once in `uninstall()`. RacyCell — `sigaction` is POD,
@@ -1046,8 +1063,8 @@ pub(crate) mod abort_handler {
         bun_core::RacyCell::new(MaybeUninit::uninit());
 
     #[cfg(unix)]
-    extern "C" fn posix_handler(_: i32, _: *const libc::siginfo_t, _: *const c_void) {
-        SHOULD_ABORT.store(true, Ordering::Release);
+    extern "C" fn posix_handler(sig: i32, _: *const libc::siginfo_t, _: *const c_void) {
+        ABORT_SIGNAL.store(sig, Ordering::Release);
     }
 
     #[cfg(windows)]
@@ -1057,7 +1074,7 @@ pub(crate) mod abort_handler {
         use bun_sys::windows;
         match ctrl {
             windows::CTRL_C_EVENT | windows::CTRL_BREAK_EVENT | windows::CTRL_CLOSE_EVENT => {
-                SHOULD_ABORT.store(true, Ordering::Release);
+                ABORT_SIGNAL.store(libc::SIGINT, Ordering::Release);
                 windows::TRUE
             }
             _ => windows::FALSE,

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1424,10 +1424,15 @@ test.skipIf(isWindows)(
       "c.test.ts": `import { test } from "bun:test"; test("ok", () => {});`,
     });
     const pids = String(dir) + "/pids.txt";
+    // The ASAN lanes run every test with no-orphans on. That makes the kernel
+    // SIGKILL the grandchild when the worker dies, before the coordinator's
+    // SIGTERM (the path under test) can reach it.
+    const env: Record<string, string | undefined> = { ...bunEnv, PIDS: pids };
+    delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--parallel=2", "--parallel-delay=0"],
-      env: { ...bunEnv, PIDS: pids },
+      env,
       cwd: String(dir),
       stdout: "ignore",
       stderr: "pipe",

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1353,6 +1353,119 @@ test("--parallel: SIGTERM on coordinator kills workers and their grandchildren",
   expect(outstanding).toEqual([]);
 }, 15000);
 
+test.skipIf(isWindows).each([
+  ["SIGTERM", 143],
+  ["SIGINT", 130],
+] as const)("--parallel: %s on the coordinator exits with %d", async (signal, code) => {
+  const fixture = `
+    import { test } from "bun:test";
+    import { appendFileSync } from "fs";
+    test("slow", async () => {
+      appendFileSync(process.env.PIDS, "started\\n");
+      await Bun.sleep(60000);
+    });
+  `;
+  using dir = tempDir("parallel-signal-code", {
+    "a.test.ts": fixture,
+    "b.test.ts": fixture,
+  });
+  const pids = String(dir) + "/pids.txt";
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--parallel-delay=0"],
+    env: { ...bunEnv, PIDS: pids },
+    cwd: String(dir),
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  for (let i = 0; i < 400; i++) {
+    const text = await Bun.file(pids)
+      .text()
+      .catch(() => "");
+    if ([...text.matchAll(/^started$/gm)].length >= 2) break;
+    await Bun.sleep(25);
+  }
+
+  proc.kill(signal);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("Interrupted");
+  expect(exitCode).toBe(code);
+});
+
+test.skipIf(isWindows)(
+  "--parallel: a worker that dies mid-file takes the processes its test spawned with it",
+  async () => {
+    // The grandchild is orphaned when the worker dies, so a zombie could still
+    // answer kill(pid, 0). It records its own termination instead.
+    const grandchild = `
+    const { appendFileSync } = require("fs");
+    process.on("SIGTERM", () => {
+      appendFileSync(process.env.PIDS, "terminated=" + process.pid + "\\n");
+      process.exit(0);
+    });
+    appendFileSync(process.env.PIDS, "grandchild=" + process.pid + "\\n");
+    setTimeout(() => {}, 60000);
+  `;
+    const crasher = (how: string) => `
+    import { test } from "bun:test";
+    import { appendFileSync } from "fs";
+    test("spawn then die", async () => {
+      const child = Bun.spawn({
+        cmd: [process.execPath, "grandchild.cjs"],
+        env: process.env,
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      child.unref();
+      // Wait until the grandchild has logged its pid.
+      while (!(await Bun.file(process.env.PIDS).text().catch(() => "")).includes("grandchild=" + child.pid)) {
+        await Bun.sleep(10);
+      }
+      ${how};
+    });
+  `;
+    using dir = tempDir("parallel-crash-grandchildren", {
+      "a.test.ts": crasher(`process.kill(process.pid, "SIGKILL")`),
+      "b.test.ts": crasher(`process.exit(0)`),
+      "c.test.ts": `import { test } from "bun:test"; test("ok", () => {});`,
+      "grandchild.cjs": grandchild,
+    });
+    const pids = String(dir) + "/pids.txt";
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", "--parallel-delay=0"],
+      env: { ...bunEnv, PIDS: pids },
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    const grandchildren = [...(await Bun.file(pids).text()).matchAll(/^grandchild=(\d+)/gm)].map(m => Number(m[1]));
+    expect(grandchildren).toHaveLength(2);
+
+    // The coordinator signals the group when it reaps the worker. The
+    // grandchildren need a moment to handle SIGTERM and log it.
+    let terminated: number[] = [];
+    for (let i = 0; i < 80; i++) {
+      terminated = [...(await Bun.file(pids).text()).matchAll(/^terminated=(\d+)/gm)].map(m => Number(m[1]));
+      if (terminated.length >= grandchildren.length) break;
+      await Bun.sleep(25);
+    }
+    // Clean up survivors so a failing run does not leak processes.
+    for (const pid of grandchildren)
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+
+    expect(stderr).toContain("worker crashed");
+    expect(stderr).toContain(" 2 fail");
+    expect(terminated.sort()).toEqual(grandchildren.sort());
+    expect(exitCode).toBe(1);
+  },
+);
+
 test("--parallel --no-isolate: a worker keeps one global and module registry across its files", async () => {
   const files: Record<string, string> = {
     "shared.ts": `export let count = 0; export const bump = () => ++count;`,

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1397,29 +1397,22 @@ test.skipIf(isWindows)(
   "--parallel: a worker that dies mid-file takes the processes its test spawned with it",
   async () => {
     // The grandchild is orphaned when the worker dies, so a zombie could still
-    // answer kill(pid, 0). It records its own termination instead.
-    const grandchild = `
-    const { appendFileSync } = require("fs");
-    process.on("SIGTERM", () => {
-      appendFileSync(process.env.PIDS, "terminated=" + process.pid + "\\n");
-      process.exit(0);
-    });
-    appendFileSync(process.env.PIDS, "grandchild=" + process.pid + "\\n");
-    setTimeout(() => {}, 60000);
-  `;
+    // answer kill(pid, 0). It records its own termination instead. A shell
+    // keeps its startup out of the timing; the trap is armed before the pid
+    // is logged.
+    const grandchild = `trap 'echo terminated=$$ >> "$PIDS"; exit 0' TERM; echo grandchild=$$ >> "$PIDS"; while :; do sleep 60; done`;
     const crasher = (how: string) => `
     import { test } from "bun:test";
-    import { appendFileSync } from "fs";
     test("spawn then die", async () => {
       const child = Bun.spawn({
-        cmd: [process.execPath, "grandchild.cjs"],
+        cmd: ["sh", "-c", ${JSON.stringify(grandchild)}],
         env: process.env,
         stdout: "ignore",
         stderr: "ignore",
       });
       child.unref();
       // Wait until the grandchild has logged its pid.
-      while (!(await Bun.file(process.env.PIDS).text().catch(() => "")).includes("grandchild=" + child.pid)) {
+      while (!(await Bun.file(process.env.PIDS).text().catch(() => "")).includes("grandchild=" + child.pid + "\\n")) {
         await Bun.sleep(10);
       }
       ${how};
@@ -1429,7 +1422,6 @@ test.skipIf(isWindows)(
       "a.test.ts": crasher(`process.kill(process.pid, "SIGKILL")`),
       "b.test.ts": crasher(`process.exit(0)`),
       "c.test.ts": `import { test } from "bun:test"; test("ok", () => {});`,
-      "grandchild.cjs": grandchild,
     });
     const pids = String(dir) + "/pids.txt";
 
@@ -1442,25 +1434,28 @@ test.skipIf(isWindows)(
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    const grandchildren = [...(await Bun.file(pids).text()).matchAll(/^grandchild=(\d+)/gm)].map(m => Number(m[1]));
-    expect(grandchildren).toHaveLength(2);
-
-    // The coordinator signals the group when it reaps the worker. The
-    // grandchildren need a moment to handle SIGTERM and log it.
+    const read = async (re: RegExp) => [...(await Bun.file(pids).text()).matchAll(re)].map(m => Number(m[1]));
+    const grandchildren = await read(/^grandchild=(\d+)$/gm);
     let terminated: number[] = [];
-    for (let i = 0; i < 80; i++) {
-      terminated = [...(await Bun.file(pids).text()).matchAll(/^terminated=(\d+)/gm)].map(m => Number(m[1]));
-      if (terminated.length >= grandchildren.length) break;
-      await Bun.sleep(25);
+    try {
+      // The coordinator signals the group when it reaps the worker. The
+      // grandchildren need a moment to handle SIGTERM and log it.
+      for (let i = 0; i < 120; i++) {
+        terminated = await read(/^terminated=(\d+)$/gm);
+        if (terminated.length >= grandchildren.length) break;
+        await Bun.sleep(25);
+      }
+    } finally {
+      // Clean up survivors so a failing run does not leak processes.
+      for (const pid of grandchildren)
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {}
     }
-    // Clean up survivors so a failing run does not leak processes.
-    for (const pid of grandchildren)
-      try {
-        process.kill(pid, "SIGKILL");
-      } catch {}
 
     expect(stderr).toContain("worker crashed");
     expect(stderr).toContain(" 2 fail");
+    expect(grandchildren).toHaveLength(2);
     expect(terminated.sort()).toEqual(grandchildren.sort());
     expect(exitCode).toBe(1);
   },


### PR DESCRIPTION
### Problem
- `bun test --parallel` exits 130 for any abort signal. `abort_all` in `src/runtime/cli/test/parallel/Coordinator.rs:234` has `self.aborted = Some(130)`. SIGTERM should give 143, which is what a serial `bun test` (killed by the default disposition) and a shell report.
- A worker that dies mid-file (`process.exit`, SIGKILL, a crash) leaves the processes its test spawned running. The file is counted as `worker crashed`, the run goes on, and the `sleep 777` from the test is still there after `bun test` exits. Only the abort path (`kill(-pid, SIGTERM)`) cleaned up descendants.

### Fix
- The signal handler stores the signal number in `ABORT_SIGNAL` (an `AtomicI32`, 0 when none) instead of a flag. `abort_all` exits with `SignalCode::to_exit_code()`, the `128 + signal` helper `filter_run` and `multi_run` already use. The Windows console handler stores SIGINT, so the result there is 130 as before.
- `reap_worker` sends SIGTERM to the worker's process group when the worker had a file in flight, through the same `terminate_process_group` helper the abort paths now share. The worker is the group leader, so the group reaches everything its tests spawned. Unix only: on Windows the coordinator's kill-on-close Job Object already covers descendants.
- Correct because the pid of a dead group leader stays reserved while any member of the group lives, so `kill(-pid)` after the exit cannot hit an unrelated process. If the group is empty the call fails with ESRCH and nothing happens.
- Verified: `test/cli/test/parallel.test.ts` (two new cases, 1.4.3 fails both). Also `parallel-startup-failure.test.ts` and the JUnit suites.

### Background
- Under `--parallel` a coordinator spawns N worker processes, each in its own process group (`new_process_group: true` in `Worker.rs`), and dispatches test files to them over an IPC channel.
- Workers run with `--isolate`. Between files the isolate swap kills the subprocesses the previous file spawned. A worker that exits during a file never gets there.
- `reap_worker` runs when the coordinator has drained a worker's IPC pipe after its exit. It accounts the in-flight file as crashed and, if files remain, spawns a fresh worker.

<details><summary>Notes</summary>

Probes on bun 1.4.3 (`kill -TERM` on the coordinator 1 s into a run):

```
serial:   rc=143
parallel: rc=130
SIGINT parallel: rc=130
```

Descendants after a mid-file death, `--parallel=2`, three files: a spawns `sleep 777` then `process.kill(process.pid, "SIGKILL")`, b spawns `sleep 778` then `process.exit(0)`, c spawns `sleep 779` and passes:

```
 1 pass
 2 fail
    PID    PGID   PPID ARGS
    402     399      1 sleep 777
    409     404      1 sleep 778
```

`sleep 779` was gone: the isolate swap after c killed it. 777 and 778 outlive the run.

`--no-orphans` (`BUN_FEATURE_FLAG_NO_ORPHANS=1`) is an opt-in that covers the same case with a kernel SIGKILL (PDEATHSIG) on Linux. It is process-wide and also kills `detached` children, so the runner scopes it away from tests that expect a detached grandchild to survive. This change is the default path: the SIGTERM that `--isolate` already sends between files, extended to a worker that dies mid-file. The new test clears `BUN_FEATURE_FLAG_NO_ORPHANS` because the ASAN lanes set it, and PDEATHSIG would kill the grandchildren before the path under test runs.

#39039 (open) rewrites the same `abort_handler` store sites and asserts 130 for SIGTERM. Whichever lands second needs a small rebase, and that assertion should become 143.

Self-reviewed: 4 concerns raised, 3 addressed (`SignalCode::to_exit_code`, one shared kill helper, the `--no-orphans` note above). The #39039 ordering is recorded here for the reviewer.

The grandchild in the new test records its own termination through a SIGTERM handler. After the worker dies the grandchild is reparented, and an init that does not reap would leave a zombie that still answers `kill(pid, 0)`.

The existing test `--parallel: each worker has a unique JEST_WORKER_ID` fails on a debug build with or without this change. Its 200 ms fixture sleep is shorter than worker startup under a debug build, so one worker takes two files.

</details>

