### PR TITLE
node:stream: consume the compose() tail in flowing mode

### DIFF
--- a/src/js/internal/streams/compose.ts
+++ b/src/js/internal/streams/compose.ts
@@ -54,7 +54,6 @@ export default function compose(...streams) {
 
   let ondrain;
   let onfinish;
-  let onreadable;
   let onclose;
   let d;
 
@@ -148,31 +147,19 @@ export default function compose(...streams) {
 
   if (readable) {
     if (isNodeStream(tail)) {
-      tail.on("readable", function () {
-        if (onreadable) {
-          const cb = onreadable;
-          onreadable = null;
-          cb();
+      d._read = function () {
+        tail.resume();
+      };
+
+      tail.on("data", function (chunk) {
+        if (!d.push(chunk)) {
+          tail.pause();
         }
       });
 
       tail.on("end", function () {
         d.push(null);
       });
-
-      d._read = function () {
-        while (true) {
-          const buf = tail.read();
-          if (buf === null) {
-            onreadable = d._read;
-            return;
-          }
-
-          if (!d.push(buf)) {
-            return;
-          }
-        }
-      };
     } else if (isWebStream(tail)) {
       const readable = isTransformStream(tail) ? tail.readable : tail;
       const reader = readable.getReader();
@@ -181,12 +168,12 @@ export default function compose(...streams) {
           try {
             const { value, done } = await reader.read();
 
-            if (!d.push(value)) {
+            if (done) {
+              d.push(null);
               return;
             }
 
-            if (done) {
-              d.push(null);
+            if (!d.push(value)) {
               return;
             }
           } catch {
@@ -202,7 +189,6 @@ export default function compose(...streams) {
       err = $makeAbortError();
     }
 
-    onreadable = null;
     ondrain = null;
     onfinish = null;
 

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1689,10 +1689,9 @@ describe("node v26 stream semantics", () => {
     src.push(big);
     expect(await waitFor(() => composed.readableLength === big.length * 2 - 1)).toBe(true);
     // The second loop receives done while the buffer is still full. The fix
-    // pushes null here. Without it nothing observable changes, so this wait
-    // runs to its bound and the drain below never sees 'end'.
+    // pushes null here, before anything drains the buffer.
     src.push(null);
-    await waitFor(() => composed._readableState.ended);
+    expect(await waitFor(() => composed._readableState.ended)).toBe(true);
 
     let total = 1;
     let chunk;

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1675,7 +1675,9 @@ describe("node v26 stream semantics", () => {
     const composed = compose(src, new TransformStream());
     let ended = false;
     composed.on("end", () => (ended = true));
-    const big = Buffer.alloc(40000, "a");
+    // One chunk fits under the high water mark, two do not. The default high
+    // water mark is 16 KiB on Windows and 64 KiB elsewhere.
+    const big = Buffer.alloc(Math.floor(composed.readableHighWaterMark * 0.75), "a");
 
     // The first reader loop starts.
     composed.read(0);

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1660,6 +1660,45 @@ describe("node v26 stream semantics", () => {
     expect(log).toEqual(["data:ok", "data:boom", "error:tail-boom"]);
   });
 
+  // Upstream: nodejs/node#63699. With a web stream tail, compose runs one
+  // reader loop per _read() call. When the loop that sees done runs while the
+  // composed buffer is over the high water mark, push(value) reports
+  // backpressure. The done check has to come first or push(null) never runs.
+  it("compose with a web stream tail ends when done arrives under backpressure", async () => {
+    const waitFor = async condition => {
+      for (let i = 0; i < 200 && !condition(); i++) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      return condition();
+    };
+    const src = new Readable({ read() {} });
+    const composed = compose(src, new TransformStream());
+    let ended = false;
+    composed.on("end", () => (ended = true));
+    const big = Buffer.alloc(40000, "a");
+
+    // The first reader loop starts.
+    composed.read(0);
+    src.push(big);
+    expect(await waitFor(() => composed.readableLength === big.length)).toBe(true);
+    // readableLength - 1 is below the high water mark, so a second loop starts.
+    composed.read(1);
+    // The first loop receives this chunk. push() returns false: over the high water mark.
+    src.push(big);
+    expect(await waitFor(() => composed.readableLength === big.length * 2 - 1)).toBe(true);
+    // The second loop receives done while the buffer is still full. The fix
+    // pushes null here. Without it nothing observable changes, so this wait
+    // runs to its bound and the drain below never sees 'end'.
+    src.push(null);
+    await waitFor(() => composed._readableState.ended);
+
+    let total = 1;
+    let chunk;
+    while ((chunk = composed.read()) !== null) total += chunk.length;
+    expect(total).toBe(big.length * 2);
+    expect(await waitFor(() => ended)).toBe(true);
+  });
+
   // Upstream: v26 test-stream-writable-decoded-encoding.js.
   it("write(string, 'buffer') throws ERR_UNKNOWN_ENCODING", () => {
     for (const opts of [{ decodeStrings: false }, {}]) {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -3,7 +3,7 @@ import { describe, expect, it, jest } from "bun:test";
 import { bunEnv, bunExe, bunRun, isGlibcVersionAtLeast, isMacOS, tempDir, tmpdirSync } from "harness";
 import { createReadStream, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { Duplex, duplexPair, finished, PassThrough, Readable, Stream, Transform, Writable } from "node:stream";
+import { compose, Duplex, duplexPair, finished, PassThrough, Readable, Stream, Transform, Writable } from "node:stream";
 import { finished as finishedP } from "node:stream/promises";
 import { join } from "path";
 
@@ -1614,6 +1614,50 @@ describe("node v26 stream semantics", () => {
     const err = await promise;
     expect(err.name).toBe("AbortError");
     expect(err.code).toBe("ABORT_ERR");
+  });
+
+  // Upstream: nodejs/node#63593. compose consumes the tail in flowing mode, so
+  // the composed stream emits a chunk inside the tail's push() call.
+  it("compose emits tail output synchronously with its production", async () => {
+    const log = [];
+    const tail = new Transform({
+      transform(chunk, encoding, callback) {
+        log.push("transform:" + chunk);
+        this.push(chunk);
+        log.push("pushed:" + chunk);
+        callback();
+      },
+    });
+    const composed = compose(new PassThrough(), tail);
+    composed.on("data", chunk => log.push("data:" + chunk));
+    const ended = new Promise(resolve => composed.on("end", resolve));
+    // Let the composed stream and the tail start flowing before the first write.
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    composed.write("x");
+    composed.end("y");
+    await ended;
+    expect(log).toEqual(["transform:x", "data:x", "pushed:x", "transform:y", "data:y", "pushed:y"]);
+  });
+
+  it("compose delivers the chunks the tail pushed before it errored", async () => {
+    const log = [];
+    const tail = new Transform({
+      transform(chunk, encoding, callback) {
+        this.push(chunk);
+        callback(chunk.toString() === "boom" ? new Error("tail-boom") : null);
+      },
+    });
+    const composed = compose(new PassThrough(), tail);
+    composed.on("data", chunk => log.push("data:" + chunk));
+    composed.on("error", err => log.push("error:" + err.message));
+    const closed = new Promise(resolve => composed.on("close", resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+    composed.write("ok");
+    composed.write("boom");
+    await closed;
+    expect(log).toEqual(["data:ok", "data:boom", "error:tail-boom"]);
   });
 
   // Upstream: v26 test-stream-writable-decoded-encoding.js.

--- a/test/js/node/test/parallel/test-stream-compose.js
+++ b/test/js/node/test/parallel/test-stream-compose.js
@@ -537,3 +537,24 @@ const assert = require('assert');
   assert.strictEqual(duplex.destroyed, true);
 
 }
+
+// Regression test: compose with a web TransformStream tail must always emit
+// null (EOF) when the source finishes. The done check must precede the
+// backpressure check in the reader.read() loop; otherwise push(null) can be
+// skipped if canPushMore() returns false on the final done:true read.
+{
+  const { TransformStream } = globalThis;
+  const { Readable } = require('stream');
+
+  // A web TransformStream as the tail exercises the isWebStream code path
+  // in compose that loops over reader.read() results.
+  const ts = new TransformStream();
+  const src = Readable.from(['hello', ' ', 'world']);
+  const composed = compose(src, ts);
+
+  let result = '';
+  composed.on('data', (chunk) => { result += Buffer.from(chunk).toString(); });
+  composed.on('end', common.mustCall(() => {
+    assert.strictEqual(result, 'hello world');
+  }));
+}


### PR DESCRIPTION
### Problem
- `stream.compose()` reads its tail member in paused mode: `tail.on("readable")` plus a `tail.read()` loop inside `d._read` (`src/js/internal/streams/compose.ts:151-175`). Node v26.3.0 consumes the tail in flowing mode with a `data` listener (nodejs/node#63593). The v26.3.0 stream sync (#31826) missed this change.
- The composed stream sees tail output one tick later than Node does. Chunks the tail pushes right before it errors are lost: Bun emits only `error`, Node emits `data` for each chunk and then `error`. A differential fuzz of 5,000 generated stream chains against Node v26.3.0 traced every hang, data, error-routing, and event-order divergence to a `compose()` member.
- With a web stream tail, the reader loop calls `d.push(value)` before it checks `done`. When that push reports backpressure, `push(null)` never runs and the composed stream never ends. Node fixed this after v26.3.0 (nodejs/node#63699).

### Fix
- Port the readable section of Node's `compose.js`. A Node stream tail gets a `data` listener that pushes into the composed Duplex and calls `tail.pause()` on backpressure. `d._read` calls `tail.resume()`. The `onreadable` callback is gone.
- The web stream loop checks `done` before it pushes the value.
- The section now matches Node main line for line. `duplexify.ts` has a similar `onreadable` loop. It stays: upstream still has it.
- Verified: `test/js/node/stream/node-stream.test.js` (3 new tests, all fail on bun 1.4.3). Also the vendored `test-stream-compose.js` (synced with v26.x), `test-stream-compose-operator.js`, `test-stream-readable-compose.js`, `test-webstreams-compose.js`, and all `test-stream*.js` and `test-webstreams*.js` parallel tests.

### Background
- `compose(a, b, c)` pipes the members with `pipeline()` and returns a Duplex `d`. Writes to `d` go to the head. Reads from `d` come from the tail.
- A Readable has two modes. In paused mode a consumer waits for `readable` and calls `read()`. The `readable` event is emitted on the next tick. In flowing mode the stream emits `data` inside `push()` when its buffer is empty. So a flowing consumer observes a chunk in the same call that produced it.
- `push()` returns false when the buffer is at the high water mark. The web stream loop is an async function, so one `_read` call can start a second loop while the first is still awaiting a read. The second loop can see `done` while the buffer is still full.

<details><summary>Notes</summary>

Probe that shows the timing face (log order on bun 1.4.3 vs Node v26.3.0):

```
tail Transform logs "transform:x", push(chunk), "pushed:x"; composed.on("data") logs "data:x"
node:  transform:x, data:x, pushed:x
bun:   transform:x, pushed:x, ..., data:x
```

Probe that shows the data loss face (tail pushes, then calls back with an error):

```
node:  data:ok, data:boom, error:tail-boom, close
bun:   error:tail-boom, close
```

The web stream hang reproduces on Node v26.3.0 as well (it predates nodejs/node#63699). The new test drives it deterministically: `read(0)` starts loop A, a 40,000 byte push fills the buffer below the 65,536 high water mark, `read(1)` starts loop B, a second push makes loop A stop on backpressure, then `push(null)` hands `done` to loop B while the buffer is still full.

The five `test-webstreams-*` files that fail under `bun bd <file>` use `node:test` and fail the same way on main. None of them use `compose`.

Self-reviewed: 3 concerns raised, 3 addressed (PR framing on which change is in v26.3.0, a web stream test that fails before the fix, the `duplexify.ts` sibling loop).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->