### PR TITLE
node:fs: report the real errno from rm, and stop resolving fs stream paths

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -33,7 +33,7 @@ type FSStream = import("node:fs").ReadStream &
   };
 type FD = number;
 
-const { validateInteger, validateInt32, validateFunction } = require("internal/validators");
+const { validateInteger, validateInt32, validateFunction, getValidatedFsPath } = require("internal/validators");
 
 const kIsPerformingIO = Symbol("kIsPerformingIO");
 const kIoDone = Symbol("kIoDone");
@@ -87,12 +87,6 @@ function streamFileHandleClose(this: FileHandle, fd: FD, cb: (err?: any) => void
   this.close().then(() => cb(), cb);
 }
 
-function getValidatedPath(p: any) {
-  if (p instanceof URL) return Bun.fileURLToPath(p as URL);
-  if (typeof p !== "string") throw $ERR_INVALID_ARG_TYPE("path", "string or URL", p);
-  return require("node:path").resolve(p);
-}
-
 function copyObject(source) {
   const target = {};
   // Node tests for prototype lookups, so { ...source } will not work.
@@ -142,7 +136,7 @@ function ReadStream(this: FSStream, path, options): void {
   if (fd == null) {
     this[kFs] = customFs || fs;
     this.fd = null;
-    this.path = getValidatedPath(path);
+    this.path = getValidatedFsPath(path);
     const { flags, mode } = options;
     this.flags = flags === undefined ? "r" : flags;
     this.mode = mode === undefined ? 0o666 : mode;
@@ -384,10 +378,7 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
   if (fd == null) {
     this[kFs] = customFs || fs;
     this.fd = null;
-    // Internal $fastPath callers (writableFromFileSink) discard .path; do not
-    // resolve it - path.resolve("") needs process.cwd(), which throws when
-    // the cwd has been deleted (Node still spawns children in that state).
-    this.path = fastPath ? path : getValidatedPath(path);
+    this.path = fastPath ? path : getValidatedFsPath(path);
     const { flags, mode } = options;
     this.flags = flags === undefined ? "w" : flags;
     this.mode = mode === undefined ? 0o666 : mode;

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -339,14 +339,11 @@ const exports = {
       options = { ...options };
     }
     if (!options?.force || !options?.recursive) {
-      // node validates in JS with an lstat first: it reports ERR_FS_EISDIR for
-      // directories and rethrows lstat errors (ENOTDIR, EACCES, ...) as-is
-      // (same check as rmSync)
+      // node lstats first: ERR_FS_EISDIR for directories, other lstat errors rethrown as-is
       let stats;
       try {
         stats = await fs.lstat(path);
       } catch (err) {
-        // let the native call produce ENOENT (respects force)
         if (err?.code !== "ENOENT") throw err;
       }
       if (stats?.isDirectory() && !options?.recursive) {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -338,16 +338,18 @@ const exports = {
       // Normalize here so the native parser sees exactly that set.
       options = { ...options };
     }
-    if (!options?.recursive) {
-      // node validates in JS and reports ERR_FS_EISDIR for directories
+    if (!options?.force || !options?.recursive) {
+      // node validates in JS with an lstat first: it reports ERR_FS_EISDIR for
+      // directories and rethrows lstat errors (ENOTDIR, EACCES, ...) as-is
       // (same check as rmSync)
       let stats;
       try {
         stats = await fs.lstat(path);
-      } catch {
-        // let the native call produce the error (respects force/ENOENT)
+      } catch (err) {
+        // let the native call produce ENOENT (respects force)
+        if (err?.code !== "ENOENT") throw err;
       }
-      if (stats?.isDirectory()) {
+      if (stats?.isDirectory() && !options?.recursive) {
         throw require("internal/fs/cp-sync").fsEisdirError({
           code: "EISDIR",
           message: "is a directory",

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -561,13 +561,11 @@ var access = function access(path, mode, callback) {
       options = { ...options };
     }
     if (!options?.force || !options?.recursive) {
-      // node validates in JS with an lstat first: it reports ERR_FS_EISDIR for
-      // directories and rethrows lstat errors (ENOTDIR, EACCES, ...) as-is
+      // node lstats first: ERR_FS_EISDIR for directories, other lstat errors rethrown as-is
       let stats;
       try {
         stats = fs.lstatSync(path);
       } catch (err) {
-        // let the native call produce ENOENT (respects force)
         if (err?.code !== "ENOENT") throw err;
       }
       if (stats?.isDirectory() && !options?.recursive) {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -560,15 +560,17 @@ var access = function access(path, mode, callback) {
       // Normalize here so the native parser sees exactly that set.
       options = { ...options };
     }
-    if (!options?.recursive) {
-      // node validates in JS and reports ERR_FS_EISDIR for directories
+    if (!options?.force || !options?.recursive) {
+      // node validates in JS with an lstat first: it reports ERR_FS_EISDIR for
+      // directories and rethrows lstat errors (ENOTDIR, EACCES, ...) as-is
       let stats;
       try {
         stats = fs.lstatSync(path);
-      } catch {
-        // let the native call produce the error (respects force/ENOENT)
+      } catch (err) {
+        // let the native call produce ENOENT (respects force)
+        if (err?.code !== "ENOENT") throw err;
       }
-      if (stats?.isDirectory()) {
+      if (stats?.isDirectory() && !options?.recursive) {
         throw require("internal/fs/cp-sync").fsEisdirError({
           code: "EISDIR",
           message: "is a directory",

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7541,8 +7541,7 @@ impl NodeFS {
                     sys::Error::from_code(E::ENOENT, sys::Tag::lstat).with_path(args.path.slice())
                 );
             }
-            return Err(sys::Error::from_code(map_rm_errno_narrow(e1), sys::Tag::rm)
-                .with_path(args.path.slice()));
+            return Err(sys::Error::from_code(e1, sys::Tag::rm).with_path(args.path.slice()));
         }
         Ok(())
     }
@@ -9260,19 +9259,6 @@ fn map_anyerror_to_errno_rm_tree(err: &crate::Error) -> E {
         "InvalidUtf8" | "InvalidWtf8" | "BadPathName" => E::EINVAL,
         "FileNotFound" => E::ENOENT,
         "IsDir" => E::EISDIR,
-        _ => E::EFAULT,
-    }
-}
-
-// `rm` non-recursive unlink/rmdir fallback — narrower table; anything not
-// listed here falls through to EFAULT.
-//
-// `bun_sys::unlink`/`libc::rmdir` yield a raw errno. Notably raw EPERM —
-// like EISDIR/ENOTDIR/ENOTEMPTY — intentionally falls through to EFAULT here.
-fn map_rm_errno_narrow(e: E) -> E {
-    match e {
-        E::EACCES => E::EACCES,
-        E::ELOOP | E::ENAMETOOLONG | E::ENOMEM | E::EROFS | E::EBUSY | E::ENOENT => e,
         _ => E::EFAULT,
     }
 }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3548,6 +3548,30 @@ describe("rm", () => {
     expect(existsSync(path)).toBe(false);
   });
 
+  // Node runs an lstat() before the removal and rethrows its error. A path
+  // that goes through a regular file is ENOTDIR, tagged lstat, for every
+  // option set that lstats (everything except { recursive, force }).
+  it.skipIf(isWindows)("reports ENOTDIR from lstat for a path that goes through a file", async () => {
+    using dir = tempDir("rm-enotdir", { "file.txt": "x" });
+    const path = join(String(dir), "file.txt", "child");
+    const pick = (e: any) => ({ code: e.code, syscall: e.syscall, path: e.path });
+    const expected = { code: "ENOTDIR", syscall: "lstat", path };
+
+    for (const options of [undefined, { force: true }, { recursive: true }]) {
+      expect(() => rmSync(path, options)).toThrow(expect.objectContaining(expected));
+      expect(await fs.promises.rm(path, options).then(() => null, pick)).toEqual(expected);
+      const cbErr = await new Promise(resolve => fs.rm(path, options, resolve));
+      expect(pick(cbErr)).toEqual(expected);
+    }
+
+    expect(await fs.promises.rm(path, { recursive: true, force: true }).then(() => null, pick)).toEqual({
+      code: "ENOTDIR",
+      syscall: "rm",
+      path,
+    });
+    expect(readFileSync(join(String(dir), "file.txt"), "utf8")).toBe("x");
+  });
+
   // On Windows a leading-separator, drive-less path like "/foo/bar" is
   // "rooted" and must be resolved against the cwd's drive. existsSync/
   // statSync/unlinkSync all do this; recursive rmSync must agree
@@ -3748,6 +3772,36 @@ describe("rmdirSync", () => {
 });
 
 describe("createReadStream", () => {
+  // Node hands the path to open() as given. It does not path.resolve() it, so
+  // a ".." through a missing directory fails and stream.path keeps the input.
+  it("keeps the path as given and does not resolve it before open", async () => {
+    using dir = tempDir("read-stream-path", { "file.txt": "hello" });
+    const file = join(String(dir), "file.txt");
+    const openResult = (stream: fs.ReadStream) =>
+      new Promise<any>(resolve => {
+        stream.on("open", () => resolve("open"));
+        stream.on("error", e => resolve({ code: e.code, syscall: e.syscall, path: e.path }));
+      }).finally(() => stream.destroy());
+
+    const bufferStream = createReadStream(Buffer.from(file));
+    expect(bufferStream.path).toEqual(Buffer.from(file));
+    expect(await openResult(bufferStream)).toBe("open");
+
+    const urlStream = createReadStream(Bun.pathToFileURL(file));
+    expect(urlStream.path).toBe(file);
+    expect(await openResult(urlStream)).toBe("open");
+
+    // Windows normalizes ".." in the path inside the open() call itself.
+    if (!isWindows) {
+      for (const path of [`${String(dir)}/nope/../file.txt`, file + "/"]) {
+        const stream = createReadStream(path);
+        expect(stream.path).toBe(path);
+        const code = path.endsWith("/") ? "ENOTDIR" : "ENOENT";
+        expect(await openResult(stream)).toEqual({ code, syscall: "open", path });
+      }
+    }
+  });
+
   it("works (1 chunk)", async () => {
     return await new Promise((resolve, reject) => {
       var stream = createReadStream(import.meta.dir + "/readFileSync.txt", {});
@@ -4291,6 +4345,28 @@ describe("fs.ReadStream", () => {
 });
 
 describe("createWriteStream", () => {
+  it("keeps the path as given and does not resolve it before open", async () => {
+    using dir = tempDir("write-stream-path", { "file.txt": "hello" });
+    const file = join(String(dir), "file.txt");
+    const openResult = (stream: fs.WriteStream) =>
+      new Promise<any>(resolve => {
+        stream.on("open", () => resolve("open"));
+        stream.on("error", e => resolve({ code: e.code, syscall: e.syscall, path: e.path }));
+      }).finally(() => stream.destroy());
+
+    const bufferStream = createWriteStream(Buffer.from(file), { flags: "a" });
+    expect(bufferStream.path).toEqual(Buffer.from(file));
+    expect(await openResult(bufferStream)).toBe("open");
+
+    if (!isWindows) {
+      const path = `${String(dir)}/nope/../file.txt`;
+      const stream = createWriteStream(path, { flags: "a" });
+      expect(stream.path).toBe(path);
+      expect(await openResult(stream)).toEqual({ code: "ENOENT", syscall: "open", path });
+    }
+    expect(readFileSync(file, "utf8")).toBe("hello");
+  });
+
   it.todoIf(isBroken && isWindows)("simple write stream finishes", async () => {
     const streamPath = join(tmpdirSync(), "create-write-stream.txt");
     const { promise: done, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
### Problem
- `fs.rmSync("file.txt/child")` (and `fs.rm`, `fs.promises.rm`) throws `EFAULT: bad address in system call argument, rm 'file.txt/child'`. Node throws `ENOTDIR: not a directory, lstat 'file.txt/child'`. Cause: `map_rm_errno_narrow` (`src/runtime/node/node_fs.rs:9272`) maps every unlink errno outside a short list (ENOTDIR, EPERM, EISDIR, EIO, ...) to EFAULT. The JS wrapper also swallows every error from its lstat, where node rethrows all but ENOENT.
- `fs.createReadStream("nope/../file.txt")` opens `file.txt`. Node fails with ENOENT because the kernel walks `nope` first. Cause: `getValidatedPath` in `src/js/internal/fs/streams.ts:93` runs `path.resolve()` on the path before `open()`. `stream.path` is absolute instead of the given value, and a Buffer path throws `ERR_INVALID_ARG_TYPE`.

### Fix
- `NodeFS::rm`, non-recursive branch: pass the unlink errno through with the `rm` tag. The narrow table is deleted.
- `rmSync` and `promises.rm`: run the pre-removal lstat when `!force || !recursive`, like node, and rethrow every lstat error except ENOENT. ENOENT still goes to the native call, which handles `force` and tags it `lstat`. The ERR_FS_EISDIR check stays for the non-recursive case only.
- `ReadStream` and `WriteStream`: validate the path with the existing `getValidatedFsPath` (URL to path, string or Buffer as given, null byte check) and hand it to `open()` unchanged.
- Verified: `test/js/node/fs/fs.test.ts` (3 new tests, all fail on the released bun). Also the node tests `test-fs-rm*.js`, `test-fs-rmdir*.js`, every `test-fs-read-stream*`, `test-fs-write-stream*` and `test-file-write-stream*` file, and `fs-leak.test.js`.

### Background
- Node's `rm` runs `validateRmOptions` in JS before anything else. It does an `lstat` unless both `force` and `recursive` are set. That lstat reports a directory as ERR_FS_EISDIR and rethrows any other error as-is, so most path errors from `rm` carry the `lstat` tag. Only ENOENT is suppressed, and only with `force`.
- The non-recursive native path is a plain `unlink(2)`. The EFAULT table came from the original port, where the underlying library exposed a narrow error set. `bun_sys::unlink` returns the raw errno, so no mapping is needed.
- Node's `fs.ReadStream` stores the path as given (`toPathIfFileURL` plus `validatePath`) and passes it to `fs.open`. It never resolves it. Relative paths resolve against the cwd at open time inside the kernel.

<details><summary>Notes</summary>

Found by a semantic-parity sweep of `node:fs` against node v26.3.0. Both divergences reproduce on bun 1.3.14 through 1.4.3 and main.

Repro outputs, node v26.3.0 against this branch, are identical for these scripts:

```js
// rm
const fs = require("fs"); // cwd has file.txt and dir/
for (const o of [undefined, { force: true }, { recursive: true }]) {
  try { fs.rmSync("file.txt/child", o); } catch (e) { console.log(e.code, e.syscall, e.path); }
}
// before: EFAULT rm file.txt/child (x2), ENOTDIR rm file.txt/child
// after:  ENOTDIR lstat file.txt/child (x3)
```

```js
// streams
fs.createReadStream("nope/../file.txt").on("open", () => console.log("open"))
  .on("error", e => console.log(e.code, e.path));
// before: open (stream.path is "/abs/cwd/file.txt")
// after:  ENOENT nope/../file.txt
```

The native change is only reachable when the lstat succeeds and the unlink still fails (EPERM from a sticky directory or an immutable file, EISDIR for root on some systems, EIO). Those cases need privileges or a special mount, so the test covers the JS side (ENOTDIR through lstat) and the recursive-with-force path (ENOTDIR tagged `rm`, from the tree walker's own table).

On Windows the Win32 layer collapses `..` before the filesystem sees the path, so node opens the file there too. The stream test skips the `..` case on Windows and still checks `stream.path` and Buffer paths. The rm ENOTDIR test is posix-only: libuv reports a path through a file differently on Windows.

Related open PRs, not the same change: #35749 fixes the same EFAULT fallback in the recursive walker's table (`map_anyerror_to_errno_rm_tree`). #38550 handles the Windows EPERM race in the same non-recursive branch.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->