### PR TITLE
test: skip ASAN-gated Node tests on Bun's ASAN builds

### DIFF
--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -309,17 +309,20 @@ const isOpenBSD = process.platform === 'openbsd';
 const isLinux = process.platform === 'linux';
 const isMacOS = process.platform === 'darwin';
 // Bun: process.config.variables.asan is always 0 (node-gyp would otherwise
-// build addons with -fsanitize=address), so ask the runtime directly. The
-// binding is expose-internals-gated; fall back to the CI binary name.
-const isASan = process.config.variables.asan === 1 || bunIsASan();
-function bunIsASan() {
+// build addons with -fsanitize=address), so ask the runtime directly. Lazy,
+// because loading bun:internal-for-testing pulls in many internal modules.
+// The binding is expose-internals-gated; fall back to the CI binary name.
+let isASan;
+function getIsASan() {
+  if (isASan !== undefined) return isASan;
+  if (process.config.variables.asan === 1) return (isASan = true);
   try {
     const { isASANEnabled } = require('bun:internal-for-testing');
-    if (typeof isASANEnabled === 'function') return isASANEnabled();
+    if (typeof isASANEnabled === 'function') return (isASan = isASANEnabled());
   } catch {
     // gated in release builds without BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1
   }
-  return path.basename(process.execPath).includes('bun-asan');
+  return (isASan = path.basename(process.execPath).includes('bun-asan'));
 }
 const isRiscv64 = process.arch === 'riscv64';
 const isDebug = process.features.debug;
@@ -1235,7 +1238,9 @@ const common = {
   hasMultiLocalhost,
   invalidArgTypeHelper,
   isAlive,
-  isASan,
+  get isASan() {
+    return getIsASan();
+  },
   isDebug,
   isDumbTerminal,
   isFreeBSD,

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -308,7 +308,19 @@ const isFreeBSD = process.platform === 'freebsd';
 const isOpenBSD = process.platform === 'openbsd';
 const isLinux = process.platform === 'linux';
 const isMacOS = process.platform === 'darwin';
-const isASan = process.config.variables.asan === 1;
+// Bun: process.config.variables.asan is always 0 (node-gyp would otherwise
+// build addons with -fsanitize=address), so ask the runtime directly. The
+// binding is expose-internals-gated; fall back to the CI binary name.
+const isASan = process.config.variables.asan === 1 || bunIsASan();
+function bunIsASan() {
+  try {
+    const { isASANEnabled } = require('bun:internal-for-testing');
+    if (typeof isASANEnabled === 'function') return isASANEnabled();
+  } catch {
+    // gated in release builds without BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1
+  }
+  return path.basename(process.execPath).includes('bun-asan');
+}
 const isRiscv64 = process.arch === 'riscv64';
 const isDebug = process.features.debug;
 function isPi() {


### PR DESCRIPTION
### Problem
- `test/js/node/test/parallel/test-crypto-dh-leak.js` fails on the Debian 13 x64-asan lane with `AssertionError: before=276508672 after=299560960`. The test asserts RSS growth below 20 MB across 50k `setPublicKey` and `setPrivateKey` calls. Builds 110810 and 110828 both saw about 22 MB.
- The growth is the ASAN quarantine, not a leak. Each call frees the old BIGNUM through `DH_set0_key`, and ASAN keeps freed memory in quarantine instead of reusing it. Locally the same test shows 15 to 18 MB under `bun bd`, 7 MB with `ASAN_OPTIONS=quarantine_size_mb=1`, and 4 MB on a release build.
- Node skips this test under ASAN through `common.isASan`. Bun's `test/js/node/test/common/index.js:311` derives it from `process.config.variables.asan === 1`, and `BunProcess.cpp:2924` always reports 0 (a 1 makes node-gyp build addons with `-fsanitize=address`). So the skip never fired.

### Fix
- `common.isASan` is now a lazy getter. It asks the runtime through `isASANEnabled` from `bun:internal-for-testing`, the same probe `test/harness.ts` uses. The node test runner already sets `BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1`, and debug builds expose the module unconditionally. Without the module it falls back to the `bun-asan` binary name. The getter is lazy because loading `bun:internal-for-testing` evaluates about a dozen internal modules, and `require('../common')` must stay cheap for every vendored test.
- The release, musl, and Windows lanes still run the test, so the leak check is kept where RSS is meaningful.
- Two other vendored tests read `common.isASan`: `test-crypto-secure-heap.js` now skips under ASAN like Node, and `test-v8-serialize-leak.js` takes its ASAN branch with the same bound.
- Verified: `bun bd test/js/node/test/parallel/test-crypto-dh-leak.js` prints `1..0 # Skipped: ASan messes with memory measurements`. The release binary still runs the test and passes. `test-crypto-secure-heap.js`, `test-v8-serialize-leak.js`, and `test-crypto-dh-odd-key.js` pass under `bun bd`.

### Background
- The ASAN allocator puts freed blocks in a quarantine (256 MB by default) so later use-after-free is detected. RSS measured across many free calls therefore grows by about the freed bytes plus redzones, even with no leak.
- `bun:internal-for-testing` is a built-in module that is gated behind `BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1` in release builds. `isASANEnabled()` is a side-effect-free `#if ASAN_ENABLED` probe in `src/jsc/bindings/InternalForTesting.cpp`.
- No source change is involved. The test file is unchanged since #17850 and the DH code has not changed recently. The growth has always sat near the limit on the ASAN lane.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · no src or test change; test-proof not applicable

<!-- robobun:evidence:end -->
