### PR TITLE
fetch: fall back to read+write when sendfile(2) refuses a Bun.file() body

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -50,6 +50,9 @@ pub struct InternalState<'a> {
     pub(crate) request_stage: HTTPStage,
     pub(crate) response_stage: HTTPStage,
     pub(crate) certificate_info: Option<CertificateInfo>,
+    /// Set when `sendfile(2)` refused the request body fd. `to_result` moves
+    /// it into the next progress update for the JS thread.
+    pub(crate) sendfile_fallback: Option<crate::send_file::SendfileFallback>,
 }
 
 // Struct-of-bools so the
@@ -122,6 +125,7 @@ impl Default for InternalState<'_> {
             request_stage: HTTPStage::Pending,
             response_stage: HTTPStage::Pending,
             certificate_info: None,
+            sendfile_fallback: None,
         }
     }
 }

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -50,8 +50,7 @@ pub struct InternalState<'a> {
     pub(crate) request_stage: HTTPStage,
     pub(crate) response_stage: HTTPStage,
     pub(crate) certificate_info: Option<CertificateInfo>,
-    /// Set when `sendfile(2)` refused the request body fd. `to_result` moves
-    /// it into the next progress update for the JS thread.
+    /// Moved into the next progress update by `to_result`.
     pub(crate) sendfile_fallback: Option<crate::send_file::SendfileFallback>,
 }
 

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -13,12 +13,10 @@ pub struct SendFile {
     pub content_size: usize,
 }
 
-/// Handed to the JS thread when `sendfile(2)` refused the fd after the request
-/// head went out. The JS thread streams the rest of the file from `offset`
-/// into `buffer`, which the HTTP thread drains as a `HTTPRequestBody::Stream`.
+/// The rest of a refused sendfile body: the JS thread streams the file from
+/// `offset` for `remain` bytes into `buffer`.
 pub struct SendfileFallback {
-    /// The JS side's ref. The HTTP thread holds the other one in
-    /// `http_request_body::Stream::buffer`.
+    /// The JS side's ref; the HTTP thread holds the other one.
     pub buffer: bun_ptr::RefPtr<crate::ThreadSafeStreamBuffer>,
     pub offset: usize,
     pub remain: usize,
@@ -73,8 +71,7 @@ impl SendFile {
                     }
                 }
                 bun_sys::E::EAGAIN => {}
-                // Same set as the statx and copy_file_range fallbacks: the
-                // syscall is refused for this fd, not failing on it.
+                // Same set as the statx and copy_file_range fallbacks.
                 bun_sys::E::EINVAL
                 | bun_sys::E::ENOSYS
                 | bun_sys::E::EOPNOTSUPP
@@ -158,9 +155,7 @@ pub(crate) enum Status {
     Done,
     #[cfg(not(windows))]
     Err(crate::Error),
-    /// The kernel, a seccomp policy, or the filesystem refused `sendfile(2)`
-    /// for this fd. Nothing was sent by this call. The caller hands the rest
-    /// of the body to the JS thread as a `SendfileFallback`.
+    /// `sendfile(2)` is refused for this fd. Nothing was sent by this call.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     Refused,
     Again,

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -1,16 +1,9 @@
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
 use core::ptr;
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use bun_core::feature_flags;
 use bun_sys::{self, Fd};
 use bun_url::URL;
-
-/// Set once `sendfile(2)` answers `ENOSYS`. The JS thread reads it in
-/// `is_eligible`, so later uploads skip the missing syscall and read the
-/// file into memory as on other platforms.
-static SENDFILE_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Copy, Clone)]
 pub struct SendFile {
@@ -18,19 +11,23 @@ pub struct SendFile {
     pub remain: usize,
     pub offset: usize,
     pub content_size: usize,
-    /// Set once `sendfile(2)` refuses the fd (seccomp, a filesystem without
-    /// `splice_read`, an old kernel). The rest of the body goes through
-    /// `pread` + `write` from `offset`, so nothing already sent is repeated.
-    pub use_read_write: bool,
+}
+
+/// Handed to the JS thread when `sendfile(2)` refused the fd after the request
+/// head went out. The JS thread streams the rest of the file from `offset`
+/// into `buffer`, which the HTTP thread drains as a `HTTPRequestBody::Stream`.
+pub struct SendfileFallback {
+    /// The JS side's ref. The HTTP thread holds the other one in
+    /// `http_request_body::Stream::buffer`.
+    pub buffer: bun_ptr::RefPtr<crate::ThreadSafeStreamBuffer>,
+    pub offset: usize,
+    pub remain: usize,
 }
 
 impl SendFile {
     pub fn is_eligible(url: &URL) -> bool {
         // `if cfg!()` is fine here: both branches type-check (no platform-only items referenced).
         if cfg!(windows) || !feature_flags::STREAMING_FILE_UPLOADS_FOR_HTTP_CLIENT {
-            return false;
-        }
-        if SENDFILE_UNAVAILABLE.load(Ordering::Relaxed) {
             return false;
         }
         url.is_http() && url.href.len() > 0
@@ -48,9 +45,6 @@ impl SendFile {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let _ = adjusted_count; // unused on Linux path
-            if self.use_read_write {
-                return self.write_with_read_write(socket_fd);
-            }
             let mut signed_offset: i64 = i64::try_from(self.offset).expect("int cast");
             let begin = self.offset;
             // this does the syscall directly, without libc
@@ -84,13 +78,7 @@ impl SendFile {
                 bun_sys::E::EINVAL
                 | bun_sys::E::ENOSYS
                 | bun_sys::E::EOPNOTSUPP
-                | bun_sys::E::EPERM => {
-                    if errcode == bun_sys::E::ENOSYS {
-                        SENDFILE_UNAVAILABLE.store(true, Ordering::Relaxed);
-                    }
-                    self.use_read_write = true;
-                    return self.write_with_read_write(socket_fd);
-                }
+                | bun_sys::E::EPERM => return Status::Refused,
                 _ => return Status::Err(bun_errno::from_errno(errcode as i32).into()),
             }
         }
@@ -163,44 +151,6 @@ impl SendFile {
 
         Status::Again
     }
-
-    /// Copy from `offset` to the socket until the socket would block, the
-    /// window is sent, or the file ends early. `pread` keeps the fd's file
-    /// position untouched, so a partial socket write is resumed at `offset`
-    /// on the next writable event.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn write_with_read_write(&mut self, socket_fd: Fd) -> Status {
-        let mut stack_buf = bun_core::vec::UninitBuf::<{ 16 * 4096 }>::uninit();
-        // SAFETY: `pread` is the only writer of `buf`; only `buf[..read]` is read back.
-        let buf = unsafe { stack_buf.as_bytes_mut() };
-        loop {
-            if self.remain == 0 {
-                return Status::Done;
-            }
-            let want = buf.len().min(self.remain);
-            let Ok(signed_offset) = i64::try_from(self.offset) else {
-                return Status::Err(bun_errno::SystemErrno::EOVERFLOW.into());
-            };
-            let read = match bun_sys::pread(self.fd, &mut buf[..want], signed_offset) {
-                Ok(0) => return Status::Done,
-                Ok(n) => n,
-                Err(err) => return Status::Err(crate::Error::Sys(err.into())),
-            };
-            let mut sent = 0;
-            while sent < read {
-                match bun_sys::write(socket_fd, &buf[sent..read]) {
-                    Ok(0) => return Status::Again,
-                    Ok(n) => {
-                        sent += n;
-                        self.offset += n;
-                        self.remain -= n;
-                    }
-                    Err(err) if err.get_errno() == bun_sys::E::EAGAIN => return Status::Again,
-                    Err(err) => return Status::Err(crate::Error::Sys(err.into())),
-                }
-            }
-        }
-    }
 }
 
 pub(crate) enum Status {
@@ -208,5 +158,10 @@ pub(crate) enum Status {
     Done,
     #[cfg(not(windows))]
     Err(crate::Error),
+    /// The kernel, a seccomp policy, or the filesystem refused `sendfile(2)`
+    /// for this fd. Nothing was sent by this call. The caller hands the rest
+    /// of the body to the JS thread as a `SendfileFallback`.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    Refused,
     Again,
 }

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -1,9 +1,16 @@
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
 use core::ptr;
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use bun_core::feature_flags;
 use bun_sys::{self, Fd};
 use bun_url::URL;
+
+/// Set once `sendfile(2)` answers `ENOSYS`. The JS thread reads it in
+/// `is_eligible`, so later uploads skip the missing syscall and read the
+/// file into memory as on other platforms.
+static SENDFILE_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Copy, Clone)]
 pub struct SendFile {
@@ -21,6 +28,9 @@ impl SendFile {
     pub fn is_eligible(url: &URL) -> bool {
         // `if cfg!()` is fine here: both branches type-check (no platform-only items referenced).
         if cfg!(windows) || !feature_flags::STREAMING_FILE_UPLOADS_FOR_HTTP_CLIENT {
+            return false;
+        }
+        if SENDFILE_UNAVAILABLE.load(Ordering::Relaxed) {
             return false;
         }
         url.is_http() && url.href.len() > 0
@@ -75,6 +85,9 @@ impl SendFile {
                 | bun_sys::E::ENOSYS
                 | bun_sys::E::EOPNOTSUPP
                 | bun_sys::E::EPERM => {
+                    if errcode == bun_sys::E::ENOSYS {
+                        SENDFILE_UNAVAILABLE.store(true, Ordering::Relaxed);
+                    }
                     self.use_read_write = true;
                     return self.write_with_read_write(socket_fd);
                 }

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -11,6 +11,10 @@ pub struct SendFile {
     pub remain: usize,
     pub offset: usize,
     pub content_size: usize,
+    /// Set once `sendfile(2)` refuses the fd (seccomp, a filesystem without
+    /// `splice_read`, an old kernel). The rest of the body goes through
+    /// `pread` + `write` from `offset`, so nothing already sent is repeated.
+    pub use_read_write: bool,
 }
 
 impl SendFile {
@@ -34,6 +38,9 @@ impl SendFile {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let _ = adjusted_count; // unused on Linux path
+            if self.use_read_write {
+                return self.write_with_read_write(socket_fd);
+            }
             let mut signed_offset: i64 = i64::try_from(self.offset).expect("int cast");
             let begin = self.offset;
             // this does the syscall directly, without libc
@@ -55,12 +62,23 @@ impl SendFile {
                 .saturating_sub((self.offset as u64).saturating_sub(begin as u64))
                 as usize;
 
-            if errcode != bun_sys::E::SUCCESS || self.remain == 0 || val == 0 {
-                if errcode == bun_sys::E::SUCCESS {
-                    return Status::Done;
+            match errcode {
+                bun_sys::E::SUCCESS => {
+                    if self.remain == 0 || val == 0 {
+                        return Status::Done;
+                    }
                 }
-
-                return Status::Err(bun_errno::from_errno(errcode as i32).into());
+                bun_sys::E::EAGAIN => {}
+                // Same set as the statx and copy_file_range fallbacks: the
+                // syscall is refused for this fd, not failing on it.
+                bun_sys::E::EINVAL
+                | bun_sys::E::ENOSYS
+                | bun_sys::E::EOPNOTSUPP
+                | bun_sys::E::EPERM => {
+                    self.use_read_write = true;
+                    return self.write_with_read_write(socket_fd);
+                }
+                _ => return Status::Err(bun_errno::from_errno(errcode as i32).into()),
             }
         }
 
@@ -131,6 +149,44 @@ impl SendFile {
         }
 
         Status::Again
+    }
+
+    /// Copy from `offset` to the socket until the socket would block, the
+    /// window is sent, or the file ends early. `pread` keeps the fd's file
+    /// position untouched, so a partial socket write is resumed at `offset`
+    /// on the next writable event.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn write_with_read_write(&mut self, socket_fd: Fd) -> Status {
+        let mut stack_buf = bun_core::vec::UninitBuf::<{ 16 * 4096 }>::uninit();
+        // SAFETY: `pread` is the only writer of `buf`; only `buf[..read]` is read back.
+        let buf = unsafe { stack_buf.as_bytes_mut() };
+        loop {
+            if self.remain == 0 {
+                return Status::Done;
+            }
+            let want = buf.len().min(self.remain);
+            let Ok(signed_offset) = i64::try_from(self.offset) else {
+                return Status::Err(bun_errno::SystemErrno::EOVERFLOW.into());
+            };
+            let read = match bun_sys::pread(self.fd, &mut buf[..want], signed_offset) {
+                Ok(0) => return Status::Done,
+                Ok(n) => n,
+                Err(err) => return Status::Err(crate::Error::Sys(err.into())),
+            };
+            let mut sent = 0;
+            while sent < read {
+                match bun_sys::write(socket_fd, &buf[sent..read]) {
+                    Ok(0) => return Status::Again,
+                    Ok(n) => {
+                        sent += n;
+                        self.offset += n;
+                        self.remain -= n;
+                    }
+                    Err(err) if err.get_errno() == bun_sys::E::EAGAIN => return Status::Again,
+                    Err(err) => return Status::Err(crate::Error::Sys(err.into())),
+                }
+            }
+        }
     }
 }
 

--- a/src/http/ThreadSafeStreamBuffer.rs
+++ b/src/http/ThreadSafeStreamBuffer.rs
@@ -101,6 +101,12 @@ impl ThreadSafeStreamBuffer {
         self.callback = Some(Callback::init(callback, context));
     }
 
+    /// Main thread; the http thread already holds its ref.
+    pub fn set_drain_callback_shared<T>(&mut self, callback: fn(*mut T), context: *mut T) {
+        let _guard = self.mutex.lock_guard();
+        self.callback = Some(Callback::init(callback, context));
+    }
+
     /// Main thread; the request may still be in flight on the http thread.
     pub fn clear_drain_callback(&mut self) {
         let _guard = self.mutex.lock_guard();

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -462,9 +462,7 @@ pub struct HTTPClientResult<'a> {
     /// If is not chunked encoded and Content-Length is not provided this will be unknown
     pub body_size: BodySize,
     pub certificate_info: Option<CertificateInfo>,
-    /// Set once per request, when `sendfile(2)` refused the body fd after the
-    /// head went out. The JS side streams the rest of the file into
-    /// `SendfileFallback::buffer`. Unused on other platforms.
+    /// Set once, when `sendfile(2)` refused the body fd after the head went out.
     pub sendfile_fallback: Option<SendfileFallback>,
 }
 
@@ -3230,10 +3228,8 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
-    /// `sendfile(2)` refused the body fd after the head (with its
-    /// Content-Length) went out. Turn the rest of the request into a stream
-    /// body and ask the JS thread to feed it from `offset` for `remain` bytes.
-    /// The JS side writes raw bytes: the framing is already fixed by the head.
+    /// Turn the rest of a refused sendfile body into a stream body that the
+    /// JS thread feeds from `offset` for `remain` bytes.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn switch_sendfile_to_stream<const IS_SSL: bool>(
         &mut self,
@@ -3247,8 +3243,7 @@ impl<'a> HTTPClient<'a> {
             offset,
             remain
         );
-        // Intrusive `ref_count` starts at 2: one for this thread's
-        // `Stream::buffer`, one for the JS thread via the progress update.
+        // Two initial refs: one for `Stream::buffer`, one for the JS thread.
         let buffer = core::ptr::NonNull::new(ThreadSafeStreamBuffer::new(
             ThreadSafeStreamBuffer::default(),
         ))

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -61,7 +61,7 @@ pub use http_thread::HttpThread as HTTPThread;
 pub use http_thread::shutdown_for_exit;
 pub use internal_state::InternalState;
 pub use proxy_tunnel::ProxyTunnel;
-pub use send_file::SendFile;
+pub use send_file::{SendFile, SendfileFallback};
 pub use signals::Signals;
 pub use thread_safe_stream_buffer::ThreadSafeStreamBuffer;
 #[path = "ssl_config.rs"]
@@ -462,6 +462,10 @@ pub struct HTTPClientResult<'a> {
     /// If is not chunked encoded and Content-Length is not provided this will be unknown
     pub body_size: BodySize,
     pub certificate_info: Option<CertificateInfo>,
+    /// Set once per request, when `sendfile(2)` refused the body fd after the
+    /// head went out. The JS side streams the rest of the file into
+    /// `SendfileFallback::buffer`. Unused on other platforms.
+    pub sendfile_fallback: Option<SendfileFallback>,
 }
 
 impl<'a> HTTPClientResult<'a> {
@@ -539,6 +543,7 @@ impl<'a> HTTPClientResult<'a> {
             metadata: self.metadata,
             body_size: self.body_size,
             certificate_info: self.certificate_info,
+            sendfile_fallback: self.sendfile_fallback,
         }
     }
 }
@@ -3225,6 +3230,44 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
+    /// `sendfile(2)` refused the body fd after the head (with its
+    /// Content-Length) went out. Turn the rest of the request into a stream
+    /// body and ask the JS thread to feed it from `offset` for `remain` bytes.
+    /// The JS side writes raw bytes: the framing is already fixed by the head.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn switch_sendfile_to_stream<const IS_SSL: bool>(
+        &mut self,
+        offset: usize,
+        remain: usize,
+        socket: HttpSocket<IS_SSL>,
+    ) {
+        bun_core::scoped_log!(
+            fetch,
+            "sendfile refused, streaming from offset={} remain={}",
+            offset,
+            remain
+        );
+        // Intrusive `ref_count` starts at 2: one for this thread's
+        // `Stream::buffer`, one for the JS thread via the progress update.
+        let buffer = core::ptr::NonNull::new(ThreadSafeStreamBuffer::new(
+            ThreadSafeStreamBuffer::default(),
+        ))
+        .expect("Box::into_raw is never null");
+        self.state.original_request_body = HTTPRequestBody::Stream(http_request_body::Stream {
+            buffer: Some(buffer),
+            ended: false,
+        });
+        self.flags.is_streaming_request_body = true;
+        self.state.sendfile_fallback = Some(SendfileFallback {
+            // SAFETY: adopts the second of the two initial refs.
+            buffer: unsafe { bun_ptr::RefPtr::from_raw(buffer.as_ptr()) },
+            offset,
+            remain,
+        });
+        let ctx = self.get_ssl_ctx::<IS_SSL>();
+        self.progress_update::<IS_SSL>(ctx, socket);
+    }
+
     pub(crate) fn on_writable<const IS_FIRST_CALL: bool, const IS_SSL: bool>(
         &mut self,
         socket: HttpSocket<IS_SSL>,
@@ -3367,6 +3410,12 @@ impl<'a> HTTPClient<'a> {
                             #[cfg(not(windows))]
                             crate::send_file::Status::Err(err) => {
                                 self.close_and_fail::<IS_SSL>(err, socket);
+                                return;
+                            }
+                            #[cfg(any(target_os = "linux", target_os = "android"))]
+                            crate::send_file::Status::Refused => {
+                                let (offset, remain) = (sendfile.offset, sendfile.remain);
+                                self.switch_sendfile_to_stream::<IS_SSL>(offset, remain, socket);
                                 return;
                             }
                             crate::send_file::Status::Again => {
@@ -4423,6 +4472,7 @@ impl<'a> HTTPClient<'a> {
                         || self.state.request_stage == RequestStage::ProxyBody)
                         && self.flags.is_streaming_request_body,
                     is_http2: self.flags.protocol != Protocol::Http1_1,
+                    sendfile_fallback: self.state.sendfile_fallback.take(),
                 };
             }
         }
@@ -4444,6 +4494,7 @@ impl<'a> HTTPClient<'a> {
                 || self.state.request_stage == RequestStage::ProxyBody)
                 && self.flags.is_streaming_request_body,
             is_http2: self.flags.protocol != Protocol::Http1_1,
+            sendfile_fallback: self.state.sendfile_fallback.take(),
         }
     }
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1543,6 +1543,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         remain: (blob_offset + original_size) as usize,
                         offset: blob_offset as usize,
                         content_size: original_size.min(stat_size) as usize,
+                        use_read_write: false,
                     };
 
                     if bun_sys::S::ISREG(stat.st_mode as u32) {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1543,7 +1543,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         remain: (blob_offset + original_size) as usize,
                         offset: blob_offset as usize,
                         content_size: original_size.min(stat_size) as usize,
-                        use_read_write: false,
                     };
 
                     if bun_sys::S::ISREG(stat.st_mode as u32) {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -147,8 +147,7 @@ pub struct FetchTasklet {
     pub(crate) is_waiting_body: bool,
     pub(crate) is_waiting_abort: bool,
     pub(crate) is_waiting_request_stream_start: bool,
-    /// The request body started as sendfile and its head carries a
-    /// Content-Length. The stream that replaced it writes raw bytes.
+    /// The head already carries a Content-Length, so the stream writes raw bytes.
     pub(crate) sendfile_fallback_active: bool,
     pub(crate) mutex: Mutex,
 
@@ -590,12 +589,9 @@ impl FetchTasklet {
         self.get_current_response().map(|r| unsafe { &mut *r })
     }
 
-    /// The HTTP thread reports that `sendfile(2)` refused the body fd after
-    /// the head went out. Replace the sendfile body with a `FileReader`
-    /// stream over the same file from `fallback.offset`, limited to
-    /// `fallback.remain` bytes, so the next `can_stream` starts it like a
-    /// `Bun.file().stream()` body. Returns the sendfile body: the reader dups
-    /// the fd when it starts, so the caller closes this one afterwards.
+    /// Replace a refused sendfile body with a `FileReader` stream over the same
+    /// fd from `fallback.offset`, limited to `fallback.remain` bytes. Returns
+    /// the sendfile body; the caller closes its fd once the reader dup'd it.
     fn adopt_sendfile_fallback(
         &mut self,
         fallback: http::SendfileFallback,

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -997,8 +997,7 @@ impl FetchTasklet {
         if self.is_waiting_request_stream_start && self.result.can_stream {
             // start streaming
             let started = self.start_request_stream();
-            // The reader dup'd the sendfile fd when it started. Either way the
-            // sendfile body is done with it.
+            // The reader has its own dup of the fd now.
             if let Some(mut body) = refused_sendfile.take() {
                 body.detach();
             }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -25,9 +25,11 @@ use bun_threading::Mutex;
 use bun_url::URL as ZigURL;
 
 use crate::api::bun_x509 as X509;
+use crate::webcore::blob::store::StoreExt as _;
 use crate::webcore::blob::{Any as AnyBlob, Blob, SizeType as BlobSizeType, Store as BlobStore};
 use crate::webcore::body::{self, Body, Value as BodyValue, ValueError as BodyValueError};
 use crate::webcore::fetch::fetch_request_body_sink::{FetchRequestBodySink, RequestBodyChunk};
+use crate::webcore::node_types::PathOrFileDescriptor;
 use crate::webcore::readable_stream::{ReadableStream, Strong as ReadableStreamStrong};
 use crate::webcore::response::HeadersRef;
 use crate::webcore::sink::JSSink;
@@ -145,6 +147,9 @@ pub struct FetchTasklet {
     pub(crate) is_waiting_body: bool,
     pub(crate) is_waiting_abort: bool,
     pub(crate) is_waiting_request_stream_start: bool,
+    /// The request body started as sendfile and its head carries a
+    /// Content-Length. The stream that replaced it writes raw bytes.
+    pub(crate) sendfile_fallback_active: bool,
     pub(crate) mutex: Mutex,
 
     pub(crate) tracker: AsyncTaskTracker,
@@ -585,6 +590,60 @@ impl FetchTasklet {
         self.get_current_response().map(|r| unsafe { &mut *r })
     }
 
+    /// The HTTP thread reports that `sendfile(2)` refused the body fd after
+    /// the head went out. Replace the sendfile body with a `FileReader`
+    /// stream over the same file from `fallback.offset`, limited to
+    /// `fallback.remain` bytes, so the next `can_stream` starts it like a
+    /// `Bun.file().stream()` body. Returns the sendfile body: the reader dups
+    /// the fd when it starts, so the caller closes this one afterwards.
+    fn adopt_sendfile_fallback(
+        &mut self,
+        fallback: http::SendfileFallback,
+    ) -> JsResult<Option<HTTPRequestBody>> {
+        let HTTPRequestBody::Sendfile(sendfile) = self.request_body else {
+            return Ok(None);
+        };
+        bun_output::scoped_log!(
+            FetchTasklet,
+            "sendfile refused, streaming offset={} remain={}",
+            fallback.offset,
+            fallback.remain
+        );
+        let global_this = self.global_this;
+        let http::SendfileFallback {
+            buffer,
+            offset,
+            remain,
+        } = fallback;
+        // SAFETY: `buffer` is our ref on the live buffer; the HTTP thread holds
+        // the other one. The setter takes the buffer's mutex.
+        unsafe {
+            (*buffer.as_ptr()).set_drain_callback_shared::<FetchTasklet>(
+                FetchTasklet::on_write_request_data_drain,
+                std::ptr::from_mut(self),
+            );
+        }
+        self.request_body_streaming_buffer = Some(buffer);
+        self.sendfile_fallback_active = true;
+
+        let store = bun_core::handle_oom(BlobStore::init_file(
+            PathOrFileDescriptor::Fd(sendfile.fd),
+            None,
+        ));
+        let blob = Blob::init_with_store(store, &global_this);
+        blob.offset.set(offset as BlobSizeType);
+        blob.size.set(remain as BlobSizeType);
+        let stream_value = ReadableStream::from_blob_copy_ref(&global_this, &blob, 0)?;
+        let stream = ReadableStream::from_js(stream_value, &global_this)?
+            .expect("from_blob_copy_ref returns a ReadableStream");
+        let old = core::mem::replace(
+            &mut self.request_body,
+            HTTPRequestBody::ReadableStream(ReadableStreamStrong::init(stream, &global_this)),
+        );
+        self.is_waiting_request_stream_start = true;
+        Ok(Some(old))
+    }
+
     fn start_request_stream(&mut self) -> JsResult<()> {
         self.is_waiting_request_stream_start = false;
         debug_assert!(matches!(
@@ -924,9 +983,30 @@ impl FetchTasklet {
             }
         };
 
+        let mut refused_sendfile: Option<HTTPRequestBody> = None;
+        if let Some(fallback) = self.result.sendfile_fallback.take() {
+            match self.adopt_sendfile_fallback(fallback) {
+                Ok(old) => refused_sendfile = old,
+                Err(err) => {
+                    self.mutex.unlock();
+                    if is_done {
+                        // SAFETY: `self` is the live heap tasklet; we hold a ref.
+                        FetchTasklet::deref(std::ptr::from_mut(self));
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
         if self.is_waiting_request_stream_start && self.result.can_stream {
             // start streaming
-            if let Err(err) = self.start_request_stream() {
+            let started = self.start_request_stream();
+            // The reader dup'd the sendfile fd when it started. Either way the
+            // sendfile body is done with it.
+            if let Some(mut body) = refused_sendfile.take() {
+                body.detach();
+            }
+            if let Err(err) = started {
                 // The VM is being stopped: leave like the `!script_allowed()` gate above does.
                 self.mutex.unlock();
                 if is_done {
@@ -961,6 +1041,9 @@ impl FetchTasklet {
             if self.metadata.is_some() && !self.is_waiting_body {
                 vm.jsc_vm().drain_microtasks();
             }
+        }
+        if let Some(mut body) = refused_sendfile {
+            body.detach();
         }
         // if we already respond the metadata and still need to process the body
         if self.is_waiting_body {
@@ -1879,6 +1962,7 @@ impl FetchTasklet {
             is_waiting_body: false,
             is_waiting_abort: false,
             is_waiting_request_stream_start: false,
+            sendfile_fallback_active: false,
             mutex: Mutex::new(),
             // SAFETY: jsc_vm derived from FFI ptr above; AsyncTaskTracker::init only
             // bumps a counter on the VM.
@@ -2123,6 +2207,7 @@ impl FetchTasklet {
     pub(crate) fn skip_chunked_framing(&self) -> bool {
         self.upgraded_connection
             || self.result.is_http2
+            || self.sendfile_fallback_active
             || (self.request_headers.get(b"content-length").is_some()
                 && self.request_headers.get(b"transfer-encoding").is_none())
     }
@@ -2368,6 +2453,7 @@ impl FetchTasklet {
         let prev_metadata = task_ref.result.metadata.take();
         let prev_cert_info = task_ref.result.certificate_info.take();
         let prev_can_stream = task_ref.result.can_stream;
+        let prev_sendfile_fallback = task_ref.result.sendfile_fallback.take();
         // `result.body` borrows the HTTP thread's scratch buffer on non-terminal
         // callbacks; the terminal callback carries the bytes in `body_owned`
         // instead. Capture both before `detach_lifetime` clears them in the
@@ -2380,6 +2466,10 @@ impl FetchTasklet {
         // can_stream is a one-shot signal to start the request body stream; don't let a
         // later coalesced result clobber it before the JS thread sees it.
         task_ref.result.can_stream = task_ref.result.can_stream || prev_can_stream;
+        // Same one-shot rule for the sendfile fallback handoff.
+        if task_ref.result.sendfile_fallback.is_none() {
+            task_ref.result.sendfile_fallback = prev_sendfile_fallback;
+        }
 
         // Preserve pending certificate info if it was preovided in the previous update.
         if task_ref.result.certificate_info.is_none() {

--- a/test/js/bun/http/fetch-file-upload-sendfile-refused-fixture.ts
+++ b/test/js/bun/http/fetch-file-upload-sendfile-refused-fixture.ts
@@ -78,14 +78,17 @@ await using server = Bun.serve({
   },
 });
 
-const res = await fetch(server.url, { method: "PUT", body: Bun.file(path) });
-const body = await res.json();
-console.log(
-  JSON.stringify({
+// Two uploads: the second one runs after the first refusal was observed.
+const results = [];
+for (let i = 0; i < 2; i++) {
+  const res = await fetch(server.url, { method: "PUT", body: Bun.file(path) });
+  const body = await res.json();
+  results.push({
     status: res.status,
     ok: body.hash === expectedHash,
     contentLength: body.contentLength,
     received: body.received,
     expected: size,
-  }),
-);
+  });
+}
+console.log(JSON.stringify(results));

--- a/test/js/bun/http/fetch-file-upload-sendfile-refused-fixture.ts
+++ b/test/js/bun/http/fetch-file-upload-sendfile-refused-fixture.ts
@@ -1,0 +1,91 @@
+// Installs a seccomp filter that makes sendfile(2) fail with the errno in
+// argv[2], then uploads a Bun.file() body over plain HTTP. The upload must
+// complete through the read+write fallback. Linux only.
+import { dlopen, ptr } from "bun:ffi";
+import { libcPathForDlopen } from "harness";
+import { join } from "node:path";
+
+const errnoByName: Record<string, number> = { EINVAL: 22, ENOSYS: 38, EOPNOTSUPP: 95, EPERM: 1 };
+const errno = errnoByName[process.argv[2]];
+if (errno === undefined) throw new Error(`unknown errno ${process.argv[2]}`);
+
+const NR_sendfile = process.arch === "x64" ? 40 : 71;
+const NR_seccomp = process.arch === "x64" ? 317 : 277;
+
+const { symbols: libc } = dlopen(libcPathForDlopen(), {
+  prctl: { args: ["i32", "u64", "u64", "u64", "u64"], returns: "i32" },
+  syscall: { args: ["i64", "i64", "i64", "ptr"], returns: "i64" },
+});
+
+// struct sock_filter { u16 code; u8 jt; u8 jf; u32 k; }
+const filter = new DataView(new ArrayBuffer(4 * 8));
+function insn(i: number, code: number, jt: number, jf: number, k: number) {
+  filter.setUint16(i * 8, code, true);
+  filter.setUint8(i * 8 + 2, jt);
+  filter.setUint8(i * 8 + 3, jf);
+  filter.setUint32(i * 8 + 4, k, true);
+}
+const BPF_LD_W_ABS = 0x20;
+const BPF_JMP_JEQ_K = 0x15;
+const BPF_RET_K = 0x06;
+const SECCOMP_RET_ERRNO = 0x00050000;
+const SECCOMP_RET_ALLOW = 0x7fff0000;
+insn(0, BPF_LD_W_ABS, 0, 0, 0); // A = seccomp_data.nr
+insn(1, BPF_JMP_JEQ_K, 0, 1, NR_sendfile);
+insn(2, BPF_RET_K, 0, 0, SECCOMP_RET_ERRNO | errno);
+insn(3, BPF_RET_K, 0, 0, SECCOMP_RET_ALLOW);
+
+// struct sock_fprog { u16 len; struct sock_filter *filter; }
+const prog = new DataView(new ArrayBuffer(16));
+prog.setUint16(0, 4, true);
+prog.setBigUint64(8, BigInt(ptr(filter.buffer)), true);
+
+const PR_SET_NO_NEW_PRIVS = 38;
+if (libc.prctl(PR_SET_NO_NEW_PRIVS, 1n, 0n, 0n, 0n) !== 0) {
+  console.log("SKIP: prctl(PR_SET_NO_NEW_PRIVS) failed");
+  process.exit(77);
+}
+const SECCOMP_SET_MODE_FILTER = 1;
+const SECCOMP_FILTER_FLAG_TSYNC = 1;
+if (libc.syscall(BigInt(NR_seccomp), BigInt(SECCOMP_SET_MODE_FILTER), BigInt(SECCOMP_FILTER_FLAG_TSYNC), ptr(prog.buffer)) !== 0n) {
+  console.log("SKIP: seccomp(SET_MODE_FILTER) failed");
+  process.exit(77);
+}
+
+const size = 256 * 1024 + 123;
+const bytes = Buffer.alloc(size);
+for (let i = 0; i < size; i++) bytes[i] = (i * 7) & 0xff;
+const path = join(process.argv[3], "upload.bin");
+await Bun.write(path, bytes);
+const expectedHash = Bun.CryptoHasher.hash("sha256", bytes, "hex");
+
+await using server = Bun.serve({
+  port: 0,
+  development: false,
+  maxRequestBodySize: size * 2,
+  async fetch(req) {
+    const hasher = new Bun.CryptoHasher("sha256");
+    let received = 0;
+    for await (const chunk of req.body!) {
+      hasher.update(chunk);
+      received += chunk.length;
+    }
+    return Response.json({
+      contentLength: req.headers.get("content-length"),
+      received,
+      hash: hasher.digest("hex"),
+    });
+  },
+});
+
+const res = await fetch(server.url, { method: "PUT", body: Bun.file(path) });
+const body = await res.json();
+console.log(
+  JSON.stringify({
+    status: res.status,
+    ok: body.hash === expectedHash,
+    contentLength: body.contentLength,
+    received: body.received,
+    expected: size,
+  }),
+);

--- a/test/js/bun/http/fetch-file-upload-sendfile-refused-fixture.ts
+++ b/test/js/bun/http/fetch-file-upload-sendfile-refused-fixture.ts
@@ -57,7 +57,16 @@ const bytes = Buffer.alloc(size);
 for (let i = 0; i < size; i++) bytes[i] = (i * 7) & 0xff;
 const path = join(process.argv[3], "upload.bin");
 await Bun.write(path, bytes);
-const expectedHash = Bun.CryptoHasher.hash("sha256", bytes, "hex");
+const sliceStart = 12345;
+const sliceEnd = sliceStart + 100_000;
+
+// The whole file, then the same file again after the first refusal, then a
+// slice so the fallback has to start at an offset other than 0.
+const uploads = [
+  { body: Bun.file(path), bytes },
+  { body: Bun.file(path), bytes },
+  { body: Bun.file(path).slice(sliceStart, sliceEnd), bytes: bytes.subarray(sliceStart, sliceEnd) },
+];
 
 await using server = Bun.serve({
   port: 0,
@@ -78,17 +87,16 @@ await using server = Bun.serve({
   },
 });
 
-// Two uploads: the second one runs after the first refusal was observed.
 const results = [];
-for (let i = 0; i < 2; i++) {
-  const res = await fetch(server.url, { method: "PUT", body: Bun.file(path) });
+for (const upload of uploads) {
+  const res = await fetch(server.url, { method: "PUT", body: upload.body });
   const body = await res.json();
   results.push({
     status: res.status,
-    ok: body.hash === expectedHash,
+    ok: body.hash === Bun.CryptoHasher.hash("sha256", upload.bytes, "hex"),
     contentLength: body.contentLength,
     received: body.received,
-    expected: size,
+    expected: upload.bytes.length,
   });
 }
 console.log(JSON.stringify(results));

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -178,13 +178,14 @@ describe.skipIf(!isLinux)("Bun.file() upload falls back to read+write when sendf
         return;
       }
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual({
+      const upload = {
         status: 200,
         ok: true,
         contentLength: String(256 * 1024 + 123),
         received: 256 * 1024 + 123,
         expected: 256 * 1024 + 123,
-      });
+      };
+      expect(JSON.parse(stdout)).toEqual([upload, upload]);
       expect(exitCode).toBe(0);
     });
   }

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -161,8 +161,8 @@ test.todoIf(isBroken && isWindows)(
 
 // The plain-HTTP upload path uses sendfile(2) on Linux for files >= 32 KiB.
 // The fixture installs a seccomp filter that refuses sendfile with one errno
-// and checks the body still arrives, byte-exact, through read+write.
-describe.skipIf(!isLinux)("Bun.file() upload falls back to read+write when sendfile(2) is refused", () => {
+// and checks the body still arrives, byte-exact, through the stream path.
+describe.skipIf(!isLinux)("Bun.file() upload falls back to a stream when sendfile(2) is refused", () => {
   for (const errno of ["EINVAL", "ENOSYS", "EOPNOTSUPP", "EPERM"]) {
     test.concurrent(errno, async () => {
       using dir = tempDir("fetch-sendfile-refused", {});
@@ -178,14 +178,14 @@ describe.skipIf(!isLinux)("Bun.file() upload falls back to read+write when sendf
         return;
       }
       expect(stderr).toBe("");
-      const upload = {
+      const upload = (bytes: number) => ({
         status: 200,
         ok: true,
-        contentLength: String(256 * 1024 + 123),
-        received: 256 * 1024 + 123,
-        expected: 256 * 1024 + 123,
-      };
-      expect(JSON.parse(stdout)).toEqual([upload, upload]);
+        contentLength: String(bytes),
+        received: bytes,
+        expected: bytes,
+      });
+      expect(JSON.parse(stdout)).toEqual([upload(256 * 1024 + 123), upload(256 * 1024 + 123), upload(100_000)]);
       expect(exitCode).toBe(0);
     });
   }

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, withoutAggressiveGC } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -158,6 +158,37 @@ test.todoIf(isBroken && isWindows)(
   },
   10_000,
 );
+
+// The plain-HTTP upload path uses sendfile(2) on Linux for files >= 32 KiB.
+// The fixture installs a seccomp filter that refuses sendfile with one errno
+// and checks the body still arrives, byte-exact, through read+write.
+describe.skipIf(!isLinux)("Bun.file() upload falls back to read+write when sendfile(2) is refused", () => {
+  for (const errno of ["EINVAL", "ENOSYS", "EOPNOTSUPP", "EPERM"]) {
+    test.concurrent(errno, async () => {
+      using dir = tempDir("fetch-sendfile-refused", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "fetch-file-upload-sendfile-refused-fixture.ts"), errno, String(dir)],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode === 77) {
+        console.warn(`SKIP ${errno}: ${stdout.trim()}`);
+        return;
+      }
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        status: 200,
+        ok: true,
+        contentLength: String(256 * 1024 + 123),
+        received: 256 * 1024 + 123,
+        expected: 256 * 1024 + 123,
+      });
+      expect(exitCode).toBe(0);
+    });
+  }
+});
 
 describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
   // The sendfile fast path is entered when the backing file is >= 32 KiB.


### PR DESCRIPTION
### Problem
- On Linux a plain-HTTP `fetch()` with a `Bun.file()` body of 32 KiB or more is uploaded with `sendfile(2)`. When the kernel, a seccomp policy, or the source filesystem refuses the syscall (`EINVAL`, `ENOSYS`, `EOPNOTSUPP`, `EPERM`), the fetch rejects with `EINVAL fetching "http://..."` after the request head was already written. The body never reaches the server.
- The cause is `SendFile::write` (`src/http/SendFile.rs:58`). Every errno other than success returned `Status::Err`, and `RequestStage::Body` in `src/http/lib.rs` then closes the socket.
- No user has reported this. The repro injects the errno with a seccomp filter. `Bun.write(dst, Bun.file(src))` (`src/sys/copy_file.rs:404`) and the `statx` wrapper (`src/sys/lib.rs:2338`) already fall back on the same errno set. #41474 adds the same fallback to `Bun.serve` file responses.

### Fix
- On those four errnos `SendFile::write` returns `Status::Refused`. The HTTP thread then turns the request body into a `HTTPRequestBody::Stream` with a fresh `ThreadSafeStreamBuffer`, sets `is_streaming_request_body`, and sends a progress update that carries a `SendfileFallback` (the JS side's buffer ref, the current offset, the remaining length).
- The JS thread (`FetchTasklet::adopt_sendfile_fallback`) builds a `FileReader` stream over the same fd from that offset, limited to the remaining bytes, and the existing `can_stream` path starts it. This is the same code that uploads a `Bun.file().stream()` body. The head already carries the Content-Length, so `skip_chunked_framing` is true and the stream writes raw bytes.
- The Linux arm also treats `EAGAIN` from `sendfile` as `Status::Again` instead of failing the request. The macOS and FreeBSD arms already do this.
- Verified: `test/js/bun/http/fetch-file-upload.test.ts` (4 new cases, one per errno. Each does a full upload, a second upload, and a sliced upload at a non-zero offset. All 4 fail on bun 1.4.3). Also `fetch-compress.test.ts`, `content-length.test.js`, `body-stream.test.ts`, `fetch-abort-stream-body.test.ts`.

### Background
- `SendFile` is the HTTP-thread state for one file upload: the fd, the current `offset`, and the `remain` count. `RequestStage::Body` calls `write` once per writable event.
- A stream body is a `ThreadSafeStreamBuffer` shared by both threads. The JS thread appends bytes, the HTTP thread flushes them to the socket and reports a drain. `FileReader` is the native source behind `Bun.file().stream()`. It reads with `pread` from a start offset, up to a limit.
- `HTTPClientResult` is the only HTTP-thread to JS-thread channel. `can_stream` already rides on it as a one-shot signal. `SendfileFallback` follows the same rule in `FetchTasklet::callback`.

<details><summary>Notes</summary>

The first version of this PR had a `pread` + `write` loop inside `SendFile`. Jarred asked for the non-sendfile path so the fallback runs through `FileReader`. This version does that.

The reader dups the fd when it starts (`Lazy::open_file_blob`), inside `start_request_stream`. The sendfile body is detached, which closes the original fd, right after that call.

Open PR #36212 edits the same block in `SendFile::write` to reject a truncated body. Whichever lands second needs a small rebase.

The fixture installs the filter with `seccomp(2)` and `SECCOMP_FILTER_FLAG_TSYNC` so the HTTP thread is covered even if it already exists. It exits 77 when the filter cannot be installed and the test skips.

A 48 MiB upload against a reader that sleeps per chunk also completed through the fallback (backpressure and drain through the stream buffer).

`cargo check -p bun_runtime` passes for linux, aarch64-apple-darwin, and x86_64-pc-windows-msvc.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/fetch-file-upload.test.ts

<!-- robobun:evidence:end -->