### PR TITLE
hot reloader: follow a retargeted symlink on the import path

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -2343,6 +2343,34 @@ impl<ValueType, const COUNT: usize, const REMOVE_TRAILING_SLASHES: bool>
         let _key = Self::key_hash(denormalized_key);
         self.index.remove(&_key).is_some()
     }
+
+    /// Removes every present entry whose value satisfies `pred`. Not-found
+    /// markers carry no value and stay. Returns how many were removed. The
+    /// values stay allocated: the map never frees a slot.
+    pub fn remove_where(&mut self, mut pred: impl FnMut(&ValueType) -> bool) -> usize {
+        let _guard = self.mutex.lock();
+        let mut doomed: Vec<HashKeyType> = Vec::new();
+        for (&hash, &index) in &self.index {
+            if index.index() == NOT_FOUND.index() || index.index() == UNASSIGNED.index() {
+                continue;
+            }
+            let value: &ValueType = if index.is_overflow() {
+                self.overflow_list.at_index_mut(index)
+            } else {
+                // SAFETY: a non-sentinel, non-overflow index was assigned by
+                // `put`, which initialized this slot via `.write()`.
+                unsafe { self.backing_buf[index.index() as usize].assume_init_ref() }
+            };
+            if pred(value) {
+                doomed.try_reserve(1).unwrap_or_else(|_| out_of_memory());
+                doomed.push(hash);
+            }
+        }
+        for hash in &doomed {
+            self.index.remove(hash);
+        }
+        doomed.len()
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -2371,6 +2371,15 @@ impl<ValueType, const COUNT: usize, const REMOVE_TRAILING_SLASHES: bool>
         }
         doomed.len()
     }
+
+    /// Drops every not-found marker. Returns how many there were.
+    pub fn clear_not_found(&mut self) -> usize {
+        let _guard = self.mutex.lock();
+        let before = self.index.len();
+        self.index
+            .retain(|_, index| index.index() != NOT_FOUND.index());
+        before - self.index.len()
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -845,9 +845,8 @@ where
         true
     }
 
-    /// Keeps the cached listing of `dir` reachable for later events on that
-    /// directory after the resolver cache for it is busted, as the Directory
-    /// arm of `on_file_update` does for the directory the event is for.
+    /// Keeps the listing of `dir` reachable for later events on it after
+    /// the resolver cache is busted.
     #[cfg(not(windows))]
     fn tombstone_entries(&mut self, dir: &[u8]) {
         let rfs: &mut Fs::file_system::RealFS = &mut FileSystem::instance().fs;
@@ -1196,23 +1195,17 @@ where
                             }
                         }
 
-                        // A changed entry can be a directory the module graph
-                        // resolved through: a retargeted directory symlink
-                        // (`cur -> v1` becomes `cur -> v2`), a replaced
-                        // directory, or a followed file symlink. The resolver
-                        // caches the old real path under the entry's own path
-                        // and nothing watches the new target, so bust that
-                        // cache and reload.
+                        // A changed entry the module graph resolved through
+                        // (a retargeted symlink, a replaced directory) has a
+                        // stale real path in the resolver cache.
                         if IS_KQUEUE {
-                            // kqueue names no entry. Check every symlink the
-                            // resolver followed inside this directory.
+                            // kqueue names no entry: check every followed symlink.
                             if let Some(dir_ent) = entries_option {
                                 // SAFETY: dir_ent points into rfs.entries (or a
                                 // tombstoned copy); both outlive this loop
                                 // iteration. Shared access only.
                                 let dir_ent = unsafe { &*dir_ent };
-                                // Collected under the lock, checked after it:
-                                // `bust_dir_cache` takes the same lock.
+                                // `bust_dir_cache` takes `entries_mutex` too.
                                 let mut followed: Vec<&'static Fs::Entry> = Vec::new();
                                 {
                                     let _entries_lock = rfs.entries_mutex.lock_guard();

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -7,6 +7,8 @@ use bun_collections::StringSet;
 use bun_core::Output;
 use bun_core::ZStr;
 #[cfg(not(windows))]
+use bun_paths::PathBuffer;
+#[cfg(not(windows))]
 use bun_paths::SEP;
 use bun_paths::strings;
 #[cfg(not(windows))]
@@ -117,6 +119,10 @@ impl HotReloaderCtx for VirtualMachine {
         VirtualMachine::bust_dir_cache(self, path)
     }
 
+    fn bust_dir_cache_tree(&mut self, path: &[u8]) -> bool {
+        self.transpiler.resolver.bust_dir_cache_tree(path)
+    }
+
     fn get_loaders(&self) -> &bun_ast::LoaderHashTable {
         &self.transpiler.options.loaders
     }
@@ -209,6 +215,9 @@ pub trait HotReloaderCtx {
 
     /// Returns whether anything was busted.
     fn bust_dir_cache(&mut self, path: &[u8]) -> bool;
+
+    /// `bust_dir_cache` for `path` and every cached directory below it.
+    fn bust_dir_cache_tree(&mut self, path: &[u8]) -> bool;
 
     /// `&transpiler.options.loaders`.
     fn get_loaders(&self) -> &bun_ast::LoaderHashTable;
@@ -786,6 +795,75 @@ where
         self.tombstones.get(key).copied()
     }
 
+    /// Writes `dir/name` into `buf`, NUL-terminated. `None` when it does not
+    /// fit.
+    #[cfg(not(windows))]
+    fn join_entry_path<'b>(buf: &'b mut PathBuffer, dir: &[u8], name: &[u8]) -> Option<&'b ZStr> {
+        let dir = strings::trim_right(dir, &[SEP]);
+        let len = dir.len() + 1 + name.len();
+        if len >= buf.len() {
+            return None;
+        }
+        buf[..dir.len()].copy_from_slice(dir);
+        buf[dir.len()] = SEP;
+        buf[dir.len() + 1..len].copy_from_slice(name);
+        buf[len] = 0;
+        // SAFETY: buf[len] == 0 written above.
+        Some(ZStr::from_buf(&buf[..], len))
+    }
+
+    /// Drops what the resolver cached under `dir/name` and below. Returns
+    /// true when there was something to drop, which means a resolution went
+    /// through `dir/name` as a directory.
+    #[cfg(not(windows))]
+    fn bust_changed_entry(&mut self, dir: &[u8], name: &[u8]) -> bool {
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let Some(child) = Self::join_entry_path(&mut buf, dir, name) else {
+            return false;
+        };
+        self.tombstone_entries(child.as_bytes());
+        self.ctx_mut().bust_dir_cache_tree(child.as_bytes())
+    }
+
+    /// Whether the symlink `entry` inside `dir` now resolves somewhere else
+    /// than where the resolver followed it. Drops the resolver cache for the
+    /// link when it does.
+    #[cfg(not(windows))]
+    fn symlink_entry_changed(&mut self, dir: &[u8], entry: &Fs::Entry) -> bool {
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let Some(child) = Self::join_entry_path(&mut buf, dir, entry.base()) else {
+            return false;
+        };
+        let mut real_buf = bun_paths::path_buffer_pool::get();
+        if bun_sys::realpath(child, &mut real_buf)
+            .is_ok_and(|real| real == entry.followed_symlink())
+        {
+            return false;
+        }
+        self.tombstone_entries(child.as_bytes());
+        self.ctx_mut().bust_dir_cache_tree(child.as_bytes());
+        true
+    }
+
+    /// Keeps the cached listing of `dir` reachable for later events on that
+    /// directory after the resolver cache for it is busted, as the Directory
+    /// arm of `on_file_update` does for the directory the event is for.
+    #[cfg(not(windows))]
+    fn tombstone_entries(&mut self, dir: &[u8]) {
+        let rfs: &mut Fs::file_system::RealFS = &mut FileSystem::instance().fs;
+        let Some(existing) = rfs.entries.get(dir) else {
+            return;
+        };
+        let existing: *mut Fs::EntriesOption = existing;
+        let mut key = bun_paths::path_buffer_pool::get();
+        if dir.len() + 1 >= key.len() {
+            return;
+        }
+        key[..dir.len()].copy_from_slice(dir);
+        key[dir.len()] = SEP;
+        self.put_tombstone(&key[..dir.len() + 1], existing);
+    }
+
     pub(crate) fn on_error(_: &mut Self, err: &bun_sys::Error) {
         // `bun_sys::Error::name()` does the errno→tag-name lookup.
         Output::err(err.name(), "Watcher crashed", ());
@@ -1118,6 +1196,80 @@ where
                             }
                         }
 
+                        // A changed entry can be a directory the module graph
+                        // resolved through: a retargeted directory symlink
+                        // (`cur -> v1` becomes `cur -> v2`), a replaced
+                        // directory, or a followed file symlink. The resolver
+                        // caches the old real path under the entry's own path
+                        // and nothing watches the new target, so bust that
+                        // cache and reload.
+                        if IS_KQUEUE {
+                            // kqueue names no entry. Check every symlink the
+                            // resolver followed inside this directory.
+                            if let Some(dir_ent) = entries_option {
+                                // SAFETY: dir_ent points into rfs.entries (or a
+                                // tombstoned copy); both outlive this loop
+                                // iteration. Shared access only.
+                                let dir_ent = unsafe { &*dir_ent };
+                                // Collected under the lock, checked after it:
+                                // `bust_dir_cache` takes the same lock.
+                                let mut followed: Vec<&'static Fs::Entry> = Vec::new();
+                                {
+                                    let _entries_lock = rfs.entries_mutex.lock_guard();
+                                    if let Fs::EntriesOption::Entries(listing) = dir_ent {
+                                        for &entry_ptr in listing.data.values() {
+                                            // SAFETY: EntryStore-owned slot, never freed.
+                                            let entry: &'static Fs::Entry = unsafe { &*entry_ptr };
+                                            if !entry.followed_symlink().is_empty() {
+                                                bun_core::handle_oom(followed.try_reserve(1));
+                                                followed.push(entry);
+                                            }
+                                        }
+                                    }
+                                }
+                                for entry in followed {
+                                    if self.symlink_entry_changed(file_path, entry) {
+                                        current_task.append(current_hash);
+                                    }
+                                }
+                            }
+                        } else {
+                            for changed_name_ in affected_inotify {
+                                let changed_name: &[u8] = match changed_name_ {
+                                    Some(z) => z.as_bytes(),
+                                    None => continue,
+                                };
+                                if changed_name.is_empty()
+                                    || changed_name[0] == b'~'
+                                    || changed_name[0] == b'.'
+                                {
+                                    continue;
+                                }
+                                let followed_symlink = match entries_option {
+                                    Some(dir_ent) => {
+                                        let _entries_lock = rfs.entries_mutex.lock_guard();
+                                        // SAFETY: dir_ent points into rfs.entries
+                                        // (or a tombstoned copy); both outlive
+                                        // this loop iteration. Shared access only.
+                                        match unsafe { &*dir_ent } {
+                                            Fs::EntriesOption::Entries(listing) => {
+                                                listing.get(changed_name).is_some_and(|e| {
+                                                    !e.entry().followed_symlink().is_empty()
+                                                })
+                                            }
+                                            Fs::EntriesOption::Err(_) => false,
+                                        }
+                                    }
+                                    None => false,
+                                };
+                                if self.bust_changed_entry(file_path, changed_name)
+                                    || followed_symlink
+                                {
+                                    current_task.append(current_hash);
+                                }
+                            }
+                        }
+
                         if let Some(dir_ent) = entries_option {
                             // SAFETY: dir_ent points into rfs.entries (or a tombstoned copy);
                             // both outlive this loop iteration. Shared access only —
@@ -1340,6 +1492,10 @@ impl<'a> HotReloaderCtx for bun_bundler::BundleV2<'a> {
 
     fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
         bun_bundler::BundleV2::bust_dir_cache(self, path)
+    }
+
+    fn bust_dir_cache_tree(&mut self, path: &[u8]) -> bool {
+        self.transpiler.resolver.bust_dir_cache_tree(path)
     }
 
     fn get_loaders(&self) -> &bun_ast::LoaderHashTable {

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -816,12 +816,17 @@ where
     /// true when there was something to drop, which means a resolution went
     /// through `dir/name` as a directory.
     #[cfg(not(windows))]
-    fn bust_changed_entry(&mut self, dir: &[u8], name: &[u8]) -> bool {
+    fn bust_changed_entry(
+        &mut self,
+        rfs: &mut Fs::file_system::RealFS,
+        dir: &[u8],
+        name: &[u8],
+    ) -> bool {
         let mut buf = bun_paths::path_buffer_pool::get();
         let Some(child) = Self::join_entry_path(&mut buf, dir, name) else {
             return false;
         };
-        self.tombstone_entries(child.as_bytes());
+        self.tombstone_entries(rfs, child.as_bytes());
         self.ctx_mut().bust_dir_cache_tree(child.as_bytes())
     }
 
@@ -829,7 +834,12 @@ where
     /// than where the resolver followed it. Drops the resolver cache for the
     /// link when it does.
     #[cfg(not(windows))]
-    fn symlink_entry_changed(&mut self, dir: &[u8], entry: &Fs::Entry) -> bool {
+    fn symlink_entry_changed(
+        &mut self,
+        rfs: &mut Fs::file_system::RealFS,
+        dir: &[u8],
+        entry: &Fs::Entry,
+    ) -> bool {
         let mut buf = bun_paths::path_buffer_pool::get();
         let Some(child) = Self::join_entry_path(&mut buf, dir, entry.base()) else {
             return false;
@@ -840,7 +850,7 @@ where
         {
             return false;
         }
-        self.tombstone_entries(child.as_bytes());
+        self.tombstone_entries(rfs, child.as_bytes());
         self.ctx_mut().bust_dir_cache_tree(child.as_bytes());
         true
     }
@@ -848,8 +858,7 @@ where
     /// Keeps the listing of `dir` reachable for later events on it after
     /// the resolver cache is busted.
     #[cfg(not(windows))]
-    fn tombstone_entries(&mut self, dir: &[u8]) {
-        let rfs: &mut Fs::file_system::RealFS = &mut FileSystem::instance().fs;
+    fn tombstone_entries(&mut self, rfs: &mut Fs::file_system::RealFS, dir: &[u8]) {
         let Some(existing) = rfs.entries.get(dir) else {
             return;
         };
@@ -1221,7 +1230,7 @@ where
                                     }
                                 }
                                 for entry in followed {
-                                    if self.symlink_entry_changed(file_path, entry) {
+                                    if self.symlink_entry_changed(rfs, file_path, entry) {
                                         current_task.append(current_hash);
                                     }
                                 }
@@ -1255,7 +1264,7 @@ where
                                     }
                                     None => false,
                                 };
-                                if self.bust_changed_entry(file_path, changed_name)
+                                if self.bust_changed_entry(rfs, file_path, changed_name)
                                     || followed_symlink
                                 {
                                     current_task.append(current_hash);

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -166,9 +166,10 @@ impl Entry {
     }
 
     /// The real path a resolution followed this symlink to. Empty when the
-    /// entry is not a symlink or was never stat'd. No I/O.
-    #[inline]
+    /// entry is not a symlink or was never stat'd. No I/O. Safe from any
+    /// thread: every `cache` rewrite holds `mutex`.
     pub fn followed_symlink(&self) -> &'static [u8] {
+        let _guard = self.mutex.lock_guard();
         self.cache().symlink.as_bytes()
     }
 

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -165,6 +165,13 @@ impl Entry {
         self.cache.set(c);
     }
 
+    /// The real path a resolution followed this symlink to. Empty when the
+    /// entry is not a symlink or was never stat'd. No I/O.
+    #[inline]
+    pub fn followed_symlink(&self) -> &'static [u8] {
+        self.cache().symlink.as_bytes()
+    }
+
     #[inline(always)]
     pub(crate) fn set_cache_symlink(&self, symlink: Interned) {
         let mut c = self.cache.get();

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1044,6 +1044,9 @@ pub mod fs {
         pub(crate) fn remove(&mut self, key: &[u8]) -> bool {
             self.inner().remove(key)
         }
+        pub(crate) fn remove_where(&mut self, pred: impl FnMut(&EntriesOption) -> bool) -> usize {
+            self.inner().remove_where(pred)
+        }
     }
 
     /// The active filesystem backend (always the real filesystem).
@@ -1356,6 +1359,19 @@ pub mod fs {
             // `read_directory`/`dir_info_cached_maybe_log`).
             let _g = self.entries_mutex.lock_guard();
             self.entries.remove(file_path)
+        }
+
+        /// Evicts every cached listing of a directory below `dir_with_slash`
+        /// (`dir_with_slash` itself excluded). Returns how many were removed.
+        pub(crate) fn bust_entries_cache_below(&mut self, dir_with_slash: &[u8]) -> usize {
+            let _g = self.entries_mutex.lock_guard();
+            self.entries.remove_where(|entry| match entry {
+                EntriesOption::Entries(listing) => {
+                    listing.dir.len() > dir_with_slash.len()
+                        && listing.dir.starts_with(dir_with_slash)
+                }
+                EntriesOption::Err(_) => false,
+            })
         }
 
         /// lstat + (if symlink) open + fstat +

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1047,6 +1047,9 @@ pub mod fs {
         pub(crate) fn remove_where(&mut self, pred: impl FnMut(&EntriesOption) -> bool) -> usize {
             self.inner().remove_where(pred)
         }
+        pub(crate) fn clear_not_found(&mut self) -> usize {
+            self.inner().clear_not_found()
+        }
     }
 
     /// The active filesystem backend (always the real filesystem).
@@ -1365,13 +1368,16 @@ pub mod fs {
         /// (`dir_with_slash` itself excluded). Returns how many were removed.
         pub(crate) fn bust_entries_cache_below(&mut self, dir_with_slash: &[u8]) -> usize {
             let _g = self.entries_mutex.lock_guard();
-            self.entries.remove_where(|entry| match entry {
+            let listings = self.entries.remove_where(|entry| match entry {
                 EntriesOption::Entries(listing) => {
                     listing.dir.len() > dir_with_slash.len()
                         && listing.dir.starts_with(dir_with_slash)
                 }
                 EntriesOption::Err(_) => false,
-            })
+            });
+            // A not-found marker has no key to match, and a path that did
+            // not exist under the old target can exist under the new one.
+            listings + self.entries.clear_not_found()
         }
 
         /// lstat + (if symlink) open + fstat +

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -488,6 +488,11 @@ pub struct Resolver<'a> {
     pub elapsed: u64, // tracing
 
     pub watcher: Option<AnyResolveWatcher>,
+    /// Directories that hold a followed symlink, found while `entries_mutex`
+    /// was held. The watcher takes its own mutex, which the watcher thread
+    /// holds while it takes `entries_mutex`, so the watch is registered once
+    /// `entries_mutex` is released (`flush_link_dir_watches`).
+    link_dir_watches: Vec<(&'static [u8], FD)>,
 
     pub caches: CacheSet,
     pub generation: Generation,
@@ -625,6 +630,7 @@ impl<'a> Resolver<'a> {
             debug_logs: None,
             elapsed: 0,
             watcher: from.watcher,
+            link_dir_watches: Vec::new(),
             caches: CacheSet::init(),
             generation: from.generation,
             package_manager: from.package_manager,
@@ -925,6 +931,7 @@ impl<'a> Resolver<'a> {
             debug_logs: None,
             elapsed: 0,
             watcher: None,
+            link_dir_watches: Vec::new(),
             generation: 0,
             package_manager: None,
             on_wake_package_manager: Default::default(),
@@ -2441,15 +2448,35 @@ impl<'a> Resolver<'a> {
         first_bust || second_bust
     }
 
+    /// Registers the directory watches queued by `dir_info_uncached`. Call
+    /// without `entries_mutex` held.
+    fn flush_link_dir_watches(&mut self) {
+        if self.link_dir_watches.is_empty() {
+            return;
+        }
+        let Some(watcher) = self.watcher else {
+            self.link_dir_watches.clear();
+            return;
+        };
+        for (dir, fd) in self.link_dir_watches.drain(..) {
+            watcher.watch(dir, fd);
+        }
+    }
+
     /// `bust_dir_cache` for `path` and for every cached directory below it.
     /// A retargeted directory symlink makes the real path cached by each of
     /// them stale at once. Returns whether anything was busted.
     pub fn bust_dir_cache_tree(&mut self, path: &[u8]) -> bool {
-        let exact = self.bust_dir_cache(path);
+        // `dir_info_cached_miss` caches every directory from the top down, so
+        // nothing is cached below a path that is not cached itself. That
+        // keeps the two map walks below off the path of a plain file save.
+        if !self.bust_dir_cache(path) {
+            return false;
+        }
         let mut buf = bun_paths::path_buffer_pool::get();
         let path = strings::without_trailing_slash_windows_path(path);
         if path.len() + 1 >= buf.len() {
-            return exact;
+            return true;
         }
         buf[..path.len()].copy_from_slice(path);
         buf[path.len()] = SEP;
@@ -2458,14 +2485,18 @@ impl<'a> Resolver<'a> {
         let dirs_below = self.dir_cache_mut().remove_where(|info| {
             info.abs_path.len() > dir_with_slash.len() && info.abs_path.starts_with(dir_with_slash)
         });
+        // A not-found marker has no key to match, and a path that did not
+        // exist under the old target can exist under the new one.
+        let not_found = self.dir_cache_mut().clear_not_found();
         bun_core::scoped_log!(
             ResolverDev,
-            "Bust below {} = {}, {}",
+            "Bust below {} = {}, {}, {}",
             bstr::BStr::new(dir_with_slash),
             entries_below,
-            dirs_below
+            dirs_below,
+            not_found
         );
-        exact || entries_below > 0 || dirs_below > 0
+        true
     }
 
     /// bust both the named file and a parent directory, because `./hello` can resolve
@@ -4245,7 +4276,9 @@ impl<'a> Resolver<'a> {
                 .map(DirInfoRef::from_slot));
         }
 
-        self.dir_info_cached_miss(enable_logging, input_path, top_result)
+        let result = self.dir_info_cached_miss(enable_logging, input_path, top_result);
+        self.flush_link_dir_watches();
+        result
     }
 
     /// Cold tail of [`dir_info_cached_maybe_log`]: the directory walk +
@@ -6313,10 +6346,10 @@ impl<'a> Resolver<'a> {
                             // Only the real path gets watched through the
                             // files under it. Watch the link's own directory
                             // so a retarget of the link is seen.
-                            if FeatureFlags::WATCH_DIRECTORIES {
-                                if let Some(watcher) = self.watcher.as_ref() {
-                                    watcher.watch(parent_entries.dir, parent_entries.fd);
-                                }
+                            if FeatureFlags::WATCH_DIRECTORIES && self.watcher.is_some() {
+                                bun_core::handle_oom(self.link_dir_watches.try_reserve(1));
+                                self.link_dir_watches
+                                    .push((parent_entries.dir, parent_entries.fd));
                             }
                         } else if !parent_.abs_real_path.is_empty() {
                             // this might leak a little i'm not sure

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1608,9 +1608,13 @@ impl<'a> Resolver<'a> {
                     // Watch the link's directory: a retarget is invisible
                     // from the real path.
                     if FeatureFlags::WATCH_DIRECTORIES {
-                        if let Some(watcher) = self.watcher.as_ref() {
-                            if let Some((link_dir, fd)) =
-                                dir.get_entries_const().map(|e| (e.dir, e.fd))
+                        if let Some(watcher) = self.watcher {
+                            if let Some((link_dir, fd)) = self
+                                .fs_mut()
+                                .fs
+                                .entries
+                                .at_index(dir.entries)
+                                .and_then(|e| e.dir_and_fd())
                             {
                                 watcher.watch(link_dir, fd);
                             }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3184,7 +3184,10 @@ impl<'a> Resolver<'a> {
                     }
                 };
 
-                match self.dir_info_for_resolution(dir_path_for_resolution, resolved_package_id) {
+                let dir_info_result =
+                    self.dir_info_for_resolution(dir_path_for_resolution, resolved_package_id);
+                self.flush_link_dir_watches();
+                match dir_info_result {
                     Ok(dir_info_to_use_) => {
                         if let Some(pkg_dir_info) = dir_info_to_use_ {
                             let abs_package_path = pkg_dir_info.abs_path;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3184,10 +3184,7 @@ impl<'a> Resolver<'a> {
                     }
                 };
 
-                let dir_info_result =
-                    self.dir_info_for_resolution(dir_path_for_resolution, resolved_package_id);
-                self.flush_link_dir_watches();
-                match dir_info_result {
+                match self.dir_info_for_resolution(dir_path_for_resolution, resolved_package_id) {
                     Ok(dir_info_to_use_) => {
                         if let Some(pkg_dir_info) = dir_info_to_use_ {
                             let abs_package_path = pkg_dir_info.abs_path;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1598,6 +1598,19 @@ impl<'a> Resolver<'a> {
                             bstr::BStr::new(symlink_path)
                         ));
                     }
+
+                    // The watcher watches the real path's directory. Watch
+                    // the link's own directory so a retarget of the link is
+                    // seen.
+                    if FeatureFlags::WATCH_DIRECTORIES {
+                        if let Some(watcher) = self.watcher.as_ref() {
+                            if let Some((link_dir, fd)) =
+                                dir.get_entries_const().map(|e| (e.dir, e.fd))
+                            {
+                                watcher.watch(link_dir, fd);
+                            }
+                        }
+                    }
                 } else if !dir.abs_real_path.is_empty() {
                     // When the directory is a symlink, we don't need to call getFdPath.
                     let parts = [dir.abs_real_path, query.entry().base()];
@@ -2426,6 +2439,33 @@ impl<'a> Resolver<'a> {
             second_bust
         );
         first_bust || second_bust
+    }
+
+    /// `bust_dir_cache` for `path` and for every cached directory below it.
+    /// A retargeted directory symlink makes the real path cached by each of
+    /// them stale at once. Returns whether anything was busted.
+    pub fn bust_dir_cache_tree(&mut self, path: &[u8]) -> bool {
+        let exact = self.bust_dir_cache(path);
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let path = strings::without_trailing_slash_windows_path(path);
+        if path.len() + 1 >= buf.len() {
+            return exact;
+        }
+        buf[..path.len()].copy_from_slice(path);
+        buf[path.len()] = SEP;
+        let dir_with_slash: &[u8] = &buf[..path.len() + 1];
+        let entries_below = self.fs_mut().fs.bust_entries_cache_below(dir_with_slash);
+        let dirs_below = self.dir_cache_mut().remove_where(|info| {
+            info.abs_path.len() > dir_with_slash.len() && info.abs_path.starts_with(dir_with_slash)
+        });
+        bun_core::scoped_log!(
+            ResolverDev,
+            "Bust below {} = {}, {}",
+            bstr::BStr::new(dir_with_slash),
+            entries_below,
+            dirs_below
+        );
+        exact || entries_below > 0 || dirs_below > 0
     }
 
     /// bust both the named file and a parent directory, because `./hello` can resolve
@@ -6270,6 +6310,14 @@ impl<'a> Resolver<'a> {
                                 logs.add_note(buf);
                             }
                             info.abs_real_path = symlink;
+                            // Only the real path gets watched through the
+                            // files under it. Watch the link's own directory
+                            // so a retarget of the link is seen.
+                            if FeatureFlags::WATCH_DIRECTORIES {
+                                if let Some(watcher) = self.watcher.as_ref() {
+                                    watcher.watch(parent_entries.dir, parent_entries.fd);
+                                }
+                            }
                         } else if !parent_.abs_real_path.is_empty() {
                             // this might leak a little i'm not sure
                             let parts = [parent_.abs_real_path, base];

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -488,10 +488,9 @@ pub struct Resolver<'a> {
     pub elapsed: u64, // tracing
 
     pub watcher: Option<AnyResolveWatcher>,
-    /// Directories that hold a followed symlink, found while `entries_mutex`
-    /// was held. The watcher takes its own mutex, which the watcher thread
-    /// holds while it takes `entries_mutex`, so the watch is registered once
-    /// `entries_mutex` is released (`flush_link_dir_watches`).
+    /// Directories that hold a followed symlink, to watch once
+    /// `entries_mutex` is released (the watcher thread takes `entries_mutex`
+    /// under the watcher mutex).
     link_dir_watches: Vec<(&'static [u8], FD)>,
 
     pub caches: CacheSet,
@@ -1606,9 +1605,8 @@ impl<'a> Resolver<'a> {
                         ));
                     }
 
-                    // The watcher watches the real path's directory. Watch
-                    // the link's own directory so a retarget of the link is
-                    // seen.
+                    // Watch the link's directory: a retarget is invisible
+                    // from the real path.
                     if FeatureFlags::WATCH_DIRECTORIES {
                         if let Some(watcher) = self.watcher.as_ref() {
                             if let Some((link_dir, fd)) =
@@ -2467,9 +2465,8 @@ impl<'a> Resolver<'a> {
     /// A retargeted directory symlink makes the real path cached by each of
     /// them stale at once. Returns whether anything was busted.
     pub fn bust_dir_cache_tree(&mut self, path: &[u8]) -> bool {
-        // `dir_info_cached_miss` caches every directory from the top down, so
-        // nothing is cached below a path that is not cached itself. That
-        // keeps the two map walks below off the path of a plain file save.
+        // Directories are cached from the top down, so nothing is cached
+        // below a path that is not cached itself.
         if !self.bust_dir_cache(path) {
             return false;
         }
@@ -2482,6 +2479,8 @@ impl<'a> Resolver<'a> {
         buf[path.len()] = SEP;
         let dir_with_slash: &[u8] = &buf[..path.len() + 1];
         let entries_below = self.fs_mut().fs.bust_entries_cache_below(dir_with_slash);
+        // `DirInfo` slots are written under `entries_mutex`.
+        let _entries_lock = self.fs_ref().fs.entries_mutex.lock_guard();
         let dirs_below = self.dir_cache_mut().remove_where(|info| {
             info.abs_path.len() > dir_with_slash.len() && info.abs_path.starts_with(dir_with_slash)
         });
@@ -6343,9 +6342,8 @@ impl<'a> Resolver<'a> {
                                 logs.add_note(buf);
                             }
                             info.abs_real_path = symlink;
-                            // Only the real path gets watched through the
-                            // files under it. Watch the link's own directory
-                            // so a retarget of the link is seen.
+                            // Watch the link's directory: a retarget is
+                            // invisible from the real path.
                             if FeatureFlags::WATCH_DIRECTORIES && self.watcher.is_some() {
                                 bun_core::handle_oom(self.link_dir_watches.try_reserve(1));
                                 self.link_dir_watches

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -776,3 +776,134 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+
+// Reads stdout line by line. `next()` resolves with the next non-empty line.
+function lineReader(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  const lines: string[] = [];
+  return {
+    async next(): Promise<string> {
+      while (lines.length === 0) {
+        const { value, done } = await reader.read();
+        if (done) throw new Error("stdout closed");
+        buffered += decoder.decode(value, { stream: true });
+        const parts = buffered.split("\n");
+        buffered = parts.pop() ?? "";
+        lines.push(...parts.filter(line => line.length > 0));
+      }
+      return lines.shift()!;
+    },
+  };
+}
+
+// Retargets the link at `linkPath` with a rename over it, as `ln -sfn` does.
+function retargetSymlink(linkPath: string, target: string) {
+  symlinkSync(target, linkPath + ".tmp");
+  renameSync(linkPath + ".tmp", linkPath);
+}
+
+// The resolver keys a module by its real path and the watcher watches that
+// real path. An import that goes through a symlink has to follow the link when
+// the link changes, not stay bound to the file the link pointed to at first.
+describe.skipIf(isWindows)("--hot follows a retargeted symlink on the import path", () => {
+  async function run(files: Record<string, string>, links: Record<string, string>) {
+    const dir = tempDir("hot-symlink", files);
+    for (const [link, target] of Object.entries(links)) {
+      symlinkSync(target, join(String(dir), link));
+    }
+    const runner = spawn({
+      cmd: [bunExe(), "--hot", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+    return { dir, runner, stdout: lineReader(runner.stdout), path: (p: string) => join(String(dir), p) };
+  }
+
+  it("directory symlink", async () => {
+    const { dir, runner, stdout, path } = await run(
+      {
+        "entry.ts": `import "./cur/app.ts";`,
+        "v1/app.ts": `console.log("MARK_V1");`,
+        "v2/app.ts": `console.log("MARK_V2");`,
+      },
+      { cur: "v1" },
+    );
+    using _dir = dir;
+    await using _runner = runner;
+    expect(await stdout.next()).toBe("MARK_V1");
+
+    retargetSymlink(path("cur"), "v2");
+    expect(await stdout.next()).toBe("MARK_V2");
+
+    // An edit to the new target is seen.
+    writeFileSync(path("v2/app.ts"), `console.log("MARK_V2_EDITED");`);
+    expect(await stdout.next()).toBe("MARK_V2_EDITED");
+  });
+
+  it("directory symlink with a directory below it", async () => {
+    const { dir, runner, stdout, path } = await run(
+      {
+        "entry.ts": `import "./cur/sub/app.ts";`,
+        "v1/sub/app.ts": `console.log("MARK_V1");`,
+        "v2/sub/app.ts": `console.log("MARK_V2");`,
+      },
+      { cur: "v1" },
+    );
+    using _dir = dir;
+    await using _runner = runner;
+    expect(await stdout.next()).toBe("MARK_V1");
+
+    retargetSymlink(path("cur"), "v2");
+    expect(await stdout.next()).toBe("MARK_V2");
+
+    writeFileSync(path("v2/sub/app.ts"), `console.log("MARK_V2_EDITED");`);
+    expect(await stdout.next()).toBe("MARK_V2_EDITED");
+  });
+
+  it("directory symlink in a directory with no loaded module", async () => {
+    const { dir, runner, stdout, path } = await run(
+      {
+        "src/entry.ts": `import "../links/cur/app.ts";`,
+        "entry.ts": `import "./src/entry.ts";`,
+        "v1/app.ts": `console.log("MARK_V1");`,
+        "v2/app.ts": `console.log("MARK_V2");`,
+        "links/.keep": "",
+      },
+      { "links/cur": "../v1" },
+    );
+    using _dir = dir;
+    await using _runner = runner;
+    expect(await stdout.next()).toBe("MARK_V1");
+
+    retargetSymlink(path("links/cur"), "../v2");
+    expect(await stdout.next()).toBe("MARK_V2");
+
+    writeFileSync(path("v2/app.ts"), `console.log("MARK_V2_EDITED");`);
+    expect(await stdout.next()).toBe("MARK_V2_EDITED");
+  });
+
+  it("file symlink", async () => {
+    const { dir, runner, stdout, path } = await run(
+      {
+        "entry.ts": `import "./app.ts";`,
+        "v1/app.ts": `console.log("MARK_V1");`,
+        "v2/app.ts": `console.log("MARK_V2");`,
+      },
+      { "app.ts": "v1/app.ts" },
+    );
+    using _dir = dir;
+    await using _runner = runner;
+    expect(await stdout.next()).toBe("MARK_V1");
+
+    retargetSymlink(path("app.ts"), "v2/app.ts");
+    expect(await stdout.next()).toBe("MARK_V2");
+
+    writeFileSync(path("v2/app.ts"), `console.log("MARK_V2_EDITED");`);
+    expect(await stdout.next()).toBe("MARK_V2_EDITED");
+  });
+});

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -887,6 +887,24 @@ describe.skipIf(isWindows)("--hot follows a retargeted symlink on the import pat
     expect(await stdout.next()).toBe("MARK_V2_EDITED");
   });
 
+  it("directory symlink whose new target has a directory the old one lacked", async () => {
+    const { dir, runner, stdout, path } = await run(
+      {
+        "entry.ts": `import("./cur/sub/app.ts").catch(() => console.log("MARK_MISSING"));`,
+        "v1/app.ts": `console.log("MARK_V1");`,
+        "v2/sub/app.ts": `console.log("MARK_V2");`,
+      },
+      { cur: "v1" },
+    );
+    using _dir = dir;
+    await using _runner = runner;
+    expect(await stdout.next()).toBe("MARK_MISSING");
+
+    // The resolver cached `cur/sub` as not found under v1.
+    retargetSymlink(path("cur"), "v2");
+    expect(await stdout.next()).toBe("MARK_V2");
+  });
+
   it("file symlink", async () => {
     const { dir, runner, stdout, path } = await run(
       {


### PR DESCRIPTION
### Problem
- Under `bun --hot entry.ts`, an import that goes through a symlink (`import "./cur/app.ts"` with `cur -> v1`) stays bound to `v1/app.ts` after the link is swapped to `v2`. Edits to `v2/app.ts` are not seen. A reload of the entry still runs `v1/app.ts`. The same applies to `bun --watch`.
- The resolver caches the real path of `/dir/cur` in its `DirInfo` (`abs_real_path`, `src/resolver/resolver.rs:6312`). The hot reloader's directory-event handler (`src/jsc/hot_reloader.rs`, `Kind::Directory` arm) busts the cache for `/dir` only, never for the changed entry `/dir/cur`, and never reloads for it. The watcher watches only the real path `v1/`, so nothing sees `v2/`.

### Fix
- On a directory event, the hot reloader busts the resolver cache for each named entry and every directory below it (`Resolver::bust_dir_cache_tree`, new). When there was something to bust, or when the old listing shows the entry as a followed symlink (`Entry::followed_symlink`, new), it enqueues a reload. On kqueue, where events carry no names, it compares each followed symlink in the listing with `realpath` and reloads on a change.
- The resolver now watches the directory that holds a followed symlink (file or directory) when it resolves through it. So the retarget is seen when no loaded module sits next to the link.
- Correct because the next resolution re-reads the link and finds `v2`. The reload loads `v2/app.ts`, which adds it to the watch list. Without the tree bust, `import "./cur/sub/app.ts"` kept the stale `v1/sub` real path in the cached `DirInfo` of `/dir/cur/sub`.
- Verified: `test/cli/hot/hot.test.ts` (4 new tests, all fail on stock bun 1.4.3 by timeout). Also all of `test/cli/hot/`, `test/bake/dev/hot.test.ts` and `test/js/bun/resolve/resolve.test.ts`.

### Background
- The hot reloader runs on the watcher thread. Each loaded file and its parent directory are watched by real path. A directory event carries the changed entry names on inotify (Linux) and nothing on kqueue (macOS).
- The resolver has two caches keyed by path: `entries` (directory listings) and `dir_cache` (`DirInfo`, which holds the real path of a symlinked directory). Both are `BSSMapInner` maps keyed by a path hash, so a prefix removal walks the values (`remove_where`, new).
- `bust_dir_cache` stays exact-key. `bust_dir_cache_tree` is the new prefix form for a retargeted or replaced directory.
- Windows is unchanged. Its directory events carry no names in this code path, and the tests skip there.

<details><summary>Notes</summary>

Manual repro (fails on 1.4.3, passes with this build):

```sh
mkdir -p /tmp/h/v1 /tmp/h/v2 && cd /tmp/h
echo 'console.log("V1")' > v1/app.ts; echo 'console.log("V2")' > v2/app.ts
ln -s v1 cur; echo 'import "./cur/app.ts"' > entry.ts
bun --hot entry.ts &
ln -s v2 t && mv -T t cur            # now prints V2
echo 'console.log("V2b")' > v2/app.ts   # now prints V2b
```

The entrypoint itself behind a symlink (`bun --hot current/entry.ts` with `current -> releases/v1`) is not covered. The VM stores the entry by real path and reloads that path. A restart is needed there.

Links inside `node_modules` and links outside the project root are not watched, the same policy the watcher applies to every directory (`Watcher::on_maybe_watch_directory`).

An edit to the old target (`v1/app.ts`) after the swap still triggers a reload, because the watch list is never pruned under `--hot`. The reload runs the right module.

Self-reviewed. The review raised the nested directory case, the missing watch on the link's directory, and the missing tombstone for the busted listing. All three are addressed in this diff. It also asked to stack this on #40587 and to share a mechanism with #41489 (dev server). This PR is independent of both: the tree bust here is prefix based and does not depend on the alias bust in #40587.

The kqueue path compares `realpath` with the real path the resolver got from `F_GETPATH`. It is not run locally (Linux container). CI on macOS covers it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->