### PR TITLE
resolver: anchor a relative require.resolve paths entry at the cwd

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1971,12 +1971,23 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    // Node anchors a relative `paths` entry at the cwd
+                    // (`Module._nodeModulePaths` starts with `path.resolve(from)`).
+                    let mut abs_buf = bun_paths::path_buffer_pool::get();
+                    let custom_dir: &[u8] = if bun_paths::is_absolute(custom_utf8.slice()) {
+                        custom_utf8.slice()
+                    } else {
+                        use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
+                        match join_abs_string_buf_checked::<platform::Auto>(
+                            self.fs_ref().top_level_dir,
+                            &mut *abs_buf,
+                            &[custom_utf8.slice()],
+                        ) {
+                            Some(dir) => dir,
+                            None => continue,
+                        }
+                    };
+                    match self.check_package_path(custom_dir, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1971,8 +1971,7 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8();
-                    // Node anchors a relative `paths` entry at the cwd
-                    // (`Module._nodeModulePaths` starts with `path.resolve(from)`).
+                    // A relative entry is cwd-relative, like Node's `path.resolve(from)`.
                     let mut abs_buf = bun_paths::path_buffer_pool::get();
                     let custom_dir: &[u8] = if bun_paths::is_absolute(custom_utf8.slice()) {
                         custom_utf8.slice()

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1977,12 +1977,10 @@ impl<'a> Resolver<'a> {
                     let custom_dir: &[u8] = if bun_paths::is_absolute(custom_utf8.slice()) {
                         custom_utf8.slice()
                     } else {
-                        use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
-                        match join_abs_string_buf_checked::<platform::Auto>(
-                            self.fs_ref().top_level_dir,
-                            &mut *abs_buf,
-                            &[custom_utf8.slice()],
-                        ) {
+                        match self
+                            .fs_ref()
+                            .abs_buf_checked(&[custom_utf8.slice()], &mut *abs_buf)
+                        {
                             Some(dir) => dir,
                             None => continue,
                         }

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -199,3 +199,40 @@ test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is no
     Module._resolveFilename("path", __filename, false, { paths: { 0: "/some/path" } });
   }).toThrow();
 });
+
+test("require.resolve anchors a relative options.paths entry at the cwd", () => {
+  // Node resolves a relative entry with path.resolve(), so it is relative to process.cwd().
+  const { path: dir, cleanup } = createTempDir("require-resolve-relative-paths", {
+    "lib/node_modules/relative-paths-pkg/package.json": JSON.stringify({
+      name: "relative-paths-pkg",
+      main: "index.js",
+    }),
+    "lib/node_modules/relative-paths-pkg/index.js": "module.exports = 'relative-paths';",
+  });
+  const previousCwd = process.cwd();
+
+  try {
+    process.chdir(dir);
+    const expected = resolve(dir, "lib/node_modules/relative-paths-pkg/index.js");
+
+    expect(require.resolve("relative-paths-pkg", { paths: ["./lib"] })).toBe(expected);
+    expect(require.resolve("relative-paths-pkg", { paths: ["lib"] })).toBe(expected);
+
+    const fakeParent = new Module("/some/other/directory/file.js");
+    fakeParent.filename = "/some/other/directory/file.js";
+    fakeParent.paths = Module._nodeModulePaths("/some/other/directory");
+    expect(Module._resolveFilename("relative-paths-pkg", fakeParent, false, { paths: ["lib"] })).toBe(expected);
+
+    // An entry that does not exist under the cwd is not found.
+    let caught;
+    try {
+      require.resolve("relative-paths-pkg", { paths: ["./missing"] });
+    } catch (err) {
+      caught = err.code;
+    }
+    expect(caught).toBe("MODULE_NOT_FOUND");
+  } finally {
+    process.chdir(previousCwd);
+    cleanup();
+  }
+});


### PR DESCRIPTION
### Problem
- `require.resolve("pkg", { paths: ["./lib"] })` throws `MODULE_NOT_FOUND` in Bun. Node resolves it to `<cwd>/lib/node_modules/pkg/index.js`. The same applies to `Module._resolveFilename(..., { paths })` and `createRequire(...).resolve`.
- The cause: the resolver passes each `paths` entry as-is to `check_package_path` (`src/resolver/resolver.rs:1974`). `dir_info_cached` (`resolver.rs:4192`) returns no `DirInfo` for a non-absolute path, so the entry is never searched. Node runs `path.resolve(from)` on each entry in `Module._nodeModulePaths` first.

### Fix
- In the `custom_dir_paths` package loop, a non-absolute entry is joined against the cwd (`top_level_dir`) with host-native path semantics. The joined path lives in a pooled path buffer for the duration of that one `check_package_path` call.
- Absolute entries are passed through unchanged. The relative-specifier loop (`./x` with `paths`) already joins against the cwd via `abs_buf_checked`, so it needs no change.
- `process.chdir()` updates `top_level_dir`, so the anchor follows the current cwd like Node's `process.cwd()`.
- Verified: `test/js/node/module/module-resolve-filename-paths.test.js` (new test, passes under `node --test` v26.3.0, fails on bun 1.4.3). Also `test/js/node/module/node-module-module.test.js` and `test/js/bun/resolve/`.

### Background
- `custom_dir_paths` is a per-call slot on the resolver. `Bun__resolveSyncWithPaths` (`src/runtime/api/BunObject.rs`) sets it from `options.paths` and clears it when the resolve returns. The resolver then searches only those directories, not the importer's ancestors.
- `top_level_dir` on the resolver's `FileSystem` is the process cwd. `process.chdir` rewrites it.
- #31566 contains the same resolver change plus C++ changes that are already on main in another form. That PR conflicts with main in three files. This PR carries only the resolver part.

<details><summary>Notes</summary>

Matrix checked against node v26.3.0 from a directory with `lib/node_modules/foo/index.js` and `lib/bar.js`. Entries `./lib`, `lib`, `../<dir>/lib`, absolute, `.`. Specifiers `foo`, `./bar`, `./bar.js`, `foo/index.js`. Before the fix the six bare-name cells with a relative entry differed. After the fix all 20 cells match.

When the cwd has no `package.json` and the `paths` entry does not exist, Bun falls through to auto-install from the global cache where Node throws `MODULE_NOT_FOUND`. That is the existing auto-install extension and is unchanged here.

`test/js/bun/resolve/load-same-js-file-a-lot.test.ts` ("load the same empty JS file 2000 times") times out at 5 s in this debug container with and without this diff.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/module/module-resolve-filename-paths.test.js
bun test v1.4.3 (f42e98025)

test/js/node/module/module-resolve-filename-paths.test.js:
(pass) Module._resolveFilename respects options.paths for package resolution [56.06ms]
(pass) Module._resolveFilename respects options.paths for relative paths [11.15ms]
(pass) Module._resolveFilename with overridden function receives options.paths [17.18ms]
(pass) require.resolve respects options.paths for package resolution [13.80ms]
(pass) require.resolve with relative path and options.paths (Next.js use case) [10.92ms]
(pass) Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array [11.23ms]
213 | 
214 |   try {
215 |     process.chdir(dir);
216 |     const expected = resolve(dir, "lib/node_modules/relative-paths-pkg/index.js");
217 | 
218 |     expect(require.resolve("relative-paths-pkg", { paths: ["./lib"] })).toBe(expected);
                 ^
ResolveMessage: Cannot find module 'relative-paths-pkg'
Require stack:
- /workspace/bun/test/js/node/module/module-re
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/module/module-resolve-filename-paths.test.js:
(pass) Module._resolveFilename respects options.paths for package resolution [1.58ms]
(pass) Module._resolveFilename respects options.paths for relative paths [0.40ms]
(pass) Module._resolveFilename with overridden function receives options.paths [0.74ms]
(pass) require.resolve respects options.paths for package resolution [0.62ms]
(pass) require.resolve with relative path and options.paths (Next.js use case) [0.64ms]
(pass) Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array [0.18ms]
213 | 
214 |   try {
215 |     process.chdir(dir);
216 |     const expected = resolve(dir, "lib/node_modules/relative-paths-pkg/index.js");
217 | 
218 |     expect(require.resolve("relative-paths-pkg", { paths: ["./lib"] })).toBe(expected);
                 ^
ResolveMessage: Cannot find module 'relative-paths-pkg'
Require stack:
- /workspace/bun/test/js/node/module/module-resolve-filename-paths.test.js
      at <anonymous> (/workspace/bun/test/js/node/module/module-resolve-filename-paths.test.js:218:12)
(fail) require.resolve anchors a relative options.paths
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/module/module-resolve-filename-paths.test.js
bun test v1.4.3 (f42e98025)

test/js/node/module/module-resolve-filename-paths.test.js:
(pass) Module._resolveFilename respects options.paths for package resolution [364.29ms]
(pass) Module._resolveFilename respects options.paths for relative paths [6.03ms]
(pass) Module._resolveFilename with overridden function receives options.paths [9.85ms]
(pass) require.resolve respects options.paths for package resolution [8.29ms]
(pass) require.resolve with relative path and options.paths (Next.js use case) [6.97ms]
(pass) Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array [8.21ms]
(pass) require.resolve anchors a relative options.paths entry at the cwd [13.81ms]

 7 pass
 0 fail
 14 expect() calls
Ran 7 tests across 1 file. [2.46s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     403d5a9647
  features     baseline

23 deps, 131 codegen, 1172 objects in 893ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [15.00ms]
[3/1244] gen bindgenv2
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [4.00ms]
[6/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1216] fetch zlib
[zlib] up to date
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [32.00ms]
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs                           | 20 ++++++++----
 .../module/module-resolve-filename-paths.test.js   | 37 ++++++++++++++++++++++
 2 files changed, 51 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/resolver/resolver.rs                                      7      4      6
…st/js/node/module/module-resolve-filename-paths.test.js      1      0      6
```

</details>

**root cause** · written by the author bot

When `require.resolve(id, { paths: [...] })` or `Module._resolveFilename` received a relative `paths` entry, the resolver passed it straight to `dir_info_cached`, which cannot locate a non-absolute directory, so every lookup through that entry failed with `MODULE_NOT_FOUND` even when the package existed. The fix makes the `custom_dir_paths` loop in `resolver.rs` check `bun_paths::is_absolute()` and, for relative entries, join them against the current working directory via the existing `FileSystem::abs_buf_checked` helper into a pooled buffer before calling `check_package_path`, leaving abso…

<!-- robobun:evidence:end -->