### PR TITLE
sql: reject a query that is cancelled before it runs

### DIFF
--- a/src/js/internal/sql/query.ts
+++ b/src/js/internal/sql/query.ts
@@ -100,15 +100,17 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   #run() {
     const { [_handler]: handler, [_queryStatus]: status } = this;
 
-    if (
-      status &
-      (SQLQueryStatus.executed | SQLQueryStatus.error | SQLQueryStatus.cancelled | SQLQueryStatus.invalidHandle)
-    ) {
+    if (status & (SQLQueryStatus.executed | SQLQueryStatus.error | SQLQueryStatus.invalidHandle)) {
       return;
     }
 
     if (this[_flags] & SQLQueryFlags.notTagged) {
       this.reject(this[_adapter].notTaggedCallError());
+      return;
+    }
+
+    if (status & SQLQueryStatus.cancelled) {
+      this.reject(this[_adapter].queryCancelledError());
       return;
     }
 
@@ -130,15 +132,17 @@ class Query<T, Handle extends BaseQueryHandle<any>> extends PublicPromise<T> {
   async #runAsync() {
     const { [_handler]: handler, [_queryStatus]: status } = this;
 
-    if (
-      status &
-      (SQLQueryStatus.executed | SQLQueryStatus.error | SQLQueryStatus.cancelled | SQLQueryStatus.invalidHandle)
-    ) {
+    if (status & (SQLQueryStatus.executed | SQLQueryStatus.error | SQLQueryStatus.invalidHandle)) {
       return;
     }
 
     if (this[_flags] & SQLQueryFlags.notTagged) {
       this.reject(this[_adapter].notTaggedCallError());
+      return;
+    }
+
+    if (status & SQLQueryStatus.cancelled) {
+      this.reject(this[_adapter].queryCancelledError());
       return;
     }
 

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -914,6 +914,59 @@ describe("Query Execution", () => {
     expect(result2).toHaveLength(1);
     expect(result2[0].id).toBe(2);
   });
+
+  // These tests `await` the cancelled query directly. A pending promise inside
+  // `expect().rejects` does not trip the test timeout, so a hang would stall the file.
+  function settle(promise: Promise<unknown>) {
+    return promise.then(
+      () => "resolved",
+      (error: Error & { code?: string }) => ({ code: error.code, message: error.message }),
+    );
+  }
+
+  test("cancel() before the query runs rejects when awaited", async () => {
+    const query = sql`SELECT 1 AS x`;
+    query.cancel();
+    expect(query.cancelled).toBe(true);
+
+    expect(await settle(query)).toEqual({ code: "ERR_SQLITE_QUERY_CANCELLED", message: "Query cancelled" });
+    // The connection stays usable.
+    expect(await sql`SELECT 2 AS x`).toEqual([{ x: 2 }]);
+  });
+
+  test("cancel() before the query runs settles a Promise.all batch", async () => {
+    const cancelled = sql`SELECT 1 AS x`;
+    cancelled.cancel();
+    const live = sql`SELECT 2 AS x`;
+
+    expect(await settle(Promise.all([cancelled, live]))).toEqual({
+      code: "ERR_SQLITE_QUERY_CANCELLED",
+      message: "Query cancelled",
+    });
+    expect(await live).toEqual([{ x: 2 }]);
+  });
+
+  test("cancel() before execute() rejects instead of running", async () => {
+    await sql`CREATE TABLE cancel_before_execute (id INTEGER)`;
+    const query = sql`INSERT INTO cancel_before_execute VALUES (1)`;
+    query.cancel();
+    query.execute();
+
+    expect(await settle(query)).toEqual({ code: "ERR_SQLITE_QUERY_CANCELLED", message: "Query cancelled" });
+    expect(await sql`SELECT count(*) AS n FROM cancel_before_execute`).toEqual([{ n: 0 }]);
+  });
+
+  // A query that never runs opens no connection, so the server does not need to exist.
+  test.each([
+    ["postgres://u:p@127.0.0.1:9/db", "ERR_POSTGRES_QUERY_CANCELLED"],
+    ["mysql://u:p@127.0.0.1:9/db", "ERR_MYSQL_QUERY_CANCELLED"],
+  ])("cancel() before the query runs rejects for %s", async (url, code) => {
+    await using remote = new SQL(url);
+    const query = remote`SELECT 1 AS x`;
+    query.cancel();
+
+    expect(await settle(query)).toEqual({ code, message: "Query cancelled" });
+  });
 });
 
 describe("Parameterized Queries", () => {


### PR DESCRIPTION
### Problem
- `query.cancel()` on a `Bun.SQL` query that has not run yet leaves the promise pending forever. `await q` never resumes, and a `Promise.all` that contains the query stalls. This affects sqlite, postgres, and mysql alike.
- The cause is in `src/js/internal/sql/query.ts`. `cancel()` sets the `cancelled` status bit and calls `handle.cancel()` only when the query already executed. The later `#run()` and `#runAsync()` (triggered by `.then`, `await`, or `execute()`) return early on the `cancelled` bit without a `reject()`, so nothing can settle the promise.

### Fix
- `#run()` and `#runAsync()` now reject with the adapter's `queryCancelledError()` when they see the `cancelled` bit on a query that has not executed. The `executed`, `error`, and `invalidHandle` early returns are unchanged.
- This matches what the pool handlers in `src/js/bun/sql.ts` already do for a query that is cancelled while it waits for a connection: `query.reject(pool.queryCancelledError())`. The `reject()` path sets the `error` bit, so a second run is still a no-op.
- The rejection is lazy. It happens when something consumes the query, so `q.cancel()` on a query that nobody awaits does not raise an unhandled rejection.
- Verified: `test/js/sql/sqlite-sql.test.ts` (5 new tests, all time out on the released bun). Also the full `sqlite-sql.test.ts`, `local-sql.test.ts`, `sql-prepare-false.test.ts`, and `sql-reserve-abort.test.ts`.

### Background
- `Query` extends `Promise`. A query is lazy: the constructor only stores the SQL and values. The first `.then`, `.catch`, `.finally`, `execute()`, or `run()` call starts it.
- `Query` keeps a status bitfield (`active`, `cancelled`, `error`, `executed`, `invalidHandle`). `cancel()` only flips the bit when the query has not executed, because there is no native handle to cancel yet.
- Each adapter provides `queryCancelledError()`. The codes are `ERR_SQLITE_QUERY_CANCELLED`, `ERR_POSTGRES_QUERY_CANCELLED`, and `ERR_MYSQL_QUERY_CANCELLED`.

<details><summary>Notes</summary>

Repro on bun 1.3.14, 1.4.2, and main:

```ts
import { SQL } from "bun";
const sql = new SQL(":memory:");
const q = sql`select 1 as x`;
q.cancel();
await q; // never resumes
```

The new tests await the query directly through a small `settle()` helper instead of `expect(q).rejects`. A pending promise inside `expect().rejects` does not trip the test timeout in `bun test`, so the unfixed build would hang the file instead of failing the test. That runner behaviour is tracked separately.

The postgres and mysql cases use an unreachable server URL on purpose. A query that never runs never opens a connection, so the tests do not need a database.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/sqlite-sql.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [124.57ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [12.89ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [42.39ms]
(pass) Connection & Initialization > should handle connection with options object [105.39ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [18.29ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [28.06ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [47.26ms]
(pass) Connection & Initialization > should work with relative paths [43.76ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [46.89ms]
(pass) Connection & Initialization >
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [10.18ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [1.57ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [1.79ms]
(pass) Connection & Initialization > should handle connection with options object [7.46ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [0.38ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [14.76ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [28.51ms]
(pass) Connection & Initialization > should work with relative paths [25.98ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [40.17ms]
(pass) Connection & Initialization > Environment Variable Handling > should handle DATABASE_URL with :memory: [0.60ms]
(pass) Connection & Initialization > Environment Variable Handling > should h
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/sqlite-sql.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [122.88ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [13.32ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [44.34ms]
(pass) Connection & Initialization > should handle connection with options object [107.75ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [18.77ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [28.52ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [56.24ms]
(pass) Connection & Initialization > should work with relative paths [47.52ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [58.63ms]
(pass) Connection & Initialization >
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     380febfa78
  features     baseline

23 deps, 131 codegen, 1172 objects in 621ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [21.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [6.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] fetch zlib
[zlib] up to date
[7/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[9/1243] gen .bind.ts → GeneratedBindings.cpp
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/query.ts   | 20 +++++++++-------
 test/js/sql/sqlite-sql.test.ts | 53 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 65 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/js/internal/sql/query.ts        1      2     16
test/js/sql/sqlite-sql.test.ts      2      2     16
```

</details>

**root cause** · written by the author bot

In `Bun.SQL`, `query.cancel()` on a query that had not yet executed only set the `cancelled` status bit, and the subsequent `#run()` / `#runAsync()` (triggered by `.then` or `await`) early-returned on that bit without ever calling `reject()`, leaving the promise pending forever across the sqlite, postgres, and mysql adapters. The fix gives the `cancelled` bit its own branch in both `#run()` and `#runAsync()` that rejects with the adapter's `queryCancelledError()`, mirroring the adjacent `notTaggedCallError()` pattern so the promise settles with the same "Query cancelled" error an executed-t…

<!-- robobun:evidence:end -->