### PR TITLE
shell: end the statement at the newline that ends a comment

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -3469,12 +3469,13 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
         self.chars.peek()
     }
 
+    /// A comment runs to the end of the line. A backslash inside it is
+    /// literal, so an escaped newline ends the comment too. The newline
+    /// still delimits the statement, so it is pushed as a token.
     fn eat_comment(&mut self) {
-        while let Some(peeked) = self.eat() {
-            if peeked.escaped {
-                continue;
-            }
-            if peeked.char == u32::from(b'\n') {
+        while let Some(c) = self.eat() {
+            if c.char == u32::from(b'\n') {
+                self.tokens.push(Token::Newline);
                 break;
             }
         }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -923,6 +923,31 @@ booga"
       .runAsTest("quotes");
   });
 
+  describe("comments", () => {
+    TestBuilder.command /* sh */ `echo one # note
+echo two`
+      .stdout("one\ntwo\n")
+      .runAsTest("trailing comment ends the statement");
+
+    TestBuilder.command /* sh */ `echo one # note \\
+echo two`
+      .stdout("one\ntwo\n")
+      .runAsTest("backslash inside a comment does not continue the line");
+
+    TestBuilder.command /* sh */ `rm -rf build   # clean the previous output
+cp -R src build
+ls`
+      .ensureTempDir()
+      .directory("src")
+      .file("src/index.js", "keep me\n")
+      .directory("build")
+      .file("build/old.js", "stale\n")
+      .stdout(out => expect(out.split("\n").filter(Boolean).sort()).toEqual(["build", "src"]))
+      .fileEquals("src/index.js", "keep me\n")
+      .fileEquals("build/index.js", "keep me\n")
+      .runAsTest("rm with a trailing comment does not take the next line as arguments");
+  });
+
   describe("glob expansion", () => {
     // Issue #8403: https://github.com/oven-sh/bun/issues/8403
     TestBuilder.command`ls *.sdfljsfsdf`

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -821,6 +821,71 @@ describe("lex shell", () => {
     expect(JSON.parse(lex({ raw: [source] }))).toEqual(expected);
   });
 
+  // A comment runs to the end of the line. The newline that ends it still
+  // delimits the statement, like an unquoted newline outside a comment.
+  test.each([
+    [
+      "trailing comment ends the statement",
+      "echo one # note\necho two",
+      [
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "one" },
+        { Delimit: {} },
+        { Newline: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "two" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    [
+      "trailing comment with CRLF",
+      "echo one # note\r\necho two",
+      [
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "one" },
+        { Delimit: {} },
+        { Newline: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "two" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    [
+      "backslash inside a comment does not continue the line",
+      "echo one # note \\\necho two",
+      [
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "one" },
+        { Delimit: {} },
+        { Newline: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "two" },
+        { Delimit: {} },
+        { Eof: {} },
+      ],
+    ],
+    [
+      "comment on its own line",
+      "# note\necho two",
+      [{ Newline: {} }, { Text: "echo" }, { Delimit: {} }, { Text: "two" }, { Delimit: {} }, { Eof: {} }],
+    ],
+    [
+      "comment on the last line",
+      "echo one # note",
+      [{ Text: "echo" }, { Delimit: {} }, { Text: "one" }, { Delimit: {} }, { Eof: {} }],
+    ],
+  ])("comment: %s", (_name, source, expected) => {
+    expect(JSON.parse(lex({ raw: [source] }))).toEqual(expected);
+  });
+
   describe("errors", async () => {
     // This is disallowed because the js object references get turned into special vars: $__bun_0, $__bun_1, etc.
     // this will break things inside of a quote.


### PR DESCRIPTION
### Problem
- A `#` comment that follows a command on the same line swallows the newline. The words on the next line are appended to the current command. `rm -rf build   # clean` followed by `cp -R src build` runs the single command `rm -rf build cp -R src build` and deletes `src`.
- The cause is `eat_comment` in `src/shell_parser/parse.rs:3472`. It consumes characters up to and including the `\n` but never pushes `Token::Newline`. The lexer then continues the same simple command on the next line. A comment on its own line is not affected because the newline before it already delimited the statement.

### Fix
- `eat_comment` pushes `Token::Newline` when it consumes the newline. The next line starts a new statement, like an unquoted newline outside a comment.
- A backslash inside a comment is literal in bash. The scanner no longer skips an escaped newline, so `# note \` followed by a newline ends the comment too.
- Verified: `test/js/bun/shell/lex.test.ts` (5 new token cases, 4 fail on 1.4.3) and `test/js/bun/shell/bunshell.test.ts` (3 new cases, all fail on 1.4.3). Also `parse.test.ts`, `shell-seq-condexpr.test.ts`, `bunshell-file.test.ts`.

### Background
- The shell lexer turns the script text into a flat token list. `Token::Newline` and `Token::Semicolon` end a statement. `Token::Delimit` ends a word.
- `#` starts a comment only when it is preceded by whitespace and is outside quotes. The word before the `#` was already delimited by that whitespace, so the comment site only needs the statement delimiter.
- The output string index `j` is not advanced by comment characters, so `word_start` stays correct after the comment.

<details><summary>Notes</summary>

Repro on 1.4.3:

```ts
import { $ } from "bun";
console.log(JSON.stringify((await $`echo one # note
echo two`.quiet()).stdout.toString()));
```

Before: `"one echo two\n"`. After: `"one\ntwo\n"`. CRLF line endings behave the same.

Consecutive `Newline` tokens (a comment on its own line now yields two) are already handled: `parse_stmt` returns an empty statement and the script loop skips newlines.

</details>
