### PR TITLE
types: document the real behavior of socket.shutdown() and socket.timeout()

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6536,11 +6536,20 @@ declare module "bun" {
     ref(): void;
 
     /**
-     * Set a timeout until the socket automatically closes.
+     * Set an idle timeout for the socket.
+     *
+     * When the timeout elapses, the `timeout` handler is called. The socket is
+     * not closed. Call `end()`, `close()`, or `terminate()` from the handler to
+     * close it.
+     *
+     * The timer has a granularity of 4 seconds. The handler runs on a 4 second
+     * tick, so the real delay is up to 4 seconds shorter or up to 3 seconds
+     * longer than `seconds`. `timeout(1)` fires at the next tick, which is
+     * between 0 and 4 seconds away. Pass `0` to disable the timeout.
      *
      * To reset the timeout, call this function again.
      *
-     * When a timeout happens, the `timeout` callback is called and the socket is closed.
+     * @param seconds The timeout in seconds.
      */
     timeout(seconds: number): void;
 
@@ -6557,23 +6566,29 @@ declare module "bun" {
     terminate(): void;
 
     /**
-     * Shuts down the write-half or both halves of the connection.
-     * This allows the socket to enter a half-closed state where it can still receive data
-     * but can no longer send data (`halfClose = true`), or close both read and write
-     * (`halfClose = false`, similar to `end()` but potentially more immediate depending on OS).
-     * Calls the `shutdown(2)` syscall internally.
+     * Shuts down one half of the connection with the `shutdown(2)` syscall.
      *
-     * @param halfClose If `true`, only shuts down the write side (allows receiving). If `false` or omitted, shuts down both read and write. Defaults to `false`.
+     * With no argument (or `false`), this shuts down the write side. The peer
+     * receives a FIN. The socket can still receive data, and `write()` returns
+     * `-1` from then on. This is the half-close that `end()` in `node:net`
+     * performs.
+     *
+     * With `true`, this shuts down the read side instead. The socket stops
+     * receiving data. The kernel reports end of file on the next read, so the
+     * `end` handler is called. Unless the socket was created with
+     * `allowHalfOpen: true`, it is then closed in full.
+     *
+     * @param shutdownRead If `true`, shut down the read side. If `false` or omitted, shut down the write side. Defaults to `false`.
      * @example
      * ```ts
-     * // Stop sending data, but allow receiving
-     * socket.shutdown(true);
-     *
-     * // Shutdown both reading and writing
+     * // Stop sending data, but keep receiving
      * socket.shutdown();
+     *
+     * // Stop receiving data
+     * socket.shutdown(true);
      * ```
      */
-    shutdown(halfClose?: boolean): void;
+    shutdown(shutdownRead?: boolean): void;
 
     /**
      * The ready state of the socket.


### PR DESCRIPTION
### Problem
- `bun.d.ts` documents `socket.shutdown(halfClose)` as: `true` shuts down the write side, no argument shuts down both sides. The code does the reverse. `shutdown()` is `SHUT_WR` (the peer sees a FIN, the socket still receives). `shutdown(true)` is `SHUT_RD` (`src/runtime/socket/socket_body.rs:3158`). With the default `allowHalfOpen: false`, `SHUT_RD` then closes the socket in full.
- `bun.d.ts` documents `socket.timeout(seconds)` as: the socket is closed when the timeout fires. `on_timeout` (`socket_body.rs:1011`) only calls the `timeout` handler. `readyState` stays `1`. The timer also runs on a 4 second tick (`packages/bun-usockets/src/socket.c:100`), so `timeout(1)` fires at up to 4 seconds and `timeout(5)` at up to 8 seconds.

### Fix
- Rewrite the two doc comments so they describe what the code does. No runtime code changes.
- `shutdown()` keeps its `SHUT_WR` meaning because `node:net`'s `end()` depends on it (`src/js/node/net.ts`, `endNT`). The doc before #19410 described `shutdown()` this way. The parameter is renamed from `halfClose` to `shutdownRead` to match its effect.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts` (21 pass). The behavior claims were checked against a scripted python peer on bun 1.4.3 and main: FIN seen by the peer, `write()` result after shutdown, `end`/`close` handler order, and `readyState` after `timeout` fired.

### Background
- `shutdown(2)` closes one direction of a TCP connection. `SHUT_WR` sends a FIN and keeps the read side open (half-close). `SHUT_RD` makes the next read return end of file and does not notify the peer.
- uSockets checks socket timeouts from a sweep timer that runs every 4 seconds (`LIBUS_TIMEOUT_GRANULARITY`). `us_socket_timeout` stores the timeout as `(seconds + 3) >> 2` ticks, so the handler runs at a tick boundary.

<details><summary>Notes</summary>

Observed with a python peer that logs what it receives:

```
shutdown()      bun: open, data:from-peer, write -> -1, data:again, close(clean)   peer: recv b'' (FIN), both sends ok
shutdown(false) same as shutdown()
shutdown(true)  bun: open, end, close(clean), write -> -1                          peer: recv b'' , second send EPIPE
shutdown(true) with allowHalfOpen: true
                bun: open, end, write -> 14                                        peer: recv b'after-shutdown', both sends ok
timeout(1)      handler at 4.00s, readyState 1 after 12s
timeout(2)      handler at 4.00s
timeout(5)      handler at 8.00s
timeout(0)      never fires
```

The doc text for `shutdown` was introduced in #19410. The earlier text read: "Shutdown writes to a socket. This makes the socket a half-closed socket. It can still receive data."

Changing the behavior instead (for example `shutdown(true)` as `SHUT_WR`, or an automatic close on timeout) would be a breaking change. This PR only fixes the documentation.
</details>
