### PR TITLE
Bump lol-html so descendant selector matching is linear in nesting depth

### DIFF
--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -26,7 +26,7 @@ import type { Dependency } from "../source.ts";
 // base commit is recorded here so a rebase onto a new upstream tag is
 // `git rebase --onto <new-tag> <LOLHTML_UPSTREAM_BASE> bun` in the fork.
 const LOLHTML_UPSTREAM_BASE = "77127cd2b8545998756e8d64e36ee2313c4bb312"; // v2.7.2
-const LOLHTML_COMMIT = "725ce499aa9b71e38b7a2d0a9fbb6d7294a4079e";
+const LOLHTML_COMMIT = "ea6125b7efcb1a6cb016d7edd6360c234864634f";
 void LOLHTML_UPSTREAM_BASE;
 
 export const lolhtml: Dependency = {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -3207,3 +3207,41 @@ describe("GC pressure mid-rewrite", () => {
     });
   });
 });
+
+describe("selector VM complexity", () => {
+  // The selector VM used to re-run every ancestor's descendant-combinator
+  // jumps for every start tag, and each ancestor held one copy per partial
+  // match, so "div div div div" over N nested <div>s was O(N^4): depth 600
+  // (6.6 KB) took about two minutes. A stray end tag scanned the whole open
+  // stack, so "<a></b>" x 40k (280 KB) was O(N^2) and took about 2.5 s.
+  // Both now run in well under a second. The spawn timeout is the assertion.
+  it("descendant combinators and stray end tags stay linear in nesting depth", async () => {
+    const depth = 600;
+    const fixture = /* js */ `
+      const depth = ${depth};
+      const deep = Buffer.alloc(depth * 5, "<div>").toString() + "x" + Buffer.alloc(depth * 6, "</div>").toString();
+      let matched = 0;
+      const deepOut = new HTMLRewriter().on("div div div div", { element() { matched++; } }).transform(deep);
+
+      const stray = Buffer.alloc(40_000 * 7, "<a></b>").toString();
+      let strayMatched = 0;
+      const strayOut = new HTMLRewriter().on("nomatch", { element() { strayMatched++; } }).transform(stray);
+
+      console.log(JSON.stringify({ matched, deepSame: deepOut === deep, strayMatched, straySame: strayOut === stray }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ matched: depth - 3, deepSame: true, strayMatched: 0, straySame: true }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `new HTMLRewriter().on("div div div div div", ...)` over nested `<div>` elements runs in O(depth^5). A 1.7 KB document (depth 160) takes 10 s and 467 MB on bun 1.4.2. Doubling the depth multiplies the time by about 2^(k-1) for a k-part descendant selector. A server that rewrites untrusted HTML can be pinned with a few KB.
- The cause is in lol-html's selector VM (`vendor/lolhtml/src/selectors_vm/mod.rs:124`). Every ancestor whose descendant step matched pushed its own copy of the hereditary jump set, and every start tag re-ran all of them. `Stack::pop_up_to` also scanned the whole open stack for each stray end tag, so `"<a></b>" x 100k` ran in O(N^2) (15 s).

### Fix
- Pin `oven-sh/lol-html` at `ea6125b`, the head of the `bun` branch, in `scripts/build/deps/lolhtml.ts`. That commit is a cherry-pick of upstream cloudflare/lol-html#331 (lol-html v3.0.1): oven-sh/lol-html#2, merged. The stack keeps one flat list of distinct active hereditary jump ranges, pruned by depth on pop, and an open-name count map so a stray end tag is rejected in O(1).
- Correct because re-running the same address range against the same start tag was already a no-op after the matched payload set union, so dedup-once execution produces the same matches. Upstream carries the same change.
- Depth 160 with a 5-part selector drops from 10 s to 16 ms (debug build). Depth 16000 with `div div` drops from 2.2 s to 0.9 s (debug).
- Verified: `test/js/workerd/html-rewriter.test.js` (new test, stock bun times out). Also `html-rewriter-doctype`, `html-rewriter-end-error`, `html-rewriter-leak`, `htmlrewriter-additional-bugs`, and `bundler_html`.

### Background
- lol-html compiles selectors to a small program. A descendant combinator (`a b`) becomes a "hereditary jump": when `a` matches, the stack item for that element records the address range for the `b` step, and every later descendant runs that range.
- Bun builds lol-html from `oven-sh/lol-html`, branch `bun`, as a path dependency. The fork is v2.7.2 plus content-handler suspension. Upstream is at v3.0.1 with a larger API change, so this PR takes only the one commit.
- The fork memory limiter (`max_allowed_memory_usage`) counts stack items, not the per-item jump vectors. So a memory cap would not have caught this growth.

<details><summary>Notes</summary>

Measured on the baked bun 1.4.3-canary (stock) vs the patched debug build:

```
selector "div div div div div", depth 120: 3340 ms / 176 MB  ->  13 ms
selector "div div div div div", depth 160: ~10 s           ->  16 ms
selector "div div div",         depth 1600: 10631 ms        -> 101 ms
selector "div div",             depth 16000: ~2.2 s         -> 935 ms (debug)
"<a></b>" x 50000:              3803 ms                     -> (100k) 569 ms (debug)
```

Fork PR: https://github.com/oven-sh/lol-html/pull/2, fast-forwarded into the `bun` branch, so `ea6125b` is its head. Supersedes #35930, the interim vendor-patch PR from before the vendoring moved to the fork.

lol-html checks on the fork commit: `cargo test --lib` 172 pass, `cargo test --features integration_test` 3 pass, `cargo clippy --all-targets` no new warnings (the two existing ones are in `rewriter/mod.rs` and `rewriter/settings.rs`, untouched).

The new test uses a 30 s spawn timeout as the assertion. The deep case alone takes about two minutes on stock bun with depth 600 and a 4-part selector, so the fail-before margin is large. The fixed debug build finishes the whole fixture in about 0.6 s.
</details>
