### PR TITLE
js_parser: substitute undefined, not null, for top-level this in an ES module

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -10275,7 +10275,7 @@ pub(crate) fn null_expr_data() -> js_ast::ExprData {
 pub(crate) fn null_stmt_data() -> js_ast::StmtData {
     js_ast::StmtData::SEmpty(S::Empty {})
 }
-#[inline]
+
 /// `require()` of an ES module returns a copy of the namespace with
 /// `__esModule` set, and reads `default` off `module.exports`: neither name is
 /// the export the linker would bind.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6032,7 +6032,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // compile time using expression substitution here.
                 return Some(Expr {
                     loc,
-                    data: null_value_expr(),
+                    data: js_ast::ExprData::EUndefined(E::Undefined {}),
                 });
             } else {
                 // In a CommonJS module, "this" is supposed to be the same as "exports".
@@ -10276,10 +10276,6 @@ pub(crate) fn null_stmt_data() -> js_ast::StmtData {
     js_ast::StmtData::SEmpty(S::Empty {})
 }
 #[inline]
-pub(crate) fn null_value_expr() -> js_ast::ExprData {
-    js_ast::ExprData::ENull(E::Null {})
-}
-
 /// `require()` of an ES module returns a copy of the namespace with
 /// `__esModule` set, and reads `default` off `module.exports`: neither name is
 /// the export the linker would bind.

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -5313,7 +5313,7 @@ describe.concurrent("bundler", () => {
       "/node_modules/pkg/file2.js": `export default [this, this]`,
     },
     run: {
-      stdout: "[ null, null ] [ null, null ]",
+      stdout: "[ undefined, undefined ] [ undefined, undefined ]",
     },
   });
   itBundled("default/QuotedProperty", {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3722,6 +3722,16 @@ class Foo {
     );
   });
 
+  it("top-level this in an ES module is undefined", () => {
+    expectPrinted_("console.log(this); export {}", "console.log(undefined);\n\nexport {};\n");
+    expectPrinted_(
+      "console.log(typeof this, this === undefined); export {}",
+      'console.log("undefined", true);\n\nexport {};\n',
+    );
+    expectPrinted_("const t = this; export {}", "const t = undefined;\n\nexport {};\n");
+    expectPrinted_("function f() { return this } export {}", "function f() {\n  return this;\n}\n\nexport {};\n");
+  });
+
   it("declarations named eval or arguments, and reserved words, in strict mode", () => {
     expectParseError(
       '"use strict"; var arguments = 1',


### PR DESCRIPTION
### Problem
- In an ES module, a top-level `this` evaluates to `null` in bun. `typeof this` gives `"object"` and `this === undefined` gives `false`. Node and the spec give `undefined`. This affects `bun run`, `bun build`, and `Bun.Transpiler`.
- The cause is `value_for_this` in `src/js_parser/p.rs:6029`. The parser substitutes a top-level `this` at compile time. The comment says it must be `undefined`, but the code substituted `E::Null`.

### Fix
- Substitute `E::Undefined` instead of `E::Null`. The `null_value_expr` helper had no other caller, so it is removed.
- The CommonJS branch (`this` is `exports`) and `this` inside functions and classes are not changed.
- Verified: `test/bundler/transpiler/transpiler.test.js` (new block `top-level this in an ES module is undefined`, fails on main). `test/bundler/esbuild/default.test.ts` `ThisUndefinedWarningESM` now expects `undefined`, which is what the esbuild test expects. The transpiler, `esbuild/default`, and `esbuild/ts` suites pass.

### Background
- `value_for_this` runs in the visit pass for every `E::This` that is not nested inside a function. For a file with ES module syntax it returns a replacement expression, so no runtime `fn.call(undefined)` is needed.
- `typeof this` and `this === undefined` then constant-fold from the substituted literal, which is why the wrong literal showed up in folded output as well.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 110 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/default.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.47ms]
(pass) Bun.Transpiler > normalizes \r\n [6.67ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.45ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.87ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.37ms]
(pass) Bun.Transpiler > property access inlining > works [2.78ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.68ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [52.94ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [23.60ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [306.02ms]
(pass) Bun.Transpiler > property acc
... (truncated)

release without fix: 2 failed, 110 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.11ms]
(pass) Bun.Transpiler > normalizes \r\n [0.16ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.52ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.25ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [7.86ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.42ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.06ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 110 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/default.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.51ms]
(pass) Bun.Transpiler > normalizes \r\n [7.38ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.74ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [9.42ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.86ms]
(pass) Bun.Transpiler > property access inlining > works [3.13ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.48ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [55.52ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [31.13ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [442.92ms]
(pass) Bun.Transpiler > property acc
... (truncated)

release with fix: 110 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 861ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         |  6 +-----
 test/bundler/esbuild/default.test.ts       |  2 +-
 test/bundler/transpiler/transpiler.test.js | 10 ++++++++++
 3 files changed, 12 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              2      0     16
test/bundler/esbuild/default.test.ts            1      0      5
test/bundler/transpiler/transpiler.test.js      3      3     15
```

</details>

<!-- robobun:evidence:end -->