### PR TITLE
Add React development fields to Bun.markdown.react elements

### DIFF
--- a/src/jsc/bindings/JSReactElement.cpp
+++ b/src/jsc/bindings/JSReactElement.cpp
@@ -17,10 +17,7 @@ static constexpr PropertyOffset keyOffset = 2;
 static constexpr PropertyOffset refOffset = 3;
 static constexpr PropertyOffset propsOffset = 4;
 
-// Development structure only. These are the fields React's development
-// build adds in `ReactElement()` (react.development.js). React's development
-// renderers read and write them without guards, for example
-// `element._store.validated = 1` in react-server-dom-webpack.
+// Development structure only: the fields React's development build adds in `ReactElement()`.
 static constexpr PropertyOffset ownerOffset = 5;
 static constexpr PropertyOffset storeOffset = 6;
 static constexpr PropertyOffset debugInfoOffset = 7;
@@ -119,8 +116,7 @@ static JSObject* createElement(Zig::GlobalObject* global, uint8_t reactVersion, 
         return element;
     }
 
-    // `validated` is 1, the value React's JSX runtime gives static children.
-    // The markdown tree is static, so React must not ask for keys on it.
+    // `validated = 1` is what React's JSX runtime gives static children, so React does not ask for keys.
     JSObject* store = constructEmptyObject(vm, global->JSReactElementStoreStructure());
     store->putDirectOffset(vm, Bun::JSReactElement::storeValidatedOffset, jsNumber(1));
 

--- a/src/jsc/bindings/JSReactElement.cpp
+++ b/src/jsc/bindings/JSReactElement.cpp
@@ -10,11 +10,40 @@ using namespace JSC;
 namespace Bun {
 namespace JSReactElement {
 
+// Shared by the production and development structures.
 static constexpr PropertyOffset typeofOffset = 0;
 static constexpr PropertyOffset typeOffset = 1;
 static constexpr PropertyOffset keyOffset = 2;
 static constexpr PropertyOffset refOffset = 3;
 static constexpr PropertyOffset propsOffset = 4;
+
+// Development structure only. These are the fields React's development
+// build adds in `ReactElement()` (react.development.js). React's development
+// renderers read and write them without guards, for example
+// `element._store.validated = 1` in react-server-dom-webpack.
+static constexpr PropertyOffset ownerOffset = 5;
+static constexpr PropertyOffset storeOffset = 6;
+static constexpr PropertyOffset debugInfoOffset = 7;
+static constexpr PropertyOffset debugStackOffset = 8;
+static constexpr PropertyOffset debugTaskOffset = 9;
+
+// `_store` structure.
+static constexpr PropertyOffset storeValidatedOffset = 0;
+
+static constexpr unsigned devFieldAttributes = PropertyAttribute::DontEnum | PropertyAttribute::DontDelete;
+
+static Structure* addProperty(VM& vm, Structure* structure, ASCIILiteral name, unsigned attributes, PropertyOffset expectedOffset)
+{
+    JSC::PropertyOffset offset;
+    structure = structure->addPropertyTransition(
+        vm,
+        structure,
+        JSC::Identifier::fromString(vm, name),
+        attributes,
+        offset);
+    ASSERT_UNUSED(expectedOffset, offset == expectedOffset);
+    return structure;
+}
 
 Structure* createStructure(VM& vm, JSGlobalObject* globalObject)
 {
@@ -23,46 +52,45 @@ Structure* createStructure(VM& vm, JSGlobalObject* globalObject)
         globalObject->objectPrototype(),
         5);
 
-    JSC::PropertyOffset offset;
-    structure = structure->addPropertyTransition(
-        vm,
-        structure,
-        JSC::Identifier::fromString(vm, "$$typeof"_s),
-        0,
-        offset);
-    ASSERT(offset == typeofOffset);
+    structure = addProperty(vm, structure, "$$typeof"_s, 0, typeofOffset);
+    structure = addProperty(vm, structure, "type"_s, 0, typeOffset);
+    structure = addProperty(vm, structure, "key"_s, 0, keyOffset);
+    structure = addProperty(vm, structure, "ref"_s, 0, refOffset);
+    structure = addProperty(vm, structure, "props"_s, 0, propsOffset);
 
-    structure = structure->addPropertyTransition(
-        vm,
-        structure,
-        JSC::Identifier::fromString(vm, "type"_s),
-        0,
-        offset);
-    ASSERT(offset == typeOffset);
+    return structure;
+}
 
-    structure = structure->addPropertyTransition(
-        vm,
-        structure,
-        JSC::Identifier::fromString(vm, "key"_s),
-        0,
-        offset);
-    ASSERT(offset == keyOffset);
+Structure* createDevStructure(VM& vm, JSGlobalObject* globalObject)
+{
+    JSC::Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(
+        globalObject,
+        globalObject->objectPrototype(),
+        10);
 
-    structure = structure->addPropertyTransition(
-        vm,
-        structure,
-        JSC::Identifier::fromString(vm, "ref"_s),
-        0,
-        offset);
-    ASSERT(offset == refOffset);
+    structure = addProperty(vm, structure, "$$typeof"_s, 0, typeofOffset);
+    structure = addProperty(vm, structure, "type"_s, 0, typeOffset);
+    structure = addProperty(vm, structure, "key"_s, 0, keyOffset);
+    // React's development build defines `ref` as non-enumerable.
+    structure = addProperty(vm, structure, "ref"_s, PropertyAttribute::DontEnum | 0, refOffset);
+    structure = addProperty(vm, structure, "props"_s, 0, propsOffset);
+    structure = addProperty(vm, structure, "_owner"_s, 0, ownerOffset);
+    structure = addProperty(vm, structure, "_store"_s, 0, storeOffset);
+    structure = addProperty(vm, structure, "_debugInfo"_s, devFieldAttributes, debugInfoOffset);
+    structure = addProperty(vm, structure, "_debugStack"_s, devFieldAttributes, debugStackOffset);
+    structure = addProperty(vm, structure, "_debugTask"_s, devFieldAttributes, debugTaskOffset);
 
-    structure = structure->addPropertyTransition(
-        vm,
-        structure,
-        JSC::Identifier::fromString(vm, "props"_s),
-        0,
-        offset);
-    ASSERT(offset == propsOffset);
+    return structure;
+}
+
+Structure* createStoreStructure(VM& vm, JSGlobalObject* globalObject)
+{
+    JSC::Structure* structure = globalObject->structureCache().emptyObjectStructureForPrototype(
+        globalObject,
+        globalObject->objectPrototype(),
+        1);
+
+    structure = addProperty(vm, structure, "validated"_s, devFieldAttributes, storeValidatedOffset);
 
     return structure;
 }
@@ -77,28 +105,54 @@ static JSC::Symbol* createTypeofSymbol(VM& vm, uint8_t reactVersion)
     return JSC::Symbol::create(vm, vm.symbolRegistry().symbolForKey("react.transitional.element"_s));
 }
 
+static JSObject* createElement(Zig::GlobalObject* global, uint8_t reactVersion, bool development, JSValue type, JSValue props)
+{
+    VM& vm = global->vm();
+
+    if (!development) {
+        JSObject* element = constructEmptyObject(vm, global->JSReactElementStructure());
+        element->putDirectOffset(vm, Bun::JSReactElement::typeofOffset, createTypeofSymbol(vm, reactVersion));
+        element->putDirectOffset(vm, Bun::JSReactElement::typeOffset, type);
+        element->putDirectOffset(vm, Bun::JSReactElement::keyOffset, jsNull());
+        element->putDirectOffset(vm, Bun::JSReactElement::refOffset, jsNull());
+        element->putDirectOffset(vm, Bun::JSReactElement::propsOffset, props);
+        return element;
+    }
+
+    // `validated` is 1, the value React's JSX runtime gives static children.
+    // The markdown tree is static, so React must not ask for keys on it.
+    JSObject* store = constructEmptyObject(vm, global->JSReactElementStoreStructure());
+    store->putDirectOffset(vm, Bun::JSReactElement::storeValidatedOffset, jsNumber(1));
+
+    JSObject* element = constructEmptyObject(vm, global->JSReactElementDevStructure());
+    element->putDirectOffset(vm, Bun::JSReactElement::typeofOffset, createTypeofSymbol(vm, reactVersion));
+    element->putDirectOffset(vm, Bun::JSReactElement::typeOffset, type);
+    element->putDirectOffset(vm, Bun::JSReactElement::keyOffset, jsNull());
+    element->putDirectOffset(vm, Bun::JSReactElement::refOffset, jsNull());
+    element->putDirectOffset(vm, Bun::JSReactElement::propsOffset, props);
+    element->putDirectOffset(vm, Bun::JSReactElement::ownerOffset, jsNull());
+    element->putDirectOffset(vm, Bun::JSReactElement::storeOffset, store);
+    element->putDirectOffset(vm, Bun::JSReactElement::debugInfoOffset, jsNull());
+    element->putDirectOffset(vm, Bun::JSReactElement::debugStackOffset, jsNull());
+    element->putDirectOffset(vm, Bun::JSReactElement::debugTaskOffset, jsNull());
+    return element;
+}
+
 extern "C" JSC::EncodedJSValue JSReactElement__create(
     JSGlobalObject* globalObject,
     uint8_t reactVersion,
+    bool development,
     EncodedJSValue type,
     EncodedJSValue props)
 {
     auto* global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
-    VM& vm = global->vm();
-
-    JSObject* element = constructEmptyObject(vm, global->JSReactElementStructure());
-    element->putDirectOffset(vm, Bun::JSReactElement::typeofOffset, createTypeofSymbol(vm, reactVersion));
-    element->putDirectOffset(vm, Bun::JSReactElement::typeOffset, JSValue::decode(type));
-    element->putDirectOffset(vm, Bun::JSReactElement::keyOffset, jsNull());
-    element->putDirectOffset(vm, Bun::JSReactElement::refOffset, jsNull());
-    element->putDirectOffset(vm, Bun::JSReactElement::propsOffset, JSValue::decode(props));
-
-    return JSValue::encode(element);
+    return JSValue::encode(createElement(global, reactVersion, development, JSValue::decode(type), JSValue::decode(props)));
 }
 
 extern "C" JSC::EncodedJSValue JSReactElement__createFragment(
     JSGlobalObject* globalObject,
     uint8_t reactVersion,
+    bool development,
     EncodedJSValue children)
 {
     auto* global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
@@ -110,12 +164,5 @@ extern "C" JSC::EncodedJSValue JSReactElement__createFragment(
     JSObject* props = constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
     props->putDirect(vm, JSC::Identifier::fromString(vm, "children"_s), JSValue::decode(children));
 
-    JSObject* element = constructEmptyObject(vm, global->JSReactElementStructure());
-    element->putDirectOffset(vm, Bun::JSReactElement::typeofOffset, createTypeofSymbol(vm, reactVersion));
-    element->putDirectOffset(vm, Bun::JSReactElement::typeOffset, fragmentSymbol);
-    element->putDirectOffset(vm, Bun::JSReactElement::keyOffset, jsNull());
-    element->putDirectOffset(vm, Bun::JSReactElement::refOffset, jsNull());
-    element->putDirectOffset(vm, Bun::JSReactElement::propsOffset, props);
-
-    return JSValue::encode(element);
+    return JSValue::encode(createElement(global, reactVersion, development, fragmentSymbol, props));
 }

--- a/src/jsc/bindings/JSReactElement.h
+++ b/src/jsc/bindings/JSReactElement.h
@@ -10,6 +10,8 @@ namespace Bun {
 namespace JSReactElement {
 
 Structure* createStructure(VM& vm, JSGlobalObject* globalObject);
+Structure* createDevStructure(VM& vm, JSGlobalObject* globalObject);
+Structure* createStoreStructure(VM& vm, JSGlobalObject* globalObject);
 
 } // namespace JSReactElement
 } // namespace Bun
@@ -17,10 +19,12 @@ Structure* createStructure(VM& vm, JSGlobalObject* globalObject);
 extern "C" JSC::EncodedJSValue JSReactElement__create(
     JSGlobalObject* globalObject,
     uint8_t reactVersion,
+    bool development,
     EncodedJSValue type,
     EncodedJSValue props);
 
 extern "C" JSC::EncodedJSValue JSReactElement__createFragment(
     JSGlobalObject* globalObject,
     uint8_t reactVersion,
+    bool development,
     EncodedJSValue children);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2275,6 +2275,12 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_JSReactElementStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              init.set(Bun::JSReactElement::createStructure(init.vm, init.owner));
          } },
+        { OBJECT_OFFSETOF(GlobalObject, m_JSReactElementDevStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
+             init.set(Bun::JSReactElement::createDevStructure(init.vm, init.owner));
+         } },
+        { OBJECT_OFFSETOF(GlobalObject, m_JSReactElementStoreStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
+             init.set(Bun::JSReactElement::createStoreStructure(init.vm, init.owner));
+         } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSMarkdownListItemMetaStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              init.set(Bun::MarkdownMeta::createListItemMetaStructure(init.vm, init.owner));
          } },

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -287,6 +287,8 @@ public:
     Structure* CommonJSModuleObjectStructure() const { return m_commonJSModuleObjectStructure.getInitializedOnMainThread(this); }
     Structure* JSSocketAddressDTOStructure() const { return m_JSSocketAddressDTOStructure.getInitializedOnMainThread(this); }
     Structure* JSReactElementStructure() const { return m_JSReactElementStructure.getInitializedOnMainThread(this); }
+    Structure* JSReactElementDevStructure() const { return m_JSReactElementDevStructure.getInitializedOnMainThread(this); }
+    Structure* JSReactElementStoreStructure() const { return m_JSReactElementStoreStructure.getInitializedOnMainThread(this); }
     Structure* JSMarkdownListItemMetaStructure() const { return m_JSMarkdownListItemMetaStructure.getInitializedOnMainThread(this); }
     Structure* JSMarkdownListMetaStructure() const { return m_JSMarkdownListMetaStructure.getInitializedOnMainThread(this); }
     Structure* JSMarkdownCellMetaStructure() const { return m_JSMarkdownCellMetaStructure.getInitializedOnMainThread(this); }
@@ -630,6 +632,8 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_commonJSModuleObjectStructure)                       \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketAddressDTOStructure)                         \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSReactElementStructure)                             \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_JSReactElementDevStructure)                          \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_JSReactElementStoreStructure)                        \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSMarkdownListItemMetaStructure)                     \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSMarkdownListMetaStructure)                         \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSMarkdownCellMetaStructure)                         \

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -344,8 +344,21 @@ unsafe extern "C" {
     safe fn JSReactElement__createFragment(
         global_object: &JSGlobalObject,
         react_version: u8,
+        development: bool,
         children: JSValue,
     ) -> JSValue;
+}
+
+/// How `Bun.markdown.react` shapes the elements it creates.
+#[derive(Clone, Copy)]
+struct ReactMode {
+    /// 0: `Symbol.for("react.element")` (React 18 and older).
+    /// 1: `Symbol.for("react.transitional.element")` (React 19+).
+    version: u8,
+    /// Add the fields React's development build puts on every element
+    /// (`_owner`, `_store`, `_debugInfo`, `_debugStack`, `_debugTask`).
+    /// React's development renderers read them without guards.
+    development: bool,
 }
 
 fn render_react_impl(
@@ -368,8 +381,20 @@ fn render_react_impl(
         }
     }
 
-    let children = render_ast(global_this, callframe, marked_args, Some(react_version))?;
-    let fragment = JSReactElement__createFragment(global_this, react_version, children);
+    // Same condition React uses to pick its development build.
+    let development = global_this
+        .bun_vm()
+        .env_loader()
+        .get(b"NODE_ENV")
+        .is_none_or(|node_env| node_env != b"production");
+
+    let mode = ReactMode {
+        version: react_version,
+        development,
+    };
+    let children = render_ast(global_this, callframe, marked_args, Some(mode))?;
+    let fragment =
+        JSReactElement__createFragment(global_this, mode.version, mode.development, children);
     marked_args.append(fragment);
     Ok(fragment)
 }
@@ -378,7 +403,7 @@ fn render_ast(
     global_this: &JSGlobalObject,
     callframe: &CallFrame,
     marked_args: &mut MarkedArgumentBuffer,
-    react_version: Option<u8>,
+    react_mode: Option<ReactMode>,
 ) -> JsResult<JSValue> {
     let [input_value, components_value, opts_value] = callframe.arguments_as_array::<3>();
 
@@ -406,7 +431,7 @@ fn render_ast(
         input,
         marked_args,
         options.heading_ids,
-        react_version,
+        react_mode,
     ) {
         Ok(r) => r,
         Err(_) => return Err(global_this.throw_out_of_memory()),
@@ -428,10 +453,10 @@ fn render_ast(
 
 /// Renderer that builds an object AST from markdown.
 ///
-/// In plain mode (`react_version == None`), each element becomes:
+/// In plain mode (`react_mode == None`), each element becomes:
 /// `{ type: "tagName", props: { ...metadata, children: [...] } }`
 ///
-/// In React mode (`react_version != None`), each element becomes a valid React element
+/// In React mode (`react_mode != None`), each element becomes a valid React element
 /// created via a cached JSC Structure with putDirectOffset:
 /// `{ $$typeof: Symbol.for('react.element'), type: "tagName", key: null, ref: null, props: { ...metadata, children: [...] } }`
 ///
@@ -446,13 +471,14 @@ struct ParseRenderer<'a> {
     src_text: &'a [u8],
     heading_tracker: md::helpers::HeadingIdTracker,
     components: Components,
-    react_version: Option<u8>,
+    react_mode: Option<ReactMode>,
 }
 
 unsafe extern "C" {
     safe fn JSReactElement__create(
         global_object: &JSGlobalObject,
         react_version: u8,
+        development: bool,
         element_type: JSValue,
         props: JSValue,
     ) -> JSValue;
@@ -555,7 +581,7 @@ impl<'a> ParseRenderer<'a> {
         src_text: &'a [u8],
         marked_args: &'a mut MarkedArgumentBuffer,
         heading_ids: bool,
-        react_version: Option<u8>,
+        react_mode: Option<ReactMode>,
     ) -> Result<ParseRenderer<'a>, bun_alloc::AllocError> {
         let mut self_ = ParseRenderer {
             global_object,
@@ -565,7 +591,7 @@ impl<'a> ParseRenderer<'a> {
             src_text,
             heading_tracker: md::helpers::HeadingIdTracker::init(heading_ids),
             components: Components::default(),
-            react_version,
+            react_mode,
         };
         // Root entry — its children array becomes the return value
         let root_array =
@@ -661,8 +687,14 @@ impl<'a> ParseRenderer<'a> {
     /// a cached Structure and putDirectOffset. In plain mode, creates a
     /// simple `{ type, props }` object.
     fn create_element(&mut self, type_val: JSValue, props: JSValue) -> JSValue {
-        if let Some(version) = self.react_version {
-            let obj = JSReactElement__create(self.global_object, version, type_val, props);
+        if let Some(mode) = self.react_mode {
+            let obj = JSReactElement__create(
+                self.global_object,
+                mode.version,
+                mode.development,
+                type_val,
+                props,
+            );
             self.marked_args.append(obj);
             obj
         } else {

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -349,15 +349,11 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-/// How `Bun.markdown.react` shapes the elements it creates.
 #[derive(Clone, Copy)]
 struct ReactMode {
-    /// 0: `Symbol.for("react.element")` (React 18 and older).
-    /// 1: `Symbol.for("react.transitional.element")` (React 19+).
+    /// 0 for `react.element` (React 18 and older), 1 for `react.transitional.element`.
     version: u8,
-    /// Add the fields React's development build puts on every element
-    /// (`_owner`, `_store`, `_debugInfo`, `_debugStack`, `_debugTask`).
-    /// React's development renderers read them without guards.
+    /// Add the `_store` / `_owner` / `_debug*` fields React's development build expects.
     development: bool,
 }
 

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import React from "react";
 import { renderToString } from "react-dom/server";
 
@@ -666,5 +667,100 @@ describe("Bun.markdown.react renderToString with component overrides", () => {
     }
     const html = reactRender("# Title\n\nParagraph\n", { h1: H1 });
     expect(html).toBe('<h1 class="big">Title</h1><p>Paragraph</p>');
+  });
+});
+
+// ============================================================================
+// Development-only element fields (React's dev renderers read them unguarded)
+// ============================================================================
+
+describe("Bun.markdown.react development fields", () => {
+  const script = `
+    const root = Bun.markdown.react("- a\\n- b\\n");
+    const list = root.props.children[0];
+    const item = list.props.children[0];
+    const describeEl = el => ({
+      names: Object.getOwnPropertyNames(el),
+      keys: Object.keys(el),
+      owner: el._owner,
+      store: el._store && Object.getOwnPropertyDescriptor(el._store, "validated"),
+      debugInfo: el._debugInfo,
+      debugStack: el._debugStack,
+      debugTask: el._debugTask,
+    });
+    console.log(JSON.stringify({ root: describeEl(root), list: describeEl(list), item: describeEl(item) }));
+  `;
+
+  async function run(NODE_ENV: string | undefined) {
+    const env = { ...bunEnv };
+    if (NODE_ENV === undefined) delete env.NODE_ENV;
+    else env.NODE_ENV = NODE_ENV;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  const devShape = {
+    names: ["$$typeof", "type", "key", "ref", "props", "_owner", "_store", "_debugInfo", "_debugStack", "_debugTask"],
+    keys: ["$$typeof", "type", "key", "props", "_owner", "_store"],
+    owner: null,
+    store: { value: 1, writable: true, enumerable: false, configurable: false },
+    debugInfo: null,
+    debugStack: null,
+    debugTask: null,
+  };
+
+  test.each(["development", "test", undefined])("NODE_ENV=%s adds the fields React's dev build expects", async nodeEnv => {
+    const { root, list, item } = await run(nodeEnv);
+    expect(root).toEqual(devShape);
+    expect(list).toEqual(devShape);
+    expect(item).toEqual(devShape);
+  });
+
+  test("NODE_ENV=production keeps the production shape", async () => {
+    const { root, list, item } = await run("production");
+    const prodShape = {
+      names: ["$$typeof", "type", "key", "ref", "props"],
+      keys: ["$$typeof", "type", "key", "ref", "props"],
+      owner: undefined,
+      store: undefined,
+      debugInfo: undefined,
+      debugStack: undefined,
+      debugTask: undefined,
+    };
+    expect(root).toEqual(prodShape);
+    expect(list).toEqual(prodShape);
+    expect(item).toEqual(prodShape);
+  });
+
+  test("react-server-dom marks elements validated without throwing", () => {
+    // react-server-dom-webpack's development build does `element._store.validated = 1`
+    // on every element it renders. It must not throw.
+    const root = Markdown.react("# Title\n\n- a\n- b\n");
+    const visit = (node: any) => {
+      if (node === null || typeof node !== "object") return;
+      if (Array.isArray(node)) return node.forEach(visit);
+      expect(node._owner).toBeNull();
+      expect(node._debugStack).toBeNull();
+      expect(node._debugTask).toBeNull();
+      node._store.validated = 1;
+      expect(node._store.validated).toBe(1);
+      visit(node.props.children);
+    };
+    visit(root);
+  });
+
+  test("list items do not trigger the missing key warning", () => {
+    const errors: string[] = [];
+    const original = console.error;
+    console.error = (...args: any[]) => errors.push(args.map(String).join(" "));
+    try {
+      expect(reactRender("- a\n- b\n- c\n")).toBe("<ul><li>a</li><li>b</li><li>c</li></ul>");
+    } finally {
+      console.error = original;
+    }
+    expect(errors).toEqual([]);
   });
 });

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -676,7 +676,7 @@ describe("Bun.markdown.react renderToString with component overrides", () => {
 
 describe("Bun.markdown.react development fields", () => {
   const script = `
-    const root = Bun.markdown.react("- a\\n- b\\n");
+    const root = Bun.markdown.react("- a\\n- b\\n", undefined, { reactVersion: Number(process.env.MD_REACT_VERSION) });
     const list = root.props.children[0];
     const item = list.props.children[0];
     const describeEl = el => ({
@@ -691,8 +691,8 @@ describe("Bun.markdown.react development fields", () => {
     console.log(JSON.stringify({ root: describeEl(root), list: describeEl(list), item: describeEl(item) }));
   `;
 
-  async function run(NODE_ENV: string | undefined) {
-    const env = { ...bunEnv };
+  async function run(NODE_ENV: string | undefined, reactVersion = 19) {
+    const env = { ...bunEnv, MD_REACT_VERSION: String(reactVersion) };
     if (NODE_ENV === undefined) delete env.NODE_ENV;
     else env.NODE_ENV = NODE_ENV;
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env, stderr: "pipe" });
@@ -721,6 +721,13 @@ describe("Bun.markdown.react development fields", () => {
       expect(item).toEqual(devShape);
     },
   );
+
+  test("reactVersion: 18 gets the same development fields", async () => {
+    const { root, list, item } = await run("development", 18);
+    expect(root).toEqual(devShape);
+    expect(list).toEqual(devShape);
+    expect(item).toEqual(devShape);
+  });
 
   test("NODE_ENV=production keeps the production shape", async () => {
     const { root, list, item } = await run("production");

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -738,21 +738,34 @@ describe("Bun.markdown.react development fields", () => {
     expect(item).toEqual(prodShape);
   });
 
-  test("react-server-dom marks elements validated without throwing", () => {
+  test("react-server-dom marks elements validated without throwing", async () => {
     // react-server-dom-webpack's development build does `element._store.validated = 1`
     // on every element it renders. It must not throw.
-    const root = Markdown.react("# Title\n\n- a\n- b\n");
-    const visit = (node: any) => {
-      if (node === null || typeof node !== "object") return;
-      if (Array.isArray(node)) return node.forEach(visit);
-      expect(node._owner).toBeNull();
-      expect(node._debugStack).toBeNull();
-      expect(node._debugTask).toBeNull();
-      node._store.validated = 1;
-      expect(node._store.validated).toBe(1);
-      visit(node.props.children);
-    };
-    visit(root);
+    const visitScript = `
+      const root = Bun.markdown.react("# Title\\n\\n- a\\n- b\\n");
+      let visited = 0;
+      const visit = node => {
+        if (node === null || typeof node !== "object") return;
+        if (Array.isArray(node)) return node.forEach(visit);
+        if (node._owner !== null || node._debugStack !== null || node._debugTask !== null) {
+          throw new Error("missing development fields on " + String(node.type));
+        }
+        node._store.validated = 1;
+        visited++;
+        visit(node.props.children);
+      };
+      visit(root);
+      console.log(visited);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", visitScript],
+      env: { ...bunEnv, NODE_ENV: "development" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("5\n");
+    expect(exitCode).toBe(0);
   });
 
   test("list items do not trigger the missing key warning", () => {

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -712,12 +712,15 @@ describe("Bun.markdown.react development fields", () => {
     debugTask: null,
   };
 
-  test.each(["development", "test", undefined])("NODE_ENV=%s adds the fields React's dev build expects", async nodeEnv => {
-    const { root, list, item } = await run(nodeEnv);
-    expect(root).toEqual(devShape);
-    expect(list).toEqual(devShape);
-    expect(item).toEqual(devShape);
-  });
+  test.each(["development", "test", undefined])(
+    "NODE_ENV=%s adds the fields React's dev build expects",
+    async nodeEnv => {
+      const { root, list, item } = await run(nodeEnv);
+      expect(root).toEqual(devShape);
+      expect(list).toEqual(devShape);
+      expect(item).toEqual(devShape);
+    },
+  );
 
   test("NODE_ENV=production keeps the production shape", async () => {
     const { root, list, item } = await run("production");


### PR DESCRIPTION
### Problem
- Rendering a `Bun.markdown.react()` tree through `react-server-dom-webpack` in development fails with `undefined is not an object (evaluating 'result._store.validated = 1')`. Production mode works.
- React's development build adds `_owner`, `_store`, `_debugInfo`, `_debugStack` and `_debugTask` to every element in `ReactElement()` (`react.development.js`). Its development renderers read and write these without guards. The native element from `src/jsc/bindings/JSReactElement.cpp` had only `$$typeof`, `type`, `key`, `ref` and `props`.

### Fix
- When `NODE_ENV` is not `production` (the condition React uses to pick its development build), `JSReactElement__create` and `JSReactElement__createFragment` build the element from a second cached structure with the five extra fields. The attributes match React: `_owner` and `_store` enumerable, `ref`, `_debugInfo`, `_debugStack` and `_debugTask` non-enumerable, `_store.validated` non-enumerable and writable.
- `_store.validated` starts at 1. That is the value React's JSX runtime gives static children. With 0, `react-dom` in development would warn about missing keys on every list item and paragraph, which it does not do today.
- Production keeps the five-field shape and the same structure as before.
- Verified: `test/js/bun/md/md-react.test.ts` (new `development fields` block, 4 of 6 tests fail on bun 1.4.3). Also all of `test/js/bun/md/`. The reporter's repro passes in both modes.
- Self-reviewed: 3 concerns raised, 3 addressed in the notes below (runtime `process.env.NODE_ENV` writes, `reactVersion: 18`, `Object.freeze`).

### Background
- A React element is a plain object. `$$typeof` marks it as an element. In development, React also keeps bookkeeping on it: `_store.validated` records whether a key check ran, `_owner` is the component that created it, and the `_debug*` fields carry stack and task info for devtools.
- `Bun.markdown.react()` creates elements natively (`src/runtime/api/MarkdownObject.rs` calls into `JSReactElement.cpp`) with a cached JSC `Structure` so every element has the same shape and property writes go straight to a slot.
- The `NODE_ENV` value comes from the process env loader (`vm.env_loader()`), the same source that fills `process.env`. `Bun.serve` uses the same check for its `development` default.

<details><summary>Notes</summary>

- Repro: https://github.com/nikhilsnayak/bun-markdown-rsc-repro with `NODE_ENV=development bun --conditions=react-server repro.js`.
- Sites in `react-server-dom-webpack-server.node.development.js` (19.2.8) that read the fields: `result._store.validated = 1` (line 1629), `child._store.validated` (1814), `value._owner`, `value._debugStack`, `value._debugTask` (2635 to 2641, logs "Attempted to render <%s> without development properties" if any is `undefined`), `value._store.validated` (2659, 3316).
- `react-dom` development (`warnForMissingKey`) only warns when `child._store` exists and `validated` is 0. The old elements had no `_store`, so no warning. `validated = 1` keeps that behavior.
- Dev element property order is `$$typeof, type, key, ref, props, _owner, _store, _debugInfo, _debugStack, _debugTask`. React's order puts `ref` after `_owner`. Only non-enumerable order differs, `Object.keys` matches React.
- The dev element is not frozen. React freezes its elements in development, but nothing in the renderers depends on it. Production React elements are not frozen either.
- The check reads the env loader, not the JS `process.env` object. A write such as `process.env.NODE_ENV = "production"` at runtime is not seen by this check (the same is true for `Bun.serve`). The env loader gets that write-through in #40571. Until then, set `NODE_ENV` before bun starts.
- `reactVersion: 18` gets the same development field set as React 19. React 18's development renderers read `_store`, `_self` and `_source` behind guards (`test/node_modules/react-dom/cjs/react-dom.development.js`), and `validated: 1` is truthy where React 18 expects a boolean, so the React 19 shape does not crash React 18 and does not add key warnings. A third structure for React 18 did not seem worth the code.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-react.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/md/md-react.test.ts:
(pass) Bun.markdown.react > returns a Fragment element [6.61ms]
(pass) Bun.markdown.react > fragment children are React elements [6.01ms]
(pass) Bun.markdown.react > element has type, key, ref, props [6.12ms]
(pass) Bun.markdown.react > heading levels 1-6 [14.19ms]
(pass) Bun.markdown.react > text is plain strings in children [3.72ms]
(pass) Bun.markdown.react > nested inline elements are React elements [6.55ms]
(pass) Bun.markdown.react > link has href in props [5.89ms]
(pass) Bun.markdown.react > image has src and alt in props [6.32ms]
(pass) Bun.markdown.react > reference-style link has href/title in props [6.40ms]
(pass) Bun.markdown.react > shortcut reference link has href/title in props [5.76ms]
(pass) Bun.markdown.react > collapsed reference link has href in props [5.06ms]
(pass) Bun.markdown.react > reference-style image has src/title in props [6.38ms]
(pass) Bun.markdown.react > code block with language [4.45ms]
(pass) Bun.markdown.rea
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (5987b0d55)

test/js/bun/md/md-react.test.ts:
(pass) Bun.markdown.react > returns a Fragment element [0.86ms]
(pass) Bun.markdown.react > fragment children are React elements [0.10ms]
(pass) Bun.markdown.react > element has type, key, ref, props [0.09ms]
(pass) Bun.markdown.react > heading levels 1-6 [0.16ms]
(pass) Bun.markdown.react > text is plain strings in children [0.04ms]
(pass) Bun.markdown.react > nested inline elements are React elements [0.08ms]
(pass) Bun.markdown.react > link has href in props [0.09ms]
(pass) Bun.markdown.react > image has src and alt in props [0.07ms]
(pass) Bun.markdown.react > reference-style link has href/title in props [0.07ms]
(pass) Bun.markdown.react > shortcut reference link has href/title in props [0.05ms]
(pass) Bun.markdown.react > collapsed reference link has href in props [0.04ms]
(pass) Bun.markdown.react > reference-style image has src/title in props [0.07ms]
(pass) Bun.markdown.react > code block with language [0.05ms]
(pass) Bun.markdown.react > hr is void element [0.05ms]
(pass) Bun.markdown.react > br produces React element [0.16ms]
(pass) Bun.markdown.react > ordered list with start [0.06ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-react.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/md/md-react.test.ts:
(pass) Bun.markdown.react > returns a Fragment element [9.78ms]
(pass) Bun.markdown.react > fragment children are React elements [6.81ms]
(pass) Bun.markdown.react > element has type, key, ref, props [6.76ms]
(pass) Bun.markdown.react > heading levels 1-6 [14.96ms]
(pass) Bun.markdown.react > text is plain strings in children [3.22ms]
(pass) Bun.markdown.react > nested inline elements are React elements [6.52ms]
(pass) Bun.markdown.react > link has href in props [5.96ms]
(pass) Bun.markdown.react > image has src and alt in props [6.51ms]
(pass) Bun.markdown.react > reference-style link has href/title in props [6.44ms]
(pass) Bun.markdown.react > shortcut reference link has href/title in props [5.88ms]
(pass) Bun.markdown.react > collapsed reference link has href in props [4.52ms]
(pass) Bun.markdown.react > reference-style image has src/title in props [6.02ms]
(pass) Bun.markdown.react > code block with language [4.73ms]
(pass) Bun.markdown.rea
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1066ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/126] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSReactElement.cpp  | 151 ++++++++++++++++++++++-------------
 src/jsc/bindings/JSReactElement.h    |   4 +
 src/jsc/bindings/ZigGlobalObject.cpp |   6 ++
 src/jsc/bindings/ZigGlobalObject.h   |   4 +
 src/runtime/api/MarkdownObject.rs    |  50 +++++++++---
 test/js/bun/md/md-react.test.ts      | 119 +++++++++++++++++++++++++++
 6 files changed, 269 insertions(+), 65 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/jsc/bindings/JSReactElement.cpp       1      2     15
src/jsc/bindings/JSReactElement.h         0      0     15
src/jsc/bindings/ZigGlobalObject.cpp      0      0     15
src/jsc/bindings/ZigGlobalObject.h        0      0     15
src/runtime/api/MarkdownObject.rs         1      0     15
test/js/bun/md/md-react.test.ts           0      0     15
```

</details>

**root cause** · written by the author bot

Bun.markdown.react() built React elements with only `$$typeof`, `type`, `key`, `ref`, and `props`, so in development builds React's server renderer crashed when it tried to set `_store.validated` on an element that had no `_store` field. The fix has the native JSReactElement constructor populate the development metadata React expects (`_store` with `validated`, plus `_owner`, `_debugInfo`, `_debugStack`, and `_debugTask` as appropriate for the React version), so the elements match the shape `React.createElement` produces. Production output is unchanged and new tests cover both the React 18 …

<!-- robobun:evidence:end -->