### PR TITLE
Poll a tty fd in Bun.file(fd).stream() the way stdin is polled

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -137,19 +137,35 @@ impl Lazy {
 
         let fd: Fd = match &file.pathlike {
             PathOrFileDescriptor::Fd(pl_fd) => {
-                if pl_fd.stdio_tag().is_some() {
-                    'brk: {
-                        #[cfg(unix)]
-                        {
-                            let rc = open_as_nonblocking_tty(pl_fd.native(), sys::O::RDONLY);
-                            if rc > -1 {
-                                is_nonblocking = true;
-                                file.is_atty = Some(true);
-                                break 'brk Fd::from_native(rc);
-                            }
-                        }
-                        break 'brk *pl_fd;
+                // A tty is read through a private O_NONBLOCK description of the
+                // same terminal, so the reader can poll it and stop at any time
+                // without touching the flags of the caller's fd. stdio falls
+                // back to polling the shared fd; any other fd falls back to a
+                // dup the reader owns.
+                #[cfg(not(unix))]
+                let reopened_tty: Option<Fd> = None;
+                #[cfg(unix)]
+                let reopened_tty: Option<Fd> = {
+                    let is_tty = pl_fd.stdio_tag().is_some()
+                        || *file.is_atty.get_or_insert_with(|| sys::isatty(*pl_fd));
+                    let rc = if is_tty {
+                        open_as_nonblocking_tty(pl_fd.native(), sys::O::RDONLY)
+                    } else {
+                        -1
+                    };
+                    if rc > -1 {
+                        is_nonblocking = true;
+                        file.is_atty = Some(true);
+                        Some(Fd::from_native(rc))
+                    } else {
+                        None
                     }
+                };
+
+                if let Some(fd) = reopened_tty {
+                    fd
+                } else if pl_fd.stdio_tag().is_some() {
+                    *pl_fd
                 } else {
                     let duped = sys::dup_with_flags(*pl_fd, 0);
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -137,11 +137,9 @@ impl Lazy {
 
         let fd: Fd = match &file.pathlike {
             PathOrFileDescriptor::Fd(pl_fd) => {
-                // A tty is read through a private O_NONBLOCK description of the
-                // same terminal, so the reader can poll it and stop at any time
-                // without touching the flags of the caller's fd. stdio falls
-                // back to polling the shared fd; any other fd falls back to a
-                // dup the reader owns.
+                // A tty is polled through a private O_NONBLOCK reopen, which
+                // leaves the caller's fd flags alone. Fallback: stdio polls the
+                // shared fd, any other fd polls a dup the reader owns.
                 #[cfg(not(unix))]
                 let reopened_tty: Option<Fd> = None;
                 #[cfg(unix)]

--- a/test/js/bun/util/bun-file-fd-read.test.ts
+++ b/test/js/bun/util/bun-file-fd-read.test.ts
@@ -53,17 +53,22 @@ describe.skipIf(isWindows)("Bun.file(fd) read", () => {
   // A tty fd other than stdin used to be read like a regular file: the stream
   // returned nothing and held nothing, so the process exited before any input.
   // It now gets the same polled, privately reopened terminal as Bun.stdin.
-  test("stream() on a /dev/tty fd polls the terminal and cancel() releases it", async () => {
+  //
+  // macOS resolves a /dev/tty fd back to /dev/tty, the controlling-terminal
+  // alias, and kqueue rejects that device with EINVAL. Open the pty slave
+  // itself there. Linux resolves both to a device epoll accepts.
+  const ttyPath = process.platform === "darwin" ? "/dev/fd/0" : "/dev/tty";
+  test("stream() on a tty fd other than stdin polls the terminal and cancel() releases it", async () => {
     let output = "";
     let wrote = false;
     const decoder = new TextDecoder();
-    const proc = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
           const fs = require("fs");
-          const fd = fs.openSync("/dev/tty", "r");
+          const fd = fs.openSync(${JSON.stringify(ttyPath)}, "r");
           const reader = Bun.file(fd).stream().getReader();
           const first = reader.read();
           console.log("ready");

--- a/test/js/bun/util/bun-file-fd-read.test.ts
+++ b/test/js/bun/util/bun-file-fd-read.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { closeSync, openSync } from "fs";
-import { isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // Reading a Bun.file() backed by a file descriptor goes through
@@ -48,5 +48,60 @@ describe.skipIf(isWindows)("Bun.file(fd) read", () => {
 
     expect(await withFd(path, fd => Bun.file(fd).text())).toBe("");
     expect((await withFd(path, fd => Bun.file(fd).arrayBuffer())).byteLength).toBe(0);
+  });
+
+  // A tty fd other than stdin used to be read like a regular file: the stream
+  // returned nothing and held nothing, so the process exited before any input.
+  // It now gets the same polled, privately reopened terminal as Bun.stdin.
+  test("stream() on a /dev/tty fd polls the terminal and cancel() releases it", async () => {
+    let output = "";
+    let wrote = false;
+    const decoder = new TextDecoder();
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("fs");
+          const fd = fs.openSync("/dev/tty", "r");
+          const reader = Bun.file(fd).stream().getReader();
+          const first = reader.read();
+          console.log("ready");
+          const { value } = await first;
+          console.log("chunk", JSON.stringify(Buffer.from(value).toString()));
+          // A second read is pending on the terminal while cancel() runs.
+          const second = reader.read();
+          await reader.cancel();
+          console.log("cancelled", JSON.stringify(await second));
+          // The caller still owns its fd.
+          console.log("fd", fs.fstatSync(fd).isCharacterDevice() ? "open" : "closed");
+        `,
+      ],
+      env: bunEnv,
+      terminal: {
+        cols: 200,
+        rows: 24,
+        data(terminal, chunk: Uint8Array) {
+          output += decoder.decode(chunk, { stream: true });
+          if (!wrote && output.includes("ready")) {
+            wrote = true;
+            terminal.write("hello\n");
+          }
+        },
+      },
+    });
+    const exitCode = await proc.exited;
+    proc.terminal?.close();
+    output += decoder.decode();
+
+    // The pty echoes the typed line before the child reads it.
+    expect(Bun.stripANSI(output).split(/\r?\n/).filter(Boolean)).toEqual([
+      "ready",
+      "hello",
+      'chunk "hello\\n"',
+      'cancelled {"done":true}',
+      "fd open",
+    ]);
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.file(fd).stream()` on a tty fd other than stdin never delivers input. `fs.openSync("/dev/tty")` then `stream().getReader().read()` hangs forever under a pty, and with no pending read the process exits before any input.
- `Lazy::open_file_blob` (`src/runtime/webcore/FileReader.rs:135`) only applied the tty path to fd 0, 1 and 2. Any other fd was treated as a regular file: a dup with synchronous reads and no poll.

### Fix
- The tty path now applies to any fd that `isatty()`: the reader reopens the terminal by `ttyname` with `O_NONBLOCK` (`open_as_nonblocking_tty`) and polls that private description. The caller's fd keeps its flags and stays open.
- When the reopen is denied, the reader polls a dup it owns and reads only when `poll(2)` reports data, the same fallback stdin already has. A pty master is never reopened (the existing TIOCGPTN guard) and gets the polled dup, which also reads an `O_NONBLOCK` master.
- Verified: `test/js/bun/util/bun-file-fd-read.test.ts` (one new test under `Bun.Terminal`, hangs on 1.4.3). Also `tty.test.ts`, `process-stdin`, `streams.test.js`, `bun-file*`, `node-stream`, `child_process`, `spawn`.

### Background
- `FileReader` is the native source behind `Bun.file().stream()`. A pollable fd registers a `FilePoll` and reads on readiness, which holds the event loop. A non-pollable fd is read synchronously with `pread`, which a tty does not support.
- libuv's `uv_tty_init` reopens a tty through `/dev/pts/N` so that `O_NONBLOCK` never leaks onto a shared description. Bun ports that as `open_as_nonblocking_tty` in `c-bindings.cpp` and used it for stdio only.

<details><summary>Notes</summary>

This came out of a fuzz ledger item: `tty.ReadStream` on a `/dev/tty` fd cannot be destroyed until the user presses Enter, and that line is lost. Routing `tty.ReadStream` through this pollable reader fixes that, but #41495 replaces `tty.ReadStream` with a `net.Socket` over a native TTY handle that reopens the terminal the same way, and #41421 edits the same constructor for an `O_NONBLOCK` fd. So this PR carries only the `FileReader` change, which stands on its own.

macOS: `ttyname_r` of an fd opened from `/dev/tty` (the controlling-terminal alias) returns `/dev/tty` again, and kqueue rejects that device with `EINVAL`. That is a kqueue limit (libuv falls back to a `select` thread for it) and it applies to stdin the same way. A pty slave opened by its own path works, so the test opens `/dev/fd/0` on macOS and `/dev/tty` on Linux.

Probed on Linux: a blocking `/dev/tty` fd, a pty master with and without `O_NONBLOCK`, and stdin all deliver data and `cancel()` releases the poll. Pre-existing debug-only timing failures, identical on main: `stdin-fixtures.test.ts` (1 s auto-kill) and `child_process.test.ts` "extra stdio pipes are not double-closed on GC".
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/bun-file-fd-read.test.ts

<!-- robobun:evidence:end -->
