### PR TITLE
Reset raw mode on a tty opened on fd >= 3 when a signal exits the process

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -600,17 +600,14 @@ extern "C" void bun_restore_stdio()
 {
 
 #if !OS(WINDOWS)
-    // We might be a background job that doesn't own the TTY so block SIGTTOU
-    // before making the tcsetattr() calls, otherwise that signal suspends us.
+    // tcsetattr() from a background job raises SIGTTOU, which would stop us.
     sigset_t sa;
     sigset_t old_mask;
     sigemptyset(&sa);
     sigaddset(&sa, SIGTTOU);
     pthread_sigmask(SIG_BLOCK, &sa, &old_mask);
 
-    // A tty that setRawMode() touched and that is not one of fds 0-2 (for
-    // example `fs.openSync("/dev/tty")`) is only known to the libuv-style
-    // snapshot. Node's ResetStdio() does the same call first.
+    // Covers a raw tty outside fds 0-2, like node's ResetStdio().
     uv_tty_reset_mode();
 
     // Only suppress the restore when Bun is a pipeline producer (stdout is a

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -593,12 +593,17 @@ static termios termios_to_restore_later[3];
 // from normal execution; sig_atomic_t is the only integral type POSIX
 // guarantees can be accessed atomically across that boundary.
 extern "C" volatile sig_atomic_t bun_stdio_modified[3] = { 0, 0, 0 };
+extern "C" int uv_tty_reset_mode(void);
 #endif
 
 extern "C" void bun_restore_stdio()
 {
 
 #if !OS(WINDOWS)
+    // A tty that setRawMode() touched and that is not one of fds 0-2 (for
+    // example `fs.openSync("/dev/tty")`) is only known to the libuv-style
+    // snapshot. Node's ResetStdio() does the same call first.
+    uv_tty_reset_mode();
 
     // Only suppress the restore when Bun is a pipeline producer (stdout is a
     // pipe, not a TTY) and it didn't touch termios itself. That's the #29592

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -600,6 +600,14 @@ extern "C" void bun_restore_stdio()
 {
 
 #if !OS(WINDOWS)
+    // We might be a background job that doesn't own the TTY so block SIGTTOU
+    // before making the tcsetattr() calls, otherwise that signal suspends us.
+    sigset_t sa;
+    sigset_t old_mask;
+    sigemptyset(&sa);
+    sigaddset(&sa, SIGTTOU);
+    pthread_sigmask(SIG_BLOCK, &sa, &old_mask);
+
     // A tty that setRawMode() touched and that is not one of fds 0-2 (for
     // example `fs.openSync("/dev/tty")`) is only known to the libuv-style
     // snapshot. Node's ResetStdio() does the same call first.
@@ -626,20 +634,13 @@ extern "C" void bun_restore_stdio()
         if (pipeline_producer && !bun_stdio_modified[fd])
             continue;
 
-        sigset_t sa;
         int err;
-
-        // We might be a background job that doesn't own the TTY so block SIGTTOU
-        // before making the tcsetattr() call, otherwise that signal suspends us.
-        sigemptyset(&sa);
-        sigaddset(&sa, SIGTTOU);
-
-        pthread_sigmask(SIG_BLOCK, &sa, nullptr);
         do
             err = tcsetattr(fd, TCSANOW, &termios_to_restore_later[fd]);
         while (err == -1 && errno == EINTR);
-        pthread_sigmask(SIG_UNBLOCK, &sa, nullptr);
     }
+
+    pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
 #endif
 }
 

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -186,8 +186,8 @@ static int ttySetMode(int fd, int mode, BunTTYState& state, int action)
     // Bun.Terminal calls through here too. See #29592.
     //
     // Marked on every transition, including setRawMode(true)→(false), so
-    // the signal-exit path (which runs only bun_restore_stdio, not the
-    // atexit uv_tty_reset_mode hook) still restores cooked mode on Ctrl-C.
+    // the signal-exit path (bun_restore_stdio) still writes the startup
+    // snapshot back on Ctrl-C when Bun is a pipeline producer.
     if (fd >= 0 && fd < 3) {
         bun_stdio_modified[fd] = 1;
     }

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -186,8 +186,7 @@ static int ttySetMode(int fd, int mode, BunTTYState& state, int action)
     // Bun.Terminal calls through here too. See #29592.
     //
     // Marked on every transition, including setRawMode(true)→(false), so
-    // the signal-exit path (bun_restore_stdio) still writes the startup
-    // snapshot back on Ctrl-C when Bun is a pipeline producer.
+    // bun_restore_stdio still restores a pipeline producer's stdio on Ctrl-C.
     if (fd >= 0 && fd < 3) {
         bun_stdio_modified[fd] = 1;
     }

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -192,6 +192,78 @@ describe("ReadStream.prototype.setRawMode", () => {
   });
 });
 
+// A raw tty that is not one of fds 0-2 (fs.openSync("/dev/tty")) is only
+// known to the libuv-style snapshot that uv_tty_reset_mode() restores. The
+// SIGINT/SIGTERM exit path restored fds 0-2 only, so the terminal stayed raw
+// after Ctrl-C. Node's ResetStdio() calls uv_tty_reset_mode() first.
+describe.skipIf(isWindows)("setRawMode on a tty opened on fd >= 3", () => {
+  const ICANON = process.platform === "darwin" ? 0x100 : 0x2;
+  const ECHO = 0x8;
+
+  // `shell` wraps the bun child so that its stdout is a pipe (the
+  // pipeline-producer case that skips the fds 0-2 restore) while the pty
+  // stays its controlling terminal.
+  async function run(shell: string, signal: "SIGINT" | "SIGTERM") {
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const ready = Promise.withResolvers<void>();
+    const script = `
+      const fs = require("node:fs");
+      const tty = require("node:tty");
+      const fd = fs.openSync("/dev/tty", "r+");
+      new tty.ReadStream(fd).setRawMode(true);
+      fs.writeSync(fd, "RAW " + process.pid + " " + fd + "\\n");
+      setInterval(() => {}, 1000);
+    `;
+
+    const proc = Bun.spawn({
+      cmd: ["sh", "-c", shell, "sh", bunExe(), script],
+      env: bunEnv,
+      terminal: {
+        data(_terminal, chunk: Uint8Array) {
+          buffer += decoder.decode(chunk, { stream: true });
+          if (/RAW \d+ \d+\r?\n/.test(buffer)) ready.resolve();
+        },
+      },
+    });
+    const terminal = proc.terminal!;
+    try {
+      const isRaw = () => (terminal.localFlags & (ICANON | ECHO)) === 0;
+      const observed: Record<string, boolean> = { beforeRaw: isRaw() };
+
+      let signaled = false;
+      const exitedEarly = proc.exited.then(code => {
+        if (!signaled) {
+          throw new Error(`child exited early with code ${code}; output: ${JSON.stringify(buffer)}`);
+        }
+      });
+      await Promise.race([ready.promise, exitedEarly]);
+
+      const [, pid, fd] = buffer.match(/RAW (\d+) (\d+)\r?\n/)!;
+      expect(Number(fd)).toBeGreaterThanOrEqual(3);
+      observed.afterRaw = isRaw();
+
+      signaled = true;
+      process.kill(Number(pid), signal);
+      await proc.exited;
+      observed.afterSignal = isRaw();
+      return observed;
+    } finally {
+      terminal.close();
+    }
+  }
+
+  const cooked = { beforeRaw: false, afterRaw: true, afterSignal: false };
+
+  test("SIGINT restores cooked mode when stdout is a pipe", async () => {
+    expect(await run('"$1" -e "$2" | cat', "SIGINT")).toEqual(cooked);
+  });
+
+  test("SIGTERM restores cooked mode when stdout is a pipe", async () => {
+    expect(await run('"$1" -e "$2" | cat', "SIGTERM")).toEqual(cooked);
+  });
+});
+
 describe("WriteStream.prototype.getColorDepth", () => {
   const getColorDepth = (env: Record<string, string>) => WriteStream.prototype.getColorDepth.call(undefined, env);
 


### PR DESCRIPTION
### Problem
- A tty that `tty.ReadStream(fd).setRawMode(true)` puts into raw mode on an fd >= 3 (`fs.openSync("/dev/tty")`) stays raw after `kill -INT` or `kill -TERM` ends the process. The shell prompt comes back with no echo and no line editing. Node resets it.
- The cause is `bun_restore_stdio` (`src/jsc/bindings/c-bindings.cpp:598`). It writes the startup termios back to fds 0-2 only, and skips even those when stdout is a pipe and Bun did not touch that fd (the #29592 rule). The libuv-style snapshot that `uv_tty_reset_mode()` restores (`src/jsc/bindings/wtf-bindings.cpp:45`) covers the raw fd, but it ran only from the `atexit` hook, which a signal death skips.

### Fix
- `bun_restore_stdio` calls `uv_tty_reset_mode()` before the fds 0-2 loop. This is the order node's `ResetStdio()` uses.
- Correct because the snapshot exists only when Bun itself left cooked mode (`ttySetMode` takes it), so the #29592 pipeline-producer case is untouched. Every caller of `bun_restore_stdio` benefits: the SIGINT/SIGTERM handler, the crash handler, and the `--watch` reload.
- Verified: `test/js/node/tty.test.ts` (two new cases, both fail on bun 1.4.3-canary). Also `test/js/bun/terminal/`, `test/js/node/nodettywrap.test.ts`, `test/regression/issue/26286.test.ts`.

### Background
- `bun_initialize_process` snapshots the termios of each stdio fd that is a tty at startup and installs `onExitSignal` for SIGINT and SIGTERM. That handler calls `bun_restore_stdio`, then re-raises the signal.
- `ttySetMode` (the port of libuv's `uv_tty_set_mode`) keeps a per-stream termios, and a process-wide copy of the first fd that left cooked mode. `uv_tty_reset_mode()` writes that copy back. In node, `ResetStdio()` calls it first on every exit path.
- The test runs the child as `sh -c '"$1" -e "$2" | cat'` under `Bun.Terminal`, so stdout is a pipe and the pty is still the controlling terminal. The child opens `/dev/tty`, goes raw, prints its pid, and the test sends the signal and reads `terminal.localFlags`.

<details><summary>Notes</summary>

- A third case (all stdio piped, `</dev/null 2>&1 | cat`) also stays raw. There no exit handler exists at all: `bun_initialize_process` installs one only when a stdio fd is a tty. That is the handler-install policy #38843 changes, so this PR leaves it alone. Node installs its handlers unconditionally.
- The ledger framing "after Ctrl-C" is not exact: raw mode clears ISIG on that tty, so the trigger is an external `kill`, a supervisor, or a Bun crash.
- `uv_tty_reset_mode` returns EBUSY when `ttySetMode` holds its spinlock at that moment. The fds 0-2 loop still runs in that case.
- Found by a pty fuzz harness. No open issue.
- Self-reviewed: the review asked to keep the restore line and drop a lazy signal-handler install that competed with #38843. Done.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tty.test.ts

<!-- robobun:evidence:end -->