### PR TITLE
Cap each source line in the dev error page at 1024 bytes

### DIFF
--- a/src/runtime/server/DevErrorPage.rs
+++ b/src/runtime/server/DevErrorPage.rs
@@ -188,7 +188,7 @@ fn write_message_data(w: &mut Vec<u8>, text: &[u8], location: Option<&Location>)
         w.extend_from_slice(b",\"namespace\":");
         write_string(w, &location.namespace);
         w.extend_from_slice(b",\"line_text\":");
-        write_string(w, location.line_text.as_deref().unwrap_or(b""));
+        write_source_line_text(w, location.line_text.as_deref().unwrap_or(b""));
         write!(
             w,
             ",\"line\":{},\"column\":{},\"offset\":{}}}",

--- a/src/runtime/server/DevErrorPage.rs
+++ b/src/runtime/server/DevErrorPage.rs
@@ -126,8 +126,7 @@ fn write_stack_trace(w: &mut Vec<u8>, stack: &StackTrace) {
     w.extend_from_slice(b"]}");
 }
 
-/// Same cap as the terminal error printer in `VirtualMachine.rs`. A minified
-/// bundle is one line, so without it the page carries the whole bundle.
+/// Same cap as `MAX_LINE_LENGTH` in the terminal error printer (`VirtualMachine.rs`).
 const MAX_SOURCE_LINE_LENGTH: usize = 1024;
 
 fn write_source_line_text(w: &mut Vec<u8>, text: &[u8]) {

--- a/src/runtime/server/DevErrorPage.rs
+++ b/src/runtime/server/DevErrorPage.rs
@@ -120,10 +120,28 @@ fn write_stack_trace(w: &mut Vec<u8>, stack: &StackTrace) {
             w.push(b',');
         }
         write!(w, "{{\"line\":{},\"text\":", source_line.line + 1).unwrap();
-        write_string(w, &source_line.text);
+        write_source_line_text(w, &source_line.text);
         w.push(b'}');
     }
     w.extend_from_slice(b"]}");
+}
+
+/// Same cap as the terminal error printer in `VirtualMachine.rs`. A minified
+/// bundle is one line, so without it the page carries the whole bundle.
+const MAX_SOURCE_LINE_LENGTH: usize = 1024;
+
+fn write_source_line_text(w: &mut Vec<u8>, text: &[u8]) {
+    if text.len() <= MAX_SOURCE_LINE_LENGTH {
+        return write_string(w, text);
+    }
+    let mut end = MAX_SOURCE_LINE_LENGTH;
+    while end > 0 && !strings::is_utf8_char_boundary(text[end]) {
+        end -= 1;
+    }
+    let mut clamped = Vec::with_capacity(end + 3);
+    clamped.extend_from_slice(&text[..end]);
+    clamped.extend_from_slice("…".as_bytes());
+    write_string(w, &clamped);
 }
 
 /// bun-error treats `-1` as "no line/column" (e.g. frames without a source position).

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2133,7 +2133,6 @@ it.concurrent("dev error page caps each source line like the terminal printer do
       const payload = JSON.parse(match[1]);
       console.log(JSON.stringify({
         status: res.status,
-        bodyLength: html.length,
         literalMentions: html.split("literal-2999-0123456789").length - 1,
         sourceLines: payload.problems.exceptions[0].stack.source_lines.map(l => ({ line: l.line, length: l.text.length })),
       }));
@@ -2157,7 +2156,6 @@ it.concurrent("dev error page caps each source line like the terminal printer do
   expect(out.sourceLines[0].length).toBeLessThanOrEqual(1025);
   // The literals live past the cap, so the page must not carry them.
   expect(out.literalMentions).toBe(0);
-  expect(out.bodyLength).toBeLessThan(literals.length);
   expect(stderr).toContain("long-line boom");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2114,7 +2114,10 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
 });
 
 it.concurrent("dev error page caps each source line like the terminal printer does", async () => {
-  // One minified line: 3000 string literals, then the throw at the end of the line.
+  // One minified line: a 3-byte "€" that starts at byte 1023 (so the 1024-byte cap lands inside it),
+  // then 3000 string literals, then the throw at the end of the line.
+  const head = `var keep=["${Buffer.alloc(1012, "a").toString()}`;
+  expect(Buffer.byteLength(head)).toBe(1023);
   const literals = Array.from({ length: 3000 }, (_, i) => `"literal-${i}-0123456789"`).join(",");
   using dir = tempDir("serve-dev-error-page-long-line", {
     "server.ts": `
@@ -2134,12 +2137,12 @@ it.concurrent("dev error page caps each source line like the terminal printer do
       console.log(JSON.stringify({
         status: res.status,
         literalMentions: html.split("literal-2999-0123456789").length - 1,
-        sourceLines: payload.problems.exceptions[0].stack.source_lines.map(l => ({ line: l.line, length: l.text.length })),
+        sourceLines: payload.problems.exceptions[0].stack.source_lines,
       }));
       server.stop(true);
       process.exit(0);
     `,
-    "minified.js": `var keep=[${literals}];export function boom(){keep.length;throw new Error("long-line boom")}\n`,
+    "minified.js": `${head}€",${literals}];export function boom(){keep.length;throw new Error("long-line boom")}\n`,
   });
   await using proc = Bun.spawn({
     cmd: [bunExe(), "server.ts"],
@@ -2152,8 +2155,8 @@ it.concurrent("dev error page caps each source line like the terminal printer do
   const out = JSON.parse(stdout.trim().split("\n").at(-1)!);
 
   expect(out.status).toBe(500);
-  expect(out.sourceLines).toEqual([{ line: 1, length: expect.any(Number) }]);
-  expect(out.sourceLines[0].length).toBeLessThanOrEqual(1025);
+  // The cut backs up to the start of the "€" instead of splitting it.
+  expect(out.sourceLines).toEqual([{ line: 1, text: `${head}…` }]);
   // The literals live past the cap, so the page must not carry them.
   expect(out.literalMentions).toBe(0);
   expect(stderr).toContain("long-line boom");

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2113,6 +2113,55 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
   expect(exitCode).toBe(0);
 });
 
+it.concurrent("dev error page caps each source line like the terminal printer does", async () => {
+  // One minified line: 3000 string literals, then the throw at the end of the line.
+  const literals = Array.from({ length: 3000 }, (_, i) => `"literal-${i}-0123456789"`).join(",");
+  using dir = tempDir("serve-dev-error-page-long-line", {
+    "server.ts": `
+      import { boom } from "./minified.js";
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        development: true,
+        fetch() {
+          return boom();
+        },
+      });
+      const res = await fetch(server.url);
+      const html = await res.text();
+      const match = /<script id="__bunfallback" type="application\\/json">([^<]*)<\\/script>/.exec(html);
+      const payload = JSON.parse(match[1]);
+      console.log(JSON.stringify({
+        status: res.status,
+        bodyLength: html.length,
+        literalMentions: html.split("literal-2999-0123456789").length - 1,
+        sourceLines: payload.problems.exceptions[0].stack.source_lines.map(l => ({ line: l.line, length: l.text.length })),
+      }));
+      server.stop(true);
+      process.exit(0);
+    `,
+    "minified.js": `var keep=[${literals}];export function boom(){keep.length;throw new Error("long-line boom")}\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const out = JSON.parse(stdout.trim().split("\n").at(-1)!);
+
+  expect(out.status).toBe(500);
+  expect(out.sourceLines).toEqual([{ line: 1, length: expect.any(Number) }]);
+  expect(out.sourceLines[0].length).toBeLessThanOrEqual(1025);
+  // The literals live past the cap, so the page must not carry them.
+  expect(out.literalMentions).toBe(0);
+  expect(out.bodyLength).toBeLessThan(literals.length);
+  expect(stderr).toContain("long-line boom");
+  expect(exitCode).toBe(0);
+});
+
 it.concurrent("dev error page ships a bun-error bundle that evaluates and registers the renderer", async () => {
   using dir = tempDir("serve-dev-error-page-bundle", {
     "server.ts": `


### PR DESCRIPTION
### Problem
- The development error page (`Bun.serve` in development mode, a route throws) embeds the source lines around the top frame. It puts each line in full. A minified bundle is one line, so a `bun build --production` bundle run by plain `bun` answers a throw with a 500 page that carries the whole bundle line: every string literal in the bundle. A 168 KB bundle gave a 224 KB page.
- The terminal printer caps a source line at 1024 bytes (`src/jsc/VirtualMachine.rs:6211`, `MAX_LINE_LENGTH`). `write_stack_trace` in `src/runtime/server/DevErrorPage.rs:118` had no cap.

### Fix
- `write_source_line_text` clamps each source line at 1024 bytes, backs up to a UTF-8 char boundary, and appends `…` to show the cut. The frontend highlights the whole line and does not index into it by column, so a prefix cut renders the same way it does in the terminal.
- This does not change when the dev page is served. A production bundle that runs without `NODE_ENV=production` still gets the development default. It only bounds what the page carries.
- Verified: `test/js/bun/http/serve.test.ts` (`dev error page caps each source line like the terminal printer does`: a 77 KB line, the page must not carry the literals past the cap. Stock bun fails with a 76970 char line). The other dev error page tests pass. Two unrelated tests in that file fail in this container (port 1003 as root, an egress proxy).

### Background
- `DevErrorPage` renders the JSON that `packages/bun-error` reads. `source_lines` is the top frame's line plus up to 5 lines before it, taken from the original source through the source map.
- The same exception object feeds the terminal printer, which already clamps. The page path was written later and did not copy that clamp.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->