### PR TITLE
fs.rm: continue past vanished entries, retry transient errors, report the failing path

### DIFF
--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -247,6 +247,9 @@ mod platform {
                     };
                     if rc < 0 {
                         let e = sys::last_errno();
+                        if e == libc::EINTR {
+                            continue 'start_over;
+                        }
                         // FreeBSD reports ENOENT when iterating an unlinked
                         // but still-open directory.
                         if e == libc::ENOENT {
@@ -344,10 +347,11 @@ mod platform {
                         )
                     };
                     if rc < 0 {
-                        return Err(sys::Error::from_code_int(
-                            sys::last_errno(),
-                            Tag::getdents64,
-                        ));
+                        let e = sys::last_errno();
+                        if e == libc::EINTR {
+                            continue 'start_over;
+                        }
+                        return Err(sys::Error::from_code_int(e, Tag::getdents64));
                     }
                     if rc == 0 {
                         return Ok(None);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -373,33 +373,6 @@ fn encoding_to_node(e: Encoding) -> bun_core::NodeEncoding {
 /// `super::stat` swaps to `pub use bun_sys::PosixStat` this alias collapses.
 use super::stat::PosixStat;
 
-/// Node `fs.rm` mapping helper — maps an error-set *name* string back to a
-/// `crate::Error` variant so the callers' `map_anyerror_to_errno*` tables (which
-/// match on `err.name()`) keep round-tripping.
-#[inline]
-fn err_from_static(name: &'static str) -> crate::Error {
-    match name {
-        "FileNotFound" => crate::Error::FileNotFound,
-        "AccessDenied" => crate::Error::AccessDenied,
-        "PermissionDenied" => crate::Error::PermissionDenied,
-        "SymLinkLoop" => crate::Error::SymLinkLoop,
-        "NameTooLong" => crate::Error::NameTooLong,
-        "SystemResources" => crate::Error::SystemResources,
-        "ReadOnlyFileSystem" => crate::Error::ReadOnlyFileSystem,
-        "FileSystem" => crate::Error::FileSystem,
-        "FileBusy" => crate::Error::FileBusy,
-        "NotDir" => crate::Error::NotDir,
-        "IsDir" => crate::Error::IsDir,
-        "DirNotEmpty" => crate::Error::DirNotEmpty,
-        "SystemFdQuotaExceeded" => crate::Error::SystemFdQuotaExceeded,
-        "ProcessFdQuotaExceeded" => crate::Error::ProcessFdQuotaExceeded,
-        "BadPathName" => crate::Error::BadPathName,
-        "FileTooBig" => crate::Error::FileTooBig,
-        "NoDevice" => crate::Error::NoDevice,
-        _ => crate::Error::Unexpected,
-    }
-}
-
 /// `preallocate_supported` / `preallocate_length` — these consts have
 /// no equivalent in `bun_sys` (only `preallocate_file()` exists there), so
 /// define them locally so the write-file fast path keeps its 2 MiB guard.
@@ -7458,28 +7431,6 @@ impl NodeFS {
     }
 
     pub(crate) fn rmdir(&mut self, args: &args::RmDir, _: Flavor) -> Maybe<ret::Rmdir> {
-        if args.recursive {
-            // On Windows a rooted-but-driveless path ("/tmp/foo") must resolve
-            // against the cwd drive.
-            // Our dt_* helpers go through Syscall::*at → to_nt_path /
-            // normalize_path_windows, which do NOT add the cwd drive, turning
-            // "/tmp/foo" into a nonexistent NT name (ENOENT). Pre-resolve with
-            // slice_z so the path already carries a drive letter, the same way
-            // existsSync/statSync/unlinkSync see it.
-            #[cfg(windows)]
-            let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
-            #[cfg(not(windows))]
-            let resolved = args.path.slice();
-            if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::Directory)
-            {
-                let mut errno: E = map_anyerror_to_errno(&err);
-                if cfg!(windows) && errno == E::ENOTDIR {
-                    errno = E::ENOENT;
-                }
-                return Err(sys::Error::from_code(errno, sys::Tag::rmdir));
-            }
-            return Ok(());
-        }
         #[cfg(windows)]
         {
             return match Syscall::rmdir(args.path.slice_z(&mut self.sync_error_buf)) {
@@ -7508,8 +7459,12 @@ impl NodeFS {
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
             let resolved = args.path.slice();
-            if let Err(err) = zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File) {
-                if matches!(err, crate::Error::FileNotFound) {
+            if let Err(err) = rm_with_retries(args, || {
+                zig_delete_tree(&sys::Dir::cwd(), resolved, sys::FileKind::File)
+            }) {
+                // The walker swallows ENOENT below the root, so this is the
+                // root itself.
+                if err.get_errno() == E::ENOENT {
                     if args.force {
                         return Ok(());
                     }
@@ -7519,17 +7474,15 @@ impl NodeFS {
                     return Err(sys::Error::from_code(E::ENOENT, sys::Tag::lstat)
                         .with_path(args.path.slice()));
                 }
-                return Err(sys::Error::from_code(
-                    map_anyerror_to_errno_rm_tree(&err),
-                    sys::Tag::rm,
-                )
-                .with_path(args.path.slice()));
+                // `err.path` names the entry that failed, not the root.
+                return Err(sys::Error::from_code(err.get_errno(), sys::Tag::rm)
+                    .with_path(without_nt_prefix::<u8>(&err.path)));
             }
             return Ok(());
         }
 
         let dest = args.path.slice_z(&mut self.sync_error_buf);
-        if let Err(err1) = sys::unlink(dest) {
+        if let Err(err1) = rm_with_retries(args, || sys::unlink(dest)) {
             let e1 = err1.get_errno();
             if e1 == E::ENOENT {
                 if args.force {
@@ -7541,8 +7494,7 @@ impl NodeFS {
                     sys::Error::from_code(E::ENOENT, sys::Tag::lstat).with_path(args.path.slice())
                 );
             }
-            return Err(sys::Error::from_code(map_rm_errno_narrow(e1), sys::Tag::rm)
-                .with_path(args.path.slice()));
+            return Err(err1.with_path_and_syscall(args.path.slice(), sys::Tag::rm));
         }
         Ok(())
     }
@@ -9214,69 +9166,6 @@ impl ReaddirEntry for Buffer {
     }
 }
 
-// There are three distinct error→errno tables: rmdir-recursive,
-// rm-recursive, and rm non-recursive unlink/rmdir. An earlier draft
-// collapsed them into one, which silently mapped AccessDenied→EPERM for `rm`
-// (Node returns EACCES there) and widened the narrow table. Split back out
-// per call site.
-fn map_anyerror_to_errno(err: &crate::Error) -> E {
-    match err.name() {
-        "AccessDenied" => E::EPERM,
-        "PermissionDenied" => E::EPERM,
-        "FileTooBig" => E::EFBIG,
-        "SymLinkLoop" => E::ELOOP,
-        "ProcessFdQuotaExceeded" => E::ENFILE,
-        "NameTooLong" => E::ENAMETOOLONG,
-        "SystemFdQuotaExceeded" => E::EMFILE,
-        "SystemResources" => E::ENOMEM,
-        "ReadOnlyFileSystem" => E::EROFS,
-        "FileSystem" => E::EIO,
-        "FileBusy" | "DeviceBusy" => E::EBUSY,
-        "NotDir" => E::ENOTDIR,
-        "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
-        "FileNotFound" => E::ENOENT,
-        "IsDir" => E::EISDIR,
-        _ => E::EFAULT,
-    }
-}
-
-// `rm` recursive (zig_delete_tree) — same shape as the rmdir table above except
-// AccessDenied maps to EACCES, not EPERM.
-fn map_anyerror_to_errno_rm_tree(err: &crate::Error) -> E {
-    match err.name() {
-        "AccessDenied" => E::EACCES,
-        "PermissionDenied" => E::EPERM,
-        "DirNotEmpty" => E::ENOTEMPTY,
-        "FileTooBig" => E::EFBIG,
-        "SymLinkLoop" => E::ELOOP,
-        "ProcessFdQuotaExceeded" => E::ENFILE,
-        "NameTooLong" => E::ENAMETOOLONG,
-        "SystemFdQuotaExceeded" => E::EMFILE,
-        "SystemResources" => E::ENOMEM,
-        "ReadOnlyFileSystem" => E::EROFS,
-        "FileSystem" => E::EIO,
-        "FileBusy" | "DeviceBusy" => E::EBUSY,
-        "NotDir" => E::ENOTDIR,
-        "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
-        "FileNotFound" => E::ENOENT,
-        "IsDir" => E::EISDIR,
-        _ => E::EFAULT,
-    }
-}
-
-// `rm` non-recursive unlink/rmdir fallback — narrower table; anything not
-// listed here falls through to EFAULT.
-//
-// `bun_sys::unlink`/`libc::rmdir` yield a raw errno. Notably raw EPERM —
-// like EISDIR/ENOTDIR/ENOTEMPTY — intentionally falls through to EFAULT here.
-fn map_rm_errno_narrow(e: E) -> E {
-    match e {
-        E::EACCES => E::EACCES,
-        E::ELOOP | E::ENAMETOOLONG | E::ENOMEM | E::EROFS | E::EBUSY | E::ENOENT => e,
-        _ => E::EFAULT,
-    }
-}
-
 /// # Safety
 /// `path` must point to a valid NUL-terminated C string.
 #[unsafe(no_mangle)]
@@ -9300,41 +9189,66 @@ pub(crate) unsafe extern "C" fn Bun__mkdirp(
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// zig_delete_tree — recursive delete-tree. Returns `FileNotFound`
-// instead of ignoring it, which is required to match the behavior of Node.js's
-// `fs.rm` { recursive: true, force: false }.
+// zig_delete_tree — recursive delete-tree. An error names the entry that
+// failed (`sys::Error::path`) and carries the raw errno. ENOENT below the
+// root is not an error: another process removed the entry first. ENOENT
+// for the root itself is returned, which `fs.rm` with `force: false` needs.
 // ──────────────────────────────────────────────────────────────────────────
 
-// Implemented on top of
-// `bun_sys` primitives (`openat` + `unlinkat`) and *errno* values, mapping the
-// errno back to the error-set name strings the callers'
-// `map_anyerror_to_errno*` tables expect. The structure: 16-slot stack,
-// treat_as_dir flip-flop, close-then-deleteDir, retry-on-DirNotEmpty.
+// Implemented on top of `bun_sys` primitives (`openat` + `unlinkat`). The
+// structure: 16-slot stack, treat_as_dir flip-flop, close-then-deleteDir,
+// retry-on-DirNotEmpty.
+
+/// Runs `remove` up to `maxRetries + 1` times. A retry happens for the
+/// errors Node's rimraf retries (EBUSY, EMFILE, ENFILE, ENOTEMPTY, EPERM)
+/// after a sleep of `retryDelay * attempt` milliseconds. A retry that finds
+/// the path gone is a success: the first attempt proved the path existed.
+fn rm_with_retries(
+    opts: &args::RmDir,
+    mut remove: impl FnMut() -> sys::Maybe<()>,
+) -> sys::Maybe<()> {
+    let mut retries: u32 = 0;
+    loop {
+        match remove() {
+            Ok(()) => return Ok(()),
+            Err(err) if retries > 0 && err.get_errno() == E::ENOENT => return Ok(()),
+            Err(err)
+                if retries < opts.max_retries
+                    && matches!(
+                        err.get_errno(),
+                        E::EBUSY | E::EMFILE | E::ENFILE | E::ENOTEMPTY | E::EPERM
+                    ) =>
+            {
+                retries += 1;
+                std::thread::sleep(core::time::Duration::from_millis(
+                    u64::from(retries) * u64::from(opts.retry_delay),
+                ));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+/// The path of the entry the walker is working on: `sub_path`, then the name
+/// of each directory entered below it (the stack items that own a name),
+/// then `name` when given.
+fn dt_entry_path(sub_path: &[u8], stack: &[DeleteTreeStackItem], name: Option<&[u8]>) -> Vec<u8> {
+    let mut path = Vec::with_capacity(sub_path.len() + 64);
+    path.extend_from_slice(sub_path);
+    for item in stack.iter().filter(|item| !item.name_is_borrowed) {
+        path.push(bun_paths::SEP);
+        path.extend_from_slice(&item.name);
+    }
+    if let Some(name) = name {
+        path.push(bun_paths::SEP);
+        path.extend_from_slice(name);
+    }
+    path
+}
 
 #[inline]
-fn dt_err(errno: E) -> crate::Error {
-    // Reverse of the `map_anyerror_to_errno*` tables above — round-trip through
-    // the error-set name so existing callers don't have to change.
-    err_from_static(match errno {
-        E::ENOENT => "FileNotFound",
-        E::EACCES => "AccessDenied",
-        E::EPERM => "PermissionDenied",
-        E::ELOOP => "SymLinkLoop",
-        E::ENAMETOOLONG => "NameTooLong",
-        E::ENOMEM => "SystemResources",
-        E::EROFS => "ReadOnlyFileSystem",
-        E::EIO => "FileSystem",
-        E::EBUSY => "FileBusy",
-        E::ENOTDIR => "NotDir",
-        E::EISDIR => "IsDir",
-        E::ENOTEMPTY => "DirNotEmpty",
-        E::EMFILE => "SystemFdQuotaExceeded",
-        E::ENFILE => "ProcessFdQuotaExceeded",
-        E::EINVAL => "BadPathName",
-        E::EFBIG => "FileTooBig",
-        E::ENODEV => "NoDevice",
-        _ => "Unexpected",
-    })
+fn dt_err(errno: E, tag: sys::Tag, path: &[u8]) -> sys::Error {
+    sys::Error::from_code(errno, tag).with_path(path)
 }
 
 #[inline]
@@ -9385,10 +9299,11 @@ fn dt_delete_file(parent: &sys::Dir, name: &[u8]) -> Result<(), E> {
             if matches!(errno, E::EPERM | E::EACCES) {
                 // No-follow stat — don't follow symlinks, to match unlinkat.
                 // `z` (a `&ZStr`, `Copy`) is still valid — `unlinkat` only borrowed it.
-                if let Ok(st) = Syscall::lstatat(parent.fd, z) {
-                    if sys::S::ISDIR(st.st_mode as u32) {
-                        return Err(E::EISDIR);
-                    }
+                match Syscall::lstatat(parent.fd, z) {
+                    Ok(st) if sys::S::ISDIR(st.st_mode as u32) => return Err(E::EISDIR),
+                    // Removed by another process between the two calls.
+                    Err(e) if e.get_errno() == E::ENOENT => return Err(E::ENOENT),
+                    _ => {}
                 }
             }
             Err(errno)
@@ -9430,7 +9345,7 @@ pub(crate) fn zig_delete_tree(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<()> {
+) -> sys::Maybe<()> {
     let initial_iterable_dir =
         match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint)? {
             Some(d) => d,
@@ -9464,7 +9379,10 @@ pub(crate) fn zig_delete_tree(
             let entry = match stack[top_idx].iter.next() {
                 Ok(Some(e)) => e,
                 Ok(None) => break,
-                Err(err) => return Err(dt_err(err.get_errno())),
+                // Linux reports ENOENT from getdents64 on a directory that was
+                // removed while open. Nothing is left to delete in it.
+                Err(err) if err.get_errno() == E::ENOENT => break,
+                Err(err) => return Err(err.with_path(&dt_entry_path(sub_path, stack, None))),
             };
             // `entry.name` borrows the iterator's internal buffer and
             // is invalidated by the next `next()` call. Copy it once here so
@@ -9492,6 +9410,8 @@ pub(crate) fn zig_delete_tree(
                                 treat_as_dir = false;
                                 continue 'handle_entry;
                             }
+                            // Another process removed it first.
+                            Err(E::ENOENT) => break 'handle_entry,
                             #[cfg(target_os = "macos")]
                             Err(e @ (E::EACCES | E::EPERM)) => {
                                 // Same as the pop-delete site below: node's rimraf
@@ -9510,25 +9430,53 @@ pub(crate) fn zig_delete_tree(
                                     ),
                                     Err(E::ENOTEMPTY | E::EEXIST)
                                 ) {
-                                    return Err(dt_err(E::ENOTEMPTY));
+                                    return Err(dt_err(
+                                        E::ENOTEMPTY,
+                                        sys::Tag::rmdir,
+                                        &dt_entry_path(sub_path, stack, None),
+                                    ));
                                 }
-                                return Err(dt_err(e));
+                                return Err(dt_err(
+                                    e,
+                                    sys::Tag::open,
+                                    &dt_entry_path(sub_path, stack, Some(&entry_name)),
+                                ));
                             }
-                            Err(e) => return Err(dt_err(e)),
+                            Err(e) => {
+                                return Err(dt_err(
+                                    e,
+                                    sys::Tag::open,
+                                    &dt_entry_path(sub_path, stack, Some(&entry_name)),
+                                ));
+                            }
                         }
                     } else {
                         let top_fd = stack[top_idx].iter.iter.dir;
-                        zig_delete_tree_min_stack_size_with_kind_hint(
+                        match zig_delete_tree_min_stack_size_with_kind_hint(
                             sys::Dir::borrow(&top_fd),
                             &entry_name,
                             entry.kind,
-                        )?;
-                        break 'handle_entry;
+                        ) {
+                            Ok(()) => break 'handle_entry,
+                            Err(e) => {
+                                // Another process removed it first.
+                                if e.get_errno() == E::ENOENT {
+                                    break 'handle_entry;
+                                }
+                                return Err(e.with_path(&dt_entry_path(
+                                    sub_path,
+                                    stack,
+                                    Some(&entry_name),
+                                )));
+                            }
+                        }
                     }
                 } else {
                     let top_fd = stack[top_idx].iter.iter.dir;
                     match dt_delete_file(sys::Dir::borrow(&top_fd), &entry_name) {
                         Ok(()) => break 'handle_entry,
+                        // Another process removed it first.
+                        Err(E::ENOENT) => break 'handle_entry,
                         Err(E::EISDIR) => {
                             treat_as_dir = true;
                             continue 'handle_entry;
@@ -9553,15 +9501,28 @@ pub(crate) fn zig_delete_tree(
                                 ),
                                 Err(E::ENOTEMPTY | E::EEXIST)
                             ) {
-                                return Err(dt_err(E::ENOTEMPTY));
+                                return Err(dt_err(
+                                    E::ENOTEMPTY,
+                                    sys::Tag::rmdir,
+                                    &dt_entry_path(sub_path, stack, None),
+                                ));
                             }
-                            return Err(dt_err(e));
+                            return Err(dt_err(
+                                e,
+                                sys::Tag::unlink,
+                                &dt_entry_path(sub_path, stack, Some(&entry_name)),
+                            ));
                         }
                         // "EPERM because it's a directory" is OS-dependent
                         // (Linux returns EISDIR; macOS returns EPERM). We only
-                        // get errno, so forward EPERM as PermissionDenied —
-                        // caller maps it.
-                        Err(e) => return Err(dt_err(e)),
+                        // get errno, so forward EPERM as is — the caller maps it.
+                        Err(e) => {
+                            return Err(dt_err(
+                                e,
+                                sys::Tag::unlink,
+                                &dt_entry_path(sub_path, stack, Some(&entry_name)),
+                            ));
+                        }
                     }
                 }
             }
@@ -9580,6 +9541,14 @@ pub(crate) fn zig_delete_tree(
             sub_path
         } else {
             &top.name
+        };
+        // `top` is no longer on the stack, so pass its name explicitly.
+        let top_path = |stack: &[DeleteTreeStackItem]| {
+            dt_entry_path(
+                sub_path,
+                stack,
+                (!top.name_is_borrowed).then_some(&top.name[..]),
+            )
         };
 
         let mut need_to_retry = false;
@@ -9607,12 +9576,16 @@ pub(crate) fn zig_delete_tree(
                         dt_delete_dir(sys::Dir::borrow(&ancestor.parent_dir), ancestor_name),
                         Err(E::ENOTEMPTY | E::EEXIST)
                     ) {
-                        return Err(dt_err(E::ENOTEMPTY));
+                        return Err(dt_err(
+                            E::ENOTEMPTY,
+                            sys::Tag::rmdir,
+                            &dt_entry_path(sub_path, stack, None),
+                        ));
                     }
                 }
-                return Err(dt_err(e));
+                return Err(dt_err(e, sys::Tag::rmdir, &top_path(stack)));
             }
-            Err(e) => return Err(dt_err(e)),
+            Err(e) => return Err(dt_err(e, sys::Tag::rmdir, &top_path(stack))),
         }
 
         if need_to_retry {
@@ -9631,7 +9604,7 @@ pub(crate) fn zig_delete_tree(
                             // That's fine, we were trying to remove this directory anyway.
                             continue 'process_stack;
                         }
-                        Err(e) => return Err(dt_err(e)),
+                        Err(e) => return Err(dt_err(e, sys::Tag::open, &top_path(stack))),
                     }
                 } else {
                     match dt_delete_file(sys::Dir::borrow(&parent_dir), name) {
@@ -9641,14 +9614,7 @@ pub(crate) fn zig_delete_tree(
                             treat_as_dir = true;
                             continue 'handle_entry;
                         }
-                        Err(E::ENOTDIR) => {
-                            #[cfg(debug_assertions)]
-                            unreachable!();
-                            // "Unexpected" → caller's fallthrough arm = EFAULT.
-                            #[cfg(not(debug_assertions))]
-                            return Err(err_from_static("Unexpected"));
-                        }
-                        Err(e) => return Err(dt_err(e)),
+                        Err(e) => return Err(dt_err(e, sys::Tag::unlink, &top_path(stack))),
                     }
                 }
             };
@@ -9670,7 +9636,7 @@ fn zig_delete_tree_open_initial_subpath(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<Option<sys::Dir>> {
+) -> sys::Maybe<Option<sys::Dir>> {
     // Treat as a file by default
     let mut treat_as_dir = kind_hint == sys::FileKind::Directory;
     loop {
@@ -9678,9 +9644,9 @@ fn zig_delete_tree_open_initial_subpath(
             return match dt_open_dir(self_, sub_path) {
                 Ok(d) => Ok(Some(d)),
                 // NotDir/FileNotFound surface here (no fall-through to
-                // deleteFile) — deliberate, so `FileNotFound` propagates
+                // deleteFile) — deliberate, so ENOENT propagates
                 // (see the zig_delete_tree banner above).
-                Err(e) => Err(dt_err(e)),
+                Err(e) => Err(dt_err(e, sys::Tag::open, sub_path)),
             };
         } else {
             match dt_delete_file(self_, sub_path) {
@@ -9689,17 +9655,21 @@ fn zig_delete_tree_open_initial_subpath(
                     treat_as_dir = true;
                     continue;
                 }
-                Err(e) => return Err(dt_err(e)),
+                Err(e) => return Err(dt_err(e, sys::Tag::unlink, sub_path)),
             }
         }
     }
 }
 
+/// Deletes `sub_path` (relative to `self_`) with one open directory at a
+/// time. The walker above switches to this once its stack is full. An error
+/// names `sub_path`, not the deeper entry that failed: this function does
+/// not keep the chain of directory names it descended through.
 fn zig_delete_tree_min_stack_size_with_kind_hint(
     self_: &sys::Dir,
     sub_path: &[u8],
     kind_hint: sys::FileKind,
-) -> crate::Result<()> {
+) -> sys::Maybe<()> {
     'start_over: loop {
         let mut dir = match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint)? {
             Some(d) => d,
@@ -9721,13 +9691,15 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
         // Here we must avoid recursion, in order to provide O(1) memory guarantee of this function.
         // Go through each entry and if it is not a directory, delete it. If it is a directory,
         // open it, and close the original directory. Repeat. Then start the entire operation over.
-        let result: crate::Result<()> = 'scan_dir: loop {
+        let result: sys::Maybe<()> = 'scan_dir: loop {
             let mut dir_it = DirIterator::WrappedIterator::init(dir.fd);
             'dir_it: loop {
                 let entry = match dir_it.next() {
                     Ok(Some(e)) => e,
                     Ok(None) => break 'dir_it,
-                    Err(err) => break 'scan_dir Err(dt_err(err.get_errno())),
+                    // See the main walker: the directory was removed while open.
+                    Err(err) if err.get_errno() == E::ENOENT => break 'dir_it,
+                    Err(err) => break 'scan_dir Err(err.with_path(sub_path)),
                 };
                 let entry_name: Vec<u8> = entry.name.slice().to_vec();
                 let mut treat_as_dir = entry.kind == sys::FileKind::Directory;
@@ -9751,7 +9723,7 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                                 // That's fine, we were trying to remove this directory anyway.
                                 continue 'dir_it;
                             }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
+                            Err(e) => break 'scan_dir Err(dt_err(e, sys::Tag::open, sub_path)),
                         }
                     } else {
                         match dt_delete_file(&dir, &entry_name) {
@@ -9761,14 +9733,7 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                                 treat_as_dir = true;
                                 continue 'handle_entry;
                             }
-                            Err(E::ENOTDIR) => {
-                                #[cfg(debug_assertions)]
-                                unreachable!();
-                                // "Unexpected" → caller's fallthrough arm = EFAULT.
-                                #[cfg(not(debug_assertions))]
-                                break 'scan_dir Err(err_from_static("Unexpected"));
-                            }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
+                            Err(e) => break 'scan_dir Err(dt_err(e, sys::Tag::unlink, sub_path)),
                         }
                     }
                 }
@@ -9789,14 +9754,14 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                         continue 'start_over;
                     }
                     Err(e) => {
-                        return Err(dt_err(e));
+                        return Err(dt_err(e, sys::Tag::rmdir, sub_path));
                     }
                 }
             } else {
                 match dt_delete_dir(self_, sub_path) {
                     Ok(()) | Err(E::ENOENT) => return Ok(()),
                     Err(E::ENOTEMPTY) | Err(E::EEXIST) => continue 'start_over,
-                    Err(e) => return Err(dt_err(e)),
+                    Err(e) => return Err(dt_err(e, sys::Tag::rmdir, sub_path)),
                 }
             }
         };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7479,7 +7479,8 @@ impl NodeFS {
         }
 
         let dest = args.path.slice_z(&mut self.sync_error_buf);
-        if let Err(err1) = rm_with_retries(args, || sys::unlink(dest)) {
+        // Node ignores maxRetries and retryDelay when recursive is not true.
+        if let Err(err1) = sys::unlink(dest) {
             let e1 = err1.get_errno();
             if e1 == E::ENOENT {
                 if args.force {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7451,8 +7451,7 @@ impl NodeFS {
     pub(crate) fn rm(&mut self, args: &args::Rm, _: Flavor) -> Maybe<ret::Rm> {
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if args.recursive {
-            // Syscall::*at does not add the cwd drive to a rooted path
-            // ("/tmp/foo"); slice_z does.
+            // slice_z adds the cwd drive to a rooted path; Syscall::*at does not.
             #[cfg(windows)]
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
@@ -9187,12 +9186,10 @@ pub(crate) unsafe extern "C" fn Bun__mkdirp(
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// zig_delete_tree — recursive delete-tree. Errors carry the raw errno and the
-// path of the entry that failed. ENOENT is only returned for the root.
+// zig_delete_tree — recursive delete-tree. ENOENT is only returned for the root.
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Retries `remove` on the errors Node's rimraf retries, `maxRetries` times,
-/// sleeping `retryDelay * attempt` ms. A retry that finds the path gone succeeds.
+/// Retries `remove` on the errors Node's rimraf retries, `maxRetries` times.
 fn rm_with_retries(
     opts: &args::RmDir,
     mut remove: impl FnMut() -> sys::Maybe<()>,
@@ -9648,8 +9645,7 @@ fn zig_delete_tree_open_initial_subpath(
     }
 }
 
-/// One open directory at a time, for trees deeper than the stack above.
-/// Errors name `sub_path`: the chain of names below it is not kept.
+/// Deletes a tree deeper than the stack above with one open directory at a time.
 fn zig_delete_tree_min_stack_size_with_kind_hint(
     self_: &sys::Dir,
     sub_path: &[u8],

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7451,12 +7451,8 @@ impl NodeFS {
     pub(crate) fn rm(&mut self, args: &args::Rm, _: Flavor) -> Maybe<ret::Rm> {
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if args.recursive {
-            // On Windows a rooted-but-driveless path ("/tmp/foo") must resolve
-            // against the cwd drive. The dt_* helpers go through
-            // Syscall::*at -> to_nt_path / normalize_path_windows, which do not
-            // add the drive and would turn "/tmp/foo" into a nonexistent NT
-            // name (ENOENT). Pre-resolve with slice_z so the path carries a
-            // drive letter, the same way existsSync/statSync/unlinkSync see it.
+            // Syscall::*at does not add the cwd drive to a rooted path
+            // ("/tmp/foo"); slice_z does.
             #[cfg(windows)]
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]
@@ -9191,20 +9187,12 @@ pub(crate) unsafe extern "C" fn Bun__mkdirp(
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// zig_delete_tree — recursive delete-tree. An error names the entry that
-// failed (`sys::Error::path`) and carries the raw errno. ENOENT below the
-// root is not an error: another process removed the entry first. ENOENT
-// for the root itself is returned, which `fs.rm` with `force: false` needs.
+// zig_delete_tree — recursive delete-tree. Errors carry the raw errno and the
+// path of the entry that failed. ENOENT is only returned for the root.
 // ──────────────────────────────────────────────────────────────────────────
 
-// Implemented on top of `bun_sys` primitives (`openat` + `unlinkat`). The
-// structure: 16-slot stack, treat_as_dir flip-flop, close-then-deleteDir,
-// retry-on-DirNotEmpty.
-
-/// Runs `remove` up to `maxRetries + 1` times. A retry happens for the
-/// errors Node's rimraf retries (EBUSY, EMFILE, ENFILE, ENOTEMPTY, EPERM)
-/// after a sleep of `retryDelay * attempt` milliseconds. A retry that finds
-/// the path gone is a success: the first attempt proved the path existed.
+/// Retries `remove` on the errors Node's rimraf retries, `maxRetries` times,
+/// sleeping `retryDelay * attempt` ms. A retry that finds the path gone succeeds.
 fn rm_with_retries(
     opts: &args::RmDir,
     mut remove: impl FnMut() -> sys::Maybe<()>,
@@ -9231,9 +9219,7 @@ fn rm_with_retries(
     }
 }
 
-/// The path of the entry the walker is working on: `sub_path`, then the name
-/// of each directory entered below it (the stack items that own a name),
-/// then `name` when given.
+/// `sub_path` joined with the directory names on `stack`, then `name`.
 fn dt_entry_path(sub_path: &[u8], stack: &[DeleteTreeStackItem], name: Option<&[u8]>) -> Vec<u8> {
     let mut path = Vec::with_capacity(sub_path.len() + 64);
     path.extend_from_slice(sub_path);
@@ -9381,8 +9367,7 @@ pub(crate) fn zig_delete_tree(
             let entry = match stack[top_idx].iter.next() {
                 Ok(Some(e)) => e,
                 Ok(None) => break,
-                // Linux reports ENOENT from getdents64 on a directory that was
-                // removed while open. Nothing is left to delete in it.
+                // getdents64 on a directory removed while open: nothing left.
                 Err(err) if err.get_errno() == E::ENOENT => break,
                 Err(err) => return Err(err.with_path(&dt_entry_path(sub_path, stack, None))),
             };
@@ -9663,10 +9648,8 @@ fn zig_delete_tree_open_initial_subpath(
     }
 }
 
-/// Deletes `sub_path` (relative to `self_`) with one open directory at a
-/// time. The walker above switches to this once its stack is full. An error
-/// names `sub_path`, not the deeper entry that failed: this function does
-/// not keep the chain of directory names it descended through.
+/// One open directory at a time, for trees deeper than the stack above.
+/// Errors name `sub_path`: the chain of names below it is not kept.
 fn zig_delete_tree_min_stack_size_with_kind_hint(
     self_: &sys::Dir,
     sub_path: &[u8],
@@ -9699,7 +9682,7 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                 let entry = match dir_it.next() {
                     Ok(Some(e)) => e,
                     Ok(None) => break 'dir_it,
-                    // See the main walker: the directory was removed while open.
+                    // The directory was removed while open: nothing left.
                     Err(err) if err.get_errno() == E::ENOENT => break 'dir_it,
                     Err(err) => break 'scan_dir Err(err.with_path(sub_path)),
                 };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7451,10 +7451,12 @@ impl NodeFS {
     pub(crate) fn rm(&mut self, args: &args::Rm, _: Flavor) -> Maybe<ret::Rm> {
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if args.recursive {
-            // See the matching comment in `rmdir`: pre-resolve the path on
-            // Windows so rooted-but-driveless paths ("/tmp/foo") get the cwd
-            // drive prepended before reaching the dt_* / Syscall::*at helpers,
-            // which do not do that themselves.
+            // On Windows a rooted-but-driveless path ("/tmp/foo") must resolve
+            // against the cwd drive. The dt_* helpers go through
+            // Syscall::*at -> to_nt_path / normalize_path_windows, which do not
+            // add the drive and would turn "/tmp/foo" into a nonexistent NT
+            // name (ENOENT). Pre-resolve with slice_z so the path carries a
+            // drive letter, the same way existsSync/statSync/unlinkSync see it.
             #[cfg(windows)]
             let resolved = args.path.slice_z(&mut self.sync_error_buf).as_bytes();
             #[cfg(not(windows))]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -346,7 +346,11 @@ pub mod dir_iterator {
                         )
                     };
                     if rc < 0 {
-                        return Err(Error::from_code_int(super::last_errno(), Tag::getdents64));
+                        let e = super::last_errno();
+                        if e == libc::EINTR {
+                            continue;
+                        }
+                        return Err(Error::from_code_int(e, Tag::getdents64));
                     }
                     if rc == 0 {
                         return Ok(None);
@@ -510,6 +514,9 @@ pub mod dir_iterator {
                     let rc = unsafe { getdents(dir.native(), self.buf.as_mut_ptr(), BUF_SIZE) };
                     if rc < 0 {
                         let e = super::last_errno();
+                        if e == libc::EINTR {
+                            continue;
+                        }
                         // FreeBSD reports ENOENT when iterating an unlinked
                         // but still-open directory.
                         if e == libc::ENOENT {

--- a/test/js/node/fs/rm-recursive-errors.test.ts
+++ b/test/js/node/fs/rm-recursive-errors.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import fs from "node:fs";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+
+// A second thread deletes the same tree, from the end of each directory
+// listing, while the main thread walks it from the front. The two meet in
+// the middle, so the walker sees entries that vanish between `getdents` and
+// `unlinkat`, and directories that vanish between `getdents` and `openat`.
+const deleter = `
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const { workerData } = require("node:worker_threads");
+  const { tree, sab } = workerData;
+  const dirs = fs.readdirSync(tree).map(d => path.join(tree, d));
+  const files = dirs.flatMap(d => fs.readdirSync(d).map(f => path.join(d, f))).reverse();
+  Atomics.wait(new Int32Array(sab), 0, 0);
+  for (const f of files) {
+    try { fs.unlinkSync(f); } catch {}
+  }
+  for (const d of dirs.reverse()) {
+    try { fs.rmdirSync(d); } catch {}
+  }
+`;
+
+function makeTree(dir: string) {
+  const tree = path.join(dir, "tree");
+  fs.mkdirSync(tree);
+  for (let d = 0; d < 8; d++) {
+    const sub = path.join(tree, "d" + d);
+    fs.mkdirSync(sub);
+    for (let i = 0; i < 250; i++) fs.writeFileSync(path.join(sub, "f" + i), "");
+  }
+  return tree;
+}
+
+async function raceDeleter(tree: string, run: () => Promise<void> | void) {
+  const sab = new SharedArrayBuffer(4);
+  const worker = new Worker(deleter, { eval: true, workerData: { tree, sab } });
+  await new Promise<void>(resolve => worker.once("online", resolve));
+  const flag = new Int32Array(sab);
+  Atomics.store(flag, 0, 1);
+  Atomics.notify(flag, 0);
+  try {
+    await run();
+  } finally {
+    await worker.terminate();
+  }
+}
+
+describe("fs.rm recursive while another thread deletes the same tree", () => {
+  test("rmSync with force removes the whole tree", async () => {
+    using dir = tempDir("rm-race-sync", {});
+    const tree = makeTree(String(dir));
+    await raceDeleter(tree, () => fs.rmSync(tree, { recursive: true, force: true }));
+    expect(fs.existsSync(tree)).toBe(false);
+  });
+
+  test("rmSync without force does not report a vanished child as ENOENT", async () => {
+    using dir = tempDir("rm-race-sync-noforce", {});
+    const tree = makeTree(String(dir));
+    await raceDeleter(tree, () => fs.rmSync(tree, { recursive: true }));
+    expect(fs.existsSync(tree)).toBe(false);
+  });
+
+  test("fs.promises.rm removes the whole tree", async () => {
+    using dir = tempDir("rm-race-async", {});
+    const tree = makeTree(String(dir));
+    await raceDeleter(tree, () => fs.promises.rm(tree, { recursive: true, force: true }));
+    expect(fs.existsSync(tree)).toBe(false);
+  });
+
+  // Two recursive walkers on the same tree, started at the same instant. The
+  // one that falls behind in a directory still holds it open when the other
+  // removes it, and its next `getdents64` on that directory reports ENOENT.
+  test("two rmSync walkers on the same tree both succeed", async () => {
+    using dir = tempDir("rm-race-two-walkers", {});
+    const tree = makeTree(String(dir));
+    const sab = new SharedArrayBuffer(4);
+    const worker = new Worker(
+      `
+      const fs = require("node:fs");
+      const { parentPort, workerData } = require("node:worker_threads");
+      const flag = new Int32Array(workerData.sab);
+      Atomics.wait(flag, 0, 0);
+      Atomics.store(flag, 0, 2);
+      try {
+        fs.rmSync(workerData.tree, { recursive: true });
+        parentPort.postMessage("ok");
+      } catch (e) {
+        parentPort.postMessage(e.code + " " + e.path);
+      }
+      `,
+      { eval: true, workerData: { tree, sab } },
+    );
+    const workerResult = new Promise<string>(resolve => worker.once("message", resolve));
+    await new Promise<void>(resolve => worker.once("online", resolve));
+    const flag = new Int32Array(sab);
+    Atomics.store(flag, 0, 1);
+    Atomics.notify(flag, 0);
+    while (Atomics.load(flag, 0) !== 2) {}
+    try {
+      fs.rmSync(tree, { recursive: true });
+      expect(await workerResult).toBe("ok");
+      expect(fs.existsSync(tree)).toBe(false);
+    } finally {
+      await worker.terminate();
+    }
+  });
+});
+
+// Runs `script` in a bun with a small descriptor limit. The script builds
+// `root/a/b/c.txt`, then opens descriptors until EMFILE and frees two: enough
+// to open `root` and `a`, not `b`.
+async function runWithFewDescriptors(dir: string, script: string) {
+  const file = path.join(dir, "script.js");
+  fs.writeFileSync(
+    file,
+    `
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const root = path.join(${JSON.stringify(dir)}, "root");
+    fs.mkdirSync(path.join(root, "a", "b"), { recursive: true });
+    fs.writeFileSync(path.join(root, "a", "b", "c.txt"), "");
+    const fds = [];
+    for (;;) {
+      try {
+        fds.push(fs.openSync(__filename, "r"));
+      } catch (e) {
+        if (e.code !== "EMFILE") throw e;
+        break;
+      }
+    }
+    fs.closeSync(fds.pop());
+    fs.closeSync(fds.pop());
+    ${script}
+    `,
+  );
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", `ulimit -n 64 && exec "$0" "$1"`, bunExe(), file],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+describe.skipIf(isWindows)("fs.rm recursive under EMFILE", () => {
+  test("the error names the entry that failed", async () => {
+    using dir = tempDir("rm-emfile-path", {});
+    const result = await runWithFewDescriptors(
+      String(dir),
+      `
+      try {
+        fs.rmSync(root, { recursive: true });
+        console.log(JSON.stringify({ ok: true }));
+      } catch (e) {
+        console.log(JSON.stringify({ code: e.code, syscall: e.syscall, path: e.path }));
+      }
+      `,
+    );
+    expect(result).toEqual({
+      code: "EMFILE",
+      syscall: "rm",
+      path: path.join(String(dir), "root", "a", "b"),
+    });
+  });
+
+  test("maxRetries retries after the descriptors are released", async () => {
+    using dir = tempDir("rm-emfile-retry", {});
+    const result = await runWithFewDescriptors(
+      String(dir),
+      `
+      setTimeout(() => {
+        for (const fd of fds.splice(0, 8)) fs.closeSync(fd);
+      }, 10);
+      fs.promises.rm(root, { recursive: true, maxRetries: 20, retryDelay: 20 }).then(
+        () => console.log(JSON.stringify({ ok: true, exists: fs.existsSync(root) })),
+        e => console.log(JSON.stringify({ code: e.code, path: e.path })),
+      );
+      `,
+    );
+    expect(result).toEqual({ ok: true, exists: false });
+  });
+
+  test("without maxRetries the error is reported at once", async () => {
+    using dir = tempDir("rm-emfile-noretry", {});
+    const result = await runWithFewDescriptors(
+      String(dir),
+      `
+      fs.promises.rm(root, { recursive: true }).then(
+        () => console.log(JSON.stringify({ ok: true })),
+        e => console.log(JSON.stringify({ code: e.code, path: e.path })),
+      );
+      `,
+    );
+    expect(result).toEqual({ code: "EMFILE", path: path.join(String(dir), "root", "a", "b") });
+  });
+});

--- a/test/js/node/fs/rm-recursive-errors.test.ts
+++ b/test/js/node/fs/rm-recursive-errors.test.ts
@@ -35,15 +35,22 @@ function makeTree(dir: string) {
   return tree;
 }
 
+function startWorker(source: string, workerData: object) {
+  const worker = new Worker(source, { eval: true, workerData });
+  const failed = new Promise<never>((_, reject) => worker.once("error", reject));
+  const online = new Promise<void>(resolve => worker.once("online", resolve));
+  return { worker, failed, online };
+}
+
 async function raceDeleter(tree: string, run: () => Promise<void> | void) {
   const sab = new SharedArrayBuffer(4);
-  const worker = new Worker(deleter, { eval: true, workerData: { tree, sab } });
-  await new Promise<void>(resolve => worker.once("online", resolve));
+  const { worker, failed, online } = startWorker(deleter, { tree, sab });
+  await Promise.race([online, failed]);
   const flag = new Int32Array(sab);
   Atomics.store(flag, 0, 1);
   Atomics.notify(flag, 0);
   try {
-    await run();
+    await Promise.race([run(), failed]);
   } finally {
     await worker.terminate();
   }
@@ -74,17 +81,21 @@ describe("fs.rm recursive while another thread deletes the same tree", () => {
   // Two recursive walkers on the same tree, started at the same instant. The
   // one that falls behind in a directory still holds it open when the other
   // removes it, and its next `getdents64` on that directory reports ENOENT.
+  // If one walker is stalled until the other has removed the root, it sees a
+  // missing root, which `rm` without `force` reports as ENOENT on the root.
+  // That is not the bug under test, so a root ENOENT counts as a success.
   test("two rmSync walkers on the same tree both succeed", async () => {
     using dir = tempDir("rm-race-two-walkers", {});
     const tree = makeTree(String(dir));
     const sab = new SharedArrayBuffer(4);
-    const worker = new Worker(
+    const { worker, failed, online } = startWorker(
       `
       const fs = require("node:fs");
       const { parentPort, workerData } = require("node:worker_threads");
       const flag = new Int32Array(workerData.sab);
       Atomics.wait(flag, 0, 0);
       Atomics.store(flag, 0, 2);
+      Atomics.notify(flag, 0);
       try {
         fs.rmSync(workerData.tree, { recursive: true });
         parentPort.postMessage("ok");
@@ -92,17 +103,24 @@ describe("fs.rm recursive while another thread deletes the same tree", () => {
         parentPort.postMessage(e.code + " " + e.path);
       }
       `,
-      { eval: true, workerData: { tree, sab } },
+      { tree, sab },
     );
     const workerResult = new Promise<string>(resolve => worker.once("message", resolve));
-    await new Promise<void>(resolve => worker.once("online", resolve));
+    await Promise.race([online, failed]);
     const flag = new Int32Array(sab);
     Atomics.store(flag, 0, 1);
     Atomics.notify(flag, 0);
-    while (Atomics.load(flag, 0) !== 2) {}
+    expect(Atomics.wait(flag, 0, 1, 10_000)).not.toBe("timed-out");
     try {
-      fs.rmSync(tree, { recursive: true });
-      expect(await workerResult).toBe("ok");
+      let main = "ok";
+      try {
+        fs.rmSync(tree, { recursive: true });
+      } catch (e: any) {
+        main = e.code + " " + e.path;
+      }
+      const results = [main, await Promise.race([workerResult, failed])];
+      expect(results.filter(r => r !== "ok" && r !== `ENOENT ${tree}`)).toEqual([]);
+      expect(results).toContain("ok");
       expect(fs.existsSync(tree)).toBe(false);
     } finally {
       await worker.terminate();


### PR DESCRIPTION
### Problem
- `fs.rm(dir, { recursive: true })` fails with `ENOENT` when another process removes a child between `getdents64` and `unlinkat`/`openat`, or removes a directory the walker still has open (Linux `getdents64` then reports `ENOENT`). With `force: true` the caller reads that `ENOENT` as "the root is missing" and returns success with the rest of the tree still on disk (`zig_delete_tree` in `src/runtime/node/node_fs.rs` and the `FileNotFound` check in `rm()`).
- `maxRetries` and `retryDelay` are parsed but never used. `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY` and `EPERM` fail on the first attempt.
- The walker reports errors as error-set names. `dt_err` maps any errno outside its table to `Unexpected`, which `map_anyerror_to_errno*` turns into `EFAULT`. The non-recursive path has a third table with the same `EFAULT` fallthrough. The reported `path` is always the root, never the entry that failed.

### Fix
- `zig_delete_tree` returns `sys::Maybe<()>`: the raw errno plus the path of the entry that failed (`dt_entry_path` joins the root with the stack of directory names). `ENOENT` for a child, and `ENOENT` from `getdents64` on a directory that was removed while open, continue the walk. Only the root can return `ENOENT`, so the `force` check in `rm()` is correct again. The three name tables are gone, the non-recursive `unlink` reports its raw errno, and the unreachable recursive branch of the native `rmdir` is removed (the JS layer routes recursive `rmdir` through `rm`).
- `rm_with_retries` wraps the recursive walk. It retries the errors Node's `rimraf` retries, `maxRetries` times, after a sleep of `retryDelay * attempt` ms. A retry that finds the path gone succeeds, as in Node. The non-recursive `unlink` is not retried: Node ignores `maxRetries` when `recursive` is not true.
- Both `getdents64` iterators (`dir_iterator.rs`, `sys/lib.rs`) loop on `EINTR`. On macOS, `dt_delete_file` reports `ENOENT` when the entry vanishes between `unlinkat` and the `lstatat` that disambiguates `EPERM`.
- Verified: `test/js/node/fs/rm-recursive-errors.test.ts` (7 tests, all fail on main). Also `fs.test.ts`, `promises.test.js`, `test-fs-rm.js`, and `cargo check` for darwin and windows targets.

### Background
- `zig_delete_tree` is the recursive delete walker behind `fs.rm` with `recursive: true`. It keeps a stack of open directory descriptors (16 deep) and iterates each with `getdents64`. Past 16 levels it switches to `zig_delete_tree_min_stack_size_with_kind_hint`, which keeps one descriptor open and restarts from its root after each directory.
- Node's async `fs.rm` is `lib/internal/fs/rimraf.js`. It ignores `ENOENT` on a child, retries the whole removal on `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY` and `EPERM`, and reports the path of the child that failed. The sync path (C++ `RmSync`) sleeps between retries the same way this change does.
- `sys::Error` carries `errno`, the syscall tag and a `path`. `rm()` re-tags the walker's error as `rm` and strips the Windows `\\?\` prefix from the path.

<details><summary>Notes</summary>

Related open PRs that each cover one face of this: #35800 and #39710 (ENOENT race), #35749 (errno passthrough), #35927 (failing path), #39003 (maxRetries), #41486 (ENOTDIR instead of EFAULT on the non-recursive path, the JS-side `lstat` rethrow, and an unrelated stream path fix). This change covers their Linux and macOS parts in one walker. Not covered: the Windows `STATUS_DELETE_PENDING` mapping on the directory open from #39710, and the `lstat` rethrow and stream path fix from #41486. #41486 owns the removal of `map_rm_errno_narrow`. This branch needs a rebase once it merges.

The race tests start a worker that deletes the same tree while the main thread walks it. Three tests use a deleter that unlinks from the end of each listing, so the walker sees entries vanish between `getdents64` and `unlinkat`/`openat`. On the released binary they fail 29 of 30 runs. The fourth test runs two recursive walkers at once: the one that falls behind still holds a directory open when the other removes it, and its next `getdents64` reports `ENOENT` (`IS_DEADDIR`, verified with a raw `syscall(SYS_getdents64)` on tmpfs and overlayfs). Without the iterator arm it failed 5 of 6 runs. With the fix the file passed 8 of 8 runs under the debug build.

The `EMFILE` tests run bun under `ulimit -n 64`, open descriptors until `EMFILE`, then free two: enough to open `root` and `root/a`, not `root/a/b`. That gives a deterministic `EMFILE` at a known entry. The retry test frees descriptors from a timer on the main thread while the walk retries on the pool thread.

Retries sleep on the calling thread. For the async flavours that is a work-pool thread, blocked for at most `retryDelay * maxRetries * (maxRetries + 1) / 2` ms. Node's C++ `rmSync` sleeps the same way. Node's async `rimraf` uses `setTimeout` instead.

The `EINTR` arms have no test: `getdents64` does not return `EINTR` on a local filesystem without syscall injection. They are the Linux and BSD twins of the existing `getdirentries64` loop on macOS.

The deep-tree walker (`zig_delete_tree_min_stack_size_with_kind_hint`) names the depth-16 directory in its error, not the deeper entry, because it does not keep the chain of names it descended through.

Suites run: `test/js/node/fs/rm-recursive-errors.test.ts` (x8), `test/js/node/fs/fs.test.ts`, `test/js/node/fs/promises.test.js`, `test/js/node/fs/dir.test.ts`, `test/js/node/test/parallel/test-fs-rm.js`, `test-fs-rmdir-throws-on-file.js`, `bun scripts/rust-check-all.ts aarch64-apple-darwin x86_64-pc-windows-msvc`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/rm-recursive-errors.test.ts

<!-- robobun:evidence:end -->

