### PR TITLE
Default a compiled executable to production mode

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -364,7 +364,7 @@ Standalone executables can automatically load configuration files from the direc
 - **`tsconfig.json`** and **`package.json`** loading is **disabled** — these are typically only needed at development time, and the bundler already uses them when compiling
 - **`.env`** and **`bunfig.toml`** loading is **enabled** — these often contain runtime configuration that may vary per deployment
 
-A standalone executable treats an unset `NODE_ENV` (or `BUN_ENV`) as `production`. It loads `.env.production`, not `.env.development`, and `Bun.serve()` defaults to `development: false`. Set `NODE_ENV=development` in the environment to get the development behavior.
+A standalone executable runs as `production` unless `NODE_ENV` (or `BUN_ENV`) is `development` or `test`. An unset variable, or any other value, counts as production. It loads `.env.production`, not `.env.development`, and `Bun.serve()` defaults to `development: false`. Set `NODE_ENV=development` in the environment to get the development behavior.
 
 <Note>
   In a future version of Bun, `.env` and `bunfig.toml` may also be disabled by default for more deterministic behavior.

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -364,7 +364,7 @@ Standalone executables can automatically load configuration files from the direc
 - **`tsconfig.json`** and **`package.json`** loading is **disabled** — these are typically only needed at development time, and the bundler already uses them when compiling
 - **`.env`** and **`bunfig.toml`** loading is **enabled** — these often contain runtime configuration that may vary per deployment
 
-A standalone executable runs in production mode unless `NODE_ENV` (or `BUN_ENV`) is set to `development` or `test`. So it loads `.env.production`, not `.env.development`, and `Bun.serve()` defaults to `development: false`.
+A standalone executable treats an unset `NODE_ENV` (or `BUN_ENV`) as `production`. It loads `.env.production`, not `.env.development`, and `Bun.serve()` defaults to `development: false`. Set `NODE_ENV=development` in the environment to get the development behavior.
 
 <Note>
   In a future version of Bun, `.env` and `bunfig.toml` may also be disabled by default for more deterministic behavior.

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -364,6 +364,8 @@ Standalone executables can automatically load configuration files from the direc
 - **`tsconfig.json`** and **`package.json`** loading is **disabled** — these are typically only needed at development time, and the bundler already uses them when compiling
 - **`.env`** and **`bunfig.toml`** loading is **enabled** — these often contain runtime configuration that may vary per deployment
 
+A standalone executable runs in production mode unless `NODE_ENV` (or `BUN_ENV`) is set to `development` or `test`. So it loads `.env.production`, not `.env.development`, and `Bun.serve()` defaults to `development: false`.
+
 <Note>
   In a future version of Bun, `.env` and `bunfig.toml` may also be disabled by default for more deterministic behavior.
 </Note>
@@ -550,6 +552,8 @@ The result is a single file you can deploy anywhere without installing Node.js, 
 ```
 
 Bun serves the frontend assets with the correct MIME types and cache headers. Bun replaces the HTML import with a manifest object that `Bun.serve` uses to serve the pre-bundled assets.
+
+Inside a compiled executable, `Bun.serve()` defaults to `development: false`. An uncaught error in a route handler returns a plain `500` response instead of the development error page, which includes the error message, the stack trace, and the source. To get the development behavior, run the executable with `NODE_ENV=development` or pass `development: true` to `Bun.serve()`. See [Automatic config loading](#automatic-config-loading).
 
 For more on building full-stack applications, see the [full-stack guide](/bundler/fullstack).
 

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -765,6 +765,11 @@ declare module "bun" {
 
       /**
        * Whether to render contextual errors with Bun's error page
+       *
+       * Inside a standalone executable (`bun build --compile`), the default
+       * is `false` unless the `NODE_ENV` (or `BUN_ENV`) environment variable
+       * is `development` or `test`.
+       *
        * @default process.env.NODE_ENV !== 'production'
        */
       development?: Development;

--- a/src/bun.js.rs
+++ b/src/bun.js.rs
@@ -25,6 +25,19 @@ pub(crate) fn apply_standalone_runtime_flags(
     b.resolver.opts.load_package_json = !graph
         .flags
         .contains(GraphFlags::DISABLE_AUTOLOAD_PACKAGE_JSON);
+
+    // A compiled executable is a deployment artifact: boot as production (so
+    // `Bun.serve` defaults to `development: false` and `.env.production` is
+    // the dotenv suffix) unless the process env asks for development or test.
+    // `configure_defines` runs after this and still honours an explicit
+    // `NODE_ENV` / `BUN_ENV`.
+    let env = b.env_mut();
+    bun_core::handle_oom(env.load_process());
+    let node_env = env.get_node_env().unwrap_or(b"");
+    if node_env != b"development" && node_env != b"test" {
+        b.options.set_production(true);
+        b.resolver.opts.set_production(true);
+    }
 }
 
 #[cold]

--- a/src/bun.js.rs
+++ b/src/bun.js.rs
@@ -26,11 +26,7 @@ pub(crate) fn apply_standalone_runtime_flags(
         .flags
         .contains(GraphFlags::DISABLE_AUTOLOAD_PACKAGE_JSON);
 
-    // A compiled executable is a deployment artifact: boot as production (so
-    // `Bun.serve` defaults to `development: false` and `.env.production` is
-    // the dotenv suffix) unless the process env asks for development or test.
-    // `configure_defines` runs after this and still honours an explicit
-    // `NODE_ENV` / `BUN_ENV`.
+    // A compiled executable boots as production unless NODE_ENV/BUN_ENV says otherwise.
     let env = b.env_mut();
     bun_core::handle_oom(env.load_process());
     let node_env = env.get_node_env().unwrap_or(b"");

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1406,7 +1406,7 @@ impl<'a> BundleOptions<'a> {
         self.rewrite_jest_for_tests
     }
 
-    pub(crate) fn set_production(&mut self, value: bool) {
+    pub fn set_production(&mut self, value: bool) {
         if self.force_node_env == ForceNodeEnv::Unspecified {
             self.production = value;
             self.jsx.development = !value;

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1332,22 +1332,24 @@ describe("bundler", () => {
     contentType: "text/html;charset=utf-8",
     leaks: true,
   });
+  // bunEnv clears NODE_ENV but not BUN_ENV. Clear both so the shell cannot leak in.
+  const nodeEnv = (env: Record<string, string> = {}) => ({ NODE_ENV: undefined, BUN_ENV: undefined, ...env });
   itBundled("compile/ServeDefaultsToProduction", {
     compile: true,
     files: { "/entry.ts": serveDevelopmentEntry("") },
     run: [
-      { stdout: serveProduction },
-      { env: { NODE_ENV: "production" }, stdout: serveProduction },
-      { env: { NODE_ENV: "development" }, stdout: serveDevelopment },
-      { env: { BUN_ENV: "development" }, stdout: serveDevelopment },
-      { env: { NODE_ENV: "test" }, stdout: serveDevelopment },
-      { env: { NODE_ENV: "staging" }, stdout: serveProduction },
+      { env: nodeEnv(), stdout: serveProduction },
+      { env: nodeEnv({ NODE_ENV: "production" }), stdout: serveProduction },
+      { env: nodeEnv({ NODE_ENV: "development" }), stdout: serveDevelopment },
+      { env: nodeEnv({ BUN_ENV: "development" }), stdout: serveDevelopment },
+      { env: nodeEnv({ NODE_ENV: "test" }), stdout: serveDevelopment },
+      { env: nodeEnv({ NODE_ENV: "staging" }), stdout: serveProduction },
     ],
   });
   itBundled("compile/ServeExplicitDevelopment", {
     compile: true,
     files: { "/entry.ts": serveDevelopmentEntry("development: true,") },
-    run: { stdout: serveDevelopment },
+    run: { env: nodeEnv(), stdout: serveDevelopment },
   });
   itBundled("compile/Utf8", {
     compile: true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1298,6 +1298,55 @@ describe("bundler", () => {
     },
     run: { stdout: JSON.stringify({ server: "client sees the text", clientHasLiteral: true, clientHasBunfs: false }) },
   });
+
+  // A compiled executable defaults Bun.serve to production. The dev error page
+  // (message, stack, source) must not be served unless the user opts in.
+  const serveDevelopmentEntry = (options: string) => /* js */ `
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      ${options}
+      routes: { "/boom": () => { throw new Error("secret-stack-detail"); } },
+      fetch() { return new Response("nf", { status: 404 }); },
+    });
+    const res = await fetch(server.url + "boom", { headers: { accept: "text/html" } });
+    const body = await res.text();
+    console.log(JSON.stringify({
+      development: server.development,
+      status: res.status,
+      contentType: res.headers.get("content-type"),
+      leaks: body.includes("secret-stack-detail"),
+    }));
+    server.stop(true);
+    process.exit(0);
+  `;
+  const serveProduction = JSON.stringify({
+    development: false,
+    status: 500,
+    contentType: "text/plain",
+    leaks: false,
+  });
+  const serveDevelopment = JSON.stringify({
+    development: true,
+    status: 500,
+    contentType: "text/html;charset=utf-8",
+    leaks: true,
+  });
+  itBundled("compile/ServeDefaultsToProduction", {
+    compile: true,
+    files: { "/entry.ts": serveDevelopmentEntry("") },
+    run: [
+      { stdout: serveProduction },
+      { env: { NODE_ENV: "production" }, stdout: serveProduction },
+      { env: { NODE_ENV: "development" }, stdout: serveDevelopment },
+      { env: { BUN_ENV: "development" }, stdout: serveDevelopment },
+    ],
+  });
+  itBundled("compile/ServeExplicitDevelopment", {
+    compile: true,
+    files: { "/entry.ts": serveDevelopmentEntry("development: true,") },
+    run: { stdout: serveDevelopment },
+  });
   itBundled("compile/Utf8", {
     compile: true,
     files: {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1340,6 +1340,8 @@ describe("bundler", () => {
       { env: { NODE_ENV: "production" }, stdout: serveProduction },
       { env: { NODE_ENV: "development" }, stdout: serveDevelopment },
       { env: { BUN_ENV: "development" }, stdout: serveDevelopment },
+      { env: { NODE_ENV: "test" }, stdout: serveDevelopment },
+      { env: { NODE_ENV: "staging" }, stdout: serveProduction },
     ],
   });
   itBundled("compile/ServeExplicitDevelopment", {

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -95,8 +95,8 @@ describe("bundler", () => {
       "/.env.production": `TEST_VAR=from_production`,
     },
     run: [
-      { stdout: "from_production", setCwd: true },
-      { stdout: "from_development", setCwd: true, env: { NODE_ENV: "development" } },
+      { stdout: "from_production", setCwd: true, env: { NODE_ENV: undefined, BUN_ENV: undefined } },
+      { stdout: "from_development", setCwd: true, env: { NODE_ENV: "development", BUN_ENV: undefined } },
     ],
   });
 

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -81,6 +81,25 @@ describe("bundler", () => {
     },
   });
 
+  // A standalone executable runs as production, so it loads .env.production
+  // unless NODE_ENV asks for development.
+  itBundled("compile/AutoloadDotenvProductionSuffix", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env.development": `TEST_VAR=from_development`,
+      "/.env.production": `TEST_VAR=from_production`,
+    },
+    run: [
+      { stdout: "from_production", setCwd: true },
+      { stdout: "from_development", setCwd: true, env: { NODE_ENV: "development" } },
+    ],
+  });
+
   // Test that bunfig.toml is loaded by default (preload is executed)
   itBundled("compile/AutoloadBunfigDefault", {
     compile: true,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -424,7 +424,8 @@ export interface BundlerTestRunOptions {
    */
   errorLineMatch?: RegExp;
 
-  env?: Record<string, string>;
+  /** An `undefined` value removes the variable inherited from `bunEnv`. */
+  env?: Record<string, string | undefined>;
 
   runtime?: "bun" | "node";
 


### PR DESCRIPTION
### Problem
- A `bun build --compile` executable serves the development error page by default. `Bun.serve()` reports `development: true`, and an uncaught error in a route handler returns a 50 KB `text/html` page with the message, the stack (`/$bunfs/root/app:7:11`), and the source line. Same on 1.3.14, 1.4.0, 1.4.2, and canary.
- The `--compile` help text says "Implies --production", but nothing sets production for a compiled executable. `ServerConfig::from_js` (`src/runtime/server/ServerConfig.rs:639-645`) only leaves development mode when the runtime `NODE_ENV` is `production` or `vm.transpiler.options.production` is set. The standalone boot sets neither.

### Fix
- `apply_standalone_runtime_flags` (`src/bun.js.rs`) now calls `set_production(true)` on the transpiler and resolver options unless `NODE_ENV` or `BUN_ENV` in the process env is `development` or `test`. This runs before `configure_defines`, so an explicit `NODE_ENV` still applies through the existing path. `development: true` in `Bun.serve()` still wins. Workers in the executable go through the same hook.
- Visible effects: `Bun.serve()` defaults to `development: false`, and the dotenv loader picks `.env.production` instead of `.env.development`. Both match what `NODE_ENV=production ./app` does today.
- `set_production` on `bun_bundler::BundleOptions` becomes `pub` so the runtime crate can call it. `ServerConfig.rs` is unchanged.
- Verified: `test/bundler/bundler_compile.test.ts` (`compile/ServeDefaultsToProduction`, `compile/ServeExplicitDevelopment`) and `test/bundler/bundler_compile_autoload.test.ts` (`compile/AutoloadDotenvProductionSuffix`). All three fail on the stock binary and pass with this change. Also ran all of `bundler_compile`, `bundler_compile_autoload`, `compile-argv`, and `bun-serve-html` (153 pass).

### Background
- `options.production` is the transpiler flag that `bun run` derives from `NODE_ENV=production`. `ServerConfig::from_js` reads it to pick the `Bun.serve` default, and `run_env_loader` reads it to pick the `.env.<suffix>` file.
- `apply_standalone_runtime_flags` is the hook that applies the executable's embedded flags (dotenv, tsconfig, package.json autoload) to the transpiler at boot, before `configure_defines` loads the env.
- Not changed: the bundler still inlines `process.env.NODE_ENV` as the build-time value (`"development"` when unset), so code that checks `process.env.NODE_ENV !== "production"` inside the executable still sees development. #32851 makes that a runtime read. #38672 edits the same hook for the autoload-off case and will need a small rebase.

<details><summary>Notes</summary>

Repro on 1.4.3-canary:

```ts
const srv = Bun.serve({ port: 0, routes: { "/boom": () => { throw new Error("secret-stack-detail"); } }, fetch: () => new Response("nf", { status: 404 }) });
const r = await fetch(`${srv.url}boom`, { headers: { accept: "text/html" } });
console.log({ dev: srv.development, ct: r.headers.get("content-type"), leaks: (await r.text()).includes("secret-stack-detail") });
```

`bun build --compile app.ts --outfile app && ./app` printed `{ dev: true, ct: "text/html;charset=utf-8", leaks: true }`. `NODE_ENV=production ./app` printed `{ dev: false, ct: "text/plain", leaks: false }`.

A first version set the default in `ServerConfig::from_js` only. Review moved it to the standalone boot hook so it uses the existing `production` flag, honours `BUN_ENV`, and does not duplicate the `NODE_ENV` parsing in `configure_defines`.

`NODE_ENV=test` keeps the non-production default so a compiled executable under a test runner behaves like `bun run`.

Related: #26373 (the help text promise), #32851 (runtime `NODE_ENV` read), #38672 (same hook, autoload-off inlining).

Self-reviewed: 2 concerns raised. The split-brain with the inlined `process.env.NODE_ENV` is pre-existing and tracked by #32851, so this change documents it instead of widening scope. The overlap with #38672 is a small merge in one function.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->