### PR TITLE
install: honor umask for bin targets under the isolated linker

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1938,6 +1938,13 @@ pub(crate) fn install_isolated_packages(
         }
     }
 
+    // Read the process umask once, before install tasks spawn. `bin::Linker`
+    // chmods each bin target to `0o777 & !umask` from the thread pool.
+    #[cfg(unix)]
+    {
+        crate::bin::Linker::ensure_umask();
+    }
+
     {
         // Conditionally initialized (only when progress is shown); definite-
         // initialization analysis guarantees no use before assignment.

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1938,8 +1938,7 @@ pub(crate) fn install_isolated_packages(
         }
     }
 
-    // Read the process umask once, before install tasks spawn. `bin::Linker`
-    // chmods each bin target to `0o777 & !umask` from the thread pool.
+    // Must run before the thread pool starts: the probe sets umask(0) briefly.
     #[cfg(unix)]
     {
         crate::bin::Linker::ensure_umask();

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -556,56 +556,57 @@ test("can install folder dependencies on root package", async () => {
 
 // Bin targets get `0o777 & ~umask`, the same as the hoisted linker. For
 // workspace and `file:` dependencies the target is the source file in the repo.
-test.skipIf(isWindows).each([
+describe.each([
   ["022", 0o755],
   ["077", 0o700],
-])("bin targets honor umask %s", async (umask, expectedMode) => {
-  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+])("umask %s", (umask, expectedMode) => {
+  test.skipIf(isWindows)("bin targets honor umask", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
-  await Promise.all([
-    write(
-      packageJson,
-      JSON.stringify({
-        name: "umask-root",
-        workspaces: ["packages/*"],
-        dependencies: {
-          tool: "workspace:*",
-          dep: "file:./dep",
-        },
-      }),
-    ),
-    write(
-      join(packageDir, "packages", "tool", "package.json"),
-      JSON.stringify({ name: "tool", version: "1.0.0", bin: { tool: "./cli.js" } }),
-    ),
-    write(join(packageDir, "packages", "tool", "cli.js"), "#!/usr/bin/env node\nconsole.log(1)\n"),
-    write(join(packageDir, "dep", "package.json"), JSON.stringify({ name: "dep", version: "1.0.0", bin: "d.js" })),
-    write(join(packageDir, "dep", "d.js"), "#!/bin/sh\necho d\n"),
-  ]);
-  await Promise.all([
-    chmod(join(packageDir, "packages", "tool", "cli.js"), 0o644),
-    chmod(join(packageDir, "dep", "d.js"), 0o644),
-  ]);
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "umask-root",
+          workspaces: ["packages/*"],
+          dependencies: {
+            tool: "workspace:*",
+            dep: "file:./dep",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "tool", "package.json"),
+        JSON.stringify({ name: "tool", version: "1.0.0", bin: { tool: "./cli.js" } }),
+      ),
+      write(join(packageDir, "packages", "tool", "cli.js"), "#!/usr/bin/env node\nconsole.log(1)\n"),
+      write(join(packageDir, "dep", "package.json"), JSON.stringify({ name: "dep", version: "1.0.0", bin: "d.js" })),
+      write(join(packageDir, "dep", "d.js"), "#!/bin/sh\necho d\n"),
+    ]);
+    await Promise.all([
+      chmod(join(packageDir, "packages", "tool", "cli.js"), 0o644),
+      chmod(join(packageDir, "dep", "d.js"), 0o644),
+    ]);
 
-  await using proc = spawn({
-    cmd: ["sh", "-c", `umask ${umask} && exec "$0" install`, bunExe()],
-    cwd: packageDir,
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+    await using proc = spawn({
+      cmd: ["sh", "-c", `umask ${umask} && exec "$0" install`, bunExe()],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const modes = [
+      join(packageDir, "packages", "tool", "cli.js"),
+      join(packageDir, "dep", "d.js"),
+      join(packageDir, "node_modules", ".bin", "tool"),
+      join(packageDir, "node_modules", ".bin", "dep"),
+    ].map(p => (statSync(p).mode & 0o777).toString(8));
+    expect(modes).toEqual(Array(4).fill(expectedMode.toString(8)));
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("error:");
-  expect(stdout).toContain("installed");
-  expect(exitCode).toBe(0);
-
-  const modes = [
-    join(packageDir, "packages", "tool", "cli.js"),
-    join(packageDir, "dep", "d.js"),
-    join(packageDir, "node_modules", ".bin", "tool"),
-    join(packageDir, "node_modules", ".bin", "dep"),
-  ].map(p => (statSync(p).mode & 0o777).toString(8));
-  expect(modes).toEqual(Array(4).fill(expectedMode.toString(8)));
 });
 
 describe("isolated workspaces", () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readFileSync, readlinkSync, statSync } from "fs";
-import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { chmod, mkdir, readlink, rm, symlink } from "fs/promises";
+import { VerdaccioRegistry, bunEnv, bunExe, isWindows, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
 import { basename, dirname, join } from "path";
 import { pathToFileURL } from "url";
@@ -552,6 +552,60 @@ test("can install folder dependencies on root package", async () => {
     join("..", "..", "..", "node_modules", ".bun", "root-file-dep@root", "node_modules", "root-file-dep"),
     await file(packageJson).json(),
   ]);
+});
+
+// Bin targets get `0o777 & ~umask`, the same as the hoisted linker. For
+// workspace and `file:` dependencies the target is the source file in the repo.
+test.skipIf(isWindows).each([
+  ["022", 0o755],
+  ["077", 0o700],
+])("bin targets honor umask %s", async (umask, expectedMode) => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "umask-root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          tool: "workspace:*",
+          dep: "file:./dep",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, "packages", "tool", "package.json"),
+      JSON.stringify({ name: "tool", version: "1.0.0", bin: { tool: "./cli.js" } }),
+    ),
+    write(join(packageDir, "packages", "tool", "cli.js"), "#!/usr/bin/env node\nconsole.log(1)\n"),
+    write(join(packageDir, "dep", "package.json"), JSON.stringify({ name: "dep", version: "1.0.0", bin: "d.js" })),
+    write(join(packageDir, "dep", "d.js"), "#!/bin/sh\necho d\n"),
+  ]);
+  await Promise.all([
+    chmod(join(packageDir, "packages", "tool", "cli.js"), 0o644),
+    chmod(join(packageDir, "dep", "d.js"), 0o644),
+  ]);
+
+  await using proc = spawn({
+    cmd: ["sh", "-c", `umask ${umask} && exec "$0" install`, bunExe()],
+    cwd: packageDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("installed");
+  expect(exitCode).toBe(0);
+
+  const modes = [
+    join(packageDir, "packages", "tool", "cli.js"),
+    join(packageDir, "dep", "d.js"),
+    join(packageDir, "node_modules", ".bin", "tool"),
+    join(packageDir, "node_modules", ".bin", "dep"),
+  ].map(p => (statSync(p).mode & 0o777).toString(8));
+  expect(modes).toEqual(Array(4).fill(expectedMode.toString(8)));
 });
 
 describe("isolated workspaces", () => {


### PR DESCRIPTION
### Problem
- Under the isolated linker, `bun install` chmods every bin target to `0o777`, whatever the umask is. For `workspace:` and `file:` dependencies the bin target is the source file in the repo, so `packages/tool/cli.js` in the checkout becomes world-writable and `git status` shows the mode change. The hoisted linker gives `0o755` (umask 022) or `0o700` (umask 077) on the same tree.
- `bin::Linker::chmod_on_ok` (`src/install/bin.rs:1325`) computes `0o777 & !UMASK`. `UMASK` is filled by `bin::Linker::ensure_umask()`, and only `hoisted_install.rs:270` and `link_command.rs:117` call it. `install_isolated_packages` (`src/install/isolated_install.rs`) never does, so `UMASK` stays 0 there.

### Fix
- Call `bin::Linker::ensure_umask()` once in `install_isolated_packages`, before the install tasks spawn. This mirrors the hoisted path.
- The call has to happen on the main thread before the thread pool starts: `ensure_umask` probes the umask with `umask(0)` then `umask(prev)`, and a concurrent file create inside that window would get the wrong mode.
- Verified: `test/cli/install/isolated-install.test.ts` ("bin targets honor umask 022 / 077", both fail on 1.4.3 with `777`). Also `bun-install-native-binlink.test.ts` and `isolated-relink.test.ts`.

### Background
- On POSIX the umask is a per-process mask of permission bits that file creation clears. `0o777 & !umask` is the mode a shell would give a new executable.
- The bin linker creates `node_modules/.bin/<name>` as a symlink to the package's bin file and chmods the target so it is executable. Under the isolated linker a `workspace:` or `file:` package is hardlinked or symlinked into `node_modules/.bun`, so that target is the file in the source tree.
- #29726 (directory modes) carries the same one-line call as a side effect. This PR is the minimal fix for the bin-target case only.

<details><summary>Notes</summary>

Repro (1.4.3, before the fix):

```
umask 022 isolated: packages/tool/cli.js=777 dep/d.js=777 .bin/dep->777
umask 022 hoisted:  packages/tool/cli.js=755 dep/d.js=755 .bin/dep->755
umask 077 isolated: packages/tool/cli.js=777 dep/d.js=777 .bin/dep->777
umask 077 hoisted:  packages/tool/cli.js=700 dep/d.js=700 .bin/dep->700
```

After the fix the isolated rows match the hoisted rows.

`bun link` already calls `ensure_umask()` (`link_command.rs:117`) so it is not affected.

`test/cli/install/bun-link.test.ts` ("should link dependency without crashing") times out at 5s on this debug build with and without this change. It is not related.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->