### PR TITLE
node:buffer: match Node on fill/compare start offsets, detached indexOf, and inspect extras

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1142,10 +1142,8 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
     size_t sourceEndInit = castedThis->byteLength();
     size_t sourceEnd = sourceEndInit;
 
-    // Node validates the offsets in argument order, each through validateOffset:
-    // a start is any integer in [0, 2**53 - 1] (a start past the end is an
-    // empty range below, not an error), an end is bounded by its own buffer's
-    // length. The first invalid one is the one the error names.
+    // Node's validateOffset, in argument order: a start is bounded by 2**53 - 1
+    // (past the end is an empty range, not an error), an end by its buffer.
     JSValue targetStartValue = callFrame->argument(1);
     if (!targetStartValue.isUndefined()) {
         Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &targetStart);
@@ -1413,13 +1411,12 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     // ── 2. Pure offset / end coercion (no user JS) ──────────────────────
     // Node routes both through validateOffset (= validateInteger), so a
     // fractional or NaN offset/end throws ERR_OUT_OF_RANGE "an integer"
-    // instead of being truncated. The offset is bounded only by Node's
-    // kMaxLength (2**53 - 1): one past `end` is an empty range below, not
-    // an error. parseEncoding above may have detached/resized the buffer,
-    // but the `limit` captured pre-coercion is still the correct
-    // Node-compat upper bound for ERR_OUT_OF_RANGE; the final write range
-    // is clamped against a separate post-coercion byteLength read further
-    // down.
+    // instead of being truncated. The offset is bounded by 2**53 - 1, not
+    // the buffer: past `end` is an empty range below. parseEncoding above
+    // may have detached/resized the buffer, but the `limit` captured
+    // pre-coercion is still the correct Node-compat upper bound for
+    // ERR_OUT_OF_RANGE; the final write range is clamped against a
+    // separate post-coercion byteLength read further down.
     //     https://github.com/nodejs/node/blob/v22.9.0/lib/buffer.js#L1066-L1079
     if (!offsetValue.isUndefined()) {
         Bun::V::validateInteger(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &offset);
@@ -1791,9 +1788,8 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
     // and byteLength from the buffer right before use, and check for detachment
     // after all JS calls in each code path are complete.
 
-    // Helper: re-fetch buffer state after JS calls. A detached haystack is an
-    // empty one, like in Node: an empty needle is still found at 0, anything
-    // else is -1. computeIndexOfRange never reads the vector for length 0.
+    // Helper: re-fetch buffer state after JS calls. A detached haystack reads
+    // as empty, like in Node; computeIndexOfRange never touches a length-0 vector.
     auto refetchBufferState = [&](const uint8_t*& typedVector, size_t& len) {
         if (buffer->isDetached()) [[unlikely]] {
             typedVector = nullptr;
@@ -1928,13 +1924,8 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_inspectBody(JSC::JSGlobalOb
             }
             result.append(' ');
 
-            // Node's Buffer.prototype[inspect.custom] copies the extra
-            // properties onto a null-prototype object, runs util.inspect on
-            // it with the caller's options plus `breakLength: Infinity,
-            // compact: true`, and keeps the part between
-            // "[Object: null prototype] { " and " }". That is what gives
-            // the keys and values the same quoting, colors and depth as
-            // the surrounding output.
+            // Like Node: util.inspect a null-prototype copy of the extras with
+            // the caller's options, then strip "[Object: null prototype] { " and " }".
             JSObject* extras = JSC::constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
             for (auto ident : array) {
                 auto value = castedThis->get(globalObject, ident);
@@ -1942,9 +1933,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_inspectBody(JSC::JSGlobalOb
                 extras->putDirect(vm, ident, value);
             }
 
-            // Spread defines the copies, so not objectAssignGeneric: its [[Set]]
-            // would run a setter that userland put on Object.prototype under one
-            // of the option names.
+            // Define the copies (like Node's spread), so no Object.prototype setter runs.
             JSObject* options = JSC::constructEmptyObject(globalObject);
             if (auto* ctxObject = dynamicDowncast<JSObject>(ctx)) {
                 PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -81,6 +81,7 @@
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 
 extern "C" bool Bun__Node__ZeroFillBuffers;
 
@@ -95,9 +96,6 @@ extern "C" void highway_bswap64(uint8_t* data, size_t len);
 extern "C" size_t highway_index_of_char(const uint8_t* haystack, size_t haystack_len, uint8_t needle);
 extern "C" size_t highway_last_index_of_char(const uint8_t* haystack, size_t haystack_len, uint8_t needle);
 static constexpr size_t kHighwayNotFound = ~static_cast<size_t>(0);
-
-// export fn Bun__inspect_singleline(globalThis: *JSGlobalObject, value: JSValue) bun.String
-extern "C" BunString Bun__inspect_singleline(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
 
 using namespace JSC;
 using namespace WebCore;
@@ -1149,48 +1147,41 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
     JSValue sourceStartValue = jsUndefined();
     JSValue sourceEndValue = jsUndefined();
 
+    // Node's validateOffset: a start is any integer in [0, 2**53 - 1] (a start
+    // past the end is an empty range below, not an error), an end is bounded by
+    // its own buffer's length.
     switch (callFrame->argumentCount()) {
     default:
         sourceEndValue = callFrame->uncheckedArgument(4);
         if (sourceEndValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceEndValue, "sourceEnd"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &sourceEnd);
+            Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceEndValue, "sourceEnd"_s, jsNumber(0), jsNumber(sourceEndInit), &sourceEnd);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
         [[fallthrough]];
     case 4:
         sourceStartValue = callFrame->uncheckedArgument(3);
         if (sourceStartValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceStartValue, "sourceStart"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &sourceStart);
+            Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceStartValue, "sourceStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &sourceStart);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
         [[fallthrough]];
     case 3:
         targetEndValue = callFrame->uncheckedArgument(2);
         if (targetEndValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetEndValue, "targetEnd"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &targetEnd);
+            Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetEndValue, "targetEnd"_s, jsNumber(0), jsNumber(targetEndInit), &targetEnd);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
         [[fallthrough]];
     case 2:
         targetStartValue = callFrame->uncheckedArgument(1);
         if (targetStartValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &targetStart);
+            Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &targetStart);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
         break;
     case 1:
     case 0:
         break;
-    }
-
-    // Validate end values against their respective buffer lengths to prevent OOB access.
-    // This matches Node.js behavior where targetEnd is validated against target.length
-    // and sourceEnd is validated against source.length.
-    if (targetEnd > targetEndInit) {
-        return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "targetEnd"_s, 0, targetEndInit, targetEndValue);
-    }
-    if (sourceEnd > sourceEndInit) {
-        return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceEnd"_s, 0, sourceEndInit, sourceEndValue);
     }
 
     // When start >= end for either side, return early per Node.js semantics.
@@ -1439,14 +1430,16 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     // ── 2. Pure offset / end coercion (no user JS) ──────────────────────
     // Node routes both through validateOffset (= validateInteger), so a
     // fractional or NaN offset/end throws ERR_OUT_OF_RANGE "an integer"
-    // instead of being truncated. parseEncoding above may have
-    // detached/resized the buffer, but the `limit` captured pre-coercion
-    // is still the correct Node-compat upper bound for ERR_OUT_OF_RANGE;
-    // the final write range is clamped against a separate post-coercion
-    // byteLength read further down.
+    // instead of being truncated. The offset is bounded only by Node's
+    // kMaxLength (2**53 - 1): one past `end` is an empty range below, not
+    // an error. parseEncoding above may have detached/resized the buffer,
+    // but the `limit` captured pre-coercion is still the correct
+    // Node-compat upper bound for ERR_OUT_OF_RANGE; the final write range
+    // is clamped against a separate post-coercion byteLength read further
+    // down.
     //     https://github.com/nodejs/node/blob/v22.9.0/lib/buffer.js#L1066-L1079
     if (!offsetValue.isUndefined()) {
-        Bun::V::validateInteger(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &offset);
+        Bun::V::validateInteger(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &offset);
         RETURN_IF_EXCEPTION(scope, {});
         // Node only reads `end` once `offset` is present: fill(v, undefined, end)
         // ignores end (it is never validated) and fills the whole buffer.
@@ -1815,18 +1808,17 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
     // and byteLength from the buffer right before use, and check for detachment
     // after all JS calls in each code path are complete.
 
-    // Helper: re-fetch buffer state after JS calls. Returns false if the buffer
-    // was detached; the caller returns -1 (matches Node.js for a detached
-    // haystack). A merely EMPTY haystack is not -1; see computeIndexOfRange.
-    auto refetchBufferState = [&](const uint8_t*& typedVector, size_t& len) -> bool {
+    // Helper: re-fetch buffer state after JS calls. A detached haystack is an
+    // empty one, like in Node: an empty needle is still found at 0, anything
+    // else is -1. computeIndexOfRange never reads the vector for length 0.
+    auto refetchBufferState = [&](const uint8_t*& typedVector, size_t& len) {
         if (buffer->isDetached()) [[unlikely]] {
             typedVector = nullptr;
             len = 0;
-            return false;
+            return;
         }
         typedVector = buffer->typedVector();
         len = buffer->byteLength();
-        return true;
     };
 
     if (std::isnan(byteOffsetD)) byteOffsetD = dir ? 0 : byteLength;
@@ -1835,7 +1827,7 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         auto byteValue = static_cast<uint8_t>((valueValue.toInt32(lexicalGlobalObject)) % 256);
         RETURN_IF_EXCEPTION(scope, -1);
         const uint8_t* typedVector;
-        if (!refetchBufferState(typedVector, byteLength)) return -1;
+        refetchBufferState(typedVector, byteLength);
         return indexOfNumber(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, endD, byteValue);
     }
 
@@ -1855,14 +1847,14 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         auto* str = valueValue.toString(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(scope, -1);
         const uint8_t* typedVector;
-        if (!refetchBufferState(typedVector, byteLength)) return -1;
+        refetchBufferState(typedVector, byteLength);
         return indexOfString(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, endD, str, encoding.value());
     }
 
     if (auto* array = dynamicDowncast<JSC::JSUint8Array>(valueValue)) {
         if (!encoding.has_value()) encoding = BufferEncodingType::utf8;
         const uint8_t* typedVector;
-        if (!refetchBufferState(typedVector, byteLength)) return -1;
+        refetchBufferState(typedVector, byteLength);
         // A needle whose backing buffer was detached by a valueOf/toPrimitive
         // callback above reports byteLength()==0; computeIndexOfRange's
         // empty-needle path handles that (clamped to `end`) without touching
@@ -1952,17 +1944,41 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_inspectBody(JSC::JSGlobalOb
                 result.append(',');
             }
             result.append(' ');
-            size_t i = 0;
+
+            // Node's Buffer.prototype[inspect.custom] copies the extra
+            // properties onto a null-prototype object, runs util.inspect on
+            // it with the caller's options plus `breakLength: Infinity,
+            // compact: true`, and keeps the part between
+            // "[Object: null prototype] { " and " }". That is what gives
+            // the keys and values the same quoting, colors and depth as
+            // the surrounding output.
+            JSObject* extras = JSC::constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
             for (auto ident : array) {
-                if (i > 0) result.append(", "_s);
-                result.append(ident.string());
-                result.append(": "_s);
                 auto value = castedThis->get(globalObject, ident);
                 RETURN_IF_EXCEPTION(scope, {});
-                auto inspected = Bun__inspect_singleline(globalObject, value).transferToWTFString();
+                extras->putDirect(vm, ident, value);
+            }
+
+            JSObject* options = JSC::constructEmptyObject(globalObject);
+            if (ctx.isObject()) {
+                JSC::objectAssignGeneric(globalObject, vm, options, asObject(ctx));
                 RETURN_IF_EXCEPTION(scope, {});
-                result.append(inspected);
-                i++;
+            }
+            options->putDirect(vm, Identifier::fromString(vm, "breakLength"_s), jsDoubleNumber(std::numeric_limits<double>::infinity()));
+            options->putDirect(vm, Identifier::fromString(vm, "compact"_s), jsBoolean(true));
+
+            JSFunction* inspectFn = globalObject->utilInspectFunction();
+            RETURN_IF_EXCEPTION(scope, {});
+            MarkedArgumentBuffer args;
+            args.append(extras);
+            args.append(options);
+            JSValue inspected = JSC::call(globalObject, inspectFn, ArgList(args), "util.inspect"_s);
+            RETURN_IF_EXCEPTION(scope, {});
+            auto inspectedString = inspected.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            constexpr size_t prefixLength = sizeof("[Object: null prototype] { ") - 1;
+            if (inspectedString.length() > prefixLength + 2) {
+                result.append(StringView(inspectedString).substring(prefixLength, inspectedString.length() - prefixLength - 2));
             }
         }
     }

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1142,11 +1142,10 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
     size_t sourceEndInit = castedThis->byteLength();
     size_t sourceEnd = sourceEndInit;
 
-    // Node's validateOffset, in argument order: a start is bounded by 2**53 - 1
-    // (past the end is an empty range, not an error), an end by its buffer.
+    // Node's validateOffset, in argument order: a start by kMaxOffset, an end by its buffer.
     JSValue targetStartValue = callFrame->argument(1);
     if (!targetStartValue.isUndefined()) {
-        Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &targetStart);
+        Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsDoubleNumber(Bun::Buffer::kMaxOffset), &targetStart);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     JSValue targetEndValue = callFrame->argument(2);
@@ -1156,7 +1155,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
     }
     JSValue sourceStartValue = callFrame->argument(3);
     if (!sourceStartValue.isUndefined()) {
-        Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceStartValue, "sourceStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &sourceStart);
+        Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceStartValue, "sourceStart"_s, jsNumber(0), jsDoubleNumber(Bun::Buffer::kMaxOffset), &sourceStart);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     JSValue sourceEndValue = callFrame->argument(4);
@@ -1411,15 +1410,14 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     // ── 2. Pure offset / end coercion (no user JS) ──────────────────────
     // Node routes both through validateOffset (= validateInteger), so a
     // fractional or NaN offset/end throws ERR_OUT_OF_RANGE "an integer"
-    // instead of being truncated. The offset is bounded by 2**53 - 1, not
-    // the buffer: past `end` is an empty range below. parseEncoding above
-    // may have detached/resized the buffer, but the `limit` captured
-    // pre-coercion is still the correct Node-compat upper bound for
-    // ERR_OUT_OF_RANGE; the final write range is clamped against a
-    // separate post-coercion byteLength read further down.
+    // instead of being truncated. parseEncoding above may have
+    // detached/resized the buffer, but the `limit` captured pre-coercion
+    // is still the correct Node-compat upper bound for ERR_OUT_OF_RANGE;
+    // the final write range is clamped against a separate post-coercion
+    // byteLength read further down.
     //     https://github.com/nodejs/node/blob/v22.9.0/lib/buffer.js#L1066-L1079
     if (!offsetValue.isUndefined()) {
-        Bun::V::validateInteger(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &offset);
+        Bun::V::validateInteger(scope, lexicalGlobalObject, offsetValue, "offset"_s, jsNumber(0), jsDoubleNumber(Bun::Buffer::kMaxOffset), &offset);
         RETURN_IF_EXCEPTION(scope, {});
         // Node only reads `end` once `offset` is present: fill(v, undefined, end)
         // ignores end (it is never validated) and fills the whole buffer.

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1142,46 +1142,29 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
     size_t sourceEndInit = castedThis->byteLength();
     size_t sourceEnd = sourceEndInit;
 
-    JSValue targetStartValue = jsUndefined();
-    JSValue targetEndValue = jsUndefined();
-    JSValue sourceStartValue = jsUndefined();
-    JSValue sourceEndValue = jsUndefined();
-
-    // Node's validateOffset: a start is any integer in [0, 2**53 - 1] (a start
-    // past the end is an empty range below, not an error), an end is bounded by
-    // its own buffer's length.
-    switch (callFrame->argumentCount()) {
-    default:
-        sourceEndValue = callFrame->uncheckedArgument(4);
-        if (sourceEndValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceEndValue, "sourceEnd"_s, jsNumber(0), jsNumber(sourceEndInit), &sourceEnd);
-            RETURN_IF_EXCEPTION(throwScope, {});
-        }
-        [[fallthrough]];
-    case 4:
-        sourceStartValue = callFrame->uncheckedArgument(3);
-        if (sourceStartValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceStartValue, "sourceStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &sourceStart);
-            RETURN_IF_EXCEPTION(throwScope, {});
-        }
-        [[fallthrough]];
-    case 3:
-        targetEndValue = callFrame->uncheckedArgument(2);
-        if (targetEndValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetEndValue, "targetEnd"_s, jsNumber(0), jsNumber(targetEndInit), &targetEnd);
-            RETURN_IF_EXCEPTION(throwScope, {});
-        }
-        [[fallthrough]];
-    case 2:
-        targetStartValue = callFrame->uncheckedArgument(1);
-        if (targetStartValue != jsUndefined()) {
-            Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &targetStart);
-            RETURN_IF_EXCEPTION(throwScope, {});
-        }
-        break;
-    case 1:
-    case 0:
-        break;
+    // Node validates the offsets in argument order, each through validateOffset:
+    // a start is any integer in [0, 2**53 - 1] (a start past the end is an
+    // empty range below, not an error), an end is bounded by its own buffer's
+    // length. The first invalid one is the one the error names.
+    JSValue targetStartValue = callFrame->argument(1);
+    if (!targetStartValue.isUndefined()) {
+        Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &targetStart);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+    JSValue targetEndValue = callFrame->argument(2);
+    if (!targetEndValue.isUndefined()) {
+        Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetEndValue, "targetEnd"_s, jsNumber(0), jsNumber(targetEndInit), &targetEnd);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+    JSValue sourceStartValue = callFrame->argument(3);
+    if (!sourceStartValue.isUndefined()) {
+        Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceStartValue, "sourceStart"_s, jsNumber(0), jsDoubleNumber(JSC::maxSafeInteger()), &sourceStart);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+    JSValue sourceEndValue = callFrame->argument(4);
+    if (!sourceEndValue.isUndefined()) {
+        Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceEndValue, "sourceEnd"_s, jsNumber(0), jsNumber(sourceEndInit), &sourceEnd);
+        RETURN_IF_EXCEPTION(throwScope, {});
     }
 
     // When start >= end for either side, return early per Node.js semantics.
@@ -1959,10 +1942,20 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_inspectBody(JSC::JSGlobalOb
                 extras->putDirect(vm, ident, value);
             }
 
+            // Spread defines the copies, so not objectAssignGeneric: its [[Set]]
+            // would run a setter that userland put on Object.prototype under one
+            // of the option names.
             JSObject* options = JSC::constructEmptyObject(globalObject);
-            if (ctx.isObject()) {
-                JSC::objectAssignGeneric(globalObject, vm, options, asObject(ctx));
+            if (auto* ctxObject = dynamicDowncast<JSObject>(ctx)) {
+                PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+                ctxObject->methodTable()->getOwnPropertyNames(ctxObject, globalObject, names, DontEnumPropertiesMode::Exclude);
                 RETURN_IF_EXCEPTION(scope, {});
+                for (const auto& name : names) {
+                    JSValue value = ctxObject->get(globalObject, name);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    options->putDirectMayBeIndex(globalObject, name, value);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
             }
             options->putDirect(vm, Identifier::fromString(vm, "breakLength"_s), jsDoubleNumber(std::numeric_limits<double>::infinity()));
             options->putDirect(vm, Identifier::fromString(vm, "compact"_s), jsBoolean(true));

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -49,6 +49,10 @@ bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject*, JSC::ThrowScop
 namespace Buffer {
 
 const size_t kMaxLength = MAX_ARRAY_BUFFER_SIZE;
+// Node's validateOffset bound (its kMaxLength, 2**53 - 1). Separate from
+// kMaxLength here because JSC caps an ArrayBuffer at 2**32 bytes, and a
+// start offset past the end of a buffer is an empty range, not an error.
+const size_t kMaxOffset = (size_t(1) << 53) - 1;
 const size_t kStringMaxLength = WTF::String::MaxLength;
 const size_t MAX_LENGTH = MAX_ARRAY_BUFFER_SIZE;
 const size_t MAX_STRING_LENGTH = WTF::String::MaxLength;

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -5560,7 +5560,7 @@ describe("util.inspect(buffer) with extra own properties", () => {
     expect(inspect(buf, { colors: true })).toBe(
       "<Buffer 03, x: \x1b[32m'y'\x1b[39m, \x1b[32m'a-b'\x1b[39m: [ \x1b[33m1\x1b[39m, \x1b[32m'two'\x1b[39m ], \x1b[32mSymbol(s)\x1b[39m: { a: { b: \x1b[36m[Object]\x1b[39m } }>",
     );
-    // Called directly, with no inspect function as the third argument.
+    // The hook called directly, outside util.inspect.
     expect(buf[custom](0, {})).toBe(expected);
   });
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
+import { inspect } from "node:util";
 import vm from "node:vm";
 
 const BufferModule = await import("buffer");
@@ -5432,5 +5433,153 @@ describe("read*/write* after JIT tier-up", () => {
     // Out-of-range integral offsets, including |offset| > 2**53, get the bounds message.
     expect(() => scratch.readIntLE(2 ** 53, 2)).toThrow(">= 0 and <= 14");
     expect(() => scratch.readIntLE(1.5, 2)).toThrow("an integer");
+  });
+});
+
+describe("fill() and compare() offsets past the end of the buffer", () => {
+  // Node bounds a start offset only by its kMaxLength (2**53 - 1). A start at or past
+  // the end is an empty range: fill() is a no-op and compare() sees an empty side.
+  const MAX = 2 ** 53 - 1;
+
+  it("fill() with an offset past the end is a no-op", () => {
+    for (const offset of [3, 4, 2 ** 32, 2 ** 32 + 1, 2 ** 40, MAX]) {
+      const buf = Buffer.alloc(3);
+      expect(buf.fill(1, offset)).toBe(buf);
+      expect([...buf]).toEqual([0, 0, 0]);
+    }
+    expect([...Buffer.alloc(3).fill(1, 2 ** 33, 1)]).toEqual([0, 0, 0]);
+  });
+
+  it("fill() rejects an offset above 2**53 - 1 and an end above the length", () => {
+    expect(() => Buffer.alloc(3).fill(1, 2 ** 53)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "offset" is out of range. It must be >= 0 && <= ${MAX}. Received 9_007_199_254_740_992`,
+      }),
+    );
+    expect(() => Buffer.alloc(3).fill(1, 0, 2 ** 33)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "end" is out of range. It must be >= 0 && <= 3. Received 8_589_934_592',
+      }),
+    );
+  });
+
+  it("compare() with a start past the end compares against an empty range", () => {
+    const buf = Buffer.alloc(3);
+    const target = Buffer.alloc(3);
+    for (const start of [3, 4, 2 ** 32, 2 ** 32 + 1, MAX]) {
+      expect(buf.compare(target, start)).toBe(1);
+      expect(buf.compare(target, 0, 3, start)).toBe(-1);
+      expect(buf.compare(target, start, 3, start)).toBe(0);
+    }
+  });
+
+  it("compare() rejects a start above 2**53 - 1 and an end above the length", () => {
+    const buf = Buffer.alloc(3);
+    const target = Buffer.alloc(3);
+    expect(() => buf.compare(target, 2 ** 53)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "targetStart" is out of range. It must be >= 0 && <= ${MAX}. Received 9_007_199_254_740_992`,
+      }),
+    );
+    expect(() => buf.compare(target, 0, 3, 2 ** 53)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: `The value of "sourceStart" is out of range. It must be >= 0 && <= ${MAX}. Received 9_007_199_254_740_992`,
+      }),
+    );
+    expect(() => buf.compare(target, 0, 4)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "targetEnd" is out of range. It must be >= 0 && <= 3. Received 4',
+      }),
+    );
+    expect(() => buf.compare(target, 0, 2 ** 33)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "targetEnd" is out of range. It must be >= 0 && <= 3. Received 8_589_934_592',
+      }),
+    );
+    expect(() => buf.compare(target, 0, 3, 0, 2 ** 33)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "sourceEnd" is out of range. It must be >= 0 && <= 3. Received 8_589_934_592',
+      }),
+    );
+  });
+});
+
+describe("indexOf(), lastIndexOf() and includes() on a detached buffer", () => {
+  const detached = () => {
+    const buf = Buffer.alloc(8).fill(1);
+    buf.buffer.transfer();
+    return buf;
+  };
+
+  it("finds an empty needle at 0 and nothing else, like an empty buffer", () => {
+    const results = buf => [
+      buf.indexOf(""),
+      buf.lastIndexOf(""),
+      buf.includes(""),
+      buf.indexOf(Buffer.alloc(0)),
+      buf.lastIndexOf(Buffer.alloc(0)),
+      buf.includes(Buffer.alloc(0)),
+      buf.indexOf("", 5),
+      buf.indexOf("", "utf8"),
+      buf.indexOf("", 0, "ucs2"),
+      buf.indexOf(1),
+      buf.lastIndexOf(1),
+      buf.includes(1),
+      buf.indexOf("a"),
+      buf.lastIndexOf("a"),
+      buf.indexOf(Buffer.from([1])),
+      buf.includes(Buffer.from([1])),
+    ];
+    const expected = [0, 0, true, 0, 0, true, 0, 0, 0, -1, -1, false, -1, -1, -1, false];
+    expect(results(Buffer.alloc(0))).toEqual(expected);
+    expect(results(detached())).toEqual(expected);
+  });
+});
+
+describe("util.inspect(buffer) with extra own properties", () => {
+  const custom = Symbol.for("nodejs.util.inspect.custom");
+
+  it("formats the extra properties like util.inspect does for an object", () => {
+    const buf = Buffer.from([3]);
+    buf.x = "y";
+    buf["a-b"] = [1, "two"];
+    buf[Symbol("s")] = { a: { b: { c: 1 } } };
+    const expected = "<Buffer 03, x: 'y', 'a-b': [ 1, 'two' ], Symbol(s): { a: { b: [Object] } }>";
+    expect(inspect(buf)).toBe(expected);
+    // The native formatter (console.log, Bun.inspect) calls the same hook with its own depth.
+    expect(Bun.inspect(buf, { depth: 2 })).toBe(expected);
+    expect(inspect({ nested: buf })).toBe(`{\n  nested: ${expected}\n}`);
+    expect(inspect(buf, { depth: 0 })).toBe("<Buffer 03, x: 'y', 'a-b': [Array], Symbol(s): [Object]>");
+    expect(inspect(buf, { colors: true })).toBe(
+      "<Buffer 03, x: \x1b[32m'y'\x1b[39m, \x1b[32m'a-b'\x1b[39m: [ \x1b[33m1\x1b[39m, \x1b[32m'two'\x1b[39m ], \x1b[32mSymbol(s)\x1b[39m: { a: { b: \x1b[36m[Object]\x1b[39m } }>",
+    );
+    // Called directly, with no inspect function as the third argument.
+    expect(buf[custom](0, {})).toBe(expected);
+  });
+
+  it("shows non-enumerable properties only with showHidden", () => {
+    const buf = Buffer.from([3]);
+    buf.x = "y";
+    buf.list = [1, "two"];
+    Object.defineProperty(buf, "hidden", { value: "h", enumerable: false });
+    expect(inspect(buf)).toBe("<Buffer 03, x: 'y', list: [ 1, 'two' ]>");
+    expect(inspect(buf, { showHidden: true })).toBe(
+      "<Buffer 03, x: 'y', list: [ 1, 'two', [length]: 2 ], hidden: 'h'>",
+    );
+    expect(buf[custom](0, { showHidden: true })).toBe(
+      "<Buffer 03, x: 'y', list: [ 1, 'two', [length]: 2 ], hidden: 'h'>",
+    );
+  });
+
+  it("keeps the Node layout for an empty buffer", () => {
+    expect(inspect(Buffer.alloc(0))).toBe("<Buffer >");
+    expect(inspect(Object.assign(Buffer.alloc(0), { q: "z" }))).toBe("<Buffer q: 'z'>");
   });
 });

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -5509,6 +5509,24 @@ describe("fill() and compare() offsets past the end of the buffer", () => {
       }),
     );
   });
+
+  it("compare() names the first invalid offset in argument order", () => {
+    const buf = Buffer.alloc(3);
+    const target = Buffer.alloc(3);
+    const named = f => {
+      try {
+        f();
+      } catch (e) {
+        return e.message.match(/"(\w+)"/)[1];
+      }
+    };
+    expect([
+      named(() => buf.compare(target, 0, 4, 0, 4)),
+      named(() => buf.compare(target, 2 ** 53, 4, 0, 4)),
+      named(() => buf.compare(target, 0, 3, 2 ** 53, 4)),
+      named(() => buf.compare(target, 1.5, 4)),
+    ]).toEqual(["targetEnd", "targetStart", "sourceStart", "targetStart"]);
+  });
 });
 
 describe("indexOf(), lastIndexOf() and includes() on a detached buffer", () => {
@@ -5576,6 +5594,29 @@ describe("util.inspect(buffer) with extra own properties", () => {
     expect(buf[custom](0, { showHidden: true })).toBe(
       "<Buffer 03, x: 'y', list: [ 1, 'two', [length]: 2 ], hidden: 'h'>",
     );
+  });
+
+  it("builds its inspect options without running setters on Object.prototype", () => {
+    Object.defineProperty(Object.prototype, "depth", {
+      configurable: true,
+      set() {
+        throw new Error("polluted depth");
+      },
+    });
+    Object.defineProperty(Object.prototype, "x", {
+      configurable: true,
+      set() {
+        throw new Error("polluted x");
+      },
+    });
+    try {
+      const buf = Buffer.from([3]);
+      Object.defineProperty(buf, "x", { value: "y", enumerable: true });
+      expect(inspect(buf)).toBe("<Buffer 03, x: 'y'>");
+    } finally {
+      delete Object.prototype.depth;
+      delete Object.prototype.x;
+    }
   });
 
   it("keeps the Node layout for an empty buffer", () => {


### PR DESCRIPTION
### Problem
Three `node:buffer` behaviors differ from Node v26.3.0, all in `src/jsc/bindings/JSBuffer.cpp`:
- `buf.fill(v, offset)` and `buf.compare(t, targetStart, ..., sourceStart)` throw `ERR_OUT_OF_RANGE` for a start above 2**32 (`jsBufferPrototypeFunction_fillBody`, `jsBufferPrototypeFunction_compareBody`). Node bounds a start by its kMaxLength (2**53 - 1) and treats a start past the end as an empty range. Bun used its own kMaxLength (2**32). The end check in `compare` also printed `>= 0 and <= 3` instead of Node's `>= 0 && <= 3`.
- `indexOf('')`, `lastIndexOf('')` and `includes('')` return -1 / false on a detached Buffer (`refetchBufferState` in `indexOf`). Node reads a detached Buffer as empty, so an empty needle is found at 0.
- `util.inspect(buf)` with extra own properties prints `<Buffer 03, x: "y">` (double quotes, unquoted `a-b` keys, bare symbol names, no depth limit, no colors). Node prints `<Buffer 03, x: 'y'>`. Bun formatted each value with `Bun__inspect_singleline`.

### Fix
- `fill` and `compare` validate a start with `validateInteger(0, kMaxOffset)` like Node's `validateOffset`, in argument order. `kMaxOffset` is a new named constant in `JSBuffer.h` (2**53 - 1, Node's `kMaxLength` since nodejs/node#52465). It is separate from Bun's `kMaxLength` (2**32), which bounds an allocation size and stays in place for `alloc` and `Buffer.concat`. `compare` validates an end against its own buffer's length in the same call, which gives Node's message.
- `refetchBufferState` no longer short-circuits a detached haystack to -1. It sets length 0, and `computeIndexOfRange` already handles an empty haystack without reading the vector.
- The inspect hook copies the extra properties onto a null-prototype object, calls `util.inspect` on it with the caller's options plus `breakLength: Infinity, compact: true`, and keeps the text between `[Object: null prototype] { ` and ` }`. This is Node's `Buffer.prototype[inspect.custom]`, so keys, values, colors and depth match.
- Verified: `test/js/node/buffer.test.js` (8 new tests fail on bun 1.4.3, all 688 pass here). Also Node's `test-buffer-{fill,compare,compare-offset,indexof,includes,inspect,prototype-inspect,alloc}.js`, `util-inspect.test.js`, `console-log.test.ts`.

### Background
- `Bun::V::validateInteger` is the port of Node's `validateInteger(value, name, min, max)`. It throws `ERR_OUT_OF_RANGE` with `>= min && <= max`.
- `Bun::Buffer::kMaxLength` is `MAX_ARRAY_BUFFER_SIZE` (2**32) because JSC caps an `ArrayBuffer` there. It is the right bound for an allocation size (`alloc`, `concat`), not for a start offset, which can never index past a real buffer and is an empty range in Node.
- A detached view reports `byteLength()` 0 and a null vector. `computeIndexOfRange` returns an immediate result for an empty haystack or an empty needle, so the search code never reads the vector.
- `globalObject->utilInspectFunction()` is `node:util`'s `inspect`, the same function `internal/util/inspect.js` passes to a custom inspect hook.

<details><summary>Notes</summary>

Node reference: `validateOffset` in `lib/buffer.js` (`validateInteger(value, name, 0, kMaxLength)` with `kMaxLength = 2**53 - 1`), `_fill` (`validateOffset(offset, 'offset')`, `validateOffset(end, 'end', 0, buf.length)`, then `if (offset >= end) return buf`), `compare` (`validateOffset(targetEnd, 'targetEnd', 0, target.length)`), `IndexOfOffset` in `src/node_buffer.cc` (empty needle past the end points at the end), and `Buffer.prototype[customInspectSymbol]`.

Probe on node v26.3.0 vs bun 1.4.3, all now identical on this build:

```
fill(1, 2**32 + 1)            node: no-op           bun: ERR_OUT_OF_RANGE "offset" <= 4294967296
fill(1, 2**53)                node: ERR_OUT_OF_RANGE "offset" <= 9007199254740991
compare(t, 2**32 + 1)         node: 1               bun: ERR_OUT_OF_RANGE "targetStart"
compare(t, 0, 3, 2**32 + 1)   node: -1              bun: ERR_OUT_OF_RANGE "sourceStart"
compare(t, 0, 4)              node: ">= 0 && <= 3"  bun: ">= 0 and <= 3"
detached.indexOf('')          node: 0               bun: -1
detached.includes('')         node: true            bun: false
inspect(buf with x='y')       node: <Buffer 03, x: 'y'>   bun: <Buffer 03, x: "y">
```

Review follow-ups in this PR: `compare()` validates its offsets in argument order so the first invalid one is the one named (the switch used to run in reverse), and the inspect options copy uses define semantics so a setter on `Object.prototype` under an option name does not run. Both have tests.

`Bun.inspect(buf)` keeps its own default depth (8), so the test passes `{ depth: 2 }` to the native formatter. `console.log(buf)` uses depth 2 and matches Node.

Related open PRs for the other rows of the same report: #39073 (`toJSON` on a detached Buffer), #39028 (`isUtf8`/`isAscii` with a DataView). #36138 (`%s` of a Buffer) merged.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/buffer.test.js

<!-- robobun:evidence:end -->