### PR TITLE
test: cover fetch() recursion depth after PathBuffer scratch moved to the pool

### DIFF
--- a/test/js/web/fetch/body-async-iterator.test.ts
+++ b/test/js/web/fetch/body-async-iterator.test.ts
@@ -27,6 +27,42 @@ test("Response.bytes() with async iterable body does not crash with null deref",
   expect(exitCode).toBe(0);
 });
 
+// Each level of this recursion holds one native fetch() frame on the stack.
+// Windows used to reach 16 levels before the RangeError because that frame
+// carried three 96 KB path buffers (Linux: 387 levels with the same script).
+// With the buffers taken from the pool, a Windows debug build reaches 97
+// and a Linux debug build reaches 57. Bun 1.4.3 on Windows reaches 16.
+test("fetch() called from a body's Symbol.asyncIterator getter recurses deeply before the stack limit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      let depth = 0;
+      const signal = AbortSignal.abort();
+      const body = {
+        get [Symbol.asyncIterator]() {
+          depth++;
+          fetch("http://localhost/", { method: "POST", body, signal }).catch(() => {});
+          return undefined;
+        },
+      };
+      fetch("http://localhost/", { method: "POST", body, signal }).catch(() => {});
+      console.log(depth);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(Number(stdout.trim())).toBeGreaterThanOrEqual(32);
+  expect(exitCode).toBe(0);
+});
+
 test("Response.arrayBuffer() with async iterable body does not crash with null deref", async () => {
   await using proc = Bun.spawn({
     cmd: [


### PR DESCRIPTION
### Problem
- #41442 (e8541037c4) moved the four `PathBuffer` locals in `fetch_impl` and `NodeFS::sync_error_buf` from the stack to `bun_paths::path_buffer_pool`. On Windows, that shrank one native `fetch()` frame by about 288 KB. Its body says the test from #40680 was not included.
- #40680 carried the same source changes plus a test. It is now closed as superseded. This PR adds only its test.

### Fix
- Test only. `test/js/web/fetch/body-async-iterator.test.ts` gains one test. It spawns bun with a request body whose `Symbol.asyncIterator` getter calls `fetch()` again, so each level adds one native `fetch()` frame. It asserts at least 32 levels before the `RangeError`.
- Verified on Windows x64: bun 1.4.3 canary 76e9dcc6a (before #41442) reaches 16 and fails the test. A debug build of main at 0d0b28b90 reaches 97 and passes.
- Verified on Linux x64: release 1.4.3 reaches 387, a debug build of main reaches 57. The whole file passes with `bun bd test test/js/web/fetch/body-async-iterator.test.ts` on both platforms.

### Background
- `bun_paths::PathBuffer` is a 96 KB byte array. `fetch_impl` used to keep up to four of them as locals, and `NodeFS` embedded one as a field. The Windows main thread has a small stack, so the frame size set the recursion limit.
- `bun_paths::path_buffer_pool::get()` returns a `Guard` that borrows a heap buffer from a thread-local pool and returns it on drop. The frame then holds one pointer per buffer.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/body-async-iterator.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/body-async-iterator.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/fetch/body-async-iterator.test.ts:
(pass) Response.bytes() with async iterable body does not crash with null deref [321.50ms]
(pass) fetch() called from a body's Symbol.asyncIterator getter recurses deeply before the stack limit [346.76ms]
(pass) Response.arrayBuffer() with async iterable body does not crash with null deref [273.71ms]

 3 pass
 0 fail
 7 expect() calls
Ran 3 tests across 1 file. [3.53s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/body-async-iterator.test.ts | 36 +++++++++++++++++++++++++++
 1 file changed, 36 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/web/fetch/body-async-iterator.test.ts      1      1      6
```

</details>

<!-- robobun:evidence:end -->