### PR TITLE
node:crypto: skip DH_check for RFC 3526 named groups

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1387,10 +1387,39 @@ DHPointer DHPointer::New(size_t bits, unsigned int generator)
     return dh;
 }
 
+bool DHPointer::isNamedGroup() const
+{
+    if (!dh_) return false;
+    const BIGNUM* p = nullptr;
+    const BIGNUM* g = nullptr;
+    DH_get0_pqg(dh_.get(), &p, nullptr, &g);
+    if (!p || !g || !BN_is_word(g, DH_GENERATOR_2)) return false;
+
+    static constexpr BIGNUM* (*const kGroups[])(BIGNUM*) = {
+        BN_get_rfc3526_prime_1536,
+        BN_get_rfc3526_prime_2048,
+        BN_get_rfc3526_prime_3072,
+        BN_get_rfc3526_prime_4096,
+        BN_get_rfc3526_prime_6144,
+        BN_get_rfc3526_prime_8192,
+    };
+    unsigned bits = BN_num_bits(p);
+    for (auto getPrime : kGroups) {
+        BignumPointer known(getPrime(nullptr));
+        if (!known || BN_num_bits(known.get()) != bits) continue;
+        if (BN_cmp(known.get(), p) == 0) return true;
+    }
+    return false;
+}
+
 DHPointer::CheckResult DHPointer::check()
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (!dh_) return DHPointer::CheckResult::NONE;
+    // OpenSSL's DH_check reports no codes for a named group without running
+    // the primality tests. BoringSSL has no such shortcut, and testing the
+    // 8192-bit RFC 3526 prime takes tens of seconds. Match OpenSSL here.
+    if (isNamedGroup()) return DHPointer::CheckResult::NONE;
     int codes = 0;
     if (DH_check(dh_.get(), &codes) != 1)
         return DHPointer::CheckResult::CHECK_FAILED;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1416,9 +1416,7 @@ DHPointer::CheckResult DHPointer::check()
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (!dh_) return DHPointer::CheckResult::NONE;
-    // OpenSSL's DH_check reports no codes for a named group without running
-    // the primality tests. BoringSSL has no such shortcut, and testing the
-    // 8192-bit RFC 3526 prime takes tens of seconds. Match OpenSSL here.
+    // Like OpenSSL's DH_check: a named group needs no primality test.
     if (isNamedGroup()) return DHPointer::CheckResult::NONE;
     int codes = 0;
     if (DH_check(dh_.get(), &codes) != 1)

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -895,6 +895,9 @@ public:
     };
     CheckResult check();
 
+    // True when p and g are one of the RFC 3526 MODP groups with generator 2.
+    bool isNamedGroup() const;
+
     enum class CheckPublicKeyResult {
         NONE,
 #ifndef OPENSSL_IS_BORINGSSL

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -995,11 +995,28 @@ it("verifyError should not be on the prototype of DiffieHellman and DiffieHellma
   const dhg = crypto.createDiffieHellmanGroup("modp5");
   expect("verifyError" in crypto.DiffieHellmanGroup.prototype).toBeFalse();
   expect("verifyError" in dhg).toBeTrue();
+  expect(dhg.verifyError).toBe(0);
+});
 
-  // boringssl seems to set DH_NOT_SUITABLE_GENERATOR for both
-  // DH_GENERATOR_2 and DH_GENERATOR_5 if not using
-  // DH_generate_parameters_ex
-  expect(dhg.verifyError).toBe(8);
+// OpenSSL skips DH_check for a named group and reports verifyError 0. Without that
+// shortcut BoringSSL runs primality tests on the prime, which takes about 30s for
+// modp18 and reports DH_NOT_SUITABLE_GENERATOR (8) for generator 2.
+it("well-known MODP groups construct without a parameter check and report verifyError 0", () => {
+  const modp14 = crypto.getDiffieHellman("modp14");
+  expect(modp14.verifyError).toBe(0);
+
+  // The same prime passed as bytes is recognised too.
+  const fromPrime = crypto.createDiffieHellman(modp14.getPrime(), 2);
+  expect(fromPrime.verifyError).toBe(0);
+  expect(fromPrime.getPrime("hex")).toBe(modp14.getPrime("hex"));
+
+  for (const name of ["modp15", "modp16", "modp17", "modp18"]) {
+    expect(crypto.getDiffieHellman(name).verifyError).toBe(0);
+  }
+
+  // A prime that is not a named group still goes through DH_check.
+  const tiny = crypto.createDiffieHellman(Buffer.from("ffffffffffffffc5", "hex"), 2);
+  expect(tiny.verifyError).not.toBe(0);
 });
 it("cipher.setAAD should not throw if encoding or plaintextLength is undefined #18700", () => {
   const key = crypto.randomBytes(32);


### PR DESCRIPTION
### Problem
- `crypto.getDiffieHellman("modp18")` takes about 30 s to construct on bun 1.4.3 (modp14: 460 ms, modp15: 1.5 s, modp16: 3.4 s). Node 26 constructs each in under 1 ms. ssh2 builds one of these per handshake for the `diffie-hellman-group14/16/18-sha*` key exchanges.
- Since #32623 the constructors run `DHPointer::check()` eagerly (`src/jsc/bindings/node/crypto/JSDiffieHellmanGroupConstructor.cpp:46`, `JSDiffieHellmanConstructor.cpp:183`), like Node's eager `verifyError`. BoringSSL's `DH_check` runs Miller-Rabin on p and (p-1)/2 with no shortcut. OpenSSL 3's `DH_check` returns at once with codes 0 when `DH_get_nid` recognises a named group.
- The same BoringSSL path reports `DH_NOT_SUITABLE_GENERATOR` (8) for generator 2 on every RFC 3526 prime, so `verifyError` is 8 where Node reports 0.

### Fix
- `DHPointer::check()` (`src/jsc/bindings/ncrypto.cpp`) first calls the new `isNamedGroup()`. It compares p against the six RFC 3526 primes BoringSSL ships (`BN_get_rfc3526_prime_1536` to `_8192`) and requires g == 2. On a match it returns `CheckResult::NONE` without calling `DH_check`.
- This is the OpenSSL 3 behaviour Node has. It covers `getDiffieHellman("modpN")` and `createDiffieHellman(knownPrime, 2)`. Any other (p, g) still goes through `DH_check` unchanged.
- After the fix modp18 constructs in 0.1 ms and `verifyError` is 0 for modp5 to modp18, the same as Node 26.
- Verified: `test/js/node/crypto/node-crypto.test.js` (new test, fails on 1.4.3 with `verifyError` 8). Also all 14 vendored `test/js/node/test/parallel/test-crypto-dh*.js` pass.

### Background
- `DH_check` validates DH parameters and returns a bitmask of problems. `verifyError` exposes that bitmask to JS. Node's JS constructor reads it eagerly, so the check cost lands on construction.
- RFC 3526 defines the MODP groups modp5 and modp14 to modp18 (1536 to 8192 bits). They are fixed safe primes with generator 2. OpenSSL keeps a table of them and skips the check for a match.
- #33522 is an open PR that reimplements `DH_check` codes the way OpenSSL 3 reports them for arbitrary parameters. It does not remove the primality tests, so it does not fix the construction time. The two changes are independent.

<details><summary>Notes</summary>

Probe on bun 1.4.3 vs node 26.3.0:

```
                               bun 1.4.3            node 26
getDiffieHellman modp14        460 ms, verifyError 8    0 ms, 0
getDiffieHellman modp15       1483 ms, verifyError 8    0 ms, 0
getDiffieHellman modp16       3426 ms, verifyError 8    0 ms, 0
getDiffieHellman modp18      29875 ms, verifyError 8    0 ms, 0
createDiffieHellman(p14, 2)    464 ms, verifyError 8    0 ms, 0
```

With the fix (debug build): modp14 0.4 ms, modp15 to modp18 0.1 ms, all `verifyError` 0. `createDiffieHellman(p14, 5)` still runs `DH_check` (g is not 2) and still reports 8, as before.

The existing test in `node-crypto.test.js` expected `verifyError` 8 for modp5 with a comment that blamed BoringSSL. It now expects 0, which is what Node reports.

The candidate table is the set `FindGroup` uses. It allocates six BIGNUMs per check, which is negligible next to the DH object itself. The size check (`BN_num_bits`) skips the `BN_cmp` for all but one candidate.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (c01965ff7)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [5.89ms]
(pass) crypto.randomInt should return a number [2.34ms]
(pass) crypto.randomInt with no arguments [5.74ms]
(pass) crypto.randomInt with one argument [4.03ms]
(pass) crypto.randomInt with a callback [41.98ms]
(pass) createHash > rsa-md5 - "Hello World" [8.48ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.35ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.93ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.53ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.94ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.62ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.72ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.74ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.61ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [1.15ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.79ms]
(pass) createH
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (c01965ff7)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.12ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.06ms]
(pass) crypto.randomInt with one argument [0.02ms]
(pass) crypto.randomInt with a callback [0.57ms]
(pass) createHash > rsa-md5 - "Hello World" [0.19ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.08ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.01ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 - "Hello World" [0.12ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.04ms]
(pass) createHash > rsa-sha1-2 - "Hello World"
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.04ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" [0.02ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rsa-sha3-256 - "Hell
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (c01965ff7)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.37ms]
(pass) crypto.randomInt should return a number [2.17ms]
(pass) crypto.randomInt with no arguments [3.76ms]
(pass) crypto.randomInt with one argument [2.17ms]
(pass) crypto.randomInt with a callback [39.53ms]
(pass) createHash > rsa-md5 - "Hello World" [8.71ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.18ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.86ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.15ms]
(pass) createHash > rsa-sha1 - "Hello World" [7.52ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.38ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.60ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.65ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.26ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.81ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.54ms]
(pass) createH
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/28] gen cpp.rs (cppbind)
[3/28] gen JS modules (bundle-modules)
Preprocess modules (8893ms)
Bundle modules (60ms)
Postprocesss modules (286ms)
Bundle Functions (548ms)
Generate Code (31ms)

[9.82s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/18] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_boringssl v0.0.0 (/workspace/bun/src/boringssl)
[1m[92m   Compiling[0m bun_dns v0.0.0 (/workspace/bun/src/dns)
[1m[92m   Compiling[0m bun_sha_hmac v0.0.0 (/workspace/bun/src/sha_hmac)
[1m[92m   Compiling[0m bun_uws v0.0.0 (/workspace/bun/src/uws)
[1m[92m   Compiling[0m bun_exe_format v0.0.0 (/workspace/bun/src/exe_format)
[1m[92m   Compiling[0m bun_s3_signing v0.0.0 (/workspace/b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ncrypto.cpp            | 27 +++++++++++++++++++++++++++
 src/jsc/bindings/ncrypto.h              |  3 +++
 test/js/node/crypto/node-crypto.test.js | 25 +++++++++++++++++++++----
 3 files changed, 51 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/ncrypto.cpp                 2      2      5
src/jsc/bindings/ncrypto.h                   1      2      5
test/js/node/crypto/node-crypto.test.js      1      1      5
```

</details>

**root cause** · written by the author bot

The 1.4.0 construction-time parameter validation in `DHPointer::check()` ran a full safe-prime primality test on every `createDiffieHellmanGroup` call, including the RFC 3526 well-known groups, so each ssh2 `diffie-hellman-group14/16/18` handshake paid for a multi-thousand-bit Miller-Rabin pass that Node and OpenSSL skip. The fix recognises the well-known RFC 3526 primes up front and bypasses the primality test for them, matching the behaviour Node gets from OpenSSL's known-group shortcut while leaving the full check in place for caller-supplied parameters. A regression test in `node-crypto…

<!-- robobun:evidence:end -->