### PR TITLE
Parse If-Modified-Since and If-Unmodified-Since as RFC 9110 HTTP-date

### DIFF
--- a/src/http_types/HTTPDate.rs
+++ b/src/http_types/HTTPDate.rs
@@ -1,21 +1,10 @@
-//! RFC 9110 §5.6.7 `HTTP-date` parser.
-//!
-//! Accepts exactly the three grammars the RFC lists and nothing else:
+//! RFC 9110 §5.6.7 `HTTP-date` parser: IMF-fixdate, rfc850-date, asctime-date.
 //!
 //! ```text
-//! IMF-fixdate  = day-name "," SP day SP month SP year SP time-of-day SP GMT
-//!                  Sun, 06 Nov 1994 08:49:37 GMT
-//! rfc850-date  = day-name-l "," SP day "-" month "-" 2DIGIT SP time-of-day SP GMT
-//!                  Sunday, 06-Nov-94 08:49:37 GMT
-//! asctime-date = day-name SP month SP ( 2DIGIT / ( SP 1DIGIT ) ) SP time-of-day SP year
-//!                  Sun Nov  6 08:49:37 1994
+//! Sun, 06 Nov 1994 08:49:37 GMT
+//! Sunday, 06-Nov-94 08:49:37 GMT
+//! Sun Nov  6 08:49:37 1994
 //! ```
-//!
-//! The conditional request headers (`If-Modified-Since`,
-//! `If-Unmodified-Since`, `If-Range`) MUST be ignored when the value is not
-//! a valid HTTP-date (§13.1.3, §13.1.4, §13.1.5). The ECMAScript `Date.parse`
-//! grammar accepts far more (`2030`, `12345`, `1/1/2030`, time zones other
-//! than GMT), so it must not be used for those headers.
 
 use bun_core::strings;
 
@@ -46,11 +35,8 @@ struct Civil {
     second: u32,
 }
 
-/// Parse an `HTTP-date` into milliseconds since the Unix epoch.
-///
-/// Returns `None` for any value that is not one of the three RFC 9110
-/// grammars, for a calendar date that does not exist (`30 Feb`), and for a
-/// date before 1970.
+/// Parse an `HTTP-date` into milliseconds since the Unix epoch. `None` for
+/// any other grammar, a calendar date that does not exist, or a date before 1970.
 pub fn parse(value: &[u8]) -> Option<u64> {
     let value = strings::trim(value, b" \t");
     let civil = parse_imf_fixdate(value)
@@ -111,9 +97,7 @@ fn parse_asctime(value: &[u8]) -> Option<Civil> {
     Civil::new(year, month, day, hour, minute, second)
 }
 
-/// §5.6.7: a two-digit year that appears to be more than 50 years in the
-/// future is the most recent past year with the same last two digits. The
-/// result is the year with those digits in the window `(now - 50, now + 50]`.
+/// §5.6.7: the year with these two digits in the window `(now - 50, now + 50]`.
 fn two_digit_year(yy: u32, now_year: u32) -> u32 {
     let year = now_year - now_year % 100 + yy;
     if year > now_year + 50 {
@@ -220,8 +204,7 @@ fn days_in_month(year: u32, month: u32) -> u32 {
     }
 }
 
-/// Days since 1970-01-01 for a proleptic Gregorian date (Howard Hinnant's
-/// `days_from_civil`).
+/// Days since 1970-01-01 (Howard Hinnant's `days_from_civil`).
 fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
     let y = i64::from(year) - i64::from(month <= 2);
     let era = y.div_euclid(400);
@@ -232,7 +215,7 @@ fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
     era * 146_097 + doe - 719_468
 }
 
-/// The calendar year of a Unix timestamp (Howard Hinnant's `civil_from_days`).
+/// Calendar year of a Unix timestamp (Howard Hinnant's `civil_from_days`).
 fn civil_year_from_unix_seconds(seconds: i64) -> u32 {
     let z = seconds.div_euclid(86_400) + 719_468;
     let era = z.div_euclid(146_097);

--- a/src/http_types/HTTPDate.rs
+++ b/src/http_types/HTTPDate.rs
@@ -1,0 +1,331 @@
+//! RFC 9110 §5.6.7 `HTTP-date` parser.
+//!
+//! Accepts exactly the three grammars the RFC lists and nothing else:
+//!
+//! ```text
+//! IMF-fixdate  = day-name "," SP day SP month SP year SP time-of-day SP GMT
+//!                  Sun, 06 Nov 1994 08:49:37 GMT
+//! rfc850-date  = day-name-l "," SP day "-" month "-" 2DIGIT SP time-of-day SP GMT
+//!                  Sunday, 06-Nov-94 08:49:37 GMT
+//! asctime-date = day-name SP month SP ( 2DIGIT / ( SP 1DIGIT ) ) SP time-of-day SP year
+//!                  Sun Nov  6 08:49:37 1994
+//! ```
+//!
+//! The conditional request headers (`If-Modified-Since`,
+//! `If-Unmodified-Since`, `If-Range`) MUST be ignored when the value is not
+//! a valid HTTP-date (§13.1.3, §13.1.4, §13.1.5). The ECMAScript `Date.parse`
+//! grammar accepts far more (`2030`, `12345`, `1/1/2030`, time zones other
+//! than GMT), so it must not be used for those headers.
+
+use bun_core::strings;
+
+const DAY_NAMES: [&[u8]; 7] = [b"Sun", b"Mon", b"Tue", b"Wed", b"Thu", b"Fri", b"Sat"];
+const DAY_NAMES_LONG: [&[u8]; 7] = [
+    b"Sunday",
+    b"Monday",
+    b"Tuesday",
+    b"Wednesday",
+    b"Thursday",
+    b"Friday",
+    b"Saturday",
+];
+const MONTH_NAMES: [&[u8]; 12] = [
+    b"Jan", b"Feb", b"Mar", b"Apr", b"May", b"Jun", b"Jul", b"Aug", b"Sep", b"Oct", b"Nov", b"Dec",
+];
+
+/// A parsed calendar date and time of day in UTC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Civil {
+    year: u32,
+    /// 1..=12
+    month: u32,
+    /// 1..=31
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+}
+
+/// Parse an `HTTP-date` into milliseconds since the Unix epoch.
+///
+/// Returns `None` for any value that is not one of the three RFC 9110
+/// grammars, for a calendar date that does not exist (`30 Feb`), and for a
+/// date before 1970.
+pub fn parse(value: &[u8]) -> Option<u64> {
+    let value = strings::trim(value, b" \t");
+    let civil = parse_imf_fixdate(value)
+        .or_else(|| parse_rfc850(value))
+        .or_else(|| parse_asctime(value))?;
+    civil.to_unix_ms()
+}
+
+fn parse_imf_fixdate(value: &[u8]) -> Option<Civil> {
+    let mut p = Parser { rest: value };
+    p.one_of(&DAY_NAMES)?;
+    p.literal(b", ")?;
+    let day = p.digits(2)?;
+    p.literal(b" ")?;
+    let month = p.one_of(&MONTH_NAMES)? + 1;
+    p.literal(b" ")?;
+    let year = p.digits(4)?;
+    p.literal(b" ")?;
+    let (hour, minute, second) = p.time_of_day()?;
+    p.literal(b" GMT")?;
+    p.end()?;
+    Civil::new(year, month, day, hour, minute, second)
+}
+
+fn parse_rfc850(value: &[u8]) -> Option<Civil> {
+    let mut p = Parser { rest: value };
+    p.one_of(&DAY_NAMES_LONG)?;
+    p.literal(b", ")?;
+    let day = p.digits(2)?;
+    p.literal(b"-")?;
+    let month = p.one_of(&MONTH_NAMES)? + 1;
+    p.literal(b"-")?;
+    let year = two_digit_year(p.digits(2)?);
+    p.literal(b" ")?;
+    let (hour, minute, second) = p.time_of_day()?;
+    p.literal(b" GMT")?;
+    p.end()?;
+    Civil::new(year, month, day, hour, minute, second)
+}
+
+fn parse_asctime(value: &[u8]) -> Option<Civil> {
+    let mut p = Parser { rest: value };
+    p.one_of(&DAY_NAMES)?;
+    p.literal(b" ")?;
+    let month = p.one_of(&MONTH_NAMES)? + 1;
+    p.literal(b" ")?;
+    let day = if p.literal(b" ").is_some() {
+        p.digits(1)?
+    } else {
+        p.digits(2)?
+    };
+    p.literal(b" ")?;
+    let (hour, minute, second) = p.time_of_day()?;
+    p.literal(b" ")?;
+    let year = p.digits(4)?;
+    p.end()?;
+    Civil::new(year, month, day, hour, minute, second)
+}
+
+/// §5.6.7: a two-digit year that appears to be more than 50 years in the
+/// future is the most recent past year with the same last two digits.
+fn two_digit_year(yy: u32) -> u32 {
+    let now_year = civil_year_from_unix_seconds(bun_core::time::timestamp());
+    let year = now_year - now_year % 100 + yy;
+    if year > now_year + 50 {
+        year - 100
+    } else {
+        year
+    }
+}
+
+struct Parser<'a> {
+    rest: &'a [u8],
+}
+
+impl Parser<'_> {
+    fn literal(&mut self, lit: &[u8]) -> Option<()> {
+        let head = self.rest.get(..lit.len())?;
+        if !head.eq_ignore_ascii_case(lit) {
+            return None;
+        }
+        self.rest = &self.rest[lit.len()..];
+        Some(())
+    }
+
+    /// Match one of `names` (ASCII case-insensitive). Returns its index.
+    fn one_of(&mut self, names: &[&[u8]]) -> Option<u32> {
+        names
+            .iter()
+            .position(|name| self.literal(name).is_some())
+            .map(|i| i as u32)
+    }
+
+    fn digits(&mut self, n: usize) -> Option<u32> {
+        let head = self.rest.get(..n)?;
+        let mut value = 0u32;
+        for &b in head {
+            if !b.is_ascii_digit() {
+                return None;
+            }
+            value = value * 10 + u32::from(b - b'0');
+        }
+        self.rest = &self.rest[n..];
+        Some(value)
+    }
+
+    fn time_of_day(&mut self) -> Option<(u32, u32, u32)> {
+        let hour = self.digits(2)?;
+        self.literal(b":")?;
+        let minute = self.digits(2)?;
+        self.literal(b":")?;
+        let second = self.digits(2)?;
+        // Seconds run to 60 for a leap second.
+        if hour > 23 || minute > 59 || second > 60 {
+            return None;
+        }
+        Some((hour, minute, second))
+    }
+
+    fn end(&self) -> Option<()> {
+        self.rest.is_empty().then_some(())
+    }
+}
+
+impl Civil {
+    fn new(year: u32, month: u32, day: u32, hour: u32, minute: u32, second: u32) -> Option<Self> {
+        if !(1..=12).contains(&month) || day == 0 || day > days_in_month(year, month) {
+            return None;
+        }
+        Some(Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        })
+    }
+
+    fn to_unix_ms(self) -> Option<u64> {
+        let days = days_from_civil(self.year, self.month, self.day);
+        if days < 0 {
+            return None;
+        }
+        let seconds = days as u64 * 86_400
+            + u64::from(self.hour) * 3_600
+            + u64::from(self.minute) * 60
+            + u64::from(self.second);
+        Some(seconds * 1_000)
+    }
+}
+
+fn is_leap_year(year: u32) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+/// Days since 1970-01-01 for a proleptic Gregorian date (Howard Hinnant's
+/// `days_from_civil`).
+fn days_from_civil(year: u32, month: u32, day: u32) -> i64 {
+    let y = i64::from(year) - i64::from(month <= 2);
+    let era = y.div_euclid(400);
+    let yoe = y - era * 400;
+    let m = i64::from(month);
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + i64::from(day) - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// The calendar year of a Unix timestamp (Howard Hinnant's `civil_from_days`).
+fn civil_year_from_unix_seconds(seconds: i64) -> u32 {
+    let z = seconds.div_euclid(86_400) + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (y + i64::from(m <= 2)) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOV_6_1994: u64 = 784_111_777_000;
+
+    #[test]
+    fn accepts_the_three_rfc_grammars() {
+        assert_eq!(parse(b"Sun, 06 Nov 1994 08:49:37 GMT"), Some(NOV_6_1994));
+        assert_eq!(parse(b"Sunday, 06-Nov-94 08:49:37 GMT"), Some(NOV_6_1994));
+        assert_eq!(parse(b"Sun Nov  6 08:49:37 1994"), Some(NOV_6_1994));
+        assert_eq!(
+            parse(b"Wed, 01 Jan 2025 00:00:00 GMT"),
+            Some(1_735_689_600_000)
+        );
+        assert_eq!(parse(b"Thu, 01 Jan 1970 00:00:00 GMT"), Some(0));
+        assert_eq!(
+            parse(b"  Sun, 06 Nov 1994 08:49:37 GMT\t"),
+            Some(NOV_6_1994)
+        );
+        assert_eq!(parse(b"sun, 06 nov 1994 08:49:37 gmt"), Some(NOV_6_1994));
+    }
+
+    #[test]
+    fn rejects_date_parse_only_grammars() {
+        for junk in [
+            &b""[..],
+            b"2030",
+            b"12345",
+            b"10",
+            b"1/1/2030",
+            b"January 2030",
+            b"March 2001",
+            b"2025-01-01T00:00:00Z",
+            b"Tue, 31 Dec 2024 16:00:01 PST",
+            b"Wed, 01 Jan 2025 00:00:00 UTC",
+            b"Wed, 01 Jan 2025 00:00:00 +0000",
+            b"Wed, 01 Jan 2025 00:00:00",
+            b"Wed, 1 Jan 2025 00:00:00 GMT",
+            b"Wed, 01 Jan 2025 00:00 GMT",
+            b"Wed, 01 Jan 2025 24:00:00 GMT",
+            b"Wed, 01 Jan 2025 00:60:00 GMT",
+            b"Wed, 01 Jan 2025 00:00:00 GMT garbage",
+            b"Sun, 30 Feb 2025 00:00:00 GMT",
+            b"Sat, 31 Apr 2025 00:00:00 GMT",
+            b"Wed, 01 Jan 1969 00:00:00 GMT",
+            b"garbage",
+        ] {
+            assert_eq!(parse(junk), None, "{}", bstr::BStr::new(junk));
+        }
+    }
+
+    #[test]
+    fn leap_day_and_leap_second() {
+        assert_eq!(
+            parse(b"Thu, 29 Feb 2024 00:00:00 GMT"),
+            Some(1_709_164_800_000)
+        );
+        assert_eq!(parse(b"Thu, 29 Feb 2023 00:00:00 GMT"), None);
+        assert_eq!(parse(b"Thu, 29 Feb 1900 00:00:00 GMT"), None);
+        assert_eq!(
+            parse(b"Tue, 31 Dec 2024 23:59:60 GMT"),
+            Some(1_735_689_600_000)
+        );
+    }
+
+    #[test]
+    fn two_digit_year_is_never_more_than_50_years_ahead() {
+        let now = civil_year_from_unix_seconds(bun_core::time::timestamp());
+        for yy in 0..100 {
+            let year = two_digit_year(yy);
+            assert_eq!(year % 100, yy);
+            assert!(
+                year <= now + 50 && year > now - 50,
+                "{yy} -> {year} (now {now})"
+            );
+        }
+    }
+
+    #[test]
+    fn civil_year_round_trips() {
+        assert_eq!(civil_year_from_unix_seconds(0), 1970);
+        assert_eq!(civil_year_from_unix_seconds(NOV_6_1994 as i64 / 1000), 1994);
+        assert_eq!(civil_year_from_unix_seconds(1_735_689_600), 2025);
+        assert_eq!(civil_year_from_unix_seconds(1_735_689_599), 2024);
+    }
+}

--- a/src/http_types/HTTPDate.rs
+++ b/src/http_types/HTTPDate.rs
@@ -83,7 +83,8 @@ fn parse_rfc850(value: &[u8]) -> Option<Civil> {
     p.literal(b"-")?;
     let month = p.one_of(&MONTH_NAMES)? + 1;
     p.literal(b"-")?;
-    let year = two_digit_year(p.digits(2)?);
+    let now_year = civil_year_from_unix_seconds(bun_core::time::timestamp());
+    let year = two_digit_year(p.digits(2)?, now_year);
     p.literal(b" ")?;
     let (hour, minute, second) = p.time_of_day()?;
     p.literal(b" GMT")?;
@@ -111,12 +112,14 @@ fn parse_asctime(value: &[u8]) -> Option<Civil> {
 }
 
 /// §5.6.7: a two-digit year that appears to be more than 50 years in the
-/// future is the most recent past year with the same last two digits.
-fn two_digit_year(yy: u32) -> u32 {
-    let now_year = civil_year_from_unix_seconds(bun_core::time::timestamp());
+/// future is the most recent past year with the same last two digits. The
+/// result is the year with those digits in the window `(now - 50, now + 50]`.
+fn two_digit_year(yy: u32, now_year: u32) -> u32 {
     let year = now_year - now_year % 100 + yy;
     if year > now_year + 50 {
         year - 100
+    } else if year + 50 <= now_year {
+        year + 100
     } else {
         year
     }
@@ -310,15 +313,21 @@ mod tests {
 
     #[test]
     fn two_digit_year_is_never_more_than_50_years_ahead() {
-        let now = civil_year_from_unix_seconds(bun_core::time::timestamp());
-        for yy in 0..100 {
-            let year = two_digit_year(yy);
-            assert_eq!(year % 100, yy);
-            assert!(
-                year <= now + 50 && year > now - 50,
-                "{yy} -> {year} (now {now})"
-            );
+        for now in [2000, 2026, 2049, 2050, 2051, 2099, 2100] {
+            for yy in 0..100 {
+                let year = two_digit_year(yy, now);
+                assert_eq!(year % 100, yy);
+                assert!(
+                    year <= now + 50 && year > now - 50,
+                    "{yy} -> {year} (now {now})"
+                );
+            }
         }
+        assert_eq!(two_digit_year(94, 2026), 1994);
+        assert_eq!(two_digit_year(76, 2026), 2076);
+        assert_eq!(two_digit_year(77, 2026), 1977);
+        assert_eq!(two_digit_year(0, 2050), 2100);
+        assert_eq!(two_digit_year(0, 2049), 2000);
     }
 
     #[test]

--- a/src/http_types/HTTPDate.rs
+++ b/src/http_types/HTTPDate.rs
@@ -1,10 +1,4 @@
 //! RFC 9110 §5.6.7 `HTTP-date` parser: IMF-fixdate, rfc850-date, asctime-date.
-//!
-//! ```text
-//! Sun, 06 Nov 1994 08:49:37 GMT
-//! Sunday, 06-Nov-94 08:49:37 GMT
-//! Sun Nov  6 08:49:37 1994
-//! ```
 
 use bun_core::strings;
 
@@ -35,8 +29,7 @@ struct Civil {
     second: u32,
 }
 
-/// Parse an `HTTP-date` into milliseconds since the Unix epoch. `None` for
-/// any other grammar, a calendar date that does not exist, or a date before 1970.
+/// Parse an `HTTP-date` into Unix milliseconds. `None` for any other grammar or a date before 1970.
 pub fn parse(value: &[u8]) -> Option<u64> {
     let value = strings::trim(value, b" \t");
     let civil = parse_imf_fixdate(value)

--- a/src/http_types/lib.rs
+++ b/src/http_types/lib.rs
@@ -5,6 +5,7 @@ pub mod Encoding;
 pub mod FetchCacheMode;
 pub mod FetchRedirect;
 pub mod FetchRequestMode;
+pub mod HTTPDate;
 pub mod Method;
 pub mod URLPath;
 pub mod h2;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4798,12 +4798,8 @@ fn __bun_get_vm_ctx(kind: bun_io::AllocatorType) -> bun_io::EventLoopCtx {
 /// `bun.String`, call `String.parseDate(&s, vm.global)`, return the integer
 /// value if finite and non-negative, else `None`. Lives in this crate (the
 /// caller is `server::StaticRoute`) so `bun_uws_sys` (T0) has no upward hook
-/// into `bun_jsc`.
-///
-/// This is the lenient `Date.parse` grammar. It is only for the server's own
-/// `Last-Modified` header. A client's `If-Modified-Since` /
-/// `If-Unmodified-Since` goes through `bun_http_types::HTTPDate::parse`, which
-/// accepts only an RFC 9110 HTTP-date.
+/// into `bun_jsc`. Lenient `Date.parse` grammar: for the server's own
+/// `Last-Modified` only. Client dates use `bun_http_types::HTTPDate::parse`.
 pub(crate) fn parse_http_date(value: &[u8]) -> Option<u64> {
     let vm = bun_jsc::virtual_machine::VirtualMachine::get();
     // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4796,9 +4796,14 @@ fn __bun_get_vm_ctx(kind: bun_io::AllocatorType) -> bun_io::EventLoopCtx {
 
 /// `dateForHeader`: wrap the header bytes in a
 /// `bun.String`, call `String.parseDate(&s, vm.global)`, return the integer
-/// value if finite and non-negative, else `None`. Lives in this crate (callers
-/// are `server::FileRoute` / `server::StaticRoute`) so `bun_uws_sys` (T0) has
-/// no upward hook into `bun_jsc`.
+/// value if finite and non-negative, else `None`. Lives in this crate (the
+/// caller is `server::StaticRoute`) so `bun_uws_sys` (T0) has no upward hook
+/// into `bun_jsc`.
+///
+/// This is the lenient `Date.parse` grammar. It is only for the server's own
+/// `Last-Modified` header. A client's `If-Modified-Since` /
+/// `If-Unmodified-Since` goes through `bun_http_types::HTTPDate::parse`, which
+/// accepts only an RFC 9110 HTTP-date.
 pub(crate) fn parse_http_date(value: &[u8]) -> Option<u64> {
     let vm = bun_jsc::virtual_machine::VirtualMachine::get();
     // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4798,8 +4798,7 @@ fn __bun_get_vm_ctx(kind: bun_io::AllocatorType) -> bun_io::EventLoopCtx {
 /// `bun.String`, call `String.parseDate(&s, vm.global)`, return the integer
 /// value if finite and non-negative, else `None`. Lives in this crate (the
 /// caller is `server::StaticRoute`) so `bun_uws_sys` (T0) has no upward hook
-/// into `bun_jsc`. Lenient `Date.parse` grammar: for the server's own
-/// `Last-Modified` only. Client dates use `bun_http_types::HTTPDate::parse`.
+/// into `bun_jsc`.
 pub(crate) fn parse_http_date(value: &[u8]) -> Option<u64> {
     let vm = bun_jsc::virtual_machine::VirtualMachine::get();
     // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -4,8 +4,8 @@ use core::mem::size_of;
 use bun_core::String as BunString;
 use bun_core::strings;
 use bun_http::{Headers, Method};
-use bun_http_types::ETag;
 use bun_http_types::ETag::StringPointer;
+use bun_http_types::{ETag, HTTPDate};
 use bun_io::Closer;
 use bun_io::FileType;
 use bun_ptr::{RefPtr, ThisPtr};
@@ -494,10 +494,7 @@ pub(crate) fn status_for_preconditions(
             if !ETag::if_match(etag, im) {
                 return 412;
             }
-        } else if let Some(ius) = req
-            .header(b"if-unmodified-since")
-            .and_then(crate::jsc_hooks::parse_http_date)
-        {
+        } else if let Some(ius) = req.header(b"if-unmodified-since").and_then(HTTPDate::parse) {
             if let Some(lm) = last_modified_ms {
                 if lm / 1000 > ius / 1000 {
                     return 412;
@@ -515,10 +512,7 @@ pub(crate) fn status_for_preconditions(
                 return 304;
             }
             // Did not match: fall through to Range/200 without consulting IMS.
-        } else if let Some(ims) = req
-            .header(b"if-modified-since")
-            .and_then(crate::jsc_hooks::parse_http_date)
-        {
+        } else if let Some(ims) = req.header(b"if-modified-since").and_then(HTTPDate::parse) {
             // Compare at second precision: the Last-Modified we emit is
             // second-granular (HTTP-date), so a sub-second mtime would never
             // satisfy `<=` against the client's echoed value otherwise.

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -7,7 +7,7 @@ use core::mem::size_of;
 use bun_http::headers::api::StringPointer;
 use bun_http::headers::append_etag;
 use bun_http::{Headers, Method};
-use bun_http_types::ETag;
+use bun_http_types::{ETag, HTTPDate};
 use bun_ptr::{RefPtr, ThisPtr};
 
 use bun_http_types::MimeType::MimeType;
@@ -496,14 +496,12 @@ impl StaticRoute {
         };
 
         // Step 1: If-Match (strong comparison); step 2: If-Unmodified-Since
-        // (only when If-Match is absent).
+        // (only when If-Match is absent). A client date that is not a valid
+        // HTTP-date is ignored (§13.1.3, §13.1.4).
         let precondition_failed =
             if let Some(im) = req.header(b"if-match").filter(|v| !v.is_empty()) {
                 !ETag::if_match(etag, im)
-            } else if let Some(ius) = req
-                .header(b"if-unmodified-since")
-                .and_then(crate::jsc_hooks::parse_http_date)
-            {
+            } else if let Some(ius) = req.header(b"if-unmodified-since").and_then(HTTPDate::parse) {
                 matches!(last_modified(), Some(lm) if lm / 1000 > ius / 1000)
             } else {
                 false
@@ -519,10 +517,7 @@ impl StaticRoute {
                 _ => false,
             }
         // Step 4: If-Modified-Since (only when If-None-Match is absent).
-        } else if let Some(ims) = req
-            .header(b"if-modified-since")
-            .and_then(crate::jsc_hooks::parse_http_date)
-        {
+        } else if let Some(ims) = req.header(b"if-modified-since").and_then(HTTPDate::parse) {
             // §13.1.3: 304 when Last-Modified <= If-Modified-Since. HTTP-date
             // is second-granular, so compare at second precision.
             match last_modified() {

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -496,8 +496,7 @@ impl StaticRoute {
         };
 
         // Step 1: If-Match (strong comparison); step 2: If-Unmodified-Since
-        // (only when If-Match is absent). A client date that is not a valid
-        // HTTP-date is ignored (§13.1.3, §13.1.4).
+        // (only when If-Match is absent).
         let precondition_failed =
             if let Some(im) = req.header(b"if-match").filter(|v| !v.is_empty()) {
                 !ETag::if_match(etag, im)

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -350,7 +350,7 @@ describe("Bun.file in serve routes", () => {
         const res2 = await fetch(new URL(`/hello.txt`, server.url), {
           method,
           headers: {
-            "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toISOString(),
+            "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toUTCString(),
           },
         });
 
@@ -364,7 +364,7 @@ describe("Bun.file in serve routes", () => {
         const res = await fetch(new URL(`/hello.txt`, server.url), {
           method,
           headers: {
-            "If-Modified-Since": new Date(Date.now() - 1000000).toISOString(),
+            "If-Modified-Since": new Date(Date.now() - 1000000).toUTCString(),
           },
         });
 
@@ -381,7 +381,7 @@ describe("Bun.file in serve routes", () => {
 
       const res2 = await fetch(new URL(`/partial.txt`, server.url), {
         headers: {
-          "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toISOString(),
+          "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toUTCString(),
           "Range": "bytes=0-3",
         },
       });
@@ -398,7 +398,7 @@ describe("Bun.file in serve routes", () => {
       const res2 = await fetch(new URL(`/hello.txt`, server.url), {
         method: "POST",
         headers: {
-          "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toISOString(),
+          "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toUTCString(),
         },
       });
 
@@ -568,6 +568,52 @@ describe("Bun.file in serve routes", () => {
         expect(res.status).toBe(200);
       });
     });
+
+    // §13.1.3 / §13.1.4: a value that is not an RFC 9110 HTTP-date MUST be
+    // ignored. `Date.parse` accepts every one of these.
+    describe.each(["/hello-blob.txt", "/custom-last-modified.txt"])(
+      "ignores a conditional date that is not an HTTP-date on %s",
+      path => {
+        const NOT_HTTP_DATES = [
+          "2030",
+          "12345",
+          "10",
+          "1/1/2030",
+          "January 2030",
+          "March 2001",
+          "Sun, 30 Feb 2025 00:00:00 GMT",
+          "Tue, 31 Dec 2024 16:00:01 PST",
+        ];
+
+        it.each(NOT_HTTP_DATES)("If-Modified-Since: %s → 200", async value => {
+          const res = await fetch(new URL(path, server.url), { headers: { "If-Modified-Since": value } });
+          expect(res.status).toBe(200);
+          expect(await res.text()).toBe("Hello, World!");
+        });
+
+        it.each(NOT_HTTP_DATES)("If-Unmodified-Since: %s → 200", async value => {
+          const res = await fetch(new URL(path, server.url), { headers: { "If-Unmodified-Since": value } });
+          expect(res.status).toBe(200);
+          expect(await res.text()).toBe("Hello, World!");
+        });
+
+        it("accepts rfc850-date and asctime-date for If-Modified-Since", async () => {
+          const results = await Promise.all(
+            ["Sunday, 06-Nov-94 08:49:37 GMT", "Sun Nov  6 08:49:37 1994", "Sun Nov  6 08:49:37 2050"].map(
+              async value => [
+                value,
+                (await fetch(new URL(path, server.url), { headers: { "If-Modified-Since": value } })).status,
+              ],
+            ),
+          );
+          expect(results).toEqual([
+            ["Sunday, 06-Nov-94 08:49:37 GMT", 200],
+            ["Sun Nov  6 08:49:37 1994", 200],
+            ["Sun Nov  6 08:49:37 2050", 304],
+          ]);
+        });
+      },
+    );
 
     it.todo("handles ETag", async () => {
       const res1 = await fetch(new URL(`/hello.txt`, server.url));
@@ -806,7 +852,7 @@ describe("Bun.file in serve routes", () => {
 
       const res2 = await fetch(new URL(`/hello.txt`, server.url), {
         headers: {
-          "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toISOString(),
+          "If-Modified-Since": new Date(Date.parse(lastModified!) + 10000).toUTCString(),
         },
       });
 

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { isBroken, isMacOS, tempDir } from "harness";
+import { bunEnv, bunExe, isBroken, isMacOS, tempDir } from "harness";
 import { routes, static_responses } from "./bun-serve-static-helpers";
 
 describe.todoIf(isBroken && isMacOS)("static", () => {
@@ -399,6 +399,53 @@ describe("static route preconditions (RFC 9110 §13.2.2)", () => {
         ["Wednesday, 21-Oct-15 07:27:59 GMT", 412],
         ["Wed Oct 21 07:27:59 2015", 412],
       ]);
+    });
+
+    // asctime-date carries no zone token and is UTC by definition (§5.6.7).
+    // `Date.parse` reads a zone-less string in the process's local time, so
+    // the result would move with TZ. Run the check in a child under a zone
+    // with a non-zero offset.
+    it("evaluates asctime-date as UTC regardless of the process TZ", async () => {
+      using dir = tempDir("serve-asctime-tz", {
+        "fixture.mjs": `
+          import { utimesSync, writeFileSync } from "node:fs";
+          const f = "asset.txt";
+          writeFileSync(f, "hello");
+          utimesSync(f, 1768478400, 1768478400); // 2026-01-15T12:00:00Z
+          const s = Bun.serve({
+            port: 0,
+            routes: {
+              "/static": new Response("hello", { headers: { "Last-Modified": "Thu, 15 Jan 2026 12:00:00 GMT" } }),
+              "/file": Bun.file(f),
+            },
+            fetch: () => new Response("fallback", { status: 599 }),
+          });
+          const out = [];
+          for (const path of ["/static", "/file"]) {
+            for (const header of ["If-Modified-Since", "If-Unmodified-Since"]) {
+              const res = await fetch(new URL(path, s.url), { headers: { [header]: "Thu Jan 15 12:00:00 2026" } });
+              out.push([path, header, res.status]);
+            }
+          }
+          s.stop(true);
+          console.log(JSON.stringify(out));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.mjs"],
+        env: { ...bunEnv, TZ: "Asia/Kolkata" },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        ["/static", "If-Modified-Since", 304],
+        ["/static", "If-Unmodified-Since", 200],
+        ["/file", "If-Modified-Since", 304],
+        ["/file", "If-Unmodified-Since", 200],
+      ]);
+      expect(exitCode).toBe(0);
     });
   });
 });

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -344,4 +344,61 @@ describe("static route preconditions (RFC 9110 §13.2.2)", () => {
       expect((await get("/s", { "If-Match": '"s1"', "If-None-Match": '"s1"' }, method)).status).toBe(304);
     });
   });
+
+  // §13.1.3 / §13.1.4: a value that is not an RFC 9110 HTTP-date (IMF-fixdate,
+  // rfc850-date, asctime-date) MUST be ignored. `Date.parse` accepts all of
+  // these, so they must not go through the JavaScript date grammar.
+  const NOT_HTTP_DATES = [
+    "2030",
+    "12345",
+    "10",
+    "1/1/2030",
+    "January 2030",
+    "March 2001",
+    "2028-01-01T00:00:00Z",
+    "Sun, 30 Feb 2025 00:00:00 GMT",
+    "Tue, 31 Dec 2024 16:00:01 PST",
+    "Wed, 21 Oct 2015 07:28:00 UTC",
+    "Wed, 21 Oct 2015 07:28:00",
+  ];
+
+  describe("ignores a conditional date that is not an HTTP-date", () => {
+    it.each(NOT_HTTP_DATES)("If-Modified-Since: %s → 200", async value => {
+      expect((await get("/s", { "If-Modified-Since": value })).status).toBe(200);
+    });
+
+    it.each(NOT_HTTP_DATES)("If-Unmodified-Since: %s → 200", async value => {
+      expect((await get("/s", { "If-Unmodified-Since": value })).status).toBe(200);
+    });
+
+    it("accepts the three RFC 9110 grammars for If-Modified-Since", async () => {
+      const results = await Promise.all(
+        [
+          "Wed, 21 Oct 2015 07:28:00 GMT",
+          "Wednesday, 21-Oct-15 07:28:00 GMT",
+          "Wed Oct 21 07:28:00 2015",
+          "Sun Nov  6 08:49:37 2050",
+        ].map(async value => [value, (await get("/s", { "If-Modified-Since": value })).status]),
+      );
+      expect(results).toEqual([
+        ["Wed, 21 Oct 2015 07:28:00 GMT", 304],
+        ["Wednesday, 21-Oct-15 07:28:00 GMT", 304],
+        ["Wed Oct 21 07:28:00 2015", 304],
+        ["Sun Nov  6 08:49:37 2050", 304],
+      ]);
+    });
+
+    it("accepts the three RFC 9110 grammars for If-Unmodified-Since", async () => {
+      const results = await Promise.all(
+        ["Wed, 21 Oct 2015 07:27:59 GMT", "Wednesday, 21-Oct-15 07:27:59 GMT", "Wed Oct 21 07:27:59 2015"].map(
+          async value => [value, (await get("/s", { "If-Unmodified-Since": value })).status],
+        ),
+      );
+      expect(results).toEqual([
+        ["Wed, 21 Oct 2015 07:27:59 GMT", 412],
+        ["Wednesday, 21-Oct-15 07:27:59 GMT", 412],
+        ["Wed Oct 21 07:27:59 2015", 412],
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `Bun.serve` parses the client's `If-Modified-Since` and `If-Unmodified-Since` with the JavaScript `Date.parse` grammar (`jsc_hooks::parse_http_date`, `src/runtime/jsc_hooks.rs:4802`). `2030`, `12345`, `10`, `1/1/2030`, `January 2030`, `Sun, 30 Feb 2025 00:00:00 GMT` and `Tue, 31 Dec 2024 16:00:01 PST` all become valid timestamps.
- A junk `If-Modified-Since` returns `304 Not Modified` for content the client never had. A junk `If-Unmodified-Since` returns `412`. RFC 9110 §13.1.3 and §13.1.4 say a recipient MUST ignore the header when the value is not a valid HTTP-date. Both static `routes` Responses and `Bun.file` routes are affected.

### Fix
- Add `bun_http_types::HTTPDate::parse` (`src/http_types/HTTPDate.rs`). It accepts only the three RFC 9110 §5.6.7 grammars (IMF-fixdate, rfc850-date, asctime-date), requires `GMT`, checks the time of day and the calendar day (no `30 Feb`, leap years), and applies the RFC rule for rfc850 two-digit years. It returns `None` for anything else.
- `StaticRoute::render_precondition` and `FileRoute::status_for_preconditions` use it for `If-Modified-Since` and `If-Unmodified-Since`. The server's own `Last-Modified` header still goes through `Date.parse`, so a user-set ISO date keeps working.
- Four existing tests in `bun-serve-file.test.ts` sent an ISO 8601 `If-Modified-Since`. They now send `toUTCString()`, which is IMF-fixdate.
- Verified: `test/js/bun/http/bun-serve-static.test.ts` and `test/js/bun/http/bun-serve-file.test.ts` (27 new cases fail on 1.4.x, pass with the fix). Also `serve-if-none-match.test.ts`, `serve-directory-routes.test.ts`, `regression/issue/29181.test.ts`, `express/res.sendFile.test.ts`, and the `bun_http_types` unit tests.

### Background
- An HTTP-date (RFC 9110 §5.6.7) is one of three fixed formats: `Sun, 06 Nov 1994 08:49:37 GMT` (the one senders must emit), `Sunday, 06-Nov-94 08:49:37 GMT`, and `Sun Nov  6 08:49:37 1994`. The time zone is always GMT.
- `Date.parse` is the ECMAScript date grammar. It accepts a bare year, a bare number, local-zone abbreviations, month names without a day, and rolls invalid days into the next month. That is why the header matched when it should not.
- Preconditions run in the §13.2.2 order: `If-Match`, else `If-Unmodified-Since` (412 on failure), then `If-None-Match`, else `If-Modified-Since` (304 on match). This PR changes only how the two date headers are parsed, not the order.

<details><summary>Notes</summary>

Ledger repro (raw sockets, static and file route, mtime 2025-01-01):

```
/static If-Modified-Since "2030" => 200            (was 304)
/static If-Modified-Since "Sun, 30 Feb 2025 00:00:00 GMT" => 200   (was 304)
/static If-Unmodified-Since "10" => 200            (was 412)
/static If-Modified-Since "Wed, 01 Jan 2025 00:00:00 GMT" => 304
/static If-Modified-Since "Tue, 31 Dec 2024 23:59:59 GMT" => 200
/file   (same results)
```

Parser details:
- Alphabetic tokens (day name, month, `GMT`) compare ASCII case-insensitively. Structure is strict: two-digit day, four-digit year (two for rfc850), `HH:MM:SS`, no trailing bytes after trimming OWS.
- Seconds up to 60 are allowed for a leap second.
- A two-digit rfc850 year more than 50 years in the future is moved back 100 years (§5.6.7). The current year comes from `bun_core::time::timestamp()`.
- Dates before 1970 return `None`, as the old code did for negative values.
- No `If-Range` support exists on main yet. #33548 adds it and uses `parse_http_date` for the `If-Range` date. Whichever lands second should switch that call to `HTTPDate::parse` (§13.1.5 has the same MUST-ignore rule).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-static.test.ts, test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->