### PR TITLE
js_parser: allow continue to any label in a chain of labels on a loop

### DIFF
--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1339,8 +1339,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let ref_ = p.new_symbol(js_ast::symbol::Kind::Label, name);
         data.name.ref_ = ref_;
         p.cur_scope().label_ref = ref_;
-        // Every label in a chain (`a: b: for (...)`) belongs to the loop's label set,
-        // so `continue a` is valid. Look through nested labels to find the statement.
+        // `a: b: for (...)`: every label in the chain belongs to the loop.
         let mut labeled = &data.stmt;
         while let StmtData::SLabel(inner) = &labeled.data {
             labeled = &inner.stmt;

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1339,7 +1339,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let ref_ = p.new_symbol(js_ast::symbol::Kind::Label, name);
         data.name.ref_ = ref_;
         p.cur_scope().label_ref = ref_;
-        match data.stmt.data {
+        // Every label in a chain (`a: b: for (...)`) belongs to the loop's label set,
+        // so `continue a` is valid. Look through nested labels to find the statement.
+        let mut labeled = &data.stmt;
+        while let StmtData::SLabel(inner) = &labeled.data {
+            labeled = &inner.stmt;
+        }
+        match labeled.data {
             StmtData::SFor(_)
             | StmtData::SForIn(_)
             | StmtData::SForOf(_)

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3714,7 +3714,10 @@ class Foo {
     // Every label in `a: b: for (...)` belongs to the loop, so `continue a` is valid.
     expectPrinted_("a: b: for (;;) { continue a }", "a:\n  b:\n    for (;; ) {\n      continue a;\n    }");
     expectPrinted_("a: b: for (;;) { continue b }", "a:\n  b:\n    for (;; ) {\n      continue b;\n    }");
-    expectPrinted_("a: b: c: while (x) { continue a }", "a:\n  b:\n    c:\n      while (x) {\n        continue a;\n      }");
+    expectPrinted_(
+      "a: b: c: while (x) { continue a }",
+      "a:\n  b:\n    c:\n      while (x) {\n        continue a;\n      }",
+    );
     expectPrinted_(
       "a: b: for (;;) { for (;;) { continue a } }",
       "a:\n  b:\n    for (;; ) {\n      for (;; ) {\n        continue a;\n      }\n    }",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3710,6 +3710,20 @@ class Foo {
     expectParseError("class Foo { #x() { this.#x += 1 } }", 'Writing to read-only method "#x" will throw');
   });
 
+  it("continue to any label in a chain of labels on a loop", () => {
+    // Every label in `a: b: for (...)` belongs to the loop, so `continue a` is valid.
+    expectPrinted_("a: b: for (;;) { continue a }", "a:\n  b:\n    for (;; ) {\n      continue a;\n    }");
+    expectPrinted_("a: b: for (;;) { continue b }", "a:\n  b:\n    for (;; ) {\n      continue b;\n    }");
+    expectPrinted_("a: b: c: while (x) { continue a }", "a:\n  b:\n    c:\n      while (x) {\n        continue a;\n      }");
+    expectPrinted_(
+      "a: b: for (;;) { for (;;) { continue a } }",
+      "a:\n  b:\n    for (;; ) {\n      for (;; ) {\n        continue a;\n      }\n    }",
+    );
+    expectParseError("a: b: { continue a }", 'Cannot "continue" to label a');
+    expectParseError("a: b: { for (;;) { continue a } }", 'Cannot "continue" to label a');
+    expectParseError("a: b: if (x) { continue b }", 'Cannot "continue" to label b');
+  });
+
   it("class bodies keep `this` and the class name as written", () => {
     expectPrinted_(
       "class Foo { static x = this; static { this.y = Foo } z = () => this }",


### PR DESCRIPTION
### Problem
- `a: b: for (;;) { continue a }` fails to parse: `error: Cannot "continue" to label a`. Node and V8 accept it. `continue b` and `break a` already work in bun.
- The cause is `s_label` in `src/js_parser/visit/visit_stmt.rs:1342`. It sets `label_stmt_is_loop` only when the direct child of the label is a loop. In a chain, the child of `a` is the label `b`, so `a` is recorded as a non-loop label.

### Fix
- `s_label` now looks through nested `SLabel` statements before it checks for a loop. Every label in the chain is marked as a loop label when the chain ends in a loop.
- This matches the spec: a LabelledStatement chain contributes every label to the iteration statement's label set, so `continue` to any of them is valid.
- A chain that ends in a block or an `if` is still rejected with the same error.
- Verified: `test/bundler/transpiler/transpiler.test.js` (new block `continue to any label in a chain of labels on a loop`, fails on main). The full file passes.

### Background
- `s_label` runs in the visit pass. It pushes a `Label` scope for each label and records `label_stmt_is_loop` on that scope.
- `s_continue` calls `find_label_symbol`, which walks the scopes upward and returns `is_loop` from the scope that holds the label. A label that is found but not a loop produces the `Cannot "continue" to label` error.
- esbuild 0.25 has the same rejection, so the original port copied it.
