### PR TITLE
js_parser: serialize enum types in decorator metadata as Number, String, or Object

### DIFF
--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -224,7 +224,7 @@ impl Property {
                 Some(value) => Some(value.deep_clone(bump)?),
                 None => None,
             },
-            ts_metadata: self.ts_metadata.clone(),
+            ts_metadata: self.ts_metadata,
         })
     }
 }
@@ -314,7 +314,7 @@ impl Fn {
             },
             arguments_ref: self.arguments_ref,
             flags: self.flags,
-            return_ts_metadata: self.return_ts_metadata.clone(),
+            return_ts_metadata: self.return_ts_metadata,
         })
     }
 }
@@ -358,7 +358,7 @@ impl Arg {
                 None => None,
             },
             is_typescript_ctor_field: self.is_typescript_ctor_field,
-            ts_metadata: self.ts_metadata.clone(),
+            ts_metadata: self.ts_metadata,
         })
     }
 }

--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -224,7 +224,7 @@ impl Property {
                 Some(value) => Some(value.deep_clone(bump)?),
                 None => None,
             },
-            ts_metadata: self.ts_metadata,
+            ts_metadata: self.ts_metadata.deep_clone(bump),
         })
     }
 }
@@ -314,7 +314,7 @@ impl Fn {
             },
             arguments_ref: self.arguments_ref,
             flags: self.flags,
-            return_ts_metadata: self.return_ts_metadata,
+            return_ts_metadata: self.return_ts_metadata.deep_clone(bump),
         })
     }
 }
@@ -358,7 +358,7 @@ impl Arg {
                 None => None,
             },
             is_typescript_ctor_field: self.is_typescript_ctor_field,
-            ts_metadata: self.ts_metadata,
+            ts_metadata: self.ts_metadata.deep_clone(bump),
         })
     }
 }

--- a/src/ast/ts.rs
+++ b/src/ast/ts.rs
@@ -178,6 +178,17 @@ pub enum Metadata {
 impl Metadata {
     pub const DEFAULT: Self = Metadata::MNone;
 
+    /// Copy the `MDot` refs into `bump` so the clone outlives the source arena.
+    pub(crate) fn deep_clone(self, bump: &bun_alloc::Arena) -> Self {
+        match self {
+            Metadata::MDot(refs) => {
+                let copied: &mut [Ref] = bump.alloc_slice_copy(refs.slice());
+                Metadata::MDot(crate::nodes::StoreSlice::new_mut(copied))
+            }
+            other => other,
+        }
+    }
+
     // the logic in finish_union, merge_union, finish_intersection and merge_intersection is
     // translated from:
     // https://github.com/microsoft/TypeScript/blob/e0a324b0503be479f2b33fd2e17c6e86c94d1297/src/compiler/transformers/typeSerializer.ts#L402

--- a/src/ast/ts.rs
+++ b/src/ast/ts.rs
@@ -150,7 +150,7 @@ impl Data {
 // Data-only; the parser-state predicates that depend on `P` stay in
 // `bun_js_parser::typescript`.
 
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Default)]
 pub enum Metadata {
     #[default]
     MNone,
@@ -171,9 +171,9 @@ pub enum Metadata {
     MSymbol,
     MPromise,
     MIdentifier(Ref),
-    // A heap `Vec` is used here because `Metadata` is lifetime-free.
-    // Decorator metadata is rare and the lists are tiny.
-    MDot(Vec<Ref>),
+    /// "a.b.c": the refs of each part, arena-owned like the AST node that holds
+    /// the metadata, so nothing is left behind when the arena is reset.
+    MDot(crate::nodes::StoreSlice<Ref>),
 }
 
 impl Metadata {

--- a/src/ast/ts.rs
+++ b/src/ast/ts.rs
@@ -171,8 +171,7 @@ pub enum Metadata {
     MSymbol,
     MPromise,
     MIdentifier(Ref),
-    /// "a.b.c": the refs of each part, arena-owned like the AST node that holds
-    /// the metadata, so nothing is left behind when the arena is reset.
+    /// "a.b.c": one ref per part, arena-owned.
     MDot(crate::nodes::StoreSlice<Ref>),
 }
 

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -78,13 +78,7 @@ fn prop_copy(p: &Property) -> Property {
         ts_decorators: bun_alloc::AstAlloc::vec(),
         key: p.key,
         value: p.value,
-        // SAFETY: this duplicates ownership of any heap allocation inside
-        // `Metadata` (`MDot` owns a global-heap `Vec<Ref>`), but the source
-        // `Property` is an arena-resident AST node whose `Drop` never runs
-        // (AST stores are bulk-freed without dropping — see the
-        // `bun_alloc::ast_alloc` module docs), so at most one of the two
-        // copies ever reaches drop glue; no double free.
-        ts_metadata: unsafe { core::ptr::read(&raw const p.ts_metadata) },
+        ts_metadata: p.ts_metadata,
     }
 }
 
@@ -103,8 +97,7 @@ fn prop_full_copy(p: &Property) -> Property {
         ts_decorators,
         key: p.key,
         value: p.value,
-        // SAFETY: see `prop_copy`.
-        ts_metadata: unsafe { core::ptr::read(&raw const p.ts_metadata) },
+        ts_metadata: p.ts_metadata,
     }
 }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8076,12 +8076,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 _ => return None,
             }
         }
-        let map: &js_ast::TSNamespaceMemberMap = &members;
-        // A namespace has no enum members, so an empty map is a namespace.
-        if map.count() == 0 {
-            return None;
-        }
-        Self::enum_members_metadata(map)
+        Self::enum_members_metadata(&members)
     }
 
     /// Re-resolve the name from the class scope like `visit_expr`, then follow symbol links.
@@ -8104,19 +8099,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// A computed member (`A = f()`) counts as a number, the only type tsc allows there.
+    /// A namespace merged into the enum adds `Property` entries that do not count.
+    /// A map with no enum members and some other entry is a plain namespace.
     fn enum_members_metadata(
         members: &js_ast::TSNamespaceMemberMap,
     ) -> Option<bun_ast::ts::Metadata> {
         let mut has_number = false;
         let mut has_string = false;
+        let mut has_other = false;
         for member in members.values() {
             match member.data {
                 js_ast::ts::Data::EnumNumber(_) | js_ast::ts::Data::EnumProperty => {
                     has_number = true
                 }
                 js_ast::ts::Data::EnumString(_) => has_string = true,
-                js_ast::ts::Data::Property | js_ast::ts::Data::Namespace(_) => return None,
+                js_ast::ts::Data::Property | js_ast::ts::Data::Namespace(_) => has_other = true,
             }
+        }
+        if has_other && !has_number && !has_string {
+            return None;
         }
         Some(if has_string && has_number {
             bun_ast::ts::Metadata::MObject

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8098,9 +8098,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Some(ref_)
     }
 
-    /// A computed member (`A = f()`) counts as a number, the only type tsc allows there.
-    /// A namespace merged into the enum adds `Property` entries that do not count.
-    /// A map with no enum members and some other entry is a plain namespace.
+    /// Computed members count as numbers (tsc allows no other), merged namespace entries do not.
     fn enum_members_metadata(
         members: &js_ast::TSNamespaceMemberMap,
     ) -> Option<bun_ast::ts::Metadata> {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8076,7 +8076,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 _ => return None,
             }
         }
-        Self::enum_members_metadata(&members)
+        // An empty map is an empty enum or an empty namespace. Only the enum is `Number`.
+        let map: &js_ast::TSNamespaceMemberMap = &members;
+        if map.count() == 0 {
+            let is_enum = self.ts_namespace_scopes.iter().any(|scope| {
+                scope.is_enum_scope
+                    && core::ptr::eq::<js_ast::TSNamespaceMemberMap>(
+                        scope.exported_members.get(),
+                        map,
+                    )
+            });
+            return is_enum.then_some(bun_ast::ts::Metadata::MNumber);
+        }
+        Self::enum_members_metadata(map)
     }
 
     /// Re-resolve the name from the class scope like `visit_expr`, then follow symbol links.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7643,7 +7643,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     .alloc_slice_fill_default::<Expr>(constructor_args.len());
                                 for (i, ca) in constructor_args.iter().enumerate() {
                                     param_array[i] = self
-                                        .serialize_metadata(ca.ts_metadata.clone())
+                                        .serialize_metadata(ca.ts_metadata)
                                         .expect("unreachable");
                                 }
                                 let items = ExprNodeList::from_arena_slice(param_array);
@@ -7735,7 +7735,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 {
                     // design:type
                     let v = self
-                        .serialize_metadata(prop.ts_metadata.clone())
+                        .serialize_metadata(prop.ts_metadata)
                         .expect("unreachable");
                     push_metadata!(b"design:type", v);
                 }
@@ -7754,7 +7754,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 .alloc_slice_fill_default::<Expr>(method_args.len());
                             for (entry, method_arg) in args_array.iter_mut().zip(method_args) {
                                 *entry = self
-                                    .serialize_metadata(method_arg.ts_metadata.clone())
+                                    .serialize_metadata(method_arg.ts_metadata)
                                     .expect("unreachable");
                             }
                             let items = ExprNodeList::from_arena_slice(args_array);
@@ -7769,7 +7769,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         {
                             let v = self
-                                .serialize_metadata(func.func.return_ts_metadata.clone())
+                                .serialize_metadata(func.func.return_ts_metadata)
                                 .expect("unreachable");
                             push_metadata!(b"design:returntype", v);
                         }
@@ -7786,7 +7786,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             .expect("infallible: variant checked");
                         {
                             let v = self
-                                .serialize_metadata(func.func.return_ts_metadata.clone())
+                                .serialize_metadata(func.func.return_ts_metadata)
                                 .expect("unreachable");
                             push_metadata!(b"design:type", v);
                         }
@@ -7821,7 +7821,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 .alloc_slice_fill_default::<Expr>(method_args.len());
                             for (entry, method_arg) in args_array.iter_mut().zip(method_args) {
                                 *entry = self
-                                    .serialize_metadata(method_arg.ts_metadata.clone())
+                                    .serialize_metadata(method_arg.ts_metadata)
                                     .expect("unreachable");
                             }
                             let items = ExprNodeList::from_arena_slice(args_array);
@@ -7836,7 +7836,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         if !method_args.is_empty() {
                             let v = self
-                                .serialize_metadata(method_args[0].ts_metadata.clone())
+                                .serialize_metadata(method_args[0].ts_metadata)
                                 .expect("unreachable");
                             push_metadata!(b"design:type", v);
                         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8040,9 +8040,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         })
     }
 
-    /// `design:type` for a type annotation that names a same-file enum. TypeScript
-    /// serializes a numeric enum as `Number`, a string enum as `String`, and a
-    /// mixed one as `Object` instead of referencing the enum object.
+    /// tsc serializes an enum type as `Number`, `String`, or `Object`, never as the enum object.
     fn ts_enum_metadata(&mut self, ref_: Ref) -> Option<bun_ast::ts::Metadata> {
         let ref_ = self.resolve_metadata_ref(ref_)?;
         if self.symbols[ref_.inner_index() as usize].kind != js_ast::symbol::Kind::TsEnum {
@@ -8055,8 +8053,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Self::enum_members_metadata(members)
     }
 
-    /// Same as `ts_enum_metadata` for a dotted type `Ns.Inner.Enum`, or for an
-    /// enum member type `Enum.Member`.
+    /// `ts_enum_metadata` for `Ns.Inner.Enum` and for a member type `Enum.Member`.
     fn ts_namespace_enum_metadata(&mut self, refs: &[Ref]) -> Option<bun_ast::ts::Metadata> {
         let root = self.resolve_metadata_ref(refs[0])?;
         let js_ast::ts::Data::Namespace(mut members) =
@@ -8087,9 +8084,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Self::enum_members_metadata(map)
     }
 
-    /// The parse pass bound the type name before a later declaration in the same
-    /// scope could exist, so look the name up again from the class being visited,
-    /// as the visit pass does for identifiers. Then follow merged symbol links.
+    /// Re-resolve the name from the class scope, as `visit_expr` does: the parse
+    /// pass bound it before a later declaration in a nested scope existed.
     fn resolve_metadata_ref(&mut self, ref_: Ref) -> Option<Ref> {
         if ref_.tag() != js_ast::base::RefTag::Symbol {
             return None;
@@ -8108,8 +8104,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Some(ref_)
     }
 
-    /// A member without a literal value (`A = f()`) counts as a number. TypeScript
-    /// only allows computed enum values that are numbers.
+    /// A computed member (`A = f()`) counts as a number, the only type tsc allows there.
     fn enum_members_metadata(
         members: &js_ast::TSNamespaceMemberMap,
     ) -> Option<bun_ast::ts::Metadata> {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8084,8 +8084,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Self::enum_members_metadata(map)
     }
 
-    /// Re-resolve the name from the class scope, as `visit_expr` does: the parse
-    /// pass bound it before a later declaration in a nested scope existed.
+    /// Re-resolve the name from the class scope like `visit_expr`, then follow symbol links.
     fn resolve_metadata_ref(&mut self, ref_: Ref) -> Option<Ref> {
         if ref_.tag() != js_ast::base::RefTag::Symbol {
             return None;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7883,6 +7883,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             M::MPromise => ident!(b"Promise"),
             M::MIdentifier(ref_) => {
+                if let Some(enum_metadata) = self.ts_enum_metadata(ref_) {
+                    return self.serialize_metadata(enum_metadata);
+                }
                 self.record_usage(ref_);
                 let e = if self.is_import_item.contains_key(&ref_) {
                     self.new_expr(
@@ -7899,6 +7902,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             M::MDot(refs) => {
                 debug_assert!(refs.len() >= 2);
+                if let Some(enum_metadata) = self.ts_namespace_enum_metadata(&refs) {
+                    return self.serialize_metadata(enum_metadata);
+                }
                 // (refs.deinit(p.arena) — arena-backed; nothing to free in Rust)
 
                 macro_rules! ref_name {
@@ -8031,6 +8037,99 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 return Ok(root);
             }
+        })
+    }
+
+    /// `design:type` for a type annotation that names a same-file enum. TypeScript
+    /// serializes a numeric enum as `Number`, a string enum as `String`, and a
+    /// mixed one as `Object` instead of referencing the enum object.
+    fn ts_enum_metadata(&mut self, ref_: Ref) -> Option<bun_ast::ts::Metadata> {
+        let ref_ = self.resolve_metadata_ref(ref_)?;
+        if self.symbols[ref_.inner_index() as usize].kind != js_ast::symbol::Kind::TsEnum {
+            return None;
+        }
+        let js_ast::ts::Data::Namespace(members) = self.ref_to_ts_namespace_member.get(&ref_)?
+        else {
+            return None;
+        };
+        Self::enum_members_metadata(members)
+    }
+
+    /// Same as `ts_enum_metadata` for a dotted type `Ns.Inner.Enum`, or for an
+    /// enum member type `Enum.Member`.
+    fn ts_namespace_enum_metadata(&mut self, refs: &[Ref]) -> Option<bun_ast::ts::Metadata> {
+        let root = self.resolve_metadata_ref(refs[0])?;
+        let js_ast::ts::Data::Namespace(mut members) =
+            *self.ref_to_ts_namespace_member.get(&root)?
+        else {
+            return None;
+        };
+        for (i, &part) in refs[1..].iter().enumerate() {
+            let is_last = i + 2 == refs.len();
+            let name = self.load_name_from_ref(part);
+            let map: &js_ast::TSNamespaceMemberMap = &members;
+            match map.get(name)?.data {
+                js_ast::ts::Data::Namespace(next) => members = next,
+                js_ast::ts::Data::EnumNumber(_) | js_ast::ts::Data::EnumProperty if is_last => {
+                    return Some(bun_ast::ts::Metadata::MNumber);
+                }
+                js_ast::ts::Data::EnumString(_) if is_last => {
+                    return Some(bun_ast::ts::Metadata::MString);
+                }
+                _ => return None,
+            }
+        }
+        let map: &js_ast::TSNamespaceMemberMap = &members;
+        // A namespace has no enum members, so an empty map is a namespace.
+        if map.count() == 0 {
+            return None;
+        }
+        Self::enum_members_metadata(map)
+    }
+
+    /// The parse pass bound the type name before a later declaration in the same
+    /// scope could exist, so look the name up again from the class being visited,
+    /// as the visit pass does for identifiers. Then follow merged symbol links.
+    fn resolve_metadata_ref(&mut self, ref_: Ref) -> Option<Ref> {
+        if ref_.tag() != js_ast::base::RefTag::Symbol {
+            return None;
+        }
+        let name = self.load_name_from_ref(ref_);
+        let found = self
+            .find_symbol_with_record_usage::<false>(bun_ast::Loc::EMPTY, name)
+            .ok()?
+            .r#ref;
+        let mut ref_ = if found.is_empty() { ref_ } else { found };
+        let mut symbol = &self.symbols[ref_.inner_index() as usize];
+        while symbol.has_link() {
+            ref_ = symbol.link.get();
+            symbol = &self.symbols[ref_.inner_index() as usize];
+        }
+        Some(ref_)
+    }
+
+    /// A member without a literal value (`A = f()`) counts as a number. TypeScript
+    /// only allows computed enum values that are numbers.
+    fn enum_members_metadata(
+        members: &js_ast::TSNamespaceMemberMap,
+    ) -> Option<bun_ast::ts::Metadata> {
+        let mut has_number = false;
+        let mut has_string = false;
+        for member in members.values() {
+            match member.data {
+                js_ast::ts::Data::EnumNumber(_) | js_ast::ts::Data::EnumProperty => {
+                    has_number = true
+                }
+                js_ast::ts::Data::EnumString(_) => has_string = true,
+                js_ast::ts::Data::Property | js_ast::ts::Data::Namespace(_) => return None,
+            }
+        }
+        Some(if has_string && has_number {
+            bun_ast::ts::Metadata::MObject
+        } else if has_string {
+            bun_ast::ts::Metadata::MString
+        } else {
+            bun_ast::ts::Metadata::MNumber
         })
     }
 

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -251,8 +251,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Err(crate::Error::StackOverflow);
         }
 
-        // The refs of a qualified name ("a.b.c") gathered across the `.` suffixes below.
-        // `ManuallyDrop` leaves the buffer in the arena, since `Metadata::MDot` points at it.
+        // Refs of a qualified name ("a.b.c"); `ManuallyDrop` keeps the buffer `MDot` points at.
         let mut dot_path: Option<core::mem::ManuallyDrop<bun_alloc::ArenaVec<'a, Ref>>> = None;
 
         loop {

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -251,6 +251,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Err(crate::Error::StackOverflow);
         }
 
+        // The refs of a qualified name ("a.b.c") gathered across the `.` suffixes below.
+        // `ManuallyDrop` leaves the buffer in the arena, since `Metadata::MDot` points at it.
+        let mut dot_path: Option<core::mem::ManuallyDrop<bun_alloc::ArenaVec<'a, Ref>>> = None;
+
         loop {
             match self.lexer.token {
                 T::TNumericLiteral => {
@@ -902,29 +906,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let r = result
                             .as_deref_mut()
                             .expect("infallible: GET_METADATA implies Some");
-                        match r {
+                        // `Metadata` is `Copy`; `head` borrows the arena, not `r`.
+                        let (head, extends_path): (Option<&[Ref]>, bool) = match *r {
                             Metadata::MIdentifier(id_ref) => {
-                                let id_ref = *id_ref;
-                                let find_result = self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
-                                let dot: &mut [Ref] =
-                                    self.arena.alloc_slice_copy(&[id_ref, find_result.r#ref]);
-                                *r = Metadata::MDot(bun_ast::StoreSlice::new_mut(dot));
+                                (Some(self.arena.alloc_slice_copy(&[id_ref])), false)
                             }
-                            Metadata::MDot(dot) => {
-                                if self.lexer.is_identifier_or_keyword() {
-                                    let find_result =
-                                        self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
-                                    let old: &[Ref] = dot.slice();
-                                    let mut grown = bun_alloc::ArenaVec::<Ref>::with_capacity_in(
-                                        old.len() + 1,
+                            Metadata::MDot(dot) if self.lexer.is_identifier_or_keyword() => {
+                                (Some(dot.slice()), true)
+                            }
+                            _ => (None, false),
+                        };
+                        if let Some(head) = head {
+                            let find_result = self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
+                            // A path that came from a nested type (`(a.b).c`) starts a new vec.
+                            let path = match &mut dot_path {
+                                Some(path) if extends_path => path,
+                                slot => {
+                                    let mut path = bun_alloc::ArenaVec::<Ref>::with_capacity_in(
+                                        (head.len() + 1).max(4),
                                         self.arena,
                                     );
-                                    grown.extend_from_slice(old);
-                                    grown.push(find_result.r#ref);
-                                    *r = Metadata::MDot(bun_ast::StoreSlice::from_bump(grown));
+                                    path.extend_from_slice(head);
+                                    slot.insert(core::mem::ManuallyDrop::new(path))
                                 }
-                            }
-                            _ => {}
+                            };
+                            path.push(find_result.r#ref);
+                            *r = Metadata::MDot(bun_ast::StoreSlice::new_mut(path.as_mut_slice()));
                         }
                     }
 

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -797,10 +797,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.lexer.next()?;
 
                     if GET_METADATA {
-                        let mut left = (**result
+                        let mut left = **result
                             .as_mut()
-                            .expect("infallible: GET_METADATA implies Some"))
-                        .clone();
+                            .expect("infallible: GET_METADATA implies Some");
                         if let Some(final_) =
                             Metadata::finish_union(&mut left, |r| self.load_name_from_ref(r))
                         {
@@ -842,10 +841,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.lexer.next()?;
 
                     if GET_METADATA {
-                        let mut left = (**result
+                        let mut left = **result
                             .as_mut()
-                            .expect("infallible: GET_METADATA implies Some"))
-                        .clone();
+                            .expect("infallible: GET_METADATA implies Some");
                         if let Some(final_) =
                             Metadata::finish_intersection(&mut left, |r| self.load_name_from_ref(r))
                         {
@@ -907,17 +905,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         match r {
                             Metadata::MIdentifier(id_ref) => {
                                 let id_ref = *id_ref;
-                                let mut dot: Vec<Ref> = Vec::with_capacity(2);
-                                dot.push(id_ref);
                                 let find_result = self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
-                                dot.push(find_result.r#ref);
-                                *r = Metadata::MDot(dot);
+                                let dot: &mut [Ref] =
+                                    self.arena.alloc_slice_copy(&[id_ref, find_result.r#ref]);
+                                *r = Metadata::MDot(bun_ast::StoreSlice::new_mut(dot));
                             }
                             Metadata::MDot(dot) => {
                                 if self.lexer.is_identifier_or_keyword() {
                                     let find_result =
                                         self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
-                                    dot.push(find_result.r#ref);
+                                    let old: &[Ref] = dot.slice();
+                                    let mut grown = bun_alloc::ArenaVec::<Ref>::with_capacity_in(
+                                        old.len() + 1,
+                                        self.arena,
+                                    );
+                                    grown.extend_from_slice(old);
+                                    grown.push(find_result.r#ref);
+                                    *r = Metadata::MDot(bun_ast::StoreSlice::from_bump(grown));
                                 }
                             }
                             _ => {}

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -661,13 +661,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             let value_name = value.name;
             let value_loc = value.loc;
+            // A literal value is known now. The visit pass fills in the rest, but
+            // decorator metadata can read this map before the enum is visited.
+            let data = match value.value.map(|v| v.data) {
+                Some(js_ast::ExprData::ENumber(num)) => {
+                    TSNamespaceMemberData::EnumNumber(num.value())
+                }
+                Some(js_ast::ExprData::EString(str_)) => TSNamespaceMemberData::EnumString(str_),
+                _ => TSNamespaceMemberData::EnumProperty,
+            };
             values.push(value);
 
             exported_members.put(
                 value_name.slice(),
                 TSNamespaceMember {
                     loc: value_loc,
-                    data: TSNamespaceMemberData::EnumProperty,
+                    data,
                 },
             )?;
 

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -661,8 +661,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             let value_name = value.name;
             let value_loc = value.loc;
-            // A literal value is known now. The visit pass fills in the rest, but
-            // decorator metadata can read this map before the enum is visited.
+            // Decorator metadata can read this map before the visit pass fills it in.
             let data = match value.value.map(|v| v.data) {
                 Some(js_ast::ExprData::ENumber(num)) => {
                     TSNamespaceMemberData::EnumNumber(num.value())

--- a/test/bundler/transpiler/decorator-metadata.test.ts
+++ b/test/bundler/transpiler/decorator-metadata.test.ts
@@ -1,5 +1,16 @@
 import "reflect-metadata";
 
+namespace MetadataNs {
+  export enum Inner {
+    X,
+  }
+  export namespace Deep {
+    export enum Inner {
+      S = "s",
+    }
+  }
+}
+
 describe("decorator metadata", () => {
   test("type serialization", () => {
     function d1() {}
@@ -542,5 +553,134 @@ describe("decorator metadata", () => {
     expect(Reflect.getMetadata("design:paramtypes", A.prototype, "method4")[0]).toBe(Object);
     expect(Reflect.getMetadata("design:type", A.prototype, "method4")).toBe(Function);
     expect(Reflect.getMetadata("design:returntype", A.prototype, "method4")).toBeUndefined();
+  });
+
+  // tsc serializes an enum type as Number, String, or Object, never as the enum object.
+  test("enum types", () => {
+    function d2(target: any, key: string) {}
+
+    class Declared {
+      @d2
+      later: Later;
+      @d2
+      laterString: LaterString;
+      @d2
+      laterAlias: LaterAlias;
+    }
+
+    enum Later {
+      A,
+      B,
+    }
+    enum LaterString {
+      A = "a",
+    }
+    enum LaterAlias {
+      A = "a",
+      B = A,
+    }
+    enum Numeric {
+      A,
+      B = 5,
+      C = A + B,
+    }
+    enum Str {
+      A = "a",
+      B = "b",
+    }
+    enum Mixed {
+      A = 1,
+      B = "b",
+    }
+    const enum Const {
+      X,
+      Y,
+    }
+    enum Computed {
+      A = (1 + 1) * 2,
+      B = Math.max(1, 2),
+    }
+    enum Merged {
+      A,
+    }
+    enum Merged {
+      B = "b",
+    }
+
+    class A {
+      @d2
+      numeric: Numeric;
+      @d2
+      str: Str;
+      @d2
+      mixed: Mixed;
+      @d2
+      constEnum: Const;
+      @d2
+      computed: Computed;
+      @d2
+      merged: Merged;
+      @d2
+      nullable: Numeric | null;
+      @d2
+      optional?: Str;
+      @d2
+      array: Numeric[];
+      @d2
+      nsInner: MetadataNs.Inner;
+      @d2
+      nsDeep: MetadataNs.Deep.Inner;
+      @d2
+      ns: typeof MetadataNs;
+      @d2
+      member: Numeric.B;
+      @d2
+      strMember: Str.A;
+      @d2
+      nsMember: MetadataNs.Deep.Inner.S;
+
+      @d2
+      method(a: Numeric, b: Str = Str.A, c: Mixed, ...rest: Numeric[]): Numeric {
+        return Numeric.A;
+      }
+    }
+
+    const type = (target: any, key: string) => Reflect.getMetadata("design:type", target, key);
+
+    expect(type(A.prototype, "numeric")).toBe(Number);
+    expect(type(A.prototype, "str")).toBe(String);
+    expect(type(A.prototype, "mixed")).toBe(Object);
+    expect(type(A.prototype, "constEnum")).toBe(Number);
+    expect(type(A.prototype, "computed")).toBe(Number);
+    expect(type(A.prototype, "merged")).toBe(Object);
+    expect(type(A.prototype, "nullable")).toBe(Number);
+    expect(type(A.prototype, "optional")).toBe(String);
+    expect(type(A.prototype, "array")).toBe(Array);
+    expect(type(A.prototype, "nsInner")).toBe(Number);
+    expect(type(A.prototype, "nsDeep")).toBe(String);
+    expect(type(A.prototype, "ns")).toBe(Object);
+    expect(type(A.prototype, "member")).toBe(Number);
+    expect(type(A.prototype, "strMember")).toBe(String);
+    expect(type(A.prototype, "nsMember")).toBe(String);
+
+    expect(Reflect.getMetadata("design:paramtypes", A.prototype, "method")).toEqual([Number, String, Object, Array]);
+    expect(Reflect.getMetadata("design:returntype", A.prototype, "method")).toBe(Number);
+
+    expect(type(Declared.prototype, "later")).toBe(Number);
+    expect(type(Declared.prototype, "laterString")).toBe(String);
+    expect(type(Declared.prototype, "laterAlias")).toBe(String);
+  });
+
+  // Unions are folded while the type is parsed, before the enum can be classified.
+  test.todo("enum in a union with its own primitive", () => {
+    function d2(target: any, key: string) {}
+    enum Numeric {
+      A,
+    }
+    class A {
+      @d2
+      value: Numeric | number;
+    }
+    expect(Reflect.getMetadata("design:type", A.prototype, "value")).toBe(Number);
   });
 });

--- a/test/bundler/transpiler/decorator-metadata.test.ts
+++ b/test/bundler/transpiler/decorator-metadata.test.ts
@@ -10,7 +10,11 @@ namespace MetadataNs {
     }
   }
   export enum Empty {}
+  export namespace EmptyNs {
+    init();
+  }
 }
+function init() {}
 
 enum WithHelpers {
   A,
@@ -642,6 +646,8 @@ describe("decorator metadata", () => {
       @d2
       nsEmpty: MetadataNs.Empty;
       @d2
+      nsEmptyNs: MetadataNs.EmptyNs;
+      @d2
       nullable: Numeric | null;
       @d2
       optional?: Str;
@@ -677,6 +683,8 @@ describe("decorator metadata", () => {
     expect(type(A.prototype, "withHelpers")).toBe(Number);
     expect(type(A.prototype, "empty")).toBe(Number);
     expect(type(A.prototype, "nsEmpty")).toBe(Number);
+    // an empty namespace is not a type in tsc; bun keeps the namespace object like before
+    expect(type(A.prototype, "nsEmptyNs")).toBe(MetadataNs.EmptyNs);
     expect(type(A.prototype, "nullable")).toBe(Number);
     expect(type(A.prototype, "optional")).toBe(String);
     expect(type(A.prototype, "array")).toBe(Array);

--- a/test/bundler/transpiler/decorator-metadata.test.ts
+++ b/test/bundler/transpiler/decorator-metadata.test.ts
@@ -9,6 +9,16 @@ namespace MetadataNs {
       S = "s",
     }
   }
+  export enum Empty {}
+}
+
+enum WithHelpers {
+  A,
+}
+namespace WithHelpers {
+  export function from(value: number) {
+    return value;
+  }
 }
 
 describe("decorator metadata", () => {
@@ -566,6 +576,10 @@ describe("decorator metadata", () => {
       laterString: LaterString;
       @d2
       laterAlias: LaterAlias;
+      @d2
+      laterNested: LaterNs.Str;
+      @d2
+      laterNestedMember: LaterNs.Str.A;
     }
 
     enum Later {
@@ -606,6 +620,7 @@ describe("decorator metadata", () => {
     enum Merged {
       B = "b",
     }
+    enum Empty {}
 
     class A {
       @d2
@@ -620,6 +635,12 @@ describe("decorator metadata", () => {
       computed: Computed;
       @d2
       merged: Merged;
+      @d2
+      withHelpers: WithHelpers;
+      @d2
+      empty: Empty;
+      @d2
+      nsEmpty: MetadataNs.Empty;
       @d2
       nullable: Numeric | null;
       @d2
@@ -653,6 +674,9 @@ describe("decorator metadata", () => {
     expect(type(A.prototype, "constEnum")).toBe(Number);
     expect(type(A.prototype, "computed")).toBe(Number);
     expect(type(A.prototype, "merged")).toBe(Object);
+    expect(type(A.prototype, "withHelpers")).toBe(Number);
+    expect(type(A.prototype, "empty")).toBe(Number);
+    expect(type(A.prototype, "nsEmpty")).toBe(Number);
     expect(type(A.prototype, "nullable")).toBe(Number);
     expect(type(A.prototype, "optional")).toBe(String);
     expect(type(A.prototype, "array")).toBe(Array);
@@ -669,6 +693,8 @@ describe("decorator metadata", () => {
     expect(type(Declared.prototype, "later")).toBe(Number);
     expect(type(Declared.prototype, "laterString")).toBe(String);
     expect(type(Declared.prototype, "laterAlias")).toBe(String);
+    expect(type(Declared.prototype, "laterNested")).toBe(String);
+    expect(type(Declared.prototype, "laterNestedMember")).toBe(String);
   });
 
   // Unions are folded while the type is parsed, before the enum can be classified.
@@ -684,3 +710,10 @@ describe("decorator metadata", () => {
     expect(Reflect.getMetadata("design:type", A.prototype, "value")).toBe(Number);
   });
 });
+
+// Declared after the classes above so the enum is not visited yet when they are lowered.
+namespace LaterNs {
+  export enum Str {
+    A = "a",
+  }
+}

--- a/test/integration/typegraphql/src/typegraphql.test.ts
+++ b/test/integration/typegraphql/src/typegraphql.test.ts
@@ -56,5 +56,6 @@ test("correct reflect.metadata types for getters", () => {
   // is manually specified.
   expect(Reflect.getMetadata("design:type", User.prototype, "enum1")).toBe(Enum1);
   expect(Reflect.getMetadata("design:type", User.prototype, "enum2")).toBe(Enum2);
-  expect(Reflect.getMetadata("design:type", User.prototype, "enum3")).toBe(Enum3);
+  // an enum declared in the same file is classified like typescript does
+  expect(Reflect.getMetadata("design:type", User.prototype, "enum3")).toBe(String);
 });


### PR DESCRIPTION
### Problem
- With `experimentalDecorators` and `emitDecoratorMetadata`, a decorated member typed with an enum gets the enum object as `design:type`. The emitted metadata is `typeof Color === "undefined" ? Object : Color`. tsc emits `Number` for a numeric enum, `String` for a string enum, and `Object` for a mixed one.
- Libraries such as TypeORM, class-transformer and NestJS call `new (Reflect.getMetadata("design:type", ...))()` or switch on the constructor. They receive a plain object that is not callable.
- `serialize_metadata` (`src/js_parser/p.rs`) only had the identifier path. #5777 mapped a known enum to `Number`. #12144 (enum inlining) dropped that branch.

### Fix
- When the type names an enum that the parser knows (declared in the same file, including `const enum`, merged enums, an enum merged with a namespace, an empty enum, forward declarations, `Ns.Deep.Enum`, and the member type `Enum.Member`), classify it from the member values: all numbers give `Number`, all strings give `String`, both give `Object`. A computed member counts as a number, which is the only type tsc allows there.
- The lookup runs when the class is lowered. The parser now records a literal initializer in the member map as it parses the enum, so an enum that is visited after the class (for example inside a later `namespace`) still classifies. The name is looked up again from the class scope, as the visit pass does for identifiers, so a later declaration in a function body resolves too.
- `Metadata::MDot` held a heap `Vec<Ref>` inside arena-owned AST nodes, and the arena reset never dropped it. ASAN reported the leak for every dotted type annotation (`Ns.Inner`) once the new test used one. The refs now live in the arena as a `StoreSlice<Ref>`, so `Metadata` is `Copy` and the clones and the `ptr::read` copies go away.
- An enum imported from another file is unchanged. The parser cannot see its members. `Enum | number` still folds to `Object` at parse time (a `test.todo` records it).
- Verified: `test/bundler/transpiler/decorator-metadata.test.ts` (new `enum types` block, fails on 1.4.3). Expected values checked against tsc 6.0.2 emit. Also `test/bundler/transpiler/`, `test/bundler/bundler_decorator_metadata.test.ts`, `test/js/bun/typescript/`, and `test/integration/typegraphql/`, whose same-file enum assertion now expects `String`.

### Background
- `emitDecoratorMetadata` makes the transpiler attach `design:type`, `design:paramtypes` and `design:returntype` to decorated members. tsc computes them with its type checker. bun computes them from the syntax of the type annotation.
- The parser keeps enum members in `ref_to_ts_namespace_member`: the enum symbol maps to a member map, and each member is `EnumNumber`, `EnumString`, or `EnumProperty` (a computed value). The enum inliner uses the same map.
- Self-reviewed: 4 concerns raised, 4 addressed (the typegraphql pin, `Enum.Member` types, the rest-parameter assertion, the PR body). Review on the PR raised 3 more (a late namespace-nested enum, an enum merged with a namespace, an empty nested enum), all addressed.

<details><summary>Notes</summary>

Repro from the report (`bun main.ts` with `experimentalDecorators`, `emitDecoratorMetadata`):

```ts
enum Color { Red, Green }
(Reflect as any).metadata = (k: string, v: any) => (t: any, p: any) => {
  if (k === "design:type") console.log(p, typeof v, v === Color ? "the enum object" : v?.name);
};
const Prop: any = () => {};
class Dto { @Prop c: Color; @Prop n: number; }
```

bun 1.4.3: `c object the enum object`. tsc 6.0.2 + node, and bun with this change: `c function Number`.

Oracle for the new test block: tsc 6.0.2 with `strict: false`. tsc 6.0 turns `strict` on by default, and with `strictNullChecks` it serializes `Enum | null` as `Object`. bun follows the non-strict rule for every `T | null` union already (`string | null` is `String` in the existing test), so the new test expects `Number` for `Numeric | null`.

Cases checked against tsc: numeric, string, mixed, `const enum`, computed members (`(1 + 1) * 2`, `Math.max(1, 2)`), `B = A` aliases, two merged blocks, an enum declared after the class in the same function, `Ns.Inner`, `Ns.Deep.Inner`, `typeof Ns`, `Enum.Member`, `Ns.Deep.Inner.S`, parameter and return types.

Known gap kept out of scope: `Enum | number` and `Enum | string` give `Object`, tsc gives the primitive. Union folding happens while the type annotation is parsed, before the enum can be resolved.

The typegraphql integration test pinned `design:type` for a same-file enum to the enum object under a comment about imported enums. The imported cases stay as they were. The same-file case now expects `String`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/decorator-metadata.test.ts test/integration/typegraphql/src/typegraphql.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/decorator-metadata.test.ts:
(pass) decorator metadata > type serialization [127.25ms]
(pass) decorator metadata > design: type, paramtypes, returntype [36.93ms]
(pass) decorator metadata > class with only constructor argument decorators [6.88ms]
(pass) decorator metadata > more types [11.29ms]
(pass) decorator metadata > rest parameters and defaults [19.79ms]
559 |   test("enum types", () => {
560 |     function d2(target: any, key: string) {}
561 | 
562 |     class Declared {
563 |       @d2
564 |       later: Later;
            ^
ReferenceError: Cannot access 'Later' before initialization.
      at <anonymous> (/workspace/bun/test/bundler/transpiler/decorator-metadata.test.ts:564:7)
(fail) decorator metadata > enum types [21.33ms]
(todo) decorator metadata > enum in a union with its own primitive

test/integration/typegraphql/src/typegraphql.test.ts:
before run
55 |   // know that
... (truncated)

release without fix: 2 failed, 1 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/transpiler/decorator-metadata.test.ts:
(pass) decorator metadata > type serialization [1.21ms]
(pass) decorator metadata > design: type, paramtypes, returntype [0.46ms]
(pass) decorator metadata > class with only constructor argument decorators [0.08ms]
(pass) decorator metadata > more types [0.12ms]
(pass) decorator metadata > rest parameters and defaults [0.32ms]
559 |   test("enum types", () => {
560 |     function d2(target: any, key: string) {}
561 | 
562 |     class Declared {
563 |       @d2
564 |       later: Later;
            ^
ReferenceError: Cannot access 'Later' before initialization.
      at <anonymous> (/workspace/bun/test/bundler/transpiler/decorator-metadata.test.ts:564:7)
(fail) decorator metadata > enum types [0.43ms]
(todo) decorator metadata > enum in a union with its own primitive

test/integration/typegraphql/src/typegraphql.test.ts:
before run
55 |   // know that if the enum comes from an import statement. type-graphql doesn't care because the field type
56 |   // is manually specified.
57 |   expect(Reflect.getMetadata("design:type", User.prototype, "enum1")).toBe(Enum1);
58 |   expect(Refl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/decorator-metadata.test.ts test/integration/typegraphql/src/typegraphql.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/decorator-metadata.test.ts:
(pass) decorator metadata > type serialization [120.19ms]
(pass) decorator metadata > design: type, paramtypes, returntype [35.06ms]
(pass) decorator metadata > class with only constructor argument decorators [5.81ms]
(pass) decorator metadata > more types [11.60ms]
(pass) decorator metadata > rest parameters and defaults [20.53ms]
(pass) decorator metadata > enum types [42.37ms]
(todo) decorator metadata > enum in a union with its own primitive

test/integration/typegraphql/src/typegraphql.test.ts:
before run
(pass) correct reflect.metadata types for getters [6.67ms]

 7 pass
 1 todo
 0 fail
 254 expect() calls
Ran 8 tests across 2 files. [22.47s]
__F:0:S:1

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ab0b511666
  features     baseline

23 deps, 131 codegen, 1172 objects in 725ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [44.00ms]
[4/1244] gen .bind.ts → GeneratedBindings.cpp
[5/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch zlib
[zlib] up to date
[8/1217] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[9/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1217] fetch tinycc
[tinycc] up to date
[11/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/rele
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/g.rs                                       |   6 +-
 src/ast/ts.rs                                      |   7 +-
 src/js_parser/lower/lower_decorators.rs            |  11 +-
 src/js_parser/p.rs                                 | 107 ++++++++++++++--
 src/js_parser/parse/parse_skip_typescript.rs       |  26 ++--
 test/bundler/transpiler/decorator-metadata.test.ts | 140 +++++++++++++++++++++
 .../typegraphql/src/typegraphql.test.ts            |   3 +-
 7 files changed, 265 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/ast/g.rs                                              0      0     15
src/ast/ts.rs                                             0      0     15
src/js_parser/lower/lower_decorators.rs                   0      0     15
src/js_parser/p.rs                                        2     10     15
src/js_parser/parse/parse_skip_typescript.rs              1      0     15
test/bundler/transpiler/decorator-metadata.test.ts        1      2     14
test/integration/typegraphql/src/typegraphql.test.ts      0      0      3
```

</details>

<!-- robobun:evidence:end -->
