### PR TITLE
ast: stop deeply nested trees from overflowing the stack in Expr::deep_clone

### DIFF
--- a/src/ast/error.rs
+++ b/src/ast/error.rs
@@ -27,9 +27,8 @@ impl bun_core::output::ErrName for Error {
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-/// Failure of `Expr::deep_clone` and friends: the clone recurses once per
-/// nesting level, so a tree the depth-guarded parsers accept can still run
-/// out of native stack here.
+/// `Expr::deep_clone` recurses once per nesting level, so a tree the
+/// depth-guarded parsers accepted can still run out of native stack here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum DeepCloneError {
     #[error("StackOverflow")]

--- a/src/ast/error.rs
+++ b/src/ast/error.rs
@@ -26,3 +26,14 @@ impl bun_core::output::ErrName for Error {
 }
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+/// Failure of `Expr::deep_clone` and friends: the clone recurses once per
+/// nesting level, so a tree the depth-guarded parsers accept can still run
+/// out of native stack here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum DeepCloneError {
+    #[error("StackOverflow")]
+    StackOverflow,
+    #[error(transparent)]
+    Alloc(#[from] bun_alloc::AllocError),
+}

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -7,9 +7,9 @@ use core::fmt;
 use crate::Loc;
 use bun_alloc::{AllocError, Arena as Bump};
 use bun_collections::VecExt;
-use bun_core::{self};
+use bun_core::{self, StackCheck};
 
-use crate::{DebugOnlyDisabler, E, G, Op, Ref};
+use crate::{DebugOnlyDisabler, DeepCloneError, E, G, Op, Ref};
 use bun_alloc::ArenaVecExt as _;
 // Re-export so downstream crates can name `ast::expr::StoreRef` (some callers
 // route through `expr::`).
@@ -112,15 +112,24 @@ impl Expr {
 }
 
 impl Expr {
-    pub fn deep_clone(&self, bump: &Bump) -> Result<Expr, AllocError> {
+    /// Deep-clone this subtree into `bump`. Returns
+    /// [`DeepCloneError::StackOverflow`] when the tree is nested deeper than
+    /// the remaining native stack allows. The parsers that produce these
+    /// trees are depth-guarded with the same `StackCheck`, but their frames
+    /// are smaller, so a tree they accept can still overflow the clone.
+    pub fn deep_clone(&self, bump: &Bump) -> Result<Expr, DeepCloneError> {
         let _g = bun_alloc::ast_alloc::DetachAstHeap::new();
-        self.deep_clone_no_detach(bump)
+        self.deep_clone_no_detach(bump, StackCheck::init())
     }
     #[inline]
-    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Expr, AllocError> {
+    pub(crate) fn deep_clone_no_detach(
+        &self,
+        bump: &Bump,
+        stack_check: StackCheck,
+    ) -> Result<Expr, DeepCloneError> {
         Ok(Expr {
             loc: self.loc,
-            data: self.data.deep_clone_no_detach(bump)?,
+            data: self.data.deep_clone_no_detach(bump, stack_check)?,
         })
     }
 
@@ -1812,7 +1821,8 @@ fn json_value_deep_clone(
     value: &E::JsonValue,
     loc: Loc,
     bump: &Bump,
-) -> Result<Expr, bun_alloc::AllocError> {
+    stack_check: StackCheck,
+) -> Result<Expr, DeepCloneError> {
     Ok(match value {
         E::JsonValue::String(s) => {
             let bytes: &[u8] = bump.alloc_slice_copy(s.slice());
@@ -1820,11 +1830,11 @@ fn json_value_deep_clone(
         }
         E::JsonValue::Object(o) => Expr {
             loc,
-            data: Data::EObjectJSON(*o).deep_clone_no_detach(bump)?,
+            data: Data::EObjectJSON(*o).deep_clone_no_detach(bump, stack_check)?,
         },
         E::JsonValue::Array(a) => Expr {
             loc,
-            data: Data::EArrayJSON(*a).deep_clone_no_detach(bump)?,
+            data: Data::EArrayJSON(*a).deep_clone_no_detach(bump, stack_check)?,
         },
         _ => Expr::from_json_value(value, loc),
     })
@@ -1863,18 +1873,25 @@ impl Data {
     /// those vecs land on global mimalloc. The guard is installed once here
     /// and at [`Expr::deep_clone`]; the recursive body goes through
     /// `*_no_detach` so we don't pay 3 TLS ops per node.
-    pub fn deep_clone(&self, bump: &Bump) -> Result<Data, AllocError> {
+    pub fn deep_clone(&self, bump: &Bump) -> Result<Data, DeepCloneError> {
         let _g = bun_alloc::ast_alloc::DetachAstHeap::new();
-        self.deep_clone_no_detach(bump)
+        self.deep_clone_no_detach(bump, StackCheck::init())
     }
 
-    fn deep_clone_no_detach(&self, bump: &Bump) -> Result<Data, AllocError> {
+    fn deep_clone_no_detach(
+        &self,
+        bump: &Bump,
+        stack_check: StackCheck,
+    ) -> Result<Data, DeepCloneError> {
+        if !stack_check.is_safe_to_recurse() {
+            return Err(DeepCloneError::StackOverflow);
+        }
         let this = *self;
         match &this {
             Data::EArray(el) => {
                 let items = el
                     .items
-                    .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?;
+                    .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?;
                 let item = bump.alloc(E::Array {
                     items,
                     comma_after_spread: el.comma_after_spread,
@@ -1900,7 +1917,12 @@ impl Data {
                             E::EString::init(key_bytes),
                             row.key_loc,
                         )),
-                        value: Some(json_value_deep_clone(&row.value, value_loc, bump)?),
+                        value: Some(json_value_deep_clone(
+                            &row.value,
+                            value_loc,
+                            bump,
+                            stack_check,
+                        )?),
                         kind: G::PropertyKind::Normal,
                         initializer: None,
                         ..Default::default()
@@ -1922,7 +1944,7 @@ impl Data {
                     Vec::with_capacity_in(rows.len(), bun_alloc::AstAlloc);
                 for (i, value) in rows.iter().enumerate() {
                     let loc = item_locs.map_or(crate::Loc::EMPTY, |l| l[i]);
-                    items.push(json_value_deep_clone(value, loc, bump)?);
+                    items.push(json_value_deep_clone(value, loc, bump, stack_check)?);
                 }
                 let item = bump.alloc(E::Array {
                     items,
@@ -1935,7 +1957,7 @@ impl Data {
             Data::EUnary(el) => {
                 let item = bump.alloc(E::Unary {
                     op: el.op,
-                    value: el.value.deep_clone_no_detach(bump)?,
+                    value: el.value.deep_clone_no_detach(bump, stack_check)?,
                     flags: el.flags,
                 });
                 Ok(Data::EUnary(StoreRef::from_bump(item)))
@@ -1943,8 +1965,8 @@ impl Data {
             Data::EBinary(el) => {
                 let item = bump.alloc(E::Binary {
                     op: el.op,
-                    left: el.left.deep_clone_no_detach(bump)?,
-                    right: el.right.deep_clone_no_detach(bump)?,
+                    left: el.left.deep_clone_no_detach(bump, stack_check)?,
+                    right: el.right.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::EBinary(StoreRef::from_bump(item)))
             }
@@ -1953,7 +1975,7 @@ impl Data {
                 let src_props: &[G::Property] = el.properties.slice();
                 let mut properties = bun_alloc::ArenaVec::with_capacity_in(src_props.len(), bump);
                 for prop in src_props.iter() {
-                    properties.push(prop.deep_clone(bump)?);
+                    properties.push(prop.deep_clone(bump, stack_check)?);
                 }
                 let properties = crate::StoreSlice::new_mut(properties.into_bump_slice_mut());
 
@@ -1961,10 +1983,10 @@ impl Data {
                     class_keyword: el.class_keyword,
                     ts_decorators: el
                         .ts_decorators
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     class_name: el.class_name,
                     extends: match &el.extends {
-                        Some(e) => Some(e.deep_clone_no_detach(bump)?),
+                        Some(e) => Some(e.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
                     body_loc: el.body_loc,
@@ -1977,10 +1999,10 @@ impl Data {
             }
             Data::ENew(el) => {
                 let item = bump.alloc(E::New {
-                    target: el.target.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
                     args: el
                         .args
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     can_be_unwrapped_if_unused: el.can_be_unwrapped_if_unused,
                     close_parens_loc: el.close_parens_loc,
                 });
@@ -1988,16 +2010,16 @@ impl Data {
             }
             Data::EFunction(el) => {
                 let item = bump.alloc(E::Function {
-                    func: el.func.deep_clone(bump)?,
+                    func: el.func.deep_clone(bump, stack_check)?,
                 });
                 Ok(Data::EFunction(StoreRef::from_bump(item)))
             }
             Data::ECall(el) => {
                 let item = bump.alloc(E::Call {
-                    target: el.target.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
                     args: el
                         .args
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     optional_chain: el.optional_chain,
                     is_direct_eval: el.is_direct_eval,
                     close_paren_loc: el.close_paren_loc,
@@ -2008,7 +2030,7 @@ impl Data {
             }
             Data::EDot(el) => {
                 let item = bump.alloc(E::Dot {
-                    target: el.target.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
                     name: el.name,
                     name_loc: el.name_loc,
                     optional_chain: el.optional_chain,
@@ -2020,8 +2042,8 @@ impl Data {
             }
             Data::EIndex(el) => {
                 let item = bump.alloc(E::Index {
-                    target: el.target.deep_clone_no_detach(bump)?,
-                    index: el.index.deep_clone_no_detach(bump)?,
+                    target: el.target.deep_clone_no_detach(bump, stack_check)?,
+                    index: el.index.deep_clone_no_detach(bump, stack_check)?,
                     optional_chain: el.optional_chain,
                     is_import_property_use: el.is_import_property_use,
                 });
@@ -2030,7 +2052,7 @@ impl Data {
             Data::EArrow(el) => {
                 let mut args = bun_alloc::ArenaVec::with_capacity_in(el.args.len(), bump);
                 for i in 0..el.args.len() {
-                    args.push(el.args[i].deep_clone(bump)?);
+                    args.push(el.args[i].deep_clone(bump, stack_check)?);
                 }
                 let item = bump.alloc(E::Arrow {
                     args: crate::StoreSlice::new(args.into_bump_slice()),
@@ -2048,13 +2070,15 @@ impl Data {
             Data::EJsxElement(el) => {
                 let item = bump.alloc(E::JSXElement {
                     tag: match &el.tag {
-                        Some(tag) => Some(tag.deep_clone_no_detach(bump)?),
+                        Some(tag) => Some(tag.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
-                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump))?,
+                    properties: el
+                        .properties
+                        .try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
                     children: el
                         .children
-                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump))?,
+                        .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
                     key_prop_index: el.key_prop_index,
                     flags: el.flags,
                     close_tag_loc: el.close_tag_loc,
@@ -2063,7 +2087,9 @@ impl Data {
             }
             Data::EObject(el) => {
                 let item = bump.alloc(E::Object {
-                    properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump))?,
+                    properties: el
+                        .properties
+                        .try_deep_clone_with(|p| p.deep_clone(bump, stack_check))?,
                     comma_after_spread: el.comma_after_spread,
                     is_single_line: el.is_single_line,
                     is_parenthesized: el.is_parenthesized,
@@ -2074,14 +2100,14 @@ impl Data {
             }
             Data::ESpread(el) => {
                 let item = bump.alloc(E::Spread {
-                    value: el.value.deep_clone_no_detach(bump)?,
+                    value: el.value.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::ESpread(StoreRef::from_bump(item)))
             }
             Data::ETemplate(el) => {
                 let item = bump.alloc(E::Template {
                     tag: match &el.tag {
-                        Some(tag) => Some(tag.deep_clone_no_detach(bump)?),
+                        Some(tag) => Some(tag.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
                     parts: el.parts,
@@ -2100,14 +2126,14 @@ impl Data {
             }
             Data::EAwait(el) => {
                 let item = bump.alloc(E::Await {
-                    value: el.value.deep_clone_no_detach(bump)?,
+                    value: el.value.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::EAwait(StoreRef::from_bump(item)))
             }
             Data::EYield(el) => {
                 let item = bump.alloc(E::Yield {
                     value: match &el.value {
-                        Some(value) => Some(value.deep_clone_no_detach(bump)?),
+                        Some(value) => Some(value.deep_clone_no_detach(bump, stack_check)?),
                         None => None,
                     },
                     is_star: el.is_star,
@@ -2116,16 +2142,16 @@ impl Data {
             }
             Data::EIf(el) => {
                 let item = bump.alloc(E::If {
-                    test: el.test.deep_clone_no_detach(bump)?,
-                    yes: el.yes.deep_clone_no_detach(bump)?,
-                    no: el.no.deep_clone_no_detach(bump)?,
+                    test: el.test.deep_clone_no_detach(bump, stack_check)?,
+                    yes: el.yes.deep_clone_no_detach(bump, stack_check)?,
+                    no: el.no.deep_clone_no_detach(bump, stack_check)?,
                 });
                 Ok(Data::EIf(StoreRef::from_bump(item)))
             }
             Data::EImport(el) => {
                 let item = bump.alloc(E::Import {
-                    expr: el.expr.deep_clone_no_detach(bump)?,
-                    options: el.options.deep_clone_no_detach(bump)?,
+                    expr: el.expr.deep_clone_no_detach(bump, stack_check)?,
+                    options: el.options.deep_clone_no_detach(bump, stack_check)?,
                     import_record_index: el.import_record_index,
                     namespace_ref: el.namespace_ref,
                 });

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -112,11 +112,7 @@ impl Expr {
 }
 
 impl Expr {
-    /// Deep-clone this subtree into `bump`. Returns
-    /// [`DeepCloneError::StackOverflow`] when the tree is nested deeper than
-    /// the remaining native stack allows. The parsers that produce these
-    /// trees are depth-guarded with the same `StackCheck`, but their frames
-    /// are smaller, so a tree they accept can still overflow the clone.
+    /// Deep-clone this subtree into `bump`.
     pub fn deep_clone(&self, bump: &Bump) -> Result<Expr, DeepCloneError> {
         let _g = bun_alloc::ast_alloc::DetachAstHeap::new();
         self.deep_clone_no_detach(bump, StackCheck::init())

--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -195,7 +195,8 @@ impl Property {
     pub(crate) fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Property, bun_alloc::AllocError> {
+        stack_check: bun_core::StackCheck,
+    ) -> core::result::Result<Property, crate::DeepCloneError> {
         let mut class_static_block: Option<crate::StoreRef<ClassStaticBlock>> = None;
         if let Some(csb_ref) = self.class_static_block_ref() {
             let new_block: &mut ClassStaticBlock = bump.alloc(ClassStaticBlock {
@@ -206,7 +207,7 @@ impl Property {
         }
         Ok(Property {
             initializer: match self.initializer {
-                Some(init) => Some(init.deep_clone(bump)?),
+                Some(init) => Some(init.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             kind: self.kind,
@@ -215,13 +216,13 @@ impl Property {
             // Vec<Expr> per-element deep clone.
             ts_decorators: self
                 .ts_decorators
-                .try_deep_clone_with(|e| e.deep_clone(bump))?,
+                .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
             key: match self.key {
-                Some(key) => Some(key.deep_clone(bump)?),
+                Some(key) => Some(key.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             value: match self.value {
-                Some(value) => Some(value.deep_clone(bump)?),
+                Some(value) => Some(value.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             ts_metadata: self.ts_metadata.clone(),
@@ -298,11 +299,12 @@ impl Fn {
     pub(crate) fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Fn, bun_alloc::AllocError> {
+        stack_check: bun_core::StackCheck,
+    ) -> core::result::Result<Fn, crate::DeepCloneError> {
         let src_args: &[Arg] = self.args.slice();
         let args: &mut [Arg] = bump.alloc_slice_fill_default::<Arg>(src_args.len());
         for i in 0..args.len() {
-            args[i] = src_args[i].deep_clone(bump)?;
+            args[i] = src_args[i].deep_clone(bump, stack_check)?;
         }
         Ok(Fn {
             name: self.name,
@@ -346,15 +348,16 @@ impl Arg {
     pub(crate) fn deep_clone(
         &self,
         bump: &bun_alloc::Arena,
-    ) -> core::result::Result<Arg, bun_alloc::AllocError> {
+        stack_check: bun_core::StackCheck,
+    ) -> core::result::Result<Arg, crate::DeepCloneError> {
         Ok(Arg {
             // Vec<Expr> per-element deep clone.
             ts_decorators: self
                 .ts_decorators
-                .try_deep_clone_with(|e| e.deep_clone(bump))?,
+                .try_deep_clone_with(|e| e.deep_clone_no_detach(bump, stack_check))?,
             binding: self.binding,
             default: match self.default {
-                Some(d) => Some(d.deep_clone(bump)?),
+                Some(d) => Some(d.deep_clone_no_detach(bump, stack_check)?),
                 None => None,
             },
             is_typescript_ctor_field: self.is_typescript_ctor_field,

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2855,7 +2855,7 @@ pub mod binding;
 pub mod char_freq;
 pub mod e;
 pub mod error;
-pub use error::{Error, Result};
+pub use error::{DeepCloneError, Error, Result};
 pub mod expr;
 pub mod fold_string_addition;
 pub mod g;

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -281,14 +281,10 @@ impl<C: CompletionStruct> BundleThread<C> {
         let transpiler = match completion.create_and_configure_transpiler(bump) {
             Ok(transpiler) => transpiler,
             Err(err) => {
-                // The transpiler (if it was allocated) is already dropped by
-                // the callee. Restore the AST-allocator thread-local and
-                // release the store's global-heap state, as the success path
-                // does below.
+                // The callee dropped the transpiler. Unwind the AST store as
+                // the success path does below.
                 ast_memory_store.pop();
-                // SAFETY: the unique `&mut` slot from `bump.alloc` above;
-                // nothing else references it. The arena bytes are bulk-freed
-                // by `heap`'s `Drop`.
+                // SAFETY: the unique `&mut` slot from `bump.alloc` above.
                 unsafe {
                     core::ptr::drop_in_place(std::ptr::from_mut::<bun_ast::ASTMemoryAllocator>(
                         ast_memory_store,

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -278,7 +278,25 @@ impl<C: CompletionStruct> BundleThread<C> {
         ast_memory_store.push();
 
         // Allocate + configure folded — see `create_and_configure_transpiler` doc.
-        let transpiler = completion.create_and_configure_transpiler(bump)?;
+        let transpiler = match completion.create_and_configure_transpiler(bump) {
+            Ok(transpiler) => transpiler,
+            Err(err) => {
+                // The transpiler (if it was allocated) is already dropped by
+                // the callee. Restore the AST-allocator thread-local and
+                // release the store's global-heap state, as the success path
+                // does below.
+                ast_memory_store.pop();
+                // SAFETY: the unique `&mut` slot from `bump.alloc` above;
+                // nothing else references it. The arena bytes are bulk-freed
+                // by `heap`'s `Drop`.
+                unsafe {
+                    core::ptr::drop_in_place(std::ptr::from_mut::<bun_ast::ASTMemoryAllocator>(
+                        ast_memory_store,
+                    ));
+                }
+                return Err(err);
+            }
+        };
 
         transpiler.resolver.generation = generation;
 

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -443,7 +443,21 @@ impl DefineDataExt for DefineData {
         // `.into()` deep-walking T2→T4 and re-boxing the payload; now `.into()`
         // is identity, so without `deep_clone` the `DefineData.value` dangles
         // into a freed slab and `process.env.NODE_ENV` reads garbage.
-        let data: ExprData = expr.data.deep_clone(bump)?;
+        let data: ExprData = match expr.data.deep_clone(bump) {
+            Ok(data) => data,
+            Err(bun_ast::DeepCloneError::StackOverflow) => {
+                log.add_error_fmt_opts(
+                    format_args!("JSON document is too deeply nested"),
+                    bun_ast::AddErrorOptions {
+                        source: Some(&source),
+                        loc: expr.loc,
+                        ..Default::default()
+                    },
+                );
+                return Err(crate::Error::Parsers(bun_parsers::Error::StackOverflow));
+            }
+            Err(bun_ast::DeepCloneError::Alloc(e)) => return Err(e.into()),
+        };
         let can_be_removed_if_unused = bun_ast::expr::Tag::is_primitive_literal(data.tag());
         Ok(DefineData {
             value: data,

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -74,9 +74,7 @@ impl MapEntry {
 pub type Map = StringHashMap<MapEntry>;
 
 /// Parses `source` and clones the tree out of the thread-local `Store` into
-/// `bump`, so the result survives the `Store` resets that later lookups do.
-/// The clone recurses once per nesting level and reports a too-deep tree the
-/// same way the parser does.
+/// `bump`, so the result survives the `Store` resets of later lookups.
 fn parse_package_json(
     source: &Source,
     log: &mut Log,

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -65,7 +65,7 @@ impl MapEntry {
     pub(crate) fn reparse_root(&mut self, log: &mut Log) -> Result<(), Error> {
         let json_bump = bun_alloc::Arena::new();
         let parsed = parse_package_json(&self.source, log, &json_bump, false)?;
-        self.root = bun_core::handle_oom(parsed.root.deep_clone(&json_bump));
+        self.root = parsed.root;
         self.json_arena = json_bump;
         Ok(())
     }
@@ -73,13 +73,17 @@ impl MapEntry {
 
 pub type Map = StringHashMap<MapEntry>;
 
+/// Parses `source` and clones the tree out of the thread-local `Store` into
+/// `bump`, so the result survives the `Store` resets that later lookups do.
+/// The clone recurses once per nesting level and reports a too-deep tree the
+/// same way the parser does.
 fn parse_package_json(
     source: &Source,
     log: &mut Log,
     bump: &bun_alloc::Arena,
     guess_indentation: bool,
 ) -> Result<json::JsonResult, crate::Error> {
-    Ok(json::parse_package_json_utf8_with_opts(
+    let mut parsed = json::parse_package_json_utf8_with_opts(
         json::JSONOptions {
             json_warn_duplicate_keys: false,
             guess_indentation,
@@ -88,7 +92,23 @@ fn parse_package_json(
         source,
         log,
         bump,
-    )?)
+    )?;
+    parsed.root = match parsed.root.deep_clone(bump) {
+        Ok(root) => root,
+        Err(bun_ast::DeepCloneError::StackOverflow) => {
+            log.add_error_fmt_opts(
+                format_args!("JSON document is too deeply nested"),
+                bun_ast::AddErrorOptions {
+                    source: Some(source),
+                    loc: parsed.root.loc,
+                    ..Default::default()
+                },
+            );
+            return Err(bun_parsers::Error::StackOverflow.into());
+        }
+        Err(bun_ast::DeepCloneError::Alloc(err)) => return Err(err.into()),
+    };
+    Ok(parsed)
 }
 
 #[derive(Clone, Copy)]

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -214,7 +214,7 @@ impl WorkspacePackageJSONCache {
         };
 
         let value = MapEntry {
-            root: bun_core::handle_oom(parsed.root.deep_clone(&json_bump)),
+            root: parsed.root,
             source,
             indentation: parsed.indentation,
             indentation_guessed: opts.guess_indentation,

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -502,7 +502,15 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
         Ok(r) => r,
         Err(_) => return Err(MigratePnpmLockfileError::YamlParseError),
     };
-    let mut root: Expr = bun_core::handle_oom(_root.deep_clone(&yaml_arena));
+    let mut root: Expr = match _root.deep_clone(&yaml_arena) {
+        Ok(root) => root,
+        Err(bun_ast::DeepCloneError::StackOverflow) => {
+            return Err(MigratePnpmLockfileError::YamlParseError);
+        }
+        Err(bun_ast::DeepCloneError::Alloc(_)) => {
+            return Err(MigratePnpmLockfileError::OutOfMemory);
+        }
+    };
 
     // pnpm 11 writes `---<env lockfile>---<lockfile>`; the last document is the lockfile.
     if let Some(mut documents) = root.as_array() {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1213,11 +1213,9 @@ impl CompletionStruct for JSBundleCompletionTask {
         let tp: *mut Transpiler<'a> = transpiler;
         // SAFETY: `tp` aliases nothing in `self`; lives in `bump`.
         if let Err(err) = self.configure_bundler(unsafe { &mut *tp }, bump) {
-            // The arena never runs `Drop`; release the transpiler's
-            // global-heap state here, as `generate_in_new_thread` does on the
-            // success path.
+            // The arena never runs `Drop`; release the transpiler's heap state.
             // SAFETY: `tp` is the unique slot from `bump.alloc`; the reborrow
-            // above has ended and nothing else references it.
+            // above has ended.
             unsafe { core::ptr::drop_in_place(tp) };
             return Err(err);
         }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1212,7 +1212,15 @@ impl CompletionStruct for JSBundleCompletionTask {
         // not `self`) to the trait method.
         let tp: *mut Transpiler<'a> = transpiler;
         // SAFETY: `tp` aliases nothing in `self`; lives in `bump`.
-        self.configure_bundler(unsafe { &mut *tp }, bump)?;
+        if let Err(err) = self.configure_bundler(unsafe { &mut *tp }, bump) {
+            // The arena never runs `Drop`; release the transpiler's
+            // global-heap state here, as `generate_in_new_thread` does on the
+            // success path.
+            // SAFETY: `tp` is the unique slot from `bump.alloc`; the reborrow
+            // above has ended and nothing else references it.
+            unsafe { core::ptr::drop_in_place(tp) };
+            return Err(err);
+        }
         // SAFETY: `tp` was the unique `&'a mut` slot from `bump.alloc`; the
         // reborrow above has ended.
         Ok(unsafe { &mut *tp })

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -305,6 +305,55 @@ describe("Bun.build", () => {
     });
   });
 
+  // The JSON parser is depth-guarded, but the clone of the parsed define value
+  // out of the thread-local AST store recurses once per nesting level with
+  // larger frames. Each depth below fell into that window on one build flavor
+  // (release or ASAN). Spawned because the crash takes the test runner with it.
+  for (const depth of [1000, 10000]) {
+    test.concurrent(`a define value nested ${depth} levels deep is an error, not a crash`, async () => {
+      const value = Buffer.alloc(depth, "[").toString() + "1" + Buffer.alloc(depth, "]").toString();
+      using dir = tempDir("bun-build-deep-define", {
+        "entry.js": `console.log(X);`,
+        "build.js": `
+          const r = await Bun.build({ entrypoints: ["./entry.js"], define: { X: process.argv[2] }, throw: false });
+          console.log(JSON.stringify({ success: r.success, logs: r.logs.map(l => l.message) }));
+        `,
+      });
+
+      await using cli = Bun.spawn({
+        cmd: [bunExe(), "build", "entry.js", "--define", `X=${value}`],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [cliStdout, cliStderr, cliExitCode] = await Promise.all([cli.stdout.text(), cli.stderr.text(), cli.exited]);
+      // A depth the native stack can hold builds; a deeper one is a parse error.
+      if (cliExitCode === 0) {
+        expect(cliStdout).toContain(value);
+      } else {
+        expect(cliStderr).toContain("JSON document is too deeply nested");
+        expect(cliExitCode).toBe(1);
+      }
+
+      await using api = Bun.spawn({
+        cmd: [bunExe(), "build.js", value],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [apiStdout, apiStderr, apiExitCode] = await Promise.all([api.stdout.text(), api.stderr.text(), api.exited]);
+      expect(apiStderr).toBe("");
+      expect(JSON.parse(apiStdout)).toEqual(
+        cliExitCode === 0
+          ? { success: true, logs: [] }
+          : { success: false, logs: ["JSON document is too deeply nested"] },
+      );
+      expect(apiExitCode).toBe(0);
+    });
+  }
+
   // https://github.com/oven-sh/bun/issues/12818
   test("sourcemap + build error crash case", async () => {
     const dir = tempDirWithFiles("build", {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -328,7 +328,9 @@ describe("Bun.build", () => {
         stderr: "pipe",
       });
       const [cliStdout, cliStderr, cliExitCode] = await Promise.all([cli.stdout.text(), cli.stderr.text(), cli.exited]);
-      // A depth the native stack can hold builds; a deeper one is a parse error.
+      // A depth the native stack can hold builds; a deeper one is a parse
+      // error. The CLI and the bundler thread reach the limit at different
+      // depths, so each outcome is checked on its own.
       if (cliExitCode === 0) {
         expect(cliStdout).toContain(value);
       } else {
@@ -345,8 +347,9 @@ describe("Bun.build", () => {
       });
       const [apiStdout, apiStderr, apiExitCode] = await Promise.all([api.stdout.text(), api.stderr.text(), api.exited]);
       expect(apiStderr).toBe("");
-      expect(JSON.parse(apiStdout)).toEqual(
-        cliExitCode === 0
+      const apiResult = JSON.parse(apiStdout);
+      expect(apiResult).toEqual(
+        apiResult.success
           ? { success: true, logs: [] }
           : { success: false, logs: ["JSON document is too deeply nested"] },
       );

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -11380,3 +11380,29 @@ it.each([
     expect(exitCode).not.toBe(0);
   });
 });
+
+// The JSON parser is depth-guarded, but the clone of the parsed manifest out of
+// the thread-local AST store recurses once per nesting level with larger frames.
+// Each depth below fell into that window on one build flavor (release or ASAN).
+for (const depth of [700, 16000]) {
+  it.concurrent(`reports a package.json nested ${depth} levels deep instead of crashing`, async () => {
+    const open = Buffer.alloc(depth * 5, '{"a":').toString();
+    const close = Buffer.alloc(depth, "}").toString();
+    using dir = tempDir("bun-install-deep-package-json", {
+      "package.json": `{"name":"h","version":"1.0.0","dependencies":${open}"file:./dep"${close}}`,
+      "dep/package.json": `{"name":"dep","version":"1.0.0"}`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toStartWith("bun install v1.");
+    expect(stderr).toMatch(/JSON document is too deeply nested|dependencies expects a map of specifiers/);
+    expect(exitCode).toBe(1);
+  });
+}


### PR DESCRIPTION
### Problem
- A package.json nested about 10000 levels deep under any key kills `bun install`, `bun add`, `bun remove`, `bun update`, `bun pm pack` and `bun publish` with `panic(main thread): Segmentation fault`. A `--define` or `Bun.build({ define })` value nested a few thousand levels deep kills `bun build` the same way. 1.3.14 reported a clean `StackOverflow: failed to parse`.
- Cause: `Expr::deep_clone` (`src/ast/expr.rs:115`) recurses once per nesting level through `G::Property::deep_clone` (`src/ast/g.rs:195`) and never checks the stack. The JSON parser is guarded by `StackCheck`, but its frames are smaller, so a depth it accepts can still overflow the clone. Under ASAN the window is about 600 to 1000 levels, on release about 10000 to 35000.

### Fix
- `deep_clone` seats a `StackCheck` and returns the new `bun_ast::DeepCloneError::StackOverflow` when fewer than 128 KiB of stack remain. The enum has exactly two variants, `StackOverflow` and `Alloc`, so a caller cannot treat it as OOM by accident (the old `Result<_, AllocError>` went through `handle_oom`).
- The three callers report it like the parsers do: the install manifest cache logs `JSON document is too deeply nested` and returns `bun_parsers::Error::StackOverflow`, the pnpm migration returns `YamlParseError`, `DefineData::parse` logs the same message and returns the parser error.
- `Bun.build` leaked the transpiler's heap state on every configuration error: `generate_in_new_thread` (`src/bundler/BundleThread.rs:281`) returned early and the arena-allocated `Transpiler` and `ASTMemoryAllocator` never ran `Drop`. The error path now drops both, as the success path does. The new test made LSan report this.
- Verified: `test/cli/install/bun-install.test.ts` (depths 700 and 16000) and `test/bundler/bun-build-api.test.ts` (depths 1000 and 10000). The shallow depth fails on ASAN, the deep one on release. Also ran both files in full.

### Background
- Parsers build `Expr` nodes in a thread-local `Store`. `bun install` resets that store before each manifest lookup, so the manifest cache clones the tree into an arena first. `DefineData::parse` clones for the same reason.
- `bun_core::StackCheck` reads the thread's stack end once and compares it with the current frame address. The JSON, YAML and TOML parsers use it with the same threshold.
- Values in a `bun_alloc::Arena` never run `Drop`. Code that puts a `Transpiler` there must `drop_in_place` it before the arena goes away.

<details><summary>Notes</summary>

Repro on 1.4.3-canary (f42e98025), release build:

```
mkdir dep; echo '{"name":"dep","version":"1.0.0"}' > dep/package.json
python3 -c "print('{\"name\":\"h\",\"version\":\"1.0.0\",\"dependencies\":' + '{\"a\":'*16000 + '\"file:./dep\"' + '}'*16000 + '}')" > package.json
bun install   # rc 139, segfault
bun build a.js --define "X=$(python3 -c "print('['*10000 + '1' + ']'*10000)")"   # rc 139
```

ASAN frames: `__asan_memcpy` <- `Data::deep_clone_no_detach` expr.rs:1872 <- `Expr::deep_clone_no_detach` :123 <- `Expr::deep_clone` :117 <- `G::Property::deep_clone` g.rs:220 <- `Data::deep_clone_no_detach::{closure#8}` :2066, repeated.

Fix output, install: `error: JSON document is too deeply nested` then `StackOverflow: failed to parse '<path>/package.json'`, rc 1. `bun build --define`: `error: JSON document is too deeply nested at defines.json:1:N`, rc 1. `Bun.build`: `success: false`, one `BuildMessage` with the same text. `Bun.Transpiler`: throws `StackOverflow Failed to load define`.

The check runs at the top of `Data::deep_clone_no_detach`, once per node, a frame-address compare. `StackCheck` is a no-op on the install worker pool (it opts out of stack bounds), the same as the JSON parser there. The manifest cache runs on the main thread. Both manifest cache sites now share one parse helper that does the clone.

`G::Property`, `G::Fn` and `G::Arg` call the crate-private `deep_clone_no_detach` instead of the public entry, which also drops a redundant `DetachAstHeap` guard per property.

The define test checks the CLI and the `Bun.build` outcome on their own: the two reach the limit at different depths (Windows CI: the CLI built a 10000-deep value, the bundler thread rejected it).

Leak numbers under `ASAN_OPTIONS=detect_leaks=1` for `Bun.build({ define })` with a value too deep for the bundler thread: 7957 bytes in 199 allocations before the error-path fix, 476 bytes in 6 after. A successful build reports 772 bytes in 5 allocations (objects alive at exit, unchanged by this PR).

Other suites: `test/bundler/bun-build-api.test.ts` in full (65 pass, the two `bytecode:` tests time out at 5 s in this container on main as well).
</details>
