### PR TITLE
fetch: stream a Bun.file() body that is a FIFO, socket, or device instead of reading it on the JS thread

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6982,7 +6982,10 @@ impl NodeFS {
         // For certain files, the size might be 0 but the file might still have contents.
         // https://github.com/oven-sh/bun/issues/1220
         let max_size: u64 = args.max_size.map(|v| v as u64).unwrap_or(BLOB_SIZE_MAX);
-        let has_max_size = args.max_size.is_some();
+        // A blob whose size is still unknown passes `BLOB_SIZE_MAX`. That is
+        // not a bound: a FIFO or device must be read to EOF, not to the
+        // first buffer's capacity.
+        let has_max_size = max_size != BLOB_SIZE_MAX;
 
         let size: u64 = (stat_.st_size as i64)
             .min(max_size as i64) // Only used in DOMFormData

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -341,6 +341,37 @@ fn reject_on_exception(
     Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))
 }
 
+/// Replace a blob body that has a file or S3 store with a `ReadableStream`
+/// over the same store. The HTTP client then sends it chunked. Returns
+/// `Ok(false)` when no stream could be created. `body` is detached on an
+/// error so the store ref is not leaked (`HTTPRequestBody` has no `Drop`).
+fn stream_blob_body(
+    global_this: &JSGlobalObject,
+    body: &mut HTTPRequestBody,
+    recommended_chunk_size: blob::SizeType,
+) -> JsResult<bool> {
+    let stream = ReadableStream::from_blob_copy_ref(
+        global_this,
+        body.any_blob().blob(),
+        recommended_chunk_size,
+    )
+    .and_then(|value| ReadableStream::from_js(value, global_this));
+    let stream = match stream {
+        Ok(Some(stream)) => stream,
+        Ok(None) => return Ok(false),
+        Err(err) => {
+            body.detach();
+            return Err(err);
+        }
+    };
+    let mut old = core::mem::replace(
+        body,
+        HTTPRequestBody::ReadableStream(readable_stream::Strong::init(stream, global_this)),
+    );
+    old.detach();
+    Ok(true)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // URLType
 // ──────────────────────────────────────────────────────────────────────────
@@ -1440,29 +1471,12 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // *moved* into `FetchOptions`.
 
     if body.is_s3() {
-        'prepare_body: {
-            // is a S3 file we can use chunked here
-
-            if let Some(stream) = ReadableStream::from_js(
-                ReadableStream::from_blob_copy_ref(
-                    global_this,
-                    body.any_blob().blob(),
-                    s3::MultiPartUploadOptions::DEFAULT_PART_SIZE as crate::webcore::blob::SizeType,
-                )?,
-                global_this,
-            )? {
-                let mut old = core::mem::replace(
-                    &mut body,
-                    HTTPRequestBody::ReadableStream(readable_stream::Strong::init(
-                        stream,
-                        global_this,
-                    )),
-                );
-                // HTTPRequestBody has no Drop
-                // impl, so a bare `drop(old)` would leak the S3 Blob.Store ref.
-                old.detach();
-                break 'prepare_body;
-            }
+        // is a S3 file we can use chunked here
+        if !stream_blob_body(
+            global_this,
+            &mut body,
+            s3::MultiPartUploadOptions::DEFAULT_PART_SIZE as crate::webcore::blob::SizeType,
+        )? {
             let rejected_value =
                 JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                     global_this,
@@ -1480,6 +1494,41 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // `path.slice_z()` (the `vm.node_fs()` accessor is gated behind a
             // jsc↔runtime cycle).
             let mut open_path_buf = PathBuffer::uninit();
+
+            // A FIFO, socket, or character device has no size. Opening a FIFO
+            // blocks until a writer appears, reading it into memory blocks the
+            // JS thread until the writer closes, and one buffer's worth would
+            // ship as the Content-Length. So stat before open, and stream a
+            // non-regular file with chunked transfer encoding instead: the
+            // stream reader opens the fd itself and polls it. A stat error is
+            // left for the open below, which reports it.
+            let is_regular_file = {
+                let store = body.store().expect("needs_to_read_file implies store");
+                let stat = match &store.data.as_file().pathlike {
+                    PathOrFileDescriptor::Fd(fd) => bun_sys::fstat(*fd),
+                    PathOrFileDescriptor::Path(path) => {
+                        bun_sys::stat(path.slice_z(&mut open_path_buf))
+                    }
+                };
+                match stat {
+                    Ok(stat) => bun_sys::S::ISREG(stat.st_mode as u32),
+                    Err(_) => true,
+                }
+            };
+            if !is_regular_file {
+                if !stream_blob_body(global_this, &mut body, 0)? {
+                    let rejected_value =
+                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                            global_this,
+                            global_this
+                                .create_error_instance(format_args!("Failed to start file stream")),
+                        );
+                    body.detach();
+                    return Ok(rejected_value);
+                }
+                break 'prepare_body;
+            }
+
             let opened_fd_res: bun_sys::Result<bun_sys::Fd> = {
                 let store = body.store().expect("needs_to_read_file implies store");
                 match &store.data.as_file().pathlike {
@@ -1520,12 +1569,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         Err(_) => break 'use_sendfile,
                     };
 
-                    #[cfg(target_os = "macos")]
-                    {
-                        // macOS only supports regular files for sendfile()
-                        if !bun_sys::S::ISREG(stat.st_mode as u32) {
-                            break 'use_sendfile;
-                        }
+                    // The path was a regular file at the stat above. If it
+                    // was replaced since, sendfile is the wrong tool.
+                    if !bun_sys::S::ISREG(stat.st_mode as u32) {
+                        break 'use_sendfile;
                     }
 
                     // if it's < 32 KB, it's not worth it
@@ -1539,25 +1586,20 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
                     // `http::SendFile` fields are `usize`; blob sizes/offsets
                     // are `blob::SizeType` (u64) — hence the `as usize` casts.
-                    let mut sf = http::SendFile {
+                    // The slice window is clamped to the file: `remain` is the
+                    // exact byte count we will send, and that is the Content-Length.
+                    let stat_size_usize = stat_size as usize;
+                    let offset = (blob_offset as usize).min(stat_size_usize);
+                    let remain = ((blob_offset + original_size) as usize)
+                        .max(offset)
+                        .min(stat_size_usize)
+                        .saturating_sub(offset);
+                    let sf = http::SendFile {
                         fd: opened_fd,
-                        remain: (blob_offset + original_size) as usize,
-                        offset: blob_offset as usize,
-                        content_size: original_size.min(stat_size) as usize,
+                        remain,
+                        offset,
+                        content_size: remain,
                     };
-
-                    if bun_sys::S::ISREG(stat.st_mode as u32) {
-                        let stat_size_usize = stat_size as usize;
-                        sf.offset = sf.offset.min(stat_size_usize);
-                        sf.remain = sf
-                            .remain
-                            .max(sf.offset)
-                            .min(stat_size_usize)
-                            .saturating_sub(sf.offset);
-                        // `remain` is now the exact byte count we will send (the slice
-                        // window clamped to the file); that is the Content-Length.
-                        sf.content_size = sf.remain;
-                    }
                     body.detach();
                     body = HTTPRequestBody::Sendfile(sf);
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1502,7 +1502,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // non-regular file with chunked transfer encoding instead: the
             // stream reader opens the fd itself and polls it. A stat error is
             // left for the open below, which reports it.
-            let is_regular_file = {
+            //
+            // On macOS a named pipe read through the event loop never sees
+            // EOF (#40099 fixes that), so a FIFO keeps the buffered read there
+            // until that lands. The read then blocks but delivers every byte.
+            let stream_body = {
                 let store = body.store().expect("needs_to_read_file implies store");
                 let stat = match &store.data.as_file().pathlike {
                     PathOrFileDescriptor::Fd(fd) => bun_sys::fstat(*fd),
@@ -1511,11 +1515,15 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     }
                 };
                 match stat {
-                    Ok(stat) => bun_sys::S::ISREG(stat.st_mode as u32),
-                    Err(_) => true,
+                    Ok(stat) => {
+                        let mode = stat.st_mode as u32;
+                        !bun_sys::S::ISREG(mode)
+                            && !(cfg!(target_os = "macos") && bun_sys::S::ISFIFO(mode))
+                    }
+                    Err(_) => false,
                 }
             };
-            if !is_regular_file {
+            if stream_body {
                 if !stream_blob_body(global_this, &mut body, 0)? {
                     let rejected_value =
                         JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1500,8 +1500,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // JS thread until the writer closes, and one buffer's worth would
             // ship as the Content-Length. So stat before open, and stream a
             // non-regular file with chunked transfer encoding instead: the
-            // stream reader opens the fd itself and polls it. A stat error is
-            // left for the open below, which reports it.
+            // stream reader opens the fd itself and polls it. A stat error and
+            // a directory are left for the open and read below, which reject
+            // before any request goes on the wire.
             //
             // On macOS a named pipe read through the event loop never sees
             // EOF (#40099 fixes that), so a FIFO keeps the buffered read there
@@ -1518,6 +1519,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     Ok(stat) => {
                         let mode = stat.st_mode as u32;
                         !bun_sys::S::ISREG(mode)
+                            && !bun_sys::S::ISDIR(mode)
                             && !(cfg!(target_os = "macos") && bun_sys::S::ISFIFO(mode))
                     }
                     Err(_) => false,

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -322,6 +322,71 @@ describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
     expect(await writer.exited).toBe(0);
   });
 
+  // The writer sends 1 KB (less than the smallest pipe buffer, so it never
+  // blocks) and then stays alive without writing more. With the bug, fetch()
+  // blocks the JS thread in a read that never returns, so the abort never
+  // fires. With the fix, the abort rejects the fetch while the writer is still
+  // alive, and the FIFO fd is closed afterwards. It runs in a child process so
+  // the hang cannot take the test runner with it.
+  test.concurrent.todoIf(isMacOS)("abort during a trickling FIFO body rejects and closes the fd", async () => {
+    using dir = tempDir("fetch-fifo-upload-abort", {
+      "fixture.ts": `
+        import { readdirSync, readlinkSync, realpathSync } from "node:fs";
+        const fifo = realpathSync("fifo");
+        const writer = Bun.spawn({
+          cmd: ["sh", "-c", "exec 3<>fifo; head -c 1024 /dev/zero >&3; read x"],
+          stdin: "pipe",
+          stdout: "ignore",
+          stderr: "inherit",
+        });
+        const firstChunk = Promise.withResolvers();
+        using server = Bun.serve({
+          port: 0,
+          development: false,
+          async fetch(req) {
+            try {
+              for await (const chunk of req.body) firstChunk.resolve(chunk.byteLength);
+            } catch {}
+            return new Response("ok");
+          },
+        });
+        const ac = new AbortController();
+        const pending = fetch(server.url, { method: "POST", body: Bun.file(fifo), signal: ac.signal });
+        await firstChunk.promise;
+        ac.abort();
+        let outcome = "resolved";
+        try {
+          await pending;
+        } catch (e) {
+          outcome = e.name;
+        }
+        const fdsOnFifo = () =>
+          readdirSync("/proc/self/fd").filter(fd => {
+            try {
+              return readlinkSync("/proc/self/fd/" + fd) === fifo;
+            } catch {
+              return false;
+            }
+          }).length;
+        while (fdsOnFifo() > 0) await Bun.sleep(1);
+        console.log(JSON.stringify({ outcome, writerAlive: writer.exitCode === null, fdsOnFifo: fdsOnFifo() }));
+        writer.kill();
+      `,
+    });
+    mkfifo(join(String(dir), "fifo"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(JSON.stringify({ outcome: "AbortError", writerAlive: true, fdsOnFifo: 0 }) + "\n");
+    expect(exitCode).toBe(0);
+  });
+
   // The writer opens the FIFO only after it reads a line from stdin, and the
   // fixture writes that line after fetch() returns. With the bug, fetch()
   // blocks the JS thread inside a read of the FIFO, so the line is never

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -383,6 +383,24 @@ describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
   });
 });
 
+test("a directory body rejects before any request reaches the origin", async () => {
+  using dir = tempDir("fetch-dir-body", {});
+  let requests = 0;
+  await using server = Bun.serve({
+    port: 0,
+    development: false,
+    fetch() {
+      requests++;
+      return new Response("ok");
+    },
+  });
+
+  await expect(fetch(server.url, { method: "POST", body: Bun.file(String(dir)) })).rejects.toThrow("EISDIR");
+  // A second request on the same origin proves the first never arrived.
+  expect(await (await fetch(server.url, { method: "POST", body: "x" })).text()).toBe("ok");
+  expect(requests).toBe(1);
+});
+
 test("missing file throws the expected error", async () => {
   Bun.gc(true);
   // Run this 1000 times to check for GC bugs

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isBroken, isWindows, tempDir, tls, withoutAggressiveGC } from "harness";
+import { mkfifo } from "mkfifo";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -219,6 +220,123 @@ describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
     expect(await res.text()).toBe("ok");
     expect(res.status).toBe(200);
     expect({ contentLength, received }).toEqual({ contentLength: String(fileSize - 10), received: fileSize - 10 });
+  });
+});
+
+// A FIFO has no size, so its bytes cannot be read into memory up front.
+// The body must be streamed with chunked transfer encoding, and the read
+// must not block the JS thread.
+describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
+  const SIZE = 1024 * 1024;
+  const payload = Buffer.alloc(SIZE);
+  for (let i = 0; i < SIZE; i++) payload[i] = (i * 7) & 0xff;
+  const payloadHash = Bun.CryptoHasher.hash("sha256", payload, "hex");
+
+  function newSeen() {
+    return { contentLength: "?" as string | null, transferEncoding: "?" as string | null, hash: "" };
+  }
+
+  function startOrigin(seen: ReturnType<typeof newSeen>, tlsOptions?: object) {
+    return Bun.serve({
+      port: 0,
+      development: false,
+      maxRequestBodySize: SIZE * 2,
+      ...(tlsOptions ? { tls: tlsOptions } : {}),
+      async fetch(req) {
+        seen.contentLength = req.headers.get("content-length");
+        seen.transferEncoding = req.headers.get("transfer-encoding");
+        const hasher = new Bun.CryptoHasher("sha256");
+        for await (const chunk of req.body!) hasher.update(chunk);
+        seen.hash = hasher.digest("hex");
+        return new Response("ok");
+      },
+    });
+  }
+
+  for (const scheme of ["http", "https"] as const) {
+    test.concurrent(`${scheme}: every byte arrives, chunked`, async () => {
+      using dir = tempDir("fetch-fifo-upload", { "payload.bin": payload });
+      const fifo = join(String(dir), "fifo");
+      mkfifo(fifo);
+
+      await using writer = Bun.spawn({
+        cmd: ["sh", "-c", `cat payload.bin > fifo`],
+        cwd: String(dir),
+        env: bunEnv,
+      });
+
+      const seen = newSeen();
+      await using server = startOrigin(seen, scheme === "https" ? tls : undefined);
+      const res = await fetch(server.url, {
+        method: "POST",
+        body: Bun.file(fifo),
+        tls: { rejectUnauthorized: false },
+      });
+      expect(await res.text()).toBe("ok");
+      expect(res.status).toBe(200);
+      expect(seen).toEqual({ contentLength: null, transferEncoding: "chunked", hash: payloadHash });
+      expect(await writer.exited).toBe(0);
+    });
+  }
+
+  // The writer opens the FIFO only after it reads a line from stdin, and the
+  // fixture writes that line after fetch() returns. With the bug, fetch()
+  // blocks the JS thread inside a read of the FIFO, so the line is never
+  // written and the fixture never prints. It runs in a child process so the
+  // hang cannot take the test runner with it.
+  test.concurrent("fetch() returns before the writer has produced any bytes", async () => {
+    using dir = tempDir("fetch-fifo-upload-wait", {
+      "payload.bin": payload,
+      "fixture.ts": `
+        const writer = Bun.spawn({
+          cmd: ["sh", "-c", "read go; cat payload.bin > fifo"],
+          stdin: "pipe",
+          stdout: "inherit",
+          stderr: "inherit",
+        });
+        const seen = { contentLength: "?", transferEncoding: "?", hash: "" };
+        using server = Bun.serve({
+          port: 0,
+          development: false,
+          maxRequestBodySize: ${SIZE * 2},
+          async fetch(req) {
+            seen.contentLength = req.headers.get("content-length");
+            seen.transferEncoding = req.headers.get("transfer-encoding");
+            const hasher = new Bun.CryptoHasher("sha256");
+            for await (const chunk of req.body) hasher.update(chunk);
+            seen.hash = hasher.digest("hex");
+            return new Response("ok");
+          },
+        });
+        const pending = fetch(server.url, { method: "POST", body: Bun.file("fifo") });
+        console.log("fetch-called");
+        writer.stdin.write("go\\n");
+        await writer.stdin.end();
+        const res = await pending;
+        console.log(JSON.stringify({ status: res.status, text: await res.text(), seen, writerExit: await writer.exited }));
+      `,
+    });
+    mkfifo(join(String(dir), "fifo"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      "fetch-called\n" +
+        JSON.stringify({
+          status: 200,
+          text: "ok",
+          seen: { contentLength: null, transferEncoding: "chunked", hash: payloadHash },
+          writerExit: 0,
+        }) +
+        "\n",
+    );
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -368,8 +368,10 @@ describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
               return false;
             }
           }).length;
+        // Ends only once the FIFO fd is closed. A leak keeps the fixture here
+        // until the test times out.
         while (fdsOnFifo() > 0) await Bun.sleep(1);
-        console.log(JSON.stringify({ outcome, writerAlive: writer.exitCode === null, fdsOnFifo: fdsOnFifo() }));
+        console.log(JSON.stringify({ outcome, writerAlive: writer.exitCode === null }));
         writer.kill();
       `,
     });
@@ -383,7 +385,7 @@ describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout).toBe(JSON.stringify({ outcome: "AbortError", writerAlive: true, fdsOnFifo: 0 }) + "\n");
+    expect(stdout).toBe(JSON.stringify({ outcome: "AbortError", writerAlive: true }) + "\n");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isBroken, isWindows, tempDir, tls, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isBroken, isMacOS, isWindows, tempDir, tls, withoutAggressiveGC } from "harness";
 import { mkfifo } from "mkfifo";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -226,7 +226,11 @@ describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
 // A FIFO has no size, so its bytes cannot be read into memory up front.
 // The body must be streamed with chunked transfer encoding, and the read
 // must not block the JS thread.
-describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
+//
+// todo on macOS: a named pipe read through the event loop never reaches EOF
+// there (#30520), so the chunked body never ends. The same todo covers
+// "Bun.file() read text from pipe" in test/js/web/streams/streams.test.js.
+describe.skipIf(isWindows).todoIf(isMacOS)("Bun.file(fifo) upload", () => {
   const SIZE = 1024 * 1024;
   const payload = Buffer.alloc(SIZE);
   for (let i = 0; i < SIZE; i++) payload[i] = (i * 7) & 0xff;

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -253,8 +253,8 @@ describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
     });
   }
 
-  for (const scheme of ["http", "https"] as const) {
-    test.concurrent(`${scheme}: every byte arrives, chunked`, async () => {
+  describe.each(["http", "https"] as const)("%s", scheme => {
+    test.concurrent("every byte arrives, chunked", async () => {
       using dir = tempDir("fetch-fifo-upload", { "payload.bin": payload });
       const fifo = join(String(dir), "fifo");
       mkfifo(fifo);
@@ -277,7 +277,7 @@ describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
       expect(seen).toEqual({ contentLength: null, transferEncoding: "chunked", hash: payloadHash });
       expect(await writer.exited).toBe(0);
     });
-  }
+  });
 
   // The writer opens the FIFO only after it reads a line from stdin, and the
   // fixture writes that line after fetch() returns. With the bug, fetch()

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -227,10 +227,10 @@ describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
 // The body must be streamed with chunked transfer encoding, and the read
 // must not block the JS thread.
 //
-// todo on macOS: a named pipe read through the event loop never reaches EOF
-// there (#30520), so the chunked body never ends. The same todo covers
-// "Bun.file() read text from pipe" in test/js/web/streams/streams.test.js.
-describe.skipIf(isWindows).todoIf(isMacOS)("Bun.file(fifo) upload", () => {
+// On macOS a named pipe read through the event loop never reaches EOF
+// (#40099 fixes that), so fetch keeps the buffered read for a FIFO there:
+// the body arrives whole with a Content-Length, and the read still blocks.
+describe.skipIf(isWindows)("Bun.file(fifo) upload", () => {
   const SIZE = 1024 * 1024;
   const payload = Buffer.alloc(SIZE);
   for (let i = 0; i < SIZE; i++) payload[i] = (i * 7) & 0xff;
@@ -278,9 +278,48 @@ describe.skipIf(isWindows).todoIf(isMacOS)("Bun.file(fifo) upload", () => {
       });
       expect(await res.text()).toBe("ok");
       expect(res.status).toBe(200);
-      expect(seen).toEqual({ contentLength: null, transferEncoding: "chunked", hash: payloadHash });
+      expect(seen).toEqual(
+        isMacOS
+          ? { contentLength: String(SIZE), transferEncoding: null, hash: payloadHash }
+          : { contentLength: null, transferEncoding: "chunked", hash: payloadHash },
+      );
       expect(await writer.exited).toBe(0);
     });
+  });
+
+  // FormData reads each file part into memory. A FIFO part must be read to
+  // EOF, not to the first buffer's capacity.
+  test.concurrent("a FormData part backed by a FIFO arrives whole", async () => {
+    using dir = tempDir("fetch-fifo-formdata", { "payload.bin": payload });
+    const fifo = join(String(dir), "fifo");
+    mkfifo(fifo);
+
+    await using writer = Bun.spawn({
+      cmd: ["sh", "-c", `cat payload.bin > fifo`],
+      cwd: String(dir),
+      env: bunEnv,
+    });
+
+    let seen = { size: -1, hash: "" };
+    await using server = Bun.serve({
+      port: 0,
+      development: false,
+      maxRequestBodySize: SIZE * 2,
+      async fetch(req) {
+        const part = (await req.formData()).get("f") as Blob;
+        const bytes = await part.bytes();
+        seen = { size: bytes.byteLength, hash: Bun.CryptoHasher.hash("sha256", bytes, "hex") };
+        return new Response("ok");
+      },
+    });
+
+    const form = new FormData();
+    form.append("f", Bun.file(fifo), "f.bin");
+    const res = await fetch(server.url, { method: "POST", body: form });
+    expect(await res.text()).toBe("ok");
+    expect(res.status).toBe(200);
+    expect(seen).toEqual({ size: SIZE, hash: payloadHash });
+    expect(await writer.exited).toBe(0);
   });
 
   // The writer opens the FIFO only after it reads a line from stdin, and the
@@ -288,7 +327,7 @@ describe.skipIf(isWindows).todoIf(isMacOS)("Bun.file(fifo) upload", () => {
   // blocks the JS thread inside a read of the FIFO, so the line is never
   // written and the fixture never prints. It runs in a child process so the
   // hang cannot take the test runner with it.
-  test.concurrent("fetch() returns before the writer has produced any bytes", async () => {
+  test.concurrent.todoIf(isMacOS)("fetch() returns before the writer has produced any bytes", async () => {
     using dir = tempDir("fetch-fifo-upload-wait", {
       "payload.bin": payload,
       "fixture.ts": `


### PR DESCRIPTION
### Problem
- A `fetch()` whose body is `Bun.file()` on a FIFO (or a socket or character device) sends a truncated body with a wrong `Content-Length`. The origin sees `Content-Length: 262160` and 262160 bytes for a 1 MiB payload. No error is raised. A `FormData` part backed by a FIFO truncates the same way.
- The cause is `read_file_with_options` (`src/runtime/node/node_fs.rs:6985`). Both callers pass `max_size = Some(blob.size)`, and an unsized blob has `size == MAX_SIZE`. That `Some` disables buffer growth, so a file with `st_size == 0` stops at the first 256 KiB buffer plus 16 bytes.
- The fetch path also runs that read synchronously on the JS thread (`fetch.rs:1589` on main). The blocking `open()` waits for a writer, the read waits until the writer closes, and no timer fires during the `fetch()` call.

### Fix
- `has_max_size` ignores `MAX_SIZE`. An unsized blob is read to EOF, as `Bun.file(fifo).arrayBuffer()` already does. This fixes the truncation for every caller, `FormData` included.
- `fetch_impl` stats the blob's path (or fstats its fd) before the open. If it is not a regular file, the body becomes a `ReadableStream` over the same store, the way the S3 body path already does. The stream's `FileReader` opens the fd with `O_NONBLOCK` and polls it. The HTTP client sends the bytes with `Transfer-Encoding: chunked`, so nothing blocks the JS thread.
- On macOS a named pipe read through the event loop never sees EOF (#40099 fixes that), so a FIFO keeps the buffered read there. It still blocks the JS thread until the writer closes, and a writer that never closes still freezes the process, but it now delivers every byte. Regular files are unchanged: sendfile, redirects, and `compress` work as before.
- Verified: `test/js/bun/http/fetch-file-upload.test.ts` (six new tests, all fail on bun 1.4.3, 17 of 17 pass with the fix). One of them aborts a fetch while a FIFO writer is alive and silent: the fetch rejects with `AbortError` and no fd on the FIFO stays open. On the shipped bun that process freezes and the abort never fires. Also `fetch.test.ts`, `fetch-compress.test.ts`, `body-stream.test.ts`, `blob.test.ts`, `body.test.ts`, `streams.test.js`, `bun-serve-file.test.ts`, `node/fs/fs.test.ts`.

### Background
- `HTTPRequestBody` is the body the JS thread hands to the HTTP thread. It has three forms: in-memory bytes (`AnyBlob`), a `Sendfile` descriptor with a known byte count, and a `ReadableStream` whose bytes arrive through a `ThreadSafeStreamBuffer`.
- A `ReadableStream` body has no known length. The client emits `Transfer-Encoding: chunked` unless the user set a `Content-Length` header.
- `FileReader` is the native `ReadableStream` source behind `Bun.file().stream()`. For a FIFO or socket it registers the fd with the event loop poller. For a regular file it reads in chunks on demand.
- `S_ISREG` from `stat` is the only signal that a file has a size. A FIFO reports `st_size == 0` while it carries data. A blob with `size == MAX_SIZE` (2^52 - 1) has not been sized yet.

<details><summary>Notes</summary>

Repro on bun 1.4.3 (Linux): `mkfifo p; (head -c 1048576 /dev/zero > p) &` then `fetch(url, { method: "POST", body: Bun.file("p") })`. The origin receives `Content-Length: 262160`. With a writer that sleeps 2 s before it writes, the `fetch()` call itself takes 1998 ms and a 10 ms `setInterval` fires 0 times in that window. With the fix the origin receives 1048576 bytes, chunked, and the interval fires 138 times. `form.append("f", Bun.file("p"))` through the same `fetch()` delivered a 262160-byte part before the fix.

Why 262160: `read_file_with_options` reads 256 KiB before the `fstat`. `st_size` is 0, so `size` becomes the bytes already read, the buffer capacity becomes `size + 16`, and because `max_size` was set the growth arm was skipped. The next read fills the 16-byte tail, the one after gets an empty slice and returns 0.

The first attempt opened the FIFO, ran `fstat`, closed it, and then let the stream reopen it. That broke the FIFO: the close sent the writer `EPIPE` and the stream saw an immediate EOF. The stat now happens before any open.

The first CI run streamed FIFOs on macOS too. The darwin lanes showed the body never ends there (ECONNRESET after the origin's 10 s idle timeout), which is the named pipe EOF bug that #40099 fixes. The macOS gate keeps today's blocking read for FIFOs on that platform, now without the cap. The "fetch() returns before the writer" test is `todo` on macOS for that reason. The http and https tests expect `Content-Length: 1048576` there and chunked elsewhere.

Other bodies checked with the fix: a directory is excluded from the stream path, so it keeps the open and read that reject with `EISDIR` before any request is sent (a test checks that the origin never sees it). `/dev/null` sends an empty chunked body (it sent `Content-Length: 0` before). `/proc/self/status` is `S_ISREG` and keeps the buffered path.

Self-reviewed: 3 concerns raised, 2 addressed (the cap in `node_fs.rs` and the macOS gate). Not taken: deriving the file type from the blob store's `seekable` flag instead of a stat. That flag is only set after the blob has been sized, so a fresh `Bun.file(path)` would still need the stat.

Local failures seen and judged unrelated: the s3 suite and three `fetch.test.ts` tests need outbound network, the "bad permissions" tests fail when run as root, the utf16 gc tests and `bun-write.test.js` "copyFileRange is not available > on large files" time out on the debug build (a 64M-iteration JS loop).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/fetch-file-upload.test.ts

<!-- robobun:evidence:end -->

