### PR TITLE
worker: capture a blob: entry point at construction so a later revokeObjectURL does not break the worker

### DIFF
--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -28,14 +28,13 @@ pub struct ModuleLoader {
     pub eval_source: Option<Box<bun_ast::Source>>,
     /// User's `-e` bytes under `--interactive` (see `Eval::interactive_script`).
     pub interactive_eval_script: Option<Box<[u8]>>,
-    /// A worker's `blob:` entry point, captured by `new Worker()` on the parent
-    /// thread. The loader reads it ahead of the `ObjectURLRegistry`, so a
-    /// `URL.revokeObjectURL` after construction does not break the worker.
+    /// A worker's `blob:` entry point, captured by `new Worker()`. The loader
+    /// reads it ahead of the `ObjectURLRegistry`, so a later revoke is harmless.
     pub worker_entry_blob: Option<WorkerEntryBlob>,
 }
 
-/// The Blob behind a worker's `blob:<uuid>` entry point. `blob` is a dupe of
-/// the registry entry: null `global_this`, thread-shareable `name`.
+/// A dupe of the registry entry behind a worker's `blob:<uuid>` entry point
+/// (null `global_this`, thread-shareable `name`).
 pub struct WorkerEntryBlob {
     pub uuid: [u8; 16],
     pub blob: crate::webcore_types::Blob,

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -28,6 +28,31 @@ pub struct ModuleLoader {
     pub eval_source: Option<Box<bun_ast::Source>>,
     /// User's `-e` bytes under `--interactive` (see `Eval::interactive_script`).
     pub interactive_eval_script: Option<Box<[u8]>>,
+    /// A worker's `blob:` entry point, captured by `new Worker()` on the parent
+    /// thread. The loader reads it ahead of the `ObjectURLRegistry`, so a
+    /// `URL.revokeObjectURL` after construction does not break the worker.
+    pub worker_entry_blob: Option<WorkerEntryBlob>,
+}
+
+/// The Blob behind a worker's `blob:<uuid>` entry point. `blob` is a dupe of
+/// the registry entry: null `global_this`, thread-shareable `name`.
+pub struct WorkerEntryBlob {
+    pub uuid: [u8; 16],
+    pub blob: crate::webcore_types::Blob,
+}
+
+impl WorkerEntryBlob {
+    /// `Some` when `blob_id` (the part after `blob:`) names this entry.
+    pub fn matches(&self, blob_id: &[u8]) -> Option<&crate::webcore_types::Blob> {
+        let uuid = crate::uuid::UUID::parse(blob_id).ok()?;
+        (uuid.bytes == self.uuid).then_some(&self.blob)
+    }
+}
+
+impl Drop for WorkerEntryBlob {
+    fn drop(&mut self) {
+        self.blob.deinit();
+    }
 }
 
 pub static IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS: core::sync::atomic::AtomicBool =

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4463,6 +4463,17 @@ impl VirtualMachine {
             .matches(blob_id)
     }
 
+    /// A dupe of the Blob the module loader sees for `blob:<blob_id>` (same
+    /// lookup order as [`Self::has_blob_url`]), bound to this VM's global.
+    pub fn resolve_blob_url(&self, blob_id: &[u8]) -> Option<crate::webcore_types::Blob> {
+        let blob = match self.worker_entry_blob(blob_id) {
+            Some(entry) => entry.dupe_with_content_type(true),
+            None => (runtime_hooks()?.dupe_blob_url)(blob_id)?,
+        };
+        blob.global_this.set(self.global());
+        Some(blob)
+    }
+
     /// Note: `is_a_file_path` is a runtime
     /// arg to avoid duplicating the body for both monomorphizations.
     pub(crate) fn _resolve(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2268,6 +2268,10 @@ pub struct RuntimeHooks {
     pub create_node_fs: unsafe fn(vm: *mut VirtualMachine) -> *mut c_void,
     /// `ObjectURLRegistry` lookup. Registry lives in `bun_runtime::webcore`.
     pub has_blob_url: fn(blob_id: &[u8]) -> bool,
+    /// `ObjectURLRegistry` dupe of the entry for `blob_id`: null `global_this`,
+    /// thread-shareable `name`, so any thread may own it. `None` when revoked
+    /// or never registered.
+    pub dupe_blob_url: fn(blob_id: &[u8]) -> Option<crate::webcore_types::Blob>,
     /// `Response::get_blob_without_call_frame` /
     /// `Request::get_blob_without_call_frame`. If
     /// `value` downcasts to a `Response` or `Request` (both live in
@@ -4440,6 +4444,25 @@ impl VirtualMachine {
         slice
     }
 
+    /// The module loader's view of `blob:<blob_id>`: a worker's captured entry
+    /// point first, then the process-wide `ObjectURLRegistry` (which lives in
+    /// `bun_runtime`, hence [`RuntimeHooks::has_blob_url`]).
+    pub fn has_blob_url(&self, blob_id: &[u8]) -> bool {
+        self.worker_entry_blob(blob_id).is_some()
+            || runtime_hooks()
+                .map(|h| (h.has_blob_url)(blob_id))
+                .unwrap_or(false)
+    }
+
+    /// The Blob captured by `new Worker("blob:<blob_id>")`, when this VM is
+    /// that worker's.
+    pub fn worker_entry_blob(&self, blob_id: &[u8]) -> Option<&crate::webcore_types::Blob> {
+        self.module_loader
+            .worker_entry_blob
+            .as_ref()?
+            .matches(blob_id)
+    }
+
     /// Note: `is_a_file_path` is a runtime
     /// arg to avoid duplicating the body for both monomorphizations.
     pub(crate) fn _resolve(
@@ -4499,12 +4522,7 @@ impl VirtualMachine {
         }
         if let Some(blob_id) = specifier.strip_prefix(b"blob:".as_slice()) {
             ret.result = None;
-            // `WebCore.ObjectURLRegistry` lives in `bun_runtime`; routed
-            // through [`RuntimeHooks::has_blob_url`].
-            let has = runtime_hooks()
-                .map(|h| (h.has_blob_url)(blob_id))
-                .unwrap_or(false);
-            if has {
+            if self.has_blob_url(blob_id) {
                 ret.path = self.dupe_resolved_path(specifier);
                 return Ok(());
             }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -130,9 +130,8 @@ struct WorkerVmInit {
     transform_options: bun_options_types::schema::api::TransformOptions,
     env_loader: bun_dotenv::Loader,
     proxy_env_slots: jsc::rare_data::ProxyEnvSlots,
-    /// The entry point's Blob when the specifier is a `blob:` URL, captured
-    /// now so a later `URL.revokeObjectURL` cannot affect the load (the URL
-    /// spec resolves a blob URL's entry when the URL is parsed).
+    /// The entry point's Blob for a `blob:` specifier, captured at construction
+    /// as the URL spec requires (a parsed blob URL carries its blob).
     entry_blob: Option<jsc::module_loader::WorkerEntryBlob>,
 }
 
@@ -1271,11 +1270,8 @@ fn on_unhandled_rejection(
     vm.handle_ref().request_termination();
 }
 
-/// The `<uuid>` of a `blob:<uuid>` specifier. Mirrors
-/// `bun.webcore.ObjectURLRegistry.isBlobURL`: prefix `"blob:"` AND
-/// `len >= "blob:".len + UUID.stringLength` (41). A short `"blob:foo"` is
-/// `None`, so it falls through to the resolver instead of reporting
-/// "Blob URL is missing".
+/// The `<uuid>` of a `blob:<uuid>` specifier (`ObjectURLRegistry::is_blob_url`).
+/// A short `"blob:foo"` is `None` and falls through to the resolver.
 fn blob_url_id(specifier: &[u8]) -> Option<&[u8]> {
     const BLOB_SPECIFIER_LEN: usize = b"blob:".len() + crate::uuid::UUID::STRING_LENGTH;
     (specifier.len() >= BLOB_SPECIFIER_LEN)
@@ -1283,10 +1279,8 @@ fn blob_url_id(specifier: &[u8]) -> Option<&[u8]> {
         .flatten()
 }
 
-/// `new Worker("blob:<uuid>")` on the parent thread: dupe the registry entry
-/// now so the worker owns its entry point. `None` when the specifier is not a
-/// blob URL or the URL is already revoked (the worker thread then reports
-/// "Blob URL is missing").
+/// Dupe the registry entry behind a `blob:` specifier on the parent thread.
+/// `None` for a non-blob specifier or an already revoked URL.
 fn capture_blob_url_entry(specifier: &[u8]) -> Option<jsc::module_loader::WorkerEntryBlob> {
     let blob_id = blob_url_id(specifier)?;
     let uuid = crate::uuid::UUID::parse(blob_id).ok()?;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -130,6 +130,10 @@ struct WorkerVmInit {
     transform_options: bun_options_types::schema::api::TransformOptions,
     env_loader: bun_dotenv::Loader,
     proxy_env_slots: jsc::rare_data::ProxyEnvSlots,
+    /// The entry point's Blob when the specifier is a `blob:` URL, captured
+    /// now so a later `URL.revokeObjectURL` cannot affect the load (the URL
+    /// spec resolves a blob URL's entry when the URL is parsed).
+    entry_blob: Option<jsc::module_loader::WorkerEntryBlob>,
 }
 
 enum EntryOutcome {
@@ -391,6 +395,7 @@ impl WebWorker {
             transform_options,
             env_loader,
             proxy_env_slots,
+            entry_blob: capture_blob_url_entry(spec_slice.slice()),
         };
 
         // The construction ref: handed to C++ on success, dropped on failure.
@@ -667,6 +672,7 @@ impl WebWorker {
             transform_options,
             env_loader,
             proxy_env_slots,
+            entry_blob,
         } = init;
 
         // worker-thread only field; no other thread reads `arena`.
@@ -711,6 +717,7 @@ impl WebWorker {
                 .with_mut(|a| NonNull::new(std::ptr::from_mut(a.as_mut().unwrap())));
 
             *vm_ref.proxy_env_storage.lock() = proxy_env_slots;
+            vm_ref.module_loader.worker_entry_blob = entry_blob;
 
             vm_ref.is_main_thread = false;
             VirtualMachine::set_is_main_thread_vm(false);
@@ -1262,6 +1269,33 @@ fn on_unhandled_rejection(
     vm.handle_ref().request_termination();
 }
 
+/// The `<uuid>` of a `blob:<uuid>` specifier. Mirrors
+/// `bun.webcore.ObjectURLRegistry.isBlobURL`: prefix `"blob:"` AND
+/// `len >= "blob:".len + UUID.stringLength` (41). A short `"blob:foo"` is
+/// `None`, so it falls through to the resolver instead of reporting
+/// "Blob URL is missing".
+fn blob_url_id(specifier: &[u8]) -> Option<&[u8]> {
+    const BLOB_SPECIFIER_LEN: usize = b"blob:".len() + crate::uuid::UUID::STRING_LENGTH;
+    (specifier.len() >= BLOB_SPECIFIER_LEN)
+        .then(|| specifier.strip_prefix(b"blob:".as_slice()))
+        .flatten()
+}
+
+/// `new Worker("blob:<uuid>")` on the parent thread: dupe the registry entry
+/// now so the worker owns its entry point. `None` when the specifier is not a
+/// blob URL or the URL is already revoked (the worker thread then reports
+/// "Blob URL is missing").
+fn capture_blob_url_entry(specifier: &[u8]) -> Option<jsc::module_loader::WorkerEntryBlob> {
+    let blob_id = blob_url_id(specifier)?;
+    let uuid = crate::uuid::UUID::parse(blob_id).ok()?;
+    let hooks = runtime_hooks().expect("RuntimeHooks not installed");
+    let blob = (hooks.dupe_blob_url)(blob_id)?;
+    Some(jsc::module_loader::WorkerEntryBlob {
+        uuid: uuid.bytes,
+        blob,
+    })
+}
+
 /// Resolve a worker entry-point specifier to a path the module loader can
 /// consume. The returned slice is BORROWED — it aliases `str`, the
 /// standalone module graph, or the resolver's arena; the caller must NOT
@@ -1295,14 +1329,10 @@ unsafe fn resolve_entry_point_specifier<'s>(
         return Some(str);
     }
 
-    // Spec `bun.webcore.ObjectURLRegistry.isBlobURL(str)` — prefix `"blob:"`
-    // AND `len >= specifier_len` (`"blob:".len + UUID.stringLength = 41`).
-    // A short `"blob:foo"` must fall through to the resolver below, not enter
-    // this arm and report "Blob URL is missing".
-    const BLOB_SPECIFIER_LEN: usize = b"blob:".len() + crate::uuid::UUID::STRING_LENGTH;
-    if str.len() >= BLOB_SPECIFIER_LEN && str.starts_with(b"blob:") {
-        let hooks = runtime_hooks().expect("RuntimeHooks not installed");
-        if (hooks.has_blob_url)(&str[b"blob:".len()..]) {
+    if let Some(blob_id) = blob_url_id(str) {
+        // SAFETY: per fn contract; `module_loader` is only mutated on `parent`'s
+        // owning thread, the caller's thread.
+        if unsafe { (*parent).has_blob_url(blob_id) } {
             return Some(str);
         } else {
             *error_message = BunString::static_("Blob URL is missing");

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -461,9 +461,11 @@ impl WebWorker {
         }
         // SAFETY: `WebWorker` is shared across threads by design (atomics,
         // `Guarded`, thread-confined cells — see the struct doc) and holds no
-        // parent-VM state; `init` is an owned copy — byte buffers, scalars and
-        // `Arc<RefCountedEnvValue>`s, no JSC or atom strings; the parent VM
-        // itself is kept by `_parent_ticket`.
+        // parent-VM state; `init` is an owned copy — byte buffers, scalars,
+        // `Arc<RefCountedEnvValue>`s, and `entry_blob`, a registry dupe with a
+        // null `global_this`, a `make_thread_shareable()`d `name` and
+        // atomically refcounted `store`/`content_type` (no JSC or atom
+        // strings); the parent VM itself is kept by `_parent_ticket`.
         unsafe impl Send for ThreadStart {}
         let start = ThreadStart {
             worker: thread_ref,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1343,6 +1343,11 @@ fn has_blob_url(blob_id: &[u8]) -> bool {
     crate::webcore::object_url_registry::ObjectURLRegistry::singleton().has(blob_id)
 }
 
+fn dupe_blob_url(blob_id: &[u8]) -> Option<crate::webcore::Blob> {
+    crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
+        .dupe_thread_shareable(blob_id)
+}
+
 /// `Response::get_blob_without_call_frame` /
 /// `Request::get_blob_without_call_frame`. Downcasts
 /// `value` to a `Response`/`Request` (whose data shapes + `BodyMixin` impl live
@@ -1520,6 +1525,7 @@ static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     ssl_ctx_cache_get_or_create,
     create_node_fs,
     has_blob_url,
+    dupe_blob_url,
     body_mixin_get_blob,
     process_exit,
     console_on_before_print,
@@ -3989,10 +3995,19 @@ unsafe fn get_loader_and_virtual_source<'a>(
 
     // `blob:` ObjectURL → in-memory virtual source.
     if crate::webcore::object_url_registry::is_blob_url(specifier) {
-        match crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
-            // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-            .resolve_and_dupe(&specifier[b"blob:".len()..], unsafe { &*jsc_vm }.global())
-        {
+        let blob_id = &specifier[b"blob:".len()..];
+        // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+        let vm = unsafe { &*jsc_vm };
+        // A worker's captured entry point outlives a revoke of its URL.
+        let captured = vm.worker_entry_blob(blob_id).map(|entry| {
+            let blob = entry.dupe_with_content_type(true);
+            blob.global_this.set(vm.global());
+            blob
+        });
+        match captured.or_else(|| {
+            crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
+                .resolve_and_dupe(blob_id, vm.global())
+        }) {
             Some(blob) => {
                 *blob_to_deinit = Some(blob);
                 // SAFETY: `blob_to_deinit` is `Some` (just written); we hold

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1455,9 +1455,9 @@ mod vm_loader_ctx {
     // simple field reads. This matters because `read_dir_info_package_json`
     // holds a live `&mut transpiler.resolver` across a re-entrant `read_dir_info`
     // that can call back into these hooks; a `&VirtualMachine` formed here would
-    // alias that `&mut` (SB/TB UB). The two accessors that call `&self` methods
-    // (`main`, `blob_loader`) form a transient `&VirtualMachine` scoped to the
-    // single call, which never spans the re-entrant path.
+    // alias that `&mut` (SB/TB UB). The accessors that call `&self` methods
+    // (`main`, `resolve_blob`, `blob_loader`) form a transient `&VirtualMachine`
+    // scoped to the single call, which never spans the re-entrant path.
     bun_bundler::link_impl_VmLoaderCtx! {
         Runtime for extern VirtualMachine => |this| {
             origin_host() => (*this).origin.host,
@@ -1483,11 +1483,9 @@ mod vm_loader_ctx {
                 }
             },
             is_blob_url(spec) => crate::webcore::object_url_registry::is_blob_url(spec),
-            resolve_blob(spec) => {
-                crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
-                    .resolve_and_dupe(spec, &*(*this).global)
-                    .map(|b| bun_core::heap::into_raw(Box::new(b)).cast::<()>())
-            },
+            resolve_blob(spec) => (*this)
+                .resolve_blob_url(spec)
+                .map(|b| bun_core::heap::into_raw(Box::new(b)).cast::<()>()),
             blob_loader(b) => blob(b).get_loader(&*this),
             // Returned slices borrow blob heap storage that lives until
             // `blob_deinit`; erased to `'static` per the interface signature —
@@ -3995,19 +3993,8 @@ unsafe fn get_loader_and_virtual_source<'a>(
 
     // `blob:` ObjectURL → in-memory virtual source.
     if crate::webcore::object_url_registry::is_blob_url(specifier) {
-        let blob_id = &specifier[b"blob:".len()..];
         // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-        let vm = unsafe { &*jsc_vm };
-        // A worker's captured entry point outlives a revoke of its URL.
-        let captured = vm.worker_entry_blob(blob_id).map(|entry| {
-            let blob = entry.dupe_with_content_type(true);
-            blob.global_this.set(vm.global());
-            blob
-        });
-        match captured.or_else(|| {
-            crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
-                .resolve_and_dupe(blob_id, vm.global())
-        }) {
+        match unsafe { &*jsc_vm }.resolve_blob_url(&specifier[b"blob:".len()..]) {
             Some(blob) => {
                 *blob_to_deinit = Some(blob);
                 // SAFETY: `blob_to_deinit` is `Some` (just written); we hold

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -81,6 +81,15 @@ impl ObjectURLRegistry {
         Some(blob)
     }
 
+    /// A dupe of the entry with no VM-affine state (null `global_this`,
+    /// thread-shareable `name`), for a holder on another thread.
+    pub(crate) fn dupe_thread_shareable(&self, pathname: &[u8]) -> Option<Blob> {
+        let uuid = uuid_from_pathname(pathname)?;
+        let map = self.map.lock();
+        let entry = map.get(&uuid.bytes)?;
+        Some(entry.blob.dupe_with_content_type(true))
+    }
+
     pub(crate) fn resolve_and_dupe_to_js(
         &self,
         pathname: &[u8],

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -64,32 +64,41 @@ test("Worker from a blob errors on invalid blob", async () => {
   expect(promise).rejects.toBe('BuildMessage: ModuleNotFound resolving "blob:i dont exist!" (entry point)');
 });
 
-test("Revoking an object URL after a Worker is created before it loads should throw an error", async () => {
-  const blob = new Blob([`self.postMessage("I survived. I should not have survived. That is a bug.");`], {
-    type: "application/javascript",
-  });
-
-  // This is inherently kind of racy.
-  // So we try a few times to make sure it's not just a fluke.
-  for (let attempt = 0; attempt < 10; attempt++) {
+// The Worker constructor parses the URL, and a parsed blob URL carries its
+// blob, so a revoke after construction does not affect the worker's load.
+test.each(["synchronously", "in a microtask", "in a setTimeout"])(
+  "Revoking an object URL after a Worker is created %s still loads the worker",
+  async when => {
+    const blob = new Blob([`self.postMessage("worker ran");`], { type: "application/javascript" });
     const url = URL.createObjectURL(blob);
     const worker = new Worker(url);
-    URL.revokeObjectURL(url);
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    worker.onmessage = e => resolve(e.data);
+    worker.onerror = e => reject(new Error(e.message));
+
+    if (when === "synchronously") URL.revokeObjectURL(url);
+    else if (when === "in a microtask") await Promise.resolve().then(() => URL.revokeObjectURL(url));
+    else setTimeout(() => URL.revokeObjectURL(url), 0);
 
     try {
-      const result = await new Promise((resolve, reject) => {
-        worker.onmessage = reject;
-        worker.onerror = resolve;
-      });
-      expect(result).toBeInstanceOf(ErrorEvent);
-      expect((result as ErrorEvent).message).toBe("BuildMessage: Blob URL is missing");
-      break;
-    } catch (e) {
-      if (attempt === 9) {
-        throw e;
-      }
+      expect(await promise).toBe("worker ran");
+    } finally {
+      worker.terminate();
     }
-  }
+  },
+);
+
+test("Revoking an object URL before a Worker is created errors", async () => {
+  const blob = new Blob([`self.postMessage("should not run");`], { type: "application/javascript" });
+  const url = URL.createObjectURL(blob);
+  URL.revokeObjectURL(url);
+  const worker = new Worker(url);
+  const { promise, resolve, reject } = Promise.withResolvers<ErrorEvent>();
+  worker.onmessage = reject;
+  worker.onerror = resolve;
+  const result = await promise;
+  expect(result).toBeInstanceOf(ErrorEvent);
+  expect(result.message).toBe("BuildMessage: Blob URL is missing");
 });
 
 test("Worker on a revoked blob still works", async () => {

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -88,6 +88,29 @@ test.each(["synchronously", "in a microtask", "in a setTimeout"])(
   },
 );
 
+test("An uncaught error in a Worker previews the original source after its object URL is revoked", async () => {
+  const file = new File(
+    [
+      `const x: number = 1;
+function boom(): never {
+  throw new Error("boom from blob");
+}
+boom();
+`,
+    ],
+    "worker.ts",
+  );
+  const url = URL.createObjectURL(file);
+  const worker = new Worker(url);
+  URL.revokeObjectURL(url);
+  const { promise, resolve } = Promise.withResolvers<string>();
+  worker.onerror = e => resolve(e.message);
+  const message = await promise;
+  // The preview is remapped to the TypeScript source, not the transpiled output.
+  expect(message).toContain("function boom(): never {");
+  expect(message).toContain('throw new Error("boom from blob");');
+});
+
 test("Revoking an object URL before a Worker is created errors", async () => {
   const blob = new Blob([`self.postMessage("should not run");`], { type: "application/javascript" });
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
### Problem
- `new Worker(url)` followed by `URL.revokeObjectURL(url)` (synchronously or in a microtask) fails the worker with `BuildMessage: Blob URL is missing`. Browsers and Deno run the worker. The URL spec resolves a blob URL's blob URL entry when the URL is parsed, so a revoke after the constructor cannot affect the worker's fetch. The WPT test `workers/dedicated-worker-from-blob-url.window.js` asserts this exact pattern.
- The cause: nothing captures the blob at construction. The worker thread looks the URL up in the process-wide `ObjectURLRegistry` when it loads the entry point (`src/jsc/web_worker.rs` `resolve_entry_point_specifier`, `src/runtime/jsc_hooks.rs` `get_loader_and_virtual_source`). By then the parent has removed the entry.

### Fix
- `WebWorker::create` (parent thread) dupes the registry entry for a `blob:` specifier into a `WorkerEntryBlob` and hands it to the worker VM through `WorkerVmInit`. `start_vm` stores it in `ModuleLoader::worker_entry_blob`. The VM drops it with the loader at teardown.
- All three loader lookups now go through `VirtualMachine::has_blob_url` / `resolve_blob_url`: the captured entry first, then the registry. This covers entry resolution, the module fetch, and the uncaught-error source preview.
- Correct because the registry entry already holds no VM-affine state (null global, thread-shareable name), so a dupe of it is safe to own on the worker thread. A URL revoked before construction still reports `Blob URL is missing`.
- This reverses the test "Revoking an object URL after a Worker is created before it loads should throw an error" from #11537. That test described itself as racy and needed a retry loop. It encoded the load-time lookup, not the spec.
- Verified: `test/js/web/workers/worker_blob.test.ts` (three revoke timings, the source preview after revoke, and revoke before construction; the released bun fails 3 of the new tests). Also `worker.test.ts`, `worker-terminate-lifetime.test.ts`, `worker_threads.test.ts`, `fetch/blob.test.ts` under the ASAN build.

### Background
- `URL.createObjectURL(blob)` registers a dupe of the Blob under a UUID in `ObjectURLRegistry` (`src/runtime/webcore/ObjectURLRegistry.rs`), one map for the whole process. `revokeObjectURL` removes the entry.
- A worker entry point is resolved and loaded on the worker thread, after the parent's `new Worker()` has returned. Anything the parent runs next (the revoke) races that load.
- `RuntimeHooks` is the function table `bun_runtime` hands to `bun_jsc`, because `bun_jsc` cannot depend on `bun_runtime`. The new `dupe_blob_url` slot sits next to the existing `has_blob_url` slot.

<details><summary>Notes</summary>

- Repro used for the report (bun 1.4.2 and 1.4.3, main@f42e980255): four timings, `never`, `sync`, `microtask`, `timer0`. Before the fix `sync` and `microtask` fail every run and `timer0` fails on the debug build. After the fix all four print `worker ran`.
- The source preview case: a `worker.ts` File whose entry throws. After a sync revoke, the error printer's `fetch_without_on_load_plugins` could not find the blob and fell back to the transpiled output (`const x = 1;` instead of `const x: number = 1;`). `vm_loader_ctx::resolve_blob` now uses the captured entry.
- Out of scope, same class: `import(url); URL.revokeObjectURL(url)` on the main thread still fails, since no parse-time capture exists for dynamic import. The worker fix is the cross-thread case.
- `import.meta.url` inside a blob worker is `file:///blob:<uuid>` instead of `blob:<uuid>`. Pre-existing, tracked separately.
- Related open PR #35827 (sweep worker-owned blob URLs on shutdown) touches the same registry file for a different concern.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/workers/worker_blob.test.ts
bun test v1.4.3 (c01965ff7)

test/js/web/workers/worker_blob.test.ts:
(pass) Worker from a Blob [123.46ms]
(pass) TypeScript Worker from a Blob [113.08ms]
(pass) Worker from a blob errors on invalid blob [102.26ms]
72 |     const blob = new Blob([`self.postMessage("worker ran");`], { type: "application/javascript" });
73 |     const url = URL.createObjectURL(blob);
74 |     const worker = new Worker(url);
75 |     const { promise, resolve, reject } = Promise.withResolvers<string>();
76 |     worker.onmessage = e => resolve(e.data);
77 |     worker.onerror = e => reject(new Error(e.message));
                                          ^
error: BuildMessage: Blob URL is missing
      at <anonymous> (/workspace/bun/test/js/web/workers/worker_blob.test.ts:77:38)
(fail) Revoking an object URL after a Worker is created synchronously still loads the worker [111.32ms]
72 |     const blob = new Blob([`self.postMessage("worker ran");`], { type: "application/javascript" });
73 |     const url = URL.createObje
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (3b1b8a089)

test/js/web/workers/worker_blob.test.ts:
(pass) Worker from a Blob [1.97ms]
(pass) TypeScript Worker from a Blob [2.35ms]
(pass) Worker from a blob errors on invalid blob [1.55ms]
(pass) Revoking an object URL after a Worker is created synchronously still loads the worker [1.82ms]
(pass) Revoking an object URL after a Worker is created in a microtask still loads the worker [1.13ms]
(pass) Revoking an object URL after a Worker is created in a setTimeout still loads the worker [1.27ms]
(pass) An uncaught error in a Worker previews the original source after its object URL is revoked [1.09ms]
(pass) Revoking an object URL before a Worker is created errors [0.98ms]
(pass) Worker on a revoked blob still works [1.52ms]
(pass) object URL created in one worker is usable and revocable across threads [47.46ms]

 10 pass
 0 fail
 15 expect() calls
Ran 10 tests across 1 file. [125.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/workers/worker_blob.test.ts
bun test v1.4.3 (c01965ff7)

test/js/web/workers/worker_blob.test.ts:
(pass) Worker from a Blob [127.36ms]
(pass) TypeScript Worker from a Blob [113.79ms]
(pass) Worker from a blob errors on invalid blob [102.23ms]
(pass) Revoking an object URL after a Worker is created synchronously still loads the worker [115.14ms]
(pass) Revoking an object URL after a Worker is created in a microtask still loads the worker [103.86ms]
(pass) Revoking an object URL after a Worker is created in a setTimeout still loads the worker [101.03ms]
(pass) An uncaught error in a Worker previews the original source after its object URL is revoked [113.99ms]
(pass) Revoking an object URL before a Worker is created errors [101.73ms]
(pass) Worker on a revoked blob still works [130.32ms]
(pass) object URL created in one worker is usable and revocable across threads [2209.95ms]

 10 pass
 0 fail
 15 expect() calls
Ran 10 tests across 1 file. [5.36s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 622ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ModuleLoader.rs                  | 24 +++++++++++
 src/jsc/VirtualMachine.rs                | 41 +++++++++++++++---
 src/jsc/web_worker.rs                    | 48 ++++++++++++++++-----
 src/runtime/jsc_hooks.rs                 | 26 +++++------
 src/runtime/webcore/ObjectURLRegistry.rs |  9 ++++
 test/js/web/workers/worker_blob.test.ts  | 74 +++++++++++++++++++++++---------
 6 files changed, 172 insertions(+), 50 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/ModuleLoader.rs                       2      4      7
src/jsc/VirtualMachine.rs                     4      4      7
src/jsc/web_worker.rs                         9     11      7
src/runtime/jsc_hooks.rs                      5      6      7
src/runtime/webcore/ObjectURLRegistry.rs      1      1      7
test/js/web/workers/worker_blob.test.ts       2      5      7
```

</details>

<!-- robobun:evidence:end -->