### PR TITLE
node:net: match libuv in the lookup-result to connect step

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -138,6 +138,9 @@ const bunTLSConnectOptions = Symbol.for("::buntlsconnectoptions::");
 // binding to the constructor.
 const kNativeSecureContextCtor = Symbol.for("::buntlsnativesecurecontextctor::");
 const kReinitializeHandle = Symbol("kReinitializeHandle");
+// Set on the native handle while a connect is in flight (libuv's
+// `connect_req`): a second connect on the same handle fails with EALREADY.
+const kConnectReq = Symbol("kConnectReq");
 
 const kRealListen = Symbol("kRealListen");
 const kSetNoDelay = Symbol("kSetNoDelay");
@@ -1249,6 +1252,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     $debug("Bun.Socket open");
     let { self, req } = socket.data;
     socket[owner_symbol] = self;
+    socket[kConnectReq] = undefined;
     $debug("self[kupgraded]", String(self[kupgraded]));
     // Offer a previously-negotiated session for resumption before oncomplete
     // (afterConnect) runs: a user 'connect' listener that writes immediately
@@ -1420,6 +1424,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     $debug("Bun.Socket connectError");
     let { self, req } = socket.data;
     socket[owner_symbol] = self;
+    socket[kConnectReq] = undefined;
     socket.data.req = undefined;
     // doConnect dispatches this synchronously when connect()/bind() fails at
     // the syscall; surface it as kConnectTcp/Pipe's return value (callers'
@@ -1487,6 +1492,9 @@ function traceConnectEnd(req) {
 
 function kConnectTcp(self, addressType, req, address, port) {
   $debug("SocketHandle.kConnectTcp", addressType, address, port);
+  // Node's TCPWrap parses the address with uv_ip4_addr/uv_ip6_addr for the
+  // requested family and returns EINVAL when it does not parse.
+  if (isIP(address) !== addressType) return uv().UV_EINVAL;
   return kConnectDispatch(self, req, {
     hostname: address,
     port,
@@ -1508,7 +1516,7 @@ function kConnectTcp(self, addressType, req, address, port) {
 
 function kConnectPipe(self, req, address) {
   $debug("SocketHandle.kConnectPipe");
-  return kConnectDispatch(self, req, {
+  const errno = kConnectDispatch(self, req, {
     hostname: address,
     unix: address,
     // Always half-open natively; see kConnect.
@@ -1518,15 +1526,40 @@ function kConnectPipe(self, req, address) {
     data: { self, req },
     socket: self[khandlers],
   });
+  // uv_pipe_connect never fails synchronously: a connect(2) error is stored
+  // as delayed_error and reported through the connect callback on the next
+  // loop turn. Defer the same way so 'error' follows the events a caller
+  // queued right after connect() (http's 'socket', for one).
+  if (errno) {
+    const handle = self._handle;
+    handle[kConnectReq] = req;
+    process.nextTick(() => {
+      handle[kConnectReq] = undefined;
+      // A destroy() + connect() in between gave the socket a new handle.
+      if (self._handle !== handle) return;
+      req.oncomplete(errno, handle, req, true, true);
+    });
+  }
+  return 0;
 }
 
 function kConnectDispatch(self, req, opts) {
+  const handle = self._handle;
+  if (handle[kConnectReq] !== undefined) return uv().UV_EALREADY;
   // Node's TCPWrap returns errno for sync uv_*_connect failure and defers
   // oncomplete; doConnect instead fires connectError inside this call. Bracket
   // it so connectError hands the errno back here instead of re-entering.
   req.dispatching = true;
-  const promise = doConnect(self._handle, opts);
-  req.dispatching = false;
+  handle[kConnectReq] = req;
+  let promise;
+  try {
+    promise = doConnect(handle, opts);
+  } catch (e) {
+    handle[kConnectReq] = undefined;
+    throw e;
+  } finally {
+    req.dispatching = false;
+  }
   promise.catch(_reason => {
     // eat this so there's no unhandledRejection
     // we already catch this in connectError and error

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1492,7 +1492,10 @@ function traceConnectEnd(req) {
 function kConnectTcp(self, addressType, req, address, port) {
   $debug("SocketHandle.kConnectTcp", addressType, address, port);
   // uv_ip4_addr/uv_ip6_addr reject an address of the other family.
-  if (isIP(address) !== addressType) return uv().UV_EINVAL;
+  if (isIP(address) !== addressType) {
+    traceConnectEnd(req);
+    return uv().UV_EINVAL;
+  }
   return kConnectDispatch(self, req, {
     hostname: address,
     port,
@@ -1541,7 +1544,10 @@ function kConnectPipe(self, req, address) {
 
 function kConnectDispatch(self, req, opts) {
   const handle = self._handle;
-  if (handle[kConnectReq] !== undefined) return uv().UV_EALREADY;
+  if (handle[kConnectReq] !== undefined) {
+    traceConnectEnd(req);
+    return uv().UV_EALREADY;
+  }
   // Node's TCPWrap returns errno for sync uv_*_connect failure and defers
   // oncomplete; doConnect instead fires connectError inside this call. Bracket
   // it so connectError hands the errno back here instead of re-entering.

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -138,8 +138,7 @@ const bunTLSConnectOptions = Symbol.for("::buntlsconnectoptions::");
 // binding to the constructor.
 const kNativeSecureContextCtor = Symbol.for("::buntlsnativesecurecontextctor::");
 const kReinitializeHandle = Symbol("kReinitializeHandle");
-// Set on the native handle while a connect is in flight (libuv's
-// `connect_req`): a second connect on the same handle fails with EALREADY.
+// The handle's in-flight connect, like libuv's `connect_req`.
 const kConnectReq = Symbol("kConnectReq");
 
 const kRealListen = Symbol("kRealListen");
@@ -1492,8 +1491,7 @@ function traceConnectEnd(req) {
 
 function kConnectTcp(self, addressType, req, address, port) {
   $debug("SocketHandle.kConnectTcp", addressType, address, port);
-  // Node's TCPWrap parses the address with uv_ip4_addr/uv_ip6_addr for the
-  // requested family and returns EINVAL when it does not parse.
+  // uv_ip4_addr/uv_ip6_addr reject an address of the other family.
   if (isIP(address) !== addressType) return uv().UV_EINVAL;
   return kConnectDispatch(self, req, {
     hostname: address,
@@ -1526,10 +1524,8 @@ function kConnectPipe(self, req, address) {
     data: { self, req },
     socket: self[khandlers],
   });
-  // uv_pipe_connect never fails synchronously: a connect(2) error is stored
-  // as delayed_error and reported through the connect callback on the next
-  // loop turn. Defer the same way so 'error' follows the events a caller
-  // queued right after connect() (http's 'socket', for one).
+  // uv_pipe_connect reports a connect(2) error through the callback on the
+  // next loop turn, never synchronously.
   if (errno) {
     const handle = self._handle;
     handle[kConnectReq] = req;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1338,6 +1338,25 @@ describe("node:http", () => {
     await promise;
   });
 
+  test.skipIf(process.platform === "win32")(
+    "request to a missing socketPath emits 'socket' before 'error'",
+    async () => {
+      const socketPath = `${tmpdir()}/bun-missing-${Math.random().toString(32)}.sock`;
+      const events: string[] = [];
+      const err = await new Promise<NodeJS.ErrnoException>(resolve => {
+        const req = request({ socketPath, path: "/", agent: false }, res => res.resume());
+        req.on("socket", () => events.push("socket"));
+        req.on("error", e => {
+          events.push("error:" + (req.socket ? "with-socket" : "no-socket"));
+          resolve(e);
+        });
+        req.end();
+      });
+      expect(err.code).toBe("ENOENT");
+      expect(events).toEqual(["socket", "error:with-socket"]);
+    },
+  );
+
   test("should not decompress gzip, issue#4397", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/node/net/connect-step.test.ts
+++ b/test/js/node/net/connect-step.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { isWindows, tmpdirSync } from "harness";
+import { connect, createConnection, createServer } from "node:net";
+import { join } from "node:path";
+
+// The lookup-result to connect step mirrors node's TCPWrap/PipeWrap: one
+// connect per handle, the address must parse in the family the lookup named,
+// and a pipe connect failure is reported on the next loop turn.
+describe.concurrent("connect step semantics", () => {
+  const socketDir = tmpdirSync();
+
+  async function listenCounting() {
+    let connections = 0;
+    const server = createServer(c => {
+      connections++;
+      c.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    return { server, port, connections: () => connections };
+  }
+
+  it("a lookup callback that fires twice fails the second connect with EALREADY", async () => {
+    const { server, port, connections } = await listenCounting();
+    try {
+      const events: string[] = [];
+      const err = await new Promise<NodeJS.ErrnoException>(resolve => {
+        const c = connect({
+          host: "example.invalid",
+          port,
+          autoSelectFamily: false,
+          lookup(_host, _opts, cb) {
+            cb(null, "127.0.0.1", 4);
+            cb(null, "127.0.0.1", 4);
+          },
+        });
+        c.on("connect", () => {
+          events.push("connect");
+          c.destroy();
+          resolve(Object.assign(new Error("connected"), { code: "CONNECTED" }));
+        });
+        c.on("error", e => {
+          events.push("error");
+          c.once("close", () => {
+            events.push("close");
+            resolve(e);
+          });
+        });
+      });
+      expect(err.code).toBe("EALREADY");
+      expect(err.syscall).toBe("connect");
+      expect(events).toEqual(["error", "close"]);
+      expect(connections()).toBeLessThanOrEqual(1);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("an address that does not parse in the looked-up family fails with EINVAL and opens no connection", async () => {
+    const { server, port, connections } = await listenCounting();
+    try {
+      const err = await new Promise<NodeJS.ErrnoException>(resolve => {
+        const c = connect({
+          host: "example.invalid",
+          port,
+          autoSelectFamily: false,
+          lookup(_host, _opts, cb) {
+            cb(null, "127.0.0.1", 6);
+          },
+        });
+        c.on("error", resolve);
+        c.on("connect", () => {
+          c.destroy();
+          resolve(Object.assign(new Error("connected"), { code: "CONNECTED" }));
+        });
+      });
+      expect(err.code).toBe("EINVAL");
+      expect(err.syscall).toBe("connect");
+      // Wait one loop turn so a dispatched connect would have reached the server.
+      await new Promise(resolve => setImmediate(resolve));
+      expect(connections()).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+
+  it.skipIf(isWindows)("a failed pipe connect reports its error after callbacks queued at connect()", async () => {
+    const missing = join(socketDir, "connect-step-missing.sock");
+    const result = await new Promise<{ code: string | undefined; tickRan: boolean }>(resolve => {
+      const c = createConnection(missing);
+      let tickRan = false;
+      process.nextTick(() => {
+        tickRan = true;
+      });
+      c.on("error", e => resolve({ code: (e as NodeJS.ErrnoException).code, tickRan }));
+      c.on("connect", () => {
+        c.destroy();
+        resolve({ code: "CONNECTED", tickRan });
+      });
+    });
+    expect(result).toEqual({ code: "ENOENT", tickRan: true });
+  });
+
+  it.skipIf(isWindows)(
+    "a failed pipe connect does not fail a reconnect issued before its error is reported",
+    async () => {
+      const { server, port } = await listenCounting();
+      try {
+        const missing = join(socketDir, "connect-step-missing-reconnect.sock");
+        const events: string[] = [];
+        await new Promise<void>(resolve => {
+          const c = createConnection(missing);
+          c.on("error", e => {
+            events.push("error:" + (e as NodeJS.ErrnoException).code);
+            resolve();
+          });
+          c.on("connect", () => {
+            events.push("connect");
+            c.destroy();
+            resolve();
+          });
+          c.destroy();
+          c.connect(port, "127.0.0.1");
+        });
+        expect(events).toEqual(["connect"]);
+      } finally {
+        server.close();
+      }
+    },
+  );
+});

--- a/test/js/node/net/connect-step.test.ts
+++ b/test/js/node/net/connect-step.test.ts
@@ -3,9 +3,10 @@ import { isWindows, tmpdirSync } from "harness";
 import { connect, createConnection, createServer } from "node:net";
 import { join } from "node:path";
 
-// The lookup-result to connect step mirrors node's TCPWrap/PipeWrap: one
-// connect per handle, the address must parse in the family the lookup named,
-// and a pipe connect failure is reported on the next loop turn.
+// The lookup-result to connect step mirrors node's TCPWrap/PipeWrap: the
+// address must parse in the family the lookup named, and a pipe connect
+// failure is reported on the next loop turn. The one-connect-per-handle
+// (EALREADY) cases are in socket-reconnect-live.test.ts.
 describe.concurrent("connect step semantics", () => {
   const socketDir = tmpdirSync();
 
@@ -19,42 +20,6 @@ describe.concurrent("connect step semantics", () => {
     const port = (server.address() as import("node:net").AddressInfo).port;
     return { server, port, connections: () => connections };
   }
-
-  it("a lookup callback that fires twice fails the second connect with EALREADY", async () => {
-    const { server, port, connections } = await listenCounting();
-    try {
-      const events: string[] = [];
-      const err = await new Promise<NodeJS.ErrnoException>(resolve => {
-        const c = connect({
-          host: "example.invalid",
-          port,
-          autoSelectFamily: false,
-          lookup(_host, _opts, cb) {
-            cb(null, "127.0.0.1", 4);
-            cb(null, "127.0.0.1", 4);
-          },
-        });
-        c.on("connect", () => {
-          events.push("connect");
-          c.destroy();
-          resolve(Object.assign(new Error("connected"), { code: "CONNECTED" }));
-        });
-        c.on("error", e => {
-          events.push("error");
-          c.once("close", () => {
-            events.push("close");
-            resolve(e);
-          });
-        });
-      });
-      expect(err.code).toBe("EALREADY");
-      expect(err.syscall).toBe("connect");
-      expect(events).toEqual(["error", "close"]);
-      expect(connections()).toBeLessThanOrEqual(1);
-    } finally {
-      server.close();
-    }
-  });
 
   it("an address that does not parse in the looked-up family fails with EINVAL and opens no connection", async () => {
     const { server, port, connections } = await listenCounting();

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import type { AddressInfo } from "node:net";
+import { connect, createServer } from "node:net";
 
 // connect_finish must tear down a still-live previous native socket before
 // reusing the wrapper, not alias two native sockets onto one ext slot.
-describe.concurrent("socket.connect() on an already-connected socket", () => {
+describe.concurrent("socket.connect() re-entry", () => {
   it("does not crash and emits connect for the new connection", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -99,27 +101,36 @@ describe.concurrent("socket.connect() on an already-connected socket", () => {
     });
   });
 
-  it("does not crash when reconnecting while the first connect is still in flight", async () => {
+  // libuv's uv_tcp_connect returns UV_EALREADY while the handle's connect_req
+  // is in flight, and internalConnect destroys the socket with that error.
+  // The first attempt is torn down, no 'connect' fires, and the server sees at
+  // most the one connection the first attempt opened.
+  async function connectWhileConnecting(extraConnects: string) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
           const { createServer, connect } = require("node:net");
-          const srv = createServer(c => c.on("error", () => {})).listen(0, "127.0.0.1", () => {
+          const { getSystemErrorName } = require("node:util");
+          const events = [];
+          let connections = 0;
+          const srv = createServer(c => { connections++; c.on("error", () => {}); });
+          srv.listen(0, "127.0.0.1", () => {
             const port = srv.address().port;
             const s = connect(port, "127.0.0.1");
-            // Second connect while the first is still connecting.
-            s.connect(port, "127.0.0.1");
-            s.once("connect", () => {
-              process.stdout.write("connect");
+            ${extraConnects}
+            s.on("connect", () => {
+              events.push("connect");
               s.destroy();
-              srv.close();
             });
-            s.once("error", e => {
-              process.stdout.write("err:" + e.code);
-              s.destroy();
-              srv.close();
+            s.on("error", e => events.push("error:" + e.code + ":" + getSystemErrorName(e.errno) + ":" + e.syscall));
+            s.on("close", hadError => {
+              events.push("close:" + hadError);
+              setImmediate(() => {
+                srv.close();
+                process.stdout.write(JSON.stringify({ events, connections }));
+              });
             });
           });
         `,
@@ -129,10 +140,60 @@ describe.concurrent("socket.connect() on an already-connected socket", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Node emits EALREADY here; Bun drops the first in-flight connect and
-    // completes the second. Either is acceptable so long as the process
-    // exits cleanly.
-    expect(["connect", "err:EALREADY"]).toContain(stdout);
     expect({ stderr, exitCode }).toEqual({ stderr, exitCode: 0 });
+    return JSON.parse(stdout);
+  }
+
+  const EALREADY = "error:EALREADY:EALREADY:connect";
+
+  it("while the first connect is still in flight fails with EALREADY and no connect", async () => {
+    const { events, connections } = await connectWhileConnecting(`s.connect(port, "127.0.0.1");`);
+    expect(events).toEqual([EALREADY, "close:true"]);
+    expect(connections).toBeLessThanOrEqual(1);
+  });
+
+  it("a third connect() is dropped once the EALREADY destroy cleared connecting", async () => {
+    const { events, connections } = await connectWhileConnecting(
+      `s.connect(port, "127.0.0.1"); s.connect(port, "127.0.0.1");`,
+    );
+    expect(events).toEqual([EALREADY, "close:true"]);
+    expect(connections).toBeLessThanOrEqual(1);
+  });
+
+  it("a lookup callback that fires twice fails the second connect with EALREADY", async () => {
+    let connections = 0;
+    const server = createServer(c => {
+      connections++;
+      c.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const events: string[] = [];
+      await new Promise<void>(resolve => {
+        const c = connect({
+          host: "example.invalid",
+          port,
+          autoSelectFamily: false,
+          lookup(_host, _opts, cb) {
+            cb(null, "127.0.0.1", 4);
+            cb(null, "127.0.0.1", 4);
+          },
+        });
+        c.on("connect", () => {
+          events.push("connect");
+          c.destroy();
+        });
+        c.on("error", (e: NodeJS.ErrnoException) => events.push("error:" + e.code + ":" + e.syscall));
+        c.on("close", hadError => {
+          events.push("close:" + hadError);
+          resolve();
+        });
+      });
+      expect(events).toEqual(["error:EALREADY:connect", "close:true"]);
+      expect(connections).toBeLessThanOrEqual(1);
+    } finally {
+      server.close();
+    }
   });
 });

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -140,7 +140,7 @@ describe.concurrent("socket.connect() re-entry", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stderr, exitCode }).toEqual({ stderr, exitCode: 0 });
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
     return JSON.parse(stdout);
   }
 


### PR DESCRIPTION
### Problem
- `node:net` diverges from node v26 in three places of the lookup-result to connect step. A `lookup` callback that fires twice opens two connections. Node fails the second `uv_tcp_connect` with `EALREADY`. A lookup result whose address does not parse in the family it names (`"127.0.0.1"` with family 6) connects anyway. Node gets `EINVAL` from `uv_ip4_addr`/`uv_ip6_addr`.
- A unix socket `connect()` that fails (missing path) is reported synchronously from `connect()`. libuv defers it to the connect callback. So `http.request({ socketPath })` to a missing path emits `'error'` before `'socket'`, and `req.socket` is `undefined` in the error handler.
- The cause is `kConnectTcp`/`kConnectPipe`/`kConnectDispatch` in `src/js/node/net.ts:1493`, the boundary that stands in for node's `TCPWrap`/`PipeWrap`. It had no in-flight check, no family check, and returned the pipe errno synchronously.

### Fix
- `kConnectDispatch` marks the native handle with `kConnectReq` while a connect is in flight (libuv's `connect_req`). A second dispatch on that handle returns `UV_EALREADY`. The `open` and `connectError` handlers clear the mark.
- `kConnectTcp` returns `UV_EINVAL` when `isIP(address) !== addressType`.
- `kConnectPipe` defers a synchronous errno to `process.nextTick`, and calls `req.oncomplete` (afterConnect) there. A `destroy()` + `connect()` in that window gets a new handle, so the deferred call is skipped.
- Verified: `test/js/node/net/socket-reconnect-live.test.ts`, `test/js/node/net/connect-step.test.ts`, `test/js/node/http/node-http.test.ts`. Also `test/js/node/net/`, `test/js/node/http/`, `test/js/node/tls/`, and the ported `test-net-connect*`, `test-net-autoselectfamily*`, `test-http-agent*` node tests.

### Background
- Node's `internalConnect` calls `handle.connect(req, address, port)`. `TCPWrap` parses the address for the requested family and returns `EINVAL` if that fails. libuv returns `UV_EALREADY` if the handle already has a `connect_req`. A non-zero return destroys the socket synchronously. An asynchronous failure arrives later in `afterConnect`.
- `uv_pipe_connect` never fails synchronously. It stores the `connect(2)` errno in `delayed_error` and runs the callback on the next loop turn.
- `ClientRequest.onSocket` emits `'socket'` on `process.nextTick`. The pipe error must land after that tick to match node's order.
- Supersedes #32812, which covered only the `EALREADY` case. Its native errno helper is no longer needed: `ProcessBindingUV.cpp` now sources `UV_E*` from libuv.

<details><summary>Notes</summary>

These divergences came from differential testing against node v26, not from a user report.

Probe results (node v26.3.0 vs this build, identical on every row). Events are `req` events in order, `conns` is the count of connections the origin accepted:

```
lookup cb twice (sync):   ["error:EALREADY:noSocket","socket","close"] conns=1
lookup cb twice (async, after connect): ["socket","response:200","close"] conns=1
family 4, ip ::1:         ["error:EINVAL:noSocket","socket","close"] conns=0
family 6, ip 127.0.0.1:   ["error:EINVAL:noSocket","socket","close"] conns=0
socketPath missing:       ["socket","error:ENOENT:hasSocket","close"]
tcp refused:              ["socket","error:ECONNREFUSED:hasSocket","close"]
```

Before this change bun gave `["socket","response:200","close"]` with `conns=2` for the first row (`conns=3` for three callbacks), `["socket","connect"]` with `conns=1` for the family rows, and `["error:ENOENT:noSocket","socket","close"]` for the socketPath row.

Still at parity and unchanged: `connect()` on an already connected socket re-dials and emits `connect` again (pinned by the existing test in `socket-reconnect-live.test.ts`). The `kConnectReq` mark is cleared at `open`, so it does not affect that path.

`socket-reconnect-live.test.ts` previously accepted both `connect` and `err:EALREADY` for a second `connect()` while connecting. It now asserts node's contract: one `error` with `code`/`errno`/`syscall`, `close` with `hadError = true`, no `connect`, at most one server connection. A three-`connect()` variant is included. The Windows `errno` is checked through `util.getSystemErrorName`, since libuv uses synthetic codes there.

Self-reviewed: 8 concerns raised, 3 addressed (reference and supersede #32812, tighten the permissive assertion, fold the EALREADY tests into the existing file). The pipe and family tests stay in a separate `connect-step.test.ts`, which groups the connect-step cases the existing files do not cover.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/connect-step.test.ts, test/js/node/http/node-http.test.ts

<!-- robobun:evidence:end -->