### PR TITLE
ipc: reject an empty internal JSON line and non-Uint8Array views in the Buffer envelope

### DIFF
--- a/src/js/internal/serialization_buffers.ts
+++ b/src/js/internal/serialization_buffers.ts
@@ -61,9 +61,7 @@ function restoreBuffers(envelope: unknown): unknown {
     throw new Error("failed to parse serialized buffer envelope");
   }
   const buffers = (envelope as unknown[])[1] as unknown[];
-  // Fresh from deserialization, a tagged Buffer is a plain Uint8Array. Buffer
-  // methods read the backing bytes as Uint8, so any other view is rejected
-  // rather than given the Buffer prototype.
+  // Only a Uint8Array may become a Buffer; the sender tags Buffers and nothing else.
   for (let i = 0; i < buffers.length; i++) {
     if (!isUint8Array(buffers[i])) throw new Error("failed to parse serialized buffer envelope");
   }

--- a/src/js/internal/serialization_buffers.ts
+++ b/src/js/internal/serialization_buffers.ts
@@ -3,6 +3,7 @@
 // Node ref: https://github.com/nodejs/node/blob/main/lib/internal/child_process/serialization.js
 
 const { Buffer } = require("node:buffer");
+const { isUint8Array } = require("node:util/types");
 const BufferPrototype = Buffer.prototype;
 const isBuffer = Buffer.isBuffer;
 const ObjectKeys = Object.keys;
@@ -60,10 +61,14 @@ function restoreBuffers(envelope: unknown): unknown {
     throw new Error("failed to parse serialized buffer envelope");
   }
   const buffers = (envelope as unknown[])[1] as unknown[];
+  // Fresh from deserialization, a tagged Buffer is a plain Uint8Array. Buffer
+  // methods read the backing bytes as Uint8, so any other view is rejected
+  // rather than given the Buffer prototype.
   for (let i = 0; i < buffers.length; i++) {
-    const view = buffers[i];
-    // Fresh from deserialization: plain Uint8Arrays the sender tagged.
-    if ($isTypedArrayView(view)) ObjectSetPrototypeOf(view, BufferPrototype);
+    if (!isUint8Array(buffers[i])) throw new Error("failed to parse serialized buffer envelope");
+  }
+  for (let i = 0; i < buffers.length; i++) {
+    ObjectSetPrototypeOf(buffers[i], BufferPrototype);
   }
   return (envelope as unknown[])[0];
 }

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -482,8 +482,7 @@ mod json {
             json_data = &json_data[1..];
             kind = Kind::Internal;
         }
-        // An empty payload (a bare newline, or the internal tag byte alone) is
-        // invalid JSON. `create_external` below rejects an empty slice.
+        // A bare newline or a lone tag byte is invalid JSON.
         if json_data.is_empty() {
             return Err(IPCDecodeError::InvalidFormat);
         }

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -470,10 +470,6 @@ mod json {
         };
 
         let mut json_data = &data[0..idx as usize];
-        // An empty payload (newline with no preceding data) is invalid JSON.
-        if json_data.is_empty() {
-            return Err(IPCDecodeError::InvalidFormat);
-        }
 
         #[derive(Copy, Clone, Eq, PartialEq)]
         enum Kind {
@@ -481,10 +477,15 @@ mod json {
             Internal,
         }
         let mut kind = Kind::Regular;
-        if json_data[0] == 2 {
+        if json_data.first() == Some(&2) {
             // internal message
             json_data = &json_data[1..];
             kind = Kind::Internal;
+        }
+        // An empty payload (a bare newline, or the internal tag byte alone) is
+        // invalid JSON. `create_external` below rejects an empty slice.
+        if json_data.is_empty() {
+            return Err(IPCDecodeError::InvalidFormat);
         }
 
         let is_ascii = strings::is_all_ascii(json_data);

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -122,6 +122,43 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
   });
 });
 
+describe("ipc mode json", () => {
+  it.skipIf(isWindows)("closes the channel on a line that holds only the internal tag byte", async () => {
+    // An internal JSON message is "\\x02" + json + "\\n". A line of just the tag
+    // byte strips to an empty payload. The receiver must treat it like an empty
+    // line (invalid, close the channel) instead of building an external string
+    // over a zero-length slice.
+    //
+    // The receiver runs in its own subprocess so a crash shows up as a failing
+    // assertion here rather than taking out the test runner.
+    const parent = `
+      const child = Bun.spawn({
+        cmd: [
+          process.execPath, "-e",
+          'process.on("disconnect", () => process.exit(42)); require("fs").writeSync(3, "\\\\x02\\\\n");',
+        ],
+        stdio: ["ignore", "inherit", "inherit"],
+        serialization: "json",
+        ipc(msg) { console.error("UNEXPECTED_IPC_MESSAGE", msg); },
+      });
+      console.log("CHILD_EXIT", await child.exited);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parent],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("CHILD_EXIT 42");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("ipc mode advanced", () => {
   it("unwraps the Buffer envelope before cmd dispatch", async () => {
     // A cmd-bearing message whose payload holds a Buffer travels as the
@@ -200,6 +237,58 @@ describe("ipc mode advanced", () => {
 
     expect(stdout.trim()).toBe("PARENT_OK");
     expect(stderr).not.toContain("UNEXPECTED_IPC_MESSAGE");
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(isWindows)("rejects a Buffer envelope whose buffer list holds a non-Uint8Array view", async () => {
+    // Frame type 4 carries a [message, buffers] envelope and the receiver puts
+    // Buffer.prototype on every entry of `buffers`. Only Uint8Arrays may be
+    // there: a Float64Array with that prototype reads as a Buffer whose
+    // methods index the wrong element size. The peer controls the envelope,
+    // so the receiver must check each entry and reject the frame.
+    const parent = `
+      const { types } = require("node:util");
+      const child = Bun.spawn({
+        cmd: [
+          process.execPath, "-e",
+          \`
+          const { serialize } = require("bun:jsc");
+          const f = new Float64Array([1.5]);
+          const body = serialize([{ b: f }, [f]], { binaryType: "nodebuffer" });
+          const head = Buffer.alloc(5);
+          head[0] = 4;
+          head.writeUInt32LE(body.length, 1);
+          process.on("disconnect", () => process.exit(42));
+          require("fs").writeSync(3, Buffer.concat([head, body]));
+          \`,
+        ],
+        stdio: ["ignore", "inherit", "inherit"],
+        serialization: "advanced",
+        ipc(msg, subprocess) {
+          // Delivered means the frame was accepted. Report and stop the child,
+          // which otherwise waits for a disconnect that never comes.
+          console.log("MESSAGE", Buffer.isBuffer(msg.b), types.isUint8Array(msg.b));
+          subprocess.kill();
+        },
+      });
+      process.on("uncaughtException", err => console.log("UNCAUGHT", err.message));
+      console.log("CHILD_EXIT", await child.exited);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parent],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.split("\n").filter(Boolean)).toEqual([
+      "UNCAUGHT failed to parse serialized buffer envelope",
+      "CHILD_EXIT 42",
+    ]);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/node/v8/v8-serdes-buffer.test.ts
+++ b/test/js/node/v8/v8-serdes-buffer.test.ts
@@ -52,6 +52,17 @@ describe("v8 serialize/deserialize Buffer identity", () => {
     expect(v8.deserialize(legacy)).toEqual({ buf: new Uint8Array([7]) });
   });
 
+  test("rejects an envelope whose buffer list holds a non-Uint8Array view", () => {
+    // The envelope's buffer list gets Buffer.prototype applied to each entry.
+    // A crafted payload can put any typed array there; only Uint8Arrays may
+    // become Buffers.
+    const jsc = require("bun:jsc");
+    const f = new Float64Array([1.5]);
+    const payload = jsc.serialize([{ b: f }, [f]], { binaryType: "nodebuffer" });
+    const magic = Buffer.from([0xff, 0x42, 0x55, 0x4e, 0x01]);
+    expect(() => v8.deserialize(Buffer.concat([magic, payload]))).toThrow("failed to parse serialized buffer envelope");
+  });
+
   test("circular structures with Buffers", () => {
     const obj: any = { buf: Buffer.from("c") };
     obj.self = obj;


### PR DESCRIPTION
### Problem
- JSON IPC: a line of only the internal tag byte (`\x02\n`) gets past the empty-payload check, then the tag strip leaves an empty slice. `create_external` asserts `!bytes.is_empty()` and a debug build panics in `json::decode_ipc_message` (`src/runtime/ipc.rs:473`). The bytes come from the peer, so a hostile child can trip it.
- Advanced IPC: frame type 4 is a `[message, buffers]` envelope. `restoreBuffers` (`src/js/internal/serialization_buffers.ts:66`) put `Buffer.prototype` on every typed array in `buffers`. A crafted frame can list a `Float64Array` there. The receiver then holds a "Buffer" whose backing view is not `Uint8`, and `Buffer` methods index it with the wrong element size.

### Fix
- JSON: strip the tag byte first, then check for an empty payload. A bare tag byte is now `InvalidFormat`, the same as a bare newline, and the channel closes.
- Advanced: check each entry of the buffer list with `util.types.isUint8Array` before any prototype change. Any other view makes the envelope fail with the existing "failed to parse serialized buffer envelope" error. The same code serves `v8.deserialize`, so a crafted `v8.serialize` blob is rejected too.
- Verified: `test/js/bun/spawn/spawn.ipc.test.ts` (two new cases, both fail on main) and `test/js/node/v8/v8-serdes-buffer.test.ts` (one new case). Also ran the other spawn and child_process IPC suites and a sample of the node cluster tests.

### Background
- The IPC channel has two wire modes. JSON mode is one JSON text per line. Bun prefixes its own control messages with a `0x02` byte so the receiver can tell them from user messages without a property lookup.
- Advanced mode frames are `[u8 type][u32 length][JSC structured clone bytes]`. JSC's serializer has no host object hook, so a message that holds `Buffer`s travels as type 4 with a `[message, buffers]` envelope. The receiver restores the `Buffer` prototype on the listed views, which are the same objects the message refers to.
- Both faces came from a fuzz run that wrote raw frames to the IPC descriptor.

<details><summary>Notes</summary>

Repro for the JSON face (debug build): a child spawned with `serialization: "json"` runs `require("fs").writeSync(3, "\x02\n")`. The parent panics with the `create_external` assertion. A release build does not assert. It builds a zero-length external string, `JSON.parse("")` throws, and the channel closes, which is the same outcome this change makes explicit.

Repro for the advanced face: the child builds `serialize([{ b: f }, [f]])` with `f = new Float64Array([1.5])` via `bun:jsc`, frames it as type 4 and writes it to fd 3. Before this change the parent's `ipc` callback received `msg.b` with `Buffer.isBuffer(msg.b) === true` and `util.types.isUint8Array(msg.b) === false`.

Suites run on the debug build: `spawn.ipc.test.ts`, `spawn.ipc.bun-node.test.ts`, `spawn-ipc-gc.test.ts`, `bun-ipc-inherit.test.ts`, `child_process_ipc.test.js`, `child_process_ipc_handle.test.ts`, `child_process_send_cb.test.js`, `v8-module.test.ts`, `v8-serdes-buffer.test.ts`, and `test-cluster-{advanced-serialization,basic,dgram-1,dgram-2,message,invalid-message,ipc-throw,net-listen}.js` plus `test-child-process-fork-{net,net-server,dgram}.js`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.ipc.test.ts

<!-- robobun:evidence:end -->