### PR TITLE
watcher: warn once when a watch cannot be added

### DIFF
--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -133,6 +133,9 @@ pub struct Watcher {
     pub(crate) on_file_update: fn(*mut (), &mut [WatchEvent], &[ChangedFilePath], &WatchList),
     pub(crate) on_error: fn(*mut (), sys::Error),
 
+    /// Set once the first add-watch failure has been reported.
+    pub(crate) warned_add_failure: core::sync::atomic::AtomicBool,
+
     pub thread_lock: ThreadLock,
 }
 
@@ -205,6 +208,7 @@ impl Watcher {
             evict_list_i: 0,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index_scratch: Vec::new(),
+            warned_add_failure: core::sync::atomic::AtomicBool::new(false),
             thread_lock: ThreadLock::init_unlocked(),
         });
 
@@ -793,6 +797,32 @@ impl Watcher {
             .ensure_unused_capacity(1)
             .unwrap_or_else(|_| bun_core::out_of_memory());
         self.append_directory_assume_capacity::<CLONE_FILE_PATH>(fd, file_path, hash)
+            .inspect_err(|err| self.report_add_failure(err))
+    }
+
+    /// Warns once that a watch could not be added. Callers discard the error.
+    fn report_add_failure(&self, err: &sys::Error) {
+        // A path that vanished between the parse and the watch is routine.
+        if matches!(err.get_errno(), sys::E::ENOENT | sys::E::ENOTDIR) {
+            return;
+        }
+        if self
+            .warned_add_failure
+            .swap(true, core::sync::atomic::Ordering::AcqRel)
+        {
+            return;
+        }
+        bun_core::warn!(
+            "{}\nBun cannot watch this path. Changes to paths that Bun cannot watch do not trigger a reload.",
+            err
+        );
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if err.get_errno() == sys::E::ENOSPC {
+            bun_core::note!(
+                "The inotify watch limit is reached. Raise it with \"sysctl fs.inotify.max_user_watches=524288\""
+            );
+        }
+        Output::flush();
     }
 
     /// Lazily watch a file by path (slow path).
@@ -899,7 +929,7 @@ impl Watcher {
             package_json,
         );
         self.mutex.unlock();
-        r
+        r.inspect_err(|err| self.report_add_failure(err))
     }
 
     pub fn index_of(&self, hash: HashType) -> Option<u32> {

--- a/test/cli/hot/watch-add-fail.test.ts
+++ b/test/cli/hot/watch-add-fail.test.ts
@@ -1,0 +1,91 @@
+// An LD_PRELOAD shim makes every inotify_add_watch fail with ENOSPC (what the
+// kernel returns when fs.inotify.max_user_watches is exhausted). The watcher
+// has to tell the user that it cannot watch. Without the warning, `bun --hot`
+// and the dev server start normally and never reload, with no message.
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+const SHIM_C = /* c */ `
+#include <errno.h>
+int inotify_add_watch(int fd, const char *path, unsigned int mask) {
+    (void)fd; (void)path; (void)mask;
+    errno = ENOSPC;
+    return -1;
+}
+`;
+
+const SERVE_FIXTURE = /* js */ `
+import page from "./index.html";
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  development: true,
+  routes: { "/": page },
+});
+// The route is bundled, and its files watched, on the first request.
+await fetch("http://127.0.0.1:" + server.port + "/");
+console.log("served");
+process.exit(0);
+`;
+
+let shimPath: string;
+let dir: ReturnType<typeof tempDir> | undefined;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("watch-add-fail", {
+    "shim.c": SHIM_C,
+    "hot.js": `console.log("ran"); process.exit(0);`,
+    "index.html": `<script type="module" src="./app.ts"></script>`,
+    "app.ts": `console.log("app");`,
+    "serve.js": SERVE_FIXTURE,
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c")],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+async function runWithShim(args: string[]) {
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent.skipIf(!isLinux || !cc)("bun --hot warns when inotify_add_watch fails", async () => {
+  const { stdout, stderr, exitCode } = await runWithShim(["--hot", "hot.js"]);
+  expect(stdout).toBe("ran\n");
+  expect(stderr).toContain("ENOSPC");
+  expect(stderr).toContain("Bun cannot watch this path");
+  expect(stderr).toContain("fs.inotify.max_user_watches");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent.skipIf(!isLinux || !cc)("the dev server warns when inotify_add_watch fails", async () => {
+  const { stdout, stderr, exitCode } = await runWithShim(["serve.js"]);
+  expect(stdout).toContain("served");
+  expect(stderr).toContain("ENOSPC");
+  expect(stderr).toContain("Bun cannot watch this path");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `inotify_add_watch` returning `ENOSPC` (`fs.inotify.max_user_watches` exhausted) is silent. The dev server, `bun --hot` and `bun --watch` start normally and never reload, with no message.
- Every caller of `Watcher::add_file` and `add_directory` discards the `bun_sys::Error` (`src/bundler/bundle_v2.rs:4719` and `:7245`, `src/runtime/jsc_hooks.rs:3436`). The watcher itself never reports it.

### Fix
- `Watcher::report_add_failure` (`src/watcher/Watcher.rs`) warns once per process, with the errno and the path, when `add_file` or `add_directory` fails. `ENOENT` and `ENOTDIR` are excluded: a path that vanished between the parse and the watch is routine.
- On Linux an `ENOSPC` failure adds a note with the sysctl to raise.
- The warning sits at the one place all 12 call sites go through, so `--hot`, `--watch`, the test watcher and the dev server get it at once. The error still propagates to the callers as before.
- Verified: `test/cli/hot/watch-add-fail.test.ts` (LD_PRELOAD shim that fails every `inotify_add_watch` with `ENOSPC`, covers `--hot` and the dev server, both fail on stock bun). Also `test/cli/hot/`, `test/cli/watch/`, `test/bake/dev/`. `cargo check` on linux, windows and darwin targets.

### Background
- `bun_watcher::Watcher` is the file watcher behind `--hot`, `--watch`, `bun test --watch` and the dev server. The bundler and the module loader add a watch for each file they parse.
- Output under the shim:

```
warn: ENOSPC: /tmp/x/: No space left on device (watch())
Bun cannot watch this path. Changes to paths that Bun cannot watch do not trigger a reload.
note: The inotify watch limit is reached. Raise it with "sysctl fs.inotify.max_user_watches=524288"
```

<details><summary>Notes</summary>

This PR first also carried a dev server change that follows a retargeted symlink on the import path. The self-review asked to split it: that change conflicts with the `DevServer` rework in #40255 and has no user report behind it. It is now #41539, a draft, so the direction can be decided there.

`fs.watch(dir)` already throws `ENOSPC` for the same errno. `inotify_init1` failing with `EMFILE` already prints `error: EMFILE while initializing file watcher for development server`. Only the add-watch error was dropped.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/watch-add-fail.test.ts

<!-- robobun:evidence:end -->