### PR TITLE
tls: report a fatal post-handshake SSL error over a Duplex instead of a clean close

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1961,6 +1961,19 @@ static void ssl_park_fatal_reason(struct us_socket_t *s) {
   s->ssl_fatal_error = 1;
 }
 
+/* Drain the queue into `out` as the root-cause reason string and return 1,
+ * or return 0 with nothing queued. Exported for the SSLWrapper engine
+ * (src/uws/lib.rs), which drives SSL_read itself for TLS over a duplex or a
+ * named pipe, so both engines pick the same entry. */
+int us_ssl_take_fatal_reason(char *out, size_t out_len) {
+  unsigned long ssl_queue_err = ssl_take_root_cause_error();
+  if (ssl_queue_err == 0) {
+    return 0;
+  }
+  ERR_error_string_n(ssl_queue_err, out, out_len);
+  return 1;
+}
+
 /* The post-handshake counterpart of ssl_park_fatal_reason: the handshake
  * dispatch that would consume a parked reason has already run, so the reason
  * travels with the close instead (on_close's `reason`, which node surfaces
@@ -1969,12 +1982,7 @@ static void ssl_park_fatal_reason(struct us_socket_t *s) {
  * renegotiation-limit close, a BIO write that failed with no SSL error).
  * Drains the queue and marks the socket fatal either way. */
 static int ssl_take_fatal_reason(struct us_socket_t *s, char *out, size_t out_len) {
-  int taken = 0;
-  unsigned long ssl_queue_err = ssl_take_root_cause_error();
-  if (ssl_queue_err != 0) {
-    ERR_error_string_n(ssl_queue_err, out, out_len);
-    taken = 1;
-  }
+  int taken = us_ssl_take_fatal_reason(out, out_len);
   s->ssl_fatal_error = 1;
   return taken;
 }

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -473,7 +473,7 @@ pub(crate) fn write_encrypted(ctx: *mut HTTPClient, encoded_data: &[u8]) {
     }
 }
 
-fn on_close(ctx: *mut HTTPClient) {
+fn on_close(ctx: *mut HTTPClient, _reason: Option<&core::ffi::CStr>) {
     // on_close is fired from inside SSLWrapper::shutdown (via close_raw) whose
     // caller may itself be a callback that already held `&mut *ctx`; that
     // outer borrow is required to be NLL-dead before close_raw is invoked

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -319,7 +319,7 @@ impl WebSocketProxyTunnel {
     }
 
     /// SSLWrapper callback: Called when connection is closing
-    fn on_close(this: ThisPtr<Self>) {
+    fn on_close(this: ThisPtr<Self>, _reason: Option<&core::ffi::CStr>) {
         let _guard = RefPtr::from_this(this);
 
         bun_core::scoped_log!(WebSocketProxyTunnel, "onClose");

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -99,9 +99,7 @@ pub struct Handlers {
     pub(crate) on_open: fn(*mut ()),
     pub(crate) on_handshake: fn(*mut (), bool, us_bun_verify_error_t),
     pub(crate) on_data: fn(*mut (), &[u8]),
-    /// `reason` is the OpenSSL error string of a fatal `SSL_read` failure
-    /// after the handshake (see `ssl_wrapper::Handlers::on_close`), `None` for
-    /// a clean close. Valid for the call only.
+    /// `reason`: see `ssl_wrapper::Handlers::on_close`.
     pub on_close: fn(*mut (), Option<&CStr>),
     pub(crate) on_end: fn(*mut ()),
     pub(crate) on_writable: fn(*mut ()),

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -99,7 +99,10 @@ pub struct Handlers {
     pub(crate) on_open: fn(*mut ()),
     pub(crate) on_handshake: fn(*mut (), bool, us_bun_verify_error_t),
     pub(crate) on_data: fn(*mut (), &[u8]),
-    pub on_close: fn(*mut ()),
+    /// `reason` is the OpenSSL error string of a fatal `SSL_read` failure
+    /// after the handshake (see `ssl_wrapper::Handlers::on_close`), `None` for
+    /// a clean close. Valid for the call only.
+    pub on_close: fn(*mut (), Option<&CStr>),
     pub(crate) on_end: fn(*mut ()),
     pub(crate) on_writable: fn(*mut ()),
     pub(crate) on_error: fn(*mut (), JSValue),
@@ -197,7 +200,7 @@ impl UpgradedDuplex {
         }
     }
 
-    fn on_close(this: *mut Self) {
+    fn on_close(this: *mut Self, reason: Option<&CStr>) {
         bun_output::scoped_log!(UpgradedDuplex, "onClose");
         // SAFETY: see handler note above.
         let this = unsafe { &*this };
@@ -208,7 +211,7 @@ impl UpgradedDuplex {
         let js_wrapper = this.js_wrapper;
         js_wrapper.ensure_still_alive();
 
-        (this.handlers.on_close)(this.handlers.ctx);
+        (this.handlers.on_close)(this.handlers.ctx, reason);
         // closes the underlying duplex
         this.call_write_or_end(None, false);
 

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -58,8 +58,7 @@ use crate::jsc_hooks::timer_all_mut as timer_all;
 pub struct WindowsNamedPipe {
     pub(crate) wrapper: JsCell<Option<WrapperType>>,
     pub(crate) deferred_writer_close: Cell<bool>,
-    /// The TLS close reason of a close deferred by [`Flags::WRITER_BUSY`],
-    /// owned because the engine's stack buffer is gone by the time it runs.
+    /// Owned: the engine's stack buffer is gone when the deferred close runs.
     pub(crate) deferred_close_reason: JsCell<Option<Box<CStr>>>,
     pub(crate) root: Cell<*mut WindowsNamedPipe>,
     /// Non-owning alias of the heap `uv::Pipe`. The owning
@@ -137,9 +136,7 @@ pub struct Handlers {
     pub(crate) on_open: fn(*mut c_void),
     pub(crate) on_handshake: fn(*mut c_void, bool, us_bun_verify_error_t),
     pub(crate) on_data: fn(*mut c_void, &[u8]),
-    /// `reason` is the OpenSSL error string of a fatal `SSL_read` failure
-    /// after the handshake (see `ssl_wrapper::Handlers::on_close`), `None` for
-    /// a clean close. Valid for the call only.
+    /// `reason`: see `ssl_wrapper::Handlers::on_close`.
     pub on_close: fn(*mut c_void, Option<&CStr>),
     pub(crate) on_end: fn(*mut c_void),
     pub(crate) on_writable: fn(*mut c_void),

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -19,7 +19,7 @@
 //! unified socket interface.
 
 use core::cell::Cell;
-use core::ffi::{c_uint, c_void};
+use core::ffi::{CStr, c_uint, c_void};
 #[cfg(windows)]
 use core::ptr::NonNull;
 
@@ -58,6 +58,9 @@ use crate::jsc_hooks::timer_all_mut as timer_all;
 pub struct WindowsNamedPipe {
     pub(crate) wrapper: JsCell<Option<WrapperType>>,
     pub(crate) deferred_writer_close: Cell<bool>,
+    /// The TLS close reason of a close deferred by [`Flags::WRITER_BUSY`],
+    /// owned because the engine's stack buffer is gone by the time it runs.
+    pub(crate) deferred_close_reason: JsCell<Option<Box<CStr>>>,
     pub(crate) root: Cell<*mut WindowsNamedPipe>,
     /// Non-owning alias of the heap `uv::Pipe`. The owning
     /// `Box<uv::Pipe>` is leaked in [`from`] and adopted by
@@ -134,7 +137,10 @@ pub struct Handlers {
     pub(crate) on_open: fn(*mut c_void),
     pub(crate) on_handshake: fn(*mut c_void, bool, us_bun_verify_error_t),
     pub(crate) on_data: fn(*mut c_void, &[u8]),
-    pub on_close: fn(*mut c_void),
+    /// `reason` is the OpenSSL error string of a fatal `SSL_read` failure
+    /// after the handshake (see `ssl_wrapper::Handlers::on_close`), `None` for
+    /// a clean close. Valid for the call only.
+    pub on_close: fn(*mut c_void, Option<&CStr>),
     pub(crate) on_end: fn(*mut c_void),
     pub(crate) on_writable: fn(*mut c_void),
     pub(crate) on_error: fn(*mut c_void, bun_sys::Error),
@@ -309,7 +315,8 @@ impl WindowsNamedPipe {
         if !was_busy {
             self.update_flags(|f| f.remove(Flags::WRITER_BUSY));
             if self.deferred_writer_close.replace(false) {
-                self.on_close();
+                let reason = self.deferred_close_reason.take();
+                self.on_close_with_reason(reason.as_deref());
             }
         }
         r
@@ -383,9 +390,9 @@ impl WindowsNamedPipe {
         // SAFETY: see block note above.
         unsafe { &*this }.on_keylog(d)
     }
-    fn ssl_on_close(this: *mut Self) {
+    fn ssl_on_close(this: *mut Self, reason: Option<&CStr>) {
         // SAFETY: see block note above.
-        unsafe { &*this }.on_close()
+        unsafe { &*this }.on_close_with_reason(reason)
     }
     fn ssl_write(this: *mut Self, d: &[u8]) {
         // SAFETY: see block note above.
@@ -429,8 +436,13 @@ impl WindowsNamedPipe {
     }
 
     fn on_close(&self) {
+        self.on_close_with_reason(None);
+    }
+
+    fn on_close_with_reason(&self, reason: Option<&CStr>) {
         if self.flags.get().contains(Flags::WRITER_BUSY) {
             self.deferred_writer_close.set(true);
+            self.deferred_close_reason.set(reason.map(Into::into));
             return;
         }
         bun_output::scoped_log!(WindowsNamedPipe, "onClose");
@@ -438,7 +450,7 @@ impl WindowsNamedPipe {
         self.pipe.set(None);
         if !self.flags.get().is_closed() {
             self.update_flags(|f| f.set(Flags::IS_CLOSED, true)); // only call onClose once
-            (self.handlers.on_close)(self.handlers.ctx);
+            (self.handlers.on_close)(self.handlers.ctx, reason);
             self.release_resources();
         }
     }
@@ -568,6 +580,7 @@ impl WindowsNamedPipe {
             pipe: Cell::new(Some(NonNull::from(Box::leak(pipe)))),
             wrapper: JsCell::new(None),
             deferred_writer_close: Cell::new(false),
+            deferred_close_reason: JsCell::new(None),
             root: Cell::new(core::ptr::null_mut()),
             handlers,
             // defaults:

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -298,7 +298,7 @@ impl WindowsNamedPipeContext {
         ));
     }
 
-    fn on_close(this: *mut Self) {
+    fn on_close(this: *mut Self, reason: Option<&core::ffi::CStr>) {
         // SAFETY: see `on_open`. Snapshot `socket` BEFORE clearing it, then match
         // the snapshot — the macro must not read `(*this).socket` directly here.
         let (socket, pipe) = unsafe {
@@ -306,8 +306,10 @@ impl WindowsNamedPipeContext {
             (*this).socket = SocketType::None;
             (socket, ptr::addr_of_mut!((*this).named_pipe))
         };
+        // The reason travels the same way the uSockets close reason does.
+        let reason = reason.map(|r| r.as_ptr().cast_mut().cast::<c_void>());
         match_socket!(socket, |s: NewSocket<SSL>| {
-            let closed = NewSocket::on_close(s, socket_from_named_pipe::<SSL>(pipe), 0, None);
+            let closed = NewSocket::on_close(s, socket_from_named_pipe::<SSL>(pipe), 0, reason);
             // Release the +1 ref taken in `create()`.
             s.get().deref();
             closed
@@ -388,7 +390,7 @@ impl WindowsNamedPipeContext {
             on_writable: |p| Self::on_writable(p.cast::<Self>()),
             on_error: |p, e| Self::on_error(p.cast::<Self>(), &e),
             on_timeout: |p| Self::on_timeout(p.cast::<Self>()),
-            on_close: |p| Self::on_close(p.cast::<Self>()),
+            on_close: |p, reason| Self::on_close(p.cast::<Self>(), reason),
             on_session: |p, d| Self::on_session(p.cast::<Self>(), d),
             on_keylog: |p, d| Self::on_keylog(p.cast::<Self>(), d),
         };

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -81,10 +81,8 @@ fn read_error_from_close_code(code: c_int) -> sys::Error {
     }
 }
 
-/// The OpenSSL reason the TLS engine attaches to the close of a TLS socket
-/// whose `SSL_read` failed after the handshake: `us_internal_ssl_on_data` for
-/// a uSockets socket, `SSLWrapper::handle_reading` for a duplex or named pipe.
-/// Valid for the dispatch.
+/// The OpenSSL reason a TLS engine (openssl.c or `SSLWrapper`) attaches to
+/// the close of a socket whose `SSL_read` failed after the handshake.
 fn tls_close_reason<'a, const SSL: bool>(reason: Option<*mut c_void>) -> Option<&'a [u8]> {
     if !SSL {
         return None;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -81,8 +81,10 @@ fn read_error_from_close_code(code: c_int) -> sys::Error {
     }
 }
 
-/// The OpenSSL reason `us_internal_ssl_on_data` attaches to the close of a TLS
-/// socket whose `SSL_read` failed after the handshake. Valid for the dispatch.
+/// The OpenSSL reason the TLS engine attaches to the close of a TLS socket
+/// whose `SSL_read` failed after the handshake: `us_internal_ssl_on_data` for
+/// a uSockets socket, `SSLWrapper::handle_reading` for a duplex or named pipe.
+/// Valid for the dispatch.
 fn tls_close_reason<'a, const SSL: bool>(reason: Option<*mut c_void>) -> Option<&'a [u8]> {
     if !SSL {
         return None;
@@ -91,8 +93,8 @@ fn tls_close_reason<'a, const SSL: bool>(reason: Option<*mut c_void>) -> Option<
     if ptr.is_null() {
         return None;
     }
-    // SAFETY: the caller (uSockets) passes a NUL-terminated C string that
-    // outlives this close dispatch.
+    // SAFETY: the caller passes a NUL-terminated C string that outlives this
+    // close dispatch.
     let bytes = unsafe { core::ffi::CStr::from_ptr(ptr) }.to_bytes();
     (!bytes.is_empty()).then_some(bytes)
 }
@@ -4387,7 +4389,7 @@ impl DuplexUpgradeContext {
         }
     }
 
-    fn on_close(this: bun_ptr::ThisPtr<Self>) {
+    fn on_close(this: bun_ptr::ThisPtr<Self>, reason: Option<&core::ffi::CStr>) {
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls.replace(None) {
             // `TLSSocket::on_close` consumes the +1 we hold (its scope-exit deref
@@ -4400,7 +4402,9 @@ impl DuplexUpgradeContext {
             // in `on_error` instead of reading the Handlers that `TLSSocket::on_close`
             // → `mark_inactive` just released.
             let p = tls.into_this_ptr();
-            crate::dispatch::fold(TLSSocket::on_close(p, socket, 0, None));
+            // The reason travels the same way the uSockets close reason does.
+            let reason = reason.map(|r| r.as_ptr().cast_mut().cast::<c_void>());
+            crate::dispatch::fold(TLSSocket::on_close(p, socket, 0, reason));
         }
 
         Self::deinit_in_next_tick(this);
@@ -4780,8 +4784,8 @@ pub fn js_upgrade_duplex_to_tls(
                     DuplexUpgradeContext::on_handshake(bun_ptr::ThisPtr::new(c.cast()), ok, err)
                 },
                 // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
-                on_close: |c: *mut ()| {
-                    DuplexUpgradeContext::on_close(bun_ptr::ThisPtr::new(c.cast()))
+                on_close: |c: *mut (), reason| {
+                    DuplexUpgradeContext::on_close(bun_ptr::ThisPtr::new(c.cast()), reason)
                 },
                 // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
                 on_end: |c: *mut ()| DuplexUpgradeContext::on_end(bun_ptr::ThisPtr::new(c.cast())),

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -771,6 +771,11 @@ pub mod ssl_wrapper {
             if self.flags.sent_ssl_shutdown() {
                 return Err(WriteDataError::ConnectionClosed);
             }
+            // A fatal read is mid-dispatch (its data callback wrote back):
+            // the close that follows carries the reason. Do not close here.
+            if self.flags.fatal_error() {
+                return Err(WriteDataError::ConnectionClosed);
+            }
 
             if data.is_empty() {
                 // just cycle through internal openssl's state

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -148,7 +148,7 @@ pub fn get_default_ciphers() -> &'static ZStr {
 // ═══════════════════════════════════════════════════════════════════════════
 pub mod ssl_wrapper {
     use core::cell::Cell;
-    use core::ffi::{c_int, c_void};
+    use core::ffi::{CStr, c_int, c_void};
     use core::ptr::NonNull;
 
     // Re-export the canonical BoringSSL FFI surface; the lower-tier crate now
@@ -211,6 +211,10 @@ pub mod ssl_wrapper {
     const MAX_RENEGOTIATIONS: u8 = 3;
     /// See [`MAX_RENEGOTIATIONS`].
     const MAX_RENEGOTIATION_WINDOW: core::time::Duration = core::time::Duration::from_secs(600);
+
+    /// `US_SSL_FATAL_ERROR_REASON_MAX` in openssl.c: the buffer a fatal
+    /// OpenSSL reason string is formatted into.
+    const FATAL_REASON_MAX: usize = 256;
 
     pub struct SSLWrapper<T: Copy> {
         pub handlers: Cell<Handlers<T>>,
@@ -347,7 +351,11 @@ pub mod ssl_wrapper {
         pub on_handshake: fn(T, bool, us_bun_verify_error_t),
         pub write: fn(T, &[u8]),
         pub on_data: fn(T, &[u8]),
-        pub on_close: fn(T),
+        /// The network connection must close. The reason is the OpenSSL error
+        /// string of the fatal `SSL_read` failure that caused it (a bad record,
+        /// a peer's fatal alert), `None` for every other close. It points at
+        /// the caller's stack and is valid for the call only.
+        pub on_close: fn(T, Option<&CStr>),
         /// A new resumable TLS session arrived (serialized SSL_SESSION bytes)
         /// - node's `'session'` event. `None` opts the SSL out of session
         /// parking entirely (fetch / WebSocket tunnels have no consumer).
@@ -611,7 +619,7 @@ pub mod ssl_wrapper {
                     // -> deinit) never runs and leaks the whole context graph.
                     // trigger_close_callback is idempotent (closed_notified).
                     self.flags.set_received_ssl_shutdown(true);
-                    self.trigger_close_callback();
+                    self.trigger_close_callback(None);
                     // Do not read self after the close callback: the owner's
                     // teardown chain has started.
                     return true;
@@ -661,7 +669,7 @@ pub mod ssl_wrapper {
                 }
 
                 // we need to trigger close because we are not receiving a SSL_shutdown
-                self.trigger_close_callback();
+                self.trigger_close_callback(None);
                 return false;
             }
 
@@ -674,7 +682,7 @@ pub mod ssl_wrapper {
 
                 if err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL {
                     self.flags.set_fatal_error(true);
-                    self.trigger_close_callback();
+                    self.trigger_close_callback(None);
                     return false;
                 }
             }
@@ -799,7 +807,7 @@ pub mod ssl_wrapper {
                 self.flags.set_fatal_error(
                     err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL,
                 );
-                self.trigger_close_callback();
+                self.trigger_close_callback(None);
                 return Err(WriteDataError::ConnectionClosed);
             }
             self.handle_traffic();
@@ -843,14 +851,28 @@ pub mod ssl_wrapper {
             (handlers.on_data)(handlers.ctx, data);
         }
 
-        fn trigger_close_callback(&self) {
+        fn trigger_close_callback(&self, reason: Option<&CStr>) {
             if self.flags.closed_notified() {
                 return;
             }
             self.flags.set_closed_notified(true);
             // trigger the onClose callback
             let handlers = self.handlers.get();
-            (handlers.on_close)(handlers.ctx);
+            (handlers.on_close)(handlers.ctx, reason);
+        }
+
+        /// Drain the thread's error queue after a fatal `SSL_read` into the
+        /// reason string node reports (the root cause, picked by openssl.c's
+        /// `us_ssl_take_fatal_reason` so both engines agree). `None` when
+        /// nothing was queued.
+        fn take_fatal_reason(buf: &mut [u8; FATAL_REASON_MAX]) -> Option<&CStr> {
+            // SAFETY: `buf` is writable for `buf.len()` bytes; the helper
+            // NUL-terminates within that length.
+            let taken = unsafe { us_ssl_take_fatal_reason(buf.as_mut_ptr().cast(), buf.len()) };
+            if taken == 0 {
+                return None;
+            }
+            CStr::from_bytes_until_nul(buf).ok().filter(|s| !s.is_empty())
         }
 
         fn get_verify_error(&self) -> us_bun_verify_error_t {
@@ -885,7 +907,7 @@ pub mod ssl_wrapper {
                     self.flags.set_received_ssl_shutdown(true);
                     // 2-step shutdown
                     let _ = self.shutdown(false);
-                    self.trigger_close_callback();
+                    self.trigger_close_callback(None);
 
                     return false;
                 }
@@ -927,7 +949,7 @@ pub mod ssl_wrapper {
                     self.trigger_handshake_callback(false, verify);
 
                     if self.flags.fatal_error() {
-                        self.trigger_close_callback();
+                        self.trigger_close_callback(None);
                         return false;
                     }
                     return true;
@@ -989,6 +1011,18 @@ pub mod ssl_wrapper {
                 if just_read <= 0 {
                     // SAFETY: ssl is still valid.
                     let err = unsafe { boring_sys::SSL_get_error(ssl.as_ptr(), just_read) };
+                    let is_fatal =
+                        err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL;
+                    // A bad record, a peer's fatal alert, an unexpected message:
+                    // the close carries the OpenSSL reason so the owner reports
+                    // it (node: the socket's ERR_SSL_* 'error') instead of a
+                    // clean EOF. Taken before the queue is cleared.
+                    let mut reason_buf = [0u8; FATAL_REASON_MAX];
+                    let close_reason = if is_fatal {
+                        Self::take_fatal_reason(&mut reason_buf)
+                    } else {
+                        None
+                    };
                     boring_sys::ERR_clear_error();
 
                     if err != boring_sys::SSL_ERROR_WANT_READ
@@ -1023,7 +1057,7 @@ pub mod ssl_wrapper {
                                 // we failed to renegotiate
                                 let verify = self.get_verify_error();
                                 self.trigger_handshake_callback(false, verify);
-                                self.trigger_close_callback();
+                                self.trigger_close_callback(None);
                                 return false;
                             }
                             // ok, we are done here, we need to call SSL_read again
@@ -1038,8 +1072,7 @@ pub mod ssl_wrapper {
                             let _ = self.shutdown(false);
                             self.handle_end_of_renegotiation();
                         }
-                        if err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL
-                        {
+                        if is_fatal {
                             self.flags.set_fatal_error(true);
                         }
 
@@ -1053,6 +1086,16 @@ pub mod ssl_wrapper {
                                 return false;
                             }
                         }
+                        if is_fatal {
+                            // BoringSSL sealed a fatal alert into the write BIO
+                            // on the failure. Send it before the close tears the
+                            // wrapper down, so the peer gets its own SSL error
+                            // like it does on the uSockets path.
+                            self.handle_writing(buffer);
+                            if self.ssl.get().is_none() || self.flags.closed_notified() {
+                                return false;
+                            }
+                        }
                         // A NewSessionTicket/keylog line that rode in ahead of the
                         // peer's close_notify is still parked; deliver it before the
                         // close tears the wrapper down (mirrors the C ZERO_RETURN path).
@@ -1060,7 +1103,7 @@ pub mod ssl_wrapper {
                         if self.ssl.get().is_none() || self.flags.closed_notified() {
                             return false;
                         }
-                        self.trigger_close_callback();
+                        self.trigger_close_callback(close_reason);
                         return false;
                     } else {
                         log!("wanna read/write just break");
@@ -1274,6 +1317,11 @@ pub mod ssl_wrapper {
         /// Implemented in uSockets C; reads
         /// `SSL_get_verify_result` and maps it onto the C `us_bun_verify_error_t`.
         fn us_ssl_socket_verify_error_from_ssl(ssl: *mut boring_sys::SSL) -> us_bun_verify_error_t;
+        /// Drain the thread's OpenSSL error queue into `out` as the root-cause
+        /// reason string (openssl.c picks the same entry for its own fatal
+        /// close). Returns 1 with a reason, 0 with nothing queued.
+        // SAFETY (unsafe fn): `out` writable for `out_len` bytes.
+        fn us_ssl_take_fatal_reason(out: *mut core::ffi::c_char, out_len: usize) -> c_int;
         /// Opt this SSL into the parked new-session/keylog queues
         /// (openssl.c's `us_ssl_new_session_cb` / `us_ssl_keylog_cb` skip
         /// SSLs without the marker).

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -212,8 +212,7 @@ pub mod ssl_wrapper {
     /// See [`MAX_RENEGOTIATIONS`].
     const MAX_RENEGOTIATION_WINDOW: core::time::Duration = core::time::Duration::from_secs(600);
 
-    /// `US_SSL_FATAL_ERROR_REASON_MAX` in openssl.c: the buffer a fatal
-    /// OpenSSL reason string is formatted into.
+    /// `US_SSL_FATAL_ERROR_REASON_MAX` in openssl.c.
     const FATAL_REASON_MAX: usize = 256;
 
     pub struct SSLWrapper<T: Copy> {
@@ -351,10 +350,8 @@ pub mod ssl_wrapper {
         pub on_handshake: fn(T, bool, us_bun_verify_error_t),
         pub write: fn(T, &[u8]),
         pub on_data: fn(T, &[u8]),
-        /// The network connection must close. The reason is the OpenSSL error
-        /// string of the fatal `SSL_read` failure that caused it (a bad record,
-        /// a peer's fatal alert), `None` for every other close. It points at
-        /// the caller's stack and is valid for the call only.
+        /// The OpenSSL reason of the fatal `SSL_read` that forced the close,
+        /// `None` otherwise. Points at the caller's stack: valid for the call only.
         pub on_close: fn(T, Option<&CStr>),
         /// A new resumable TLS session arrived (serialized SSL_SESSION bytes)
         /// - node's `'session'` event. `None` opts the SSL out of session
@@ -861,10 +858,8 @@ pub mod ssl_wrapper {
             (handlers.on_close)(handlers.ctx, reason);
         }
 
-        /// Drain the thread's error queue after a fatal `SSL_read` into the
-        /// reason string node reports (the root cause, picked by openssl.c's
-        /// `us_ssl_take_fatal_reason` so both engines agree). `None` when
-        /// nothing was queued.
+        /// The root-cause reason of a fatal `SSL_read`, picked the way openssl.c
+        /// picks its own. `None` when nothing was queued.
         fn take_fatal_reason(buf: &mut [u8; FATAL_REASON_MAX]) -> Option<&CStr> {
             // SAFETY: `buf` is writable for `buf.len()` bytes; the helper
             // NUL-terminates within that length.
@@ -1015,10 +1010,8 @@ pub mod ssl_wrapper {
                     let err = unsafe { boring_sys::SSL_get_error(ssl.as_ptr(), just_read) };
                     let is_fatal =
                         err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL;
-                    // A bad record, a peer's fatal alert, an unexpected message:
-                    // the close carries the OpenSSL reason so the owner reports
-                    // it (node: the socket's ERR_SSL_* 'error') instead of a
-                    // clean EOF. Taken before the queue is cleared.
+                    // The close carries the reason (node's ERR_SSL_* 'error').
+                    // Take it before the queue is cleared.
                     let mut reason_buf = [0u8; FATAL_REASON_MAX];
                     let close_reason = if is_fatal {
                         Self::take_fatal_reason(&mut reason_buf)
@@ -1089,10 +1082,8 @@ pub mod ssl_wrapper {
                             }
                         }
                         if is_fatal {
-                            // BoringSSL sealed a fatal alert into the write BIO
-                            // on the failure. Send it before the close tears the
-                            // wrapper down, so the peer gets its own SSL error
-                            // like it does on the uSockets path.
+                            // Send the alert BoringSSL sealed into the write BIO
+                            // before the close frees it, so the peer gets its error.
                             self.handle_writing(buffer);
                             if self.ssl.get().is_none() || self.flags.closed_notified() {
                                 return false;
@@ -1319,9 +1310,8 @@ pub mod ssl_wrapper {
         /// Implemented in uSockets C; reads
         /// `SSL_get_verify_result` and maps it onto the C `us_bun_verify_error_t`.
         fn us_ssl_socket_verify_error_from_ssl(ssl: *mut boring_sys::SSL) -> us_bun_verify_error_t;
-        /// Drain the thread's OpenSSL error queue into `out` as the root-cause
-        /// reason string (openssl.c picks the same entry for its own fatal
-        /// close). Returns 1 with a reason, 0 with nothing queued.
+        /// Drain the OpenSSL error queue into `out` as the root-cause reason.
+        /// Returns 1 with a reason, 0 with nothing queued.
         // SAFETY (unsafe fn): `out` writable for `out_len` bytes.
         fn us_ssl_take_fatal_reason(out: *mut core::ffi::c_char, out_len: usize) -> c_int;
         /// Opt this SSL into the parked new-session/keylog queues

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -872,7 +872,9 @@ pub mod ssl_wrapper {
             if taken == 0 {
                 return None;
             }
-            CStr::from_bytes_until_nul(buf).ok().filter(|s| !s.is_empty())
+            CStr::from_bytes_until_nul(buf)
+                .ok()
+                .filter(|s| !s.is_empty())
         }
 
         fn get_verify_error(&self) -> us_bun_verify_error_t {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -585,17 +585,22 @@ for (const { name, connect } of tests) {
 }
 
 // A TLS record that fails after the handshake is a fatal protocol error. Node
-// surfaces it as the socket's ERR_SSL_<REASON> 'error'. Bun also destroys the
-// socket with that error (the engine's only exit is a close), so 'close'
-// follows with hadError. Over a generic Duplex the TLS engine is SSLWrapper,
-// a separate SSL_read driver from the uSockets one, so it gets its own
-// coverage. A TCP proxy between the Duplex and the server injects the bytes
-// once the handshake has completed on both sides.
+// surfaces it as the socket's ERR_SSL_<REASON> 'error' (and leaves the socket
+// open). Over a generic Duplex the TLS engine is SSLWrapper, a separate
+// SSL_read driver from the uSockets one, so it gets its own coverage. A TCP
+// proxy between the Duplex and the server injects the bytes once the
+// handshake has completed on both sides. Every assertion here also holds on
+// Node.js; only the alert's code name depends on the SSL library.
 describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", () => {
   // application_data, legacy version TLS 1.2, 32 bytes of ciphertext that
   // cannot authenticate: the receiver fails the AEAD open and alerts
   // bad_record_mac.
   const BAD_RECORD = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
+  // BoringSSL names the bad_record_mac alert SSLV3_ALERT_BAD_RECORD_MAC,
+  // OpenSSL 3 names it SSL/TLS_ALERT_BAD_RECORD_MAC.
+  const ALERT_BAD_RECORD_MAC = (process.features as { openssl_is_boringssl?: boolean }).openssl_is_boringssl
+    ? "ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC"
+    : "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC";
 
   type Scenario = {
     toClient: net.Socket;
@@ -607,15 +612,15 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
   };
 
   async function run(inject: (s: Scenario) => void | Promise<void>) {
-    await using server = tls.createServer(COMMON_CERT_);
+    const server = tls.createServer(COMMON_CERT_);
     server.on("secureConnection", s => s.on("error", () => {}));
     await once(server.listen(0, "127.0.0.1"), "listening");
-    const serverSecure = once(server, "secureConnection");
+    const serverSecure = once(server, "secureConnection") as Promise<[TLSSocket]>;
 
     let toClient: net.Socket | undefined;
     let toServer: net.Socket | undefined;
     let appendOnce: Buffer | undefined;
-    await using proxy = net.createServer(c => {
+    const proxy = net.createServer(c => {
       toClient = c;
       toServer = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
       c.pipe(toServer);
@@ -635,61 +640,57 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
     const raw = net.connect((proxy.address() as AddressInfo).port, "127.0.0.1");
     await once(raw, "connect");
     const client = tls.connect({ socket: new SocketProxy(raw), rejectUnauthorized: false });
-    // A clean 'close' with no 'error' before it is the bug, so the result
-    // settles on 'close' either way instead of waiting on an 'error' that may
-    // never come.
-    let err: (Error & { library?: string; reason?: string }) | undefined;
-    client.once("error", e => (err = e));
-    const clientClose = new Promise<boolean>(resolve => client.once("close", resolve));
+    // Settle on whichever comes first: the 'error' (expected), or a 'close'
+    // with no 'error' before it (the bug). Node emits no 'close' at all here.
+    const outcome = new Promise<{ event: string; code?: string; library?: string }>(resolve => {
+      client.once("error", (err: NodeJS.ErrnoException & { library?: string }) =>
+        resolve({ event: "error", code: err.code, library: err.library }),
+      );
+      client.once("close", () => resolve({ event: "close" }));
+    });
     await once(client, "secureConnect");
     const [serverSocket] = await serverSecure;
 
-    await inject({
-      toClient: toClient!,
-      toServer: toServer!,
-      serverSocket,
-      client,
-      appendToNextServerChunk: bytes => (appendOnce = bytes),
-    });
-
-    const hadError = await clientClose;
-    return {
-      code: err?.code,
-      library: err?.library,
-      reason: err?.reason,
-      message: err?.message,
-      hadError,
-    };
+    try {
+      await inject({
+        toClient: toClient!,
+        toServer: toServer!,
+        serverSocket,
+        client,
+        appendToNextServerChunk: bytes => (appendOnce = bytes),
+      });
+      return await outcome;
+    } finally {
+      for (const s of [client, raw, serverSocket, toClient, toServer]) s?.destroy();
+      proxy.close();
+      server.close();
+    }
   }
 
   it("a record that fails to decrypt surfaces as ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC", async () => {
-    const result = await run(({ toClient }) => toClient.write(BAD_RECORD));
+    const result = await run(({ toClient }) => void toClient.write(BAD_RECORD));
     expect(result).toEqual({
+      event: "error",
       code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
       library: "SSL routines",
-      reason: "DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
-      message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:DECRYPTION_FAILED_OR_BAD_RECORD_MAC$/),
-      hadError: true,
     });
   });
 
-  it("the peer's fatal alert surfaces as ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC", async () => {
+  it("the peer's bad_record_mac alert surfaces as an ERR_SSL_*_ALERT_BAD_RECORD_MAC error", async () => {
     // The bad record goes to the server, whose SSL_read fails and sends a
     // bad_record_mac alert back. The client's SSL_read fails on that alert.
-    const result = await run(({ toServer }) => toServer.write(BAD_RECORD));
+    const result = await run(({ toServer }) => void toServer.write(BAD_RECORD));
     expect(result).toEqual({
-      code: "ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC",
+      event: "error",
+      code: ALERT_BAD_RECORD_MAC,
       library: "SSL routines",
-      reason: "SSLV3_ALERT_BAD_RECORD_MAC",
-      message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:SSLV3_ALERT_BAD_RECORD_MAC$/),
-      hadError: true,
     });
   });
 
   it("a 'data' listener that writes back does not hide the error", async () => {
     // Good data and the bad record arrive in one chunk. The engine delivers
     // the data first, the listener's write hits the now-fatal SSL, and the
-    // close that follows must still carry the read's reason.
+    // read's reason must still be the error that surfaces.
     const result = await run(async ({ serverSocket, client, appendToNextServerChunk }) => {
       client.on("data", () => client.write("back"));
       serverSocket.write("first");
@@ -697,9 +698,10 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
       appendToNextServerChunk(BAD_RECORD);
       serverSocket.write("second");
     });
-    expect(result).toMatchObject({
+    expect(result).toEqual({
+      event: "error",
       code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
-      hadError: true,
+      library: "SSL routines",
     });
   });
 });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -612,14 +612,14 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
   };
 
   async function run(inject: (s: Scenario) => void | Promise<void>) {
-    const server = tls.createServer(COMMON_CERT_);
-    server.on("secureConnection", s => s.on("error", () => {}));
-    await once(server.listen(0, "127.0.0.1"), "listening");
-    const serverSecure = once(server, "secureConnection") as Promise<[TLSSocket]>;
-
     let toClient: net.Socket | undefined;
     let toServer: net.Socket | undefined;
+    let raw: net.Socket | undefined;
+    let client: TLSSocket | undefined;
+    let serverSocket: TLSSocket | undefined;
     let appendOnce: Buffer | undefined;
+    const server = tls.createServer(COMMON_CERT_);
+    server.on("secureConnection", s => s.on("error", () => {}));
     const proxy = net.createServer(c => {
       toClient = c;
       toServer = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
@@ -635,23 +635,25 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
       c.on("error", () => {});
       toServer.on("error", () => {});
     });
-    await once(proxy.listen(0, "127.0.0.1"), "listening");
-
-    const raw = net.connect((proxy.address() as AddressInfo).port, "127.0.0.1");
-    await once(raw, "connect");
-    const client = tls.connect({ socket: new SocketProxy(raw), rejectUnauthorized: false });
-    // Settle on whichever comes first: the 'error' (expected), or a 'close'
-    // with no 'error' before it (the bug). Node emits no 'close' at all here.
-    const outcome = new Promise<{ event: string; code?: string; library?: string }>(resolve => {
-      client.once("error", (err: NodeJS.ErrnoException & { library?: string }) =>
-        resolve({ event: "error", code: err.code, library: err.library }),
-      );
-      client.once("close", () => resolve({ event: "close" }));
-    });
-    await once(client, "secureConnect");
-    const [serverSocket] = await serverSecure;
-
     try {
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const serverSecure = once(server, "secureConnection") as Promise<[TLSSocket]>;
+      await once(proxy.listen(0, "127.0.0.1"), "listening");
+
+      raw = net.connect((proxy.address() as AddressInfo).port, "127.0.0.1");
+      await once(raw, "connect");
+      client = tls.connect({ socket: new SocketProxy(raw), rejectUnauthorized: false });
+      // Settle on whichever comes first: the 'error' (expected), or a 'close'
+      // with no 'error' before it (the bug). Node emits no 'close' at all here.
+      const outcome = new Promise<{ event: string; code?: string; library?: string }>(resolve => {
+        client!.once("error", (err: NodeJS.ErrnoException & { library?: string }) =>
+          resolve({ event: "error", code: err.code, library: err.library }),
+        );
+        client!.once("close", () => resolve({ event: "close" }));
+      });
+      await once(client, "secureConnect");
+      [serverSocket] = await serverSecure;
+
       await inject({
         toClient: toClient!,
         toServer: toServer!,

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -597,7 +597,16 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
   // bad_record_mac.
   const BAD_RECORD = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
 
-  async function run(inject: (toClient: net.Socket, toServer: net.Socket) => void) {
+  type Scenario = {
+    toClient: net.Socket;
+    toServer: net.Socket;
+    serverSocket: TLSSocket;
+    client: TLSSocket;
+    // Append `bytes` to the next chunk the proxy forwards from the server.
+    appendToNextServerChunk(bytes: Buffer): void;
+  };
+
+  async function run(inject: (s: Scenario) => void | Promise<void>) {
     await using server = tls.createServer(COMMON_CERT_);
     server.on("secureConnection", s => s.on("error", () => {}));
     await once(server.listen(0, "127.0.0.1"), "listening");
@@ -605,11 +614,19 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
 
     let toClient: net.Socket | undefined;
     let toServer: net.Socket | undefined;
+    let appendOnce: Buffer | undefined;
     await using proxy = net.createServer(c => {
       toClient = c;
       toServer = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
       c.pipe(toServer);
-      toServer.pipe(c);
+      toServer.on("data", chunk => {
+        if (appendOnce) {
+          chunk = Buffer.concat([chunk, appendOnce]);
+          appendOnce = undefined;
+        }
+        c.write(chunk);
+      });
+      toServer.on("end", () => c.end());
       c.on("error", () => {});
       toServer.on("error", () => {});
     });
@@ -625,9 +642,15 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
     client.once("error", e => (err = e));
     const clientClose = new Promise<boolean>(resolve => client.once("close", resolve));
     await once(client, "secureConnect");
-    await serverSecure;
+    const [serverSocket] = await serverSecure;
 
-    inject(toClient!, toServer!);
+    await inject({
+      toClient: toClient!,
+      toServer: toServer!,
+      serverSocket,
+      client,
+      appendToNextServerChunk: bytes => (appendOnce = bytes),
+    });
 
     const hadError = await clientClose;
     return {
@@ -640,7 +663,7 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
   }
 
   it("a record that fails to decrypt surfaces as ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC", async () => {
-    const result = await run(toClient => toClient.write(BAD_RECORD));
+    const result = await run(({ toClient }) => toClient.write(BAD_RECORD));
     expect(result).toEqual({
       code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
       library: "SSL routines",
@@ -653,12 +676,29 @@ describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", (
   it("the peer's fatal alert surfaces as ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC", async () => {
     // The bad record goes to the server, whose SSL_read fails and sends a
     // bad_record_mac alert back. The client's SSL_read fails on that alert.
-    const result = await run((_toClient, toServer) => toServer.write(BAD_RECORD));
+    const result = await run(({ toServer }) => toServer.write(BAD_RECORD));
     expect(result).toEqual({
       code: "ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC",
       library: "SSL routines",
       reason: "SSLV3_ALERT_BAD_RECORD_MAC",
       message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:SSLV3_ALERT_BAD_RECORD_MAC$/),
+      hadError: true,
+    });
+  });
+
+  it("a 'data' listener that writes back does not hide the error", async () => {
+    // Good data and the bad record arrive in one chunk. The engine delivers
+    // the data first, the listener's write hits the now-fatal SSL, and the
+    // close that follows must still carry the read's reason.
+    const result = await run(async ({ serverSocket, client, appendToNextServerChunk }) => {
+      client.on("data", () => client.write("back"));
+      serverSocket.write("first");
+      await once(client, "data");
+      appendToNextServerChunk(BAD_RECORD);
+      serverSocket.write("second");
+    });
+    expect(result).toMatchObject({
+      code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
       hadError: true,
     });
   });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -584,6 +584,86 @@ for (const { name, connect } of tests) {
   });
 }
 
+// A TLS record that fails after the handshake is a fatal protocol error. Node
+// surfaces it as the socket's ERR_SSL_<REASON> 'error'. Bun also destroys the
+// socket with that error (the engine's only exit is a close), so 'close'
+// follows with hadError. Over a generic Duplex the TLS engine is SSLWrapper,
+// a separate SSL_read driver from the uSockets one, so it gets its own
+// coverage. A TCP proxy between the Duplex and the server injects the bytes
+// once the handshake has completed on both sides.
+describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", () => {
+  // application_data, legacy version TLS 1.2, 32 bytes of ciphertext that
+  // cannot authenticate: the receiver fails the AEAD open and alerts
+  // bad_record_mac.
+  const BAD_RECORD = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
+
+  async function run(inject: (toClient: net.Socket, toServer: net.Socket) => void) {
+    await using server = tls.createServer(COMMON_CERT_);
+    server.on("secureConnection", s => s.on("error", () => {}));
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const serverSecure = once(server, "secureConnection");
+
+    let toClient: net.Socket | undefined;
+    let toServer: net.Socket | undefined;
+    await using proxy = net.createServer(c => {
+      toClient = c;
+      toServer = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+      c.pipe(toServer);
+      toServer.pipe(c);
+      c.on("error", () => {});
+      toServer.on("error", () => {});
+    });
+    await once(proxy.listen(0, "127.0.0.1"), "listening");
+
+    const raw = net.connect((proxy.address() as AddressInfo).port, "127.0.0.1");
+    await once(raw, "connect");
+    const client = tls.connect({ socket: new SocketProxy(raw), rejectUnauthorized: false });
+    // A clean 'close' with no 'error' before it is the bug, so the result
+    // settles on 'close' either way instead of waiting on an 'error' that may
+    // never come.
+    let err: (Error & { library?: string; reason?: string }) | undefined;
+    client.once("error", e => (err = e));
+    const clientClose = new Promise<boolean>(resolve => client.once("close", resolve));
+    await once(client, "secureConnect");
+    await serverSecure;
+
+    inject(toClient!, toServer!);
+
+    const hadError = await clientClose;
+    return {
+      code: err?.code,
+      library: err?.library,
+      reason: err?.reason,
+      message: err?.message,
+      hadError,
+    };
+  }
+
+  it("a record that fails to decrypt surfaces as ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC", async () => {
+    const result = await run(toClient => toClient.write(BAD_RECORD));
+    expect(result).toEqual({
+      code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
+      library: "SSL routines",
+      reason: "DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
+      message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:DECRYPTION_FAILED_OR_BAD_RECORD_MAC$/),
+      hadError: true,
+    });
+  });
+
+  it("the peer's fatal alert surfaces as ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC", async () => {
+    // The bad record goes to the server, whose SSL_read fails and sends a
+    // bad_record_mac alert back. The client's SSL_read fails on that alert.
+    const result = await run((_toClient, toServer) => toServer.write(BAD_RECORD));
+    expect(result).toEqual({
+      code: "ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC",
+      library: "SSL routines",
+      reason: "SSLV3_ALERT_BAD_RECORD_MAC",
+      message: expect.stringMatching(/^error:[0-9a-f]+:SSL routines:[^:]*:SSLV3_ALERT_BAD_RECORD_MAC$/),
+      hadError: true,
+    });
+  });
+});
+
 it("setSession() should not leak the SSL_SESSION returned by d2i_SSL_SESSION", async () => {
   // d2i_SSL_SESSION returns an owned SSL_SESSION; SSL_set_session takes its own
   // reference ("the caller retains ownership"), so the caller's reference must


### PR DESCRIPTION
Stacked on #41463. Review the last commit only.

### Problem
- `tls.connect({ socket: <Duplex> })` (and node:tls over a Windows named pipe) emits a clean `'end'` and `'close'` with `hadError` false when a TLS record fails after the handshake: a bad MAC, a wrong version, a peer's fatal alert. Node emits the socket's `ERR_SSL_<REASON>` `'error'` (for example `ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`).
- The cause is `SSLWrapper::handle_reading` (`src/uws/lib.rs:1030`). On `SSL_ERROR_SSL` it called `ERR_clear_error()` right after `SSL_get_error()` and closed through `Handlers::on_close`, which carried no reason. The alert BoringSSL sealed into the write BIO was dropped too. #41463 fixes the same bug for the uSockets engine. The SSLWrapper engine is a separate `SSL_read` driver, so that fix does not reach it.

### Fix
- `handle_reading` takes the root-cause reason before the queue is cleared, through `us_ssl_take_fatal_reason`, the picker openssl.c uses for its own fatal close. It then flushes the sealed alert to the peer and closes with the reason.
- `Handlers::on_close` carries `Option<&CStr>`. `UpgradedDuplex` and `WindowsNamedPipe` forward it into `TLSSocket::on_close` through the close reason slot that #41463 added. A named pipe close deferred by a busy writer keeps an owned copy. The fetch and WebSocket proxy tunnels ignore it. `write_data` no longer closes the wrapper while a fatal read is mid-dispatch, so a `'data'` listener that writes back cannot hide the reason.
- Correct because the reason then reaches JS through the same `EPROTO` shape and the same `node:net` decomposition as the uSockets path. Both engines report one result for one failure.
- Verified: `test/js/node/tls/node-tls-connect.test.ts` ("tls.connect over a Duplex reports a fatal post-handshake SSL error", three cases). All three fail on the #41463 base and pass with this branch. The same cases also pass on Node.js v26.3.0 (see the comment below). Also `test/js/node/tls/`, `test/js/bun/net/socket.test.ts`, and the fetch and WebSocket proxy suites.

### Background
- `SSLWrapper` (`src/uws/lib.rs`) runs BoringSSL over memory BIOs for transports that are not a `us_socket_t`: a generic `Duplex`, a Windows named pipe, the fetch and WebSocket proxy tunnels. It calls its owner back through `Handlers` (`on_data`, `write`, `on_close`).
- Error queue: OpenSSL keeps a per-thread error queue. A fatal `SSL_read` leaves the reason there. Node reports the oldest entry. BoringSSL can queue a cipher-layer entry first, so the picker takes the oldest SSL-library entry.
- Fatal alert: on a failed read BoringSSL writes an alert record into the write BIO. Nothing pumps that BIO after a close, so `handle_reading` now flushes it before the close. The peer then gets its own `ERR_SSL_*ALERT_*` error.

<details><summary>Notes</summary>

- Repro: a TCP proxy between a `Duplex`-wrapped client and `tls.createServer`. After `secureConnect`, write an application_data record (`17 03 03 00 20` plus 32 bytes of `0x42`) toward the client. Node v26.3.0: `error ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`. Bun 1.4.3-canary: `end`, `close false`. With the fix: `error ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`, `close true`.
- Written toward the server instead, the server's `bad_record_mac` alert reaches the client as `ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC` (BoringSSL's name for the alert).
- Node leaves the TLSSocket open after the `'error'`. Bun destroys it with the error, because the engine's only exit on a fatal read is a close. #41463 made the same choice for the uSockets path.
- The alert flush was checked on the wire: the client sends a 19-byte application_data record (a TLS 1.3 encrypted alert) before the FIN.
- The tests assert only what holds on both runtimes: the first event is `'error'` with the `ERR_SSL_*` code and `library: "SSL routines"`. The alert's code name comes from `process.features.openssl_is_boringssl` (BoringSSL: `SSLV3_ALERT_BAD_RECORD_MAC`, OpenSSL 3: `SSL/TLS_ALERT_BAD_RECORD_MAC`).
- Self-reviewed: 9 concerns raised, 7 addressed (stacked on #41463 instead of main, the shared `net.ts` and `NewSocket::on_close` hunks dropped, the picker shared with openssl.c instead of a Rust copy, the node `'close'` wording fixed). Not addressed: the Http2SecureServer upgrade path (`_http2_upgrade.ts` `socketClose`) still drops the reason on this engine, and #32929 (the handshake-time reason on this engine) is not stacked under this PR. Both are separate changes.
- #41272 is an alternative shape for the uSockets path (an `error` dispatch before the close). It states that it does not cover the SSLWrapper engine. If that shape lands instead of #41463, the reason capture and the alert flush here stay, and only the final dispatch in `DuplexUpgradeContext::on_close` changes.
- Pre-existing failures in this container, not from this change: `SNICallback runs even when the requested servername matches the bind hostname` (localhost dual-stack) and `socket > should not call drain before handshake` (needs www.example.com).
- Cross-checked with `cargo check -p bun_runtime --target x86_64-pc-windows-msvc`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.59ms]
(pass) should thow ECONNRESET if FIN is received before handshake [323.96ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.81ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [113.40ms]
(pass) should be able to grab the JSStreamSocket constructor [13.14ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [80.19ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [83.18ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release without fix: 3 failed, 18 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.06ms]
(pass) should thow ECONNRESET if FIN is received before handshake [6.51ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.16ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [3.49ms]
(pass) should be able to grab the JSStreamSocket constructor [0.21ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [7.36ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [4.22ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.58ms]
(pass) should thow ECONNRESET if FIN is received before handshake [316.01ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.39ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [113.24ms]
(pass) should be able to grab the JSStreamSocket constructor [12.50ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [75.11ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [80.40ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 602ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c         |  20 +++-
 src/http/ProxyTunnel.rs                            |   2 +-
 .../websocket_client/WebSocketProxyTunnel.rs       |   2 +-
 src/runtime/socket/UpgradedDuplex.rs               |   7 +-
 src/runtime/socket/WindowsNamedPipe.rs             |  22 +++-
 src/runtime/socket/WindowsNamedPipeContext.rs      |   8 +-
 src/runtime/socket/socket_body.rs                  |  18 +--
 src/uws/lib.rs                                     |  73 +++++++++---
 test/js/node/tls/node-tls-connect.test.ts          | 124 +++++++++++++++++++++
 9 files changed, 234 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c                 0      0     25
src/http/ProxyTunnel.rs                                    0      0     25
src/http_jsc/websocket_client/WebSocketProxyTunnel.rs      0      0     25
src/runtime/socket/UpgradedDuplex.rs                       1      2     25
src/runtime/socket/WindowsNamedPipe.rs                     1      0     25
src/runtime/socket/WindowsNamedPipeContext.rs              1      0     25
src/runtime/socket/socket_body.rs                          3      5     25
src/uws/lib.rs                                             6      7     25
test/js/node/tls/node-tls-connect.test.ts                  8      4     25
```

</details>

<!-- robobun:evidence:end -->
