### PR TITLE
node:http2: validate the whole header list before the HPACK encoder sees it

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -444,18 +444,6 @@ function emitSessionCloseNT(self: Http2Session, frame) {
     runInFrame(frame, self.emit, self, "close");
   }
 }
-function emitErrorNT(self: any, error: any, destroy: boolean) {
-  if (destroy) {
-    if (self.listenerCount("error") > 0) {
-      self.destroy(error);
-    } else {
-      self.destroy();
-    }
-  } else if (self.listenerCount("error") > 0) {
-    self.emit("error", error);
-  }
-}
-
 function emitOutofStreamErrorNT(self: any) {
   self.destroy($ERR_HTTP2_OUT_OF_STREAMS());
 }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6264,9 +6264,10 @@ class ClientHttp2Session extends Http2Session {
       process.nextTick(emitEventNT, req, "ready");
       return req;
     } catch (e: any) {
+      // A throw from the native request() happens before any header reaches the wire or the
+      // HPACK table, so the session stays usable. Like node, the throw is the only error channel.
       if (connectionsCounted) {
         this.#connections--;
-        process.nextTick(emitErrorNT, this, e, this.#connections === 0 && this.#closed);
       }
       throw e;
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6255,6 +6255,7 @@ class ClientHttp2Session extends Http2Session {
       // Nothing reached the wire, so the session stays usable and the throw is the only error channel.
       if (connectionsCounted) {
         this.#connections--;
+        if (this.#connections === 0 && this.#closed) setImmediate(destroyIfNotDestroyedNT, this);
       }
       throw e;
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6252,8 +6252,7 @@ class ClientHttp2Session extends Http2Session {
       process.nextTick(emitEventNT, req, "ready");
       return req;
     } catch (e: any) {
-      // A throw from the native request() happens before any header reaches the wire or the
-      // HPACK table, so the session stays usable. Like node, the throw is the only error channel.
+      // Nothing reached the wire, so the session stays usable and the throw is the only error channel.
       if (connectionsCounted) {
         this.#connections--;
       }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7168,9 +7168,10 @@ impl H2FrameParser {
             0
         };
 
-        // Checked against the pre-compression bound like nghttp2, before the encoder is touched.
+        // Checked against the pre-compression bound like nghttp2 (which always counts the
+        // priority fields for HEADERS), before the encoder is touched.
         if this.max_send_header_block_length.get() != 0
-            && pending.deflate_bound() + priority_overhead
+            && pending.deflate_bound() + StreamPriority::BYTE_SIZE
                 > this.max_send_header_block_length.get() as usize
         {
             stream.state = StreamState::CLOSED;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1960,14 +1960,9 @@ impl AbortListener for SignalRef {
     }
 }
 
-/// Outbound header fields collected from JS before any of them reach the HPACK encoder.
-///
-/// The HPACK dynamic table is shared by every stream on the connection and the peer mirrors
-/// each insertion. A field that fails validation must throw before the first `encode()`:
-/// an entry inserted for an earlier field and never sent leaves the peer's table one step
-/// behind, and every later header block on the connection decodes against the wrong entries.
-/// Node validates the whole object in JS before nghttp2 encodes. Bun validates while it walks
-/// the JS object, so the walk copies the validated fields here and the encode runs afterwards.
+/// Validated outbound header fields, collected before any of them reach the HPACK encoder.
+/// An encoded field that is never sent desyncs the peer's dynamic table for the rest of the
+/// connection, so a validation throw must happen before the first `encode()`.
 #[derive(Default)]
 struct HeaderList {
     bytes: Vec<u8>,
@@ -2003,9 +1998,7 @@ impl HeaderList {
         Ok(())
     }
 
-    /// Upper bound of the encoded size, computed the way nghttp2_hd_deflate_bound does it: up
-    /// to two table size updates (6 bytes each), then per field the literal form with two
-    /// 6-byte length integers. The compressor never produces more than the literal bytes.
+    /// Same formula as nghttp2_hd_deflate_bound.
     fn deflate_bound(&self) -> usize {
         12 + self.fields.len() * 12 + self.bytes.len()
     }
@@ -5783,8 +5776,6 @@ impl H2FrameParser {
 
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
 
-        // Validate and collect the trailers. Nothing reaches the HPACK table until the whole
-        // object has been walked (see HeaderList).
         while let Some((header_name, js_value)) = iter.next()? {
             if header_name.length() == 0 {
                 continue;
@@ -5924,9 +5915,7 @@ impl H2FrameParser {
                 return Err(global_object.throw(format_args!("Failed to allocate header buffer")));
             }
             Err(_) => {
-                // nghttp2 checks maxSendHeaderBlockLength pre-deflation and fires
-                // on_frame_not_send_callback(NGHTTP2_ERR_FRAME_SIZE_ERROR); Node surfaces
-                // 'frameError' + ERR_HTTP2_STREAM_ERROR (test-http2-exceeds-server-trailer-size.js).
+                // node: 'frameError' + ERR_HTTP2_STREAM_ERROR (test-http2-exceeds-server-trailer-size.js).
                 let identifier = stream.get_identifier();
                 identifier.ensure_still_alive();
                 this.dispatch_with_2_extra(
@@ -6235,8 +6224,7 @@ impl H2FrameParser {
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
 
         // A PUSH_PROMISE carries a REQUEST, so request pseudo-headers are valid even on the server.
-        // Pseudo-headers must be encoded first, so iterate twice. The fields are collected and
-        // encoded only after both passes validated the whole object (see HeaderList).
+        // Pseudo-headers must be encoded first, so iterate twice.
         for ignore_pseudo_headers in 0..2usize {
             let iter = bun_jsc::JSPropertyIterator::init(
                 global_object,
@@ -6373,8 +6361,7 @@ impl H2FrameParser {
             .encode_header_list(&mut encoded_headers, &pending)
             .is_err()
         {
-            // Same as the request/respond encode failures: nghttp2 fails the whole
-            // session, and node never surfaces this through the pushStream callback.
+            // node never surfaces this through the pushStream callback.
             this.schedule_header_compression_session_error();
             return Ok(JSValue::js_number(-1.0));
         }
@@ -6661,7 +6648,6 @@ impl H2FrameParser {
                 global_object.throw(format_args!("Expected sensitiveHeaders to be an object"))
             );
         }
-        // Every field is validated and collected before the first HPACK encode (see HeaderList).
         let mut pending = HeaderList::default();
         // max header name length for lshpack
         let mut name_buffer = [0u8; 4096];
@@ -7182,9 +7168,7 @@ impl H2FrameParser {
             0
         };
 
-        // maxSendHeaderBlockLength is checked against the pre-compression bound, as nghttp2
-        // does (session_estimate_headers_payload): a block refused here must not have touched
-        // the HPACK table, since the session and its encoder state stay in use.
+        // Checked against the pre-compression bound like nghttp2, before the encoder is touched.
         if this.max_send_header_block_length.get() != 0
             && pending.deflate_bound() + priority_overhead
                 > this.max_send_header_block_length.get() as usize
@@ -7207,8 +7191,6 @@ impl H2FrameParser {
             return Ok(JSValue::js_number(stream_id as f64));
         }
 
-        // Every check that can refuse the block without sending it ran above. From here on the
-        // encoded block goes on the wire, or the whole session fails.
         let mut encoded_headers: Vec<u8> = Vec::new();
         if let Err(err) = this.encode_header_list(&mut encoded_headers, &pending) {
             if matches!(err, crate::Error::Alloc(_)) {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1975,8 +1975,8 @@ struct HeaderList {
 }
 
 struct HeaderField {
-    name_len: u32,
-    value_len: u32,
+    name_len: usize,
+    value_len: usize,
     never_index: bool,
 }
 
@@ -1996,8 +1996,8 @@ impl HeaderList {
         self.bytes.extend_from_slice(name);
         self.bytes.extend_from_slice(value);
         self.fields.push(HeaderField {
-            name_len: u32::try_from(name.len()).expect("header name fits u32"),
-            value_len: u32::try_from(value.len()).expect("header value fits u32"),
+            name_len: name.len(),
+            value_len: value.len(),
             never_index,
         });
         Ok(())
@@ -2013,8 +2013,8 @@ impl HeaderList {
     fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8], bool)> {
         let mut offset = 0usize;
         self.fields.iter().map(move |field| {
-            let name_end = offset + field.name_len as usize;
-            let value_end = name_end + field.value_len as usize;
+            let name_end = offset + field.name_len;
+            let value_end = name_end + field.value_len;
             let name = &self.bytes[offset..name_end];
             let value = &self.bytes[name_end..value_end];
             offset = value_end;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1960,11 +1960,92 @@ impl AbortListener for SignalRef {
     }
 }
 
+/// Outbound header fields collected from JS before any of them reach the HPACK encoder.
+///
+/// The HPACK dynamic table is shared by every stream on the connection and the peer mirrors
+/// each insertion. A field that fails validation must throw before the first `encode()`:
+/// an entry inserted for an earlier field and never sent leaves the peer's table one step
+/// behind, and every later header block on the connection decodes against the wrong entries.
+/// Node validates the whole object in JS before nghttp2 encodes. Bun validates while it walks
+/// the JS object, so the walk copies the validated fields here and the encode runs afterwards.
+#[derive(Default)]
+struct HeaderList {
+    bytes: Vec<u8>,
+    fields: Vec<HeaderField>,
+}
+
+struct HeaderField {
+    name_len: u32,
+    value_len: u32,
+    never_index: bool,
+}
+
+impl HeaderList {
+    fn push(
+        &mut self,
+        name: &[u8],
+        value: &[u8],
+        never_index: bool,
+    ) -> Result<(), bun_alloc::AllocError> {
+        self.bytes
+            .try_reserve(name.len() + value.len())
+            .map_err(|_| bun_alloc::AllocError)?;
+        self.fields
+            .try_reserve(1)
+            .map_err(|_| bun_alloc::AllocError)?;
+        self.bytes.extend_from_slice(name);
+        self.bytes.extend_from_slice(value);
+        self.fields.push(HeaderField {
+            name_len: u32::try_from(name.len()).expect("header name fits u32"),
+            value_len: u32::try_from(value.len()).expect("header value fits u32"),
+            never_index,
+        });
+        Ok(())
+    }
+
+    /// Upper bound of the encoded size, computed the way nghttp2_hd_deflate_bound does it: up
+    /// to two table size updates (6 bytes each), then per field the literal form with two
+    /// 6-byte length integers. The compressor never produces more than the literal bytes.
+    fn deflate_bound(&self) -> usize {
+        12 + self.fields.len() * 12 + self.bytes.len()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8], bool)> {
+        let mut offset = 0usize;
+        self.fields.iter().map(move |field| {
+            let name_end = offset + field.name_len as usize;
+            let value_end = name_end + field.value_len as usize;
+            let name = &self.bytes[offset..name_end];
+            let value = &self.bytes[name_end..value_end];
+            offset = value_end;
+            (name, value, field.never_index)
+        })
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // H2FrameParser impl — core methods
 // ──────────────────────────────────────────────────────────────────────────
 
 impl H2FrameParser {
+    /// Encodes every field of a fully validated header list into `encoded_headers`.
+    fn encode_header_list(
+        &self,
+        encoded_headers: &mut Vec<u8>,
+        headers: &HeaderList,
+    ) -> crate::Result<()> {
+        for (name, value, never_index) in headers.iter() {
+            bun_output::scoped_log!(
+                H2FrameParser,
+                "encode header {} {}",
+                BStr::new(name),
+                BStr::new(value)
+            );
+            self.encode_header_into_list(encoded_headers, name, value, never_index)?;
+        }
+        Ok(())
+    }
+
     /// Encodes a single header into the ArrayList, growing if needed.
     /// Returns the number of bytes written, or error on failure.
     ///
@@ -5686,10 +5767,7 @@ impl H2FrameParser {
             );
         }
 
-        let mut encoded_headers: Vec<u8> = Vec::new();
-        if encoded_headers.try_reserve(16384).is_err() {
-            return Err(global_object.throw(format_args!("Failed to allocate header buffer")));
-        }
+        let mut pending = HeaderList::default();
         // max header name length for lshpack
         let mut name_buffer = [0u8; 4096];
 
@@ -5705,7 +5783,8 @@ impl H2FrameParser {
 
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
 
-        // Encode trailer headers using HPACK
+        // Validate and collect the trailers. Nothing reaches the HPACK table until the whole
+        // object has been walked (see HeaderList).
         while let Some((header_name, js_value)) = iter.next()? {
             if header_name.length() == 0 {
                 continue;
@@ -5746,11 +5825,7 @@ impl H2FrameParser {
                 }
             };
 
-            // closure for encode error handling
-            let mut handle_encode = |this: &Self,
-                                     value: &[u8],
-                                     never_index: bool|
-             -> JsResult<Option<JSValue>> {
+            let mut collect = |value: &[u8], never_index: bool| -> JsResult<()> {
                 if !is_valid_header_value(value) {
                     let exception = global_object.to_type_error(
                         bun_jsc::ErrorCode::HTTP2_INVALID_HEADER_VALUE,
@@ -5758,46 +5833,11 @@ impl H2FrameParser {
                     );
                     return Err(global_object.throw_value(exception));
                 }
-                bun_output::scoped_log!(
-                    H2FrameParser,
-                    "encode header {} {}",
-                    BStr::new(validated_name),
-                    BStr::new(value)
-                );
-                match this.encode_header_into_list(
-                    &mut encoded_headers,
-                    validated_name,
-                    value,
-                    never_index,
-                ) {
-                    Ok(_) => Ok(None),
-                    Err(crate::Error::Alloc(bun_alloc::AllocError)) => {
-                        Err(global_object.throw(format_args!("Failed to allocate header buffer")))
-                    }
-                    Err(_) => {
-                        // nghttp2 checks maxSendHeaderBlockLength pre-deflation and fires
-                        // on_frame_not_send_callback(NGHTTP2_ERR_FRAME_SIZE_ERROR); Node surfaces
-                        // 'frameError' + ERR_HTTP2_STREAM_ERROR (test-http2-exceeds-server-trailer-size.js).
-                        let identifier = stream.get_identifier();
-                        identifier.ensure_still_alive();
-                        this.dispatch_with_2_extra(
-                            JSH2FrameParser::Gc::onFrameError,
-                            identifier,
-                            JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
-                            JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
-                        );
-                        let triggering_id = stream.id;
-                        this.end_stream(&mut stream, ErrorCode::FRAME_SIZE_ERROR);
-                        this.send_go_away(
-                            triggering_id,
-                            ErrorCode::NO_ERROR,
-                            b"",
-                            this.last_stream_id.get(),
-                            true,
-                        );
-                        Ok(Some(JSValue::UNDEFINED))
-                    }
-                }
+                pending
+                    .push(validated_name, value, never_index)
+                    .map_err(|_| {
+                        global_object.throw(format_args!("Failed to allocate header buffer"))
+                    })
             };
 
             if js_value.js_type().is_array() {
@@ -5843,11 +5883,7 @@ impl H2FrameParser {
                     };
 
                     let value_bytes = header_value_bytes(&value_view);
-                    let value = value_bytes.as_ref();
-
-                    if let Some(ret) = handle_encode(this, value, never_index)? {
-                        return Ok(ret);
-                    }
+                    collect(value_bytes.as_ref(), never_index)?;
                 }
             } else {
                 if let Some(idx) = this.single_value_index_checked(validated_name) {
@@ -5877,17 +5913,38 @@ impl H2FrameParser {
                 };
 
                 let value_bytes = header_value_bytes(&value_view);
-                let value = value_bytes.as_ref();
-                bun_output::scoped_log!(
-                    H2FrameParser,
-                    "encode header {} {}",
-                    BStr::new(name),
-                    BStr::new(value)
-                );
+                collect(value_bytes.as_ref(), never_index)?;
+            }
+        }
 
-                if let Some(ret) = handle_encode(this, value, never_index)? {
-                    return Ok(ret);
-                }
+        let mut encoded_headers: Vec<u8> = Vec::new();
+        match this.encode_header_list(&mut encoded_headers, &pending) {
+            Ok(()) => {}
+            Err(crate::Error::Alloc(bun_alloc::AllocError)) => {
+                return Err(global_object.throw(format_args!("Failed to allocate header buffer")));
+            }
+            Err(_) => {
+                // nghttp2 checks maxSendHeaderBlockLength pre-deflation and fires
+                // on_frame_not_send_callback(NGHTTP2_ERR_FRAME_SIZE_ERROR); Node surfaces
+                // 'frameError' + ERR_HTTP2_STREAM_ERROR (test-http2-exceeds-server-trailer-size.js).
+                let identifier = stream.get_identifier();
+                identifier.ensure_still_alive();
+                this.dispatch_with_2_extra(
+                    JSH2FrameParser::Gc::onFrameError,
+                    identifier,
+                    JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
+                    JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
+                );
+                let triggering_id = stream.id;
+                this.end_stream(&mut stream, ErrorCode::FRAME_SIZE_ERROR);
+                this.send_go_away(
+                    triggering_id,
+                    ErrorCode::NO_ERROR,
+                    b"",
+                    this.last_stream_id.get(),
+                    true,
+                );
+                return Ok(JSValue::UNDEFINED);
             }
         }
         let encoded_data = encoded_headers.as_slice();
@@ -6174,11 +6231,12 @@ impl H2FrameParser {
         };
 
         let mut name_buffer = [0u8; 4096];
-        let mut encoded_headers: Vec<u8> = Vec::new();
+        let mut pending = HeaderList::default();
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
 
         // A PUSH_PROMISE carries a REQUEST, so request pseudo-headers are valid even on the server.
-        // Pseudo-headers must be encoded first, so iterate twice.
+        // Pseudo-headers must be encoded first, so iterate twice. The fields are collected and
+        // encoded only after both passes validated the whole object (see HeaderList).
         for ignore_pseudo_headers in 0..2usize {
             let iter = bun_jsc::JSPropertyIterator::init(
                 global_object,
@@ -6239,7 +6297,7 @@ impl H2FrameParser {
                         None => sensitive_arg.get_truthy(global_object, name)?.is_some(),
                     }
                 };
-                let mut encode_value = |item: JSValue| -> JsResult<Option<JSValue>> {
+                let mut collect_value = |item: JSValue| -> JsResult<()> {
                     let value_view = item.to_js_string_view(global_object)?;
                     let value_bytes = header_value_bytes(&value_view);
                     let value = value_bytes.as_ref();
@@ -6254,27 +6312,11 @@ impl H2FrameParser {
                             )
                             .throw());
                     }
-                    bun_output::scoped_log!(
-                        H2FrameParser,
-                        "encode header {} {}",
-                        BStr::new(validated_name),
-                        BStr::new(value)
-                    );
-                    if this
-                        .encode_header_into_list(
-                            &mut encoded_headers,
-                            validated_name,
-                            value,
-                            never_index,
-                        )
-                        .is_err()
-                    {
-                        // Same as the request/respond encode failures: nghttp2 fails the whole
-                        // session, and node never surfaces this through the pushStream callback.
-                        this.schedule_header_compression_session_error();
-                        return Ok(Some(JSValue::js_number(-1.0)));
-                    }
-                    Ok(None)
+                    pending
+                        .push(validated_name, value, never_index)
+                        .map_err(|_| {
+                            global_object.throw(format_args!("Failed to allocate header buffer"))
+                        })
                 };
                 if js_value.js_type().is_array() {
                     let mut value_iter = js_value.array_iterator(global_object)?;
@@ -6304,9 +6346,7 @@ impl H2FrameParser {
                                 )
                                 .throw());
                         }
-                        if let Some(ret) = encode_value(item)? {
-                            return Ok(ret);
-                        }
+                        collect_value(item)?;
                     }
                 } else {
                     if let Some(idx) = this.single_value_index_checked(validated_name) {
@@ -6323,11 +6363,20 @@ impl H2FrameParser {
                         }
                         single_value_headers[idx] = true;
                     }
-                    if let Some(ret) = encode_value(js_value)? {
-                        return Ok(ret);
-                    }
+                    collect_value(js_value)?;
                 }
             }
+        }
+
+        let mut encoded_headers: Vec<u8> = Vec::new();
+        if this
+            .encode_header_list(&mut encoded_headers, &pending)
+            .is_err()
+        {
+            // Same as the request/respond encode failures: nghttp2 fails the whole
+            // session, and node never surfaces this through the pushStream callback.
+            this.schedule_header_compression_session_error();
+            return Ok(JSValue::js_number(-1.0));
         }
 
         let max_frame =
@@ -6612,10 +6661,8 @@ impl H2FrameParser {
                 global_object.throw(format_args!("Expected sensitiveHeaders to be an object"))
             );
         }
-        let mut encoded_headers: Vec<u8> = Vec::new();
-        if encoded_headers.try_reserve(16384).is_err() {
-            return Err(global_object.throw(format_args!("Failed to allocate header buffer")));
-        }
+        // Every field is validated and collected before the first HPACK encode (see HeaderList).
+        let mut pending = HeaderList::default();
         // max header name length for lshpack
         let mut name_buffer = [0u8; 4096];
         let stream_id: u32 =
@@ -6729,35 +6776,10 @@ impl H2FrameParser {
                             )
                             .throw());
                     }
-                    bun_output::scoped_log!(
-                        H2FrameParser,
-                        "encode header {} {}",
-                        BStr::new(validated_name),
-                        BStr::new(value)
-                    );
-
-                    if let Err(err) = this.encode_header_into_list(
-                        &mut encoded_headers,
-                        validated_name,
-                        value,
-                        never_index,
-                    ) {
-                        if matches!(err, crate::Error::Alloc(_)) {
-                            return Err(global_object
-                                .throw(format_args!("Failed to allocate header buffer")));
-                        }
-                        let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                            return Ok(JSValue::js_number(-1.0));
-                        };
-                        // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                        let stream = unsafe { &mut *stream };
-                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                            && stream_ctx_arg.is_object()
-                        {
-                            stream.set_context(stream_ctx_arg, global_object);
-                        }
-                        this.schedule_header_compression_session_error();
-                        return Ok(JSValue::js_number(stream_id as f64));
+                    if pending.push(validated_name, value, never_index).is_err() {
+                        return Err(
+                            global_object.throw(format_args!("Failed to allocate header buffer"))
+                        );
                     }
                 }
             }
@@ -6899,35 +6921,9 @@ impl H2FrameParser {
                                 )
                                 .throw());
                         }
-                        bun_output::scoped_log!(
-                            H2FrameParser,
-                            "encode header {} {}",
-                            BStr::new(validated_name),
-                            BStr::new(value)
-                        );
-
-                        if let Err(err) = this.encode_header_into_list(
-                            &mut encoded_headers,
-                            validated_name,
-                            value,
-                            never_index,
-                        ) {
-                            if matches!(err, crate::Error::Alloc(_)) {
-                                return Err(global_object
-                                    .throw(format_args!("Failed to allocate header buffer")));
-                            }
-                            let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                                return Ok(JSValue::js_number(-1.0));
-                            };
-                            // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                            let stream = unsafe { &mut *stream };
-                            if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                                && stream_ctx_arg.is_object()
-                            {
-                                stream.set_context(stream_ctx_arg, global_object);
-                            }
-                            this.schedule_header_compression_session_error();
-                            return Ok(JSValue::UNDEFINED);
+                        if pending.push(validated_name, value, never_index).is_err() {
+                            return Err(global_object
+                                .throw(format_args!("Failed to allocate header buffer")));
                         }
                     }
                 } else if !js_value.is_empty_or_undefined_or_null() {
@@ -6969,40 +6965,14 @@ impl H2FrameParser {
                             )
                             .throw());
                     }
-                    bun_output::scoped_log!(
-                        H2FrameParser,
-                        "encode header {} {}",
-                        BStr::new(validated_name),
-                        BStr::new(value)
-                    );
-
-                    if let Err(err) = this.encode_header_into_list(
-                        &mut encoded_headers,
-                        validated_name,
-                        value,
-                        never_index,
-                    ) {
-                        if matches!(err, crate::Error::Alloc(_)) {
-                            return Err(global_object
-                                .throw(format_args!("Failed to allocate header buffer")));
-                        }
-                        let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                            return Ok(JSValue::js_number(-1.0));
-                        };
-                        // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                        let stream = unsafe { &mut *stream };
-                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                            && stream_ctx_arg.is_object()
-                        {
-                            stream.set_context(stream_ctx_arg, global_object);
-                        }
-                        this.schedule_header_compression_session_error();
-                        return Ok(JSValue::js_number(stream_id as f64));
+                    if pending.push(validated_name, value, never_index).is_err() {
+                        return Err(
+                            global_object.throw(format_args!("Failed to allocate header buffer"))
+                        );
                     }
                 }
             }
         }
-        let encoded_size = encoded_headers.len();
 
         let Some(stream_ptr) = this.handle_received_stream_id(stream_id) else {
             return Ok(JSValue::js_number(-1.0));
@@ -7205,17 +7175,19 @@ impl H2FrameParser {
             }
             return Ok(JSValue::js_number(stream_id as f64));
         }
-        let mut length: usize = encoded_size;
-        if has_priority {
-            length += 5;
+        let priority_overhead: usize = if has_priority {
             flags |= HeadersFrameFlags::PRIORITY as u8;
-        }
+            StreamPriority::BYTE_SIZE
+        } else {
+            0
+        };
 
-        bun_output::scoped_log!(H2FrameParser, "request encoded_size {}", encoded_size);
-
-        // Check if headers block exceeds maxSendHeaderBlockLength
+        // maxSendHeaderBlockLength is checked against the pre-compression bound, as nghttp2
+        // does (session_estimate_headers_payload): a block refused here must not have touched
+        // the HPACK table, since the session and its encoder state stay in use.
         if this.max_send_header_block_length.get() != 0
-            && encoded_size > this.max_send_header_block_length.get() as usize
+            && pending.deflate_bound() + priority_overhead
+                > this.max_send_header_block_length.get() as usize
         {
             stream.state = StreamState::CLOSED;
             stream.rst_code = ErrorCode::REFUSED_STREAM.0;
@@ -7235,16 +7207,24 @@ impl H2FrameParser {
             return Ok(JSValue::js_number(stream_id as f64));
         }
 
+        // Every check that can refuse the block without sending it ran above. From here on the
+        // encoded block goes on the wire, or the whole session fails.
+        let mut encoded_headers: Vec<u8> = Vec::new();
+        if let Err(err) = this.encode_header_list(&mut encoded_headers, &pending) {
+            if matches!(err, crate::Error::Alloc(_)) {
+                return Err(global_object.throw(format_args!("Failed to allocate header buffer")));
+            }
+            this.schedule_header_compression_session_error();
+            return Ok(JSValue::js_number(stream_id as f64));
+        }
+        let encoded_size = encoded_headers.len();
+        bun_output::scoped_log!(H2FrameParser, "request encoded_size {}", encoded_size);
+
         let actual_max_frame_size = this
             .remote_settings
             .get()
             .unwrap_or_else(|| this.local_settings.get())
             .max_frame_size as usize;
-        let priority_overhead: usize = if has_priority {
-            StreamPriority::BYTE_SIZE
-        } else {
-            0
-        };
         let available_payload = actual_max_frame_size - priority_overhead;
         // Reserve one byte for the pad-length field so `encoded_size +
         // padding_overhead` never exceeds `available_payload`; otherwise the
@@ -7424,7 +7404,6 @@ impl H2FrameParser {
             // TODO: should we make use of this in the future? We validate it.
         }
 
-        let _ = length;
         Ok(JSValue::js_number(stream_id as f64))
     }
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6003,19 +6003,15 @@ describe("http2 a header call that throws leaves the HPACK encoder in sync with 
       error: "ERR_HTTP2_INVALID_HEADER_VALUE",
     },
     "invalid name": { headers: { "x-a": "AAAA", "x-b": "BBBB", "bad name": "v" }, error: "ERR_INVALID_HTTP_TOKEN" },
-    "undefined value": {
-      headers: { "x-a": "AAAA", "x-b": "BBBB", "x-u": undefined },
-      error: "ERR_HTTP2_INVALID_HEADER_VALUE",
-    },
     "null value": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-n": null }, error: "ERR_HTTP2_INVALID_HEADER_VALUE" },
     "symbol value": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-s": Symbol("s") }, error: "TypeError" },
     "throwing toString": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-t": throwingToString }, error: "BOOM" },
   };
   const kinds = Object.keys(poisons);
   // respond() drops a string value with CR/LF/NUL instead of throwing, so those two kinds do not
-  // apply to it. pushStream() skips an undefined or null value (node's mapToHeaders does the same).
+  // apply to it. pushStream() skips a null value (node's mapToHeaders does the same).
   const respondKinds = kinds.filter(k => k !== "invalid value" && k !== "invalid array element");
-  const pushKinds = kinds.filter(k => k !== "undefined value" && k !== "null value");
+  const pushKinds = kinds.filter(k => k !== "null value");
   const errorOf = err => err.code ?? err.constructor.name;
   const cleanResponse = { ":status": 200, "x-clean": "clean-value", "content-type": "text/plain" };
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5976,3 +5976,330 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+// A header call that throws on validation must leave the connection's HPACK encoder table in
+// step with the peer. Before the fix, the fields before the invalid one were already inserted
+// into the dynamic table (and never sent), so every later header block on the connection decoded
+// against the wrong entries: the next response carried a header from an earlier stream, then the
+// session died with a protocol error.
+describe("http2 a header call that throws leaves the HPACK encoder in sync with the peer", () => {
+  class Boom extends Error {
+    code = "BOOM";
+  }
+  const throwingToString = {
+    toString() {
+      throw new Boom("boom");
+    },
+  };
+  // Each poison has two valid fields (which used to reach the table) before the invalid one, and
+  // the error the call reports for it.
+  const poisons = {
+    "invalid value": {
+      headers: { "x-a": "AAAA", "x-b": "BBBB", "x-v": "a\r\nb" },
+      error: "ERR_HTTP2_INVALID_HEADER_VALUE",
+    },
+    "invalid array element": {
+      headers: { "x-a": "AAAA", "x-b": "BBBB", "x-v": ["ok", "a\nb"] },
+      error: "ERR_HTTP2_INVALID_HEADER_VALUE",
+    },
+    "invalid name": { headers: { "x-a": "AAAA", "x-b": "BBBB", "bad name": "v" }, error: "ERR_INVALID_HTTP_TOKEN" },
+    "undefined value": {
+      headers: { "x-a": "AAAA", "x-b": "BBBB", "x-u": undefined },
+      error: "ERR_HTTP2_INVALID_HEADER_VALUE",
+    },
+    "null value": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-n": null }, error: "ERR_HTTP2_INVALID_HEADER_VALUE" },
+    "symbol value": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-s": Symbol("s") }, error: "TypeError" },
+    "throwing toString": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-t": throwingToString }, error: "BOOM" },
+  };
+  const kinds = Object.keys(poisons);
+  // respond() drops a string value with CR/LF/NUL instead of throwing, so those two kinds do not
+  // apply to it. pushStream() skips an undefined or null value (node's mapToHeaders does the same).
+  const respondKinds = kinds.filter(k => k !== "invalid value" && k !== "invalid array element");
+  const pushKinds = kinds.filter(k => k !== "undefined value" && k !== "null value");
+  const errorOf = err => err.code ?? err.constructor.name;
+  const cleanResponse = { ":status": 200, "x-clean": "clean-value", "content-type": "text/plain" };
+
+  async function withServer(onStream, run, createServer = http2.createServer) {
+    const server = createServer();
+    server.on("stream", onStream);
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    const sessionErrors = [];
+    client.on("error", err => sessionErrors.push(err.code));
+    try {
+      return await run(client, sessionErrors);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  }
+
+  // One request on `client`: resolves with the response headers (no date), the trailers, and the body.
+  function get(client, path, reqHeaders = {}, onRequest = () => {}, reqOptions = undefined) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const result = { headers: null, trailers: null, body: "" };
+    const req = client.request({ ":path": path, ...reqHeaders }, reqOptions);
+    // Object.entries drops the sensitiveHeaders symbol key.
+    req.on("response", headers => {
+      delete headers.date;
+      result.headers = Object.fromEntries(Object.entries(headers));
+    });
+    req.on("trailers", trailers => (result.trailers = Object.fromEntries(Object.entries(trailers))));
+    req.setEncoding("utf8");
+    req.on("data", chunk => (result.body += chunk));
+    req.on("error", reject);
+    req.on("close", () => resolve(result));
+    onRequest(req);
+    return promise;
+  }
+
+  const clean = { headers: cleanResponse, trailers: null, body: "c" };
+  const serveClean = stream => {
+    stream.respond(cleanResponse);
+    stream.end("c");
+  };
+
+  it.each(kinds)("additionalHeaders() that throws on an %s", async kind => {
+    const thrown = [];
+    await withServer(
+      (stream, headers) => {
+        if (headers[":path"] !== "/poison") return serveClean(stream);
+        try {
+          stream.additionalHeaders({ ":status": 103, ...poisons[kind].headers });
+        } catch (err) {
+          thrown.push(errorOf(err));
+        }
+        stream.respond({ ":status": 200, "x-after-info": "1" });
+        stream.end("p");
+      },
+      async (client, sessionErrors) => {
+        expect(await get(client, "/clean1")).toEqual(clean);
+        expect(await get(client, "/poison")).toEqual({
+          headers: { ":status": 200, "x-after-info": "1" },
+          trailers: null,
+          body: "p",
+        });
+        expect(await get(client, "/clean2")).toEqual(clean);
+        expect(thrown).toEqual([poisons[kind].error]);
+        expect(sessionErrors).toEqual([]);
+      },
+    );
+  });
+
+  it.each(respondKinds)("respond() that throws on a %s", async kind => {
+    const thrown = [];
+    await withServer(
+      (stream, headers) => {
+        if (headers[":path"] !== "/poison") return serveClean(stream);
+        try {
+          stream.respond({ ":status": 200, ...poisons[kind].headers, "x-c": "CCCC" });
+        } catch (err) {
+          thrown.push(errorOf(err));
+        }
+        stream.respond({ ":status": 503, "x-fallback": "1" });
+        stream.end("p");
+      },
+      async (client, sessionErrors) => {
+        expect(await get(client, "/clean1")).toEqual(clean);
+        expect(await get(client, "/poison")).toEqual({
+          headers: { ":status": 503, "x-fallback": "1" },
+          trailers: null,
+          body: "p",
+        });
+        expect(await get(client, "/clean2")).toEqual(clean);
+        expect(thrown).toEqual([poisons[kind].error]);
+        expect(sessionErrors).toEqual([]);
+      },
+    );
+  });
+
+  // The compat layer's setHeader() accepts a Symbol or an object whose toString throws, and the
+  // implicit respond() inside res.end() is where the value fails.
+  it.each(["symbol value", "throwing toString"])(
+    "compat res.end() whose implicit respond() throws on a %s",
+    async kind => {
+      const thrown = [];
+      await withServer(
+        () => {},
+        async (client, sessionErrors) => {
+          expect(await get(client, "/clean1")).toEqual(clean);
+          expect(await get(client, "/poison")).toEqual({
+            headers: { ":status": 503, "x-fallback": "1" },
+            trailers: null,
+            body: "p",
+          });
+          expect(await get(client, "/clean2")).toEqual(clean);
+          expect(thrown).toEqual([poisons[kind].error]);
+          expect(sessionErrors).toEqual([]);
+        },
+        () =>
+          http2.createServer((req, res) => {
+            if (req.url !== "/poison") {
+              res.writeHead(200, { "x-clean": "clean-value", "content-type": "text/plain" });
+              res.end("c");
+              return;
+            }
+            for (const [name, value] of Object.entries(poisons[kind].headers)) res.setHeader(name, value);
+            try {
+              res.end("never sent");
+            } catch (err) {
+              thrown.push(errorOf(err));
+            }
+            req.stream.respond({ ":status": 503, "x-fallback": "1" });
+            req.stream.end("p");
+          }),
+      );
+    },
+  );
+
+  it.each(kinds)("server sendTrailers() that throws on an %s", async kind => {
+    const thrown = [];
+    await withServer(
+      (stream, headers) => {
+        if (headers[":path"] !== "/poison") return serveClean(stream);
+        stream.respond({ ":status": 200 }, { waitForTrailers: true });
+        stream.on("wantTrailers", () => {
+          try {
+            stream.sendTrailers(poisons[kind].headers);
+          } catch (err) {
+            thrown.push(errorOf(err));
+          }
+          stream.sendTrailers({ "x-t": "v2" });
+        });
+        stream.end("p");
+      },
+      async (client, sessionErrors) => {
+        expect(await get(client, "/clean1")).toEqual(clean);
+        expect(await get(client, "/poison")).toEqual({
+          headers: { ":status": 200 },
+          trailers: { "x-t": "v2" },
+          body: "p",
+        });
+        expect(await get(client, "/clean2")).toEqual(clean);
+        expect(thrown).toEqual([poisons[kind].error]);
+        expect(sessionErrors).toEqual([]);
+      },
+    );
+  });
+
+  it.each(kinds)("client sendTrailers() that throws on an %s", async kind => {
+    const thrown = [];
+    const seenTrailers = [];
+    await withServer(
+      (stream, headers) => {
+        stream.on("trailers", trailers => seenTrailers.push(Object.fromEntries(Object.entries(trailers))));
+        // Echo the request's custom headers so the client can see which ones decoded on its stream.
+        const echoed = {};
+        for (const name of Object.keys(headers)) {
+          if (name.startsWith("x-")) echoed[name] = headers[name];
+        }
+        stream.on("end", () => {
+          stream.respond({ ":status": 200, "x-echo": JSON.stringify(echoed) });
+          stream.end("c");
+        });
+        stream.resume();
+      },
+      async (client, sessionErrors) => {
+        const echo = headers => ({
+          headers: { ":status": 200, "x-echo": JSON.stringify(headers) },
+          trailers: null,
+          body: "c",
+        });
+        expect(await get(client, "/clean1", { "x-clean": "clean-value" })).toEqual(echo({ "x-clean": "clean-value" }));
+        expect(
+          await get(
+            client,
+            "/poison",
+            { ":method": "POST", "x-poison": "1" },
+            req => {
+              req.on("wantTrailers", () => {
+                try {
+                  req.sendTrailers(poisons[kind].headers);
+                } catch (err) {
+                  thrown.push(errorOf(err));
+                }
+                req.sendTrailers({ "x-t": "v2" });
+              });
+              req.end("body");
+            },
+            { waitForTrailers: true },
+          ),
+        ).toEqual(echo({ "x-poison": "1" }));
+        expect(await get(client, "/clean2", { "x-other": "other-value" })).toEqual(echo({ "x-other": "other-value" }));
+        expect(seenTrailers).toEqual([{ "x-t": "v2" }]);
+        expect(thrown).toEqual([poisons[kind].error]);
+        expect(sessionErrors).toEqual([]);
+      },
+    );
+  });
+
+  it.each(pushKinds)("pushStream() that fails on an %s", async kind => {
+    const pushErrors = [];
+    await withServer(
+      (stream, headers) => {
+        if (headers[":path"] !== "/poison") return serveClean(stream);
+        const respond = () => {
+          stream.respond({ ":status": 200, "x-after-push": "1" });
+          stream.end("p");
+        };
+        try {
+          stream.pushStream({ ":path": "/pushed", ...poisons[kind].headers }, err => {
+            pushErrors.push(err ? errorOf(err) : null);
+            respond();
+          });
+        } catch (err) {
+          pushErrors.push(errorOf(err));
+          respond();
+        }
+      },
+      async (client, sessionErrors) => {
+        const pushed = [];
+        client.on("stream", push => {
+          pushed.push(push);
+          push.resume();
+        });
+        expect(await get(client, "/clean1")).toEqual(clean);
+        expect(await get(client, "/poison")).toEqual({
+          headers: { ":status": 200, "x-after-push": "1" },
+          trailers: null,
+          body: "p",
+        });
+        expect(await get(client, "/clean2")).toEqual(clean);
+        expect(pushErrors).toEqual([poisons[kind].error]);
+        expect(pushed).toEqual([]);
+        expect(sessionErrors).toEqual([]);
+      },
+    );
+  });
+
+  it.each(kinds)("client request() that throws on an %s", async kind => {
+    await withServer(
+      (stream, headers) => {
+        // Echo the request's custom headers so the client can see which ones decoded on its stream.
+        const echoed = {};
+        for (const name of Object.keys(headers)) {
+          if (name.startsWith("x-")) echoed[name] = headers[name];
+        }
+        stream.respond({ ":status": 200, "x-echo": JSON.stringify(echoed) });
+        stream.end("c");
+      },
+      async (client, sessionErrors) => {
+        const echo = headers => ({
+          headers: { ":status": 200, "x-echo": JSON.stringify(headers) },
+          trailers: null,
+          body: "c",
+        });
+        expect(await get(client, "/clean1", { "x-clean": "clean-value" })).toEqual(echo({ "x-clean": "clean-value" }));
+        let thrown = null;
+        try {
+          client.request({ ":path": "/poison", ...poisons[kind].headers });
+        } catch (err) {
+          thrown = errorOf(err);
+        }
+        expect(thrown).toBe(poisons[kind].error);
+        expect(await get(client, "/clean2", { "x-other": "other-value" })).toEqual(echo({ "x-other": "other-value" }));
+        expect(sessionErrors).toEqual([]);
+      },
+    );
+  });
+});


### PR DESCRIPTION
### Problem
- `stream.sendTrailers()`, `stream.additionalHeaders()`, `stream.respond()`, `stream.pushStream()` and `session.request()` validated each header field and encoded it into the HPACK dynamic table one field at a time. When a later field failed validation (bad token, CR/LF/NUL, `undefined`, `null`, a `Symbol`, a throwing `toString`), the call threw after the earlier fields were already in the table and never sent.
- One HPACK encoder serves every stream on a connection and the peer mirrors each insertion. After such a throw every later header block on the connection decodes against the wrong entries: the next response carries a header from an earlier stream (`x-clean` on stream 3 below), then the session dies with `ERR_HTTP2_ERROR Protocol error` or a `GOAWAY COMPRESSION_ERROR`. The per-field encode was in `send_trailers`, `push_promise` and `request` in `src/runtime/api/bun/h2_frame_parser.rs`.

### Fix
- A new `HeaderList` collects the validated fields while the JS object is walked. `encode_header_list` runs once the whole object is known, so a throw during the walk leaves the table untouched. All five entry points go through one of the three native functions.
- `request()` checks `maxSendHeaderBlockLength` against the pre-compression bound (`HeaderList::deflate_bound` plus the 5 priority bytes, the formula nghttp2 uses in `session_prep_frame`) and runs the option and session-memory checks before the encode. A refused block never touches the table either.
- `ClientHttp2Session.request()` no longer re-reports a synchronous throw as a session `'error'`. The headers never reached the wire, and node reports the throw only.
- Verified: `test/js/node/http2/node-http2.test.js` (35 new rows, 33 fail on bun 1.4.3). Also the rest of `test/js/node/http2/` and node's 256 `test-http2-*.js` files (256 pass).

### Background
- HPACK (RFC 7541) compresses header blocks with a dynamic table. The encoder inserts a field, then refers to it by index in later blocks. The decoder on the other side inserts the same entries as it reads the blocks. Both tables must contain the same entries in the same order.
- A field inserted by the encoder but never sent shifts every later index by one on the peer. The peer then reads another stream's field, or fails with `COMPRESSION_ERROR`.
- nghttp2 (node) never has this problem because node validates the whole header object in JS before nghttp2 encodes, and nghttp2 checks `maxSendHeaderBlockLength` on a pre-compression bound.
- #33470 is an earlier attempt at the same fix, closed in favour of this PR. #32995 hoists the option checks above the encode for the same reason. This PR absorbs that part. The rest of #32995 (`parent: 0`, the weight clamp, the PADDED+PRIORITY layout) stays separate.

<details><summary>Notes</summary>

Repro (bun 1.4.3, bun client and bun server):

```js
import http2 from "node:http2";
const srv = http2.createServer();
srv.on("stream", (st, h) => {
  if (h[":path"] === "/poison") {
    try { st.additionalHeaders({ ":status": 103, "x-a": "AAAA", "x-v": "a\r\nb" }); } catch (e) { console.log("S threw", e.code); }
    st.respond({ ":status": 200, "x-after-info": "1" }); st.end("p");
  } else { st.respond({ ":status": 200, "x-clean": "clean-value", "content-type": "text/plain" }); st.end("c"); }
});
srv.listen(0, async () => {
  const s = http2.connect("http://127.0.0.1:" + srv.address().port);
  s.on("error", e => console.log("C sess", e.code));
  const get = p => new Promise(r => { const q = s.request({ ":path": p }); q.on("response", h => { delete h.date; console.log("C", p, JSON.stringify(h)); }); q.resume(); q.on("error", e => console.log("C", p, "err", e.code)); q.on("close", r); });
  await get("/clean1"); await get("/poison"); await get("/clean2"); s.close(); srv.close();
});
```

Before:

```
C /clean1 {":status":200,"x-clean":"clean-value","content-type":"text/plain"}
S threw ERR_HTTP2_INVALID_HEADER_VALUE
C /poison {":status":200,"x-after-info":"1","x-clean":"clean-value"}
C sess ERR_HTTP2_ERROR
C /clean2 err ERR_HTTP2_ERROR
```

After:

```
C /clean1 {":status":200,"x-clean":"clean-value","content-type":"text/plain"}
S threw ERR_HTTP2_INVALID_HEADER_VALUE
C /poison {":status":200,"x-after-info":"1"}
C /clean2 {":status":200,"x-clean":"clean-value","content-type":"text/plain"}
```

Test matrix: six poison kinds (CR/LF value, CR/LF array element, invalid name, `null`, `Symbol`, throwing `toString`) across `additionalHeaders`, `respond`, the compat `res.setHeader` + `res.end` path, server `sendTrailers`, client `sendTrailers`, `pushStream` and client `request`. Each row sends a clean request, the poisoned call, then a clean request on the same session, and asserts the response headers, trailers, body, the thrown code and no session error. `respond()` drops CR/LF string values in JS, and `pushStream()` skips `null` values, so those rows are excluded for them. There is no `undefined` row: #37953 changes what an `undefined` value does, and the sync invariant does not depend on it.

Review history: the open threads on #33470 asked for the option checks to run before the encode, for the `maxSendHeaderBlockLength` check to use the pre-compression bound, and for a throwing `request()` to still complete a pending `close()`. All three are in this PR. The oversized-field pre-check it asked for is not: an encoder failure already ends the session, so there is no table to keep in sync.

Self-reviewed: four concerns raised, three addressed (the unconditional priority bytes in the bound, the `undefined` rows, the related PRs above). Moving `HeaderList` into `h2/hpack.rs` was suggested as optional and is left for the engine rewrite.

`HeaderList` stores names and values in one flat byte buffer with per-field lengths, so the collect pass does one allocation growth path instead of one `Vec` per field. The encode pass writes into the same `encoded_headers` buffer as before.

The `send_trailers` encode failure path (frameError + stream end + graceful GOAWAY) and the `push_promise`/`request` compression-error path are unchanged, they only run after the full walk now.

Suites run: `bun bd test test/js/node/http2/` (509 pass, 6 skip, 0 fail) and `test/js/node/test/parallel/test-http2-*.js` with the debug build.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 33 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1273.26ms]
(pass) node none > Client Basics > should be able to send a POST request [900.63ms]
(pass) node none > Client Basics > constants [23.25ms]
(pass) node none > Client Basics > getDefaultSettings [8.90ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [7.54ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [4.55ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [6.35ms]
(pass) node none > Client Basics > should be able to send data using end [932.65ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [922.14ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 33 failed, 6 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.08ms]
(pass) node none > Client Basics > getDefaultSettings [0.26ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.37ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.09ms]
(pass) node none > Client Basics > is possible to abort request [2.66ms]
(pass) node none > Client Basics > aborted event should work with abortController [1.08ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.82ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.32ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [44.37ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1373.71ms]
(pass) node none > Client Basics > should be able to send a POST request [859.40ms]
(pass) node none > Client Basics > constants [28.66ms]
(pass) node none > Client Basics > getDefaultSettings [12.80ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [26.12ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [8.67ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [6.50ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [8.74ms]
(pass) node none > Client Basics > should be able to send data using end [910.71ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [905.16ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f7dc184a46
  features     baseline

23 deps, 131 codegen, 1172 objects in 1269ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] gen ErrorCode+*.h
[3/1244] fetch zlib
[zlib] up to date
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] fetch tinycc
[tinycc] up to date
[6/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[11/1216] install /workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                   |  15 +-
 src/runtime/api/bun/h2_frame_parser.rs | 362 +++++++++++++++------------------
 test/js/node/http2/node-http2.test.js  | 323 +++++++++++++++++++++++++++++
 3 files changed, 487 insertions(+), 213 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/node/http2.ts                        2      2     31
src/runtime/api/bun/h2_frame_parser.rs      9     18     32
test/js/node/http2/node-http2.test.js       1      0     31
```

</details>

**root cause** · written by the author bot

The header-serialization paths for `request`, `sendTrailers`, `additionalHeaders`, and `pushStream` validated and HPACK-encoded each field one at a time, so when a later field failed validation the call threw after earlier fields had already been inserted into the connection's shared dynamic table without ever being sent, leaving the peer's decoder out of sync and causing later header blocks to decode onto the wrong stream or trigger a COMPRESSION_ERROR GOAWAY. The fix collects and validates the complete header list into a private buffer before the encoder is touched, then performs a single…

<!-- robobun:evidence:end -->