### PR TITLE
bundler: JSON-escape the NODE_ENV auto-define value

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -888,14 +888,6 @@ pub(crate) fn defines_from_transform_options(
         let quoted_node_env: Box<[u8]> = 'brk: {
             if let Some(node_env) = node_env {
                 if !node_env.is_empty() {
-                    if (strings::starts_with_char(node_env, b'"')
-                        && strings::ends_with_char(node_env, b'"'))
-                        || (strings::starts_with_char(node_env, b'\'')
-                            && strings::ends_with_char(node_env, b'\''))
-                    {
-                        break 'brk Box::from(node_env);
-                    }
-
                     // avoid allocating if we can
                     if node_env == b"production" {
                         break 'brk Box::from(b"\"production\"".as_slice());
@@ -904,11 +896,15 @@ pub(crate) fn defines_from_transform_options(
                     } else if node_env == b"test" {
                         break 'brk Box::from(b"\"test\"".as_slice());
                     } else {
-                        let mut v = Vec::with_capacity(node_env.len() + 2);
-                        v.push(b'"');
-                        v.extend_from_slice(node_env);
-                        v.push(b'"');
-                        break 'brk v.into_boxed_slice();
+                        // The value is parsed as JSON below. Escape it so the
+                        // define always equals the runtime `process.env` string.
+                        break 'brk bun_core::fmt::format_json_string_utf8(
+                            node_env,
+                            Default::default(),
+                        )
+                        .to_string()
+                        .into_bytes()
+                        .into_boxed_slice();
                     }
                 }
             }
@@ -1634,14 +1630,14 @@ impl<'a> BundleOptions<'a> {
             }
 
             if self.is_test() {
-                break 'node_env Some(Cow::Borrowed(b"\"test\"".as_slice()));
+                break 'node_env Some(Cow::Borrowed(b"test".as_slice()));
             }
 
             if self.production {
-                break 'node_env Some(Cow::Borrowed(b"\"production\"".as_slice()));
+                break 'node_env Some(Cow::Borrowed(b"production".as_slice()));
             }
 
-            Some(Cow::Borrowed(b"\"development\"".as_slice()))
+            Some(Cow::Borrowed(b"development".as_slice()))
         };
         // reshaped for borrowck — node_env computed before passing self.log
         self.define = defines_from_transform_options(

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -171,6 +171,35 @@ describe("bundler", () => {
       NODE_ENV: "production",
     },
   });
+  // The auto-define for NODE_ENV/BUN_ENV is parsed as JSON. The value must be
+  // escaped so the bundle sees the same string the runtime does.
+  for (const [name, value] of [
+    ["ControlChars", "production\r\n\t"],
+    ["DoubleQuote", 'dev"elop'],
+    ["Backslash", "C:\\new\\table"],
+    ["WrappedInDoubleQuotes", '"production"'],
+    ["WrappedInSingleQuotes", "'production'"],
+    ["NonAscii", "prodüction \u{1F600}"],
+  ] as const) {
+    itBundled(`edgecase/NodeEnvEscaped${name}`, {
+      files: {
+        "/entry.js": /* js */ `
+          console.log(JSON.stringify([
+            process.env.NODE_ENV,
+            process.env.BUN_ENV,
+            process.env.NODE_ENV === 'production',
+          ]));
+        `,
+      },
+      target: "browser",
+      env: {
+        NODE_ENV: value,
+      },
+      run: {
+        stdout: JSON.stringify([value, value, false]),
+      },
+    });
+  }
   itBundled("edgecase/NodeEnvOptionalChaining", {
     // Matching `process?.env?.NODE_ENV` against the `process.env.NODE_ENV`
     // define would also match `Symbol?.for` etc. as side-effect-free; esbuild

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6117,3 +6117,27 @@ describe("same-target destructuring with an unstable target", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("NODE_ENV with characters that need JSON escaping", () => {
+  // The auto-define for process.env.NODE_ENV is parsed as JSON. A value with a
+  // control character or a quote must not break `new Bun.Transpiler()`.
+  it.concurrent.each([
+    ["carriage return", "production\r"],
+    ["double quote", 'dev"elop'],
+    ["backslash", "C:\\new\\table"],
+  ])("%s", async (_, value) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `var x; eval(new Bun.Transpiler().transformSync("x = process.env.NODE_ENV;")); console.log(JSON.stringify(x));`,
+      ],
+      env: { ...bunEnv, NODE_ENV: value },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(JSON.stringify(value) + "\n");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- The bundler injects `process.env.NODE_ENV` and `process.env.BUN_ENV` defines from the env value. It wraps the raw bytes in `"` with no escaping and parses the result as JSON. `NODE_ENV=$'production\r'` (a CRLF env file) fails every `bun build` with `Unterminated string literal at defines.json:1:1`, and `new Bun.Transpiler()` throws `SyntaxError Failed to load define`. `NODE_ENV='dev"elop'` inlines `"dev"`. A backslash value becomes a string with a real newline.
- The cause is `defines_from_transform_options` in `src/bundler/options.rs:888`. The runtime `process.env` is not affected, so the bundle and the runtime disagree.

### Fix
- Escape the value with `bun_core::fmt::format_json_string_utf8` before it is parsed. The define now always equals the runtime string. The `production`, `development`, and `test` fast paths stay.
- Remove the branch that passed a value wrapped in `"` or `'` through unchanged (added in #2655). With it, `NODE_ENV='"production"'` produced a production bundle, while the runtime value is `"production"` with the quotes, so `=== "production"` is false there. After this change the bundle matches the runtime. This is a behavior change for an env file that keeps literal quotes (Docker `--env-file`, compose list form): such a value no longer counts as production at bundle time.
- `load_defines` passed its defaults pre-quoted and relied on the removed branch. It now passes them raw.
- Verified: `test/bundler/bundler_edgecase.test.ts` (6 new `NodeEnvEscaped*` cases, 5 fail on 1.4.3) and `test/bundler/transpiler/transpiler.test.js` (3 new cases, all fail on 1.4.3). Also `bundler_bun`, `bundler_cjs2esm`, `jsx-production`, `esbuild/tsconfig`, and `cli/run/env.test.ts`.

### Background
- A define maps an expression such as `process.env.NODE_ENV` to a constant. The bundler stores user defines as JSON text and parses each value in `DefineData::from_input`.
- `.env` files are parsed by the dotenv loader, which strips surrounding quotes. A process env var is used as is. So the removed branch only applied to a process env var with literal quotes.
- `bun run` and `bun test` use `LoadAllWithoutInlining`, which skips this code.

<details><summary>Notes</summary>

Found by inspection during another fix, no tracker issue. Reproduced on 1.4.2, 1.4.0, 1.3.14 and main.

```sh
echo 'console.log(JSON.stringify({NODE_ENV:process.env.NODE_ENV, isProd:process.env.NODE_ENV==="production"}))' > in.js
NODE_ENV=$'production\r' bun build ./in.js        # Unterminated string literal at defines.json:1:1
NODE_ENV='dev"elop'      bun build ./in.js        # NODE_ENV: "dev"
NODE_ENV='"production"'  bun build ./in.js        # isProd: true, while `bun in.js` prints false
NODE_ENV='C:\new\table'  bun build ./in.js        # real newline and tab in the string
```

This should land before #35309. That PR makes an invalid define value a hard error, so the `dev"elop` truncation would become a build failure.

A possible follow-up: route NODE_ENV/BUN_ENV through `env_string_store_put` (the string-only lane that every other `process.env.*` define uses) so no JSON round trip is needed. I kept the JSON path here because `defines.rs` documents it as the route for a non-literal NODE_ENV, and the user hash is computed from the raw define text.

Self-reviewed: 6 concerns raised, all addressed in this description. None needed a code change.

Two `bytecode:` tests in `test/bundler/bun-build-api.test.ts` time out at 5 s under the debug build. They do not touch defines.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 33 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (c01965ff7)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [521.58ms]
(pass) bundler > edgecase/EmptyCommonJSModule [444.06ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [489.74ms]
(pass) bundler > edgecase/ImportStarFunction [432.00ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [366.72ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [108.69ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [382.80ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [201.70ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [199.78ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [271.43ms]
1131 |             return testRef(id, opts);
1132 |           }
1133 |           if (allErrors.length === 0) {
1134 |             throw new Error("Bundle Failed\ncode: " + exitCode + "\nstdout: " + stdout + "\nstderr: " + stderr);
1135 |           }
1136 |    
... (truncated)

release without fix: 8 failed, 33 skipped
bun test v1.4.3-canary.1 (c01965ff7)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [12.84ms]
(pass) bundler > edgecase/EmptyCommonJSModule [9.63ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [9.58ms]
(pass) bundler > edgecase/ImportStarFunction [11.94ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [9.77ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [4.99ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [9.26ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [4.84ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [4.62ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [4.44ms]
1131 |             return testRef(id, opts);
1132 |           }
1133 |           if (allErrors.length === 0) {
1134 |             throw new Error("Bundle Failed\ncode: " + exitCode + "\nstdout: " + stdout + "\nstderr: " + stderr);
1135 |           }
1136 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
undefined: Unterminated string literal
      at <anonymous> (/workspace/bun/test/bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 33 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (c01965ff7)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [510.23ms]
(pass) bundler > edgecase/EmptyCommonJSModule [376.96ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [431.08ms]
(pass) bundler > edgecase/ImportStarFunction [370.03ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [359.76ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [137.36ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [386.08ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [222.55ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [224.69ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [293.27ms]
(pass) bundler > edgecase/NodeEnvEscapedControlChars [542.88ms]
(pass) bundler > edgecase/NodeEnvEscapedDoubleQuote [448.97ms]
(pass) bundler > edgecase/NodeEnvEscapedBackslash [539.74ms]
(pass) bundler > edgecase/NodeEnvEscapedWrappedInDoubleQuotes [462.26ms]
... (truncated)

release with fix: 33 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/options.rs                     | 28 ++++++++++++----------------
 test/bundler/bundler_edgecase.test.ts      | 29 +++++++++++++++++++++++++++++
 test/bundler/transpiler/transpiler.test.js | 24 ++++++++++++++++++++++++
 3 files changed, 65 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/bundler/options.rs                          1      1     15
test/bundler/bundler_edgecase.test.ts           1      1      7
test/bundler/transpiler/transpiler.test.js      0      0     12
```

</details>

**root cause** · written by the author bot

The bundler's automatic `process.env.NODE_ENV` and `process.env.BUN_ENV` define wrapped the raw environment value in double quotes without escaping and then parsed the result as JSON, so control characters broke the parse entirely, embedded quotes truncated the value, backslashes became real escape sequences, and a pre-quoted value was passed through so that the bundled constant disagreed with the runtime string. The fix routes the general case through the existing JSON string formatter so the define is always a correctly escaped literal equal to the runtime value, while keeping the literal…

<!-- robobun:evidence:end -->