### PR TITLE
WebSocket: isomorphic-encode latin-1 header values on the upgrade request

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1526,8 +1526,12 @@ impl<'a> Headers8Bit<'a> {
     fn isomorphic_encode(s: &'a BunString) -> Cow<'a, [u8]> {
         if s.is_utf16() {
             let units = s.utf16();
-            debug_assert!(units.iter().all(|&u| u <= 0xFF));
-            Cow::Owned(units.iter().map(|&u| u as u8).collect())
+            if units.iter().any(|&unit| unit > 0xFF) {
+                return Cow::Owned(s.to_utf8().into_vec());
+            }
+            let mut bytes = vec![0u8; units.len()];
+            strings::copy_u16_into_u8(&mut bytes, units);
+            Cow::Owned(bytes)
         } else if s.is_8bit() && !s.is_utf8() {
             Cow::Borrowed(s.latin1())
         } else {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1527,9 +1527,13 @@ impl<'a> Headers8Bit<'a> {
 
     /// An 8-bit (Latin-1) string is already one byte per code unit. A 16-bit
     /// string only reaches here after `FetchHeaders` validation rejected every
-    /// code unit above 0x7F, so UTF-8 transcoding is the identity.
+    /// code unit above 0xFF, so each unit narrows to one byte.
     fn isomorphic_encode(s: &'a BunString) -> Cow<'a, [u8]> {
-        if s.is_8bit() && !s.is_utf8() {
+        if s.is_utf16() {
+            let units = s.utf16();
+            debug_assert!(units.iter().all(|&u| u <= 0xFF));
+            Cow::Owned(units.iter().map(|&u| u as u8).collect())
+        } else if s.is_8bit() && !s.is_utf8() {
             Cow::Borrowed(s.latin1())
         } else {
             Cow::Owned(s.to_utf8().into_vec())

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1505,10 +1505,8 @@ impl<const SSL: bool> Drop for HTTPClient<SSL> {
     }
 }
 
-/// Header name/value pairs isomorphic-encoded up front (one byte per code
-/// unit, per <https://fetch.spec.whatwg.org/#concept-header-value>), stored
-/// flat (names at even indices, values at odd) and yielded as pairs via
-/// `iter()`.
+/// Header name/value pairs as wire bytes, stored flat (names at even indices,
+/// values at odd).
 struct Headers8Bit<'a> {
     slices: Vec<Cow<'a, [u8]>>,
 }
@@ -1525,9 +1523,8 @@ impl<'a> Headers8Bit<'a> {
         Self { slices }
     }
 
-    /// An 8-bit (Latin-1) string is already one byte per code unit. A 16-bit
-    /// string only reaches here after `FetchHeaders` validation rejected every
-    /// code unit above 0xFF, so each unit narrows to one byte.
+    /// One byte per code unit (<https://fetch.spec.whatwg.org/#concept-header-value>).
+    /// `FetchHeaders` validation already rejected code units above 0xFF.
     fn isomorphic_encode(s: &'a BunString) -> Cow<'a, [u8]> {
         if s.is_utf16() {
             let units = s.utf16();
@@ -1558,8 +1555,7 @@ impl<'a> Headers8Bit<'a> {
     }
 }
 
-/// Append `name: value\r\n` byte-for-byte. `bstr::BStr`'s `Display` replaces
-/// non-UTF-8 bytes with U+FFFD, which would mangle a Latin-1 header value.
+/// Append `name: value\r\n` byte-for-byte (`bstr::BStr`'s `Display` is lossy).
 fn write_header_line(buf: &mut Vec<u8>, name: &[u8], value: &[u8]) {
     buf.extend_from_slice(name);
     buf.extend_from_slice(b": ");

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1505,8 +1505,7 @@ impl<const SSL: bool> Drop for HTTPClient<SSL> {
     }
 }
 
-/// Header name/value pairs as wire bytes, stored flat (names at even indices,
-/// values at odd).
+/// Header names and values as wire bytes, interleaved: name, value, name, value.
 struct Headers8Bit<'a> {
     slices: Vec<Cow<'a, [u8]>>,
 }
@@ -1523,8 +1522,7 @@ impl<'a> Headers8Bit<'a> {
         Self { slices }
     }
 
-    /// One byte per code unit (<https://fetch.spec.whatwg.org/#concept-header-value>).
-    /// `FetchHeaders` validation already rejected code units above 0xFF.
+    /// One byte per code unit, per <https://fetch.spec.whatwg.org/#concept-header-value>.
     fn isomorphic_encode(s: &'a BunString) -> Cow<'a, [u8]> {
         if s.is_utf16() {
             let units = s.utf16();

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -22,6 +22,7 @@
 use core::cell::Cell;
 use core::ffi::{c_int, c_void};
 use core::ptr;
+use std::borrow::Cow;
 use std::io::Write as _;
 
 use bun_boringssl as boringssl;
@@ -1504,23 +1505,35 @@ impl<const SSL: bool> Drop for HTTPClient<SSL> {
     }
 }
 
-/// Header name/value pairs decoded to UTF-8 up front (borrowed when 8-bit
-/// ASCII, else transcoded — never raw Latin-1/UTF-16 code units), stored flat
-/// (names at even indices, values at odd) and yielded as pairs via `iter()`.
+/// Header name/value pairs isomorphic-encoded up front (one byte per code
+/// unit, per <https://fetch.spec.whatwg.org/#concept-header-value>), stored
+/// flat (names at even indices, values at odd) and yielded as pairs via
+/// `iter()`.
 struct Headers8Bit<'a> {
-    slices: Vec<Utf8Bytes<'a>>,
+    slices: Vec<Cow<'a, [u8]>>,
 }
 
 impl<'a> Headers8Bit<'a> {
     fn init(names_in: &'a [BunString], values_in: &'a [BunString]) -> Self {
         debug_assert_eq!(names_in.len(), values_in.len());
-        let mut slices: Vec<Utf8Bytes<'a>> = Vec::with_capacity(names_in.len() * 2);
+        let mut slices: Vec<Cow<'a, [u8]>> = Vec::with_capacity(names_in.len() * 2);
         for (name, value) in names_in.iter().zip(values_in) {
-            slices.push(name.to_utf8());
-            slices.push(value.to_utf8());
+            slices.push(Self::isomorphic_encode(name));
+            slices.push(Self::isomorphic_encode(value));
         }
 
         Self { slices }
+    }
+
+    /// An 8-bit (Latin-1) string is already one byte per code unit. A 16-bit
+    /// string only reaches here after `FetchHeaders` validation rejected every
+    /// code unit above 0x7F, so UTF-8 transcoding is the identity.
+    fn isomorphic_encode(s: &'a BunString) -> Cow<'a, [u8]> {
+        if s.is_8bit() && !s.is_utf8() {
+            Cow::Borrowed(s.latin1())
+        } else {
+            Cow::Owned(s.to_utf8().into_vec())
+        }
     }
 
     fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8])> + '_ {
@@ -1528,7 +1541,7 @@ impl<'a> Headers8Bit<'a> {
             .as_chunks::<2>()
             .0
             .iter()
-            .map(|pair| (pair[0].slice(), pair[1].slice()))
+            .map(|pair| (&pair[0][..], &pair[1][..]))
     }
 
     /// Convert to `bun_http::Headers`.
@@ -1539,6 +1552,15 @@ impl<'a> Headers8Bit<'a> {
         }
         headers
     }
+}
+
+/// Append `name: value\r\n` byte-for-byte. `bstr::BStr`'s `Display` replaces
+/// non-UTF-8 bytes with U+FFFD, which would mangle a Latin-1 header value.
+fn write_header_line(buf: &mut Vec<u8>, name: &[u8], value: &[u8]) {
+    buf.extend_from_slice(name);
+    buf.extend_from_slice(b": ");
+    buf.extend_from_slice(value);
+    buf.extend_from_slice(b"\r\n");
 }
 
 /// Build HTTP CONNECT request for proxy tunneling.
@@ -1596,13 +1618,7 @@ fn build_connect_request(
             {
                 continue;
             }
-            write!(
-                &mut buf,
-                "{}: {}\r\n",
-                bstr::BStr::new(name),
-                bstr::BStr::new(hdrs.as_str(values[idx]))
-            )
-            .unwrap();
+            write_header_line(&mut buf, name, hdrs.as_str(values[idx]));
         }
     }
 
@@ -1686,14 +1702,6 @@ fn build_request_body(
         port: Some(port),
     };
 
-    let static_headers = [
-        picohttp::Header::new(b"Sec-WebSocket-Key", key),
-        picohttp::Header::new(b"Sec-WebSocket-Protocol", protocol),
-    ];
-
-    let headers_ = &static_headers[0..1 + (!protocol.is_empty()) as usize];
-    let pico_headers = picohttp::Headers { headers: headers_ };
-
     // Build extra headers string, skipping the ones we handle
     let mut extra_headers_buf: Vec<u8> = Vec::new();
 
@@ -1724,13 +1732,7 @@ fn build_request_body(
         ) {
             continue;
         }
-        write!(
-            &mut extra_headers_buf,
-            "{}: {}\r\n",
-            bstr::BStr::new(name_slice),
-            bstr::BStr::new(value)
-        )
-        .unwrap();
+        write_header_line(&mut extra_headers_buf, name_slice, value);
     }
 
     let extensions_line: &[u8] = if offer_permessage_deflate {
@@ -1741,49 +1743,24 @@ fn build_request_body(
 
     // Build request with user overrides
     let mut body: Vec<u8> = Vec::new();
+    write!(&mut body, "GET {} HTTP/1.1\r\n", bstr::BStr::new(pathname)).unwrap();
     if let Some(h) = user_host {
-        write!(
-            &mut body,
-            "GET {} HTTP/1.1\r\n\
-             Host: {}\r\n\
-             Connection: Upgrade\r\n\
-             Upgrade: websocket\r\n\
-             Sec-WebSocket-Version: 13\r\n\
-             {}\
-             {}\
-             {}\
-             \r\n",
-            bstr::BStr::new(pathname),
-            bstr::BStr::new(h),
-            bstr::BStr::new(extensions_line),
-            pico_headers,
-            bstr::BStr::new(&extra_headers_buf),
-        )
-        .unwrap();
-        return Ok(BuildRequestResult {
-            body,
-            expected_accept,
-        });
+        write_header_line(&mut body, b"Host", h);
+    } else {
+        write!(&mut body, "Host: {}\r\n", host_fmt).unwrap();
     }
-
-    write!(
-        &mut body,
-        "GET {} HTTP/1.1\r\n\
-         Host: {}\r\n\
-         Connection: Upgrade\r\n\
-         Upgrade: websocket\r\n\
-         Sec-WebSocket-Version: 13\r\n\
-         {}\
-         {}\
-         {}\
-         \r\n",
-        bstr::BStr::new(pathname),
-        host_fmt,
-        bstr::BStr::new(extensions_line),
-        pico_headers,
-        bstr::BStr::new(&extra_headers_buf),
-    )
-    .unwrap();
+    body.extend_from_slice(
+        b"Connection: Upgrade\r\n\
+          Upgrade: websocket\r\n\
+          Sec-WebSocket-Version: 13\r\n",
+    );
+    body.extend_from_slice(extensions_line);
+    write_header_line(&mut body, b"Sec-WebSocket-Key", key);
+    if !protocol.is_empty() {
+        write_header_line(&mut body, b"Sec-WebSocket-Protocol", protocol);
+    }
+    body.extend_from_slice(&extra_headers_buf);
+    body.extend_from_slice(b"\r\n");
     Ok(BuildRequestResult {
         body,
         expected_accept,

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -137,7 +137,10 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`, {
       headers: { "X-Latin1": latin1Value },
     });
-    ws.onerror = () => wsDone.resolve();
+    ws.onerror = e => {
+      gotHeader.reject(e);
+      wsDone.resolve();
+    };
     ws.onclose = () => wsDone.resolve();
 
     expect(await gotHeader.promise).toBe(latin1Value);

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -17,6 +17,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import net from "node:net";
+import { basename } from "node:path";
 
 // "path-\u{1F525}" forces JSC to materialize the backing StringImpl as
 // 16-bit UTF-16, which is the other half of the regression path.
@@ -85,10 +86,14 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     // "vàlüé-ñ" contains U+00E0, U+00FC, U+00E9, U+00F1 — all in Latin1
     // range, so the underlying WTFStringImpl stays 8-bit.
     const latin1Value = "vàlüé-ñ";
+    // path.basename returns a 16-bit-backed string whose code units are all
+    // <= 0xFF. It passes ByteString validation but is not 8-bit in memory.
+    const utf16BackedValue = basename("café.txt");
     const wsDone = Promise.withResolvers<void>();
     const ws = new WebSocket(`ws://127.0.0.1:${port}/`, {
       headers: {
         "X-Latin1": latin1Value,
+        "X-Utf16": utf16BackedValue,
       },
     });
     ws.onerror = () => wsDone.resolve();
@@ -99,14 +104,15 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
 
     // Header values are ByteStrings: U+00E0 goes out as the single byte 0xE0,
     // not the UTF-8 pair 0xC3 0xA0. This matches fetch(), Node and Deno.
-    const line = request
-      .toString("latin1")
-      .split("\r\n")
-      .find(l => l.startsWith("X-Latin1:"));
-    expect(line).toBeDefined();
-    const wire = Buffer.from(line!, "latin1").subarray("X-Latin1: ".length);
-    expect(wire).toEqual(Buffer.from(latin1Value, "latin1"));
-    expect(wire.toString("latin1")).toBe(latin1Value);
+    const lines = request.toString("latin1").split("\r\n");
+    const wire = (name: string) => {
+      const line = lines.find(l => l.startsWith(name + ":"));
+      expect(line).toBeDefined();
+      return Buffer.from(line!, "latin1").subarray(name.length + 2);
+    };
+    expect(wire("X-Latin1")).toEqual(Buffer.from(latin1Value, "latin1"));
+    expect(wire("X-Latin1").toString("latin1")).toBe(latin1Value);
+    expect(wire("X-Utf16")).toEqual(Buffer.from(utf16BackedValue, "latin1"));
   });
 
   test("Latin1 header value round-trips through a Bun.serve upgrade handler", async () => {

--- a/test/js/web/websocket/websocket-utf16-headers.test.ts
+++ b/test/js/web/websocket/websocket-utf16-headers.test.ts
@@ -10,7 +10,9 @@
 // (`_mi_heap_realloc_zero`) during `std.fmt.allocPrint`.
 //
 // The fix migrates the WebSocket upgrade client FFI from ZigString to
-// BunString and decodes every input with `bun.String.toUTF8(allocator)`.
+// BunString and decodes host, path and protocol to UTF-8. Header values are
+// ByteStrings (https://fetch.spec.whatwg.org/#concept-header-value) and are
+// isomorphic-encoded: one byte per code unit, the same as `fetch()`.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { once } from "node:events";
@@ -61,7 +63,7 @@ afterEach(async () => {
 });
 
 describe("WebSocket upgrade with non-ASCII inputs", () => {
-  test("Latin1 header value with high bytes is sent as UTF-8 without crashing", async () => {
+  test("Latin1 header value with high bytes is isomorphic-encoded on the wire, like fetch()", async () => {
     // Spin up a trivial TCP listener that captures the raw upgrade request
     // bytes. We only need to inspect what the client *sent*; we don't need
     // the WebSocket handshake to complete, so the server destroys the socket
@@ -77,7 +79,7 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
           socket.destroy();
         }
       });
-      socket.on("error", () => {});
+      socket.once("error", gotRequest.reject);
     });
 
     // "vàlüé-ñ" contains U+00E0, U+00FC, U+00E9, U+00F1 — all in Latin1
@@ -95,12 +97,45 @@ describe("WebSocket upgrade with non-ASCII inputs", () => {
     const request = await gotRequest.promise;
     await wsDone.promise;
 
-    // Before the fix, the upgrade request buffer would either contain raw
-    // Latin1 bytes (0xE0, 0xFC, 0xE9, 0xF1) or be completely corrupted and
-    // crash the runtime. With the fix, the header is emitted as proper UTF-8.
-    const body = request.toString("utf8");
-    expect(body).toContain("X-Latin1:");
-    expect(body).toContain(latin1Value);
+    // Header values are ByteStrings: U+00E0 goes out as the single byte 0xE0,
+    // not the UTF-8 pair 0xC3 0xA0. This matches fetch(), Node and Deno.
+    const line = request
+      .toString("latin1")
+      .split("\r\n")
+      .find(l => l.startsWith("X-Latin1:"));
+    expect(line).toBeDefined();
+    const wire = Buffer.from(line!, "latin1").subarray("X-Latin1: ".length);
+    expect(wire).toEqual(Buffer.from(latin1Value, "latin1"));
+    expect(wire.toString("latin1")).toBe(latin1Value);
+  });
+
+  test("Latin1 header value round-trips through a Bun.serve upgrade handler", async () => {
+    const latin1Value = "café-ñ";
+    const gotHeader = Promise.withResolvers<string | null>();
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        gotHeader.resolve(req.headers.get("x-latin1"));
+        if (server.upgrade(req)) return;
+        return new Response("not upgraded", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          ws.close();
+        },
+        message() {},
+      },
+    });
+
+    const wsDone = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`, {
+      headers: { "X-Latin1": latin1Value },
+    });
+    ws.onerror = () => wsDone.resolve();
+    ws.onclose = () => wsDone.resolve();
+
+    expect(await gotHeader.promise).toBe(latin1Value);
+    await wsDone.promise;
   });
 
   test("UTF-16 URL path is decoded to UTF-8 without crashing", async () => {


### PR DESCRIPTION
### Problem
- `new WebSocket(url, { headers: { "X-A": "café" } })` sends the value as UTF-8 (`63 61 66 c3 a9`). `fetch()` with the same option sends the single Latin-1 byte (`63 61 66 e9`) since #35338, and so do Node and Deno. A `Bun.serve` upgrade handler reads the WebSocket value as `cafÃ©`.
- The cause is `Headers8Bit::init` in `src/http_jsc/websocket_client/WebSocketUpgradeClient.rs`. It calls `to_utf8()` on every header name and value, which widens each Latin-1 byte above 0x7F to two UTF-8 bytes.

### Fix
- `Headers8Bit` now borrows the raw bytes of an 8-bit string. A 16-bit string whose code units all fit in one byte (for example the result of `path.basename`) narrows to one byte per unit, the same as the http2 header writer. `FetchHeaders` validation rejects code units above 0xFF, so a wider unit cannot reach this path. If one did, the value is written as UTF-8 as before, never truncated.
- The request builder wrote header lines through `bstr::BStr`'s `Display`, which replaces non-UTF-8 bytes with U+FFFD. A new `write_header_line` appends name and value byte-for-byte. The upgrade request and the proxy CONNECT request both use it.
- Correct because the Fetch spec defines a header value as a ByteString, encoded one byte per code unit (isomorphic encode). This is the rule `fetch()` and `Bun.serve` already follow.
- Verified: `test/js/web/websocket/websocket-utf16-headers.test.ts` (one test rewritten to assert wire bytes for an 8-bit and a 16-bit-backed value, one new round-trip test through `Bun.serve`; both fail on the current release). Also ran the websocket client, custom-headers, proxy, upgrade, unix, subprotocol, handshake-event, permessage-deflate and accept-header suites.
- Self-reviewed: 3 concerns raised, 2 addressed (16-bit narrowing with an explicit UTF-8 fallback, this body). Not done: extracting a shared `bun_core` latin-1 helper used by fetch, http2 and this path. That is a separate refactor.

### Background
- The WebSocket client collects the `headers` option in `WebSocket.cpp` as `FetchHeaders`, then passes each name and value as a `BunString` to `WebSocketUpgradeClient::connect`, which builds the HTTP upgrade request text in Rust.
- A `BunString` backed by a `WTF::StringImpl` is either 8-bit (Latin-1, one byte per code unit) or 16-bit (UTF-16). `to_utf8()` transcodes both to UTF-8. `latin1()` borrows the 8-bit buffer as is.
- `bstr::BStr` is a byte-slice wrapper whose `Display` impl is lossy: it decodes as UTF-8 and substitutes U+FFFD for invalid sequences. Writing Latin-1 bytes through it corrupts them.

<details><summary>Notes</summary>

Repro (prints `BUG` on the current release, `consistent` with this PR):

```js
import net from "node:net"; import { createHash } from "node:crypto";
const seen = [];
const srv = net.createServer(c => { let b = Buffer.alloc(0); c.on("data", d => { b = Buffer.concat([b, d]); const i = b.indexOf("\\r\\n\\r\\n"); if (i < 0) return;
  const head = b.subarray(0, i).toString("latin1"); const xa = head.split("\\r\\n").find(l => /^x-a:/i.test(l)) || "";
  seen.push(Buffer.from(xa, "latin1").subarray(5).toString("hex"));
  const k = head.match(/sec-websocket-key: *(.+)/i);
  if (k) { const acc = createHash("sha1").update(k[1].trim() + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest("base64");
    c.write("HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: " + acc + "\\r\\n\\r\\n"); c.write(Buffer.from([0x88, 2, 3, 0xe8])); }
  else c.end("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\nConnection: close\\r\\n\\r\\nok"); }); });
await new Promise(r => srv.listen(0, "127.0.0.1", r)); const port = srv.address().port;
await fetch(`http://127.0.0.1:${port}/f`, { headers: { "X-A": "café" } }).then(r => r.text());
await new Promise(res => { const ws = new WebSocket(`ws://127.0.0.1:${port}/w`, { headers: { "X-A": "café" } }); ws.onclose = res; ws.onerror = () => {}; });
srv.close(); console.log("fetch:", seen[0], "websocket:", seen[1], seen[0] !== seen[1] ? "BUG" : "consistent");
```

The first attempt changed only `Headers8Bit` and produced `63 61 66 ef bf bd` on the wire: the Latin-1 byte survived `Headers8Bit` and was then replaced with U+FFFD by `BStr::Display` in `build_request_body`. That is why the request builder changed too.

`Sec-WebSocket-Key` and `Sec-WebSocket-Protocol` were written through `picohttp::Headers`'s `Display`, which also goes through `BStr`. They are now written with `write_header_line` as well, since a user-supplied `Sec-WebSocket-Protocol` header value takes that path. Header order on the wire is unchanged.

The three `websocket.test.js` cases that fail locally (`should connect over https`, `should send and receive messages`, `should connect many times over https`) dial `ws.postman-echo.com` and fail identically on the current release in this sandbox.
</details>
