### PR TITLE
Guard Expr::deep_clone against stack overflow on deeply nested define values

### DIFF
--- a/src/ast/error.rs
+++ b/src/ast/error.rs
@@ -26,3 +26,15 @@ impl bun_core::output::ErrName for Error {
 }
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+/// Why `Expr::deep_clone` could not copy a tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum DeepCloneError {
+    /// The tree is nested deeper than the native stack allows. The parsers
+    /// guard their own recursion, but their frames are smaller than the
+    /// clone's, so a tree they accept can still overflow here.
+    #[error("StackOverflow")]
+    StackOverflow,
+    #[error(transparent)]
+    Alloc(#[from] bun_alloc::AllocError),
+}

--- a/src/ast/error.rs
+++ b/src/ast/error.rs
@@ -30,9 +30,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 /// Why `Expr::deep_clone` could not copy a tree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum DeepCloneError {
-    /// The tree is nested deeper than the native stack allows. The parsers
-    /// guard their own recursion, but their frames are smaller than the
-    /// clone's, so a tree they accept can still overflow here.
+    /// The tree is nested deeper than the native stack allows.
     #[error("StackOverflow")]
     StackOverflow,
     #[error(transparent)]

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -112,15 +112,19 @@ impl Expr {
 }
 
 impl Expr {
-    pub fn deep_clone(&self, bump: &Bump) -> Result<Expr, AllocError> {
+    pub fn deep_clone(&self, bump: &Bump) -> Result<Expr, crate::DeepCloneError> {
         let _g = bun_alloc::ast_alloc::DetachAstHeap::new();
-        self.deep_clone_no_detach(bump)
+        self.deep_clone_no_detach(bump, bun_core::StackCheck::init())
     }
     #[inline]
-    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Expr, AllocError> {
+    pub(crate) fn deep_clone_no_detach(
+        &self,
+        bump: &Bump,
+        stack_check: bun_core::StackCheck,
+    ) -> Result<Expr, crate::DeepCloneError> {
         Ok(Expr {
             loc: self.loc,
-            data: self.data.deep_clone_no_detach(bump)?,
+            data: self.data.deep_clone_no_detach(bump, stack_check)?,
         })
     }
 
@@ -1812,7 +1816,8 @@ fn json_value_deep_clone(
     value: &E::JsonValue,
     loc: Loc,
     bump: &Bump,
-) -> Result<Expr, bun_alloc::AllocError> {
+    stack_check: bun_core::StackCheck,
+) -> Result<Expr, crate::DeepCloneError> {
     Ok(match value {
         E::JsonValue::String(s) => {
             let bytes: &[u8] = bump.alloc_slice_copy(s.slice());
@@ -1820,11 +1825,11 @@ fn json_value_deep_clone(
         }
         E::JsonValue::Object(o) => Expr {
             loc,
-            data: Data::EObjectJSON(*o).deep_clone_no_detach(bump)?,
+            data: Data::EObjectJSON(*o).deep_clone_no_detach(bump, stack_check)?,
         },
         E::JsonValue::Array(a) => Expr {
             loc,
-            data: Data::EArrayJSON(*a).deep_clone_no_detach(bump)?,
+            data: Data::EArrayJSON(*a).deep_clone_no_detach(bump, stack_check)?,
         },
         _ => Expr::from_json_value(value, loc),
     })
@@ -1863,18 +1868,25 @@ impl Data {
     /// those vecs land on global mimalloc. The guard is installed once here
     /// and at [`Expr::deep_clone`]; the recursive body goes through
     /// `*_no_detach` so we don't pay 3 TLS ops per node.
-    pub fn deep_clone(&self, bump: &Bump) -> Result<Data, AllocError> {
+    pub fn deep_clone(&self, bump: &Bump) -> Result<Data, crate::DeepCloneError> {
         let _g = bun_alloc::ast_alloc::DetachAstHeap::new();
-        self.deep_clone_no_detach(bump)
+        self.deep_clone_no_detach(bump, bun_core::StackCheck::init())
     }
 
-    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Data, AllocError> {
+    pub(crate) fn deep_clone_no_detach(
+        &self,
+        bump: &Bump,
+        stack_check: bun_core::StackCheck,
+    ) -> Result<Data, crate::DeepCloneError> {
+        if !stack_check.is_safe_to_recurse() {
+            return Err(crate::DeepCloneError::StackOverflow);
+        }
         let this = *self;
         match &this {
             Data::EArray(el) => {
                 let items = el
                     .items
-                    .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?;
+                    .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?;
                 let item = bump.alloc(E::Array {
                     items,
                     comma_after_spread: el.comma_after_spread,
@@ -1900,7 +1912,7 @@ impl Data {
                             E::EString::init(key_bytes),
                             row.key_loc,
                         )),
-                        value: Some(json_value_deep_clone(&row.value, value_loc, bump)?),
+                        value: Some(json_value_deep_clone(&row.value, value_loc, bump, stack_check)?),
                         kind: G::PropertyKind::Normal,
                         initializer: None,
                         ..Default::default()
@@ -1922,7 +1934,7 @@ impl Data {
                     Vec::with_capacity_in(rows.len(), bun_alloc::AstAlloc);
                 for (i, value) in rows.iter().enumerate() {
                     let loc = item_locs.map_or(crate::Loc::EMPTY, |l| l[i]);
-                    items.push(json_value_deep_clone(value, loc, bump)?);
+                    items.push(json_value_deep_clone(value, loc, bump, stack_check)?);
                 }
                 let item = bump.alloc(E::Array {
                     items,
@@ -1935,7 +1947,7 @@ impl Data {
             Data::EUnary(el) => {
                 let item = bump.alloc(E::Unary {
                     op: el.op,
-                    value: el.value.deep_clone_no_detach(bump)?,
+                    value: el.value.deep_clone_no_detach(bump, stack_check)?,
                     flags: el.flags,
                 });
                 Ok(Data::EUnary(StoreRef::from_bump(item)))
@@ -1943,8 +1955,8 @@ impl Data {
             Data::EBinary(el) => {
                 let item = bump.alloc(E::Binary {
                     op: el.op,
-                    left: el.left.deep_clone_no_detach(bump)?,
-                    right: el.right.deep_clone_no_detach(bump)?,
+                    left: el.left.deep_clone_no_detach(bump, stack_check)?,
+                    right: el.right.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::EBinary(StoreRef::from_bump(item)))
             }
@@ -1953,7 +1965,7 @@ impl Data {
                 let src_props: &[G::Property] = el.properties.slice();
                 let mut properties = bun_alloc::ArenaVec::with_capacity_in(src_props.len(), bump);
                 for prop in src_props.iter() {
-                    properties.push(prop.deep_clone(bump)?);
+                    properties.push(prop.deep_clone(bump, stack_check)?);
                 }
                 let properties = crate::StoreSlice::new_mut(properties.into_bump_slice_mut());
 
@@ -1961,10 +1973,10 @@ impl Data {
                     class_keyword: el.class_keyword,
                     ts_decorators: el
                         .ts_decorators
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     class_name: el.class_name,
                     extends: match &el.extends {
-                        Some(e) => Some(e.deep_clone_no_detach(bump)?),
+                        Some(e) => Some(e.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
                     body_loc: el.body_loc,
@@ -1977,10 +1989,10 @@ impl Data {
             }
             Data::ENew(el) => {
                 let item = bump.alloc(E::New {
-                    target: el.target.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
                     args: el
                         .args
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     can_be_unwrapped_if_unused: el.can_be_unwrapped_if_unused,
                     close_parens_loc: el.close_parens_loc,
                 });
@@ -1988,16 +2000,16 @@ impl Data {
             }
             Data::EFunction(el) => {
                 let item = bump.alloc(E::Function {
-                    func: el.func.deep_clone(bump)?,
+                    func: el.func.deep_clone(bump, stack_check)?,
                 });
                 Ok(Data::EFunction(StoreRef::from_bump(item)))
             }
             Data::ECall(el) => {
                 let item = bump.alloc(E::Call {
-                    target: el.target.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
                     args: el
                         .args
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     optional_chain: el.optional_chain,
                     is_direct_eval: el.is_direct_eval,
                     close_paren_loc: el.close_paren_loc,
@@ -2008,7 +2020,7 @@ impl Data {
             }
             Data::EDot(el) => {
                 let item = bump.alloc(E::Dot {
-                    target: el.target.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
                     name: el.name,
                     name_loc: el.name_loc,
                     optional_chain: el.optional_chain,
@@ -2020,8 +2032,8 @@ impl Data {
             }
             Data::EIndex(el) => {
                 let item = bump.alloc(E::Index {
-                    target: el.target.deep_clone_no_detach(bump)?,
-                    index: el.index.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
+                    index: el.index.deep_clone_no_detach(bump, stack_check)?,
                     optional_chain: el.optional_chain,
                     is_import_property_use: el.is_import_property_use,
                 });
@@ -2030,7 +2042,7 @@ impl Data {
             Data::EArrow(el) => {
                 let mut args = bun_alloc::ArenaVec::with_capacity_in(el.args.len(), bump);
                 for i in 0..el.args.len() {
-                    args.push(el.args[i].deep_clone(bump)?);
+                    args.push(el.args[i].deep_clone(bump, stack_check)?);
                 }
                 let item = bump.alloc(E::Arrow {
                     args: crate::StoreSlice::new(args.into_bump_slice()),
@@ -2048,13 +2060,13 @@ impl Data {
             Data::EJsxElement(el) => {
                 let item = bump.alloc(E::JSXElement {
                     tag: match &el.tag {
-                        Some(tag) => Some(tag.deep_clone_no_detach(bump)?),
+                        Some(tag) => Some(tag.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
-                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump))?,
+                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
                     children: el
                         .children
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     key_prop_index: el.key_prop_index,
                     flags: el.flags,
                     close_tag_loc: el.close_tag_loc,
@@ -2063,7 +2075,7 @@ impl Data {
             }
             Data::EObject(el) => {
                 let item = bump.alloc(E::Object {
-                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump))?,
+                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
                     comma_after_spread: el.comma_after_spread,
                     is_single_line: el.is_single_line,
                     is_parenthesized: el.is_parenthesized,
@@ -2074,14 +2086,14 @@ impl Data {
             }
             Data::ESpread(el) => {
                 let item = bump.alloc(E::Spread {
-                    value: el.value.deep_clone_no_detach(bump)?,
+                    value: el.value.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::ESpread(StoreRef::from_bump(item)))
             }
             Data::ETemplate(el) => {
                 let item = bump.alloc(E::Template {
                     tag: match &el.tag {
-                        Some(tag) => Some(tag.deep_clone_no_detach(bump)?),
+                        Some(tag) => Some(tag.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
                     parts: el.parts,
@@ -2100,14 +2112,14 @@ impl Data {
             }
             Data::EAwait(el) => {
                 let item = bump.alloc(E::Await {
-                    value: el.value.deep_clone_no_detach(bump)?,
+                    value: el.value.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::EAwait(StoreRef::from_bump(item)))
             }
             Data::EYield(el) => {
                 let item = bump.alloc(E::Yield {
                     value: match &el.value {
-                        Some(value) => Some(value.deep_clone_no_detach(bump)?),
+                        Some(value) => Some(value.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
                     is_star: el.is_star,
@@ -2116,16 +2128,16 @@ impl Data {
             }
             Data::EIf(el) => {
                 let item = bump.alloc(E::If {
-                    test: el.test.deep_clone_no_detach(bump)?,
-                    yes: el.yes.deep_clone_no_detach(bump)?,
-                    no: el.no.deep_clone_no_detach(bump)?,
+                    test: el.test.deep_clone_no_detach(bump, stack_check)?,
+                    yes: el.yes.deep_clone_no_detach(bump, stack_check)?,
+                    no: el.no.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::EIf(StoreRef::from_bump(item)))
             }
             Data::EImport(el) => {
                 let item = bump.alloc(E::Import {
-                    expr: el.expr.deep_clone_no_detach(bump)?,
-                    options: el.options.deep_clone_no_detach(bump)?,
+                    expr: el.expr.deep_clone_no_detach(bump, stack_check)?,
+                    options: el.options.deep_clone_no_detach(bump, stack_check)?,
                     import_record_index: el.import_record_index,
                     namespace_ref: el.namespace_ref,
                 });

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1912,7 +1912,12 @@ impl Data {
                             E::EString::init(key_bytes),
                             row.key_loc,
                         )),
-                        value: Some(json_value_deep_clone(&row.value, value_loc, bump, stack_check)?),
+                        value: Some(json_value_deep_clone(
+                            &row.value,
+                            value_loc,
+                            bump,
+                            stack_check,
+                        )?),
                         kind: G::PropertyKind::Normal,
                         initializer: None,
                         ..Default::default()
@@ -2063,7 +2068,9 @@ impl Data {
                         Some(tag) => Some(tag.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
-                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
+                    properties: el
+                        .properties
+                        .try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
                     children: el
                         .children
                         .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
@@ -2075,7 +2082,9 @@ impl Data {
             }
             Data::EObject(el) => {
                 let item = bump.alloc(E::Object {
-                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
+                    properties: el
+                        .properties
+                        .try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
                     comma_after_spread: el.comma_after_spread,
                     is_single_line: el.is_single_line,
                     is_parenthesized: el.is_parenthesized,

--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -195,7 +195,8 @@ impl Property {
     pub(crate) fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Property, bun_alloc::AllocError> {
+        stack_check: bun_core::StackCheck,
+    ) -> Result<Property, crate::DeepCloneError> {
         let mut class_static_block: Option<crate::StoreRef<ClassStaticBlock>> = None;
         if let Some(csb_ref) = self.class_static_block_ref() {
             let new_block: &mut ClassStaticBlock = bump.alloc(ClassStaticBlock {
@@ -206,7 +207,7 @@ impl Property {
         }
         Ok(Property {
             initializer: match self.initializer {
-                Some(init) => Some(init.deep_clone(bump)?),
+                Some(init) => Some(init.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             kind: self.kind,
@@ -215,13 +216,13 @@ impl Property {
             // Vec<Expr> per-element deep clone.
             ts_decorators: self
                 .ts_decorators
-                .try_deep_clone_with(|e| e.deep_clone(bump))?,
+                .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
             key: match self.key {
-                Some(key) => Some(key.deep_clone(bump)?),
+                Some(key) => Some(key.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             value: match self.value {
-                Some(value) => Some(value.deep_clone(bump)?),
+                Some(value) => Some(value.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             ts_metadata: self.ts_metadata.clone(),
@@ -298,11 +299,12 @@ impl Fn {
     pub(crate) fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Fn, bun_alloc::AllocError> {
+        stack_check: bun_core::StackCheck,
+    ) -> Result<Fn, crate::DeepCloneError> {
         let src_args: &[Arg] = self.args.slice();
         let args: &mut [Arg] = bump.alloc_slice_fill_default::<Arg>(src_args.len());
         for i in 0..args.len() {
-            args[i] = src_args[i].deep_clone(bump)?;
+            args[i] = src_args[i].deep_clone(bump, stack_check)?;
         }
         Ok(Fn {
             name: self.name,
@@ -346,15 +348,16 @@ impl Arg {
     pub(crate) fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Arg, bun_alloc::AllocError> {
+        stack_check: bun_core::StackCheck,
+    ) -> Result<Arg, crate::DeepCloneError> {
         Ok(Arg {
             // Vec<Expr> per-element deep clone.
             ts_decorators: self
                 .ts_decorators
-                .try_deep_clone_with(|e| e.deep_clone(bump))?,
+                .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
             binding: self.binding,
             default: match self.default {
-                Some(d) => Some(d.deep_clone(bump)?),
+                Some(d) => Some(d.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             is_typescript_ctor_field: self.is_typescript_ctor_field,

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2855,7 +2855,7 @@ pub mod binding;
 pub mod char_freq;
 pub mod e;
 pub mod error;
-pub use error::{Error, Result};
+pub use error::{DeepCloneError, Error, Result};
 pub mod expr;
 pub mod fold_string_addition;
 pub mod g;

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -446,14 +446,7 @@ impl DefineDataExt for DefineData {
         let data: ExprData = match expr.data.deep_clone(bump) {
             Ok(data) => data,
             Err(bun_ast::DeepCloneError::StackOverflow) => {
-                log.add_error_fmt_opts(
-                    format_args!("JSON document is too deeply nested"),
-                    bun_ast::AddErrorOptions {
-                        source: Some(&source),
-                        loc: expr.loc,
-                        ..Default::default()
-                    },
-                );
+                bun_parsers::json::add_too_deeply_nested_error(log, &source, expr.loc);
                 return Err(bun_parsers::Error::StackOverflow.into());
             }
             Err(bun_ast::DeepCloneError::Alloc(err)) => return Err(err.into()),

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -443,7 +443,21 @@ impl DefineDataExt for DefineData {
         // `.into()` deep-walking T2→T4 and re-boxing the payload; now `.into()`
         // is identity, so without `deep_clone` the `DefineData.value` dangles
         // into a freed slab and `process.env.NODE_ENV` reads garbage.
-        let data: ExprData = expr.data.deep_clone(bump)?;
+        let data: ExprData = match expr.data.deep_clone(bump) {
+            Ok(data) => data,
+            Err(bun_ast::DeepCloneError::StackOverflow) => {
+                log.add_error_fmt_opts(
+                    format_args!("JSON document is too deeply nested"),
+                    bun_ast::AddErrorOptions {
+                        source: Some(&source),
+                        loc: expr.loc,
+                        ..Default::default()
+                    },
+                );
+                return Err(bun_parsers::Error::StackOverflow.into());
+            }
+            Err(bun_ast::DeepCloneError::Alloc(err)) => return Err(err.into()),
+        };
         let can_be_removed_if_unused = bun_ast::expr::Tag::is_primitive_literal(data.tag());
         Ok(DefineData {
             value: data,

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -65,7 +65,7 @@ impl MapEntry {
     pub(crate) fn reparse_root(&mut self, log: &mut Log) -> Result<(), Error> {
         let json_bump = bun_alloc::Arena::new();
         let parsed = parse_package_json(&self.source, log, &json_bump, false)?;
-        self.root = bun_core::handle_oom(parsed.root.deep_clone(&json_bump));
+        self.root = clone_root(&parsed.root, &self.source, log, &json_bump)?;
         self.json_arena = json_bump;
         Ok(())
     }
@@ -89,6 +89,31 @@ fn parse_package_json(
         log,
         bump,
     )?)
+}
+
+/// Clone the parsed root out of the thread-local AST store into `bump`, so
+/// the entry survives the next `initialize_store()` reset.
+fn clone_root(
+    root: &Expr,
+    source: &Source,
+    log: &mut Log,
+    bump: &bun_alloc::Arena,
+) -> Result<Expr, crate::Error> {
+    match root.deep_clone(bump) {
+        Ok(root) => Ok(root),
+        Err(bun_ast::DeepCloneError::StackOverflow) => {
+            log.add_error_fmt_opts(
+                format_args!("JSON document is too deeply nested"),
+                bun_ast::AddErrorOptions {
+                    source: Some(source),
+                    loc: root.loc,
+                    ..Default::default()
+                },
+            );
+            Err(bun_parsers::Error::StackOverflow.into())
+        }
+        Err(bun_ast::DeepCloneError::Alloc(err)) => Err(err.into()),
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -193,8 +218,15 @@ impl WorkspacePackageJSONCache {
             }
         };
 
+        let root = match clone_root(&parsed.root, &source, log, &json_bump) {
+            Ok(root) => root,
+            Err(err) => {
+                return GetResult::ParseErr(err);
+            }
+        };
+
         let value = MapEntry {
-            root: bun_core::handle_oom(parsed.root.deep_clone(&json_bump)),
+            root,
             source,
             indentation: parsed.indentation,
             indentation_guessed: opts.guess_indentation,

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -100,14 +100,7 @@ fn clone_root(
     match root.deep_clone(bump) {
         Ok(root) => Ok(root),
         Err(bun_ast::DeepCloneError::StackOverflow) => {
-            log.add_error_fmt_opts(
-                format_args!("JSON document is too deeply nested"),
-                bun_ast::AddErrorOptions {
-                    source: Some(source),
-                    loc: root.loc,
-                    ..Default::default()
-                },
-            );
+            json::add_too_deeply_nested_error(log, source, root.loc);
             Err(bun_parsers::Error::StackOverflow.into())
         }
         Err(bun_ast::DeepCloneError::Alloc(err)) => Err(err.into()),

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -91,8 +91,6 @@ fn parse_package_json(
     )?)
 }
 
-/// Clone the parsed root out of the thread-local AST store into `bump`, so
-/// the entry survives the next `initialize_store()` reset.
 fn clone_root(
     root: &Expr,
     source: &Source,

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -507,7 +507,9 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
         Err(bun_ast::DeepCloneError::StackOverflow) => {
             return Err(MigratePnpmLockfileError::YamlParseError);
         }
-        Err(bun_ast::DeepCloneError::Alloc(_)) => return Err(MigratePnpmLockfileError::OutOfMemory),
+        Err(bun_ast::DeepCloneError::Alloc(_)) => {
+            return Err(MigratePnpmLockfileError::OutOfMemory);
+        }
     };
 
     // pnpm 11 writes `---<env lockfile>---<lockfile>`; the last document is the lockfile.

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -502,7 +502,13 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
         Ok(r) => r,
         Err(_) => return Err(MigratePnpmLockfileError::YamlParseError),
     };
-    let mut root: Expr = bun_core::handle_oom(_root.deep_clone(&yaml_arena));
+    let mut root: Expr = match _root.deep_clone(&yaml_arena) {
+        Ok(root) => root,
+        Err(bun_ast::DeepCloneError::StackOverflow) => {
+            return Err(MigratePnpmLockfileError::YamlParseError);
+        }
+        Err(bun_ast::DeepCloneError::Alloc(_)) => return Err(MigratePnpmLockfileError::OutOfMemory),
+    };
 
     // pnpm 11 writes `---<env lockfile>---<lockfile>`; the last document is the lockfile.
     if let Some(mut documents) = root.as_array() {

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -348,9 +348,7 @@ fn parse_classic(
     Ok(out)
 }
 
-/// Logs the depth-limit error for a JSON document at `loc`. Callers that walk
-/// a parsed tree again (`Expr::deep_clone`) report their own overflow with
-/// the same message.
+/// Logs the depth-limit error for a JSON document at `loc`.
 #[cold]
 pub fn add_too_deeply_nested_error(
     log: &mut bun_ast::Log,

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -340,19 +340,31 @@ fn parse_classic(
     out.root = match materialize_impl(&out.root, source, bump, opts.was_originally_macro) {
         Ok(root) => root,
         Err(e) => {
-            log.add_error_fmt_opts(
-                format_args!("JSON document is too deeply nested"),
-                bun_ast::AddErrorOptions {
-                    source: Some(source),
-                    loc: out.root.loc,
-                    ..Default::default()
-                },
-            );
+            add_too_deeply_nested_error(log, source, out.root.loc);
             return Err(e);
         }
     };
     out.tape = None;
     Ok(out)
+}
+
+/// Logs the depth-limit error for a JSON document at `loc`. Callers that walk
+/// a parsed tree again (`Expr::deep_clone`) report their own overflow with
+/// the same message.
+#[cold]
+pub fn add_too_deeply_nested_error(
+    log: &mut bun_ast::Log,
+    source: &bun_ast::Source,
+    loc: bun_ast::Loc,
+) {
+    log.add_error_fmt_opts(
+        format_args!("JSON document is too deeply nested"),
+        bun_ast::AddErrorOptions {
+            source: Some(source),
+            loc,
+            ..Default::default()
+        },
+    );
 }
 
 impl ParsedJson {

--- a/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// A `define` value is parsed as JSON and then deep-cloned out of the parser's
+// thread-local store (`DefineData::parse` in `src/bundler/defines.rs`). The
+// JSON parser bounds its own recursion, but `Expr::deep_clone` used to have no
+// stack guard and its frames are larger than the parser's, so a value the
+// parser accepted could still run the clone off the end of the stack and kill
+// the process with a bare SIGSEGV.
+//
+// The window between "the parser accepts it" and "the clone overflows" depends
+// on the frame sizes of the build (debug frames are much larger) and on the
+// thread (`Bun.build` runs its bundler on a thread with a smaller stack), so
+// each door is probed at several depths. Every one must end with either a
+// successful run or the parser's "JSON document is too deeply nested" error.
+// None may die on a signal.
+
+const TOO_DEEP = "JSON document is too deeply nested";
+
+function nested(depth: number): string {
+  return "[".repeat(depth) + "1" + "]".repeat(depth);
+}
+
+describe("deeply nested define value does not overflow the stack", () => {
+  for (const depth of [700, 1000, 1300, 5000, 20000, 30000]) {
+    test.concurrent(`Bun.Transpiler, depth ${depth}`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `try {
+            new Bun.Transpiler({ define: { DEEPX: "[".repeat(${depth}) + "1" + "]".repeat(${depth}) } });
+            console.log("ok");
+          } catch (e) {
+            console.log("error: " + e.message);
+          }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(proc.signalCode).toBeNull();
+      expect(stdout).toMatch(/^(ok|error: StackOverflow Failed to load define)\n$/);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  for (const depth of [200, 250, 300, 3000, 5000]) {
+    test.concurrent(`Bun.build, depth ${depth}`, async () => {
+      using dir = tempDir("define-deep-nesting-build", {
+        "entry.ts": `console.log("ran");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const result = await Bun.build({
+            entrypoints: ["./entry.ts"],
+            define: { DEEPX: "[".repeat(${depth}) + "1" + "]".repeat(${depth}) },
+            throw: false,
+          });
+          console.log(result.success ? "ok" : "error: " + result.logs.map(String).join("\\n"));`,
+        ],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(proc.signalCode).toBeNull();
+      expect(stdout).toMatch(new RegExp(`^(ok|error: BuildMessage: ${TOO_DEEP})\n$`));
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  // Windows caps a command line at 32K characters, so the largest depth for
+  // the flag stays below that. `bunfig.toml` carries the bigger values.
+  for (const depth of [800, 1400, 12000]) {
+    test.concurrent(`bun run --define, depth ${depth}`, async () => {
+      using dir = tempDir("define-deep-nesting-cli", {
+        "entry.ts": `console.log("ran");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--define", `DEEPX=${nested(depth)}`, "./entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(proc.signalCode).toBeNull();
+      if (exitCode === 0) {
+        expect(stdout).toBe("ran\n");
+      } else {
+        expect(stderr).toContain(TOO_DEEP);
+        expect(exitCode).toBe(1);
+      }
+    });
+  }
+
+  for (const depth of [1100, 20000]) {
+    test.concurrent(`bunfig.toml [define], depth ${depth}`, async () => {
+      using dir = tempDir("define-deep-nesting-bunfig", {
+        "entry.ts": `console.log("ran");`,
+        "bunfig.toml": `[define]\n"DEEPX" = '${nested(depth)}'\n`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "./entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(proc.signalCode).toBeNull();
+      if (exitCode === 0) {
+        expect(stdout).toBe("ran\n");
+      } else {
+        expect(stderr).toContain(TOO_DEEP);
+        expect(exitCode).toBe(1);
+      }
+    });
+  }
+});

--- a/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
@@ -44,7 +44,8 @@ describe("deeply nested define value does not overflow the stack", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(proc.signalCode).toBeNull();
+    // A crash banner or sanitizer report lands on stderr; show it with the signal.
+    expect(proc.signalCode, `child killed by ${proc.signalCode}, stderr:\n${stderr}`).toBeNull();
     expect(stdout).toMatch(/^(ok|error: StackOverflow Failed to load define)\n$/);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -72,7 +73,8 @@ describe("deeply nested define value does not overflow the stack", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(proc.signalCode).toBeNull();
+    // A crash banner or sanitizer report lands on stderr; show it with the signal.
+    expect(proc.signalCode, `child killed by ${proc.signalCode}, stderr:\n${stderr}`).toBeNull();
     expect(stdout).toMatch(new RegExp(`^(ok|error: BuildMessage: ${TOO_DEEP})\n$`));
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -92,7 +94,8 @@ describe("deeply nested define value does not overflow the stack", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(proc.signalCode).toBeNull();
+    // A crash banner or sanitizer report lands on stderr; show it with the signal.
+    expect(proc.signalCode, `child killed by ${proc.signalCode}, stderr:\n${stderr}`).toBeNull();
     if (exitCode === 0) {
       expect(stdout).toBe("ran\n");
     } else {
@@ -114,7 +117,8 @@ describe("deeply nested define value does not overflow the stack", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(proc.signalCode).toBeNull();
+    // A crash banner or sanitizer report lands on stderr; show it with the signal.
+    expect(proc.signalCode, `child killed by ${proc.signalCode}, stderr:\n${stderr}`).toBeNull();
     if (exitCode === 0) {
       expect(stdout).toBe("ran\n");
     } else {

--- a/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
@@ -17,9 +17,13 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 const TOO_DEEP = "JSON document is too deeply nested";
 
+// `Buffer.alloc` fill over `.repeat`: the latter is very slow in debug JSC.
 function nested(depth: number): string {
-  return "[".repeat(depth) + "1" + "]".repeat(depth);
+  return Buffer.alloc(depth, "[").toString() + "1" + Buffer.alloc(depth, "]").toString();
 }
+
+// The same helper as source text for the child's `-e` script.
+const NESTED_FN = `const nested = d => Buffer.alloc(d, "[").toString() + "1" + Buffer.alloc(d, "]").toString();`;
 
 describe("deeply nested define value does not overflow the stack", () => {
   for (const depth of [700, 1000, 1300, 5000, 20000, 30000]) {
@@ -28,8 +32,9 @@ describe("deeply nested define value does not overflow the stack", () => {
         cmd: [
           bunExe(),
           "-e",
-          `try {
-            new Bun.Transpiler({ define: { DEEPX: "[".repeat(${depth}) + "1" + "]".repeat(${depth}) } });
+          `${NESTED_FN}
+          try {
+            new Bun.Transpiler({ define: { DEEPX: nested(${depth}) } });
             console.log("ok");
           } catch (e) {
             console.log("error: " + e.message);
@@ -56,9 +61,10 @@ describe("deeply nested define value does not overflow the stack", () => {
         cmd: [
           bunExe(),
           "-e",
-          `const result = await Bun.build({
+          `${NESTED_FN}
+          const result = await Bun.build({
             entrypoints: ["./entry.ts"],
-            define: { DEEPX: "[".repeat(${depth}) + "1" + "]".repeat(${depth}) },
+            define: { DEEPX: nested(${depth}) },
             throw: false,
           });
           console.log(result.success ? "ok" : "error: " + result.logs.map(String).join("\\n"));`,

--- a/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
+++ b/test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts
@@ -26,108 +26,100 @@ function nested(depth: number): string {
 const NESTED_FN = `const nested = d => Buffer.alloc(d, "[").toString() + "1" + Buffer.alloc(d, "]").toString();`;
 
 describe("deeply nested define value does not overflow the stack", () => {
-  for (const depth of [700, 1000, 1300, 5000, 20000, 30000]) {
-    test.concurrent(`Bun.Transpiler, depth ${depth}`, async () => {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `${NESTED_FN}
+  test.concurrent.each([700, 1000, 1300, 5000, 20000, 30000])("Bun.Transpiler, depth %d", async depth => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `${NESTED_FN}
           try {
             new Bun.Transpiler({ define: { DEEPX: nested(${depth}) } });
             console.log("ok");
           } catch (e) {
             console.log("error: " + e.message);
           }`,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(proc.signalCode).toBeNull();
-      expect(stdout).toMatch(/^(ok|error: StackOverflow Failed to load define)\n$/);
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-  }
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toMatch(/^(ok|error: StackOverflow Failed to load define)\n$/);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 
-  for (const depth of [200, 250, 300, 3000, 5000]) {
-    test.concurrent(`Bun.build, depth ${depth}`, async () => {
-      using dir = tempDir("define-deep-nesting-build", {
-        "entry.ts": `console.log("ran");`,
-      });
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `${NESTED_FN}
+  test.concurrent.each([200, 250, 300, 3000, 5000])("Bun.build, depth %d", async depth => {
+    using dir = tempDir("define-deep-nesting-build", {
+      "entry.ts": `console.log("ran");`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `${NESTED_FN}
           const result = await Bun.build({
             entrypoints: ["./entry.ts"],
             define: { DEEPX: nested(${depth}) },
             throw: false,
           });
           console.log(result.success ? "ok" : "error: " + result.logs.map(String).join("\\n"));`,
-        ],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(proc.signalCode).toBeNull();
-      expect(stdout).toMatch(new RegExp(`^(ok|error: BuildMessage: ${TOO_DEEP})\n$`));
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
     });
-  }
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toMatch(new RegExp(`^(ok|error: BuildMessage: ${TOO_DEEP})\n$`));
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 
   // Windows caps a command line at 32K characters, so the largest depth for
   // the flag stays below that. `bunfig.toml` carries the bigger values.
-  for (const depth of [800, 1400, 12000]) {
-    test.concurrent(`bun run --define, depth ${depth}`, async () => {
-      using dir = tempDir("define-deep-nesting-cli", {
-        "entry.ts": `console.log("ran");`,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "--define", `DEEPX=${nested(depth)}`, "./entry.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(proc.signalCode).toBeNull();
-      if (exitCode === 0) {
-        expect(stdout).toBe("ran\n");
-      } else {
-        expect(stderr).toContain(TOO_DEEP);
-        expect(exitCode).toBe(1);
-      }
+  test.concurrent.each([800, 1400, 12000])("bun run --define, depth %d", async depth => {
+    using dir = tempDir("define-deep-nesting-cli", {
+      "entry.ts": `console.log("ran");`,
     });
-  }
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--define", `DEEPX=${nested(depth)}`, "./entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    if (exitCode === 0) {
+      expect(stdout).toBe("ran\n");
+    } else {
+      expect(stderr).toContain(TOO_DEEP);
+      expect(exitCode).toBe(1);
+    }
+  });
 
-  for (const depth of [1100, 20000]) {
-    test.concurrent(`bunfig.toml [define], depth ${depth}`, async () => {
-      using dir = tempDir("define-deep-nesting-bunfig", {
-        "entry.ts": `console.log("ran");`,
-        "bunfig.toml": `[define]\n"DEEPX" = '${nested(depth)}'\n`,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "./entry.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(proc.signalCode).toBeNull();
-      if (exitCode === 0) {
-        expect(stdout).toBe("ran\n");
-      } else {
-        expect(stderr).toContain(TOO_DEEP);
-        expect(exitCode).toBe(1);
-      }
+  test.concurrent.each([1100, 20000])("bunfig.toml [define], depth %d", async depth => {
+    using dir = tempDir("define-deep-nesting-bunfig", {
+      "entry.ts": `console.log("ran");`,
+      "bunfig.toml": `[define]\n"DEEPX" = '${nested(depth)}'\n`,
     });
-  }
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode).toBeNull();
+    if (exitCode === 0) {
+      expect(stdout).toBe("ran\n");
+    } else {
+      expect(stderr).toContain(TOO_DEEP);
+      expect(exitCode).toBe(1);
+    }
+  });
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -11380,3 +11380,34 @@ it.each([
     expect(exitCode).not.toBe(0);
   });
 });
+
+// The JSON parser is depth-guarded, but the clone of the parsed manifest out of
+// the thread-local AST store recurses once per nesting level with larger frames.
+// Each depth below fell into that window on one build flavor (release or ASAN).
+for (const depth of [700, 16000]) {
+  it.concurrent(`reports a package.json nested ${depth} levels deep instead of crashing`, async () => {
+    const open = Buffer.alloc(depth * 5, '{"a":').toString();
+    const close = Buffer.alloc(depth, "}").toString();
+    using dir = tempDir("bun-install-deep-package-json", {
+      "package.json": `{"name":"h","version":"1.0.0","dependencies":${open}"file:./dep"${close}}`,
+      "dep/package.json": `{"name":"dep","version":"1.0.0"}`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toStartWith("bun install v1.");
+    // A depth the native stack can hold reaches the dependencies validator;
+    // a deeper one is reported by the parser or the clone as too deeply nested.
+    if (!stderr.includes("dependencies expects a map of specifiers")) {
+      expect(stderr).toContain("error: JSON document is too deeply nested");
+      expect(stderr).toContain(`StackOverflow: failed to parse '${join(String(dir), "package.json")}'`);
+    }
+    expect(exitCode).toBe(1);
+  });
+}

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -11401,6 +11401,7 @@ for (const depth of [700, 16000]) {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(proc.signalCode, `child killed by ${proc.signalCode}, stderr:\n${stderr}`).toBeNull();
     expect(stdout).toStartWith("bun install v1.");
     // A depth the native stack can hold reaches the dependencies validator;
     // a deeper one is reported by the parser or the clone as too deeply nested.

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -399,3 +399,9 @@ test/bundler/native-plugin.test.ts
 
 # Slow
 test/js/bun/typescript/type-export.test.ts
+
+# A define value that fails to parse (any syntax error, not only deep nesting)
+# leaves the log messages of the failed Bun.Transpiler constructor and the
+# Bun.build bundler thread unfreed at exit. The test exercises that error path
+# on purpose. Remove once those error paths free the transpiler they built.
+test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts


### PR DESCRIPTION
### Problem
- A deeply nested JSON `define` value kills bun with a bare SIGSEGV. All four doors crash: `bun --define`, `[define]` in `bunfig.toml`, `new Bun.Transpiler({define})`, and `Bun.build({define})`. On 1.4.3, 20000 nested arrays crash the CLI doors and 5000 crash `Bun.build` (its bundler thread has a smaller stack).
- `DefineData::parse` (`src/bundler/defines.rs:446`) parses the value with `parse_env_json` and then calls `expr.data.deep_clone(bump)`. The parser bounds its own recursion with `StackCheck`. The clone had no guard, and its frames are larger than the parser's, so a value the parser accepted still ran `Data::deep_clone_no_detach` (`src/ast/expr.rs`) off the end of the stack.

### Fix
- `Expr::deep_clone` and `Data::deep_clone` now carry a `StackCheck` through the recursion. `Data::deep_clone_no_detach` returns the new `bun_ast::DeepCloneError::StackOverflow` when the stack runs low. The `Property`, `Fn`, and `Arg` clones in `src/ast/g.rs` thread the same check.
- The define loader logs the parser's own message through a new shared helper, `bun_parsers::json::add_too_deeply_nested_error`, and returns `bun_parsers::Error::StackOverflow`. So the user sees the same error whether the parser or the clone stops first. The two other callers, the pnpm-lock migration and the workspace package.json cache, map the error the same way instead of treating every failure as out of memory.
- Correct because the check runs once per cloned node with the same headroom the parsers use, on whatever thread runs the clone. A tree that fits is cloned as before.
- Verified: `test/bundler/transpiler/define-deep-nesting-stack-overflow.test.ts` probes each door at several depths (9 of 16 crash on the unfixed debug build, 6 of 16 on release 1.4.3). Also ran the define tests in `bundler_edgecase`, `esbuild/default`, `bun-build-api`, the `test/js/bun/transpiler/` suite, and the pnpm migration suites.

### Background
- `bun_core::StackCheck` caches the thread's stack limit and `is_safe_to_recurse()` compares the stack pointer against it with 128 KB of headroom (256 KB on Windows). Every recursive walker over user-controlled nesting in bun uses it.
- `parse_env_json` builds the tree in a thread-local AST store that the next parse resets. `deep_clone` copies the tree into the define table's arena so it outlives that reset. That is why the clone runs right after a parse that already passed its own guard.
- The crash depth depends on the frame size of the build and the stack size of the thread. The debug build crashes between 700 and 1400 levels on the main thread and between 200 and 300 on the bundler thread. Release crashes between about 10k and 40k. The test probes depths in both windows.

<details><summary>Notes</summary>

Found by the internal native recursion fuzzer. There is no user report. The inputs are developer-authored config (a define value, a lockfile, a package.json) nested 10k levels or more.

Self-reviewed: 5 concerns raised, 3 addressed (provenance line, the shared depth-limit message, the test builds its input with `Buffer.alloc`). Two deferred: parsing straight into the caller's arena would remove the clone pass at all three sites, which is a larger refactor that this guard does not obstruct, and #40853 unifies the depth-limit message across parsers, which can adopt the helper added here.

Repro on 1.4.3:

```
python3 -c "print('['*20000+'1'+']'*20000,end='')" > def.txt
echo 'console.log("ran")' > y.ts
bun --define "DEEPX=$(cat def.txt)" ./y.ts          # rc=139
bun -e 'new Bun.Transpiler({define:{K:"[".repeat(2e4)+"1"+"]".repeat(2e4)}})'   # rc=139
bun -e 'await Bun.build({entrypoints:[process.argv[1]],define:{K:"[".repeat(5000)+"1"+"]".repeat(5000)}})' ./y.ts  # rc=139
```

Unfixed debug (ASAN) build, measured windows: `Bun.Transpiler` ok at 600, SIGSEGV at 700 to 1400, parser error from about 1466. `bun --define` same window. `Bun.build` ok at 100, SIGSEGV at 200 to 300, parser error from 350. With the fix every depth ends in `ok` or the too-deep error.

`DeepCloneError` is a two-variant enum instead of a new variant on `bun_ast::Error`, so the three callers match it exhaustively and none has to handle a `SyntaxError` that `deep_clone` never returns.

The `Property`, `Fn`, and `Arg` clones used to re-enter `Expr::deep_clone`, which installed a second `DetachAstHeap` guard per property. They now call the `_no_detach` path with the shared check, so the guard is installed once per top-level clone.

The test is listed in `test/no-validate-leaksan.txt`. On the ASAN lane LeakSanitizer is on, and every define value that fails to parse (a plain syntax error too, on main) leaves the failed transpiler's log unfreed at exit, so the process aborts after the test's assertions passed. The test hits that error path on purpose. The leak is reported separately; the entry says to remove it once the error paths free the transpiler.

Suites run with the debug build: `bundler_edgecase.test.ts -t define`, `esbuild/default.test.ts -t define`, `bun-build-api.test.ts -t define`, `jsx-deep-nesting-stack-overflow.test.ts`, `test/js/bun/transpiler/`, `migration/migrate.test.ts`, `migration/pnpm-lock-migration.test.ts`, `migration/pnpm-migration.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->