### PR TITLE
node:http2: handle an empty byte range in respondWithFile and respondWithFD

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3020,7 +3020,7 @@ function doSendFileFD(options, fd, headers, err, stat) {
   if (statOptions.offset <= 0) {
     statOptions.offset = 0;
   }
-  if (statOptions.length <= 0) {
+  if (statOptions.length < 0) {
     if (stat.isFile()) {
       statOptions.length = stat.size;
     } else {
@@ -3045,6 +3045,20 @@ function doSendFileFD(options, fd, headers, err, stat) {
       statOptions.length < 0
         ? stat.size - +statOptions.offset
         : Math.min(stat.size - +statOptions.offset, statOptions.length);
+    // An offset past the end of the file (or a non-integer offset/length) has no valid byte
+    // range: reset this stream instead of letting the read stream validator throw from the
+    // fstat callback, where nothing can catch it.
+    let rangeError;
+    if (!Number.isInteger(statOptions.offset) || statOptions.offset > stat.size) {
+      rangeError = $ERR_OUT_OF_RANGE("options.offset", `>= 0 && <= ${stat.size}`, statOptions.offset);
+    } else if (!Number.isInteger(statOptions.length)) {
+      rangeError = $ERR_OUT_OF_RANGE("options.length", "an integer", statOptions.length);
+    }
+    if (rangeError) {
+      if (ownsFd) tryClose(fd);
+      this.destroy(rangeError);
+      return;
+    }
     // remove content-length header
     for (let i in headers) {
       if (i?.toLowerCase() === HTTP2_HEADER_CONTENT_LENGTH) {
@@ -3070,6 +3084,13 @@ function doSendFileFD(options, fd, headers, err, stat) {
   // The file is piped to the native stream directly below; its completion runs the regular
   // _final (END_STREAM / wantTrailers) logic returned here.
   const finishNativeStream = closeWritableForFileResponse(this);
+
+  if (statOptions.length === 0) {
+    // Nothing to read (empty file, or offset at the end): end the stream without a read stream.
+    if (ownsFd) tryClose(fd);
+    finishNativeStream(() => {});
+    return;
+  }
 
   const stream = this;
   const fileStream = fs.createReadStream(null, {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3045,9 +3045,7 @@ function doSendFileFD(options, fd, headers, err, stat) {
       statOptions.length < 0
         ? stat.size - +statOptions.offset
         : Math.min(stat.size - +statOptions.offset, statOptions.length);
-    // An offset past the end of the file (or a non-integer offset/length) has no valid byte
-    // range: reset this stream instead of letting the read stream validator throw from the
-    // fstat callback, where nothing can catch it.
+    // Validated here: a throw from fs.createReadStream inside this fstat callback is uncatchable.
     let rangeError;
     if (!Number.isInteger(statOptions.offset) || statOptions.offset > stat.size) {
       rangeError = $ERR_OUT_OF_RANGE("options.offset", `>= 0 && <= ${stat.size}`, statOptions.offset);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,5 +1,5 @@
 import { jscDescribe } from "bun:jsc";
-import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe, tempDir } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
 import dc from "node:diagnostics_channel";
@@ -4734,6 +4734,102 @@ it("http2 stream.respond accepts raw-headers arrays; respondWithFD/respondWithFi
     client.close();
     server.close();
   }
+});
+it("http2 respondWithFile/respondWithFD with an empty byte range or an offset past EOF does not kill the process", async () => {
+  // An empty file, offset === size, or length: 0 answers 200 with an empty body (node v26.3.0).
+  // An offset past EOF or a non-integer offset resets only that stream; the server survives.
+  // Both used to throw ERR_OUT_OF_RANGE from the fstat callback, which was uncaught.
+  using dir = tempDir("h2-respond-file-range", {
+    "empty.css": "",
+    "full.txt": "hello world",
+    "main.mjs": `
+      import http2 from "node:http2";
+      import fs from "node:fs";
+      process.on("uncaughtException", e => {
+        console.log("UNCAUGHT", e.code);
+        process.exit(70);
+      });
+      const cases = [
+        ["empty-file", "empty.css", {}],
+        ["empty-fd", "empty.css", { fd: true }],
+        ["offset=size", "full.txt", { offset: 11 }],
+        ["offset=size+1", "full.txt", { offset: 12 }],
+        ["offset=NaN", "full.txt", { offset: NaN }],
+        ["offset=1.5", "full.txt", { offset: 1.5 }],
+        ["length=0", "full.txt", { offset: 0, length: 0 }],
+        ["offset=6", "full.txt", { offset: 6 }],
+      ];
+      const results = {};
+      const server = http2.createServer();
+      server.on("stream", (stream, headers) => {
+        const [name, file, opts] = cases[+headers[":path"].slice(1)];
+        const result = (results[name] ??= {});
+        stream.on("error", e => (result.serverError = e.code));
+        const options = { ...opts, onError: e => (result.onError = e.code) };
+        if (opts.fd) {
+          delete options.fd;
+          const fd = fs.openSync(file, "r");
+          stream.on("close", () => fs.closeSync(fd));
+          stream.respondWithFD(fd, {}, options);
+        } else {
+          stream.respondWithFile(file, {}, options);
+        }
+      });
+      server.listen(0, async () => {
+        const client = http2.connect("http://127.0.0.1:" + server.address().port);
+        for (let i = 0; i < cases.length; i++) {
+          const result = (results[cases[i][0]] ??= {});
+          await new Promise(resolve => {
+            const req = client.request({ ":path": "/" + i });
+            let body = "";
+            req.setEncoding("utf8");
+            req.on("response", h => {
+              result.status = h[":status"];
+              result.contentLength = h["content-length"];
+            });
+            req.on("data", d => (body += d));
+            req.on("error", e => (result.clientError = e.code));
+            req.on("close", () => {
+              result.body = body;
+              result.rstCode = req.rstCode;
+              resolve();
+            });
+          });
+        }
+        client.close();
+        server.close();
+        console.log(JSON.stringify(results));
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).not.toStartWith("UNCAUGHT");
+  const ok = { status: 200, contentLength: "0", body: "", rstCode: 0 };
+  const reset = {
+    serverError: "ERR_OUT_OF_RANGE",
+    clientError: "ERR_HTTP2_STREAM_ERROR",
+    body: "",
+    rstCode: http2.constants.NGHTTP2_INTERNAL_ERROR,
+  };
+  expect(JSON.parse(stdout.trim())).toEqual({
+    "empty-file": ok,
+    "empty-fd": ok,
+    "offset=size": ok,
+    "offset=size+1": reset,
+    "offset=NaN": reset,
+    "offset=1.5": reset,
+    "length=0": ok,
+    "offset=6": { status: 200, contentLength: "5", body: "world", rstCode: 0 },
+  });
+  expect(exitCode).toBe(0);
 });
 it("http2 client.request() on a destroyed or closed session uses the right error codes", async () => {
   // Node: destroyed session -> ERR_HTTP2_INVALID_SESSION,


### PR DESCRIPTION
### Problem
- `stream.respondWithFile()` or `respondWithFD()` of an empty file, or with `offset >= size`, exits the process with an uncaught `ERR_OUT_OF_RANGE The value of "end" is out of range. It must be >= 0 && <= 9007199254740991. Received -1`. `onError` does not run and nothing at the call site can catch it. A client can trigger it with a `Range` request against a server that maps the range to `options.offset`.
- The cause is `doSendFileFD` in `src/js/node/http2.ts:3081`. It passes `end: length + offset - 1` to `fs.createReadStream` from inside the `fs.fstat` callback. For a zero-length range that is `-1`, and the validator throws where no user code can catch it.
- `{ offset: 0, length: 0 }` served the whole file. Line 3023 treated `length <= 0` as "not given".

### Fix
- A range of length 0 (empty file, `offset === size`, `length: 0`) sends the headers with `content-length: 0` and ends the stream through the normal `_final` path, with no read stream. Node v26.3.0 answers `200` with an empty body for all three.
- An offset past the end of the file, or a non-integer offset or length, destroys only that stream with `ERR_OUT_OF_RANGE` (RST_STREAM `INTERNAL_ERROR`). The server keeps running. Node resets that stream too. This is also what bun 1.3.14 did.
- `length <= 0` becomes `length < 0` so `length: 0` means zero bytes, like node.
- Verified: `test/js/node/http2/node-http2.test.js` (new test, fails on the current release with the uncaught error). Also the whole file (379 pass) and the 17 `test/js/node/test/parallel/test-http2-respond-file*.js` node tests.

### Background
- `respondWithFile` opens the file, calls `fs.fstat`, and `doSendFileFD` runs in that callback. It computes the byte range from `options.offset` and `options.length`, sends the response headers, then pipes an `fs.createReadStream` over the fd into the native HTTP/2 stream.
- `closeWritableForFileResponse` ends the user-facing writable side and returns the original `_final`. The file sink calls it once the file is fully handed to the native layer. The zero-length path calls it directly.
- `onError` is for file system errors only (open, fstat), in node and here. A bad range is not routed to it.

<details><summary>Notes</summary>

Repro on bun 1.4.3 (release) and on a debug build of main, both exit 70 from the `uncaughtException` handler. Node v26.3.0 results for the same cases:

```
empty file:        200 content-length 0, empty body
respondWithFD fd:  200, empty body
offset = size:     200 content-length 0, empty body
offset = size + 1: RST_STREAM, server stream 'error' ERR_HTTP2_STREAM_ERROR
offset = NaN:      RST_STREAM
offset = 1.5:      RST_STREAM
offset 0 length 0: 200 content-length 0, empty body
offset 6:          200 content-length 5, "world"
```

With this change bun matches every row. The server-side error for the reset rows is `ERR_OUT_OF_RANGE` (names the bad option) and the RST code is `INTERNAL_ERROR` (node uses `PROTOCOL_ERROR`, from nghttp2 rejecting a negative content-length).

The FIFO case from the report (200 with an empty body) does not reproduce on 1.4.3 or on main. Bun streams the FIFO like node.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [948.13ms]
(pass) node none > Client Basics > should be able to send a POST request [632.96ms]
(pass) node none > Client Basics > constants [19.82ms]
(pass) node none > Client Basics > getDefaultSettings [7.89ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [19.84ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.47ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.93ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.41ms]
(pass) node none > Client Basics > should be able to send data using end [661.97ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [652.64ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.88ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.32ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.13ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.03ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.77ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.75ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.65ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.19ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [31.56ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1001.89ms]
(pass) node none > Client Basics > should be able to send a POST request [634.85ms]
(pass) node none > Client Basics > constants [18.98ms]
(pass) node none > Client Basics > getDefaultSettings [7.73ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [18.44ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.19ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.62ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.30ms]
(pass) node none > Client Basics > should be able to send data using end [644.90ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [627.60ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 656ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7881ms)
Bundle modules (37ms)
Postprocesss modules (167ms)
Bundle Functions (556ms)
Generate Code (39ms)

[8.69s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 39s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+6ba224af1
[build] done
bun test v1.4.3-canary.1 (6ba224af1)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.83ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.12ms]
(pass) node none > Client Basics >
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  | 23 +++++++-
 test/js/node/http2/node-http2.test.js | 98 ++++++++++++++++++++++++++++++++++-
 2 files changed, 119 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       1      5     10
test/js/node/http2/node-http2.test.js      1      3      8
```

</details>

**root cause** · written by the author bot

In `node:http2`, `respondWithFile()` and `respondWithFD()` computed the byte range for a regular file as `{start: offset, end: offset + length - 1}` without clamping, so an empty file, an offset at or past the end of the file, or a non-integer offset or length produced an invalid range (such as `end: -1`) that the `fs.createReadStream` validator rejected with `ERR_OUT_OF_RANGE` from inside the asynchronous fstat callback, where neither `onError` nor a stream `'error'` handler could catch it and the process died. The fix validates the range before creating the read stream: a non-integer offs…

<!-- robobun:evidence:end -->