### PR TITLE
cli: bound the bun create template join, exit 1 on add/remove/create usage errors

### DIFF
--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -111,14 +111,14 @@ pub fn update_package_json_and_install_with_manager(
                 Output::flush();
                 CommandLineArguments::print_help(Subcommand::Add);
 
-                Global::exit(0);
+                Global::exit(1);
             }
             Subcommand::Remove => {
                 Output::err_generic("no package specified to remove", ());
                 Output::flush();
                 CommandLineArguments::print_help(Subcommand::Remove);
 
-                Global::exit(0);
+                Global::exit(1);
             }
             Subcommand::Update => {}
             _ => {}

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -290,12 +290,19 @@ impl CreateCommand {
             positionals[1]
         };
 
-        let destination =
-            filesystem
-                .dirname_store
-                .append_slice(bun_paths::resolve_path::join_abs::<
-                    bun_paths::platform::Loose,
-                >(filesystem.top_level_dir, dirname))?;
+        let destination = {
+            let mut destination_buf = bun_paths::path_buffer_pool::get();
+            let Some(joined) = bun_paths::resolve_path::join_abs_string_buf_checked::<
+                bun_paths::platform::Loose,
+            >(filesystem.top_level_dir, &mut *destination_buf, &[dirname]) else {
+                Output::err_generic(
+                    "destination path too long: \"{}\"",
+                    format_args!("{}", bstr::BStr::new(dirname)),
+                );
+                Global::crash();
+            };
+            filesystem.dirname_store.append_slice(joined)?
+        };
 
         let mut progress = Progress {
             supports_ansi_escape_codes: Output::enable_ansi_colors_stderr(),

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1348,8 +1348,8 @@ impl CreateCommand {
                 'outer: {
                     if let Some(home_dir) = env_loader.map.get(b"BUN_CREATE_DIR") {
                         let parts = [home_dir, positional];
-                        let Some(outdir_path) = filesystem
-                            .abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
+                        let Some(outdir_path) =
+                            filesystem.abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
                         else {
                             break 'outer;
                         };
@@ -1394,8 +1394,8 @@ impl CreateCommand {
                 'outer: {
                     if let Some(home_dir) = env_loader.map.get(b"HOME") {
                         let parts = [home_dir, BUN_CREATE_DIR, positional];
-                        let Some(outdir_path) = filesystem
-                            .abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
+                        let Some(outdir_path) =
+                            filesystem.abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
                         else {
                             break 'outer;
                         };

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1302,12 +1302,20 @@ impl CreateCommand {
         // var unsupported_packages = UnsupportedPackages{};
         // SAFETY: single-threaded CLI access to module-level static path buffer
         let home_dir_buf = unsafe { &mut *HOME_DIR_BUF.get() };
+        // Leave one byte for the NUL written after each join. The positional
+        // is argv of any length: a join that does not fit is not a local
+        // template, so that lookup is skipped.
+        let join_buf_len = home_dir_buf.len() - 1;
         let template: &[u8] = 'brk: {
             let positional = positionals[0];
 
             'outer: {
                 let parts = [filesystem.top_level_dir, positional];
-                let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
+                let Some(outdir_path) =
+                    filesystem.abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
+                else {
+                    break 'outer;
+                };
                 let len = outdir_path.len();
                 home_dir_buf[len] = 0;
                 // SAFETY: home_dir_buf[len] == 0 written above
@@ -1340,7 +1348,11 @@ impl CreateCommand {
                 'outer: {
                     if let Some(home_dir) = env_loader.map.get(b"BUN_CREATE_DIR") {
                         let parts = [home_dir, positional];
-                        let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
+                        let Some(outdir_path) = filesystem
+                            .abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
+                        else {
+                            break 'outer;
+                        };
                         let len = outdir_path.len();
                         home_dir_buf[len] = 0;
                         // SAFETY: home_dir_buf[len] == 0 written above
@@ -1359,7 +1371,11 @@ impl CreateCommand {
 
                 'outer: {
                     let parts = [filesystem.top_level_dir, BUN_CREATE_DIR, positional];
-                    let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
+                    let Some(outdir_path) =
+                        filesystem.abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
+                    else {
+                        break 'outer;
+                    };
                     let len = outdir_path.len();
                     home_dir_buf[len] = 0;
                     // SAFETY: home_dir_buf[len] == 0 written above
@@ -1378,7 +1394,11 @@ impl CreateCommand {
                 'outer: {
                     if let Some(home_dir) = env_loader.map.get(b"HOME") {
                         let parts = [home_dir, BUN_CREATE_DIR, positional];
-                        let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
+                        let Some(outdir_path) = filesystem
+                            .abs_buf_checked(&parts, &mut home_dir_buf[..join_buf_len])
+                        else {
+                            break 'outer;
+                        };
                         let len = outdir_path.len();
                         home_dir_buf[len] = 0;
                         // SAFETY: home_dir_buf[len] == 0 written above

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -294,7 +294,9 @@ impl CreateCommand {
             let mut destination_buf = bun_paths::path_buffer_pool::get();
             let Some(joined) = bun_paths::resolve_path::join_abs_string_buf_checked::<
                 bun_paths::platform::Loose,
-            >(filesystem.top_level_dir, &mut *destination_buf, &[dirname]) else {
+            >(
+                filesystem.top_level_dir, &mut *destination_buf, &[dirname]
+            ) else {
                 Output::err_generic(
                     "destination path too long: \"{}\"",
                     format_args!("{}", bstr::BStr::new(dirname)),

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1302,9 +1302,7 @@ impl CreateCommand {
         // var unsupported_packages = UnsupportedPackages{};
         // SAFETY: single-threaded CLI access to module-level static path buffer
         let home_dir_buf = unsafe { &mut *HOME_DIR_BUF.get() };
-        // Leave one byte for the NUL written after each join. The positional
-        // is argv of any length: a join that does not fit is not a local
-        // template, so that lookup is skipped.
+        // One byte stays free for the NUL written after each join.
         let join_buf_len = home_dir_buf.len() - 1;
         let template: &[u8] = 'brk: {
             let positional = positionals[0];

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -298,8 +298,8 @@ impl CreateCommand {
                 filesystem.top_level_dir, &mut *destination_buf, &[dirname]
             ) else {
                 Output::err_generic(
-                    "destination path too long: \"{}\"",
-                    format_args!("{}", bstr::BStr::new(dirname)),
+                    "destination path too long: {}",
+                    format_args!("{}", bun_core::fmt::quote(dirname)),
                 );
                 Global::crash();
             };

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1819,13 +1819,15 @@ pub mod command {
             }
         }
 
-        if print_help
-            // "bun create --" / "bun create -abc --"
-            || positional_i == 0
-            || positionals[1].is_empty()
-        {
+        if print_help {
             tag_print_help(Tag::CreateCommand, true);
             Global::exit(0);
+        }
+
+        // "bun create --" / "bun create -abc --"
+        if positional_i == 0 || positionals[1].is_empty() {
+            tag_print_help(Tag::CreateCommand, true);
+            Global::exit(1);
         }
 
         let template_name = positionals[1];

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -95,6 +95,29 @@ it("should add existing package", async () => {
   );
 });
 
+it("exits 1 when no package is given", async () => {
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "bar",
+      version: "0.0.2",
+    }),
+  );
+  for (const args of [["add"], ["add", "--dev"]]) {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).toContain("error: no package specified to add");
+    expect(await exited).toBe(1);
+  }
+});
+
 it("should reject missing package", async () => {
   await writeFile(
     join(package_dir, "package.json"),

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -96,13 +96,11 @@ it("should add existing package", async () => {
 });
 
 it("exits 1 when no package is given", async () => {
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "bar",
-      version: "0.0.2",
-    }),
-  );
+  const manifest = JSON.stringify({
+    name: "bar",
+    version: "0.0.2",
+  });
+  await writeFile(join(package_dir, "package.json"), manifest);
   for (const args of [["add"], ["add", "--dev"]]) {
     const { stderr, exited } = spawn({
       cmd: [bunExe(), ...args],
@@ -115,6 +113,7 @@ it("exits 1 when no package is given", async () => {
     const err = await stderr.text();
     expect(err).toContain("error: no package specified to add");
     expect(await exited).toBe(1);
+    expect(await file(join(package_dir, "package.json")).text()).toBe(manifest);
   }
 });
 

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -16,11 +16,13 @@ beforeEach(async () => {
 });
 
 describe("should not crash", async () => {
+  // A missing template is a usage error and exits 1. Only --help exits 0.
   const args = [
     [bunExe(), "create"],
     [bunExe(), "create", ""],
     [bunExe(), "create", "--"],
     [bunExe(), "create", "--", ""],
+    [bunExe(), "create", "--x"],
     [bunExe(), "create", "--help"],
   ];
   for (let cmd of args) {
@@ -33,9 +35,27 @@ describe("should not crash", async () => {
         stderr: "inherit",
         env,
       });
-      expect(exitCode).toBe(cmd.length === 2 ? 1 : 0);
+      expect(exitCode).toBe(cmd.includes("--help") ? 0 : 1);
     });
   }
+});
+
+it("rejects a template name that does not fit the path buffer instead of crashing", async () => {
+  // cwd + "/" + template must exceed PATH_MAX (4096). The local-folder lookup
+  // joins the two into a fixed path buffer.
+  const template = Buffer.alloc(5000, "A").toString();
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "create", template, "dst"],
+    cwd: x_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).toContain(`error: unrecognised dependency format: create-${template}`);
+  expect(await exited).toBe(1);
+  expect(await exists(join(x_dir, "dst"))).toBe(false);
 });
 
 it("should create selected template with @ prefix", async () => {

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -40,9 +40,10 @@ describe("should not crash", async () => {
   }
 });
 
+// cwd + "/" + positional must exceed the path buffer (4096 bytes on Linux,
+// 1024 on macOS). On Windows the buffer is larger than the longest argv
+// token the OS accepts, so these only prove the error message there.
 it("rejects a template name that does not fit the path buffer instead of crashing", async () => {
-  // cwd + "/" + template must exceed PATH_MAX (4096). The local-folder lookup
-  // joins the two into a fixed path buffer.
   const template = Buffer.alloc(5000, "A").toString();
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "create", template, "dst"],
@@ -56,6 +57,23 @@ it("rejects a template name that does not fit the path buffer instead of crashin
   expect(err).toContain(`error: unrecognised dependency format: create-${template}`);
   expect(await exited).toBe(1);
   expect(await exists(join(x_dir, "dst"))).toBe(false);
+});
+
+it("rejects a destination that does not fit the path buffer instead of crashing", async () => {
+  const destination = Buffer.alloc(5000, "A").toString();
+  // elysia is one of the templates that bun create handles itself (not bunx),
+  // so the destination is joined before any network request.
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "create", "elysia", destination],
+    cwd: x_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).toContain(`error: destination path too long: "${destination}"`);
+  expect(await exited).toBe(1);
 });
 
 it("should create selected template with @ prefix", async () => {

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -2,7 +2,7 @@ import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
 import { exists, stat } from "fs/promises";
-import { bunExe, bunEnv as env, isPosix, tempDir, tls, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, isPosix, isWindows, tempDir, tls, tmpdirSync } from "harness";
 import { once } from "node:events";
 import * as nodetls from "node:tls";
 import { join } from "path";
@@ -59,7 +59,7 @@ it("rejects a template name that does not fit the path buffer instead of crashin
   expect(await exists(join(x_dir, "dst"))).toBe(false);
 });
 
-it("rejects a destination that does not fit the path buffer instead of crashing", async () => {
+it.skipIf(isWindows)("rejects a destination that does not fit the path buffer instead of crashing", async () => {
   const destination = Buffer.alloc(5000, "A").toString();
   // elysia is one of the templates that bun create handles itself (not bunx),
   // so the destination is joined before any network request.

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -504,6 +504,16 @@ it.concurrent("bun remove -r is rejected and leaves package.json untouched", asy
   expect(exitCode).toBe(1);
 });
 
+it.concurrent("bun remove with no package exits 1", async () => {
+  const pkg = JSON.stringify({ name: "root", dependencies: { foo: "file:./foo" } });
+  using dir = tempDir("bun-remove-no-package", { ...local("foo"), "package.json": pkg });
+
+  const { stderr, exitCode } = await remove(String(dir));
+  expect(stderr).toContain("error: no package specified to remove");
+  expect(await file(join(String(dir), "package.json")).text()).toBe(pkg);
+  expect(exitCode).toBe(1);
+});
+
 const MONOREPO_ROOT = `{
   "name": "root",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
### Problem
- `bun create <template> dst` aborts when `cwd + "/" + template` is longer than the path buffer: `panic: range end index 4105 out of range for slice of length 4095`. The cause is `CreateCommand::extract_info` (`src/runtime/cli/create_command.rs:1310`), which joins the argv positional into a fixed `PathBuffer` with the unchecked `abs_buf`. Four joins in that function take the positional.
- Three usage errors exit 0. `bun add` and `bun remove` with no package print `error: no package specified to add` (or `remove`) and exit 0 (`src/install/PackageManager/updatePackageJSONAndInstall.rs:114`). `bun create --x` prints the create usage and exits 0 (`src/runtime/cli/mod.rs:1828`), while bare `bun create` already exits 1. A CI step like `PKG=""; bun add $PKG` is green while it prints an error.

### Fix
- The four template joins use `abs_buf_checked`. A template that does not fit is not a local template, so the lookup is skipped and the name goes down the bunx path, which rejects it with `error: unrecognised dependency format: create-AAA…` and exits 1. That is the behavior of 1.3.14 at every length. The buffer slice leaves one byte for the NUL written after each join.
- `bun add` and `bun remove` with no package exit 1. `bun create` with a flag and no template exits 1. `bun create --help` still exits 0.
- Verified: `test/cli/install/bun-create.test.ts` (one new test, five cases of "should not crash" fail on the released build), `test/cli/install/bun-add.test.ts`, `test/cli/install/bun-remove.test.ts` (one new test each). The full three files pass on the debug build.

### Background
- `PathBuffer` is a fixed `[u8; PATH_MAX_BYTES]` (4096 on POSIX). `FileSystem::abs_buf` normalizes the joined parts in place and panics when the result does not fit. `abs_buf_checked` returns `None` instead. Both live in `src/resolver/lib.rs`.
- `bun create` first checks whether the template is a local file or folder (cwd, `BUN_CREATE_DIR`, `$HOME/.bun-create`). Only then does it treat the name as an npm `create-*` package and hand it to bunx.

<details><summary>Notes</summary>

From the fuzz ledger entries #22403 and #22404. Reproduced on 1.4.3:

```
bun create "$(head -c 5000 /dev/zero | tr '\0' A)" dst   # panic, rc 134
bun add; echo $?      # error: no package specified to add, rc 0
bun remove; echo $?   # rc 0
bun create --x; echo $?  # usage, rc 0
```

Not changed: `bun '' app.ts` and `bun -bri` print help and exit 0. Both reach the same path as `bun run` with no target, which lists the scripts and exits 0 on purpose. The joins later in `create_command.rs` that take `BUN_CREATE_DIR` and `HOME` are left as they are, they take env values, not argv.

The "should not crash" cases in bun-create.test.ts expected 0 for `bun create ""`, `bun create --`, `bun create -- ""`. They expect 1 now, the same as bare `bun create`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-remove.test.ts, test/cli/install/bun-create.test.ts, test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->