### PR TITLE
fix(types): correct FormData iterable types in bun-types

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1723,9 +1723,13 @@ interface FormData {
   set(name: string, value: string): void;
   set(name: string, blobValue: Blob, filename?: string): void;
   forEach(callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
+  /** Returns a list of keys in the list. */
   keys(): IterableIterator<string>;
-  values(): IterableIterator<string>;
-  entries(): IterableIterator<[string, string]>;
+  /** Returns a list of values in the list. */
+  values(): IterableIterator<Bun.FormDataEntryValue>;
+  /** Returns an array of key, value pairs for every entry in the list. */
+  entries(): IterableIterator<[string, Bun.FormDataEntryValue]>;
+  [Symbol.iterator](): IterableIterator<[string, Bun.FormDataEntryValue]>;
 }
 declare var FormData: Bun.__internal.UseLibDomIfAvailable<"FormData", { prototype: FormData; new (): FormData }>;
 

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -233,6 +233,21 @@ const writableStream = new WritableStream();
   a.keys();
   a.values();
   a.toString();
+
+  // https://github.com/oven-sh/bun/issues/27194
+  // FormData values can be a `File`, not only a `string`, and FormData itself
+  // must be directly iterable (matching entries()).
+  for (const [key, value] of a) {
+    key satisfies string;
+    value satisfies string | File;
+  }
+  for (const value of a.values()) {
+    value satisfies string | File;
+  }
+  for (const [key, value] of a.entries()) {
+    key satisfies string;
+    value satisfies string | File;
+  }
 }
 {
   const a = new Headers();

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -236,17 +236,19 @@ const writableStream = new WritableStream();
 
   // https://github.com/oven-sh/bun/issues/27194
   // FormData values can be a `File`, not only a `string`, and FormData itself
-  // must be directly iterable (matching entries()).
+  // must be directly iterable (matching entries()). Use `.is<>()` (exact
+  // type equality) rather than `satisfies`, so a regression that narrows
+  // these back to plain `string` fails type-checking again.
   for (const [key, value] of a) {
-    key satisfies string;
-    value satisfies string | File;
+    expectType(key).is<string>();
+    expectType(value).is<Bun.FormDataEntryValue>();
   }
   for (const value of a.values()) {
-    value satisfies string | File;
+    expectType(value).is<Bun.FormDataEntryValue>();
   }
   for (const [key, value] of a.entries()) {
-    key satisfies string;
-    value satisfies string | File;
+    expectType(key).is<string>();
+    expectType(value).is<Bun.FormDataEntryValue>();
   }
 }
 {


### PR DESCRIPTION
## What this fixes

`bun-types`' `FormData` interface had a couple of small but real gaps compared to both the DOM spec and Bun's own runtime behavior:

- `values()` was typed as `IterableIterator<string>` and `entries()` as `IterableIterator<[string, string]>`, even though `FormData` can hold `File` values (Bun's own `get`/`getAll`/`forEach` already correctly use `Bun.FormDataEntryValue = File | string`). This meant TypeScript would silently let you treat a `File` entry as a `string`.
- `FormData` had no `[Symbol.iterator]()`, so `for (const [k, v] of formData)` — valid, spec'd, and works at runtime — was a type error.

This is a real behavioral/type-soundness bug for anyone iterating a `FormData` that contains file uploads, not a docs-only issue.

## Changes

- `packages/bun-types/globals.d.ts`: fixed `values()`/`entries()` to use `Bun.FormDataEntryValue`, and added `[Symbol.iterator]()` matching `entries()`, mirroring `lib.dom.iterable.d.ts`'s `FormData` shape.
- `test/integration/bun-types/fixture/globals.ts`: added `satisfies` assertions over `for...of`, `values()`, and `entries()` so a regression here fails type-checking again.

## Testing

I don't have a working native build toolchain (Rust/LLVM/Go) set up locally, so I couldn't run the full `bun bd test` suite. Since this change is confined to `packages/bun-types/**/*.d.ts`, per this repo's own `CLAUDE.md` these don't need a native build — I verified it directly with the TypeScript compiler API against `packages/bun-types` (mirroring what `test/integration/bun-types/bun-types.test.ts` does), and confirmed the fixture type-checks cleanly with the new assertions, with no new diagnostics introduced by this change.

Fixes #27194


