### PR TITLE
cli: take flag arity from the auto table when the subcommand is classified

### DIFF
--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -200,7 +200,7 @@ pub struct Names {
 
 impl Names {
     /// Check if the given name matches the primary long name or any alias
-    pub(crate) fn matches_long(&self, name: &[u8]) -> bool {
+    pub fn matches_long(&self, name: &[u8]) -> bool {
         if let Some(l) = self.long {
             if name == l {
                 return true;

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -102,6 +102,7 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
     ),
     clap::param!("-g, --global                          Install globally"),
     clap::param!("--cwd <STR>                           Set a specific cwd"),
+    clap::param!("--env-file <STR>..."),
     BACKEND_PARAM,
     clap::param!(
         "--registry <STR>                      Use a specific registry by default, overriding .npmrc, bunfig.toml and environment variables"
@@ -1287,8 +1288,24 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             Global::exit(0);
         }
 
-        let mut cli = CommandLineArguments::default();
-        cli.positionals = args.positionals();
+        let mut positionals = args.positionals();
+        // `Command::which()` stepped past the values of the runtime flags in
+        // front of the keyword (`bun --preload ./x.ts install`). This table
+        // does not declare those flags, so their values come back as
+        // positionals. Drop everything before the keyword so it stays at [0].
+        // Positionals borrow argv, so the keyword is found by identity.
+        if let Some(keyword) = bun_core::argv().get(crate::subcommand_argv_index()) {
+            if let Some(k) = positionals
+                .iter()
+                .position(|p| core::ptr::eq(p.as_ptr(), keyword.as_bytes().as_ptr()))
+            {
+                positionals = &positionals[k..];
+            }
+        }
+        let mut cli = CommandLineArguments {
+            positionals,
+            ..Default::default()
+        };
         cli.yarn = args.flag(b"--yarn");
         cli.production = args.flag(b"--production") || args.flag(b"--prod");
         cli.frozen_lockfile = args.flag(b"--frozen-lockfile")

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -102,7 +102,6 @@ const SHARED_TAIL_PARAMS: &[ParamType] = &[
     ),
     clap::param!("-g, --global                          Install globally"),
     clap::param!("--cwd <STR>                           Set a specific cwd"),
-    clap::param!("--env-file <STR>..."),
     BACKEND_PARAM,
     clap::param!(
         "--registry <STR>                      Use a specific registry by default, overriding .npmrc, bunfig.toml and environment variables"
@@ -1288,22 +1287,8 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             Global::exit(0);
         }
 
-        let mut positionals = args.positionals();
-        // `Command::which()` stepped past the values of the runtime flags in
-        // front of the keyword (`bun --preload ./x.ts install`). This table
-        // does not declare those flags, so their values come back as
-        // positionals. Drop everything before the keyword so it stays at [0].
-        // Positionals borrow argv, so the keyword is found by identity.
-        if let Some(keyword) = bun_core::argv().get(crate::subcommand_argv_index()) {
-            if let Some(k) = positionals
-                .iter()
-                .position(|p| core::ptr::eq(p.as_ptr(), keyword.as_bytes().as_ptr()))
-            {
-                positionals = &positionals[k..];
-            }
-        }
         let mut cli = CommandLineArguments {
-            positionals,
+            positionals: crate::positionals_from_keyword(args.positionals()),
             ..Default::default()
         };
         cli.yarn = args.flag(b"--yarn");

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -396,6 +396,17 @@ pub struct RunCommand;
 pub static PRETEND_TO_BE_NODE: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
+/// argv index of the subcommand keyword as located by `Command::which()`
+/// in `bun_runtime::cli`: `bun test …` → 1; `bun --cwd ./dir test …` → 3.
+/// Lives here so `CommandLineArguments::parse` can read it.
+pub static SUBCOMMAND_ARGV_INDEX: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(1);
+
+#[inline]
+pub fn subcommand_argv_index() -> usize {
+    SUBCOMMAND_ARGV_INDEX.load(core::sync::atomic::Ordering::Relaxed)
+}
+
 #[cfg(not(windows))]
 use bun_core::ZStr;
 

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -396,9 +396,8 @@ pub struct RunCommand;
 pub static PRETEND_TO_BE_NODE: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
-/// argv index of the subcommand keyword as located by `Command::which()`
-/// in `bun_runtime::cli`: `bun test …` → 1; `bun --cwd ./dir test …` → 3.
-/// Lives here so `CommandLineArguments::parse` can read it.
+/// argv index of the subcommand keyword, set by `Command::which()` in
+/// `bun_runtime::cli` (`bun --cwd ./dir test` → 3).
 pub static SUBCOMMAND_ARGV_INDEX: core::sync::atomic::AtomicUsize =
     core::sync::atomic::AtomicUsize::new(1);
 
@@ -407,11 +406,8 @@ pub fn subcommand_argv_index() -> usize {
     SUBCOMMAND_ARGV_INDEX.load(core::sync::atomic::Ordering::Relaxed)
 }
 
-/// `Command::which()` steps past the values of the runtime flags in front
-/// of the keyword (`bun --preload ./x.ts install`). A command table that does
-/// not declare those flags hands their values back as positionals. Drop
-/// everything before the keyword so it stays at `[0]`. Positionals borrow
-/// argv, so the keyword is found by identity.
+/// Drop the positionals before the keyword: values of runtime flags that
+/// this command's table does not declare (`bun --preload ./x.ts install`).
 pub fn positionals_from_keyword<'a>(positionals: &'a [&'static [u8]]) -> &'a [&'static [u8]] {
     let Some(keyword) = bun_core::argv().get(subcommand_argv_index()) else {
         return positionals;

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -407,6 +407,24 @@ pub fn subcommand_argv_index() -> usize {
     SUBCOMMAND_ARGV_INDEX.load(core::sync::atomic::Ordering::Relaxed)
 }
 
+/// `Command::which()` steps past the values of the runtime flags in front
+/// of the keyword (`bun --preload ./x.ts install`). A command table that does
+/// not declare those flags hands their values back as positionals. Drop
+/// everything before the keyword so it stays at `[0]`. Positionals borrow
+/// argv, so the keyword is found by identity.
+pub fn positionals_from_keyword<'a>(positionals: &'a [&'static [u8]]) -> &'a [&'static [u8]] {
+    let Some(keyword) = bun_core::argv().get(subcommand_argv_index()) else {
+        return positionals;
+    };
+    match positionals
+        .iter()
+        .position(|p| core::ptr::eq(p.as_ptr(), keyword.as_bytes().as_ptr()))
+    {
+        Some(k) => &positionals[k..],
+        None => positionals,
+    }
+}
+
 #[cfg(not(windows))]
 use bun_core::ZStr;
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -789,22 +789,29 @@ pub(crate) enum LeadingFlag {
 }
 
 impl LeadingFlag {
-    pub(crate) fn classify(arg: &[u8]) -> Self {
+    /// `next_is_keyword`: the token after `arg` names a subcommand. A short
+    /// flag means different things to different commands (`-p` is `--print`
+    /// for `bun <file>` and `--production` for `bun install`, `-d` is
+    /// `--define` and `--dev`, `-u` is `--origin` and `--update-snapshots`),
+    /// so when the auto meaning would swallow a keyword, the keyword wins.
+    /// Long names do not collide across the tables.
+    pub(crate) fn classify(arg: &[u8], next_is_keyword: bool) -> Self {
         if arg == b"-" || arg == b"--" {
             return Self::Program;
         }
+        let no_value = Self::Flag {
+            consumes_value: false,
+            filter: false,
+        };
         if let Some(long) = arg.strip_prefix(b"--") {
             let (name, has_attached_value) = match strings::index_of_char_usize(long, b'=') {
                 Some(i) => (&long[..i], true),
                 None => (long, false),
             };
             let Some(param) = AUTO_PARAMS.iter().find(|p| p.names.matches_long(name)) else {
-                return Self::Flag {
-                    consumes_value: false,
-                    filter: false,
-                };
+                return no_value;
             };
-            if Self::is_eval(param) {
+            if Self::is_eval(param) && !has_attached_value {
                 return Self::Program;
             }
             return Self::Flag {
@@ -815,25 +822,33 @@ impl LeadingFlag {
         // A short chain (`-abc`): boolean flags share the token, the first
         // value-taking flag claims the rest of it (`-Fpat`, `-F=pat`) or, when
         // it is the last character, the next token (`-F pat`).
-        let chain = &arg[1..];
+        let chain = if arg == b"-pe" {
+            b"p".as_slice()
+        } else {
+            &arg[1..]
+        };
         for (i, &c) in chain.iter().enumerate() {
             let Some(param) = AUTO_PARAMS.iter().find(|p| p.names.short == Some(c)) else {
                 break;
             };
+            let value_is_next_token = i + 1 == chain.len();
             if Self::is_eval(param) {
-                return Self::Program;
+                // `-e` always ends the scan. `-p` yields to a keyword
+                // (`bun -p install` is `bun install --production`) and to an
+                // attached value (`bun -p=pkg x bin` is bunx's `--package`).
+                if c == b'e' || (value_is_next_token && !next_is_keyword) {
+                    return Self::Program;
+                }
+                return no_value;
             }
             if Self::takes_value(param) {
                 return Self::Flag {
-                    consumes_value: i + 1 == chain.len(),
+                    consumes_value: value_is_next_token && !next_is_keyword,
                     filter: c == b'F',
                 };
             }
         }
-        Self::Flag {
-            consumes_value: false,
-            filter: false,
-        }
+        no_value
     }
 
     fn takes_value(param: &ParamType) -> bool {
@@ -988,7 +1003,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     }
 
     ctx.args.absolute_working_dir = Some(cwd);
-    ctx.positionals = slice_to_owned(args.positionals());
+    ctx.positionals = slice_to_owned(bun_install::positionals_from_keyword(args.positionals()));
 
     if command::LOADS_CONFIG[cmd] {
         load_config_with_cmd_args(cmd, &args, ctx)?;

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -772,13 +772,10 @@ pub use bun_bunfig::arguments::{load_config_path, load_config_with_cmd_args};
 /// the attached value `e`. Bun's `-p` takes the code, so `-pe X` is `-p X`.
 pub const NODE_SHORT_ALIASES: &[(&[u8], &[u8])] = &[(b"-pe", b"-p")];
 
-/// How `Command::which()` treats a `-`-prefixed token in front of the
-/// subcommand keyword. The arity comes from `AUTO_PARAMS`, the table that
-/// parses `bun [flags] <file>`, so the sniffer and clap agree on which token
-/// is a flag's value and which is the keyword.
+/// How `Command::which()` treats a flag in front of the subcommand keyword.
+/// The arity comes from `AUTO_PARAMS` so the sniffer and clap agree.
 pub(crate) enum LeadingFlag {
-    /// Every token after this one belongs to the program: `-` (stdin),
-    /// `--`, and the code of `-e` / `--eval` / `-p` / `--print`.
+    /// The rest of argv belongs to the program (`-`, `--`, `-e`, `-p`).
     Program,
     Flag {
         /// The next argv token is this flag's value, not the keyword.
@@ -789,12 +786,8 @@ pub(crate) enum LeadingFlag {
 }
 
 impl LeadingFlag {
-    /// `next_is_keyword`: the token after `arg` names a subcommand. A short
-    /// flag means different things to different commands (`-p` is `--print`
-    /// for `bun <file>` and `--production` for `bun install`, `-d` is
-    /// `--define` and `--dev`, `-u` is `--origin` and `--update-snapshots`),
-    /// so when the auto meaning would swallow a keyword, the keyword wins.
-    /// Long names do not collide across the tables.
+    /// A short flag means different things to different commands (`-p` is
+    /// `--print` and `--production`), so a keyword wins over its auto value.
     pub(crate) fn classify(arg: &[u8], next_is_keyword: bool) -> Self {
         if arg == b"-" || arg == b"--" {
             return Self::Program;
@@ -819,9 +812,8 @@ impl LeadingFlag {
                 filter: Self::is_filter_long(name),
             };
         }
-        // A short chain (`-abc`): boolean flags share the token, the first
-        // value-taking flag claims the rest of it (`-Fpat`, `-F=pat`) or, when
-        // it is the last character, the next token (`-F pat`).
+        // Short chain: the first value-taking flag claims the rest of the
+        // token (`-Fpat`) or, when it is the last character, the next token.
         let chain = if arg == b"-pe" {
             b"p".as_slice()
         } else {
@@ -833,9 +825,8 @@ impl LeadingFlag {
             };
             let value_is_next_token = i + 1 == chain.len();
             if Self::is_eval(param) {
-                // `-e` always ends the scan. `-p` yields to a keyword
-                // (`bun -p install` is `bun install --production`) and to an
-                // attached value (`bun -p=pkg x bin` is bunx's `--package`).
+                // `-p` yields to a keyword and to an attached value (`-p=pkg`
+                // is bunx's `--package`). `-e` always ends the scan.
                 if c == b'e' || (value_is_next_token && !next_is_keyword) {
                     return Self::Program;
                 }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -772,6 +772,83 @@ pub use bun_bunfig::arguments::{load_config_path, load_config_with_cmd_args};
 /// the attached value `e`. Bun's `-p` takes the code, so `-pe X` is `-p X`.
 pub const NODE_SHORT_ALIASES: &[(&[u8], &[u8])] = &[(b"-pe", b"-p")];
 
+/// How `Command::which()` treats a `-`-prefixed token in front of the
+/// subcommand keyword. The arity comes from `AUTO_PARAMS`, the table that
+/// parses `bun [flags] <file>`, so the sniffer and clap agree on which token
+/// is a flag's value and which is the keyword.
+pub(crate) enum LeadingFlag {
+    /// Every token after this one belongs to the program: `-` (stdin),
+    /// `--`, and the code of `-e` / `--eval` / `-p` / `--print`.
+    Program,
+    Flag {
+        /// The next argv token is this flag's value, not the keyword.
+        consumes_value: bool,
+        /// `--filter` / `-F` / `--workspaces`.
+        filter: bool,
+    },
+}
+
+impl LeadingFlag {
+    pub(crate) fn classify(arg: &[u8]) -> Self {
+        if arg == b"-" || arg == b"--" {
+            return Self::Program;
+        }
+        if let Some(long) = arg.strip_prefix(b"--") {
+            let (name, has_attached_value) = match strings::index_of_char_usize(long, b'=') {
+                Some(i) => (&long[..i], true),
+                None => (long, false),
+            };
+            let Some(param) = AUTO_PARAMS.iter().find(|p| p.names.matches_long(name)) else {
+                return Self::Flag {
+                    consumes_value: false,
+                    filter: false,
+                };
+            };
+            if Self::is_eval(param) {
+                return Self::Program;
+            }
+            return Self::Flag {
+                consumes_value: !has_attached_value && Self::takes_value(param),
+                filter: Self::is_filter_long(name),
+            };
+        }
+        // A short chain (`-abc`): boolean flags share the token, the first
+        // value-taking flag claims the rest of it (`-Fpat`, `-F=pat`) or, when
+        // it is the last character, the next token (`-F pat`).
+        let chain = &arg[1..];
+        for (i, &c) in chain.iter().enumerate() {
+            let Some(param) = AUTO_PARAMS.iter().find(|p| p.names.short == Some(c)) else {
+                break;
+            };
+            if Self::is_eval(param) {
+                return Self::Program;
+            }
+            if Self::takes_value(param) {
+                return Self::Flag {
+                    consumes_value: i + 1 == chain.len(),
+                    filter: c == b'F',
+                };
+            }
+        }
+        Self::Flag {
+            consumes_value: false,
+            filter: false,
+        }
+    }
+
+    fn takes_value(param: &ParamType) -> bool {
+        matches!(param.takes_value, clap::Values::One | clap::Values::Many)
+    }
+
+    fn is_eval(param: &ParamType) -> bool {
+        matches!(param.names.long, Some(b"eval") | Some(b"print"))
+    }
+
+    fn is_filter_long(name: &[u8]) -> bool {
+        name == b"filter" || name == b"workspaces"
+    }
+}
+
 /// Parse `argv` into `api::TransformOptions` for the given subcommand.
 ///
 /// `command::tag_params(cmd)` does a runtime lookup of the per-subcommand

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -5,6 +5,7 @@ use std::io::Write as _;
 
 use bstr::BStr;
 
+use crate::cli::arguments::LeadingFlag;
 use crate::cli::command::ContextData;
 use crate::cli::{self, Command};
 use crate::run_command::{ConfigureEnvOptions, RunCommand as Run};
@@ -79,7 +80,11 @@ impl Options {
     /// - `--revision` or `--version` flags are passed without a target
     ///   command also being provided. This is not a failure.
     /// - Incorrect arguments are passed. Prints usage and exits with a failure code.
-    fn parse(ctx: &mut ContextData, argv: &[&'static ZStr]) -> Result<Options, AllocError> {
+    fn parse(
+        ctx: &mut ContextData,
+        argv: &[&'static ZStr],
+        keyword_index: usize,
+    ) -> Result<Options, AllocError> {
         let mut found_subcommand_name = false;
         let mut maybe_package_name: Option<&'static [u8]> = None;
         let mut has_version = false; //  --version
@@ -115,6 +120,17 @@ impl Options {
                     ctx.debug.run_in_bun = true;
                 } else if positional == b"--no-install" {
                     opts.no_install = true;
+                } else if i < keyword_index {
+                    // A global flag in front of `x`: its value is not the
+                    // package name. `--cwd` was applied by the caller's
+                    // `apply_leading_cwd()`.
+                    if let LeadingFlag::Flag {
+                        consumes_value: true,
+                        ..
+                    } = LeadingFlag::classify(positional)
+                    {
+                        i += 1;
+                    }
                 } else if positional == b"--package" || positional == b"-p" {
                     // Next argument should be the package name
                     i += 1;
@@ -668,11 +684,16 @@ impl BunxCommand {
         Global::exit(1);
     }
 
-    pub(crate) fn exec(ctx: &mut ContextData, argv: &[&'static ZStr]) -> crate::Result<()> {
+    /// `argv[keyword_index]` is the `x` keyword (or the `bunx` executable).
+    pub(crate) fn exec(
+        ctx: &mut ContextData,
+        argv: &[&'static ZStr],
+        keyword_index: usize,
+    ) -> crate::Result<()> {
         // Don't log stuff
         ctx.debug.silent = true;
 
-        let opts = Options::parse(ctx, argv)?;
+        let opts = Options::parse(ctx, argv, keyword_index)?;
 
         let mut requests_buf = update_request::Array::with_capacity(64);
         // SAFETY: CLI dispatch is single-threaded and `ctx_log` is consumed by

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -120,17 +120,6 @@ impl Options {
                     ctx.debug.run_in_bun = true;
                 } else if positional == b"--no-install" {
                     opts.no_install = true;
-                } else if i < keyword_index {
-                    // A global flag in front of `x`: its value is not the
-                    // package name. `--cwd` was applied by the caller's
-                    // `apply_leading_cwd()`.
-                    if let LeadingFlag::Flag {
-                        consumes_value: true,
-                        ..
-                    } = LeadingFlag::classify(positional)
-                    {
-                        i += 1;
-                    }
                 } else if positional == b"--package" || positional == b"-p" {
                     // Next argument should be the package name
                     i += 1;
@@ -166,6 +155,17 @@ impl Options {
                         Global::exit(1);
                     }
                     opts.specified_package = Some(package_value);
+                } else if i < keyword_index {
+                    // A global flag in front of `x`: its value is not the
+                    // package name. `--cwd` was applied by the caller's
+                    // `apply_leading_cwd()`.
+                    if let LeadingFlag::Flag {
+                        consumes_value: true,
+                        ..
+                    } = LeadingFlag::classify(positional, i + 1 == keyword_index)
+                    {
+                        i += 1;
+                    }
                 }
             } else {
                 if !found_subcommand_name {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -157,8 +157,7 @@ impl Options {
                     opts.specified_package = Some(package_value);
                 } else if i < keyword_index {
                     // A global flag in front of `x`: its value is not the
-                    // package name. `--cwd` was applied by the caller's
-                    // `apply_leading_cwd()`.
+                    // package name.
                     if let LeadingFlag::Flag {
                         consumes_value: true,
                         ..

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -232,11 +232,13 @@ impl CreateOptions {
             ..Default::default()
         };
 
-        if opts.positionals.len() >= 1
-            && (opts.positionals[0] == b"c" || opts.positionals[0] == b"create")
+        if let Some(i) = opts
+            .positionals
+            .iter()
+            .position(|&p| p == b"c" || p == b"create")
         {
             let mut v = core::mem::take(&mut opts.positionals).into_vec();
-            v.remove(0);
+            v.drain(..=i);
             opts.positionals = v.into_boxed_slice();
         }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -503,8 +503,6 @@ pub use bun_install::PRETEND_TO_BE_NODE;
 /// This is set `true` during `Command.which()` if argv0 is "bunx"
 static IS_BUNX_EXE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
-/// argv index of the subcommand keyword as located by `Command::which()`.
-/// Lives in `bun_install` for the same reason as `PRETEND_TO_BE_NODE`.
 pub use bun_install::SUBCOMMAND_ARGV_INDEX;
 
 bun_core::declare_scope!(CLI, hidden);
@@ -789,9 +787,8 @@ pub mod command {
         bun_install::subcommand_argv_index()
     }
 
-    /// Apply a `--cwd <dir>` / `--cwd=<dir>` that preceded the subcommand
-    /// keyword, for handlers that don't route through `arguments::parse` /
-    /// `CommandLineArguments::parse`. Last occurrence wins (clap semantics).
+    /// Apply a `--cwd` that preceded the keyword, for handlers that do not
+    /// run a clap parse. The last occurrence wins, as in clap.
     #[cold]
     pub(crate) fn apply_leading_cwd() {
         let argv = bun::argv();
@@ -973,8 +970,7 @@ pub mod command {
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
-        // A `--filter` / `--workspaces` in front of `test` or `build` names a
-        // package.json script, which the run path handles.
+        // `--filter`/`--workspaces` before `test` or `build` name a script.
         let mut saw_filter_flag = false;
         while !first_arg_name.is_empty() && first_arg_name[0] == b'-' {
             // `--interactive` stays on AutoCommand: Arguments.rs parses it and the no-target check
@@ -1871,8 +1867,7 @@ pub mod command {
             let mut remainder_i: usize = 0;
             while remainder_i < remainder.len() && positional_i < positionals.len() {
                 let slice = strings::trim(remainder[remainder_i].as_bytes(), b" \t\n");
-                // A global flag in front of `create`: neither it nor its
-                // value is the template name.
+                // A global flag in front of `create` is not the template.
                 if remainder_i + 1 < cmd_idx {
                     if slice == b"--bun" {
                         dash_dash_bun = true;

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -503,6 +503,10 @@ pub use bun_install::PRETEND_TO_BE_NODE;
 /// This is set `true` during `Command.which()` if argv0 is "bunx"
 static IS_BUNX_EXE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+/// argv index of the subcommand keyword as located by `Command::which()`.
+/// Lives in `bun_install` for the same reason as `PRETEND_TO_BE_NODE`.
+pub use bun_install::SUBCOMMAND_ARGV_INDEX;
+
 bun_core::declare_scope!(CLI, hidden);
 
 pub(crate) type LoaderColonList =
@@ -754,20 +758,8 @@ pub mod reserved_command {
 
     #[cold]
     pub(crate) fn exec() -> crate::Result<()> {
-        let mut command_name: &[u8] = b"";
-        for (i, arg) in bun::argv().iter().enumerate() {
-            if i == 0 {
-                continue;
-            }
-            if arg.len() > 1 && arg[0] == b'-' {
-                continue;
-            }
-            command_name = arg;
-            break;
-        }
-        if command_name.is_empty() {
-            command_name = bun::argv().get(1).map(|z| z.as_bytes()).unwrap_or(b"");
-        }
+        let idx = super::command::subcommand_argv_index();
+        let command_name: &[u8] = bun::argv().get(idx).map(|z| z.as_bytes()).unwrap_or(b"");
         pretty_error!(
             "<r><red>Uh-oh<r>. <b><yellow>bun {0}<r> is a subcommand reserved for future use by Bun.\n\nIf you were trying to run a package.json script called {0}, use <b><magenta>bun run {0}<r>.\n",
             bstr::BStr::new(command_name)
@@ -789,6 +781,46 @@ pub mod command {
     fn argv_zslice() -> Vec<&'static bun_core::ZStr> {
         let a = bun::argv();
         (0..a.len()).map(|i| a.get(i).unwrap()).collect()
+    }
+
+    /// See [`SUBCOMMAND_ARGV_INDEX`](super::SUBCOMMAND_ARGV_INDEX).
+    #[inline]
+    pub(crate) fn subcommand_argv_index() -> usize {
+        bun_install::subcommand_argv_index()
+    }
+
+    /// Apply a `--cwd <dir>` / `--cwd=<dir>` that preceded the subcommand
+    /// keyword, for handlers that don't route through `arguments::parse` /
+    /// `CommandLineArguments::parse`. Last occurrence wins (clap semantics).
+    #[cold]
+    pub(crate) fn apply_leading_cwd() {
+        let argv = bun::argv();
+        let end = subcommand_argv_index().min(argv.len());
+        let mut last: Option<&[u8]> = None;
+        let mut i = 1;
+        while i < end {
+            let a = argv.get(i).map(|z| z.as_bytes()).unwrap_or(b"");
+            if a == b"--cwd" {
+                if let Some(dir) = argv.get(i + 1).filter(|_| i + 1 < end) {
+                    last = Some(dir.as_bytes());
+                    i += 1;
+                }
+            } else if let Some(dir) = a.strip_prefix(b"--cwd=") {
+                last = Some(dir);
+            }
+            i += 1;
+        }
+        if let Some(dir) = last {
+            let dir_z = bun_core::ZBox::from_bytes(dir);
+            if let bun_sys::Result::Err(err) = bun_sys::chdir(&dir_z) {
+                Output::err(
+                    err,
+                    "Could not change directory to \"{}\"\n",
+                    format_args!("{}", bstr::BStr::new(dir)),
+                );
+                Global::exit(1);
+            }
+        }
     }
 
     pub use bun_options_types::command_tag::Tag;
@@ -924,6 +956,7 @@ pub mod command {
             }
             // SAFETY: single-threaded startup
             IS_BUNX_EXE.store(true, core::sync::atomic::Ordering::Relaxed);
+            SUBCOMMAND_ARGV_INDEX.store(0, core::sync::atomic::Ordering::Relaxed);
             return Tag::BunxCommand;
         }
 
@@ -936,24 +969,49 @@ pub mod command {
             return Tag::RunAsNodeCommand;
         }
 
+        let mut idx: usize = 1;
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
-        while !first_arg_name.is_empty()
-            && first_arg_name[0] == b'-'
-            && !(first_arg_name.len() > 1 && first_arg_name[1] == b'e')
-        {
+        // A `--filter` / `--workspaces` in front of `test` or `build` names a
+        // package.json script, which the run path handles.
+        let mut saw_filter_flag = false;
+        while !first_arg_name.is_empty() && first_arg_name[0] == b'-' {
             // `--interactive` stays on AutoCommand: Arguments.rs parses it and the no-target check
             // routes to RunCommand::exec_node_repl. An early ReplCommand return here would bypass
             // that and boot the legacy `bun repl` implementation instead.
+            match arguments::LeadingFlag::classify(first_arg_name) {
+                arguments::LeadingFlag::Program => return Tag::AutoCommand,
+                arguments::LeadingFlag::Flag {
+                    consumes_value,
+                    filter,
+                } => {
+                    saw_filter_flag |= filter;
+                    if consumes_value {
+                        if iter.next().is_none() {
+                            return Tag::AutoCommand;
+                        }
+                        idx += 1;
+                    }
+                }
+            }
             match iter.next() {
-                Some(n) => first_arg_name = n,
+                Some(n) => {
+                    idx += 1;
+                    first_arg_name = n;
+                }
                 None => return Tag::AutoCommand,
             }
         }
+        SUBCOMMAND_ARGV_INDEX.store(idx, core::sync::atomic::Ordering::Relaxed);
 
         type RootCommandMatcher = strings::ExactSizeMatcher<12>;
         let x = RootCommandMatcher::r#match(first_arg_name);
+        if saw_filter_flag
+            && (x == RootCommandMatcher::case(b"test") || x == RootCommandMatcher::case(b"build"))
+        {
+            return Tag::AutoCommand;
+        }
         // PERF: `if x == const` is a chain of compares rather than a jump
         // table on the packed u96 — profile if it shows up on a hot path.
         if x == RootCommandMatcher::case(b"init") {
@@ -1073,9 +1131,6 @@ pub mod command {
             if bun_core::Environment::ENABLE_FUZZILLI {
                 return Tag::FuzzilliCommand;
             }
-            return Tag::AutoCommand;
-        }
-        if x == RootCommandMatcher::case(b"-e") {
             return Tag::AutoCommand;
         }
         Tag::AutoCommand
@@ -1497,8 +1552,10 @@ pub mod command {
     #[inline(never)]
     fn exec_init() -> CmdResult {
         // InitCommand parses its own argv (no Context).
+        apply_leading_cwd();
         let argv = argv_zslice();
-        super::init_command::InitCommand::exec(&argv[2.min(argv.len())..])
+        let start = (subcommand_argv_index() + 1).min(argv.len());
+        super::init_command::InitCommand::exec(&argv[start..])
     }
 
     #[cold]
@@ -1508,7 +1565,7 @@ pub mod command {
         // exec handles both the non-tty path (dump the embedded completion
         // script to stdout) and the tty install path (bunx symlink, fpath/XDG
         // dir search, profile patching).
-        for a in bun::argv().iter().skip(2) {
+        for a in bun::argv().iter().skip(subcommand_argv_index() + 1) {
             if matches!(a, b"--help" | b"-h") {
                 tag_print_help(Tag::InstallCompletionsCommand, true);
                 Global::exit(0);
@@ -1528,6 +1585,7 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_bunx(log: &mut bun_ast::Log) -> CmdResult {
+        apply_leading_cwd();
         let ctx = init(Tag::BunxCommand, log)?;
         let start_idx = if IS_BUNX_EXE.load(core::sync::atomic::Ordering::Relaxed) {
             0
@@ -1535,7 +1593,8 @@ pub mod command {
             1
         };
         let argv = argv_zslice();
-        super::bunx_command::BunxCommand::exec(ctx, &argv[start_idx..])
+        let keyword_index = subcommand_argv_index().saturating_sub(start_idx);
+        super::bunx_command::BunxCommand::exec(ctx, &argv[start_idx..], keyword_index)
     }
 
     #[cold]
@@ -1780,10 +1839,12 @@ pub mod command {
         }
 
         // Create command wraps bunx
+        apply_leading_cwd();
         let ctx = init(Tag::CreateCommand, log)?;
         let args = argv_zslice();
+        let cmd_idx = subcommand_argv_index();
 
-        if args.len() <= 2 {
+        if args.len() <= cmd_idx + 1 {
             tag_print_help(Tag::CreateCommand, false);
             Global::exit(1);
         }
@@ -1794,7 +1855,7 @@ pub mod command {
         let mut dash_dash_bun = false;
         let mut print_help = false;
 
-        if args.len() > 2 {
+        {
             let remainder = &args[1..];
             let mut remainder_i: usize = 0;
             while remainder_i < remainder.len() && positional_i < positionals.len() {
@@ -1812,6 +1873,16 @@ pub mod command {
                             dash_dash_bun = true;
                         } else if slice == b"--help" || slice == b"-h" {
                             print_help = true;
+                        } else if remainder_i + 1 < cmd_idx {
+                            // A global flag in front of `create`: its value
+                            // is not the template name.
+                            if let arguments::LeadingFlag::Flag {
+                                consumes_value: true,
+                                ..
+                            } = arguments::LeadingFlag::classify(slice)
+                            {
+                                remainder_i += 1;
+                            }
                         }
                     }
                 }
@@ -1881,7 +1952,7 @@ To create a project with the official Next.js scaffolding tool, run\n\
             for src in &args[template_name_start..] {
                 bunx_args.push(*src);
             }
-            return BunxCommand::exec(ctx, &bunx_args);
+            return BunxCommand::exec(ctx, &bunx_args, 0);
         }
 
         CreateCommand::exec(&ctx, example_tag, template)
@@ -1930,29 +2001,15 @@ To create a project with the official Next.js scaffolding tool, run\n\
         // Parse arguments manually since the standard flow doesn't work for standalone commands
         let cli = CommandLineArguments::parse(PmSubcommand::Info)?;
         let json_output = cli.json_output;
+        // `positionals[0]` is the `info` keyword itself.
+        let positionals = match cli.positionals {
+            [b"info", rest @ ..] => rest,
+            rest => rest,
+        };
+        let package_name: &[u8] = positionals.first().copied().unwrap_or(b"");
+        let property_path: Option<&[u8]> = positionals.get(1).copied();
         let ctx = init(Tag::InfoCommand, log)?;
         let (pm, _) = PackageManager::init(ctx, cli, Subcommand::Info)?;
-
-        // Handle arguments correctly for standalone info command
-        let mut package_name: &[u8] = b"";
-        let mut property_path: Option<&[u8]> = None;
-
-        // Find non-flag arguments starting from argv[2] (after "bun info").
-        let mut found_package = false;
-        let argv = bun::argv();
-        for arg in argv.iter().skip(2) {
-            // Skip flags
-            if !arg.is_empty() && arg[0] == b'-' {
-                continue;
-            }
-            if !found_package {
-                package_name = arg;
-                found_package = true;
-            } else {
-                property_path = Some(arg);
-                break;
-            }
-        }
 
         super::pm_view_command::view(pm, package_name, property_path, json_output)
     }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -980,7 +980,10 @@ pub mod command {
             // `--interactive` stays on AutoCommand: Arguments.rs parses it and the no-target check
             // routes to RunCommand::exec_node_repl. An early ReplCommand return here would bypass
             // that and boot the legacy `bun repl` implementation instead.
-            match arguments::LeadingFlag::classify(first_arg_name) {
+            let next_is_keyword = argv
+                .get(idx + 1)
+                .is_some_and(|next| keyword_tag(next).is_some());
+            match arguments::LeadingFlag::classify(first_arg_name, next_is_keyword) {
                 arguments::LeadingFlag::Program => return Tag::AutoCommand,
                 arguments::LeadingFlag::Flag {
                     consumes_value,
@@ -1005,110 +1008,118 @@ pub mod command {
         }
         SUBCOMMAND_ARGV_INDEX.store(idx, core::sync::atomic::Ordering::Relaxed);
 
-        type RootCommandMatcher = strings::ExactSizeMatcher<12>;
-        let x = RootCommandMatcher::r#match(first_arg_name);
+        let keyword = RootCommandMatcher::r#match(first_arg_name);
         if saw_filter_flag
-            && (x == RootCommandMatcher::case(b"test") || x == RootCommandMatcher::case(b"build"))
+            && (keyword == RootCommandMatcher::case(b"test")
+                || keyword == RootCommandMatcher::case(b"build"))
         {
             return Tag::AutoCommand;
         }
+        keyword_tag(first_arg_name).unwrap_or(Tag::AutoCommand)
+    }
+
+    type RootCommandMatcher = strings::ExactSizeMatcher<12>;
+
+    /// The command a subcommand keyword names, `None` for anything else.
+    fn keyword_tag(arg: &[u8]) -> Option<Tag> {
+        let x = RootCommandMatcher::r#match(arg);
         // PERF: `if x == const` is a chain of compares rather than a jump
         // table on the packed u96 — profile if it shows up on a hot path.
         if x == RootCommandMatcher::case(b"init") {
-            return Tag::InitCommand;
+            return Some(Tag::InitCommand);
         }
         if x == RootCommandMatcher::case(b"build") || x == RootCommandMatcher::case(b"bun") {
-            return Tag::BuildCommand;
+            return Some(Tag::BuildCommand);
         }
         if x == RootCommandMatcher::case(b"discord") {
-            return Tag::DiscordCommand;
+            return Some(Tag::DiscordCommand);
         }
         if x == RootCommandMatcher::case(b"upgrade") {
-            return Tag::UpgradeCommand;
+            return Some(Tag::UpgradeCommand);
         }
         if x == RootCommandMatcher::case(b"completions") {
-            return Tag::InstallCompletionsCommand;
+            return Some(Tag::InstallCompletionsCommand);
         }
         if x == RootCommandMatcher::case(b"getcompletes") {
-            return Tag::GetCompletionsCommand;
+            return Some(Tag::GetCompletionsCommand);
         }
         if x == RootCommandMatcher::case(b"link") {
-            return Tag::LinkCommand;
+            return Some(Tag::LinkCommand);
         }
         if x == RootCommandMatcher::case(b"unlink") {
-            return Tag::UnlinkCommand;
+            return Some(Tag::UnlinkCommand);
         }
         if x == RootCommandMatcher::case(b"x") {
-            return Tag::BunxCommand;
+            return Some(Tag::BunxCommand);
         }
         if x == RootCommandMatcher::case(b"repl") {
-            return Tag::ReplCommand;
+            return Some(Tag::ReplCommand);
         }
         if x == RootCommandMatcher::case(b"i") || x == RootCommandMatcher::case(b"install") {
-            for arg in argv.iter() {
-                if arg == b"-g" || arg == b"--global" {
-                    return Tag::AddCommand;
+            for a in bun::argv().iter() {
+                if a == b"-g" || a == b"--global" {
+                    return Some(Tag::AddCommand);
                 }
             }
-            return Tag::InstallCommand;
+            return Some(Tag::InstallCommand);
         }
         if x == RootCommandMatcher::case(b"ci") {
-            return Tag::InstallCommand;
+            return Some(Tag::InstallCommand);
         }
         if x == RootCommandMatcher::case(b"c") || x == RootCommandMatcher::case(b"create") {
-            return Tag::CreateCommand;
+            return Some(Tag::CreateCommand);
         }
         if x == RootCommandMatcher::case(b"test") {
-            return Tag::TestCommand;
+            return Some(Tag::TestCommand);
         }
         if x == RootCommandMatcher::case(b"pm") {
-            return Tag::PackageManagerCommand;
+            return Some(Tag::PackageManagerCommand);
         }
         if x == RootCommandMatcher::case(b"add") || x == RootCommandMatcher::case(b"a") {
-            return Tag::AddCommand;
+            return Some(Tag::AddCommand);
         }
         if x == RootCommandMatcher::case(b"update") || x == RootCommandMatcher::case(b"up") {
-            return Tag::UpdateCommand;
+            return Some(Tag::UpdateCommand);
         }
         if x == RootCommandMatcher::case(b"patch") {
-            return Tag::PatchCommand;
+            return Some(Tag::PatchCommand);
         }
         if x == RootCommandMatcher::case(b"patch-commit") {
-            return Tag::PatchCommitCommand;
+            return Some(Tag::PatchCommitCommand);
         }
         if x == RootCommandMatcher::case(b"r")
             || x == RootCommandMatcher::case(b"remove")
             || x == RootCommandMatcher::case(b"rm")
             || x == RootCommandMatcher::case(b"uninstall")
         {
-            return Tag::RemoveCommand;
+            return Some(Tag::RemoveCommand);
         }
         if x == RootCommandMatcher::case(b"run") {
-            return Tag::RunCommand;
+            return Some(Tag::RunCommand);
         }
         if x == RootCommandMatcher::case(b"help") {
-            return Tag::HelpCommand;
+            return Some(Tag::HelpCommand);
         }
         if x == RootCommandMatcher::case(b"exec") {
-            return Tag::ExecCommand;
+            return Some(Tag::ExecCommand);
         }
         if x == RootCommandMatcher::case(b"outdated") {
-            return Tag::OutdatedCommand;
+            return Some(Tag::OutdatedCommand);
         }
         if x == RootCommandMatcher::case(b"publish") {
-            return Tag::PublishCommand;
+            return Some(Tag::PublishCommand);
         }
         if x == RootCommandMatcher::case(b"audit") {
-            return Tag::AuditCommand;
+            return Some(Tag::AuditCommand);
         }
         if x == RootCommandMatcher::case(b"info") {
-            return Tag::InfoCommand;
+            return Some(Tag::InfoCommand);
         }
         if x == RootCommandMatcher::case(b"dedupe") {
-            return Tag::DedupeCommand;
+            return Some(Tag::DedupeCommand);
         }
         if x == RootCommandMatcher::case(b"prune") {
-            return Tag::PruneCommand;
+            return Some(Tag::PruneCommand);
         }
         // reserved
         if x == RootCommandMatcher::case(b"deploy")
@@ -1119,21 +1130,21 @@ pub mod command {
             || x == RootCommandMatcher::case(b"login")
             || x == RootCommandMatcher::case(b"logout")
         {
-            return Tag::ReservedCommand;
+            return Some(Tag::ReservedCommand);
         }
         if x == RootCommandMatcher::case(b"whoami") || x == RootCommandMatcher::case(b"list") {
-            return Tag::PackageManagerCommand;
+            return Some(Tag::PackageManagerCommand);
         }
         if x == RootCommandMatcher::case(b"why") {
-            return Tag::WhyCommand;
+            return Some(Tag::WhyCommand);
         }
         if x == RootCommandMatcher::case(b"fuzzilli") {
             if bun_core::Environment::ENABLE_FUZZILLI {
-                return Tag::FuzzilliCommand;
+                return Some(Tag::FuzzilliCommand);
             }
-            return Tag::AutoCommand;
+            return None;
         }
-        Tag::AutoCommand
+        None
     }
 
     /// Initialize the process-global `CONTEXT_DATA` and publish it via
@@ -1860,6 +1871,24 @@ pub mod command {
             let mut remainder_i: usize = 0;
             while remainder_i < remainder.len() && positional_i < positionals.len() {
                 let slice = strings::trim(remainder[remainder_i].as_bytes(), b" \t\n");
+                // A global flag in front of `create`: neither it nor its
+                // value is the template name.
+                if remainder_i + 1 < cmd_idx {
+                    if slice == b"--bun" {
+                        dash_dash_bun = true;
+                    } else if slice == b"--help" || slice == b"-h" {
+                        print_help = true;
+                    } else if let arguments::LeadingFlag::Flag {
+                        consumes_value: true,
+                        ..
+                    } =
+                        arguments::LeadingFlag::classify(slice, remainder_i + 2 == cmd_idx)
+                    {
+                        remainder_i += 1;
+                    }
+                    remainder_i += 1;
+                    continue;
+                }
                 if !slice.is_empty() {
                     if !strings::has_prefix(slice, b"--") {
                         if positional_i == 1 {
@@ -1873,16 +1902,6 @@ pub mod command {
                             dash_dash_bun = true;
                         } else if slice == b"--help" || slice == b"-h" {
                             print_help = true;
-                        } else if remainder_i + 1 < cmd_idx {
-                            // A global flag in front of `create`: its value
-                            // is not the template name.
-                            if let arguments::LeadingFlag::Flag {
-                                consumes_value: true,
-                                ..
-                            } = arguments::LeadingFlag::classify(slice)
-                            {
-                                remainder_i += 1;
-                            }
                         }
                     }
                 }

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -234,11 +234,8 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
     }
 
     pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
-        // `bun_core::argv()` includes argv[0]; skip to the subcommand keyword and
-        // collect into a borrowed-slice Vec so `&[&[u8]]` callers
-        // (TrustCommand/UntrustedCommand) index `args[2..]` relative to the
-        // keyword. Flag probes (`--all`, `--trusted`) scan `all_args` instead
-        // so a flag placed before the keyword is still seen.
+        // `args` starts at the `pm` keyword (TrustCommand indexes `args[2..]`).
+        // Flag probes scan `all_args` so a flag before the keyword is seen.
         let cmd_idx = Command::subcommand_argv_index();
         let all_args: Vec<&'static [u8]> = bun_core::argv().into_iter().skip(1).collect();
         let args: &[&[u8]] = &all_args[(cmd_idx - 1).min(all_args.len())..];

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -234,15 +234,18 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
     }
 
     pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
-        // `bun_core::argv()` includes argv[0]; skip it and collect into a
-        // borrowed-slice Vec so `&[&[u8]]` callers (TrustCommand/UntrustedCommand,
-        // `left_has_any_in_right`) keep their shape.
-        let args_vec: Vec<&'static [u8]> = bun_core::argv().into_iter().skip(1).collect();
-        let args: &[&[u8]] = &args_vec;
+        // `bun_core::argv()` includes argv[0]; skip to the subcommand keyword and
+        // collect into a borrowed-slice Vec so `&[&[u8]]` callers
+        // (TrustCommand/UntrustedCommand) index `args[2..]` relative to the
+        // keyword. Flag probes (`--all`, `--trusted`) scan `all_args` instead
+        // so a flag placed before the keyword is still seen.
+        let cmd_idx = Command::subcommand_argv_index();
+        let all_args: Vec<&'static [u8]> = bun_core::argv().into_iter().skip(1).collect();
+        let args: &[&[u8]] = &all_args[(cmd_idx - 1).min(all_args.len())..];
 
         // Check if we're being invoked directly as "bun whoami" instead of "bun pm whoami"
         let is_direct_whoami = bun_core::argv()
-            .get(1)
+            .get(cmd_idx)
             .is_some_and(|arg| strings::eql_comptime(arg.as_bytes(), b"whoami"));
 
         let cli = CommandLineArguments::parse(Subcommand::Pm)?;
@@ -599,9 +602,9 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 more_packages[0] = true;
             }
 
-            let trusted_only = strings::left_has_any_in_right(args, &[b"--trusted"]);
+            let trusted_only = strings::left_has_any_in_right(&all_args, &[b"--trusted"]);
 
-            if strings::left_has_any_in_right(args, &[b"-A", b"-a", b"--all"]) {
+            if strings::left_has_any_in_right(&all_args, &[b"-A", b"-a", b"--all"]) {
                 if trusted_only {
                     // Trust is by package name, not tree position, so a trusted
                     // package nested under an untrusted parent must still be

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -249,10 +249,6 @@ impl TrustCommand {
         );
         Output::flush();
 
-        if args.len() == 2 {
-            Self::error_expected_args();
-        }
-
         // Reshaped for borrowck — see `UntrustedCommand::exec`.
         // `load_lockfile` lives until `save_to_disk` near the end, so every
         // `pm`/`pm.lockfile` access in between goes through `pm_raw`.
@@ -279,8 +275,9 @@ impl TrustCommand {
                 packages_to_trust.push(arg);
             }
         }
-        let trust_all =
-            strings::left_has_any_in_right(args, &[b"-a".as_slice(), b"--all".as_slice()]);
+        let trust_all = bun_core::argv()
+            .iter()
+            .any(|a| matches!(a, b"-a" | b"--all"));
 
         if !trust_all && packages_to_trust.is_empty() {
             Self::error_expected_args();

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -249,6 +249,20 @@ impl TrustCommand {
         );
         Output::flush();
 
+        let mut packages_to_trust: Vec<&[u8]> = Vec::with_capacity(args[2..].len());
+        for arg in &args[2..] {
+            if !arg.is_empty() && arg[0] != b'-' {
+                packages_to_trust.push(arg);
+            }
+        }
+        let trust_all = bun_core::argv()
+            .iter()
+            .any(|a| matches!(a, b"-a" | b"--all"));
+
+        if !trust_all && packages_to_trust.is_empty() {
+            Self::error_expected_args();
+        }
+
         // Reshaped for borrowck — see `UntrustedCommand::exec`.
         // `load_lockfile` lives until `save_to_disk` near the end, so every
         // `pm`/`pm.lockfile` access in between goes through `pm_raw`.
@@ -267,20 +281,6 @@ impl TrustCommand {
             for meta in slice.items_meta_mut() {
                 meta.set_has_install_script(false);
             }
-        }
-
-        let mut packages_to_trust: Vec<&[u8]> = Vec::with_capacity(args[2..].len());
-        for arg in &args[2..] {
-            if !arg.is_empty() && arg[0] != b'-' {
-                packages_to_trust.push(arg);
-            }
-        }
-        let trust_all = bun_core::argv()
-            .iter()
-            .any(|a| matches!(a, b"-a" | b"--all"));
-
-        if !trust_all && packages_to_trust.is_empty() {
-            Self::error_expected_args();
         }
 
         // SAFETY: `pm_raw` is the singleton; `pm.log` set at init, non-null.

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -507,13 +507,14 @@ impl UpgradeCommand {
     #[cold]
     pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
         let args = bun_core::argv();
-        if args.len() > 2 {
-            for arg in args.iter().skip(2) {
+        let start = Command::subcommand_argv_index() + 1;
+        if args.len() > start {
+            for arg in args.iter().skip(start) {
                 if !strings::contains(arg, b"--") {
                     bun_core::pretty_error!(
                         "<r><red>error<r><d>:<r> This command updates Bun itself, and does not take package names.\n<blue>note<r><d>:<r> Use `bun update"
                     );
-                    for arg_err in args.iter().skip(2) {
+                    for arg_err in args.iter().skip(start) {
                         bun_core::pretty_error!(" {}", bstr::BStr::new(arg_err));
                     }
                     bun_core::pretty_errorln!("` instead.");

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -469,3 +469,255 @@ describe("bun", () => {
     });
   });
 });
+
+// `Command::which()` scans argv for the first non-dash token to pick the
+// subcommand. It must step past the value of `--cwd` / `--env-file` so that
+// value isn't misread as the subcommand name.
+describe.concurrent("global flag before subcommand", () => {
+  async function run(cwd: string, argv: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...argv],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const files = {
+    "package.json": JSON.stringify({ name: "p", scripts: { greet: "echo hello-from-script" } }),
+    "app.ts": `console.log("ran:" + (process.env.FROM_ENV_FILE ?? "unset"));`,
+    "pass.test.ts": `import {test,expect} from "bun:test"; test("t", () => expect(1).toBe(1));`,
+    "my.env": "FROM_ENV_FILE=loaded\n",
+    "sub/package.json": JSON.stringify({
+      name: "sub",
+      scripts: { greet: "echo hello-from-sub" },
+      dependencies: {},
+    }),
+  };
+
+  for (const pre of [
+    ["--cwd", "."],
+    ["--env-file", "my.env"],
+    ["--cwd", ".", "--env-file", "my.env"],
+  ] as const) {
+    test(`bun ${pre.join(" ")} run <script> dispatches RunCommand`, async () => {
+      using dir = tempDir("which-run", files);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...pre, "run", "greet"]);
+      expect(stderr).not.toContain("Script not found");
+      // Misroute to AutoCommand prints the `bun run` help with exit 0.
+      expect(stdout).not.toContain("Usage:");
+      expect(stdout).toContain("hello-from-script");
+      expect(exitCode).toBe(0);
+    });
+
+    test(`bun ${pre.join(" ")} test <file> dispatches TestCommand`, async () => {
+      using dir = tempDir("which-test", files);
+      const { stderr, exitCode } = await run(String(dir), [...pre, "test", "pass.test.ts"]);
+      expect(stderr).not.toContain("Script not found");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("bun --env-file my.env run app.ts loads the env file", async () => {
+    using dir = tempDir("which-env", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--env-file", "my.env", "run", "app.ts"]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ran:loaded\n", stderr: "", exitCode: 0 });
+  });
+
+  test("bun --cwd sub run <script> resolves scripts from the --cwd dir", async () => {
+    using dir = tempDir("which-cwd", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", "sub", "run", "greet"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout).not.toContain("Usage:");
+    expect(stdout).toContain("hello-from-sub");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd sub install dispatches InstallCommand (not add 'sub')", async () => {
+    using dir = tempDir("which-install", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", "sub", "install", "--dry-run"]);
+    expect(stderr).not.toContain("Script not found");
+    // A misroute to `bun add` would print "installed <pkg>" / hit the registry;
+    // a misroute to AutoCommand would print "Script not found".
+    expect(stdout + stderr).not.toMatch(/\badd\b.*\binstall\b/);
+    expect(stdout + stderr).not.toContain('"sub"');
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --env-file my.env install does not treat the path as a package", async () => {
+    using dir = tempDir("which-install-env", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), [
+      "--env-file",
+      "my.env",
+      "install",
+      "--dry-run",
+      "--cwd",
+      "sub",
+    ]);
+    // Regression guard for the #34983 revert: `.env` must not leak as a
+    // positional and `install` must not be treated as a package name.
+    expect(stdout + stderr).not.toContain("my.env");
+    expect(stderr).not.toContain("Script not found");
+    expect(exitCode).toBe(0);
+  });
+
+  for (const cwd of [["--cwd", "target"], ["--cwd=target"]] as const) {
+    test(`bun ${cwd.join(" ")} init -y -m dispatches InitCommand in target`, async () => {
+      using dir = tempDir("which-init", { "target/.gitkeep": "" });
+      const { stderr, exitCode } = await run(String(dir), [...cwd, "init", "-y", "-m"]);
+      expect(stderr).not.toContain("Script not found");
+      expect(fs.existsSync(`${dir}/target/package.json`)).toBe(true);
+      expect(fs.existsSync(`${dir}/package.json`)).toBe(false);
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  // Shebang + chmod bin stub is Unix-only; see test/regression/issue/26207.test.ts.
+  test.skipIf(isWindows)("bun --bun x <bin> still passes --bun through", async () => {
+    // `--bun` is handled by bunx's own parser; stepping past leading flags
+    // to find the `x` keyword must not strip it.
+    using dir = tempDir("which-bunx-bun", {
+      "node_modules/.bin/probe": `#!/usr/bin/env node\nconsole.log(process.isBun ? "under-bun" : "under-node");`,
+      "package.json": JSON.stringify({ name: "p" }),
+    });
+    fs.chmodSync(`${dir}/node_modules/.bin/probe`, 0o755);
+    const baseline = await run(String(dir), ["x", "--bun", "probe"]);
+    expect(baseline.stdout.trim()).toBe("under-bun");
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--bun", "x", "probe"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout.trim()).toBe("under-bun");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd . exec <cmd> dispatches ExecCommand", async () => {
+    using dir = tempDir("which-exec", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", ".", "exec", "echo from-exec"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout).toContain("from-exec");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd . build app.ts dispatches BuildCommand", async () => {
+    using dir = tempDir("which-build", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--cwd", ".", "build", "./app.ts"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout).toContain("FROM_ENV_FILE");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun --cwd sub add --dry-run does not misread 'sub' as a package", async () => {
+    using dir = tempDir("which-add", files);
+    const { stdout, stderr } = await run(String(dir), ["--cwd", "sub", "add", "--dry-run"]);
+    expect(stdout + stderr).not.toMatch(/GET .*\/(sub|add)\b/);
+    expect(stderr).not.toContain("Script not found");
+    // Dispatching AddCommand with zero positionals prints this diagnostic;
+    // any other route (AutoCommand, or 'sub'/'add' leaking as a package name)
+    // would not.
+    expect(stderr).toContain("no package specified to add");
+  });
+
+  // The skip takes the flag's arity from the auto flag table, so every
+  // value-taking global flag in space form steps over its value.
+  const valueFlags = {
+    "pre.ts": `console.log("preloaded")`,
+    "app.ts": `console.log("ran")`,
+    "pass.test.ts": `import {test,expect} from "bun:test"; test("t", () => expect(1).toBe(1));`,
+    "package.json": JSON.stringify({ name: "p", scripts: { greet: "echo hello-from-script" } }),
+  };
+
+  for (const pre of [
+    ["--preload", "./pre.ts"],
+    ["-r", "./pre.ts"],
+    ["--require", "./pre.ts"],
+    ["--import", "./pre.ts"],
+  ]) {
+    test(`bun ${pre.join(" ")} test <file> dispatches TestCommand and preloads`, async () => {
+      using dir = tempDir("which-preload-test", valueFlags);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...pre, "test", "pass.test.ts"]);
+      expect(stderr).not.toContain("Script not found");
+      expect(stdout).toContain("preloaded");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  for (const pre of [
+    ["--define", "X=1"],
+    ["-d", "X=1"],
+    ["-r", "./pre.ts"],
+  ]) {
+    test(`bun ${pre.join(" ")} build <file> dispatches BuildCommand`, async () => {
+      using dir = tempDir("which-value-build", valueFlags);
+      const { stderr } = await run(String(dir), [...pre, "build", "./app.ts"]);
+      // `-r` is not a build flag: the build parser rejects it, which proves
+      // the dispatch reached BuildCommand.
+      expect(stderr).not.toContain("Script not found");
+    });
+  }
+
+  test("bun --console-depth 5 run <file> dispatches RunCommand", async () => {
+    using dir = tempDir("which-console-depth", valueFlags);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--console-depth", "5", "run", "app.ts"]);
+    expect(stdout).not.toContain("Usage:");
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ran\n", stderr: "", exitCode: 0 });
+  });
+
+  test("bun --preload ./pre.ts install does not treat the path or 'install' as a package", async () => {
+    using dir = tempDir("which-preload-install", valueFlags);
+    const { stderr, exitCode } = await run(String(dir), ["--preload", "./pre.ts", "install", "--dry-run"]);
+    expect(stderr).not.toContain("Script not found");
+    expect(await Bun.file(`${dir}/package.json`).text()).toBe(valueFlags["package.json"]);
+    expect(exitCode).toBe(0);
+  });
+
+  // `-`, `--`, `-e` and `-p` end the flag scan: the rest of argv belongs to
+  // the program, even when a token spells a subcommand.
+  for (const argv of [["i"], ["a"], ["x"], ["test"], ["init"], ["pm", "ls"], ["help"]]) {
+    test(`bun - ${argv.join(" ")} runs the stdin program`, async () => {
+      using dir = tempDir("which-stdin", valueFlags);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-", ...argv],
+        env: bunEnv,
+        cwd: String(dir),
+        stdin: new Blob([`console.log(JSON.stringify(process.argv.slice(2)))`]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: JSON.stringify(argv) + "\n", stderr: "", exitCode: 0 });
+      expect(fs.readdirSync(String(dir)).sort()).toEqual(Object.keys(valueFlags).sort());
+    });
+  }
+
+  for (const pre of [["-p"], ["--print"], ["-pe"]]) {
+    test(`bun ${pre.join(" ")} <code> test evaluates the code`, async () => {
+      using dir = tempDir("which-print", valueFlags);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...pre, "1+1", "test"]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "2\n", stderr: "", exitCode: 0 });
+    });
+  }
+
+  test("bun -- <file> test runs the file", async () => {
+    using dir = tempDir("which-dashdash", valueFlags);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--", "app.ts", "test"]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ran\n", stderr: "", exitCode: 0 });
+  });
+
+  // A filter flag in front of `test` names the package script.
+  const workspace = {
+    "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    "packages/pkga/package.json": JSON.stringify({ name: "pkga", scripts: { test: "echo test-from-pkga" } }),
+  };
+  for (const pre of [["--filter", "pkga"], ["-F", "pkga"], ["--filter=pkga"], ["-Fpkga"]]) {
+    test(`bun ${pre.join(" ")} test runs the package test script`, async () => {
+      using dir = tempDir("which-filter-test", workspace);
+      const { stdout, exitCode } = await run(String(dir), [...pre, "test"]);
+      expect(stdout).toContain("test-from-pkga");
+      expect(exitCode).toBe(0);
+    });
+  }
+});

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -659,6 +659,40 @@ describe.concurrent("global flag before subcommand", () => {
     });
   }
 
+  test("bun --preload ./pre.ts build <file> bundles only the entry point", async () => {
+    using dir = tempDir("which-preload-build", valueFlags);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--preload", "./pre.ts", "build", "./app.ts"]);
+    // The build table has no --preload: its value must not become an entry
+    // point, and neither may the `build` keyword.
+    expect(stderr).not.toContain("Script not found");
+    expect(stdout).toContain('console.log("ran")');
+    expect(stdout).not.toContain("preloaded");
+    expect(exitCode).toBe(0);
+  });
+
+  // A short flag means different things to different commands. When the
+  // next token is a keyword, the keyword wins.
+  test("bun -p install is install --production", async () => {
+    using dir = tempDir("which-p-install", valueFlags);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["-p", "install", "--dry-run"]);
+    expect(stderr).not.toContain("ReferenceError");
+    expect(stdout).toContain("bun install");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -d add is add --dev", async () => {
+    using dir = tempDir("which-d-add", valueFlags);
+    const { stderr } = await run(String(dir), ["-d", "add", "--dry-run"]);
+    expect(stderr).toContain("no package specified to add");
+  });
+
+  test("bun -u test <file> is test --update-snapshots", async () => {
+    using dir = tempDir("which-u-test", valueFlags);
+    const { stderr, exitCode } = await run(String(dir), ["-u", "test", "pass.test.ts"]);
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
   test("bun --console-depth 5 run <file> dispatches RunCommand", async () => {
     using dir = tempDir("which-console-depth", valueFlags);
     const { stdout, stderr, exitCode } = await run(String(dir), ["--console-depth", "5", "run", "app.ts"]);


### PR DESCRIPTION
### Problem
- `which()` (`src/runtime/cli/mod.rs`) skips every `-`-prefixed token in front of the subcommand as if it took no value. The value of a space-form global flag becomes the keyword candidate: `bun --cwd ./p test`, `bun --preload ./pre.ts test` and `bun -r ./pre.ts build x.ts` print `error: Script not found "test"` / `"build"`, and `bun --console-depth 5 run index.tsx` (the example in the runtime docs) prints the `bun run` usage and runs nothing. The `=` forms work (#10333, #12430, #23631).
- The bare `-` of a stdin program is skipped the same way, so the first program argument is matched as a subcommand: `echo 'console.log(1)' | bun - i` runs `bun install`, `bun - init` writes files into the cwd, `bun - test` runs the test runner.

### Fix
- `which()` asks the auto flag table (`AUTO_PARAMS`, the table that parses `bun [flags] <file>`) whether a leading flag takes a value and steps over that token. Short chains follow clap: `-Fpat` and `-F=pat` carry the value, `-F pat` consumes the next token. `-`, `--`, `-e`, `-p` end the scan: the rest of argv belongs to the program. A filter flag before `test` or `build` keeps routing to the package scripts, which is what the docs show and what #40546 adds for the `=` form.
- `which()` records the argv index of the keyword (`SUBCOMMAND_ARGV_INDEX`, in `bun_install` next to `PRETEND_TO_BE_NODE`). The handlers that read raw argv at a fixed offset (`init`, `info`, `create`, `x`, `upgrade`, `pm trust`, `completions`, reserved names) read from that index. This is the reader-side work of #36644, rebased.
- The install family (`CommandLineArguments::parse`) drops positionals that precede the keyword. Its table does not declare the runtime flags, so `bun --preload ./x.ts install` used to come back as positionals `[./x.ts, install]`, which `bun add` reads as a package named `install`. That leak is why #34983's first attempt was reverted.
- Verified: `test/cli/bun.test.ts` (54 cases under "global flag before subcommand", 50 fail on the release binary). Also `test/cli/run/filter-workspace.test.ts`, `bun-pm`, `bun-info`, `init`, `bunx`, `bun-upgrade`, `bun-create`, `run-eval`.

### Background
- `which()` picks the command `Tag` before any flag parsing. It walks argv past the leading flags and matches the first other token against the keyword list. Each command then parses the whole argv with its own clap table, so a flag typed before the keyword is parsed by that command.
- `bun_clap` declares each flag's arity: `None`, `One`, `Many` (one token per occurrence), or `OneOptional` (a value only when attached with `=`). The sniffer and the parsers now agree on which token is a value.
- `bun -` reads the program from stdin. Node passes everything after `-` to the program as `process.argv`.

Supersedes #36644. Fixes #10333. Fixes #12430. Fixes #23631.

<details><summary>Notes</summary>

Reproduced on 1.4.3-canary: every space-form value flag (`--cwd`, `--preload`, `-r`, `--require`, `--import`, `--define`, `-d`, `--env-file`, `--console-depth`) in front of `run`/`test`/`build` misroutes. Boolean flags and `=` forms were fine.

`-c, --config` is `OneOptional` in both tables, so the sniffer does not step over a space-form config path. #34983 changes that declaration. After it lands, `--config path` is covered by the same table lookup with no further change here.

`bun -r ./pre.ts build x.ts` now reaches the build command, which rejects `-r` (`Invalid Argument '-r'`) because build has no preload flag. Before, it printed `Script not found "build"`.

Self-reviewed with the `Bun.version` bunx user-agent test excluded: it compares against `1.4.3-debug` and fails on any debug build.

</details>
