### PR TITLE
Make loose deepEquals reject a non-enumerable match in either argument order

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -817,10 +817,11 @@ static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObj
 }
 
 // Compares the properties of o1 and o2 by the enumerable names in a1 and a2.
-// Every name in a1 must be an enumerable property of o2 with an equal value.
-// In strict mode the two name lists must have the same length, which makes the
-// name sets equal. In loose mode a property whose value is undefined counts as
-// absent, so every name in a2 that o1 does not have must be undefined on o2.
+// Every name in a1 must resolve to an enumerable property on both sides with
+// equal values. In strict mode the two name lists must have the same length,
+// which makes the name sets equal. In loose mode a property whose value is
+// undefined counts as absent, so every name in a2 that o1 does not have must be
+// absent or undefined on o2.
 // `ownOnly` must match how the name lists were built (own names, or the
 // prototype chain too). `skipName` is ignored on both sides (Error's `stack`).
 static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2, const JSC::PropertyNameArrayBuilder& a1, const JSC::PropertyNameArrayBuilder& a2, bool ownOnly, const Identifier* skipName = nullptr)
@@ -836,10 +837,18 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         if (skipName && i1 == *skipName) continue;
         PropertyName propertyName1 = PropertyName(i1);
 
-        JSValue prop1 = o1->get(globalObject, propertyName1);
+        // The name lists collect enumerable names from the whole prototype chain. A
+        // non-enumerable property nearer the object can shadow such a name, and then
+        // the name resolves to a non-enumerable property. Treat it as absent on that
+        // side, the same rule as the lookup on the other side.
+        JSValue prop1;
+        bool has1 = findEnumerableProperty(globalObject, o1, propertyName1, ownOnly, &prop1);
         RETURN_IF_EXCEPTION(scope, false);
-        if (!prop1) [[unlikely]] {
-            return false;
+        if (!has1) {
+            if (mode.isStrict) {
+                return false;
+            }
+            continue;
         }
 
         JSValue prop2;
@@ -871,9 +880,10 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         RETURN_IF_EXCEPTION(scope, false);
         if (has1) continue;
 
-        JSValue prop2 = o2->get(globalObject, propertyName2);
+        JSValue prop2;
+        bool has2 = findEnumerableProperty(globalObject, o2, propertyName2, ownOnly, &prop2);
         RETURN_IF_EXCEPTION(scope, false);
-        if (!prop2.isUndefined()) {
+        if (has2 && !prop2.isUndefined()) {
             return false;
         }
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -799,13 +799,12 @@ static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObj
     if (!hasProperty)
         return false;
 
-    // A Proxy reports no attributes. Its properties count as enumerable.
-    bool opaque = slot.isTaintedByOpaqueObject();
-    if (!opaque && (slot.attributes() & PropertyAttribute::DontEnum))
+    if (slot.attributes() & PropertyAttribute::DontEnum)
         return false;
 
     if (value) {
-        *value = opaque ? object->get(globalObject, propertyName) : slot.getValue(globalObject, propertyName);
+        // A Proxy slot carries no value. Read it through the get trap, like getIfPropertyExists().
+        *value = slot.isTaintedByOpaqueObject() ? object->get(globalObject, propertyName) : slot.getValue(globalObject, propertyName);
         RETURN_IF_EXCEPTION(scope, false);
     }
     return true;
@@ -829,21 +828,18 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         JSValue prop1;
         bool has1 = findEnumerableProperty(globalObject, o1, propertyName1, ownOnly, &prop1);
         RETURN_IF_EXCEPTION(scope, false);
-        if (!has1) {
-            if (mode.isStrict) {
-                return false;
-            }
-            continue;
-        }
-
         JSValue prop2;
         bool has2 = findEnumerableProperty(globalObject, o2, propertyName1, ownOnly, &prop2);
         RETURN_IF_EXCEPTION(scope, false);
-        if (!has2) {
-            if (!mode.isStrict && prop1.isUndefined()) {
-                continue;
-            }
+        if (!mode.isStrict) {
+            if (has1 && prop1.isUndefined()) has1 = false;
+            if (has2 && prop2.isUndefined()) has2 = false;
+        }
+        if (has1 != has2) {
             return false;
+        }
+        if (!has1) {
+            continue;
         }
 
         bool eql = mode.deepEquals(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
@@ -860,6 +856,7 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         if (skipName && i2 == *skipName) continue;
         PropertyName propertyName2 = PropertyName(i2);
 
+        // A name o1 has was compared in the first loop.
         bool has1 = findEnumerableProperty(globalObject, o1, propertyName2, ownOnly, nullptr);
         RETURN_IF_EXCEPTION(scope, false);
         if (has1) continue;
@@ -1190,12 +1187,10 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                     return true;
                 });
             } else {
-                size_t count = 0;
                 o1Structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                     if (entry.attributes() & PropertyAttribute::DontEnum || PropertyName(entry.key()).isPrivateName()) {
                         return true;
                     }
-                    count++;
 
                     JSValue left = o1->getDirect(entry.offset());
                     JSValue right;
@@ -1223,7 +1218,6 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 });
 
                 if (result) {
-                    size_t remain = count;
                     o2Structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                         if (entry.attributes() & PropertyAttribute::DontEnum || PropertyName(entry.key()).isPrivateName()) {
                             return true;
@@ -1243,12 +1237,6 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                             return false;
                         }
 
-                        if (remain == 0) {
-                            result = false;
-                            return false;
-                        }
-
-                        remain--;
                         return true;
                     });
                 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -858,7 +858,7 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         if (has1) continue;
 
         JSValue prop2;
-        bool has2 = findEnumerableProperty(globalObject, o2, propertyName2, ownOnly, &prop2);
+        bool has2 = findEnumerableProperty(globalObject, o2, propertyName2, ownOnly, mode.isStrict ? nullptr : &prop2);
         RETURN_IF_EXCEPTION(scope, false);
         if (has2 && (mode.isStrict || !prop2.isUndefined())) {
             return false;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -785,12 +785,8 @@ static constexpr DeepEqualsMode deepEqualsMode {
     checkPrototypes ? &nonIndexOwnPropertiesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity> : nullptr,
 };
 
-// Finds an enumerable property `propertyName` on `object`. `ownOnly` skips the
-// prototype chain (node compares own properties only). A non-enumerable match
-// counts as absent: the callers iterate enumerable names, so a non-enumerable
-// property on the other side must not satisfy one of them, or the result would
-// depend on the argument order. When `value` is given, the property is read
-// into it. Without it the getter does not run.
+// A non-enumerable match counts as absent. `ownOnly` skips the prototype chain.
+// The getter runs only when `value` is given.
 static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, JSC::PropertyName propertyName, bool ownOnly, JSValue* value)
 {
     VM& vm = globalObject->vm();
@@ -816,14 +812,8 @@ static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObj
     return true;
 }
 
-// Compares the properties of o1 and o2 by the enumerable names in a1 and a2.
-// Every name in a1 must resolve to an enumerable property on both sides with
-// equal values. In strict mode the two name lists must have the same length,
-// which makes the name sets equal. In loose mode a property whose value is
-// undefined counts as absent, so every name in a2 that o1 does not have must be
-// absent or undefined on o2.
-// `ownOnly` must match how the name lists were built (own names, or the
-// prototype chain too). `skipName` is ignored on both sides (Error's `stack`).
+// Compares o1 and o2 by the enumerable names in a1 and a2. Loose mode treats an
+// undefined value as absent. `ownOnly` must match how the name lists were built.
 static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2, const JSC::PropertyNameArrayBuilder& a1, const JSC::PropertyNameArrayBuilder& a2, bool ownOnly, const Identifier* skipName = nullptr)
 {
     const size_t propertyArrayLength1 = a1.size();
@@ -837,10 +827,7 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         if (skipName && i1 == *skipName) continue;
         PropertyName propertyName1 = PropertyName(i1);
 
-        // The name lists collect enumerable names from the whole prototype chain. A
-        // non-enumerable property nearer the object can shadow such a name, and then
-        // the name resolves to a non-enumerable property. Treat it as absent on that
-        // side, the same rule as the lookup on the other side.
+        // A non-enumerable property can shadow an enumerable chain name.
         JSValue prop1;
         bool has1 = findEnumerableProperty(globalObject, o1, propertyName1, ownOnly, &prop1);
         RETURN_IF_EXCEPTION(scope, false);
@@ -875,7 +862,6 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         if (skipName && i2 == *skipName) continue;
         PropertyName propertyName2 = PropertyName(i2);
 
-        // A name o1 has was compared in the loop above. The getter does not run again.
         bool has1 = findEnumerableProperty(globalObject, o1, propertyName2, ownOnly, nullptr);
         RETURN_IF_EXCEPTION(scope, false);
         if (has1) continue;
@@ -1215,9 +1201,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
                     JSValue left = o1->getDirect(entry.offset());
                     JSValue right;
-                    // Only an enumerable property on o2 can match an enumerable one on o1.
-                    // getDirect() alone would also find a non-enumerable property, which the
-                    // reverse loop skips, so the result would depend on the argument order.
+                    // getDirect() alone would also match a non-enumerable property.
                     unsigned o2Attributes = 0;
                     PropertyOffset o2Offset = o2Structure->get(vm, JSC::PropertyName(entry.key()), o2Attributes);
                     if (o2Offset != invalidOffset && !(o2Attributes & PropertyAttribute::DontEnum)) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -847,10 +847,6 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         if (!eql) return false;
     }
 
-    if (mode.isStrict) {
-        return true;
-    }
-
     for (size_t i = 0; i < propertyArrayLength2; i++) {
         const Identifier& i2 = a2[i];
         if (skipName && i2 == *skipName) continue;
@@ -864,7 +860,7 @@ static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalO
         JSValue prop2;
         bool has2 = findEnumerableProperty(globalObject, o2, propertyName2, ownOnly, &prop2);
         RETURN_IF_EXCEPTION(scope, false);
-        if (has2 && !prop2.isUndefined()) {
+        if (has2 && (mode.isStrict || !prop2.isUndefined())) {
             return false;
         }
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -719,28 +719,6 @@ static ALWAYS_INLINE bool hasExtraOwnProperties(JSC::Structure* structure)
         || hasIndexedProperties(structure->indexingType());
 }
 
-// Finds `propertyName` on `object` (prototype chain included) like
-// getIfPropertyExists(), but a non-enumerable match counts as absent. The
-// callers iterate enumerable names only, so a non-enumerable property on the
-// other side must not satisfy one of them or the result would depend on the
-// argument order. On true, the value is in `slot`.
-static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, JSC::PropertyName propertyName, PropertySlot& slot)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    bool hasProperty = object->getPropertySlot(globalObject, propertyName, slot);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (!hasProperty)
-        return false;
-
-    // A Proxy reports no attributes. Its properties count as enumerable.
-    if (slot.isTaintedByOpaqueObject()) [[unlikely]]
-        return true;
-
-    return !(slot.attributes() & PropertyAttribute::DontEnum);
-}
-
 // node compares the non-index own properties of typed arrays as well;
 // only the node entry point (checkPrototypes) pays for this.
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity = false>
@@ -782,6 +760,120 @@ static bool nonIndexOwnPropertiesEqual(JSC::JSGlobalObject* globalObject, Marked
         bool eq = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, v1, v2, gcBuffer, stack, scope, true);
         RETURN_IF_EXCEPTION(scope, false);
         if (!eq) {
+            return false;
+        }
+    }
+    return true;
+}
+
+struct DeepEqualsMode {
+    bool isStrict;
+    bool enableAsymmetricMatchers;
+    bool checkPrototypes;
+    bool skipPrototypeIdentity;
+    bool (*deepEquals)(JSC::JSGlobalObject*, JSValue, JSValue, MarkedArgumentBuffer&, Vector<std::pair<JSValue, JSValue>, 16>&, ThrowScope&, bool);
+    bool (*nonIndexOwnPropertiesEqual)(JSC::JSGlobalObject*, MarkedArgumentBuffer&, Vector<std::pair<JSValue, JSValue>, 16>&, ThrowScope&, JSObject*, JSObject*);
+};
+
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static constexpr DeepEqualsMode deepEqualsMode {
+    isStrict,
+    enableAsymmetricMatchers,
+    checkPrototypes,
+    skipPrototypeIdentity,
+    &Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>,
+    checkPrototypes ? &nonIndexOwnPropertiesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity> : nullptr,
+};
+
+// Finds an enumerable property `propertyName` on `object`. `ownOnly` skips the
+// prototype chain (node compares own properties only). A non-enumerable match
+// counts as absent: the callers iterate enumerable names, so a non-enumerable
+// property on the other side must not satisfy one of them, or the result would
+// depend on the argument order. When `value` is given, the property is read
+// into it. Without it the getter does not run.
+static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, JSC::PropertyName propertyName, bool ownOnly, JSValue* value)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    PropertySlot slot(object, ownOnly ? PropertySlot::InternalMethodType::GetOwnProperty : PropertySlot::InternalMethodType::HasProperty);
+    bool hasProperty = ownOnly
+        ? object->methodTable()->getOwnPropertySlot(object, globalObject, propertyName, slot)
+        : object->getPropertySlot(globalObject, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!hasProperty)
+        return false;
+
+    // A Proxy reports no attributes. Its properties count as enumerable.
+    bool opaque = slot.isTaintedByOpaqueObject();
+    if (!opaque && (slot.attributes() & PropertyAttribute::DontEnum))
+        return false;
+
+    if (value) {
+        *value = opaque ? object->get(globalObject, propertyName) : slot.getValue(globalObject, propertyName);
+        RETURN_IF_EXCEPTION(scope, false);
+    }
+    return true;
+}
+
+// Compares the properties of o1 and o2 by the enumerable names in a1 and a2.
+// Every name in a1 must be an enumerable property of o2 with an equal value.
+// In strict mode the two name lists must have the same length, which makes the
+// name sets equal. In loose mode a property whose value is undefined counts as
+// absent, so every name in a2 that o1 does not have must be undefined on o2.
+// `ownOnly` must match how the name lists were built (own names, or the
+// prototype chain too). `skipName` is ignored on both sides (Error's `stack`).
+static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2, const JSC::PropertyNameArrayBuilder& a1, const JSC::PropertyNameArrayBuilder& a2, bool ownOnly, const Identifier* skipName = nullptr)
+{
+    const size_t propertyArrayLength1 = a1.size();
+    const size_t propertyArrayLength2 = a2.size();
+    if (mode.isStrict && propertyArrayLength1 != propertyArrayLength2) {
+        return false;
+    }
+
+    for (size_t i = 0; i < propertyArrayLength1; i++) {
+        const Identifier& i1 = a1[i];
+        if (skipName && i1 == *skipName) continue;
+        PropertyName propertyName1 = PropertyName(i1);
+
+        JSValue prop1 = o1->get(globalObject, propertyName1);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!prop1) [[unlikely]] {
+            return false;
+        }
+
+        JSValue prop2;
+        bool has2 = findEnumerableProperty(globalObject, o2, propertyName1, ownOnly, &prop2);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!has2) {
+            if (!mode.isStrict && prop1.isUndefined()) {
+                continue;
+            }
+            return false;
+        }
+
+        bool eql = mode.deepEquals(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!eql) return false;
+    }
+
+    if (mode.isStrict) {
+        return true;
+    }
+
+    for (size_t i = 0; i < propertyArrayLength2; i++) {
+        const Identifier& i2 = a2[i];
+        if (skipName && i2 == *skipName) continue;
+        PropertyName propertyName2 = PropertyName(i2);
+
+        // A name o1 has was compared in the loop above. The getter does not run again.
+        bool has1 = findEnumerableProperty(globalObject, o1, propertyName2, ownOnly, nullptr);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (has1) continue;
+
+        JSValue prop2 = o2->get(globalObject, propertyName2);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!prop2.isUndefined()) {
             return false;
         }
     }
@@ -1057,44 +1149,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         JSObject::getOwnPropertyNames(o2, globalObject, a2, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(scope, false);
 
-        size_t propertyLength = a1.size();
-        if constexpr (isStrict) {
-            if (propertyLength != a2.size()) {
-                return false;
-            }
-        }
-
-        // take a property name from one, try to get it from both
-        for (size_t i = 0; i < propertyLength; i++) {
-            Identifier i1 = a1[i];
-            PropertyName propertyName1 = PropertyName(i1);
-
-            JSValue prop1 = o1->get(globalObject, propertyName1);
-            RETURN_IF_EXCEPTION(scope, false);
-
-            if (!prop1) [[unlikely]] {
-                return false;
-            }
-
-            JSValue prop2 = o2->getIfPropertyExists(globalObject, propertyName1);
-            RETURN_IF_EXCEPTION(scope, false);
-
-            if constexpr (!isStrict) {
-                if (prop1.isUndefined() && prop2.isEmpty()) {
-                    continue;
-                }
-            }
-
-            if (!prop2) {
-                return false;
-            }
-
-            auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (!eql) return false;
-        }
-
-        return true;
+        return enumerablePropertiesEqual(deepEqualsMode<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>, globalObject, gcBuffer, stack, scope, o1, o2, a1, a2, true);
     }
 
     if constexpr (isStrict && !checkPrototypes && !skipPrototypeIdentity) {
@@ -1247,89 +1302,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         RETURN_IF_EXCEPTION(scope, false);
     }
 
-    const size_t propertyArrayLength1 = a1.size();
-    const size_t propertyArrayLength2 = a2.size();
-    if constexpr (isStrict) {
-        if (propertyArrayLength1 != propertyArrayLength2) {
-            return false;
-        }
-    }
-
-    // take a property name from one, try to get it from both
-    for (size_t i = 0; i < propertyArrayLength1; i++) {
-        Identifier i1 = a1[i];
-        PropertyName propertyName1 = PropertyName(i1);
-
-        JSValue prop1 = o1->get(globalObject, propertyName1);
-        RETURN_IF_EXCEPTION(scope, false);
-
-        if (!prop1) [[unlikely]] {
-            return false;
-        }
-
-        JSValue prop2;
-        if constexpr (checkPrototypes) {
-            // node only matches own enumerable properties; getIfPropertyExists
-            // would also find non-enumerable or inherited ones.
-            PropertySlot slot2(o2, PropertySlot::InternalMethodType::GetOwnProperty);
-            bool has = o2->methodTable()->getOwnPropertySlot(o2, globalObject, propertyName1, slot2);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (!has || (slot2.attributes() & PropertyAttribute::DontEnum)) {
-                return false;
-            }
-            prop2 = slot2.getValue(globalObject, propertyName1);
-            RETURN_IF_EXCEPTION(scope, false);
-        } else {
-            PropertySlot slot2(o2, PropertySlot::InternalMethodType::HasProperty);
-            bool has = findEnumerableProperty(globalObject, o2, propertyName1, slot2);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (has) {
-                if (slot2.isTaintedByOpaqueObject()) [[unlikely]]
-                    prop2 = o2->get(globalObject, propertyName1);
-                else
-                    prop2 = slot2.getValue(globalObject, propertyName1);
-                RETURN_IF_EXCEPTION(scope, false);
-            }
-        }
-
-        if constexpr (!isStrict) {
-            if (prop1.isUndefined() && prop2.isEmpty()) {
-                continue;
-            }
-        }
-
-        if (!prop2) {
-            return false;
-        }
-
-        auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
-        RETURN_IF_EXCEPTION(scope, false);
-        if (!eql) return false;
-    }
-
-    if constexpr (!isStrict) {
-        // Every defined enumerable property of o2 must be an enumerable property of o1.
-        // The values were compared above, because every such name is also in a1.
-        for (size_t i = 0; i < propertyArrayLength2; i++) {
-            Identifier i2 = a2[i];
-            PropertyName propertyName2 = PropertyName(i2);
-
-            JSValue prop2 = o2->get(globalObject, propertyName2);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (prop2.isUndefined()) {
-                continue;
-            }
-
-            PropertySlot slot1(o1, PropertySlot::InternalMethodType::HasProperty);
-            bool has = findEnumerableProperty(globalObject, o1, propertyName2, slot1);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (!has) {
-                return false;
-            }
-        }
-    }
-
-    return true;
+    return enumerablePropertiesEqual(deepEqualsMode<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>, globalObject, gcBuffer, stack, scope, o1, o2, a1, a2, checkPrototypes);
 }
 
 static bool isTemporalObject(JSC::JSObject* object)
@@ -1396,25 +1369,6 @@ static std::optional<bool> temporalObjectsDequal(JSC::JSObject* o1, JSC::JSObjec
         return false;
     return std::nullopt;
 }
-
-struct DeepEqualsMode {
-    bool isStrict;
-    bool enableAsymmetricMatchers;
-    bool checkPrototypes;
-    bool skipPrototypeIdentity;
-    bool (*deepEquals)(JSC::JSGlobalObject*, JSValue, JSValue, MarkedArgumentBuffer&, Vector<std::pair<JSValue, JSValue>, 16>&, ThrowScope&, bool);
-    bool (*nonIndexOwnPropertiesEqual)(JSC::JSGlobalObject*, MarkedArgumentBuffer&, Vector<std::pair<JSValue, JSValue>, 16>&, ThrowScope&, JSObject*, JSObject*);
-};
-
-template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
-static constexpr DeepEqualsMode deepEqualsMode {
-    isStrict,
-    enableAsymmetricMatchers,
-    checkPrototypes,
-    skipPrototypeIdentity,
-    &Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>,
-    checkPrototypes ? &nonIndexOwnPropertiesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity> : nullptr,
-};
 
 // The per-type comparisons (Map, Set, Date, typed arrays, ...) are compiled once
 // and take the mode at runtime; only the dispatch and the plain-object tail in
@@ -1622,60 +1576,7 @@ static std::optional<bool> specialObjectsDequalSlow(const DeepEqualsMode& mode, 
             right->getPropertyNames(globalObject, a2, DontEnumPropertiesMode::Exclude);
             RETURN_IF_EXCEPTION(scope, {});
 
-            const size_t propertyArrayLength1 = a1.size();
-            const size_t propertyArrayLength2 = a2.size();
-            if (mode.isStrict) {
-                if (propertyArrayLength1 != propertyArrayLength2) {
-                    return false;
-                }
-            }
-
-            // take a property name from one, try to get it from both
-            size_t i;
-            for (i = 0; i < propertyArrayLength1; i++) {
-                Identifier i1 = a1[i];
-                if (i1 == vm.propertyNames->stack) continue;
-                PropertyName propertyName1 = PropertyName(i1);
-
-                JSValue prop1 = left->get(globalObject, propertyName1);
-                RETURN_IF_EXCEPTION(scope, {});
-                ASSERT(prop1);
-
-                JSValue prop2 = right->getIfPropertyExists(globalObject, propertyName1);
-                RETURN_IF_EXCEPTION(scope, {});
-
-                if (!mode.isStrict) {
-                    if (prop1.isUndefined() && prop2.isEmpty()) {
-                        continue;
-                    }
-                }
-
-                if (!prop2) {
-                    return false;
-                }
-
-                bool propertiesEqual = mode.deepEquals(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
-                RETURN_IF_EXCEPTION(scope, {});
-                if (!propertiesEqual) {
-                    return false;
-                }
-            }
-
-            // for the remaining properties in the other object, make sure they are undefined
-            for (; i < propertyArrayLength2; i++) {
-                Identifier i2 = a2[i];
-                if (i2 == vm.propertyNames->stack) continue;
-                PropertyName propertyName2 = PropertyName(i2);
-
-                JSValue prop2 = right->getIfPropertyExists(globalObject, propertyName2);
-                RETURN_IF_EXCEPTION(scope, {});
-
-                if (!prop2.isUndefined()) {
-                    return false;
-                }
-            }
-
-            return true;
+            return enumerablePropertiesEqual(mode, globalObject, gcBuffer, stack, scope, left, right, a1, a2, false, &vm.propertyNames->stack);
         }
         break;
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -719,6 +719,30 @@ static ALWAYS_INLINE bool hasExtraOwnProperties(JSC::Structure* structure)
         || hasIndexedProperties(structure->indexingType());
 }
 
+// Like getIfPropertyExists(), but a non-enumerable match counts as absent. The
+// callers iterate enumerable names only, so a non-enumerable property on the
+// other side must not satisfy one of them or the result would depend on the
+// argument order.
+static JSValue getEnumerablePropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, JSC::PropertyName propertyName)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    PropertySlot slot(object, PropertySlot::InternalMethodType::HasProperty);
+    bool hasProperty = object->getPropertySlot(globalObject, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!hasProperty)
+        return {};
+
+    if (slot.isTaintedByOpaqueObject()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, object->get(globalObject, propertyName));
+
+    if (slot.attributes() & PropertyAttribute::DontEnum)
+        return {};
+
+    RELEASE_AND_RETURN(scope, slot.getValue(globalObject, propertyName));
+}
+
 // node compares the non-index own properties of typed arrays as well;
 // only the node entry point (checkPrototypes) pays for this.
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity = false>
@@ -1128,18 +1152,13 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
                     JSValue left = o1->getDirect(entry.offset());
                     JSValue right;
-                    if constexpr (isStrict) {
-                        // Only an enumerable property on o2 can match an enumerable one on o1.
-                        // getDirect() alone would also find a non-enumerable property, which the
-                        // reverse loop skips, so the two objects would compare equal. Loose
-                        // comparison keeps matching either, as node does.
-                        unsigned o2Attributes = 0;
-                        PropertyOffset o2Offset = o2Structure->get(vm, JSC::PropertyName(entry.key()), o2Attributes);
-                        if (o2Offset != invalidOffset && !(o2Attributes & PropertyAttribute::DontEnum)) {
-                            right = o2->getDirect(o2Offset);
-                        }
-                    } else {
-                        right = o2->getDirect(vm, JSC::PropertyName(entry.key()));
+                    // Only an enumerable property on o2 can match an enumerable one on o1.
+                    // getDirect() alone would also find a non-enumerable property, which the
+                    // reverse loop skips, so the result would depend on the argument order.
+                    unsigned o2Attributes = 0;
+                    PropertyOffset o2Offset = o2Structure->get(vm, JSC::PropertyName(entry.key()), o2Attributes);
+                    if (o2Offset != invalidOffset && !(o2Attributes & PropertyAttribute::DontEnum)) {
+                        right = o2->getDirect(o2Offset);
                     }
 
                     if constexpr (!isStrict) {
@@ -1172,7 +1191,9 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                         }
 
                         // Membership check only; every left property is in `pairs` and compared below.
-                        if (o1->getDirectOffset(vm, JSC::PropertyName(entry.key())) == invalidOffset) {
+                        unsigned o1Attributes = 0;
+                        PropertyOffset o1Offset = o1Structure->get(vm, JSC::PropertyName(entry.key()), o1Attributes);
+                        if (o1Offset == invalidOffset || (o1Attributes & PropertyAttribute::DontEnum)) {
                             result = false;
                             return false;
                         }
@@ -1237,8 +1258,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     }
 
     // take a property name from one, try to get it from both
-    size_t i;
-    for (i = 0; i < propertyArrayLength1; i++) {
+    for (size_t i = 0; i < propertyArrayLength1; i++) {
         Identifier i1 = a1[i];
         PropertyName propertyName1 = PropertyName(i1);
 
@@ -1262,7 +1282,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             prop2 = slot2.getValue(globalObject, propertyName1);
             RETURN_IF_EXCEPTION(scope, false);
         } else {
-            prop2 = o2->getIfPropertyExists(globalObject, propertyName1);
+            prop2 = getEnumerablePropertyIfExists(globalObject, o2, propertyName1);
             RETURN_IF_EXCEPTION(scope, false);
         }
 
@@ -1281,16 +1301,24 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         if (!eql) return false;
     }
 
-    // for the remaining properties in the other object, make sure they are undefined
-    for (; i < propertyArrayLength2; i++) {
-        Identifier i2 = a2[i];
-        PropertyName propertyName2 = PropertyName(i2);
+    if constexpr (!isStrict) {
+        // Every defined enumerable property of o2 must be an enumerable property of o1.
+        // The values were compared above, because every such name is also in a1.
+        for (size_t i = 0; i < propertyArrayLength2; i++) {
+            Identifier i2 = a2[i];
+            PropertyName propertyName2 = PropertyName(i2);
 
-        JSValue prop2 = o2->getIfPropertyExists(globalObject, propertyName2);
-        RETURN_IF_EXCEPTION(scope, false);
+            JSValue prop2 = o2->get(globalObject, propertyName2);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (prop2.isUndefined()) {
+                continue;
+            }
 
-        if (!prop2.isUndefined()) {
-            return false;
+            JSValue prop1 = getEnumerablePropertyIfExists(globalObject, o1, propertyName2);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (!prop1) {
+                return false;
+            }
         }
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -785,8 +785,7 @@ static constexpr DeepEqualsMode deepEqualsMode {
     checkPrototypes ? &nonIndexOwnPropertiesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity> : nullptr,
 };
 
-// A non-enumerable match counts as absent. `ownOnly` skips the prototype chain.
-// The getter runs only when `value` is given.
+// A non-enumerable match counts as absent. The getter runs only when `value` is given.
 static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, JSC::PropertyName propertyName, bool ownOnly, JSValue* value)
 {
     VM& vm = globalObject->vm();
@@ -812,8 +811,7 @@ static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObj
     return true;
 }
 
-// Compares o1 and o2 by the enumerable names in a1 and a2. Loose mode treats an
-// undefined value as absent. `ownOnly` must match how the name lists were built.
+// Compares o1 and o2 by the enumerable names in a1 and a2. `ownOnly` must match how the lists were built.
 static bool enumerablePropertiesEqual(const DeepEqualsMode& mode, JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2, const JSC::PropertyNameArrayBuilder& a1, const JSC::PropertyNameArrayBuilder& a2, bool ownOnly, const Identifier* skipName = nullptr)
 {
     const size_t propertyArrayLength1 = a1.size();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -719,28 +719,26 @@ static ALWAYS_INLINE bool hasExtraOwnProperties(JSC::Structure* structure)
         || hasIndexedProperties(structure->indexingType());
 }
 
-// Like getIfPropertyExists(), but a non-enumerable match counts as absent. The
+// Finds `propertyName` on `object` (prototype chain included) like
+// getIfPropertyExists(), but a non-enumerable match counts as absent. The
 // callers iterate enumerable names only, so a non-enumerable property on the
 // other side must not satisfy one of them or the result would depend on the
-// argument order.
-static JSValue getEnumerablePropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, JSC::PropertyName propertyName)
+// argument order. On true, the value is in `slot`.
+static bool findEnumerableProperty(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, JSC::PropertyName propertyName, PropertySlot& slot)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    PropertySlot slot(object, PropertySlot::InternalMethodType::HasProperty);
     bool hasProperty = object->getPropertySlot(globalObject, propertyName, slot);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, false);
     if (!hasProperty)
-        return {};
+        return false;
 
+    // A Proxy reports no attributes. Its properties count as enumerable.
     if (slot.isTaintedByOpaqueObject()) [[unlikely]]
-        RELEASE_AND_RETURN(scope, object->get(globalObject, propertyName));
+        return true;
 
-    if (slot.attributes() & PropertyAttribute::DontEnum)
-        return {};
-
-    RELEASE_AND_RETURN(scope, slot.getValue(globalObject, propertyName));
+    return !(slot.attributes() & PropertyAttribute::DontEnum);
 }
 
 // node compares the non-index own properties of typed arrays as well;
@@ -1282,8 +1280,16 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             prop2 = slot2.getValue(globalObject, propertyName1);
             RETURN_IF_EXCEPTION(scope, false);
         } else {
-            prop2 = getEnumerablePropertyIfExists(globalObject, o2, propertyName1);
+            PropertySlot slot2(o2, PropertySlot::InternalMethodType::HasProperty);
+            bool has = findEnumerableProperty(globalObject, o2, propertyName1, slot2);
             RETURN_IF_EXCEPTION(scope, false);
+            if (has) {
+                if (slot2.isTaintedByOpaqueObject()) [[unlikely]]
+                    prop2 = o2->get(globalObject, propertyName1);
+                else
+                    prop2 = slot2.getValue(globalObject, propertyName1);
+                RETURN_IF_EXCEPTION(scope, false);
+            }
         }
 
         if constexpr (!isStrict) {
@@ -1314,9 +1320,10 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 continue;
             }
 
-            JSValue prop1 = getEnumerablePropertyIfExists(globalObject, o1, propertyName2);
+            PropertySlot slot1(o1, PropertySlot::InternalMethodType::HasProperty);
+            bool has = findEnumerableProperty(globalObject, o1, propertyName2, slot1);
             RETURN_IF_EXCEPTION(scope, false);
-            if (!prop1) {
+            if (!has) {
                 return false;
             }
         }

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -148,6 +148,68 @@ describe("Bun.deepEquals strict mode", () => {
   });
 });
 
+// A non-enumerable property must not satisfy an enumerable one on the other
+// side, in either argument order and on both the structure fast path and the
+// property-name slow path (objects with an accessor).
+describe("Bun.deepEquals with mixed enumerability", () => {
+  function nonEnumerable<T extends object>(object: T, key: PropertyKey, value: unknown): T {
+    Object.defineProperty(object, key, { value, enumerable: false });
+    return object;
+  }
+
+  // An accessor disables the structure fast path.
+  function withGetter<T extends object>(object: T): T {
+    Object.defineProperty(object, "g", { get: () => 1, enumerable: true });
+    return object;
+  }
+
+  const cases: [string, () => object, () => object][] = [
+    ["string key", () => ({ a: 1, h: 2 }), () => nonEnumerable({ a: 1 }, "h", 2)],
+    [
+      "symbol key",
+      () => ({ [Symbol.for("h")]: 2 }),
+      () => nonEnumerable({}, Symbol.for("h"), 2),
+    ],
+    ["nested", () => ({ x: { a: 1, h: 2 } }), () => ({ x: nonEnumerable({ a: 1 }, "h", 2) })],
+    ["inside an array", () => [{ a: 1, h: 2 }], () => [nonEnumerable({ a: 1 }, "h", 2)]],
+    [
+      "undefined enumerable next to a non-enumerable value",
+      () => ({ k: 2 }),
+      () => nonEnumerable({ a: undefined }, "k", 2),
+    ],
+    ["slow path", () => withGetter({ a: 1, h: 2 }), () => withGetter(nonEnumerable({ a: 1 }, "h", 2))],
+    [
+      "slow path, undefined enumerable next to a missing key",
+      () => withGetter({ a: 1, b: 1 }),
+      () => withGetter({ a: 1, x: undefined }),
+    ],
+  ];
+
+  it.each(cases)("%s is not equal in either direction", (_, makeA, makeB) => {
+    for (const strict of [false, true]) {
+      expect(Bun.deepEquals(makeA(), makeB(), strict)).toBe(false);
+      expect(Bun.deepEquals(makeB(), makeA(), strict)).toBe(false);
+    }
+  });
+
+  it("toEqual and toContainEqual reject it in either direction", () => {
+    const a = { a: 1, h: 2 };
+    const b = nonEnumerable({ a: 1 }, "h", 2);
+    expect(a).not.toEqual(b);
+    expect(b).not.toEqual(a);
+    expect([a]).not.toContainEqual(b);
+    expect([b]).not.toContainEqual(a);
+  });
+
+  it("still ignores non-enumerable properties present on both sides", () => {
+    const a = nonEnumerable({ a: 1 }, "h", 2);
+    const b = nonEnumerable({ a: 1 }, "h", 3);
+    expect(Bun.deepEquals(a, b)).toBe(true);
+    expect(Bun.deepEquals(a, b, true)).toBe(true);
+    expect(Bun.deepEquals(withGetter(a), withGetter(b))).toBe(true);
+  });
+});
+
 // The object fast path used to recurse into nested values while walking the
 // structure's PropertyTable; a getter on a nested object that added or removed
 // properties on the parent rehashed that table and freed the vector being

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -231,6 +231,17 @@ describe("Bun.deepEquals with mixed enumerability", () => {
     expect(Bun.deepEquals(a, b, true)).toBe(true);
     const c = Object.create(Object.getPrototypeOf(process));
     expect(Bun.deepEquals(c, Object.getPrototypeOf(process))).toBe(true);
+
+    // The shadowed name still counts in the name list, so the list lengths
+    // match here although the own keys differ.
+    const far = { s: 1 };
+    const mid = nonEnumerable(Object.create(far), "s", 1);
+    const shadowed = withGetter(Object.assign(Object.create(mid), { a: 1 }));
+    const extra = withGetter({ a: 1, extra: 9 });
+    expect(Bun.deepEquals(shadowed, extra, true)).toBe(false);
+    expect(Bun.deepEquals(extra, shadowed, true)).toBe(false);
+    expect(Bun.deepEquals(shadowed, extra)).toBe(false);
+    expect(Bun.deepEquals(extra, shadowed)).toBe(false);
   });
 
   it("still ignores non-enumerable properties present on both sides", () => {

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -183,6 +183,13 @@ describe("Bun.deepEquals with mixed enumerability", () => {
       () => withGetter({ a: 1, b: 1 }),
       () => withGetter({ a: 1, x: undefined }),
     ],
+    ["Error", () => Object.assign(new Error("m"), { h: 2 }), () => nonEnumerable(new Error("m"), "h", 2)],
+    [
+      "array symbol key",
+      () => Object.assign([1], { [Symbol.for("h")]: 2 }),
+      () => nonEnumerable([1], Symbol.for("h"), 2),
+    ],
+    ["array symbol key missing on one side", () => Object.assign([1], { [Symbol.for("h")]: 2 }), () => [1]],
   ];
 
   it.each(cases)("%s is not equal in either direction", (_, makeA, makeB) => {
@@ -199,6 +206,21 @@ describe("Bun.deepEquals with mixed enumerability", () => {
     expect(b).not.toEqual(a);
     expect([a]).not.toContainEqual(b);
     expect([b]).not.toContainEqual(a);
+  });
+
+  it("ignores an undefined property on the slow path in either direction", () => {
+    const withExtra = () => Object.assign(new Error("boom"), { extra: undefined, code: "E" });
+    const withoutExtra = () => Object.assign(new Error("boom"), { code: "E" });
+    expect(Bun.deepEquals(withExtra(), withoutExtra())).toBe(true);
+    expect(Bun.deepEquals(withoutExtra(), withExtra())).toBe(true);
+    expect(Bun.deepEquals(withExtra(), withoutExtra(), true)).toBe(false);
+    expect(Bun.deepEquals(withoutExtra(), withExtra(), true)).toBe(false);
+
+    const frozen = Object.freeze({ a: 1, b: undefined, nested: { d: 1, e: undefined } });
+    expect(Bun.deepEquals(frozen, Object.freeze({ a: 1, nested: { d: 1 } }))).toBe(true);
+    expect(Bun.deepEquals(Object.freeze({ a: 1, nested: { d: 1 } }), frozen)).toBe(true);
+    expect(Bun.deepEquals(withGetter({ a: 1, x: undefined }), withGetter({ a: 1 }))).toBe(true);
+    expect(Bun.deepEquals(withGetter({ a: 1 }), withGetter({ a: 1, x: undefined }))).toBe(true);
   });
 
   it("still ignores non-enumerable properties present on both sides", () => {

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -165,11 +165,7 @@ describe("Bun.deepEquals with mixed enumerability", () => {
 
   const cases: [string, () => object, () => object][] = [
     ["string key", () => ({ a: 1, h: 2 }), () => nonEnumerable({ a: 1 }, "h", 2)],
-    [
-      "symbol key",
-      () => ({ [Symbol.for("h")]: 2 }),
-      () => nonEnumerable({}, Symbol.for("h"), 2),
-    ],
+    ["symbol key", () => ({ [Symbol.for("h")]: 2 }), () => nonEnumerable({}, Symbol.for("h"), 2)],
     ["nested", () => ({ x: { a: 1, h: 2 } }), () => ({ x: nonEnumerable({ a: 1 }, "h", 2) })],
     ["inside an array", () => [{ a: 1, h: 2 }], () => [nonEnumerable({ a: 1 }, "h", 2)]],
     [

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -1,4 +1,5 @@
 import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import EventEmitter from "node:events";
 import vm from "node:vm";
 
 describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
@@ -217,6 +218,19 @@ describe("Bun.deepEquals with mixed enumerability", () => {
     expect(Bun.deepEquals(Object.freeze({ a: 1, nested: { d: 1 } }), frozen)).toBe(true);
     expect(Bun.deepEquals(withGetter({ a: 1, x: undefined }), withGetter({ a: 1 }))).toBe(true);
     expect(Bun.deepEquals(withGetter({ a: 1 }), withGetter({ a: 1, x: undefined }))).toBe(true);
+  });
+
+  // getPropertyNames lists EventEmitter.prototype.constructor (enumerable) for a
+  // subclass instance, although the subclass prototype shadows it with a
+  // non-enumerable constructor. Both sides must treat that name the same way.
+  it("treats a chain name shadowed by a non-enumerable property the same on both sides", () => {
+    class Foo extends EventEmitter {}
+    const a = withGetter(new Foo());
+    const b = withGetter(new Foo());
+    expect(Bun.deepEquals(a, b)).toBe(true);
+    expect(Bun.deepEquals(a, b, true)).toBe(true);
+    const c = Object.create(Object.getPrototypeOf(process));
+    expect(Bun.deepEquals(c, Object.getPrototypeOf(process))).toBe(true);
   });
 
   it("still ignores non-enumerable properties present on both sides", () => {

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -1284,7 +1284,8 @@ describe("Bun.JSONL", () => {
         expect(({} as any).polluted).toBeUndefined();
         expect(({} as any).bad).toBeUndefined();
         // The keys should just be normal properties
-        expect(result[0]).toStrictEqual({ __proto__: { polluted: "yes" } });
+        expect(Object.keys(result[0])).toEqual(["__proto__"]);
+        expect(result[0]).toStrictEqual(JSON.parse('{"__proto__":{"polluted":"yes"}}'));
       });
 
       test("prototype pollution via nested __proto__", () => {

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -519,6 +519,13 @@ const cases: Case[] = [
     looseBug: "reports equal",
   },
   {
+    name: "{ x: 1 } and a Proxy of an object with a non-enumerable x",
+    a: () => ({ x: 1 }),
+    b: () => new Proxy(withHiddenProperty({ y: 1 }, "x", 1), {}),
+    strict: false,
+    loose: false,
+  },
+  {
     name: "an object with a non-enumerable x and { x: 1 }",
     a: () => withHiddenProperty({}, "x", 1),
     b: () => ({ x: 1 }),

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -511,6 +511,14 @@ const cases: Case[] = [
     loose: false,
   },
   {
+    name: "{ a: undefined } and an object with a non-enumerable a",
+    a: () => ({ a: undefined }),
+    b: () => withHiddenProperty({}, "a", 999),
+    strict: false,
+    loose: false,
+    looseBug: "reports equal",
+  },
+  {
     name: "an object with a non-enumerable x and { x: 1 }",
     a: () => withHiddenProperty({}, "x", 1),
     b: () => ({ x: 1 }),

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -509,7 +509,6 @@ const cases: Case[] = [
     b: () => withHiddenProperty({}, "x", 1),
     strict: false,
     loose: false,
-    looseBug: "reports equal",
   },
   {
     name: "an object with a non-enumerable x and { x: 1 }",
@@ -524,7 +523,6 @@ const cases: Case[] = [
     b: () => withHiddenProperty({ x: 1 }, "y", 2),
     strict: false,
     loose: false,
-    looseBug: "reports equal",
   },
   {
     name: "a Date and a Date subclass instance with the same time",
@@ -586,6 +584,7 @@ const cases: Case[] = [
     b: () => Object.defineProperty({}, sym, { value: 1, enumerable: false }),
     strict: false,
     loose: true,
+    looseBug: "reports not equal",
   },
   {
     name: "typed arrays differing only in a symbol property",


### PR DESCRIPTION
### Problem
- `Bun.deepEquals(a, b)` and `Bun.deepEquals(b, a)` return different results when a key is an enumerable own property on one side and a non-enumerable own property with the same value on the other. `toEqual`, `toContainEqual`, `toHaveBeenCalledWith` and `assert.deepEqual` inherit the asymmetry. Node and Jest reject both orders.
- The loose walk in `Bun__deepEquals` (`src/jsc/bindings/bindings.cpp`) resolves each enumerable name of the first object on the second with `getDirect()` or `getIfPropertyExists()`. Both also find a non-enumerable property. The strict walk got an enumerability check in #34434, the loose walk did not.
- The property-name slow path (objects with an accessor, Errors, array symbol keys) also checked the second object's extra names by index position, so `{ a: 1, x: undefined }` and `{ a: 1, b: 1 }` compared equal in one order only.

### Fix
- The structure fast path requires the matching property on the other side to be enumerable in loose mode too, in both directions.
- The object slow path, the Error branch and the array symbol block shared one copy-pasted name walk each. One helper, `enumerablePropertiesEqual`, now does the walk for all three: every name of the first object must be an enumerable property of the second, and in loose mode every name of the second that the first does not have must be undefined. The lookup helper `findEnumerableProperty` treats a non-enumerable match as absent.
- Verified: `test/js/bun/bun-object/deep-equals.test.ts` (13 new cases, 12 fail on bun 1.4.2) and `test/js/node/assert/deep-equal.test.ts` (two `looseBug` markers removed). Also `expect.test.js`, `util.test.js`, `toMatchObject`, `jest-extended`, mock and node `test-assert*` suites.
- Self-reviewed: 13 concerns raised, 4 addressed (the Error and array sites, the shared helper, the getter double call). The Error undefined-property case from #32486 is covered here.

### Background
- `Bun__deepEquals` is a template over `isStrict`, `enableAsymmetricMatchers` and `checkPrototypes` (the node entry point). The same code serves `Bun.deepEquals`, `expect().toEqual`, `toStrictEqual` and `node:assert`.
- Plain objects take a fast path that walks the `Structure` property table when both structures allow it. Otherwise the code builds two `PropertyNameArray` lists of enumerable names and compares by name.
- Loose mode treats a property whose value is `undefined` as absent (Jest semantics). That is why the loose walk cannot compare name counts and needs the reverse pass.

<details><summary>Notes</summary>

Repro on bun 1.4.2:

```js
const A = { a: 1, h: 2 };
const B = { a: 1 }; Object.defineProperty(B, "h", { value: 2, enumerable: false });
Bun.deepEquals(A, B); // true
Bun.deepEquals(B, A); // false
```

Node 26 `assert.deepEqual` throws both ways. Jest 30 `toEqual` fails both ways (own-enumerable key counts differ).

Sites that had their own copy of the walk before this change:
- object slow path (`getPropertyNames` lists, chain lookup)
- `ErrorInstanceType` branch in `specialObjectsDequalSlow` (skips `stack`)
- array non-index symbol block (own names only, no reverse pass at all, so `[1]` with an enumerable symbol key equalled `[1]` in one order)

`DeepEqualsMode` moved above `Bun__deepEquals` so the template paths can pass it to the shared helper.

`assert.deepEqual({ a: undefined }, b)` where `b.a` is a non-enumerable 999 now passes. On bun 1.4.2 it threw. Loose mode treats an undefined value as absent and, after this change, a non-enumerable property as absent too, so both sides have no `a`. Jest's `toEqual` agrees, node does not. The new `looseBug` row in the matrix records it.

One node matrix row changed from passing to `looseBug`: an enumerable symbol key against a non-enumerable one. Node loose mode ignores symbol keys entirely. Bun loose mode (Jest semantics) compares enumerable symbol keys. The row passed before only through the asymmetry, in one order.

The reverse pass checks membership on the first object before it reads the second, so a getter on a shared name runs once per side.

The name lists come from `getPropertyNames`, which collects enumerable names from the whole prototype chain. A non-enumerable property nearer the object can shadow such a name (`process`'s prototype has a non-enumerable `constructor`, `EventEmitter.prototype.constructor` is enumerable). The helper treats a name that resolves to a non-enumerable property as absent on that side, in both passes. That keeps `test/js/node/process/call-constructor.test.js` passing.

`test/js/bun/jsonl/jsonl-parse.test.ts` compared a parsed object that has an own `__proto__` key against the literal `{ __proto__: {...} }`, which sets the prototype instead. It passed through the non-enumerable `__proto__` accessor on `Object.prototype`. The expected value is now `JSON.parse` output, which has the own key.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->

