### PR TITLE
spawn: throw from Bun.spawn when the stdin ReadableStream pump fails before it returns

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1778,6 +1778,23 @@ fn spawn_maybe_sync(
                     .on_subprocess_spawn(NonNull::new_unchecked(subprocess.process.as_ptr()))
             };
         }
+
+        // The stdin pump already failed (locked stream, start() errored, non-byte chunk). The
+        // child is watched, so it is reaped on exit. Kill it and throw the pump's reason: the
+        // caller gets the error from Bun.spawn, not from the unhandled rejection handler.
+        if let Some(promise) = promise_for_stream.as_promise() {
+            // SAFETY: `as_promise` returned a live cell held by `promise_for_stream`.
+            let promise = unsafe { &mut *promise };
+            if promise.status() == jsc::js_promise::Status::Rejected {
+                let reason = promise.result(global_this.vm());
+                // The caller never receives this Subprocess, so none of its callbacks may run.
+                let _ = Subprocess::js::on_exit_callback_take_cached(out, global_this);
+                let _ = Subprocess::js::on_disconnect_callback_take_cached(out, global_this);
+                let _ = Subprocess::js::ipc_callback_take_cached(out, global_this);
+                let _ = subprocess.try_kill(subprocess.kill_signal);
+                return Err(global_this.throw_value(reason));
+            }
+        }
         return Ok(out);
     }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1730,6 +1730,30 @@ fn spawn_maybe_sync(
 
     **should_close_memfd = false;
 
+    // The stdin pump already failed: throw its reason. The child is watched, so the kill is reaped.
+    if let Some(promise) = promise_for_stream.as_promise() {
+        // SAFETY: `as_promise` returned a live cell held by `promise_for_stream`.
+        let promise = unsafe { &mut *promise };
+        if promise.status() == jsc::js_promise::Status::Rejected {
+            debug_assert!(!is_sync);
+            let reason = promise.result(global_this.vm());
+            // The caller never receives this Subprocess, so none of its callbacks may run.
+            let _ = Subprocess::js::on_exit_callback_take_cached(out, global_this);
+            let _ = Subprocess::js::on_disconnect_callback_take_cached(out, global_this);
+            let _ = Subprocess::js::ipc_callback_take_cached(out, global_this);
+            if !subprocess.has_exited() {
+                // SAFETY: jsc_vm_ptr points to the live thread VM; `subprocess.process`
+                // is a `BackRef` (wraps `NonNull`), so its pointer is non-null.
+                unsafe {
+                    (*jsc_vm_ptr)
+                        .on_subprocess_spawn(NonNull::new_unchecked(subprocess.process.as_ptr()))
+                };
+            }
+            let _ = subprocess.try_kill(subprocess.kill_signal);
+            return Err(global_this.throw_value(reason));
+        }
+    }
+
     // Every `return Err` above is past; the Subprocess will be returned to
     // JS. Downgrade 'socket-fd' slots from OwnedFd to UnownedFd so
     // finalize_streams (on later GC) skips them and the caller is the sole
@@ -1777,21 +1801,6 @@ fn spawn_maybe_sync(
                 (*jsc_vm_ptr)
                     .on_subprocess_spawn(NonNull::new_unchecked(subprocess.process.as_ptr()))
             };
-        }
-
-        // The stdin pump already failed: throw its reason. The child is watched, so the kill is reaped.
-        if let Some(promise) = promise_for_stream.as_promise() {
-            // SAFETY: `as_promise` returned a live cell held by `promise_for_stream`.
-            let promise = unsafe { &mut *promise };
-            if promise.status() == jsc::js_promise::Status::Rejected {
-                let reason = promise.result(global_this.vm());
-                // The caller never receives this Subprocess, so none of its callbacks may run.
-                let _ = Subprocess::js::on_exit_callback_take_cached(out, global_this);
-                let _ = Subprocess::js::on_disconnect_callback_take_cached(out, global_this);
-                let _ = Subprocess::js::ipc_callback_take_cached(out, global_this);
-                let _ = subprocess.try_kill(subprocess.kill_signal);
-                return Err(global_this.throw_value(reason));
-            }
         }
         return Ok(out);
     }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1475,12 +1475,6 @@ fn spawn_maybe_sync(
         )
     });
 
-    if promise_for_stream != JSValue::ZERO && !global_this.has_exception() {
-        if let Some(err) = promise_for_stream.to_error() {
-            let _ = global_this.throw_value(err);
-        }
-    }
-
     if global_this.has_exception() {
         let err = global_this.take_exception(JsError::Thrown);
         // Ensure we kill the process so we don't leave things in an unexpected state.

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1779,9 +1779,7 @@ fn spawn_maybe_sync(
             };
         }
 
-        // The stdin pump already failed (locked stream, start() errored, non-byte chunk). The
-        // child is watched, so it is reaped on exit. Kill it and throw the pump's reason: the
-        // caller gets the error from Bun.spawn, not from the unhandled rejection handler.
+        // The stdin pump already failed: throw its reason. The child is watched, so the kill is reaped.
         if let Some(promise) = promise_for_stream.as_promise() {
             // SAFETY: `as_promise` returned a live cell held by `promise_for_stream`.
             let promise = unsafe { &mut *promise };

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -393,6 +393,14 @@ impl Stdio {
                         )
                         .throw());
                 }
+                if stream.is_locked(global) {
+                    return Err(global
+                        .err(
+                            jsc::ErrorCode::INVALID_STATE,
+                            format_args!("ReadableStream is locked"),
+                        )
+                        .throw());
+                }
 
                 *out_stdio = Stdio::ReadableStream(stream);
             }
@@ -541,6 +549,14 @@ impl Stdio {
                             "'{}' ReadableStream has already been used",
                             bstr::BStr::new(name),
                         ),
+                    )
+                    .throw());
+            }
+            if stream.is_locked(global) {
+                return Err(global
+                    .err(
+                        jsc::ErrorCode::INVALID_STATE,
+                        format_args!("'{}' ReadableStream is locked", bstr::BStr::new(name)),
                     )
                     .throw());
             }

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -171,17 +171,17 @@ impl<'a> Writable<'a> {
                         });
 
                         if let Stdio::ReadableStream(rs) = stdio {
-                            let assign_result = pipe.assign_to_stream(rs, global);
-                            if let Some(err_val) = assign_result.to_error() {
-                                subprocess.weak_file_sink_stdin_ptr.set(None);
-                                subprocess.update_flags(|f| {
-                                    f.set(Flags::DEREF_ON_STDIN_DESTROYED, false)
-                                });
-                                subprocess.deref();
-                                let _ = global.throw_value(err_val);
-                                return Err(crate::Error::JSError);
+                            match pipe.assign_to_stream(rs, global) {
+                                Ok(assign_result) => *promise_for_stream = assign_result,
+                                Err(_) => {
+                                    subprocess.weak_file_sink_stdin_ptr.set(None);
+                                    subprocess.update_flags(|f| {
+                                        f.set(Flags::DEREF_ON_STDIN_DESTROYED, false)
+                                    });
+                                    subprocess.deref();
+                                    return Err(crate::Error::JSError);
+                                }
                             }
-                            *promise_for_stream = assign_result;
                         }
 
                         return Ok(Writable::Pipe(pipe_ref));
@@ -271,15 +271,16 @@ impl<'a> Writable<'a> {
                 });
 
                 if let Stdio::ReadableStream(rs) = stdio {
-                    let assign_result = pipe.assign_to_stream(rs, global);
-                    if let Some(err_val) = assign_result.to_error() {
-                        subprocess.weak_file_sink_stdin_ptr.set(None);
-                        subprocess.update_flags(|f| f.set(Flags::DEREF_ON_STDIN_DESTROYED, false));
-                        subprocess.deref();
-                        let _ = global.throw_value(err_val);
-                        return Err(crate::Error::JSError);
+                    match pipe.assign_to_stream(rs, global) {
+                        Ok(assign_result) => *promise_for_stream = assign_result,
+                        Err(_) => {
+                            subprocess.weak_file_sink_stdin_ptr.set(None);
+                            subprocess
+                                .update_flags(|f| f.set(Flags::DEREF_ON_STDIN_DESTROYED, false));
+                            subprocess.deref();
+                            return Err(crate::Error::JSError);
+                        }
                     }
-                    *promise_for_stream = assign_result;
                 }
 
                 Ok(Writable::Pipe(pipe_ref))

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1646,10 +1646,9 @@ impl FileSink {
     }
 
     /// Pump `stream` into this sink. `Ok(UNDEFINED)` when the native fast-path took the stream,
-    /// `Ok(promise)` for a JS pump still in flight (the sink settles itself through `then`).
-    /// `Err` when the pump cannot start: the stream is already cancelled and the writer closed, and
-    /// the pump's rejection reason is the pending exception, so the caller throws it instead of the
-    /// reason escaping as an unhandled rejection nothing can catch.
+    /// `Ok(promise)` for a JS pump. A pump still in flight settles the sink through `then`. A pump
+    /// that already failed comes back as a rejected promise marked handled, with the sink torn down,
+    /// so the caller can throw its reason. `Err` when the pump could not be created at all.
     pub fn assign_to_stream(
         &mut self,
         stream: &mut ReadableStream,
@@ -1743,15 +1742,15 @@ impl FileSink {
                     }
                     bun_jsc::js_promise::Status::Rejected => {
                         // The pump failed before it returned (the source errored in start(), or
-                        // the first chunk was not bytes). Nothing holds this promise, so take its
-                        // rejection here: mark it handled and hand the reason to the caller.
+                        // the first chunk was not bytes). Nothing else holds this promise: mark
+                        // it handled here and return it, so the caller can read the reason and
+                        // rethrow it instead of the VM reporting an unhandled rejection.
                         // These don't ref().
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
                         let result = unsafe { (*js_promise).result(global_this.vm()) };
                         // SAFETY: same cell as above.
                         unsafe { (*js_promise).set_handled() };
                         self.handle_reject_stream(global_this, result)?;
-                        return Err(global_this.throw_value(result));
                     }
                 }
             }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1645,8 +1645,6 @@ impl FileSink {
         }
     }
 
-    /// Returns the JS pump's promise (`UNDEFINED` on the native path). An already-rejected promise
-    /// is marked handled and the sink torn down; the caller throws its reason.
     pub fn assign_to_stream(
         &mut self,
         stream: &mut ReadableStream,

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1645,11 +1645,16 @@ impl FileSink {
         }
     }
 
+    /// Pump `stream` into this sink. `Ok(UNDEFINED)` when the native fast-path took the stream,
+    /// `Ok(promise)` for a JS pump still in flight (the sink settles itself through `then`).
+    /// `Err` when the pump cannot start: the stream is already cancelled and the writer closed, and
+    /// the pump's rejection reason is the pending exception, so the caller throws it instead of the
+    /// reason escaping as an unhandled rejection nothing can catch.
     pub fn assign_to_stream(
         &mut self,
         stream: &mut ReadableStream,
         global_this: &JSGlobalObject,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         // SAFETY: `&mut self` carries write+dealloc provenance over the allocation.
         let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<FileSink>(self)) };
 
@@ -1675,7 +1680,7 @@ impl FileSink {
                         self.ref_();
                     }
                 }
-                return JSValue::UNDEFINED;
+                return Ok(JSValue::UNDEFINED);
             }
             readable_stream::NativeWireResult::EndedInline(err) => {
                 self.source.set(streams::SourceHandle::None);
@@ -1685,7 +1690,7 @@ impl FileSink {
                         let _ = self.end(None);
                     }
                 }
-                return JSValue::UNDEFINED;
+                return Ok(JSValue::UNDEFINED);
             }
             readable_stream::NativeWireResult::NotNative => {}
         }
@@ -1702,7 +1707,7 @@ impl FileSink {
 
         if let Some(err) = promise_result.to_error() {
             self.readable_stream.set(readable_stream::Strong::default());
-            return err;
+            return Err(global_this.throw_value(err));
         }
 
         if !promise_result.is_empty_or_undefined_or_null() {
@@ -1737,16 +1742,22 @@ impl FileSink {
                         self.handle_resolve_stream();
                     }
                     bun_jsc::js_promise::Status::Rejected => {
+                        // The pump failed before it returned (the source errored in start(), or
+                        // the first chunk was not bytes). Nothing holds this promise, so take its
+                        // rejection here: mark it handled and hand the reason to the caller.
                         // These don't ref().
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
                         let result = unsafe { (*js_promise).result(global_this.vm()) };
-                        crate::dispatch::fold(self.handle_reject_stream(global_this, result));
+                        // SAFETY: same cell as above.
+                        unsafe { (*js_promise).set_handled() };
+                        self.handle_reject_stream(global_this, result)?;
+                        return Err(global_this.throw_value(result));
                     }
                 }
             }
         }
 
-        promise_result
+        Ok(promise_result)
     }
 }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1701,8 +1701,11 @@ impl FileSink {
         );
 
         if let Some(err) = promise_result.to_error() {
-            self.readable_stream.set(readable_stream::Strong::default());
-            return Err(global_this.throw_value(err));
+            // Same outcome as a pump that rejected before returning: the caller rethrows `err`.
+            let promise = bun_jsc::JSPromise::rejected_promise(global_this, err);
+            promise.set_handled();
+            self.handle_reject_stream(global_this, err)?;
+            return Ok(promise.to_js());
         }
 
         if !promise_result.is_empty_or_undefined_or_null() {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1645,10 +1645,8 @@ impl FileSink {
         }
     }
 
-    /// Pump `stream` into this sink. `Ok(UNDEFINED)` when the native fast-path took the stream,
-    /// `Ok(promise)` for a JS pump. A pump still in flight settles the sink through `then`. A pump
-    /// that already failed comes back as a rejected promise marked handled, with the sink torn down,
-    /// so the caller can throw its reason. `Err` when the pump could not be created at all.
+    /// Returns the JS pump's promise (`UNDEFINED` on the native path). An already-rejected promise
+    /// is marked handled and the sink torn down; the caller throws its reason.
     pub fn assign_to_stream(
         &mut self,
         stream: &mut ReadableStream,
@@ -1741,10 +1739,7 @@ impl FileSink {
                         self.handle_resolve_stream();
                     }
                     bun_jsc::js_promise::Status::Rejected => {
-                        // The pump failed before it returned (the source errored in start(), or
-                        // the first chunk was not bytes). Nothing else holds this promise: mark
-                        // it handled here and return it, so the caller can read the reason and
-                        // rethrow it instead of the VM reporting an unhandled rejection.
+                        // Nothing else holds this promise; the caller rethrows its reason.
                         // These don't ref().
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
                         let result = unsafe { (*js_promise).result(global_this.vm()) };

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -332,24 +332,6 @@ describe("spawn stdin ReadableStream edge cases", () => {
     }).toThrow();
   });
 
-  test("locked ReadableStream throws from spawn", () => {
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new Uint8Array(3));
-        controller.close();
-      },
-    });
-    stream.getReader();
-
-    expect(() => {
-      spawn({
-        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
-        stdin: stream,
-        env: bunEnv,
-      });
-    }).toThrow("ReadableStream is locked");
-  });
-
   test("ReadableStream errored in start() throws its reason from spawn", () => {
     const reason = new Error("boom");
     const stream = new ReadableStream({
@@ -428,19 +410,18 @@ describe("spawn stdin ReadableStream edge cases", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A locked stream is rejected before the child is forked (covered in
+  // spawn-stdin-readable-stream.test.ts). These fail inside the pump, after the fork.
   const failingStdinStreams = {
-    locked: {
+    "errored in start()": {
       make() {
-        const stream = new ReadableStream({
+        return new ReadableStream({
           start(controller) {
-            controller.enqueue(new Uint8Array(3));
-            controller.close();
+            controller.error(new Error("start boom"));
           },
         });
-        stream.getReader();
-        return stream;
       },
-      message: "ReadableStream is locked",
+      message: "start boom",
     },
     "non-byte chunk": {
       make() {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -331,6 +331,102 @@ describe("spawn stdin ReadableStream edge cases", () => {
     }).toThrow();
   });
 
+  test("locked ReadableStream throws from spawn", () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(3));
+        controller.close();
+      },
+    });
+    stream.getReader();
+
+    expect(() => {
+      spawn({
+        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+        stdin: stream,
+        env: bunEnv,
+      });
+    }).toThrow("ReadableStream is locked");
+  });
+
+  test("ReadableStream errored in start() throws its reason from spawn", () => {
+    const reason = new Error("boom");
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.error(reason);
+      },
+    });
+
+    expect(() => {
+      spawn({
+        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+        stdin: stream,
+        env: bunEnv,
+      });
+    }).toThrow(reason);
+  });
+
+  test("ReadableStream with a non-byte chunk throws from spawn", () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(2));
+        controller.enqueue(42);
+        controller.close();
+      },
+    });
+
+    expect(() => {
+      spawn({
+        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+        stdin: stream,
+        env: bunEnv,
+      });
+    }).toThrow("write() expects a string, ArrayBufferView, or ArrayBuffer");
+  });
+
+  test("a stdin stream that fails before spawn returns never reaches the unhandled rejection handler", async () => {
+    const script = `
+      const makers = {
+        locked() {
+          const s = new ReadableStream({ start(c) { c.enqueue(new Uint8Array(3)); c.close(); } });
+          s.getReader();
+          return s;
+        },
+        errored() {
+          return new ReadableStream({ start(c) { c.error(new Error("boom")); } });
+        },
+        badChunk() {
+          return new ReadableStream({ start(c) { c.enqueue(new Uint8Array(2)); c.enqueue(42); c.close(); } });
+        },
+      };
+      for (const [name, make] of Object.entries(makers)) {
+        try {
+          Bun.spawn({ cmd: [process.execPath, "-e", "process.stdin.resume()"], stdin: make(), stdout: "ignore", stderr: "ignore" });
+          console.log(name, "did not throw");
+        } catch (e) {
+          console.log(name, "caught", e.message.includes("locked") ? "locked" : e.message);
+        }
+      }
+    `;
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(
+      [
+        "locked caught locked",
+        "errored caught boom",
+        "badChunk caught write() expects a string, ArrayBufferView, or ArrayBuffer",
+        "",
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("ReadableStream with byte stream", async () => {
     const data = new Uint8Array(256);
     for (let i = 0; i < 256; i++) {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -11,7 +11,8 @@
 
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows } from "harness";
+import { readdirSync } from "node:fs";
 
 describe("spawn stdin ReadableStream edge cases", () => {
   test("ReadableStream with exception in pull", async () => {
@@ -500,6 +501,30 @@ describe("spawn stdin ReadableStream edge cases", () => {
       expect(onExitCalls).toBe(0);
     },
   );
+
+  test.skipIf(!isLinux)("a spawn that throws on its stdin stream does not leak 'socket-fd' descriptors", async () => {
+    const countFds = () => readdirSync("/proc/self/fd").length;
+    const before = countFds();
+
+    for (let i = 0; i < 8; i++) {
+      expect(() => {
+        spawn({
+          cmd: ["sleep", "5"],
+          stdio: [failingStdinStreams["non-byte chunk"].make(), "ignore", "ignore", "socket-fd"],
+        });
+      }).toThrow("write() expects a string, ArrayBufferView, or ArrayBuffer");
+    }
+
+    // The parent-side socket closes when the unreachable Subprocess is collected after the child exits.
+    const deadline = Date.now() + 5000;
+    let after = countFds();
+    while (after > before && Date.now() < deadline) {
+      Bun.gc(true);
+      await Bun.sleep(20);
+      after = countFds();
+    }
+    expect(after).toBeLessThanOrEqual(before);
+  });
 
   test("ReadableStream with byte stream", async () => {
     const data = new Uint8Array(256);

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -427,44 +427,79 @@ describe("spawn stdin ReadableStream edge cases", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.skipIf(isWindows)("a spawn that throws on its stdin stream kills and reaps the child", async () => {
-    let onExitCalls = 0;
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new Uint8Array(2));
-        controller.enqueue(42);
-        controller.close();
+  const failingStdinStreams = {
+    locked: {
+      make() {
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(3));
+            controller.close();
+          },
+        });
+        stream.getReader();
+        return stream;
       },
-    });
+      message: "ReadableStream is locked",
+    },
+    "non-byte chunk": {
+      make() {
+        return new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(2));
+            controller.enqueue(42);
+            controller.close();
+          },
+        });
+      },
+      message: "write() expects a string, ArrayBufferView, or ArrayBuffer",
+    },
+    "direct stream whose pull throws": {
+      make() {
+        return new ReadableStream({
+          type: "direct",
+          pull() {
+            throw new Error("direct boom");
+          },
+        });
+      },
+      message: "direct boom",
+    },
+  };
 
-    expect(() => {
-      spawn({
-        cmd: ["sleep", "5"],
-        stdin: stream,
-        stdout: "ignore",
-        stderr: "ignore",
-        onExit() {
-          onExitCalls++;
-        },
-      });
-    }).toThrow("write() expects a string, ArrayBufferView, or ArrayBuffer");
+  test.skipIf(isWindows).each(Object.entries(failingStdinStreams))(
+    "a spawn that throws on its stdin stream (%s) kills and reaps the child",
+    async (_name, { make, message }) => {
+      let onExitCalls = 0;
 
-    const listChildren = () =>
-      Bun.spawnSync(["ps", "-ax", "-o", "pid=,ppid=,stat=,comm="])
-        .stdout.toString()
-        .split("\n")
-        .map(line => line.trim().split(/\s+/))
-        .filter(([, ppid, , comm]) => ppid === String(process.pid) && comm === "sleep");
+      expect(() => {
+        spawn({
+          cmd: ["sleep", "5"],
+          stdin: make(),
+          stdout: "ignore",
+          stderr: "ignore",
+          onExit() {
+            onExitCalls++;
+          },
+        });
+      }).toThrow(message);
 
-    const deadline = Date.now() + 2000;
-    let children = listChildren();
-    while (children.length > 0 && Date.now() < deadline) {
-      await Bun.sleep(20);
-      children = listChildren();
-    }
-    expect(children).toEqual([]);
-    expect(onExitCalls).toBe(0);
-  });
+      const listChildren = () =>
+        Bun.spawnSync(["ps", "-ax", "-o", "pid=,ppid=,stat=,comm="])
+          .stdout.toString()
+          .split("\n")
+          .map(line => line.trim().split(/\s+/))
+          .filter(([, ppid, , comm]) => ppid === String(process.pid) && comm === "sleep");
+
+      const deadline = Date.now() + 2000;
+      let children = listChildren();
+      while (children.length > 0 && Date.now() < deadline) {
+        await Bun.sleep(20);
+        children = listChildren();
+      }
+      expect(children).toEqual([]);
+      expect(onExitCalls).toBe(0);
+    },
+  );
 
   test("ReadableStream with byte stream", async () => {
     const data = new Uint8Array(256);

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -489,7 +489,8 @@ describe("spawn stdin ReadableStream edge cases", () => {
           .stdout.toString()
           .split("\n")
           .map(line => line.trim().split(/\s+/))
-          .filter(([, ppid, , comm]) => ppid === String(process.pid) && comm === "sleep");
+          // Linux prints the basename, macOS the executable path.
+          .filter(([, ppid, , comm]) => ppid === String(process.pid) && (comm === "sleep" || comm?.endsWith("/sleep")));
 
       const deadline = Date.now() + 2000;
       let children = listChildren();

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts
@@ -11,7 +11,7 @@
 
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 describe("spawn stdin ReadableStream edge cases", () => {
   test("ReadableStream with exception in pull", async () => {
@@ -427,6 +427,45 @@ describe("spawn stdin ReadableStream edge cases", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.skipIf(isWindows)("a spawn that throws on its stdin stream kills and reaps the child", async () => {
+    let onExitCalls = 0;
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(2));
+        controller.enqueue(42);
+        controller.close();
+      },
+    });
+
+    expect(() => {
+      spawn({
+        cmd: ["sleep", "5"],
+        stdin: stream,
+        stdout: "ignore",
+        stderr: "ignore",
+        onExit() {
+          onExitCalls++;
+        },
+      });
+    }).toThrow("write() expects a string, ArrayBufferView, or ArrayBuffer");
+
+    const listChildren = () =>
+      Bun.spawnSync(["ps", "-ax", "-o", "pid=,ppid=,stat=,comm="])
+        .stdout.toString()
+        .split("\n")
+        .map(line => line.trim().split(/\s+/))
+        .filter(([, ppid, , comm]) => ppid === String(process.pid) && comm === "sleep");
+
+    const deadline = Date.now() + 2000;
+    let children = listChildren();
+    while (children.length > 0 && Date.now() < deadline) {
+      await Bun.sleep(20);
+      children = listChildren();
+    }
+    expect(children).toEqual([]);
+    expect(onExitCalls).toBe(0);
+  });
+
   test("ReadableStream with byte stream", async () => {
     const data = new Uint8Array(256);
     for (let i = 0; i < 256; i++) {
@@ -551,25 +590,27 @@ describe("spawn stdin ReadableStream edge cases", () => {
       { stdout: "pipe", stderr: "inherit" },
     ];
 
-    for (const config of configs) {
-      const stream = new ReadableStream({
-        async pull(controller) {
-          await Bun.sleep(0);
-          controller.enqueue("test input");
-          controller.close();
-        },
-      });
+    // Run the configs at once: three sequential debug-build children do not fit the per-test budget.
+    const results = await Promise.all(
+      configs.map(async config => {
+        const stream = new ReadableStream({
+          async pull(controller) {
+            await Bun.sleep(0);
+            controller.enqueue("test input");
+            controller.close();
+          },
+        });
 
-      const proc = spawn({
-        cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
-        stdin: stream,
-        ...config,
-        env: bunEnv,
-      });
+        const proc = spawn({
+          cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+          stdin: stream,
+          ...config,
+          env: bunEnv,
+        });
 
-      const stdout = await proc.stdout.text();
-      expect(stdout).toBe("test input");
-      expect(await proc.exited).toBe(0);
-    }
+        return [await proc.stdout.text(), await proc.exited];
+      }),
+    );
+    expect(results).toEqual(configs.map(() => ["test input", 0]));
   });
 });

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -545,6 +545,121 @@ describe("spawn stdin ReadableStream", () => {
     }).toThrow("'stdin' ReadableStream has already been used");
   });
 
+  // A locked stream can never be pumped into the child (the pump's reader
+  // acquisition throws), so spawn rejects it before forking and leaves it untouched.
+  test.each([
+    {
+      how: "getReader()",
+      lock(stream: ReadableStream<string>) {
+        const reader = stream.getReader();
+        return () => reader.read();
+      },
+    },
+    {
+      how: "tee()",
+      lock(stream: ReadableStream<string>) {
+        const [branch] = stream.tee();
+        return () => branch.getReader().read();
+      },
+    },
+  ])("ReadableStream locked by $how throws synchronously instead of spawning", async ({ lock }) => {
+    const stream = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue("still readable by the lock holder");
+        controller.close();
+      },
+    });
+    const readFirstChunk = lock(stream);
+    expect(stream.locked).toBe(true);
+
+    const locked = expect.objectContaining({ code: "ERR_INVALID_STATE", message: "'stdin' ReadableStream is locked" });
+    expect(() => spawn({ cmd: [bunExe(), "-e", ""], stdin: stream, env: bunEnv })).toThrow(locked);
+    expect(() => spawn({ cmd: [bunExe(), "-e", ""], stdio: [stream, "ignore", "ignore"], env: bunEnv })).toThrow(
+      locked,
+    );
+
+    // The rejected spawn must not have cancelled the stream out from under whoever holds the lock.
+    expect(await readFirstChunk()).toEqual({ done: false, value: "still readable by the lock holder" });
+  });
+
+  test("ReadableStream rejected while locked still works as stdin once the lock is released", async () => {
+    const stream = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue("delivered on the second try");
+        controller.close();
+      },
+    });
+    const reader = stream.getReader();
+    expect(() => spawn({ cmd: [bunExe(), "-e", ""], stdin: stream, env: bunEnv })).toThrow(
+      "'stdin' ReadableStream is locked",
+    );
+    reader.releaseLock();
+
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+      stdin: stream,
+      stdout: "pipe",
+      env: bunEnv,
+    });
+    expect(await proc.stdout.text()).toBe("delivered on the second try");
+    expect(await proc.exited).toBe(0);
+  });
+
+  test.each([
+    { kind: "Response", wrap: (body: ReadableStream) => new Response(body) },
+    { kind: "Request", wrap: (body: ReadableStream) => new Request("http://localhost/", { method: "POST", body }) },
+  ])("$kind whose body stream is locked throws synchronously instead of spawning", ({ wrap }) => {
+    const wrapper = wrap(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue("body");
+          controller.close();
+        },
+      }),
+    );
+    wrapper.body!.getReader();
+
+    expect(() => spawn({ cmd: [bunExe(), "-e", ""], stdin: wrapper, env: bunEnv })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_STATE", message: "ReadableStream is locked" }),
+    );
+  });
+
+  test("rejecting a locked stdin stream is catchable and does not fail the process", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue("data");
+            controller.close();
+          },
+        });
+        stream.getReader();
+        try {
+          Bun.spawn({
+            cmd: [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
+            stdin: stream,
+            stdout: "ignore",
+          });
+          console.log("spawned");
+        } catch (e) {
+          console.log(e.code + ": " + e.message);
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("ERR_INVALID_STATE: 'stdin' ReadableStream is locked");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("ReadableStream with abort signal calls cancel", async () => {
     const controller = new AbortController();
     const cancel = mock();


### PR DESCRIPTION
### Problem
- `Bun.spawn({ stdin: stream })` with a stream that cannot be pumped (locked by `getReader()`/`tee()`, errored in `start()`, or a first chunk that is not bytes) returns a `Subprocess`. The child reads EOF and exits 0. The reason (`TypeError: Invalid state: ReadableStream is locked`, ...) then escapes as an unhandled rejection, outside any `try/catch`, and the process exits 1.
- Cause: `Stdio::extract` (`src/runtime/api/bun/spawn/stdio.rs:544`) checks only `is_disturbed`, so a locked stream passes. The pump (`readStreamIntoSink`, `BunStreamSource.cpp:1247`) rejects its promise before it returns, and `FileSink::assign_to_stream` (`FileSink.rs:1744`) handed that promise to nobody.

### Fix
- Locked: `Stdio::extract` and `extract_body_value` also check `is_locked` and throw `ERR_INVALID_STATE` before the fork. The caller's stream is not cancelled. Carried over from #38421.
- Other cases: `assign_to_stream` marks the rejected pump promise handled. After `watch()`, `spawn_maybe_sync` clears the `onExit`/`onDisconnect`/`ipc` callbacks, kills the child, and throws the reason. The exit handler reaps it.
- Rule: a pump failure known before `Bun.spawn` returns throws from it. A later failure stays async (#36236).
- Verified: `spawn-stdin-readable-stream.test.ts` (6 locked cases), `spawn-stdin-readable-stream-edge-cases.test.ts` (7 cases). All 13 fail on bun 1.4.3. Also `spawn.test.ts` and the `spawn-stdin*` suites.

### Background
- A stdin `ReadableStream` is pumped by a `FileSink` on the child's stdin pipe. `assign_to_stream` starts the JS pump, which returns a promise that settles when it ends.
- Locked is not disturbed: `getReader()` locks, only a read or a cancel disturbs. The pump's reader acquisition throws exactly when `is_locked`.
- `set_handled()` sets the flag that `handleRejectedPromises` checks before it reports a rejection.

<details><summary>Notes</summary>

- Repro on bun 1.4.2, 1.4.3-canary and main: `child saw 0 exited 0`, `script end reached`, then the TypeError banner (`Invalid state: ReadableStream is locked`, the `error()` reason, or `write() expects a string, ArrayBufferView, or ArrayBuffer`) and exit code 1. For the locked case the lock holder also read `{ done: true }` because the failed pump's teardown cancelled the stream, and a second spawn with the same stream reported `'stdin' ReadableStream has already been used`. With this change: `caught ... ReadableStream is locked`, exit code 0, the lock holder still reads its chunk, and a spawn after `releaseLock()` delivers the data.
- #38421 (same locked bug, pre-fork check only) is closed in favor of this PR. Its `stdio.rs` check and its five tests were carried over here unchanged, plus one test for a second spawn after `releaseLock()`. The locked entry in the kill-and-reap table of the edge-cases file was replaced by an errored-in-`start()` entry, since a locked stream no longer forks.
- Locked-case tests: `getReader()` and `tee()` (both `stdin:` and `stdio:` forms, the lock holder still receives the data), `Response` and `Request` with a locked body stream (`ReadableStream is locked`), a child process that shows the error is catchable and the exit code stays 0, and the second spawn after `releaseLock()`.
- Edge-case tests: errored-in-`start()` and non-byte chunk throw from `Bun.spawn`; none of locked/errored/bad-chunk reaches the unhandled rejection handler; errored-in-`start()`, non-byte chunk and a direct stream whose `pull()` throws each kill and reap the `sleep` child (checked with `ps`) without calling `onExit`; `socket-fd` descriptors close (Linux, `/proc/self/fd`).
- `promise.set_handled()` sets the `isHandled` flag that `handleRejectedPromises` (`ZigGlobalObject.cpp:3282`) checks. `Process::kill` is a no-op while the poller is `Detached`, which is the state until `watch()` runs, so the post-fork throw cannot happen earlier. The first revision returned `Err` from `assign_to_stream` and went through the `Writable::init` error arm. Review pointed out that this left the child running and unreaped (one zombie per failed spawn), because that arm detaches the child. The current revision keeps the child watched, kills it with `kill_signal`, and has a test that lists children with `ps` until none are left.
- On bun 1.4.2 the direct-stream `pull()` throw case already throws from `Bun.spawn`, but the child keeps running (the `Writable::init` arm). That case now kills and reaps too: a pump that throws at creation is wrapped in a handled rejected promise and tears the sink down through `handle_reject_stream`.
- Review also caught that the throw first sat below the block that downgrades `socket-fd` slots to `UnownedFd`, so the parent-side socket leaked. It now sits above that block. On the previous commit 8 descriptors stayed open for the full test deadline, with the fix they close in under 100 ms.
- Overlap with #36236 (same `Rejected` arm, routes the sync case through `onExit`): with no `onExit` handler that still ends in an unhandled rejection, so a sync throw is the only outlet a caller can catch. Whichever PR lands second needs a small rebase.
- Separate message for the locked case mirrors the stream consumers (`createLockedError` vs `createAlreadyUsedError` in `BunStreamConsumers.cpp`). The disturbed check runs first, so a stream that is being consumed keeps its existing message. Native-backed streams (Blob, file, fetch body) take the `to_any_blob` / `is_disturbed` paths before the lock check, as before.
- Self-review of the pre-fork check: `ReadableStream__isLocked` is a pure type test (`dynamicDowncast` plus `isReadableStreamLocked`, no user JS, no exception). `Body::to_readable_stream` never hands back a stream that is locked by construction: a pending native body (`locked_to_native_stream`) and an errored or blob body create a fresh stream, so only a body stream the caller locked is rejected. The same `is_disturbed || is_locked` pair already guards `fetch` bodies, `Blob` writers, `HTMLRewriter` and `Body` extraction. No concerns left open.
- The existing "spawn options variations" test ran three debug-build children in sequence and sat at the 5 s budget under ASAN. It now runs them at once.
- Windows arm of `Writable::init` updated the same way. `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` passes.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-stdin-readable-stream-edge-cases.test.ts

<!-- robobun:evidence:end -->
