### PR TITLE
Reject a tls array in Bun.listen and Bun.connect

### DIFF
--- a/src/codegen/bindgenv2/internal/dictionary.ts
+++ b/src/codegen/bindgenv2/internal/dictionary.ts
@@ -217,7 +217,8 @@ export function dictionary(
           auto throwScope = DECLARE_THROW_SCOPE(vm);
           auto ctx = Bun::Bindgen::LiteralConversionContext { ${toASCIILiteral(userFacingName)} };
           auto* object = value.getObject();
-          if (!object) [[unlikely]] {
+          // An array has none of the named members, so it is never a valid options bag.
+          if (!object || JSC::isJSArray(object)) [[unlikely]] {
             ctx.throwNotObject(globalObject, throwScope);
             return {};
           }

--- a/src/codegen/bindgenv2/internal/dictionary.ts
+++ b/src/codegen/bindgenv2/internal/dictionary.ts
@@ -206,6 +206,7 @@ export function dictionary(
         #include "root.h"
         #include "Generated${name}.h"
         #include "Bindgen/IDLConvert.h"
+        #include <JavaScriptCore/ArrayConstructor.h>
         #include <JavaScriptCore/Identifier.h>
 
         template<> Bun::Bindgen::Generated::${name}
@@ -217,8 +218,14 @@ export function dictionary(
           auto throwScope = DECLARE_THROW_SCOPE(vm);
           auto ctx = Bun::Bindgen::LiteralConversionContext { ${toASCIILiteral(userFacingName)} };
           auto* object = value.getObject();
+          if (!object) [[unlikely]] {
+            ctx.throwNotObject(globalObject, throwScope);
+            return {};
+          }
           // An array has none of the named members, so it is never a valid options bag.
-          if (!object || JSC::isJSArray(object)) [[unlikely]] {
+          bool isArray = JSC::isArray(&globalObject, value);
+          RETURN_IF_EXCEPTION(throwScope, {});
+          if (isArray) [[unlikely]] {
             ctx.throwNotObject(globalObject, throwScope);
             return {};
           }

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -589,6 +589,20 @@ impl SocketConfig {
         mode: SocketMode,
     ) -> JsResult<SocketConfig> {
         let generated = GeneratedSocketConfig::from_js(global_object, opts)?;
+        if matches!(generated.tls, GeneratedTls::Object(_)) {
+            // The `tls` dictionary accepts any object, including an array.
+            // `Bun.serve` takes an array of TLS options for SNI; `Bun.listen`
+            // and `Bun.connect` do not. An array has none of the named fields,
+            // so it would silently build a plaintext socket.
+            if let Some(tls) = opts.get(global_object, "tls")? {
+                if tls.js_type().is_array() {
+                    return Err(global_object.throw_invalid_arguments(format_args!(
+                        "Expected \"tls\" to be an object or a boolean, not an array. \
+                         Bun.listen and Bun.connect do not accept an array of TLS options"
+                    )));
+                }
+            }
+        }
         Self::from_generated(vm, global_object, generated, mode)
     }
 }

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -589,20 +589,6 @@ impl SocketConfig {
         mode: SocketMode,
     ) -> JsResult<SocketConfig> {
         let generated = GeneratedSocketConfig::from_js(global_object, opts)?;
-        if matches!(generated.tls, GeneratedTls::Object(_)) {
-            // The `tls` dictionary accepts any object, including an array.
-            // `Bun.serve` takes an array of TLS options for SNI; `Bun.listen`
-            // and `Bun.connect` do not. An array has none of the named fields,
-            // so it would silently build a plaintext socket.
-            if let Some(tls) = opts.get(global_object, "tls")? {
-                if tls.js_type().is_array() {
-                    return Err(global_object.throw_invalid_arguments(format_args!(
-                        "Expected \"tls\" to be an object or a boolean, not an array. \
-                         Bun.listen and Bun.connect do not accept an array of TLS options"
-                    )));
-                }
-            }
-        }
         Self::from_generated(vm, global_object, generated, mode)
     }
 }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1045,6 +1045,51 @@ it("should throw on empty unix path from truthy non-string value", () => {
   expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });
 
+it("should throw on a tls array instead of starting a plaintext socket", async () => {
+  const socket = { data() {}, open() {}, close() {} };
+  // An array has none of the TLSOptions fields. Without the check it parses as
+  // an empty config and the listener comes up as plain TCP.
+  const message = 'Expected "tls" to be an object or a boolean, not an array';
+  for (const tlsOption of [[tls], [tls, { serverName: "a.test", ...tls }], []]) {
+    expect(() => Bun.listen({ hostname: "127.0.0.1", port: 0, tls: tlsOption as any, socket })).toThrow(message);
+    expect(() => Bun.connect({ hostname: "127.0.0.1", port: 1, tls: tlsOption as any, socket })).toThrow(message);
+  }
+
+  // The same entry as a plain object still produces a TLS listener.
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    tls,
+    socket: {
+      data(s) {
+        s.write("hello");
+        s.end();
+      },
+      open() {},
+      close() {},
+    },
+  });
+  const { promise, resolve } = Promise.withResolvers<string>();
+  let received = "";
+  await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    tls: { rejectUnauthorized: false },
+    socket: {
+      open(s) {
+        s.write("ping");
+      },
+      data(_s, chunk) {
+        received += chunk.toString();
+      },
+      close() {
+        resolve(received);
+      },
+    },
+  });
+  expect(await promise).toBe("hello");
+});
+
 it("reading .listener on a closed client socket does not use-after-free handlers", async () => {
   // Client-mode Handlers is heap-allocated per-connect and freed in
   // markInactive once the socket closes. `socket.listener` read

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1056,6 +1056,7 @@ it("should throw on a tls array instead of starting a plaintext socket", async (
   }
 
   // The same entry as a plain object still produces a TLS listener.
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
   using server = Bun.listen({
     hostname: "127.0.0.1",
     port: 0,
@@ -1067,9 +1068,9 @@ it("should throw on a tls array instead of starting a plaintext socket", async (
       },
       open() {},
       close() {},
+      error: reject,
     },
   });
-  const { promise, resolve } = Promise.withResolvers<string>();
   let received = "";
   await Bun.connect({
     hostname: "127.0.0.1",
@@ -1085,6 +1086,8 @@ it("should throw on a tls array instead of starting a plaintext socket", async (
       close() {
         resolve(received);
       },
+      error: reject,
+      connectError: reject,
     },
   });
   expect(await promise).toBe("hello");

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1045,17 +1045,28 @@ it("should throw on empty unix path from truthy non-string value", () => {
   expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });
 
-it("should throw on a tls array instead of starting a plaintext socket", async () => {
+// An array has none of the TLSOptions fields. Without the check it parses as
+// an empty config and the listener comes up as plain TCP.
+describe.each([
+  ["one entry", () => [tls]],
+  ["SNI-style entries", () => [tls, { serverName: "a.test", ...tls }]],
+  ["empty", () => []],
+  ["Proxy around an array", () => new Proxy([tls], {})],
+  ["Array subclass", () => new (class extends Array {})(tls)],
+])("tls option is an array (%s)", (_label, makeTls) => {
   const socket = { data() {}, open() {}, close() {} };
-  // An array has none of the TLSOptions fields. Without the check it parses as
-  // an empty config and the listener comes up as plain TCP.
   const message = "TLSOptions must be an object";
-  for (const tlsOption of [[tls], [tls, { serverName: "a.test", ...tls }], []]) {
-    expect(() => Bun.listen({ hostname: "127.0.0.1", port: 0, tls: tlsOption as any, socket })).toThrow(message);
-    expect(() => Bun.connect({ hostname: "127.0.0.1", port: 1, tls: tlsOption as any, socket })).toThrow(message);
-  }
 
-  // The same entry as a plain object still produces a TLS listener.
+  it("Bun.listen throws instead of starting a plaintext listener", () => {
+    expect(() => Bun.listen({ hostname: "127.0.0.1", port: 0, tls: makeTls() as any, socket })).toThrow(message);
+  });
+
+  it("Bun.connect throws instead of opening a plaintext connection", () => {
+    expect(() => Bun.connect({ hostname: "127.0.0.1", port: 1, tls: makeTls() as any, socket })).toThrow(message);
+  });
+});
+
+it("the same tls entry as a plain object still produces a TLS listener", async () => {
   const { promise, resolve, reject } = Promise.withResolvers<string>();
   using server = Bun.listen({
     hostname: "127.0.0.1",
@@ -1068,7 +1079,9 @@ it("should throw on a tls array instead of starting a plaintext socket", async (
       },
       open() {},
       close() {},
-      error: reject,
+      error(_s, err) {
+        reject(err);
+      },
     },
   });
   let received = "";
@@ -1086,8 +1099,12 @@ it("should throw on a tls array instead of starting a plaintext socket", async (
       close() {
         resolve(received);
       },
-      error: reject,
-      connectError: reject,
+      error(_s, err) {
+        reject(err);
+      },
+      connectError(_s, err) {
+        reject(err);
+      },
     },
   });
   expect(await promise).toBe("hello");

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1049,7 +1049,7 @@ it("should throw on a tls array instead of starting a plaintext socket", async (
   const socket = { data() {}, open() {}, close() {} };
   // An array has none of the TLSOptions fields. Without the check it parses as
   // an empty config and the listener comes up as plain TCP.
-  const message = 'Expected "tls" to be an object or a boolean, not an array';
+  const message = "TLSOptions must be an object";
   for (const tlsOption of [[tls], [tls, { serverName: "a.test", ...tls }], []]) {
     expect(() => Bun.listen({ hostname: "127.0.0.1", port: 0, tls: tlsOption as any, socket })).toThrow(message);
     expect(() => Bun.connect({ hostname: "127.0.0.1", port: 1, tls: tlsOption as any, socket })).toThrow(message);


### PR DESCRIPTION
### Problem
- `Bun.listen({ tls: [{ key, cert }], ... })` starts a plaintext TCP listener. No error, no warning. A raw client is served in the clear, and a TLS client fails with `ERR_SSL_WRONG_VERSION_NUMBER` because its ClientHello lands in the app's `data` handler. `Bun.connect` with the same shape opens a plaintext connection.
- The `tls` option is a union of null, boolean, and the `TLSOptions` dictionary (`src/runtime/socket/SocketConfig.bindv2.ts:38`). The generated dictionary conversion accepts any object, so an array lands in the dictionary arm with none of the named members set. `SSLConfig::from_generated` (`src/runtime/socket/SSLConfig.rs:148`) then returns `None`, and `SocketConfig::from_generated` (`src/runtime/socket/Handlers.rs:500`) builds the socket with `ssl: None`.

### Fix
- The generated `convertDictionary` (`src/codegen/bindgenv2/internal/dictionary.ts`) now rejects an array with the same `TypeError` it throws for a non-object: `TLSOptions must be an object`. It uses `JSC::isArray`, the ECMAScript `IsArray` predicate, so a Proxy around an array and an Array subclass are rejected too. A bindgen dictionary is an options bag, and an array has none of its named members, so it is never a valid input.
- This is the shape the types already declare (`tls?: TLSOptions | boolean` for listen and connect). Only `Bun.serve` accepts an array of TLS options (SNI), and it checks for an array before it reaches the dictionary, so its array form is unchanged.
- `tls: {}` keeps its current meaning (no TLS). `Bun.serve` treats an empty object the same way for backwards compatibility, so this change does not touch it.
- Verified: `test/js/bun/net/socket.test.ts` (new `describe.each` "tls option is an array": five shapes, each for `Bun.listen` and `Bun.connect`, fails on the released bun; plus a TLS round trip with a plain object). Also ran `tcp-server.test.ts`, `bun-server.test.ts`, `test/js/bun/tls/`, `test/js/bun/test/fake-timers/`, `node-net-server.test.ts`, `node-tls-server.test.ts`, and `node-tls-connect.test.ts`.

### Background
- `SocketConfig` is the parsed form of the options object for `Bun.listen` and `Bun.connect`. Its `tls` field is generated by bindgen from `SocketConfig.bindv2.ts` as an ordered union: the converter tries null, then boolean, then the `TLSOptions` dictionary.
- bindgen (`src/codegen/bindgenv2/`) generates the C++ that converts a JS options object into a typed struct for Rust. Three dictionaries use it today: `SocketConfig`, `SSLConfig` (`TLSOptions`), and `FakeTimersConfig`.
- An `SSLConfig` is the native TLS configuration (key, cert, ca, ciphers, ...). `SSLConfig::from_generated` returns `None` when no member of the dictionary was present, which callers read as "no TLS".

<details><summary>Notes</summary>

- Repro on the released bun (1.4.3 canary): a listener with `tls: [entry]` served `SECRET` to a plain `Bun.connect` client with no `tls` option.
- The first revision checked for an array in `SocketConfig::from_js` after the generated parse. That read the `tls` property twice and needed a comment to explain itself. The dictionary-level check reads the value once and also covers the other `TLSOptions` consumers (`fetch`, `SecureContext`, `upgradeTLS`, valkey).
- Three tests in the suites above fail on this container regardless of the change: `should not call drain before handshake` (no outbound DNS for `www.example.com`), `allows listen on IPV6` (no IPv6 here), and `SNICallback runs even when the requested servername matches the bind hostname` (`localhost` resolves to `::1` only). All fail the same way with `USE_SYSTEM_BUN=1`.
- The empty-array case `tls: []` also throws. `Bun.serve` treats `[]` as no TLS, but `Bun.listen` never accepted an array, so there is no compatibility to keep.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->
