### PR TITLE
dev server: follow a retargeted symlink on the import path

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6687,6 +6687,24 @@ pub mod bv2_impl {
                     continue;
                 }
 
+                // `Path::set_realpath` keeps the path before symlink resolution
+                // in `pretty`. `path_with_pretty_initialized` below replaces it,
+                // so tell DevServer now: a retarget of the link must resolve
+                // this import again.
+                if path.is_symlink {
+                    if let Some(dev) = self.dev_server {
+                        dev.track_symlink_resolution(
+                            source.path.text,
+                            import_record.path.text,
+                            import_record.kind,
+                            path.pretty,
+                            path.text,
+                            ctx.target.bake_graph(),
+                        )
+                        .expect("oom");
+                    }
+                }
+
                 if let Some(dev_server) = self.dev_server_handle() {
                     'brk: {
                         if path.loader(&self.transpiler.options.loaders) == Some(Loader::Html)

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6687,10 +6687,7 @@ pub mod bv2_impl {
                     continue;
                 }
 
-                // `Path::set_realpath` keeps the path before symlink resolution
-                // in `pretty`. `path_with_pretty_initialized` below replaces it,
-                // so tell DevServer now: a retarget of the link must resolve
-                // this import again.
+                // `pretty` holds the link path only until `path_with_pretty_initialized`.
                 if path.is_symlink {
                     if let Some(dev) = self.dev_server {
                         dev.track_symlink_resolution(

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -347,6 +347,7 @@ bun_dispatch::link_interface! {
         fn handle_parse_task_failure(err: crate::Error, graph: bake_types::Graph, abs_path: &[u8], log: *const bun_ast::Log, bv2: *mut bundle_v2::BundleV2<'_>) -> Result<(), crate::Error>;
         fn put_or_overwrite_asset(path: *const (), contents: &[u8], content_hash: u64) -> Result<(), crate::Error>;
         fn track_resolution_failure(import_source: &[u8], specifier: &[u8], renderer: bake_types::Graph, loader: bun_ast::Loader) -> Result<(), crate::Error>;
+        fn track_symlink_resolution(import_source: &[u8], specifier: &[u8], kind: bun_ast::ImportKind, link_path: &[u8], real_path: &[u8], renderer: bake_types::Graph) -> Result<(), crate::Error>;
         fn is_file_cached(abs_path: &[u8], side: bake_types::Graph) -> Option<bake_types::CacheEntry>;
         fn asset_hash(abs_path: &[u8]) -> Option<u64>;
         fn current_bundle_start_data() -> *mut ();

--- a/src/runtime/bake/dev_server/memory_cost.rs
+++ b/src/runtime/bake/dev_server/memory_cost.rs
@@ -202,6 +202,7 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     other_bytes += memory_cost_array_hash_map(&dev.directory_watchers.watches);
     for dep in dev.directory_watchers.dependencies.iter() {
         other_bytes += dep.specifier.len();
+        other_bytes += dep.previous_target.as_ref().map_or(0, |t| t.len());
     }
     for dir_name in dev.directory_watchers.watches.keys() {
         other_bytes += dir_name.len();

--- a/src/runtime/bake/dev_server/memory_cost.rs
+++ b/src/runtime/bake/dev_server/memory_cost.rs
@@ -202,7 +202,9 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     other_bytes += memory_cost_array_hash_map(&dev.directory_watchers.watches);
     for dep in dev.directory_watchers.dependencies.iter() {
         other_bytes += dep.specifier.len();
-        other_bytes += dep.previous_target.as_ref().map_or(0, |t| t.len());
+        if let Some(symlink) = &dep.symlink {
+            other_bytes += symlink.link_path.len() + symlink.real_path.len();
+        }
     }
     for dir_name in dev.directory_watchers.watches.keys() {
         other_bytes += dir_name.len();

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -416,72 +416,120 @@ impl HotReloadEvent {
         // drop, so it does not hold a borrow of `dev` for the scope.
         let _g = dev.graph_safety_lock.guard();
 
-        // First handle directories, because this may mutate `event.files`
-        if dev.directory_watchers.watches.count() > 0 {
-            for changed_dir_with_slash in self.dirs.keys() {
-                let changed_dir = bun_paths::string_paths::without_trailing_slash_windows_path(
-                    changed_dir_with_slash,
-                );
-
-                // Bust resolution cache, but since Bun does not watch all
-                // directories in a codebase, this only targets the following resolutions
+        // A changed entry can be a directory symlink (`cur -> v1`). Its own
+        // `DirInfo` caches the old real path, so bust it before anything
+        // below resolves through it.
+        for changed_entry in bun_core::strings::split(&self.extra_files, &[0]) {
+            if !changed_entry.is_empty() {
                 // SAFETY: server_transpiler is initialized in DevServer::init before any
                 // HotReloadEvent can fire.
                 let _ = unsafe { dev.server_transpiler.assume_init_mut() }
                     .resolver
-                    .bust_dir_cache(changed_dir);
+                    .bust_dir_cache(changed_entry);
+            }
+        }
 
-                // if a directory watch exists for resolution failures, check those now.
-                if let Some(watcher_index) = dev.directory_watchers.watches.get_index(changed_dir) {
-                    let mut new_chain: Option<u32> = None;
-                    let mut it: Option<u32> =
-                        Some(dev.directory_watchers.watches.values()[watcher_index].first_dep);
+        // First handle directories, because this may mutate `event.files`
+        for changed_dir_with_slash in self.dirs.keys() {
+            let changed_dir = bun_paths::string_paths::without_trailing_slash_windows_path(
+                changed_dir_with_slash,
+            );
 
-                    while let Some(index) = it {
-                        // Note: reshaped for borrowck — re-index per iteration instead of
-                        // holding `dep` ref across resolver call + appendFile + freeDependencyIndex.
-                        let (source_file_path, specifier, next) = {
-                            let dep = &dev.directory_watchers.dependencies[index as usize];
-                            (dep.source_file_path, &raw const *dep.specifier, dep.next)
-                        };
-                        it = next;
+            // Bust resolution cache, but since Bun does not watch all
+            // directories in a codebase, this only targets the following resolutions
+            // SAFETY: server_transpiler is initialized in DevServer::init before any
+            // HotReloadEvent can fire.
+            let _ = unsafe { dev.server_transpiler.assume_init_mut() }
+                .resolver
+                .bust_dir_cache(changed_dir);
 
-                        // `specifier` points into the dep's owned `Box<[u8]>`, which is
-                        // not mutated until after `resolve` returns.
-                        // SAFETY: see `Dep` doc — neither slice is mutated mid-resolve.
-                        let resolved = unsafe { dev.server_transpiler.assume_init_mut() }
-                            .resolver
-                            .resolve(
-                                bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
-                                    source_file_path.slice(),
-                                ),
-                                unsafe { &*specifier },
-                                bun_ast::ImportKind::Stmt,
-                            )
-                            .is_ok();
+            // if a directory watch exists for resolution failures, check those now.
+            if let Some(watcher_index) = dev.directory_watchers.watches.get_index(changed_dir) {
+                let mut new_chain: Option<u32> = None;
+                let mut it: Option<u32> =
+                    Some(dev.directory_watchers.watches.values()[watcher_index].first_dep);
 
-                        if resolved {
-                            // this resolution result is not preserved as passing it
-                            // into BundleV2 is too complicated. the resolution is
-                            // cached, anyways.
-                            // Note: inlined `append_file` body for disjoint borrow
-                            // (`self.dirs.keys()` is held immutably across this loop).
-                            bun_core::handle_oom(self.files.get_or_put(source_file_path.slice()));
-                            dev.directory_watchers.free_dependency_index(index);
+                while let Some(index) = it {
+                    // Note: reshaped for borrowck — re-index per iteration instead of
+                    // holding `dep` ref across resolver call + appendFile + freeDependencyIndex.
+                    let (source_file_path, specifier, next, import_kind, through_symlink) = {
+                        let dep = &dev.directory_watchers.dependencies[index as usize];
+                        (
+                            dep.source_file_path,
+                            &raw const *dep.specifier,
+                            dep.next,
+                            dep.import_kind,
+                            dep.previous_target.is_some(),
+                        )
+                    };
+                    it = next;
+                    let source_dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
+                        source_file_path.slice(),
+                    );
+
+                    // `specifier` points into the dep's owned `Box<[u8]>`, which is
+                    // not mutated until after `resolve` returns.
+                    // SAFETY: see `Dep` doc — neither slice is mutated mid-resolve.
+                    let specifier: &[u8] = unsafe { &*specifier };
+
+                    if through_symlink {
+                        // A directory on the way from the changed directory to
+                        // the import can be the retargeted link. Each of them
+                        // caches its old real path, so bust them all. The walk
+                        // starts at the import itself: a specifier can name
+                        // the linked directory (`./links/cur` for its index
+                        // file), and a bust of a file path is a no-op.
+                        let mut buf = bun_paths::path_buffer_pool::get();
+                        let mut dir: &[u8] = if bun_paths::is_absolute(specifier) {
+                            specifier
                         } else {
-                            // rebuild a new linked list for unaffected files
-                            dev.directory_watchers.dependencies[index as usize].next = new_chain;
-                            new_chain = Some(index);
+                            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+                                source_dir,
+                                &mut buf.0,
+                                &[specifier],
+                            )
+                        };
+                        while dir.len() > changed_dir.len() && dir.starts_with(changed_dir) {
+                            // SAFETY: see above.
+                            let _ = unsafe { dev.server_transpiler.assume_init_mut() }
+                                .resolver
+                                .bust_dir_cache(dir);
+                            dir =
+                                bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(dir);
                         }
                     }
 
-                    if let Some(new_first_dep) = new_chain {
-                        dev.directory_watchers.watches.values_mut()[watcher_index].first_dep =
-                            new_first_dep;
+                    // SAFETY: see above.
+                    let resolve_result = unsafe { dev.server_transpiler.assume_init_mut() }
+                        .resolver
+                        .resolve(source_dir, specifier, import_kind);
+                    let resolved: Option<&[u8]> = match &resolve_result {
+                        Ok(r) => r.path_const().map(|p| p.text()),
+                        Err(_) => None,
+                    };
+
+                    if !dev.directory_watchers.dependencies[index as usize].matches_target(resolved)
+                    {
+                        // this resolution result is not preserved as passing it
+                        // into BundleV2 is too complicated. the resolution is
+                        // cached, anyways.
+                        // Note: inlined `append_file` body for disjoint borrow
+                        // (`self.dirs.keys()` is held immutably across this loop).
+                        bun_core::handle_oom(self.files.get_or_put(source_file_path.slice()));
+                        dev.directory_watchers.free_dependency_index(index);
                     } else {
-                        // without any files to depend on this watcher is freed
-                        dev.directory_watchers.free_entry(watcher_index);
+                        // rebuild a new linked list for unaffected files
+                        dev.directory_watchers.dependencies[index as usize].next = new_chain;
+                        new_chain = Some(index);
                     }
+                }
+
+                if let Some(new_first_dep) = new_chain {
+                    dev.directory_watchers.watches.values_mut()[watcher_index].first_dep =
+                        new_first_dep;
+                } else {
+                    // without any files to depend on this watcher is freed
+                    dev.directory_watchers.free_entry(watcher_index);
                 }
             }
         }
@@ -1083,7 +1131,7 @@ pub mod directory_watch_store {
             }
         }
     }
-    /// `DirectoryWatchStore.Dep` — one resolution-failure to retry on dir change.
+    /// `DirectoryWatchStore.Dep` — one resolution to retry on dir change.
     pub struct Dep {
         pub(crate) next: Option<u32>,
         /// The file used. BORROWED slice into `IncrementalGraph.bundled_files`
@@ -1091,8 +1139,25 @@ pub mod directory_watch_store {
         /// `removeDependenciesForFile` before freeing the key, so the slice
         /// outlives every read — `RawSlice` invariant.
         pub(crate) source_file_path: bun_ptr::RawSlice<u8>,
-        /// The specifier that failed. Allocated memory.
+        /// The specifier to resolve again. Allocated memory.
         pub(crate) specifier: Box<[u8]>,
+        /// The import kind the bundler resolved `specifier` with.
+        pub(crate) import_kind: bun_ast::ImportKind,
+        /// What `specifier` resolved to when the dep was recorded. `None`
+        /// for a failed resolution. `Some(real_path)` for a resolution that
+        /// went through a symlink, so a retarget of the link is detected as
+        /// a change in the resolved path.
+        pub(crate) previous_target: Option<Box<[u8]>>,
+    }
+    impl Dep {
+        /// Whether a fresh resolution result is the same as the recorded one.
+        pub(crate) fn matches_target(&self, resolved: Option<&[u8]>) -> bool {
+            match (&self.previous_target, resolved) {
+                (None, None) => true,
+                (Some(prev), Some(now)) => **prev == *now,
+                _ => false,
+            }
+        }
     }
     impl Default for Dep {
         fn default() -> Self {
@@ -1100,6 +1165,8 @@ pub mod directory_watch_store {
                 next: None,
                 source_file_path: bun_ptr::RawSlice::EMPTY,
                 specifier: Box::default(),
+                import_kind: bun_ast::ImportKind::Stmt,
+                previous_target: None,
             }
         }
     }
@@ -1142,6 +1209,12 @@ bun_bundler::link_impl_DevServerHandle! {
             (*this)
                 .directory_watchers
                 .track_resolution_failure(import_source, specifier, renderer, loader)
+                .map_err(Into::into)
+        },
+        track_symlink_resolution(import_source, specifier, kind, link_path, real_path, renderer) => {
+            (*this)
+                .directory_watchers
+                .track_symlink_resolution(import_source, specifier, kind, link_path, real_path, renderer)
                 .map_err(Into::into)
         },
         is_file_cached(abs_path, side) => {
@@ -1252,6 +1325,86 @@ impl DirectoryWatchStore {
         );
         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(joined);
 
+        self.track(
+            import_source,
+            specifier,
+            bun_ast::ImportKind::Stmt,
+            renderer,
+            &[dir],
+            None,
+        )
+    }
+
+    /// Registers directory watches so that an import that resolved through
+    /// a symlink is resolved again when the link changes. `link_path` is the
+    /// absolute path before symlink resolution, `real_path` the path after.
+    /// A later resolution that yields a different path rebuilds the importer.
+    pub(crate) fn track_symlink_resolution(
+        &mut self,
+        import_source: &[u8],
+        specifier: &[u8],
+        kind: bun_ast::ImportKind,
+        link_path: &[u8],
+        real_path: &[u8],
+        renderer: Graph,
+    ) -> Result<(), bun_alloc::AllocError> {
+        if specifier.is_empty()
+            || !bun_paths::is_absolute(import_source)
+            || !bun_paths::is_absolute(link_path)
+            || link_path == real_path
+        {
+            return Ok(());
+        }
+        // Same policy as the watcher: links inside node_modules (workspace
+        // packages, `bun link`) and links outside the project are not tracked.
+        // SAFETY: `owner()` recovers the heap DevServer; `root` is disjoint
+        // from `directory_watchers`.
+        let root: &[u8] = unsafe { &(*self.owner()).root };
+        if !link_path.starts_with(root) || bun_core::strings::contains(link_path, b"node_modules") {
+            return Ok(());
+        }
+
+        // Any component of `link_path` from the first one that differs from
+        // `real_path` can be the link. Watch the parent of each of them.
+        let platform = bun_paths::Platform::AUTO;
+        let mut first_differing_component = 0;
+        let mut i = 0;
+        while i < link_path.len().min(real_path.len()) && link_path[i] == real_path[i] {
+            if platform.is_separator(link_path[i]) {
+                first_differing_component = i + 1;
+            }
+            i += 1;
+        }
+        let mut dirs: Vec<&[u8]> = Vec::new();
+        if first_differing_component > 1 {
+            dirs.push(&link_path[..first_differing_component - 1]);
+        }
+        for (p, &c) in link_path.iter().enumerate().skip(first_differing_component) {
+            if platform.is_separator(c) {
+                dirs.push(&link_path[..p]);
+            }
+        }
+        dirs.retain(|dir| dir.len() >= root.len());
+
+        self.track(
+            import_source,
+            specifier,
+            kind,
+            renderer,
+            &dirs,
+            Some(real_path),
+        )
+    }
+
+    fn track(
+        &mut self,
+        import_source: &[u8],
+        specifier: &[u8],
+        kind: bun_ast::ImportKind,
+        renderer: Graph,
+        dirs: &[&[u8]],
+        previous_target: Option<&[u8]>,
+    ) -> Result<(), bun_alloc::AllocError> {
         // The `import_source` parameter is not a stable string. Since the
         // import source will be added to IncrementalGraph anyways, this is a
         // great place to share memory.
@@ -1281,20 +1434,25 @@ impl DirectoryWatchStore {
             }
         };
 
-        match self.insert(dir, owned_file_path, specifier) {
-            Ok(()) => Ok(()),
-            Err(DirectoryWatchInsertError::Ignore) => Ok(()), // ignoring watch errors.
-            Err(DirectoryWatchInsertError::OutOfMemory) => Err(bun_alloc::AllocError),
+        for dir in dirs {
+            match self.insert(dir, owned_file_path, specifier, kind, previous_target) {
+                Ok(()) => {}
+                Err(DirectoryWatchInsertError::Ignore) => {} // ignoring watch errors.
+                Err(DirectoryWatchInsertError::OutOfMemory) => return Err(bun_alloc::AllocError),
+            }
         }
+        Ok(())
     }
 
     /// `dir_name_to_watch` is cloned; `file_path` must outlive the watch;
-    /// `specifier` is cloned.
+    /// `specifier` and `previous_target` are cloned.
     fn insert(
         &mut self,
         dir_name_to_watch: &[u8],
         file_path: bun_ptr::RawSlice<u8>,
         specifier: &[u8],
+        kind: bun_ast::ImportKind,
+        previous_target: Option<&[u8]>,
     ) -> Result<(), DirectoryWatchInsertError> {
         debug_assert!(!specifier.is_empty());
         // TODO: watch the parent dir too.
@@ -1322,23 +1480,45 @@ impl DirectoryWatchStore {
         let gop_index = gop.index;
         let found_existing = gop.found_existing;
 
-        let specifier_cloned: Box<[u8]> =
-            if specifier[0] == b'.' || bun_paths::is_absolute(specifier) {
-                Box::<[u8]>::from(specifier)
-            } else {
-                let mut v = Vec::with_capacity(2 + specifier.len());
-                v.extend_from_slice(b"./");
-                v.extend_from_slice(specifier);
-                v.into_boxed_slice()
-            };
+        // A failed resolution is retried as a relative `Stmt` import. A
+        // symlinked resolution is retried exactly as the bundler resolved it,
+        // so a tsconfig `paths` alias stays an alias.
+        let specifier_cloned: Box<[u8]> = if previous_target.is_some()
+            || specifier[0] == b'.'
+            || bun_paths::is_absolute(specifier)
+        {
+            Box::<[u8]>::from(specifier)
+        } else {
+            let mut v = Vec::with_capacity(2 + specifier.len());
+            v.extend_from_slice(b"./");
+            v.extend_from_slice(specifier);
+            v.into_boxed_slice()
+        };
+        let previous_target: Option<Box<[u8]>> = previous_target.map(Box::<[u8]>::from);
         // errdefer free(specifier_cloned) — handled by Drop on `?` paths.
 
         if found_existing {
+            // Every rebuild of the importer reports its imports again. Update
+            // the dep it already has instead of growing the chain.
+            let mut it = Some(self.watches.values()[gop_index].first_dep);
+            while let Some(index) = it {
+                let dep = &mut self.dependencies[index as usize];
+                it = dep.next;
+                if dep.source_file_path.slice().as_ptr() == file_path.slice().as_ptr()
+                    && *dep.specifier == *specifier_cloned
+                {
+                    dep.import_kind = kind;
+                    dep.previous_target = previous_target;
+                    return Ok(());
+                }
+            }
             let prev_first = Some(self.watches.values()[gop_index].first_dep);
             let dep = self.append_dep_assume_capacity(directory_watch_store::Dep {
                 next: prev_first,
                 source_file_path: file_path,
                 specifier: specifier_cloned,
+                import_kind: kind,
+                previous_target,
             });
             self.watches.values_mut()[gop_index].first_dep = dep;
             return Ok(());
@@ -1432,6 +1612,8 @@ impl DirectoryWatchStore {
             next: None,
             source_file_path: file_path,
             specifier: specifier_cloned,
+            import_kind: kind,
+            previous_target,
         });
         self.watches.values_mut()[gop_index] = directory_watch_store::Entry {
             dir: fd,

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -452,14 +452,14 @@ impl HotReloadEvent {
                 while let Some(index) = it {
                     // Note: reshaped for borrowck — re-index per iteration instead of
                     // holding `dep` ref across resolver call + appendFile + freeDependencyIndex.
-                    let (source_file_path, specifier, next, import_kind, through_symlink) = {
+                    let (source_file_path, specifier, next, import_kind, link_path) = {
                         let dep = &dev.directory_watchers.dependencies[index as usize];
                         (
                             dep.source_file_path,
                             &raw const *dep.specifier,
                             dep.next,
                             dep.import_kind,
-                            dep.previous_target.is_some(),
+                            dep.symlink.as_ref().map(|s| &raw const *s.link_path),
                         )
                     };
                     it = next;
@@ -472,23 +472,16 @@ impl HotReloadEvent {
                     // SAFETY: see `Dep` doc — neither slice is mutated mid-resolve.
                     let specifier: &[u8] = unsafe { &*specifier };
 
-                    if through_symlink {
+                    if let Some(link_path) = link_path {
                         // A directory on the way from the changed directory to
-                        // the import can be the retargeted link. Each of them
-                        // caches its old real path, so bust them all. The walk
-                        // starts at the import itself: a specifier can name
+                        // the link path can be the retargeted link. Each of
+                        // them caches its old real path, so bust them all. The
+                        // walk starts at the link path itself, which can name
                         // the linked directory (`./links/cur` for its index
-                        // file), and a bust of a file path is a no-op.
-                        let mut buf = bun_paths::path_buffer_pool::get();
-                        let mut dir: &[u8] = if bun_paths::is_absolute(specifier) {
-                            specifier
-                        } else {
-                            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
-                                source_dir,
-                                &mut buf.0,
-                                &[specifier],
-                            )
-                        };
+                        // file). A bust of a file path is a no-op.
+                        // SAFETY: points into the dep's owned `Box<[u8]>`, not
+                        // mutated until after `resolve` returns.
+                        let mut dir: &[u8] = unsafe { &*link_path };
                         while dir.len() > changed_dir.len() && dir.starts_with(changed_dir) {
                             // SAFETY: see above.
                             let _ = unsafe { dev.server_transpiler.assume_init_mut() }
@@ -1143,18 +1136,24 @@ pub mod directory_watch_store {
         pub(crate) specifier: Box<[u8]>,
         /// The import kind the bundler resolved `specifier` with.
         pub(crate) import_kind: bun_ast::ImportKind,
-        /// What `specifier` resolved to when the dep was recorded. `None`
-        /// for a failed resolution. `Some(real_path)` for a resolution that
-        /// went through a symlink, so a retarget of the link is detected as
-        /// a change in the resolved path.
-        pub(crate) previous_target: Option<Box<[u8]>>,
+        /// `None` for a failed resolution. `Some` for a resolution that went
+        /// through a symlink, so a retarget of the link is detected as a
+        /// change in the resolved path.
+        pub(crate) symlink: Option<SymlinkTarget>,
+    }
+    /// The two paths of a resolution that went through a symlink.
+    pub struct SymlinkTarget {
+        /// The absolute path before symlink resolution.
+        pub(crate) link_path: Box<[u8]>,
+        /// The path after symlink resolution, what `specifier` resolved to.
+        pub(crate) real_path: Box<[u8]>,
     }
     impl Dep {
         /// Whether a fresh resolution result is the same as the recorded one.
         pub(crate) fn matches_target(&self, resolved: Option<&[u8]>) -> bool {
-            match (&self.previous_target, resolved) {
+            match (&self.symlink, resolved) {
                 (None, None) => true,
-                (Some(prev), Some(now)) => **prev == *now,
+                (Some(prev), Some(now)) => *prev.real_path == *now,
                 _ => false,
             }
         }
@@ -1166,7 +1165,7 @@ pub mod directory_watch_store {
                 source_file_path: bun_ptr::RawSlice::EMPTY,
                 specifier: Box::default(),
                 import_kind: bun_ast::ImportKind::Stmt,
-                previous_target: None,
+                symlink: None,
             }
         }
     }
@@ -1392,7 +1391,7 @@ impl DirectoryWatchStore {
             kind,
             renderer,
             &dirs,
-            Some(real_path),
+            Some((link_path, real_path)),
         )
     }
 
@@ -1403,7 +1402,7 @@ impl DirectoryWatchStore {
         kind: bun_ast::ImportKind,
         renderer: Graph,
         dirs: &[&[u8]],
-        previous_target: Option<&[u8]>,
+        symlink: Option<(&[u8], &[u8])>,
     ) -> Result<(), bun_alloc::AllocError> {
         // The `import_source` parameter is not a stable string. Since the
         // import source will be added to IncrementalGraph anyways, this is a
@@ -1435,7 +1434,7 @@ impl DirectoryWatchStore {
         };
 
         for dir in dirs {
-            match self.insert(dir, owned_file_path, specifier, kind, previous_target) {
+            match self.insert(dir, owned_file_path, specifier, kind, symlink) {
                 Ok(()) => {}
                 Err(DirectoryWatchInsertError::Ignore) => {} // ignoring watch errors.
                 Err(DirectoryWatchInsertError::OutOfMemory) => return Err(bun_alloc::AllocError),
@@ -1445,14 +1444,14 @@ impl DirectoryWatchStore {
     }
 
     /// `dir_name_to_watch` is cloned; `file_path` must outlive the watch;
-    /// `specifier` and `previous_target` are cloned.
+    /// `specifier` and `symlink` (link path, real path) are cloned.
     fn insert(
         &mut self,
         dir_name_to_watch: &[u8],
         file_path: bun_ptr::RawSlice<u8>,
         specifier: &[u8],
         kind: bun_ast::ImportKind,
-        previous_target: Option<&[u8]>,
+        symlink: Option<(&[u8], &[u8])>,
     ) -> Result<(), DirectoryWatchInsertError> {
         debug_assert!(!specifier.is_empty());
         // TODO: watch the parent dir too.
@@ -1483,18 +1482,21 @@ impl DirectoryWatchStore {
         // A failed resolution is retried as a relative `Stmt` import. A
         // symlinked resolution is retried exactly as the bundler resolved it,
         // so a tsconfig `paths` alias stays an alias.
-        let specifier_cloned: Box<[u8]> = if previous_target.is_some()
-            || specifier[0] == b'.'
-            || bun_paths::is_absolute(specifier)
-        {
-            Box::<[u8]>::from(specifier)
-        } else {
-            let mut v = Vec::with_capacity(2 + specifier.len());
-            v.extend_from_slice(b"./");
-            v.extend_from_slice(specifier);
-            v.into_boxed_slice()
-        };
-        let previous_target: Option<Box<[u8]>> = previous_target.map(Box::<[u8]>::from);
+        let specifier_cloned: Box<[u8]> =
+            if symlink.is_some() || specifier[0] == b'.' || bun_paths::is_absolute(specifier) {
+                Box::<[u8]>::from(specifier)
+            } else {
+                let mut v = Vec::with_capacity(2 + specifier.len());
+                v.extend_from_slice(b"./");
+                v.extend_from_slice(specifier);
+                v.into_boxed_slice()
+            };
+        let symlink: Option<directory_watch_store::SymlinkTarget> = symlink.map(
+            |(link_path, real_path)| directory_watch_store::SymlinkTarget {
+                link_path: Box::<[u8]>::from(link_path),
+                real_path: Box::<[u8]>::from(real_path),
+            },
+        );
         // errdefer free(specifier_cloned) — handled by Drop on `?` paths.
 
         if found_existing {
@@ -1508,7 +1510,7 @@ impl DirectoryWatchStore {
                     && *dep.specifier == *specifier_cloned
                 {
                     dep.import_kind = kind;
-                    dep.previous_target = previous_target;
+                    dep.symlink = symlink;
                     return Ok(());
                 }
             }
@@ -1518,7 +1520,7 @@ impl DirectoryWatchStore {
                 source_file_path: file_path,
                 specifier: specifier_cloned,
                 import_kind: kind,
-                previous_target,
+                symlink,
             });
             self.watches.values_mut()[gop_index].first_dep = dep;
             return Ok(());
@@ -1613,7 +1615,7 @@ impl DirectoryWatchStore {
             source_file_path: file_path,
             specifier: specifier_cloned,
             import_kind: kind,
-            previous_target,
+            symlink,
         });
         self.watches.values_mut()[gop_index] = directory_watch_store::Entry {
             dir: fd,

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -416,9 +416,7 @@ impl HotReloadEvent {
         // drop, so it does not hold a borrow of `dev` for the scope.
         let _g = dev.graph_safety_lock.guard();
 
-        // A changed entry can be a directory symlink (`cur -> v1`). Its own
-        // `DirInfo` caches the old real path, so bust it before anything
-        // below resolves through it.
+        // A changed entry can be a directory symlink whose `DirInfo` caches the old real path.
         for changed_entry in bun_core::strings::split(&self.extra_files, &[0]) {
             if !changed_entry.is_empty() {
                 // SAFETY: server_transpiler is initialized in DevServer::init before any
@@ -473,12 +471,8 @@ impl HotReloadEvent {
                     let specifier: &[u8] = unsafe { &*specifier };
 
                     if let Some(link_path) = link_path {
-                        // A directory on the way from the changed directory to
-                        // the link path can be the retargeted link. Each of
-                        // them caches its old real path, so bust them all. The
-                        // walk starts at the link path itself, which can name
-                        // the linked directory (`./links/cur` for its index
-                        // file). A bust of a file path is a no-op.
+                        // Any directory between the changed one and the link path
+                        // can be the link. A bust of a file path is a no-op.
                         // SAFETY: points into the dep's owned `Box<[u8]>`, not
                         // mutated until after `resolve` returns.
                         let mut dir: &[u8] = unsafe { &*link_path };
@@ -1136,9 +1130,7 @@ pub mod directory_watch_store {
         pub(crate) specifier: Box<[u8]>,
         /// The import kind the bundler resolved `specifier` with.
         pub(crate) import_kind: bun_ast::ImportKind,
-        /// `None` for a failed resolution. `Some` for a resolution that went
-        /// through a symlink, so a retarget of the link is detected as a
-        /// change in the resolved path.
+        /// `Some` for a resolution that went through a symlink.
         pub(crate) symlink: Option<SymlinkTarget>,
     }
     /// The two paths of a resolution that went through a symlink.
@@ -1334,10 +1326,7 @@ impl DirectoryWatchStore {
         )
     }
 
-    /// Registers directory watches so that an import that resolved through
-    /// a symlink is resolved again when the link changes. `link_path` is the
-    /// absolute path before symlink resolution, `real_path` the path after.
-    /// A later resolution that yields a different path rebuilds the importer.
+    /// Resolves `specifier` again when a directory on `link_path` changes.
     pub(crate) fn track_symlink_resolution(
         &mut self,
         import_source: &[u8],
@@ -1354,8 +1343,7 @@ impl DirectoryWatchStore {
         {
             return Ok(());
         }
-        // Same policy as the watcher: links inside node_modules (workspace
-        // packages, `bun link`) and links outside the project are not tracked.
+        // Same policy as the watcher: no node_modules, nothing outside the project.
         // SAFETY: `owner()` recovers the heap DevServer; `root` is disjoint
         // from `directory_watchers`.
         let root: &[u8] = unsafe { &(*self.owner()).root };
@@ -1363,8 +1351,7 @@ impl DirectoryWatchStore {
             return Ok(());
         }
 
-        // Any component of `link_path` from the first one that differs from
-        // `real_path` can be the link. Watch the parent of each of them.
+        // Watch the parent of every component that can be the link.
         let platform = bun_paths::Platform::AUTO;
         let mut first_differing_component = 0;
         let mut i = 0;
@@ -1479,9 +1466,7 @@ impl DirectoryWatchStore {
         let gop_index = gop.index;
         let found_existing = gop.found_existing;
 
-        // A failed resolution is retried as a relative `Stmt` import. A
-        // symlinked resolution is retried exactly as the bundler resolved it,
-        // so a tsconfig `paths` alias stays an alias.
+        // A symlinked resolution is retried with the specifier as the bundler resolved it.
         let specifier_cloned: Box<[u8]> =
             if symlink.is_some() || specifier[0] == b'.' || bun_paths::is_absolute(specifier) {
                 Box::<[u8]>::from(specifier)
@@ -1500,8 +1485,7 @@ impl DirectoryWatchStore {
         // errdefer free(specifier_cloned) — handled by Drop on `?` paths.
 
         if found_existing {
-            // Every rebuild of the importer reports its imports again. Update
-            // the dep it already has instead of growing the chain.
+            // A rebuild of the importer reports the same import again.
             let mut it = Some(self.watches.values()[gop_index].first_dep);
             while let Some(index) = it {
                 let dep = &mut self.dependencies[index as usize];

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,6 +1,6 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
-import { renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { devTest, emptyHtmlFile } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
@@ -640,5 +640,128 @@ devTest("dev.write resolves only after the new module body has run", {
     // dev.write resolves on bun:afterUpdate, i.e. after replaceModules has
     // awaited the 500ms TLA. Acking on WS receipt would see "initial" here.
     expect(await c.js`globalThis.marker`).toBe("updated");
+  },
+});
+
+// The resolver keys a module by its real path. An import that goes through
+// a symlink has to follow the link when the link changes, not the file it
+// pointed to when it was first bundled.
+devTest("import through a file symlink follows the link when it is retargeted", {
+  skip: ["win32"],
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["app.ts"] }),
+    "v1/app.ts": `console.log("MARK_V1");`,
+    "v2/app.ts": `console.log("MARK_V2");`,
+  },
+  async test(dev) {
+    symlinkSync("v1/app.ts", dev.join("app.ts"));
+    await using c = await dev.client("/");
+    await c.expectMessage("MARK_V1");
+
+    // Retarget the link with a rename over it, as `ln -sfn` does.
+    await c.expectReload(async () => {
+      await using _wait = await dev.batchChanges();
+      symlinkSync("v2/app.ts", dev.join("app.ts.tmp"));
+      renameSync(dev.join("app.ts.tmp"), dev.join("app.ts"));
+    });
+    await c.expectMessage("MARK_V2");
+
+    // An edit to the new target is seen.
+    await c.expectReload(async () => {
+      await dev.write("v2/app.ts", `console.log("MARK_V2_EDITED");`);
+    });
+    await c.expectMessage("MARK_V2_EDITED");
+
+    // Replacing the link with a regular file is seen too.
+    await c.expectReload(async () => {
+      await using _wait = await dev.batchChanges();
+      unlinkSync(dev.join("app.ts"));
+      writeFileSync(dev.join("app.ts"), `console.log("MARK_REGULAR");`);
+    });
+    await c.expectMessage("MARK_REGULAR");
+  },
+});
+
+devTest("import through a directory symlink follows the link when it is retargeted", {
+  skip: ["win32"],
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["links/cur/app.ts"] }),
+    "v1/app.ts": `console.log("MARK_V1");`,
+    "v2/app.ts": `console.log("MARK_V2");`,
+  },
+  async test(dev) {
+    // The link lives in a directory the server has not listed yet, so the
+    // resolver sees it as a link on the first resolution.
+    mkdirSync(dev.join("links"));
+    symlinkSync("../v1", dev.join("links/cur"));
+    await using c = await dev.client("/");
+    await c.expectMessage("MARK_V1");
+
+    await c.expectReload(async () => {
+      await using _wait = await dev.batchChanges();
+      symlinkSync("../v2", dev.join("links/cur.tmp"));
+      renameSync(dev.join("links/cur.tmp"), dev.join("links/cur"));
+    });
+    await c.expectMessage("MARK_V2");
+
+    await c.expectReload(async () => {
+      await dev.write("v2/app.ts", `console.log("MARK_V2_EDITED");`);
+    });
+    await c.expectMessage("MARK_V2_EDITED");
+  },
+});
+
+devTest("import that names a directory symlink follows the link when it is retargeted", {
+  skip: ["win32"],
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["entry.ts"] }),
+    "entry.ts": `import "./links/cur";`,
+    "v1/index.ts": `console.log("MARK_V1");`,
+    "v2/index.ts": `console.log("MARK_V2");`,
+  },
+  async test(dev) {
+    mkdirSync(dev.join("links"));
+    symlinkSync("../v1", dev.join("links/cur"));
+    await using c = await dev.client("/");
+    await c.expectMessage("MARK_V1");
+
+    await c.expectReload(async () => {
+      await using _wait = await dev.batchChanges();
+      symlinkSync("../v2", dev.join("links/cur.tmp"));
+      renameSync(dev.join("links/cur.tmp"), dev.join("links/cur"));
+    });
+    await c.expectMessage("MARK_V2");
+  },
+});
+
+devTest("tsconfig paths alias through a symlink is resolved again with the alias", {
+  skip: ["win32"],
+  files: {
+    "tsconfig.json": `{ "compilerOptions": { "paths": { "@/*": ["./links/*"] } } }`,
+    "index.html": emptyHtmlFile({ scripts: ["entry.ts"] }),
+    "entry.ts": `import "@/cur/app.ts";`,
+    "v1/app.ts": `console.log("MARK_V1");`,
+    "v2/app.ts": `console.log("MARK_V2");`,
+  },
+  async test(dev) {
+    mkdirSync(dev.join("links"));
+    symlinkSync("../v1", dev.join("links/cur"));
+    await using c = await dev.client("/");
+    await c.expectMessage("MARK_V1");
+
+    // An unrelated change in a watched directory must not rebuild the
+    // importer: the alias still resolves to the same file.
+    const linesBefore = dev.output.lines.length;
+    await c.expectNoWebSocketActivity(async () => {
+      await dev.write("links/unrelated.txt", "x");
+    });
+    expect(dev.output.lines.slice(linesBefore).join("\n")).not.toContain("Reloaded");
+
+    await c.expectReload(async () => {
+      await using _wait = await dev.batchChanges();
+      symlinkSync("../v2", dev.join("links/cur.tmp"));
+      renameSync(dev.join("links/cur.tmp"), dev.join("links/cur"));
+    });
+    await c.expectMessage("MARK_V2");
   },
 });


### PR DESCRIPTION
### Problem
- The dev server (`Bun.serve` with HTML routes, `development: true`) keys a module by its real path. When an import goes through a symlink (`app.ts -> v1/app.ts`, or `cur -> v1` on the path) and the link is retargeted, the served bundle stays on the first target forever. Edits to the new target are not seen. Replacing the link with a regular file is not seen.
- Two causes. Nothing maps the link path back to the importer, so the rename event on the link is "nothing to bundle". And `process_file_list` (`src/runtime/bake/dev_server/mod.rs:420`) only busted the resolver dir cache when a resolution-failure watch existed, so even a rebuild of the importer re-resolved from a stale `DirEntry`.

### Fix
- `DirectoryWatchStore` now records a resolution that went through a symlink, next to the resolution failures it already tracks. `Dep.symlink` holds the link path and the real path the import resolved to, `Dep.import_kind` the kind the bundler used. On a directory event the import is resolved again with the same specifier and kind, and the importer is rebuilt when the result differs. The bundler reports these through a new `track_symlink_resolution` vtable method, called when `path.is_symlink`, before `path_with_pretty_initialized` overwrites the link path.
- `process_file_list` busts the dir cache on every directory event, and also busts the changed entry and each directory from the link path up to the watched directory (kqueue events carry no entry name). A directory symlink caches its old real path in its own `DirInfo`, so a bust of the parent alone is not enough.
- `insert` updates an existing dep for the same (importer, specifier) instead of appending a duplicate on every rebuild.
- Verified: `test/bake/dev/hot.test.ts` (four new devTests: file link, directory link, a specifier that names the linked directory, a tsconfig `paths` alias through a link; all fail on stock bun). Also all of `test/bake/dev/`, `test/bake/dev-and-prod.test.ts`, `test/cli/hot/`.

### Background
- `IncrementalGraph` keys files by `Path.text`. The resolver's `set_realpath` moves the link path into `Path.pretty` and puts the real path in `text`, so the graph never sees the link path.
- `DirectoryWatchStore` is the dev server's list of "resolve this again when directory D changes" entries. Before this change it only held failed resolutions, and it was the only thing that triggered a dir cache bust.
- The resolver caches a directory listing (`DirEntry`) and a `DirInfo` per directory. A `DirInfo` for a symlinked directory stores `abs_real_path`, and children inherit it, so a stale one keeps resolving into the old target.

<details><summary>Notes</summary>

This is a draft. It was split out of #41489 after a self-review: it touches `DirectoryWatchStore` and adds a use of its `owner()` accessor, which #40255 reworks, and no user has reported the symlink case. The watcher warning landed in #41489 on its own. The question for a maintainer is whether this should land at all, and if so, before or after #40255.

The finding comes from a fuzz ledger. Ledger sequence with the fix, file link and directory link: `MARK_V1, MARK_V2, MARK_V2, MARK_V2_EDITED, MARK_REGULAR, MARK_REGULAR` (stock bun: `V1, V1, V1_EDITED, V1_EDITED, V1_EDITED, V1_EDITED`).

Which directories to watch for a symlinked resolution: any component of the link path from the first one that differs from the real path can be the link, so the parent of each of those components is registered. Links inside `node_modules` and outside the project root are not tracked, the same policy the watcher applies to directories.

Known limits. A symlinked directory whose parent listing was cached before the link existed is not resolved to its real path by the resolver (the parent's `DirEntry` has no entry for it). The graph then keys the module by the link path, and this change does not apply. The directory tests create the link in a fresh subdirectory for that reason. The `--hot` runtime reloader has the same directory-link face in `src/jsc/hot_reloader.rs` and is tracked separately.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->
