### PR TITLE
Mint the inspector token for a ws:// URL with no path

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -779,7 +779,13 @@ const defaultPort = 6499;
 
 function parseUrl(input: string): URL {
   if (input.startsWith("ws://") || input.startsWith("ws+unix://")) {
-    return new URL(input);
+    const url = new URL(input);
+    // A trailing slash is the explicit opt-out of the UUID token. `ws://host:port`
+    // without any path parses to "/" too, so only the spelled-out form keeps it.
+    if (url.protocol === "ws:" && url.pathname === "/" && !/^ws:\/\/[^/?#]*\//.test(input)) {
+      url.pathname = `/${randomId()}`;
+    }
+    return url;
   }
   const url = new URL(`ws://${defaultHostname}:${defaultPort}/${randomId()}`);
   for (const part of input.split(/(\[[a-z0-9:]+\])|:/).filter(Boolean)) {

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -191,6 +191,24 @@ describe("websocket", () => {
       },
     },
     {
+      args: ["--inspect=ws://localhost:0"],
+      url: {
+        protocol: "ws:",
+        hostname: "localhost",
+        port: anyPort,
+        pathname: anyPathname,
+      },
+    },
+    {
+      args: ["--inspect=ws://127.0.0.1:0"],
+      url: {
+        protocol: "ws:",
+        hostname: "127.0.0.1",
+        port: anyPort,
+        pathname: anyPathname,
+      },
+    },
+    {
       args: ["--inspect=ws://localhost/"],
       url: {
         protocol: "ws:",


### PR DESCRIPTION
### Problem
- `bun --inspect=ws://127.0.0.1:0` (and `BUN_INSPECT=ws://127.0.0.1:0`) listens on `ws://127.0.0.1:PORT/` with no UUID in the path. Any local process can open that WebSocket and run `Runtime.evaluate`. The non-URL form `--inspect=127.0.0.1:0` mints a UUID.
- The cause is `parseUrl` in `src/js/internal/debugger.ts:780`. It returns `new URL(input)` as is for `ws://` input. `new URL("ws://127.0.0.1:0")` has pathname `/`, the same as the spelled-out `ws://127.0.0.1:0/`, so the no-path form reads as the explicit opt-out.

### Fix
- When a `ws://` input has no slash after the authority, set the pathname to a fresh UUID. The spelled-out `ws://host:port/` keeps `/`. That matches the non-URL forms: `--inspect=127.0.0.1:0` mints, `--inspect=127.0.0.1:0/` does not (both asserted in `test/cli/inspect/inspect.test.ts`).
- `ws+unix://` is unchanged. A unix socket path is the whole URL.
- Verified: `test/cli/inspect/inspect.test.ts` (two new cases: `ws://localhost:0` and `ws://127.0.0.1:0`, both fail on stock bun). The full file passes (31 pass, 2 todo).

### Background
- The inspector path is the bearer token. `isOriginAllowed` blocks browsers from foreign origins, and `isHostAllowed` blocks DNS rebinding, but a non-browser client sends neither header. Without the UUID, the only guard for such a client is the loopback bind.
- `--inspect` accepts two spellings: `host:port/path` (parsed by hand) and a full `ws://` URL (parsed by `new URL`). The hand parser only sets a path when the input contains one, so a missing path gets the UUID. The URL parser cannot tell a missing path from `/`.
- `BUN_INSPECT` goes through the same `parseUrl`. It prints no banner by design (editor extensions set it and read the URL they passed).
