### PR TITLE
error: do not read a frame's source URL from disk unless the loader loaded it

### DIFF
--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -3,7 +3,7 @@
 use core::ffi::c_void;
 use std::sync::Arc;
 
-use bun_collections::{HashMap, IdentityContext, TaggedPtrUnion};
+use bun_collections::{HashMap, IdentityContext, StringArrayHashMap, TaggedPtrUnion};
 use bun_core::MutableString;
 use bun_core::Ordinal;
 use bun_ptr::tagged_pointer::TagType;
@@ -16,6 +16,9 @@ use bun_wyhash::hash;
 pub struct SavedSourceMap {
     /// Only accessed between [`Self::lock`] and [`Self::unlock`].
     map: HashTable,
+    /// Every path ever inserted into `map`, by bytes. `map` keys are hashes,
+    /// so a membership test for an untrusted path must not go through it.
+    paths: StringArrayHashMap<()>,
     mutex: Mutex,
 }
 
@@ -141,6 +144,7 @@ impl SavedSourceMap {
         };
         if refers_to_provider {
             self.map.remove(&key);
+            self.paths.swap_remove(path);
             // SAFETY: `old_value` was stored by us; the table's ownership of
             // it ends here.
             unsafe { Self::release_value(old_value) };
@@ -248,15 +252,17 @@ impl SavedSourceMap {
                 v.insert(value.ptr());
             }
         }
+        if !self.paths.contains(path) {
+            self.paths.insert(path, ());
+        }
         self.unlock();
         Ok(())
     }
 
-    /// Whether the module loader registered a source map for `path`.
+    /// Whether the module loader registered a source map for exactly `path`.
     pub(crate) fn has_mapping(&mut self, path: &[u8]) -> bool {
-        let h = hash(path);
         self.lock();
-        let found = self.map.contains_key(&h);
+        let found = self.paths.contains(path);
         self.unlock();
         found
     }

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -252,6 +252,19 @@ impl SavedSourceMap {
         Ok(())
     }
 
+    /// Returns `true` when a source map is registered for `path`. The module
+    /// loader registers a path here only when it loads and transpiles that
+    /// path. The error printer uses this to decide whether a stack frame's
+    /// source URL names a module the loader actually loaded, before it reads
+    /// that path from disk for a code-frame excerpt.
+    pub(crate) fn has_mapping(&mut self, path: &[u8]) -> bool {
+        let h = hash(path);
+        self.lock();
+        let found = self.map.contains_key(&h);
+        self.unlock();
+        found
+    }
+
     /// You must call `sourcemap.map.deref()` or you will leak memory
     fn get_with_content(
         &mut self,

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -252,11 +252,7 @@ impl SavedSourceMap {
         Ok(())
     }
 
-    /// Returns `true` when a source map is registered for `path`. The module
-    /// loader registers a path here only when it loads and transpiles that
-    /// path. The error printer uses this to decide whether a stack frame's
-    /// source URL names a module the loader actually loaded, before it reads
-    /// that path from disk for a code-frame excerpt.
+    /// Whether the module loader registered a source map for `path`.
     pub(crate) fn has_mapping(&mut self, path: &[u8]) -> bool {
         let h = hash(path);
         self.lock();

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -16,8 +16,7 @@ use bun_wyhash::hash;
 pub struct SavedSourceMap {
     /// Only accessed between [`Self::lock`] and [`Self::unlock`].
     map: HashTable,
-    /// Every path ever inserted into `map`, by bytes. `map` keys are hashes,
-    /// so a membership test for an untrusted path must not go through it.
+    /// Every path inserted into `map`, by bytes (`map` keys are only hashes).
     paths: StringArrayHashMap<()>,
     mutex: Mutex,
 }

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -258,8 +258,17 @@ impl SavedSourceMap {
         Ok(())
     }
 
-    /// Whether the module loader registered a source map for exactly `path`.
-    pub(crate) fn has_mapping(&mut self, path: &[u8]) -> bool {
+    /// Records a path that a loaded module's own source map names as an original source.
+    pub(crate) fn trust_path(&mut self, path: &[u8]) {
+        self.lock();
+        if !self.paths.contains(path) {
+            self.paths.insert(path, ());
+        }
+        self.unlock();
+    }
+
+    /// Whether `path` is exactly a loaded module, or an original source one of them maps to.
+    pub(crate) fn is_loaded_path(&mut self, path: &[u8]) -> bool {
         self.lock();
         let found = self.paths.contains(path);
         self.unlock();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5833,8 +5833,7 @@ impl VirtualMachine {
         }
 
         let already_remapped = frames[top].remapped;
-        // A frame parsed from an `error.stack` string names whatever the thrown
-        // code chose (`//# sourceURL`). Read it from disk only if the loader loaded it.
+        // A frame parsed from `error.stack` names whatever the thrown code chose.
         let allow_source_from_disk = if already_remapped {
             let url = frames[top].source_url.to_utf8();
             self.source_mappings.has_mapping(url.slice())

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5833,6 +5833,19 @@ impl VirtualMachine {
         }
 
         let already_remapped = frames[top].remapped;
+        // Only read a frame's source URL from disk for a code-frame excerpt
+        // when the module loader loaded that URL. The already-remapped branch
+        // parses frames out of an `error.stack` string, so the URL can be a
+        // name the running code chose (a `//# sourceURL` directive in node:vm
+        // or eval code), not a module the loader ever loaded. The non-remapped
+        // branch resolves through the source-map table, which is already the
+        // loaded-module check.
+        let allow_source_from_disk = if already_remapped {
+            let url = frames[top].source_url.to_utf8();
+            self.source_mappings.has_mapping(url.slice())
+        } else {
+            true
+        };
         let resolved = {
             let top_source_url = frames[top].source_url.to_utf8();
             let maybe_lookup: Option<bun_sourcemap::mapping::Lookup> = if already_remapped {
@@ -5898,6 +5911,9 @@ impl VirtualMachine {
                 }
                 if top_frame_is_builtin {
                     // Avoid printing "export default 'native'"
+                    break 'code bun_core::Utf8Bytes::EMPTY;
+                }
+                if !allow_source_from_disk {
                     break 'code bun_core::Utf8Bytes::EMPTY;
                 }
                 let mut log = bun_ast::Log::default();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5833,13 +5833,8 @@ impl VirtualMachine {
         }
 
         let already_remapped = frames[top].remapped;
-        // Only read a frame's source URL from disk for a code-frame excerpt
-        // when the module loader loaded that URL. The already-remapped branch
-        // parses frames out of an `error.stack` string, so the URL can be a
-        // name the running code chose (a `//# sourceURL` directive in node:vm
-        // or eval code), not a module the loader ever loaded. The non-remapped
-        // branch resolves through the source-map table, which is already the
-        // loaded-module check.
+        // A frame parsed from an `error.stack` string names whatever the thrown
+        // code chose (`//# sourceURL`). Read it from disk only if the loader loaded it.
         let allow_source_from_disk = if already_remapped {
             let url = frames[top].source_url.to_utf8();
             self.source_mappings.has_mapping(url.slice())

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6866,7 +6866,8 @@ impl VirtualMachine {
         source_url: &[u8],
     ) -> Option<bun_core::String> {
         let display_url = lookup.display_source_url_if_needed(source_url)?;
-        self.source_mappings.trust_path(display_url.to_utf8().slice());
+        self.source_mappings
+            .trust_path(display_url.to_utf8().slice());
         Some(display_url)
     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5632,10 +5632,8 @@ impl VirtualMachine {
                     bun_sourcemap::SourceContentHandling::NoSourceContents,
                 )
                 .map(|lookup| {
-                    (
-                        lookup.display_source_url_if_needed(source_url.slice()),
-                        lookup,
-                    )
+                    let display_url = self.remapped_source_url(&lookup, source_url.slice());
+                    (display_url, lookup)
                 })
             };
             if let Some((display_url, lookup)) = resolved {
@@ -5836,7 +5834,7 @@ impl VirtualMachine {
         // A frame parsed from `error.stack` names whatever the thrown code chose.
         let allow_source_from_disk = if already_remapped {
             let url = frames[top].source_url.to_utf8();
-            self.source_mappings.has_mapping(url.slice())
+            self.source_mappings.is_loaded_path(url.slice()) || self.is_embedded_module(url.slice())
         } else {
             true
         };
@@ -5872,7 +5870,7 @@ impl VirtualMachine {
             maybe_lookup.map(|lookup| {
                 let mapping = lookup.mapping;
                 let display_url = if !already_remapped {
-                    lookup.display_source_url_if_needed(top_source_url.slice())
+                    self.remapped_source_url(&lookup, top_source_url.slice())
                 } else {
                     None
                 };
@@ -5989,10 +5987,8 @@ impl VirtualMachine {
                         bun_sourcemap::SourceContentHandling::NoSourceContents,
                     )
                     .map(|lookup| {
-                        (
-                            lookup.display_source_url_if_needed(source_url.slice()),
-                            lookup,
-                        )
+                        let display_url = self.remapped_source_url(&lookup, source_url.slice());
+                        (display_url, lookup)
                     })
                 };
                 if let Some((display_url, lookup)) = resolved {
@@ -6853,6 +6849,26 @@ impl VirtualMachine {
 
         let _ = writer.write_all(b"\n");
         let _ = writer.flush();
+    }
+
+    /// Whether `path` is a file embedded in this `bun build --compile` executable.
+    fn is_embedded_module(&self, path: &[u8]) -> bool {
+        bun_options_types::standalone_path::is_bun_standalone_file_path(path)
+            && self
+                .standalone_module_graph
+                .is_some_and(|graph| graph.find_assume_standalone_path(path).is_some())
+    }
+
+    /// The URL a frame at `source_url` displays after `lookup` remaps it, if it changes.
+    /// The new URL comes from a loaded module's own map, so the printer may read it later.
+    fn remapped_source_url(
+        &mut self,
+        lookup: &bun_sourcemap::mapping::Lookup,
+        source_url: &[u8],
+    ) -> Option<bun_core::String> {
+        let display_url = lookup.display_source_url_if_needed(source_url)?;
+        self.source_mappings.trust_path(display_url.to_utf8().slice());
+        Some(display_url)
     }
 
     /// Looks up the source-map mapping for `path` at `line:column`.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6859,8 +6859,7 @@ impl VirtualMachine {
                 .is_some_and(|graph| graph.find_assume_standalone_path(path).is_some())
     }
 
-    /// The URL a frame at `source_url` displays after `lookup` remaps it, if it changes.
-    /// The new URL comes from a loaded module's own map, so the printer may read it later.
+    /// The URL `lookup` remaps `source_url` to, recorded as a path the printer may read.
     fn remapped_source_url(
         &mut self,
         lookup: &bun_sourcemap::mapping::Lookup,

--- a/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
+++ b/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
@@ -8,7 +8,7 @@ throw new Error("hello");
 Error: hello
     at hellohello.js:2:16
     at runInNewContext (unknown)
-    at <anonymous> (<this-url>:6:5)"
+    at <anonymous> (<this-url>:8:5)"
 `;
 
 exports[`can get sourceURL inside node:vm 1`] = `
@@ -17,7 +17,7 @@ exports[`can get sourceURL inside node:vm 1`] = `
 error: hello
       at hello (hellohello.js:4:24)
       at hellohello.js:7:6
-      at <anonymous> (<this-url>:21:15)
+      at <anonymous> (<this-url>:23:15)
 "
 `;
 
@@ -27,6 +27,6 @@ exports[`eval sourceURL is correct 1`] = `
 error: hello
       at hello (hellohello.js:4:24)
       at eval (hellohello.js:7:6)
-      at <anonymous> (<this-url>:39:15)
+      at <anonymous> (<this-url>:41:15)
 "
 `;

--- a/test/js/node/vm/vm-sourceUrl.test.ts
+++ b/test/js/node/vm/vm-sourceUrl.test.ts
@@ -67,8 +67,8 @@ describe.concurrent("error printer does not read attacker-named source files", (
         test(`vm code does not leak a named file's contents (${label})`, async () => {
           using dir = tempDir("vm-sourceurl-leak", {
             "secret.txt": CANARY + "\n",
-            "run.js": `
-              const vm = require("node:vm");
+            "run.mjs": `
+              import * as vm from "node:vm";
               const target = process.env.CANARY_PATH + ${JSON.stringify(nul ? "\0.js" : "")};
               const code = 'function f(){ throw new Error("boom") }; f()' ${
                 via === "sourceURL" ? `+ '\\n//# sourceURL=' + target` : ""
@@ -83,7 +83,7 @@ describe.concurrent("error printer does not read attacker-named source files", (
           });
 
           await using proc = Bun.spawn({
-            cmd: [bunExe(), path.join(String(dir), "run.js")],
+            cmd: [bunExe(), path.join(String(dir), "run.mjs")],
             env: { ...bunEnv, CANARY_PATH: path.join(String(dir), "secret.txt") },
             stdout: "pipe",
             stderr: "pipe",

--- a/test/js/node/vm/vm-sourceUrl.test.ts
+++ b/test/js/node/vm/vm-sourceUrl.test.ts
@@ -104,19 +104,57 @@ describe.concurrent("error printer does not read attacker-named source files", (
   }
 });
 
-test.concurrent("a real module still shows its source code frame", async () => {
-  using dir = tempDir("vm-sourceurl-real", {
-    "app.ts": `function doWork(): void {\n  throw new Error("real module error");\n}\ndoWork();\n`,
+// Frames parsed back out of an already-materialized `error.stack` are the
+// gated path. A loaded module, an original source named by a loaded module's
+// source map, and a file embedded in a compiled executable must keep their
+// code frame there.
+describe.concurrent("a loaded module still shows its source code frame", () => {
+  const app = `function doWork(): void {
+  throw new Error("real module error");
+}
+try {
+  doWork();
+} catch (e) {
+  void (e as Error).stack;
+  console.error(e);
+}
+`;
+
+  async function run(cmd: string[], cwd: string) {
+    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { output: stdout + stderr, exitCode };
+  }
+
+  test("run from source", async () => {
+    using dir = tempDir("vm-sourceurl-real", { "app.ts": app });
+    const { output, exitCode } = await run([bunExe(), "app.ts"], String(dir));
+    expect(output).toContain(`throw new Error("real module error");`);
+    expect(output).toContain("app.ts:2:");
+    expect(exitCode).toBe(0);
   });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(String(dir), "app.ts")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+
+  test("bundled with an external source map", async () => {
+    using dir = tempDir("vm-sourceurl-bundled", { "src/app.ts": app });
+    const build = await run(
+      [bunExe(), "build", "--target=bun", "--sourcemap=external", "--outdir=dist", "src/app.ts"],
+      String(dir),
+    );
+    expect(build.exitCode).toBe(0);
+    const { output, exitCode } = await run([bunExe(), "dist/app.js"], String(dir));
+    // The frame names the original `src/app.ts`, which the map points at.
+    expect(output).toContain(`throw new Error("real module error");`);
+    expect(output).toContain(`${path.join("src", "app.ts")}:2:`);
+    expect(exitCode).toBe(0);
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(stderr).toContain("real module error");
-  // The original source line is read from disk and shown as the code frame.
-  expect(stderr).toContain(`throw new Error("real module error");`);
-  expect(exitCode).not.toBe(0);
+
+  test("compiled executable", async () => {
+    using dir = tempDir("vm-sourceurl-compiled", { "app.ts": app });
+    const exe = path.join(String(dir), process.platform === "win32" ? "app.exe" : "app");
+    const build = await run([bunExe(), "build", "--compile", "app.ts", "--outfile", exe], String(dir));
+    expect(build.exitCode).toBe(0);
+    const { output, exitCode } = await run([exe], String(dir));
+    expect(output).toContain(`throw new Error("real module error");`);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/vm/vm-sourceUrl.test.ts
+++ b/test/js/node/vm/vm-sourceUrl.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { runInNewContext } from "node:vm";
 import path from "node:path";
+import { runInNewContext } from "node:vm";
 
 test("can get sourceURL from eval inside node:vm", () => {
   try {

--- a/test/js/node/vm/vm-sourceUrl.test.ts
+++ b/test/js/node/vm/vm-sourceUrl.test.ts
@@ -1,5 +1,7 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { runInNewContext } from "node:vm";
+import path from "node:path";
 
 test("can get sourceURL from eval inside node:vm", () => {
   try {
@@ -49,4 +51,67 @@ hello();
 `,
   );
   expect(err.replaceAll(import.meta.path, "<this-url>")).toMatchSnapshot();
+});
+
+const CANARY = "SECRET_CANARY_DO_NOT_LEAK_8f2a";
+
+// The error printer reads a frame's source file from disk for a code-frame
+// excerpt. A `//# sourceURL` directive, or a node:vm `filename`, lets the code
+// that throws choose that source URL. The printer must not open a file the
+// module loader never loaded.
+describe.concurrent("error printer does not read attacker-named source files", () => {
+  for (const caught of [true, false]) {
+    for (const nul of [false, true]) {
+      const label = `${caught ? "caught" : "uncaught"}${nul ? " with interior NUL in the path" : ""}`;
+      test(`vm sourceURL does not leak a file's contents (${label})`, async () => {
+        using dir = tempDir("vm-sourceurl-leak", {
+          "secret.txt": CANARY + "\n",
+          "run.js": `
+            const vm = require("node:vm");
+            const target = process.env.CANARY_PATH + ${JSON.stringify(nul ? "\0.js" : "")};
+            const code = 'function f(){ throw new Error("boom") }; f()\\n//# sourceURL=' + target;
+            ${
+              caught
+                ? `try { vm.runInNewContext(code, {}, { filename: "sandbox.js" }); } catch (e) { console.error(e); }`
+                : `vm.runInNewContext(code, {}, { filename: "sandbox.js" });`
+            }
+          `,
+        });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), path.join(String(dir), "run.js")],
+          env: { ...bunEnv, CANARY_PATH: path.join(String(dir), "secret.txt") },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        const output = stdout + stderr;
+
+        // The error is still reported.
+        expect(output).toContain("boom");
+        // The file's contents are never shown.
+        expect(output).not.toContain(CANARY);
+        // An interior NUL in the name must not crash the printer.
+        if (caught) expect(exitCode).toBe(0);
+        else expect(exitCode).not.toBe(134); // SIGABRT
+      });
+    }
+  }
+});
+
+test.concurrent("a real module still shows its source code frame", async () => {
+  using dir = tempDir("vm-sourceurl-real", {
+    "app.ts": `function doWork(): void {\n  throw new Error("real module error");\n}\ndoWork();\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(String(dir), "app.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("real module error");
+  // The original source line is read from disk and shown as the code frame.
+  expect(stderr).toContain(`throw new Error("real module error");`);
+  expect(exitCode).not.toBe(0);
 });

--- a/test/js/node/vm/vm-sourceUrl.test.ts
+++ b/test/js/node/vm/vm-sourceUrl.test.ts
@@ -88,11 +88,7 @@ describe.concurrent("error printer does not read attacker-named source files", (
             stdout: "pipe",
             stderr: "pipe",
           });
-          const [stdout, stderr, exitCode] = await Promise.all([
-            proc.stdout.text(),
-            proc.stderr.text(),
-            proc.exited,
-          ]);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
           const output = stdout + stderr;
 
           // The error is still reported.

--- a/test/js/node/vm/vm-sourceUrl.test.ts
+++ b/test/js/node/vm/vm-sourceUrl.test.ts
@@ -60,41 +60,50 @@ const CANARY = "SECRET_CANARY_DO_NOT_LEAK_8f2a";
 // that throws choose that source URL. The printer must not open a file the
 // module loader never loaded.
 describe.concurrent("error printer does not read attacker-named source files", () => {
-  for (const caught of [true, false]) {
-    for (const nul of [false, true]) {
-      const label = `${caught ? "caught" : "uncaught"}${nul ? " with interior NUL in the path" : ""}`;
-      test(`vm sourceURL does not leak a file's contents (${label})`, async () => {
-        using dir = tempDir("vm-sourceurl-leak", {
-          "secret.txt": CANARY + "\n",
-          "run.js": `
-            const vm = require("node:vm");
-            const target = process.env.CANARY_PATH + ${JSON.stringify(nul ? "\0.js" : "")};
-            const code = 'function f(){ throw new Error("boom") }; f()\\n//# sourceURL=' + target;
-            ${
-              caught
-                ? `try { vm.runInNewContext(code, {}, { filename: "sandbox.js" }); } catch (e) { console.error(e); }`
-                : `vm.runInNewContext(code, {}, { filename: "sandbox.js" });`
-            }
-          `,
-        });
+  for (const via of ["sourceURL", "filename"] as const) {
+    for (const caught of [true, false]) {
+      for (const nul of [false, true]) {
+        const label = `${via}, ${caught ? "caught" : "uncaught"}${nul ? ", interior NUL in the path" : ""}`;
+        test(`vm code does not leak a named file's contents (${label})`, async () => {
+          using dir = tempDir("vm-sourceurl-leak", {
+            "secret.txt": CANARY + "\n",
+            "run.js": `
+              const vm = require("node:vm");
+              const target = process.env.CANARY_PATH + ${JSON.stringify(nul ? "\0.js" : "")};
+              const code = 'function f(){ throw new Error("boom") }; f()' ${
+                via === "sourceURL" ? `+ '\\n//# sourceURL=' + target` : ""
+              };
+              const options = { filename: ${via === "filename" ? "target" : '"sandbox.js"'} };
+              ${
+                caught
+                  ? `try { vm.runInNewContext(code, {}, options); } catch (e) { console.error(e); }`
+                  : `vm.runInNewContext(code, {}, options);`
+              }
+            `,
+          });
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), path.join(String(dir), "run.js")],
-          env: { ...bunEnv, CANARY_PATH: path.join(String(dir), "secret.txt") },
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        const output = stdout + stderr;
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), path.join(String(dir), "run.js")],
+            env: { ...bunEnv, CANARY_PATH: path.join(String(dir), "secret.txt") },
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([
+            proc.stdout.text(),
+            proc.stderr.text(),
+            proc.exited,
+          ]);
+          const output = stdout + stderr;
 
-        // The error is still reported.
-        expect(output).toContain("boom");
-        // The file's contents are never shown.
-        expect(output).not.toContain(CANARY);
-        // An interior NUL in the name must not crash the printer.
-        if (caught) expect(exitCode).toBe(0);
-        else expect(exitCode).not.toBe(134); // SIGABRT
-      });
+          // The error is still reported.
+          expect(output).toContain("boom");
+          // The file's contents are never shown.
+          expect(output).not.toContain(CANARY);
+          // An interior NUL in the name must not crash the printer. An
+          // uncaught error exits 1, a caught one exits 0.
+          expect(exitCode).toBe(caught ? 0 : 1);
+        });
+      }
     }
   }
 });


### PR DESCRIPTION
### Problem
- The error printer reads the top frame's source URL from disk for a code-frame excerpt. The running code chooses that URL (`//# sourceURL`, or a `node:vm` `filename`), so code in `node:vm` can name any path and make the host print that file.
- `remap_zig_exception` (`src/jsc/VirtualMachine.rs`) calls `fetch_without_on_load_plugins(PrintSource)` on the URL. The contents reach `console.error`, the uncaught printer, `Bun.inspect`, and the default `Bun.serve` 500 body. The read is whole-file. An interior NUL aborts a debug or ASan build.

```js
vm.runInNewContext('function f(){ throw new Error("x") }; f()\n//# sourceURL=/etc/hostname', {});
// stock bun prints the contents of /etc/hostname as the "1 | ..." code frame
```

### Fix
- Read from disk only when the loader produced the URL. Frames parsed out of an `error.stack` string (`remapped == true`, the path `node:vm` and `eval` errors take) are attacker-chosen. Live frames are unchanged.
- `SavedSourceMap` keeps every registered path by bytes (`paths`). A hash-only check is not enough: the fetch normalizes `..`, so a colliding string could still name a real file.
- Two more loader-produced URLs are trusted: the original source a loaded module's map names (`remapped_source_url` records it via `trust_path`), and a file embedded in a `bun build --compile` executable (`is_embedded_module`).
- Verified: `test/js/node/vm/vm-sourceUrl.test.ts`. Eight leak cases fail on stock bun. Three loaded-module cases (source, external map, compiled) take the stack-string path and keep their excerpt. Also the vm, inspect-error, stack, and bundler_compile suites.

### Background
- `ZigException` frames come from live JSC frames, which keep the source in memory, or from the `error.stack` string when only that is left. The parsed form has no source, so the printer re-read the file the frame names.
- `SavedSourceMap` maps a module path to its source map. The loader inserts an entry when it transpiles a module or loads one with a `//# sourceMappingURL`.

<details><summary>Notes</summary>

- Confirmed the branch with a debug build: the `node:vm` error reaches `remap_zig_exception` with `frames[top].remapped == true`, so it took the stack-string branch that fetched unconditionally.
- Cost: `node:vm` code run under a real `filename` (`vm.runInThisContext`, `vm.Script`, the jest and vitest runtime shape) had a code frame read from that file. It now has none on this path, since the loader never loaded the file. The `filename` rows of the test matrix assert this. The frame line and column are unchanged. Node prints the in-memory line for this case, so neither the old nor the new output matches it.
- The leak matrix: `sourceURL` and `filename`, caught and uncaught, with and without an interior NUL.
- Not covered here, left for a follow-up and for maintainer direction on the larger design:
  - A `//# sourceURL` that collides with a path the app itself loaded still excerpts that module's file, not the code that ran. This discloses only the app's own source.
  - A per-frame source-origin kind (File, Eval, VM, ...) would let the printer take every non-file excerpt from the `SourceProvider` it already holds. That restores the `vm` `filename` excerpt with the text that ran, fixes the collision case, and matches Node. The string-parsed frame has no provider handle today, so it is not a cheap addition to this gate.
- Self-reviewed: four concerns raised, three addressed (hash-only membership, source-map originals, embedded files). The remaining one is the `vm` `filename` cost above.
- `BUN_DISABLE_SOURCE_CODE_PREVIEW` still suppresses the excerpt entirely, unaffected.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm-sourceUrl.test.ts

<!-- robobun:evidence:end -->