### PR TITLE
install: stop bun pm untrusted and bun pm trust from treating workspace members as blocked

### DIFF
--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -16,7 +16,7 @@ use bun_install::package_manager_real::{
 };
 use bun_install::{
     self as install, DEFAULT_TRUSTED_DEPENDENCIES_LIST, DependencyID, LifecycleScriptSubprocess,
-    PackageID, PackageManager, Resolution,
+    PackageID, PackageManager, Resolution, ResolutionTag,
 };
 use bun_paths::AutoAbsPath;
 
@@ -24,6 +24,20 @@ use crate::cli::Command;
 use crate::package_manager_command::PackageManagerCommand;
 
 type DepIdSet = ArrayHashMap<DependencyID, (), ArrayIdentityContext>;
+
+/// Mirrors the installers' enqueue gate (`PackageInstaller` and the isolated
+/// `Installer`): the root and workspace members are first-party, their scripts
+/// always run at install, so they are never "blocked".
+fn scripts_blocked_at_install(
+    lockfile: &Lockfile,
+    alias: &[u8],
+    pkg_name: &[u8],
+    resolution: &Resolution,
+) -> bool {
+    resolution.tag != ResolutionTag::Root
+        && resolution.tag != ResolutionTag::Workspace
+        && !lockfile.has_trusted_dependency(alias, pkg_name, resolution)
+}
 
 pub(crate) struct DefaultTrustedCommand;
 
@@ -97,7 +111,7 @@ impl UntrustedCommand {
             let alias = dep.name.slice(buf);
             let pkg_name = packages.items_name()[package_id as usize].slice(buf);
             let resolution = &resolutions[package_id as usize];
-            if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
+            if scripts_blocked_at_install(lockfile, alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
         }
@@ -318,7 +332,7 @@ impl TrustCommand {
             let alias = dep.name.slice(buf);
             let pkg_name = packages.items_name()[package_id as usize].slice(buf);
             let resolution = &resolutions[package_id as usize];
-            if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
+            if scripts_blocked_at_install(lockfile, alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
         }
@@ -399,7 +413,8 @@ impl TrustCommand {
 
                         for package_name_from_cli in &packages_to_trust {
                             if strings::eql_long(package_name_from_cli, alias, true)
-                                && !lockfile.has_trusted_dependency(
+                                && scripts_blocked_at_install(
+                                    lockfile,
                                     alias,
                                     packages.items_name()[package_id as usize].slice(buf),
                                     resolution,

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -25,9 +25,7 @@ use crate::package_manager_command::PackageManagerCommand;
 
 type DepIdSet = ArrayHashMap<DependencyID, (), ArrayIdentityContext>;
 
-/// Mirrors the installers' enqueue gate (`PackageInstaller` and the isolated
-/// `Installer`): the root and workspace members are first-party, their scripts
-/// always run at install, so they are never "blocked".
+/// The installers' enqueue gate: root and workspace scripts always run.
 fn scripts_blocked_at_install(
     lockfile: &Lockfile,
     alias: &[u8],

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -732,6 +732,84 @@ test.concurrent(
   },
 );
 
+for (const linker of ["hoisted", "isolated"]) {
+  test.concurrent(`bun pm untrusted and trust skip workspace members, whose scripts ran at install (${linker})`, async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+
+    await writeFile(
+      packageJson,
+      JSON.stringify({
+        name: "mono",
+        private: true,
+        workspaces: ["packages/*"],
+        dependencies: {
+          "@scope/a": "workspace:*",
+        },
+      }),
+    );
+    await mkdir(join(packageDir, "packages", "a"), { recursive: true });
+    await writeFile(
+      join(packageDir, "packages", "a", "package.json"),
+      JSON.stringify({
+        name: "@scope/a",
+        version: "1.0.0",
+        scripts: {
+          postinstall: `echo ran >> postinstall.log`,
+        },
+      }),
+    );
+
+    let { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", `--linker=${linker}`],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    let err = await stderr.text();
+    let out = await stdout.text();
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).not.toContain("Blocked");
+    expect(await exited).toBe(0);
+    expect(await file(join(packageDir, "packages", "a", "postinstall.log")).text()).toBe("ran\n");
+
+    ({ stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "untrusted"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    out = await stdout.text();
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Found 0 untrusted dependencies with scripts");
+    expect(out).not.toContain("@scope/a");
+    expect(await exited).toBe(0);
+
+    // `bun pm trust` must not run the member's scripts a second time or write
+    // the member's name into `trustedDependencies`.
+    ({ stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "trust", "--all"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+    err = await stderr.text();
+    out = await stdout.text();
+    expect(err).toContain("0 scripts ran");
+    expect(await exited).toBe(1);
+    expect(await file(join(packageDir, "packages", "a", "postinstall.log")).text()).toBe("ran\n");
+    expect(await file(packageJson).json()).not.toHaveProperty("trustedDependencies");
+  });
+}
+
 // waiter thread is only a thing on Linux.
 for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
   describe.concurrent("lifecycle scripts" + (forceWaiterThread ? " (waiter thread)" : ""), async () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -733,81 +733,84 @@ test.concurrent(
 );
 
 for (const linker of ["hoisted", "isolated"]) {
-  test.concurrent(`bun pm untrusted and trust skip workspace members, whose scripts ran at install (${linker})`, async () => {
-    using ctx = await setupTest();
-    const { packageDir, packageJson, env } = ctx;
+  test.concurrent(
+    `bun pm untrusted and trust skip workspace members, whose scripts ran at install (${linker})`,
+    async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
 
-    await writeFile(
-      packageJson,
-      JSON.stringify({
-        name: "mono",
-        private: true,
-        workspaces: ["packages/*"],
-        dependencies: {
-          "@scope/a": "workspace:*",
-        },
-      }),
-    );
-    await mkdir(join(packageDir, "packages", "a"), { recursive: true });
-    await writeFile(
-      join(packageDir, "packages", "a", "package.json"),
-      JSON.stringify({
-        name: "@scope/a",
-        version: "1.0.0",
-        scripts: {
-          postinstall: `echo ran >> postinstall.log`,
-        },
-      }),
-    );
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "mono",
+          private: true,
+          workspaces: ["packages/*"],
+          dependencies: {
+            "@scope/a": "workspace:*",
+          },
+        }),
+      );
+      await mkdir(join(packageDir, "packages", "a"), { recursive: true });
+      await writeFile(
+        join(packageDir, "packages", "a", "package.json"),
+        JSON.stringify({
+          name: "@scope/a",
+          version: "1.0.0",
+          scripts: {
+            postinstall: `echo ran >> postinstall.log`,
+          },
+        }),
+      );
 
-    let { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "install", `--linker=${linker}`],
-      cwd: packageDir,
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env,
-    });
-    let err = await stderr.text();
-    let out = await stdout.text();
-    expect(err).toContain("Saved lockfile");
-    expect(err).not.toContain("error:");
-    expect(out).not.toContain("Blocked");
-    expect(await exited).toBe(0);
-    expect(await file(join(packageDir, "packages", "a", "postinstall.log")).text()).toBe("ran\n");
+      let { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", `--linker=${linker}`],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      let err = await stderr.text();
+      let out = await stdout.text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(out).not.toContain("Blocked");
+      expect(await exited).toBe(0);
+      expect(await file(join(packageDir, "packages", "a", "postinstall.log")).text()).toBe("ran\n");
 
-    ({ stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "pm", "untrusted"],
-      cwd: packageDir,
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env,
-    }));
-    err = await stderr.text();
-    out = await stdout.text();
-    expect(err).not.toContain("error:");
-    expect(out).toContain("Found 0 untrusted dependencies with scripts");
-    expect(out).not.toContain("@scope/a");
-    expect(await exited).toBe(0);
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "pm", "untrusted"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      }));
+      err = await stderr.text();
+      out = await stdout.text();
+      expect(err).not.toContain("error:");
+      expect(out).toContain("Found 0 untrusted dependencies with scripts");
+      expect(out).not.toContain("@scope/a");
+      expect(await exited).toBe(0);
 
-    // `bun pm trust` must not run the member's scripts a second time or write
-    // the member's name into `trustedDependencies`.
-    ({ stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "pm", "trust", "--all"],
-      cwd: packageDir,
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env,
-    }));
-    err = await stderr.text();
-    out = await stdout.text();
-    expect(err).toContain("0 scripts ran");
-    expect(await exited).toBe(1);
-    expect(await file(join(packageDir, "packages", "a", "postinstall.log")).text()).toBe("ran\n");
-    expect(await file(packageJson).json()).not.toHaveProperty("trustedDependencies");
-  });
+      // `bun pm trust` must not run the member's scripts a second time or write
+      // the member's name into `trustedDependencies`.
+      ({ stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "pm", "trust", "--all"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      }));
+      err = await stderr.text();
+      out = await stdout.text();
+      expect(err).toContain("0 scripts ran");
+      expect(await exited).toBe(1);
+      expect(await file(join(packageDir, "packages", "a", "postinstall.log")).text()).toBe("ran\n");
+      expect(await file(packageJson).json()).not.toHaveProperty("trustedDependencies");
+    },
+  );
 }
 
 // waiter thread is only a thing on Linux.


### PR DESCRIPTION
### Problem
- In a workspace whose member has a `postinstall`, `bun install` runs the script (correct). `bun pm untrusted` then lists the member under "had their lifecycle scripts blocked during install". `bun pm trust <member>` or `bun pm trust --all` runs the member's scripts a second time and writes the member's name into the root `trustedDependencies`.
- Cause: both installers enqueue scripts when `resolution.tag == Workspace || is_trusted` (`src/install/PackageInstaller.rs:1955`, `src/install/isolated_install/Installer.rs:1619`). `bun pm untrusted` and `bun pm trust` (`src/runtime/cli/pm_trusted_command.rs:100`, `:321`, `:402`) only called `has_trusted_dependency`, which returns false for a workspace member unless its name is in `trustedDependencies`.

### Fix
- A helper `scripts_blocked_at_install` in `pm_trusted_command.rs` mirrors the installers' gate: a `Root` or `Workspace` resolution is never blocked. The three trust checks in the two commands use it.
- Correct because the commands now report and remediate exactly the set of packages the installers skipped. Under the hoisted linker every linked member was listed, under isolated only members that are root dependencies. Both cases now print `Found 0 untrusted dependencies with scripts`.
- Verified: `test/cli/install/bun-install-lifecycle-scripts.test.ts`, two new cases (hoisted and isolated) that fail on stock bun. The rest of the file passes except three cases that need `node` on PATH and fail the same way on main.

### Background
- `trustedDependencies` is the package.json allow-list for third-party lifecycle scripts. `Lockfile::has_trusted_dependency` (`src/install/lockfile.rs:3272`) answers "is this dependency on that list". It does not know that first-party packages never need to be on it.
- Workspace members resolve with `ResolutionTag::Workspace`. Their scripts are the user's own code, so the installers run them without a trust check.
- `bun pm untrusted` lists the dependencies whose scripts the install skipped. `bun pm trust` runs those scripts and records the names in `trustedDependencies`.

<details><summary>Notes</summary>

Repro on bun 1.4.3-canary (f42e98025):

```
mkdir -p packages/a
echo '{ "name": "mono", "private": true, "workspaces": ["packages/*"], "dependencies": { "@scope/a": "workspace:*" } }' > package.json
echo '{ "name": "@scope/a", "version": "1.0.0", "scripts": { "postinstall": "echo ran >> log" } }' > packages/a/package.json
bun install            # runs postinstall once
bun pm untrusted       # lists ./node_modules/@scope/a @workspace:packages/a as blocked
bun pm trust @scope/a  # runs postinstall again, adds "trustedDependencies": ["@scope/a"]
```

Suites run: `test/cli/install/bun-install-lifecycle-scripts.test.ts` (121 pass, 3 pre-existing environment failures: `node -p should work in postinstall scripts`, `ensureTempNodeGypScript works` x2, all `command not found`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->