### PR TITLE
Make Bun.indexOfLine find a newline after an invalid UTF-8 lead byte

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1340,29 +1340,16 @@ fn index_of_line(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResul
     };
 
     let bytes = buffer.byte_slice();
-    let mut current_offset = offset;
-    let end = bytes.len() as u32;
-
-    while current_offset < end as usize {
-        if let Some(i) = strings::index_of_newline_or_non_ascii(bytes, current_offset as u32) {
-            let byte = bytes[i as usize];
-            if byte > 0x7F {
-                current_offset =
-                    i as usize + (strings::wtf8_byte_sequence_length(byte) as usize).max(1);
-                continue;
-            }
-
-            if byte == b'\n' {
-                return Ok(JSValue::js_number(i as f64));
-            }
-
-            current_offset = i as usize + 1;
-        } else {
-            break;
-        }
+    if offset >= bytes.len() {
+        return Ok(JSValue::js_number_from_int32(-1));
     }
 
-    Ok(JSValue::js_number_from_int32(-1))
+    // A newline byte is never part of a multi-byte UTF-8 sequence, so a
+    // plain byte search is correct for valid and invalid input alike.
+    Ok(match strings::index_of_char_usize(&bytes[offset..], b'\n') {
+        Some(i) => JSValue::js_number((offset + i) as f64),
+        None => JSValue::js_number_from_int32(-1),
+    })
 }
 
 #[bun_jsc::host_fn]

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1344,8 +1344,7 @@ fn index_of_line(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResul
         return Ok(JSValue::js_number_from_int32(-1));
     }
 
-    // A newline byte is never part of a multi-byte UTF-8 sequence, so a
-    // plain byte search is correct for valid and invalid input alike.
+    // 0x0A never appears inside a multi-byte UTF-8 sequence.
     Ok(
         match strings::index_of_char_usize(&bytes[offset..], b'\n') {
             Some(i) => JSValue::js_number((offset + i) as f64),

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1346,10 +1346,12 @@ fn index_of_line(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResul
 
     // A newline byte is never part of a multi-byte UTF-8 sequence, so a
     // plain byte search is correct for valid and invalid input alike.
-    Ok(match strings::index_of_char_usize(&bytes[offset..], b'\n') {
-        Some(i) => JSValue::js_number((offset + i) as f64),
-        None => JSValue::js_number_from_int32(-1),
-    })
+    Ok(
+        match strings::index_of_char_usize(&bytes[offset..], b'\n') {
+            Some(i) => JSValue::js_number((offset + i) as f64),
+            None => JSValue::js_number_from_int32(-1),
+        },
+    )
 }
 
 #[bun_jsc::host_fn]

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -127,3 +127,39 @@ test("indexOfLine skips multi-byte sequences correctly", () => {
   expect(indexOfLine(buf3, 3)).toBe(6);
   expect(indexOfLine(buf3, 7)).toBe(11);
 });
+
+test("indexOfLine finds a newline after a truncated multi-byte lead byte", () => {
+  // A lead byte whose continuation bytes are missing must not hide the
+  // newline that follows it.
+  const cases = [
+    { bytes: [0xf0, 0x0a], expected: 1 },
+    { bytes: [0xe2, 0x82, 0x0a], expected: 2 },
+    { bytes: [0xc3, 0x0a, 0x41, 0x0a], expected: 1 },
+    { bytes: [0x41, 0xf0, 0x0a, 0x0a], expected: 2 },
+    { bytes: [0x80, 0x0a], expected: 1 },
+    { bytes: [0xff, 0x0a], expected: 1 },
+    { bytes: [0xf0], expected: -1 },
+    { bytes: [0xf0, 0x90], expected: -1 },
+  ];
+  expect(cases.map(({ bytes }) => indexOfLine(new Uint8Array(bytes)))).toEqual(cases.map(c => c.expected));
+  // The same with an offset that lands on the lead byte.
+  expect(indexOfLine(new Uint8Array([0x41, 0x42, 0xf0, 0x0a]), 2)).toBe(3);
+  // A valid sequence directly before the newline still works.
+  expect(indexOfLine(new Uint8Array([0xf0, 0x9f, 0x98, 0x8b, 0x0a]))).toBe(4);
+});
+
+test("console async iterator splits lines after a truncated multi-byte lead byte", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "for await (const line of console) console.log(JSON.stringify(line))"],
+    env: bunEnv,
+    stdin: new Uint8Array([0xf0, 0x0a, 0x62, 0x0a]),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Only the split matters here. What the iterator yields after the last
+  // newline is a separate question.
+  expect(stdout).toStartWith('"\ufffd"\n"b"\n');
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -1,5 +1,5 @@
 import { indexOfLine } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("indexOfLine handles non-number offset", () => {
@@ -128,24 +128,25 @@ test("indexOfLine skips multi-byte sequences correctly", () => {
   expect(indexOfLine(buf3, 7)).toBe(11);
 });
 
-test("indexOfLine finds a newline after a truncated multi-byte lead byte", () => {
-  // A lead byte whose continuation bytes are missing must not hide the
-  // newline that follows it.
-  const cases = [
-    { bytes: [0xf0, 0x0a], expected: 1 },
-    { bytes: [0xe2, 0x82, 0x0a], expected: 2 },
-    { bytes: [0xc3, 0x0a, 0x41, 0x0a], expected: 1 },
-    { bytes: [0x41, 0xf0, 0x0a, 0x0a], expected: 2 },
-    { bytes: [0x80, 0x0a], expected: 1 },
-    { bytes: [0xff, 0x0a], expected: 1 },
-    { bytes: [0xf0], expected: -1 },
-    { bytes: [0xf0, 0x90], expected: -1 },
-  ];
-  expect(cases.map(({ bytes }) => indexOfLine(new Uint8Array(bytes)))).toEqual(cases.map(c => c.expected));
-  // The same with an offset that lands on the lead byte.
-  expect(indexOfLine(new Uint8Array([0x41, 0x42, 0xf0, 0x0a]), 2)).toBe(3);
-  // A valid sequence directly before the newline still works.
-  expect(indexOfLine(new Uint8Array([0xf0, 0x9f, 0x98, 0x8b, 0x0a]))).toBe(4);
+// A lead byte whose continuation bytes are missing must not hide the newline
+// that follows it.
+describe.each([
+  { bytes: [0xf0, 0x0a], offset: 0, expected: 1 },
+  { bytes: [0xe2, 0x82, 0x0a], offset: 0, expected: 2 },
+  { bytes: [0xc3, 0x0a, 0x41, 0x0a], offset: 0, expected: 1 },
+  { bytes: [0x41, 0xf0, 0x0a, 0x0a], offset: 0, expected: 2 },
+  { bytes: [0x80, 0x0a], offset: 0, expected: 1 },
+  { bytes: [0xff, 0x0a], offset: 0, expected: 1 },
+  { bytes: [0xf0], offset: 0, expected: -1 },
+  { bytes: [0xf0, 0x90], offset: 0, expected: -1 },
+  // the offset lands on the lead byte
+  { bytes: [0x41, 0x42, 0xf0, 0x0a], offset: 2, expected: 3 },
+  // a valid sequence directly before the newline
+  { bytes: [0xf0, 0x9f, 0x98, 0x8b, 0x0a], offset: 0, expected: 4 },
+])("indexOfLine with invalid UTF-8 $bytes at offset $offset", ({ bytes, offset, expected }) => {
+  test(`returns ${expected}`, () => {
+    expect(indexOfLine(new Uint8Array(bytes), offset)).toBe(expected);
+  });
 });
 
 test("console async iterator splits lines after a truncated multi-byte lead byte", async () => {


### PR DESCRIPTION
### Problem
- `Bun.indexOfLine(new Uint8Array([0xF0, 0x0A]))` returns -1. The newline at index 1 is hidden. Through the console async iterator, `for await (const line of console)` on stdin `"\xF0\nb\n"` yields one line `"\uFFFD\nb\n"` instead of two lines.
- The cause is `index_of_line` in `src/runtime/api/BunObject.rs:1349`. When the scan stops at a byte above 0x7F, it advances by `wtf8_byte_sequence_length(byte)` (2 to 4) without a check of the continuation bytes. A bare lead byte followed by `\n` skips the `\n`.

### Fix
- Replace the scan loop with `strings::index_of_char_usize(&bytes[offset..], b'\n')`. A `\n` (0x0A) is never a byte inside a multi-byte UTF-8 sequence, so a byte search gives the same result as the old loop on valid input and the correct result on invalid input.
- The old loop also stopped at every control byte and restarted the SIMD scan after each one. The byte search has no such restart.
- Verified: `test/js/bun/util/index-of-line.test.ts` (two new tests, both fail on 1.4.2 and on main). Also `test/js/bun/console/`.

### Background
- `Bun.indexOfLine(buffer, offset)` returns the index of the first `\n` at or after `offset`, or -1. The console async iterator in `src/js/builtins/ConsoleObject.ts` uses it to split stdin into lines before it decodes them.
- `wtf8_byte_sequence_length` maps a lead byte to the length its high bits declare. It does not look at the bytes that follow.

<details><summary>Notes</summary>

Repro on 1.4.2 and on main (before the fix):

```
Bun.indexOfLine(new Uint8Array([0xF0, 0x0A]))             // -1, expected 1
Bun.indexOfLine(new Uint8Array([0xC3, 0x0A, 0x41, 0x0A])) // 3, expected 1
Bun.indexOfLine(new Uint8Array([0xE2, 0x82, 0x0A]))       // -1, expected 2
printf '\xf0\nb\n' | bun -e 'for await (const l of console) console.log(JSON.stringify(l))'
// "\ufffd\nb\n"   expected "\ufffd" then "b"
```

The console iterator test asserts only the split. The trailing empty line that the iterator yields after the last newline is existing behaviour and is the subject of #33478.

Suites run: `test/js/bun/util/index-of-line.test.ts`, `test/js/bun/console/` (4 files, 86 pass, 1 skip).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/index-of-line.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/util/index-of-line.test.ts:
(pass) indexOfLine handles non-number offset [15.08ms]

       const a = 1;

       const b = 2;

       😋const c = 3; // handles unicode

       😋 Get Emoji — All Emojis to ✂️

       const b = 2;

       const c = 3;
(pass) indexOfLine [22.24ms]
(pass) indexOfLine is linear on large input with a non-ASCII byte [353.15ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via structuredClone [13.64ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via ArrayBuffer.prototype.transfer [5.87ms]
(pass) indexOfLine skips multi-byte sequences correctly [4.22ms]
143 |   { bytes: [0x41, 0x42, 0xf0, 0x0a], offset: 2, expected: 3 },
144 |   // a valid sequence directly before the newline
145 |   { bytes: [0xf0, 0x9f, 0x98, 0x8b, 0x0a], offset: 0, expected: 4 },
146 | ])("indexOfLine with invalid UTF-8 $bytes at offset $offset", ({ bytes, offset, expected }) => {
147 |   tes
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/util/index-of-line.test.ts:
(pass) indexOfLine handles non-number offset [0.08ms]

       const a = 1;

       const b = 2;

       😋const c = 3; // handles unicode

       😋 Get Emoji — All Emojis to ✂️

       const b = 2;

       const c = 3;
(pass) indexOfLine [0.12ms]
(pass) indexOfLine is linear on large input with a non-ASCII byte [7.03ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via structuredClone [0.20ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via ArrayBuffer.prototype.transfer [0.06ms]
(pass) indexOfLine skips multi-byte sequences correctly [0.04ms]
143 |   { bytes: [0x41, 0x42, 0xf0, 0x0a], offset: 2, expected: 3 },
144 |   // a valid sequence directly before the newline
145 |   { bytes: [0xf0, 0x9f, 0x98, 0x8b, 0x0a], offset: 0, expected: 4 },
146 | ])("indexOfLine with invalid UTF-8 $bytes at offset $offset", ({ bytes, offset, expected }) => {
147 |   test(`returns ${expected}`, () => {
148 |     expect(indexOfLine(new Uint8Array(bytes), offset)).toBe(expected);
                                                         
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/index-of-line.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/util/index-of-line.test.ts:
(pass) indexOfLine handles non-number offset [15.86ms]

       const a = 1;

       const b = 2;

       😋const c = 3; // handles unicode

       😋 Get Emoji — All Emojis to ✂️

       const b = 2;

       const c = 3;
(pass) indexOfLine [27.27ms]
(pass) indexOfLine is linear on large input with a non-ASCII byte [282.93ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via structuredClone [14.88ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via ArrayBuffer.prototype.transfer [6.28ms]
(pass) indexOfLine skips multi-byte sequences correctly [3.89ms]
(pass) indexOfLine with invalid UTF-8 [ 240, 10 ] at offset 0 > returns 1 [2.15ms]
(pass) indexOfLine with invalid UTF-8 [ 226, 130, 10 ] at offset 0 > returns 2 [0.33ms]
(pass) indexOfLine with invalid UTF-8 [ 195, 10, 65, 10 ] at offset 0 > returns 1 [0.19ms]
(pass) indexOfLine with invalid UTF-8 [ 65, 240, 10,
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ea1aefb1ce
  features     baseline

23 deps, 131 codegen, 1172 objects in 731ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [38.00ms]
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[6/1217] fetch tinycc
[tinycc] up to date
[7/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/BunObject.rs           | 30 ++++++++------------------
 test/js/bun/util/index-of-line.test.ts | 39 +++++++++++++++++++++++++++++++++-
 2 files changed, 47 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/BunObject.rs                2      3     12
test/js/bun/util/index-of-line.test.ts      2      4     12
```

</details>

**root cause** · written by the author bot

`Bun.indexOfLine` advanced past non-ASCII bytes by the lead byte's declared UTF-8 sequence length without validating the continuation bytes, so a truncated or invalid sequence could cause the scan to step over a newline byte and join lines that should have been split. The fix replaces that loop with a bounds check on the offset followed by a direct byte search for 0x0A, which is correct because a newline byte can never appear as a continuation or lead byte in any UTF-8 or WTF-8 sequence. This makes the search equivalent to the old behavior on valid input and correct on invalid input, with r…

<!-- robobun:evidence:end -->