### PR TITLE
node:assert: compare KeyObject and CryptoKey material in deep equality

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -134,6 +134,8 @@
 #include "FetchHeaders.h"
 #include "DOMURL.h"
 #include "JSDOMURL.h"
+#include "node/crypto/JSKeyObject.h"
+#include "webcrypto/JSCryptoKey.h"
 
 #include <string_view>
 #include <bun-uws/src/App.h>
@@ -1381,6 +1383,50 @@ static constexpr DeepEqualsMode deepEqualsMode {
     checkPrototypes ? &nonIndexOwnPropertiesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity> : nullptr,
 };
 
+// KeyObject and CryptoKey keep their key material in C++ and have no own
+// properties, so the generic own-property walk would call any two keys equal.
+// Follow node's comparisons.js: a KeyObject compares by type and key material,
+// a CryptoKey also by extractable, algorithm and usages. Returns std::nullopt
+// when neither side is a key, or when the keys match and the own enumerable
+// properties still have to be compared.
+static std::optional<bool> cryptoKeysDequal(const DeepEqualsMode& mode, JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
+{
+    if (auto* keyObject1 = dynamicDowncast<Bun::JSKeyObject>(o1)) {
+        auto* keyObject2 = dynamicDowncast<Bun::JSKeyObject>(o2);
+        if (!keyObject2)
+            return false;
+        bool equal = keyObject1->handle().deepEquals(globalObject, scope, keyObject2->handle());
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!equal)
+            return false;
+        return std::nullopt;
+    }
+    if (auto* cryptoKey1 = dynamicDowncast<WebCore::JSCryptoKey>(o1)) {
+        auto* cryptoKey2 = dynamicDowncast<WebCore::JSCryptoKey>(o2);
+        if (!cryptoKey2)
+            return false;
+
+        const Identifier algorithmName = Identifier::fromString(globalObject->vm(), "algorithm"_s);
+        JSValue algorithm1 = cryptoKey1->get(globalObject, algorithmName);
+        RETURN_IF_EXCEPTION(scope, {});
+        JSValue algorithm2 = cryptoKey2->get(globalObject, algorithmName);
+        RETURN_IF_EXCEPTION(scope, {});
+        bool sameAlgorithm = mode.deepEquals(globalObject, algorithm1, algorithm2, gcBuffer, stack, scope, true);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!sameAlgorithm)
+            return false;
+
+        bool equal = Bun::KeyObject::cryptoKeysDeepEqual(globalObject, scope, cryptoKey1->wrapped(), cryptoKey2->wrapped());
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!equal)
+            return false;
+        return std::nullopt;
+    }
+    if (o2->inherits<Bun::JSKeyObject>() || o2->inherits<WebCore::JSCryptoKey>())
+        return false;
+    return std::nullopt;
+}
+
 // The per-type comparisons (Map, Set, Date, typed arrays, ...) are compiled once
 // and take the mode at runtime; only the dispatch and the plain-object tail in
 // `specialObjectsDequal` below stay specialised per mode.
@@ -2123,6 +2169,11 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             std::optional<bool> temporalEqual = temporalObjectsDequal(obj1, obj2);
             if (temporalEqual.has_value())
                 return temporalEqual;
+
+            std::optional<bool> keysEqual = cryptoKeysDequal(deepEqualsMode<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>, globalObject, gcBuffer, stack, scope, obj1, obj2);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (keysEqual.has_value())
+                return keysEqual;
 
             const bool isSymbol1 = obj1->inherits<SymbolObject>();
             const bool isBigInt1 = obj1->inherits<BigIntObject>();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1383,9 +1383,7 @@ static constexpr DeepEqualsMode deepEqualsMode {
     checkPrototypes ? &nonIndexOwnPropertiesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity> : nullptr,
 };
 
-// KeyObject and CryptoKey keep their state in C++ with no own properties, so
-// compare the key material like node's comparisons.js. std::nullopt means
-// "continue with the own-property walk".
+// Key material compare from node's comparisons.js. nullopt: continue with the own-property walk.
 static std::optional<bool> cryptoKeysDequal(const DeepEqualsMode& mode, JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
 {
     if (auto* keyObject1 = dynamicDowncast<Bun::JSKeyObject>(o1)) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1383,12 +1383,9 @@ static constexpr DeepEqualsMode deepEqualsMode {
     checkPrototypes ? &nonIndexOwnPropertiesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity> : nullptr,
 };
 
-// KeyObject and CryptoKey keep their key material in C++ and have no own
-// properties, so the generic own-property walk would call any two keys equal.
-// Follow node's comparisons.js: a KeyObject compares by type and key material,
-// a CryptoKey also by extractable, algorithm and usages. Returns std::nullopt
-// when neither side is a key, or when the keys match and the own enumerable
-// properties still have to be compared.
+// KeyObject and CryptoKey keep their state in C++ with no own properties, so
+// compare the key material like node's comparisons.js. std::nullopt means
+// "continue with the own-property walk".
 static std::optional<bool> cryptoKeysDequal(const DeepEqualsMode& mode, JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
 {
     if (auto* keyObject1 = dynamicDowncast<Bun::JSKeyObject>(o1)) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1405,18 +1405,9 @@ static std::optional<bool> cryptoKeysDequal(const DeepEqualsMode& mode, JSC::JSG
         auto* cryptoKey2 = dynamicDowncast<WebCore::JSCryptoKey>(o2);
         if (!cryptoKey2)
             return false;
-
-        const Identifier algorithmName = Identifier::fromString(globalObject->vm(), "algorithm"_s);
-        JSValue algorithm1 = cryptoKey1->get(globalObject, algorithmName);
-        RETURN_IF_EXCEPTION(scope, {});
-        JSValue algorithm2 = cryptoKey2->get(globalObject, algorithmName);
-        RETURN_IF_EXCEPTION(scope, {});
-        bool sameAlgorithm = mode.deepEquals(globalObject, algorithm1, algorithm2, gcBuffer, stack, scope, true);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (!sameAlgorithm)
-            return false;
-
-        bool equal = Bun::KeyObject::cryptoKeysDeepEqual(globalObject, scope, cryptoKey1->wrapped(), cryptoKey2->wrapped());
+        bool equal = Bun::KeyObject::cryptoKeysDeepEqual(globalObject, scope, cryptoKey1, cryptoKey2, [&](JSValue algorithm1, JSValue algorithm2) {
+            return mode.deepEquals(globalObject, algorithm1, algorithm2, gcBuffer, stack, scope, true);
+        });
         RETURN_IF_EXCEPTION(scope, {});
         if (!equal)
             return false;

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -920,6 +920,34 @@ std::optional<bool> KeyObject::equals(const KeyObject& other) const
     }
 }
 
+bool KeyObject::deepEquals(JSGlobalObject* globalObject, ThrowScope& scope, const KeyObject& other) const
+{
+    std::optional<bool> result = equals(other);
+    if (!result.has_value()) {
+        ERR::CRYPTO_UNSUPPORTED_OPERATION(scope, globalObject);
+        return false;
+    }
+    return *result;
+}
+
+bool KeyObject::cryptoKeysDeepEqual(JSGlobalObject* globalObject, ThrowScope& scope, WebCore::CryptoKey& key1, WebCore::CryptoKey& key2)
+{
+    if (key1.type() != key2.type() || key1.extractable() != key2.extractable() || key1.usagesBitmap() != key2.usagesBitmap())
+        return false;
+
+    auto handle1 = create(key1);
+    if (handle1.hasException()) {
+        WebCore::propagateException(*globalObject, scope, handle1.releaseException());
+        return false;
+    }
+    auto handle2 = create(key2);
+    if (handle2.hasException()) {
+        WebCore::propagateException(*globalObject, scope, handle2.releaseException());
+        return false;
+    }
+    return handle1.returnValue().deepEquals(globalObject, scope, handle2.returnValue());
+}
+
 static std::optional<Vector<uint8_t>> marshalAsymmetricKey(const ncrypto::EVPKeyPointer& pkey, bool isPublic)
 {
     return WebCore::marshalEVPKey(pkey.get(), isPublic);

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -930,9 +930,21 @@ bool KeyObject::deepEquals(JSGlobalObject* globalObject, ThrowScope& scope, cons
     return *result;
 }
 
-bool KeyObject::cryptoKeysDeepEqual(JSGlobalObject* globalObject, ThrowScope& scope, WebCore::CryptoKey& key1, WebCore::CryptoKey& key2)
+bool KeyObject::cryptoKeysDeepEqual(JSGlobalObject* globalObject, ThrowScope& scope, WebCore::JSCryptoKey* cryptoKey1, WebCore::JSCryptoKey* cryptoKey2, const WTF::Function<bool(JSValue, JSValue)>& algorithmsEqual)
 {
+    auto& key1 = cryptoKey1->wrapped();
+    auto& key2 = cryptoKey2->wrapped();
     if (key1.type() != key2.type() || key1.extractable() != key2.extractable() || key1.usagesBitmap() != key2.usagesBitmap())
+        return false;
+
+    const Identifier algorithmName = Identifier::fromString(globalObject->vm(), "algorithm"_s);
+    JSValue algorithm1 = cryptoKey1->get(globalObject, algorithmName);
+    RETURN_IF_EXCEPTION(scope, false);
+    JSValue algorithm2 = cryptoKey2->get(globalObject, algorithmName);
+    RETURN_IF_EXCEPTION(scope, false);
+    bool sameAlgorithm = algorithmsEqual(algorithm1, algorithm2);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!sameAlgorithm)
         return false;
 
     auto handle1 = create(key1);

--- a/src/jsc/bindings/node/crypto/KeyObject.h
+++ b/src/jsc/bindings/node/crypto/KeyObject.h
@@ -8,6 +8,7 @@
 
 namespace WebCore {
 class CryptoKey;
+class JSCryptoKey;
 }
 
 namespace Bun {
@@ -113,9 +114,9 @@ public:
     // `equals` for node's deep equality: throws ERR_CRYPTO_UNSUPPORTED_OPERATION
     // when the key material cannot be compared, like KeyObject.prototype.equals.
     bool deepEquals(JSC::JSGlobalObject*, JSC::ThrowScope&, const KeyObject& other) const;
-    // The CryptoKey half of node's deep equality that needs no recursion: type,
-    // extractable, usages, and key material. The caller compares `algorithm`.
-    static bool cryptoKeysDeepEqual(JSC::JSGlobalObject*, JSC::ThrowScope&, WebCore::CryptoKey&, WebCore::CryptoKey&);
+    // node's deep equality for two CryptoKeys: type, extractable, `algorithm`
+    // (compared by the caller's recursion), usages, and key material.
+    static bool cryptoKeysDeepEqual(JSC::JSGlobalObject*, JSC::ThrowScope&, WebCore::JSCryptoKey*, WebCore::JSCryptoKey*, const WTF::Function<bool(JSC::JSValue, JSC::JSValue)>& algorithmsEqual);
     JSC::JSValue toCryptoKey(JSC::JSGlobalObject*, JSC::ThrowScope&,
         JSC::JSValue algorithmValue, JSC::JSValue extractableValue, JSC::JSValue keyUsagesValue);
 

--- a/src/jsc/bindings/node/crypto/KeyObject.h
+++ b/src/jsc/bindings/node/crypto/KeyObject.h
@@ -111,11 +111,9 @@ public:
     JSC::JSObject* asymmetricKeyDetails(JSC::JSGlobalObject*, JSC::ThrowScope&);
 
     std::optional<bool> equals(const KeyObject& other) const;
-    // `equals` for node's deep equality: throws ERR_CRYPTO_UNSUPPORTED_OPERATION
-    // when the key material cannot be compared, like KeyObject.prototype.equals.
+    // `equals` that throws ERR_CRYPTO_UNSUPPORTED_OPERATION instead of returning nullopt.
     bool deepEquals(JSC::JSGlobalObject*, JSC::ThrowScope&, const KeyObject& other) const;
-    // node's deep equality for two CryptoKeys: type, extractable, `algorithm`
-    // (compared by the caller's recursion), usages, and key material.
+    // node's CryptoKey deep equality. `algorithmsEqual` is the caller's recursion.
     static bool cryptoKeysDeepEqual(JSC::JSGlobalObject*, JSC::ThrowScope&, WebCore::JSCryptoKey*, WebCore::JSCryptoKey*, const WTF::Function<bool(JSC::JSValue, JSC::JSValue)>& algorithmsEqual);
     JSC::JSValue toCryptoKey(JSC::JSGlobalObject*, JSC::ThrowScope&,
         JSC::JSValue algorithmValue, JSC::JSValue extractableValue, JSC::JSValue keyUsagesValue);

--- a/src/jsc/bindings/node/crypto/KeyObject.h
+++ b/src/jsc/bindings/node/crypto/KeyObject.h
@@ -110,6 +110,12 @@ public:
     JSC::JSObject* asymmetricKeyDetails(JSC::JSGlobalObject*, JSC::ThrowScope&);
 
     std::optional<bool> equals(const KeyObject& other) const;
+    // `equals` for node's deep equality: throws ERR_CRYPTO_UNSUPPORTED_OPERATION
+    // when the key material cannot be compared, like KeyObject.prototype.equals.
+    bool deepEquals(JSC::JSGlobalObject*, JSC::ThrowScope&, const KeyObject& other) const;
+    // The CryptoKey half of node's deep equality that needs no recursion: type,
+    // extractable, usages, and key material. The caller compares `algorithm`.
+    static bool cryptoKeysDeepEqual(JSC::JSGlobalObject*, JSC::ThrowScope&, WebCore::CryptoKey&, WebCore::CryptoKey&);
     JSC::JSValue toCryptoKey(JSC::JSGlobalObject*, JSC::ThrowScope&,
         JSC::JSValue algorithmValue, JSC::JSValue extractableValue, JSC::JSValue keyUsagesValue);
 

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -745,16 +745,9 @@ static bool compareBranch(JSC::JSGlobalObject* globalObject, JSC::MarkedArgument
             return false;
         auto* actualKey = uncheckedDowncast<WebCore::JSCryptoKey>(actual.asCell());
         auto* expectedKey = uncheckedDowncast<WebCore::JSCryptoKey>(expected.asCell());
-        const JSC::Identifier algorithmName = JSC::Identifier::fromString(vm, "algorithm"_s);
-        JSValue actualAlgorithm = actualKey->get(globalObject, algorithmName);
-        RETURN_IF_EXCEPTION(scope, false);
-        JSValue expectedAlgorithm = expectedKey->get(globalObject, algorithmName);
-        RETURN_IF_EXCEPTION(scope, false);
-        bool sameAlgorithm = compareBranch(globalObject, gcBuffer, cycles, scope, actualAlgorithm, expectedAlgorithm);
-        RETURN_IF_EXCEPTION(scope, false);
-        if (!sameAlgorithm)
-            return false;
-        bool equal = Bun::KeyObject::cryptoKeysDeepEqual(globalObject, scope, actualKey->wrapped(), expectedKey->wrapped());
+        bool equal = Bun::KeyObject::cryptoKeysDeepEqual(globalObject, scope, actualKey, expectedKey, [&](JSValue actualAlgorithm, JSValue expectedAlgorithm) {
+            return compareBranch(globalObject, gcBuffer, cycles, scope, actualAlgorithm, expectedAlgorithm);
+        });
         RETURN_IF_EXCEPTION(scope, false);
         if (!equal)
             return false;

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -729,18 +729,34 @@ static bool compareBranch(JSC::JSGlobalObject* globalObject, JSC::MarkedArgument
     if (actualIsKeyObject || expectedIsKeyObject) {
         if (!actualIsKeyObject || !expectedIsKeyObject)
             return false;
-        // KeyObject.prototype.equals, called like the JS implementation did.
-        JSC::JSObject* actualObject = actual.getObject();
-        JSValue equalsFunction = actualObject->get(globalObject, JSC::Identifier::fromString(vm, "equals"_s));
+        auto& actualHandle = uncheckedDowncast<Bun::JSKeyObject>(actual.asCell())->handle();
+        auto& expectedHandle = uncheckedDowncast<Bun::JSKeyObject>(expected.asCell())->handle();
+        bool equal = actualHandle.deepEquals(globalObject, scope, expectedHandle);
         RETURN_IF_EXCEPTION(scope, false);
-        auto callData = JSC::getCallData(equalsFunction);
-        if (callData.type == JSC::CallData::Type::None)
+        if (!equal)
             return false;
-        JSC::MarkedArgumentBuffer args;
-        args.append(expected);
-        JSValue result = JSC::call(globalObject, equalsFunction, callData, actual, args);
+        return withCycleGuard(globalObject, gcBuffer, cycles, scope, actual, expected, objectSubset);
+    }
+
+    const bool actualIsCryptoKey = actual.isCell() && actual.asCell()->inherits<WebCore::JSCryptoKey>();
+    const bool expectedIsCryptoKey = expected.isCell() && expected.asCell()->inherits<WebCore::JSCryptoKey>();
+    if (actualIsCryptoKey || expectedIsCryptoKey) {
+        if (!actualIsCryptoKey || !expectedIsCryptoKey)
+            return false;
+        auto* actualKey = uncheckedDowncast<WebCore::JSCryptoKey>(actual.asCell());
+        auto* expectedKey = uncheckedDowncast<WebCore::JSCryptoKey>(expected.asCell());
+        const JSC::Identifier algorithmName = JSC::Identifier::fromString(vm, "algorithm"_s);
+        JSValue actualAlgorithm = actualKey->get(globalObject, algorithmName);
         RETURN_IF_EXCEPTION(scope, false);
-        if (!result.toBoolean(globalObject))
+        JSValue expectedAlgorithm = expectedKey->get(globalObject, algorithmName);
+        RETURN_IF_EXCEPTION(scope, false);
+        bool sameAlgorithm = compareBranch(globalObject, gcBuffer, cycles, scope, actualAlgorithm, expectedAlgorithm);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!sameAlgorithm)
+            return false;
+        bool equal = Bun::KeyObject::cryptoKeysDeepEqual(globalObject, scope, actualKey->wrapped(), expectedKey->wrapped());
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!equal)
             return false;
         return withCycleGuard(globalObject, gcBuffer, cycles, scope, actual, expected, objectSubset);
     }

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -1,4 +1,5 @@
 import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import { createSecretKey } from "node:crypto";
 import vm from "node:vm";
 
 describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
@@ -47,6 +48,35 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     const b = new FakeMap();
     expect(deepEquals(a, b)).toBe(false);
     expect(deepEquals(b, a)).toBe(false);
+  });
+
+  // KeyObject and CryptoKey have no own properties; compare the key material,
+  // like node's assert and util do.
+  it("KeyObjects and CryptoKeys compare by key material", () => {
+    const keyA = createSecretKey(Buffer.from("secret-A"));
+    const keyA2 = createSecretKey(Buffer.from("secret-A"));
+    const keyB = createSecretKey(Buffer.from("secret-B"));
+    expect(deepEquals(keyA, keyA2)).toBe(true);
+    expect(deepEquals(keyA, keyB)).toBe(false);
+    expect(deepEquals({ k: keyA }, { k: keyB })).toBe(false);
+    expect(deepEquals(keyA, {})).toBe(false);
+    expect(deepEquals({}, keyA)).toBe(false);
+    expect(keyA).toEqual(keyA2);
+    expect(keyA).not.toEqual(keyB);
+    expect(keyA).not.toStrictEqual(keyB);
+
+    const hmac = { name: "HMAC", hash: "SHA-256" };
+    const cryptoKeyA = keyA.toCryptoKey(hmac, true, ["sign"]);
+    const cryptoKeyA2 = keyA2.toCryptoKey(hmac, true, ["sign"]);
+    const cryptoKeyB = keyB.toCryptoKey(hmac, true, ["sign"]);
+    expect(deepEquals(cryptoKeyA, cryptoKeyA2)).toBe(true);
+    expect(deepEquals(cryptoKeyA, cryptoKeyB)).toBe(false);
+    expect(deepEquals(cryptoKeyA, keyA.toCryptoKey(hmac, false, ["sign"]))).toBe(false);
+    expect(deepEquals(cryptoKeyA, keyA.toCryptoKey(hmac, true, ["verify"]))).toBe(false);
+    expect(deepEquals(cryptoKeyA, keyA.toCryptoKey({ name: "HMAC", hash: "SHA-512" }, true, ["sign"]))).toBe(false);
+    expect(deepEquals(cryptoKeyA, keyA)).toBe(false);
+    expect(cryptoKeyA).toEqual(cryptoKeyA2);
+    expect(cryptoKeyA).not.toEqual(cryptoKeyB);
   });
 
   // we may change this in the future

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -3,6 +3,7 @@
 // cross-checked against Node.js. Cases Bun gets wrong today are marked `test.failing`.
 import { describe, expect, test } from "bun:test";
 import assert from "node:assert";
+import { createPublicKey, createSecretKey, generateKeyPairSync } from "node:crypto";
 import util from "node:util";
 
 type Thunk = () => unknown;
@@ -24,6 +25,20 @@ interface Case {
 
 const sym = Symbol("shared");
 const sharedArrayBuffer = new ArrayBuffer(4);
+
+const secretKeyA = createSecretKey(Buffer.from("secret-A"));
+const secretKeyA2 = createSecretKey(Buffer.from("secret-A"));
+const secretKeyB = createSecretKey(Buffer.from("secret-B"));
+const ecPairA = generateKeyPairSync("ec", { namedCurve: "P-256" });
+const ecPairB = generateKeyPairSync("ec", { namedCurve: "P-256" });
+const ecPublicA2 = createPublicKey(ecPairA.publicKey.export({ type: "spki", format: "pem" }));
+const hmac256 = { name: "HMAC", hash: "SHA-256" };
+const cryptoKeyA = secretKeyA.toCryptoKey(hmac256, true, ["sign"]);
+const cryptoKeyA2 = secretKeyA2.toCryptoKey(hmac256, true, ["sign"]);
+const cryptoKeyB = secretKeyB.toCryptoKey(hmac256, true, ["sign"]);
+const cryptoKeyANotExtractable = secretKeyA.toCryptoKey(hmac256, false, ["sign"]);
+const cryptoKeyAVerify = secretKeyA.toCryptoKey(hmac256, true, ["verify"]);
+const cryptoKeyASha512 = secretKeyA.toCryptoKey({ name: "HMAC", hash: "SHA-512" }, true, ["sign"]);
 
 function float64WithNaNPayload(bits: bigint) {
   const arr = new Float64Array(1);
@@ -943,6 +958,102 @@ const cases: Case[] = [
     strict: true,
     loose: true,
   },
+
+  // KeyObject and CryptoKey: node compares the key material (comparisons.js isKeyObject /
+  // isCryptoKey arms), not the (empty) set of own properties.
+  {
+    name: "two secret keys with the same material",
+    a: () => secretKeyA,
+    b: () => secretKeyA2,
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "two secret keys with different material",
+    a: () => secretKeyA,
+    b: () => secretKeyB,
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "objects holding secret keys with different material",
+    a: () => ({ k: secretKeyA }),
+    b: () => ({ k: secretKeyB }),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "a secret key with an extra own property and a plain one",
+    a: () => Object.assign(createSecretKey(Buffer.from("secret-A")), { x: 1 }),
+    b: () => secretKeyA,
+    strict: false,
+    loose: false,
+  },
+  { name: "a secret key and an empty object", a: () => secretKeyA, b: () => ({}), strict: false, loose: false },
+  {
+    name: "two public keys with the same material",
+    a: () => ecPairA.publicKey,
+    b: () => ecPublicA2,
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "two public keys from different key pairs",
+    a: () => ecPairA.publicKey,
+    b: () => ecPairB.publicKey,
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two private keys from different key pairs",
+    a: () => ecPairA.privateKey,
+    b: () => ecPairB.privateKey,
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "a public key and the private key of the same pair",
+    a: () => ecPairA.publicKey,
+    b: () => ecPairA.privateKey,
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two CryptoKeys with the same material",
+    a: () => cryptoKeyA,
+    b: () => cryptoKeyA2,
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "two CryptoKeys with different material",
+    a: () => cryptoKeyA,
+    b: () => cryptoKeyB,
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two CryptoKeys that differ only in extractable",
+    a: () => cryptoKeyA,
+    b: () => cryptoKeyANotExtractable,
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two CryptoKeys that differ only in usages",
+    a: () => cryptoKeyA,
+    b: () => cryptoKeyAVerify,
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two CryptoKeys that differ only in algorithm",
+    a: () => cryptoKeyA,
+    b: () => cryptoKeyASha512,
+    strict: false,
+    loose: false,
+  },
+  { name: "a CryptoKey and a KeyObject", a: () => cryptoKeyA, b: () => secretKeyA, strict: false, loose: false },
 ];
 
 function caught(fn: () => void): (Error & { code?: string }) | null {
@@ -1117,6 +1228,15 @@ describe("detached ArrayBuffer", () => {
     expect(() =>
       assert.partialDeepStrictEqual(Object.assign(key, { x: 1 }), crypto.createSecretKey(Buffer.from("secret"))),
     ).not.toThrow();
+  });
+
+  test("assert.partialDeepStrictEqual compares CryptoKey material, algorithm, usages and extractable", () => {
+    expect(() => assert.partialDeepStrictEqual(cryptoKeyA, cryptoKeyA2)).not.toThrow();
+    expect(() => assert.partialDeepStrictEqual(cryptoKeyA, cryptoKeyB)).toThrow(assert.AssertionError);
+    expect(() => assert.partialDeepStrictEqual(cryptoKeyA, cryptoKeyASha512)).toThrow(assert.AssertionError);
+    expect(() => assert.partialDeepStrictEqual(cryptoKeyA, cryptoKeyAVerify)).toThrow(assert.AssertionError);
+    expect(() => assert.partialDeepStrictEqual(cryptoKeyA, cryptoKeyANotExtractable)).toThrow(assert.AssertionError);
+    expect(() => assert.partialDeepStrictEqual(cryptoKeyA, secretKeyA)).toThrow(assert.AssertionError);
   });
 
   test("error matches Node's message", () => {


### PR DESCRIPTION
### Problem
- `util.isDeepStrictEqual`, `assert.deepStrictEqual`, `assert.deepEqual` and `Bun.deepEquals` report any two `KeyObject`s or `CryptoKey`s as equal. `assert.deepStrictEqual(createSecretKey(a), createSecretKey(b))` passes for any `a` and `b`. Node throws `ERR_ASSERTION`. A test that asserts two keys are equal can never fail.
- The cause is the own-property walk in `Bun__deepEquals` (`src/jsc/bindings/bindings.cpp`). Both classes keep their state in C++ and have no own enumerable properties, so the walk compares nothing.

### Fix
- A new arm in the `ObjectType` tail of `specialObjectsDequal`, next to the Temporal arm. It follows node's `comparisons.js`: a `KeyObject` compares by type and key material. A `CryptoKey` compares by type, extractable, `algorithm` (deep, with the caller's mode), usages and key material. Both then compare own enumerable properties as before.
- The key material compare throws `ERR_CRYPTO_UNSUPPORTED_OPERATION` when OpenSSL cannot compare the keys, the same as `KeyObject.prototype.equals` and node's handle `equals`.
- The native `assert.partialDeepStrictEqual` port (`src/jsc/modules/NodeUtilTypesModule.cpp`) shares the helpers. It already handled `KeyObject` through a JS call to `equals`. It now also handles `CryptoKey`.
- Verified: `test/js/node/assert/deep-equal.test.ts` (22 matrix cases, 20 fail on 1.4.2) and `test/js/bun/bun-object/deep-equals.test.ts` (fails on 1.4.2). Also `test/js/node/assert/`, node's `test-assert*.js`, `crypto.key-objects.test.ts`, `test/js/bun/test/expect*`.

### Background
- `specialObjectsDequal` is the per-type dispatch inside the deep equality walk. It returns `false` to reject a pair, `true` to accept it, and `std::nullopt` to continue with the generic own-property compare. All four entry points (node strict, node loose, `Bun.deepEquals`, `expect().toEqual`) share this template, so `expect(keyA).toEqual(keyB)` now compares key material too. The new bun-object test pins that.
- `JSKeyObject` and `JSCryptoKey` both use the `ObjectType` cell type, so the arm lives in the `c1Type == ObjectType` tail, not in the `switch`.
- `KeyObject::create(CryptoKey&)` already converts WebCrypto key material to a node `KeyObject` handle. The `CryptoKey` arm uses it for the material compare.
- #35374 (draft, stacked) carries an older version of this arm in its `bindings.cpp` hunk 2. This PR supersedes that hunk with two deliberate differences: it throws on an unsupported compare instead of falling through, and it deep-compares the `algorithm` dictionary instead of the identifier only.

<details><summary>Notes</summary>

Node v26.3.0 reference: `lib/internal/util/comparisons.js`, the `isKeyObject` and `isCryptoKey` arms of `objectComparisonStart`. Both run in every mode (strict, loose, partial) and fall through to `keyCheck` afterwards.

Repro on 1.4.2 (node v26.3.0 in the comment):

```js
import assert from "node:assert";
import util from "node:util";
import { createSecretKey, generateKeyPairSync } from "node:crypto";
const a = createSecretKey(Buffer.from("secret-A")), b = createSecretKey(Buffer.from("secret-B"));
util.isDeepStrictEqual(a, b);         // true   (node: false)
assert.deepStrictEqual(a, b);         // passes (node: ERR_ASSERTION)
assert.deepEqual({ k: a }, { k: b }); // passes (node: ERR_ASSERTION)
const p1 = generateKeyPairSync("ec", { namedCurve: "P-256" }).publicKey;
const p2 = generateKeyPairSync("ec", { namedCurve: "P-256" }).publicKey;
assert.deepStrictEqual(p1, p2);       // passes (node: ERR_ASSERTION)
const k1 = await crypto.subtle.importKey("raw", Buffer.from("k1k1k1k1k1k1k1k1"), { name: "HMAC", hash: "SHA-256" }, true, ["sign"]);
const k2 = await crypto.subtle.importKey("raw", Buffer.from("k2k2k2k2k2k2k2k2"), { name: "HMAC", hash: "SHA-256" }, true, ["sign"]);
assert.deepStrictEqual(k1, k2);       // passes (node: ERR_ASSERTION)
assert.partialDeepStrictEqual(k1, k2); // passes (node: ERR_ASSERTION)
```

`algorithm` is read through the JS getter. `JSCryptoKey` caches the dictionary object in `m_algorithm`, so the read is cheap and the compared objects are plain objects with `Object.prototype`.

The `ObjectType` tail of `specialObjectsDequalSlow` is not reachable for `ObjectType` cells (the dispatch only sends the listed cell types there), so the arm is added to the templated function only.

Suites run with the debug build: `test/js/node/assert/` (7 files), `test/js/node/test/parallel/test-assert{,-checktag,-class,-deep-with-error,-typedarray-deepequal}.js`, `test/js/node/crypto/crypto.key-objects.test.ts`, `test/js/node/util/test-util-types.test.js`, `test/js/bun/test/expect.test.ts`, `test/js/bun/test/expect/`, `test/js/bun/bun-object/`.

Self-reviewed: 3 concerns raised, 3 addressed (reference #35374 and state the semantic differences, add a `Bun.deepEquals` / `toEqual` test, fold the duplicated `CryptoKey` arm into one helper).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->