### PR TITLE
fetch: take an s3:// key as written, encode it once on the wire

### DIFF
--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1379,26 +1379,16 @@ impl Request {
             ))));
         }
 
-        // An `s3://` URL keeps its key bytes as written, so that
-        // `fetch(new Request(url))` addresses the same object as `fetch(url)`
-        // and `Bun.file(url)`: see `bun_url::is_s3_url`.
+        // An `s3://` URL keeps its key bytes as written, see `bun_url::is_s3_url`.
         if !bun_url::is_s3_url(req.url.get()) {
             let href = bun_url::href_from_string(req.url.get());
             if href.is_empty() {
-                // globalThis.throw can cause GC, which could cause the above string to be freed.
-                // so we must increment the reference count before calling it.
                 let err = global_this.err_invalid_url(format_args!(
                     "Failed to construct 'Request': Invalid URL \"{}\"",
                     req.url.get()
                 ));
                 bail!(Err(global_this.throw_value(err)));
             }
-
-            // hrefFromString increments the reference count if they end up being
-            // the same
-            //
-            // we increment the reference count on usage above, so we must
-            // decrement it to be perfectly balanced.
 
             req.url.set(href);
         }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1379,24 +1379,29 @@ impl Request {
             ))));
         }
 
-        let href = bun_url::href_from_string(req.url.get());
-        if href.is_empty() {
-            // globalThis.throw can cause GC, which could cause the above string to be freed.
-            // so we must increment the reference count before calling it.
-            let err = global_this.err_invalid_url(format_args!(
-                "Failed to construct 'Request': Invalid URL \"{}\"",
-                req.url.get()
-            ));
-            bail!(Err(global_this.throw_value(err)));
+        // An `s3://` URL keeps its key bytes as written, so that
+        // `fetch(new Request(url))` addresses the same object as `fetch(url)`
+        // and `Bun.file(url)`: see `bun_url::is_s3_url`.
+        if !bun_url::is_s3_url(req.url.get()) {
+            let href = bun_url::href_from_string(req.url.get());
+            if href.is_empty() {
+                // globalThis.throw can cause GC, which could cause the above string to be freed.
+                // so we must increment the reference count before calling it.
+                let err = global_this.err_invalid_url(format_args!(
+                    "Failed to construct 'Request': Invalid URL \"{}\"",
+                    req.url.get()
+                ));
+                bail!(Err(global_this.throw_value(err)));
+            }
+
+            // hrefFromString increments the reference count if they end up being
+            // the same
+            //
+            // we increment the reference count on usage above, so we must
+            // decrement it to be perfectly balanced.
+
+            req.url.set(href);
         }
-
-        // hrefFromString increments the reference count if they end up being
-        // the same
-        //
-        // we increment the reference count on usage above, so we must
-        // decrement it to be perfectly balanced.
-
-        req.url.set(href);
 
         if matches!(req.body_value(), BodyValue::Blob(_)) && req.headers.get().is_some() {
             if let BodyValue::Blob(blob) = req.body_value() {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -530,12 +530,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // immediately move that buffer into `url_proxy_buffer` and re-parse `url` to
     // borrow it.
     //
-    // An `s3://` URL is a bucket and a key, not a WHATWG URL. `Bun.file` and
-    // `S3Client.file` take the key bytes as written and the signer
-    // percent-encodes them once. The WHATWG serializer would percent-encode
-    // spaces and non-ASCII, drop `.`/`..` segments and strip tabs first, so
-    // `fetch` would then address a different object than `Bun.file` does.
-    let mut url_proxy_buffer = if url_str.starts_with_ascii(b"s3://") {
+    // An `s3://` URL skips the WHATWG serializer: see `bun_url::is_s3_url`.
+    let mut url_proxy_buffer = if bun_url::is_s3_url(&url_str) {
         url_str.to_utf8().to_vec()
     } else {
         let owned_url = match ZigURL::from_string(&url_str) {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -529,22 +529,32 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // `ZigURL::from_string` returns `OwnedURL` (owns href buffer); we
     // immediately move that buffer into `url_proxy_buffer` and re-parse `url` to
     // borrow it.
-    let owned_url = match ZigURL::from_string(&url_str) {
-        Ok(u) => u,
-        Err(_) => {
-            let err = ctx.to_type_error(
-                jsc::ErrorCode::INVALID_URL,
-                format_args!("fetch() URL is invalid"),
-            );
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
-        }
+    //
+    // An `s3://` URL is a bucket and a key, not a WHATWG URL. `Bun.file` and
+    // `S3Client.file` take the key bytes as written and the signer
+    // percent-encodes them once. The WHATWG serializer would percent-encode
+    // spaces and non-ASCII, drop `.`/`..` segments and strip tabs first, so
+    // `fetch` would then address a different object than `Bun.file` does.
+    let mut url_proxy_buffer = if url_str.starts_with_ascii(b"s3://") {
+        url_str.to_utf8().to_vec()
+    } else {
+        let owned_url = match ZigURL::from_string(&url_str) {
+            Ok(u) => u,
+            Err(_) => {
+                let err = ctx.to_type_error(
+                    jsc::ErrorCode::INVALID_URL,
+                    format_args!("fetch() URL is invalid"),
+                );
+                return Ok(
+                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                        global_this,
+                        err,
+                    ),
+                );
+            }
+        };
+        owned_url.into_href().into_vec()
     };
-    let mut url_proxy_buffer = owned_url.into_href().into_vec();
     let mut url = parse_url_detached!(&url_proxy_buffer[..]);
     if url.is_file() {
         url_type = URLType::File;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -528,9 +528,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     // `ZigURL::from_string` returns `OwnedURL` (owns href buffer); we
     // immediately move that buffer into `url_proxy_buffer` and re-parse `url` to
-    // borrow it.
-    //
-    // An `s3://` URL skips the WHATWG serializer: see `bun_url::is_s3_url`.
+    // borrow it. An `s3://` URL is kept as written, see `bun_url::is_s3_url`.
     let mut url_proxy_buffer = if bun_url::is_s3_url(&url_str) {
         url_str.to_utf8().to_vec()
     } else {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -191,12 +191,15 @@ pub use whatwg::{
 
 /// `s3://bucket/key` is a bucket and key bytes, not a WHATWG URL. The key is
 /// taken as written (spaces, non-ASCII, `%XX`, `.`/`..` segments, tabs) and
-/// the S3 signer percent-encodes it once. `fetch`, `Request` and `Bun.file`
-/// all use this check, so the same string addresses the same object. The
-/// scheme match is case-sensitive, the same as `Bun.file`.
+/// the S3 signer percent-encodes it once. `fetch` and `Request` skip the
+/// WHATWG serializer when this is true, so the string reaches the signer
+/// with the same key bytes as `Bun.file("s3://...")`, which checks the
+/// `s3://` prefix of its path bytes. The scheme match is case-insensitive,
+/// the same as [`URL::is_s3`], which decides whether `fetch` signs the
+/// request.
 #[inline]
 pub fn is_s3_url(input: &BunString) -> bool {
-    input.starts_with_ascii(b"s3://")
+    input.starts_with_ascii(b"s3://") || input.starts_with_ascii(b"S3://")
 }
 
 // URL is a pure view struct — every field is a slice into `href` (or a

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -189,9 +189,7 @@ pub use whatwg::{
     file_url_from_string, href_from_string, join, origin_from_slice, path_from_file_url,
 };
 
-/// `s3://bucket/key` holds raw key bytes, not a WHATWG URL: `fetch` and
-/// `Request` must not serialize it, or the S3 signer encodes the key twice.
-/// Case-insensitive like [`URL::is_s3`].
+/// `s3://bucket/key` holds raw key bytes: never URL-serialize it. Case-insensitive like [`URL::is_s3`].
 #[inline]
 pub fn is_s3_url(input: &BunString) -> bool {
     input.starts_with_ascii(b"s3://") || input.starts_with_ascii(b"S3://")

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -189,6 +189,16 @@ pub use whatwg::{
     file_url_from_string, href_from_string, join, origin_from_slice, path_from_file_url,
 };
 
+/// `s3://bucket/key` is a bucket and key bytes, not a WHATWG URL. The key is
+/// taken as written (spaces, non-ASCII, `%XX`, `.`/`..` segments, tabs) and
+/// the S3 signer percent-encodes it once. `fetch`, `Request` and `Bun.file`
+/// all use this check, so the same string addresses the same object. The
+/// scheme match is case-sensitive, the same as `Bun.file`.
+#[inline]
+pub fn is_s3_url(input: &BunString) -> bool {
+    input.starts_with_ascii(b"s3://")
+}
+
 // URL is a pure view struct — every field is a slice into `href` (or a
 // literal default).
 #[derive(Clone)]

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -189,14 +189,9 @@ pub use whatwg::{
     file_url_from_string, href_from_string, join, origin_from_slice, path_from_file_url,
 };
 
-/// `s3://bucket/key` is a bucket and key bytes, not a WHATWG URL. The key is
-/// taken as written (spaces, non-ASCII, `%XX`, `.`/`..` segments, tabs) and
-/// the S3 signer percent-encodes it once. `fetch` and `Request` skip the
-/// WHATWG serializer when this is true, so the string reaches the signer
-/// with the same key bytes as `Bun.file("s3://...")`, which checks the
-/// `s3://` prefix of its path bytes. The scheme match is case-insensitive,
-/// the same as [`URL::is_s3`], which decides whether `fetch` signs the
-/// request.
+/// `s3://bucket/key` holds raw key bytes, not a WHATWG URL: `fetch` and
+/// `Request` must not serialize it, or the S3 signer encodes the key twice.
+/// Case-insensitive like [`URL::is_s3`].
 #[inline]
 pub fn is_s3_url(input: &BunString) -> bool {
     input.starts_with_ascii(b"s3://") || input.starts_with_ascii(b"S3://")

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -2181,17 +2181,21 @@ describe("presigned url signature", () => {
   });
 });
 
-describe("s3:// url key encoding", () => {
+describe.concurrent("s3:// url key encoding", () => {
   // fetch("s3://..."), fetch(new Request("s3://...")), Bun.file("s3://...")
   // and S3Client.file(key) must address the same object: the key bytes after
   // "s3://bucket/" are taken as written and percent-encoded once on the wire.
+  // fetch signs an "S3://" URL too, so the scheme check is case-insensitive
+  // there. Bun.file("S3://...") is a local path, so that row skips it.
   it.each([
-    ["my file.txt", "/bkt/my%20file.txt"],
-    ["\u00fc.txt", "/bkt/%C3%BC.txt"],
-    ["my%20file.txt", "/bkt/my%2520file.txt"],
-    ["dir/../x.txt", "/bkt/dir/../x.txt"],
-    ["a\tb", "/bkt/a%09b"],
-  ])("fetch, Request, Bun.file and S3Client.file send the same path for key %j", async (key, expectedPath) => {
+    ["s3://", "my file.txt", "/bkt/my%20file.txt"],
+    ["s3://", "\u00fc.txt", "/bkt/%C3%BC.txt"],
+    ["s3://", "my%20file.txt", "/bkt/my%2520file.txt"],
+    ["s3://", "dir/../x.txt", "/bkt/dir/../x.txt"],
+    ["s3://", "a\tb", "/bkt/a%09b"],
+    ["S3://", "my file.txt", "/bkt/my%20file.txt"],
+  ])("fetch, Request, Bun.file and S3Client.file send the same path for %s%j", async (scheme, key, expectedPath) => {
+    const viaFile = scheme === "s3://";
     const fixture = `
       const http = require("node:http");
       const seen = [];
@@ -2213,11 +2217,13 @@ describe("s3:// url key encoding", () => {
         virtualHostedStyle: false,
       };
       const key = ${JSON.stringify(key)};
-      const url = "s3://bkt/" + key;
+      const url = ${JSON.stringify(scheme)} + "bkt/" + key;
       await (await fetch(url, { s3: options })).text();
       await (await fetch(new Request(url), { s3: options })).text();
-      await Bun.file(url, options).text();
-      await new Bun.S3Client({ ...options, bucket: "bkt" }).file(key).text();
+      if (${viaFile}) {
+        await Bun.file(url, options).text();
+        await new Bun.S3Client({ ...options, bucket: "bkt" }).file(key).text();
+      }
       server.close();
       console.log(JSON.stringify(seen));
     `;
@@ -2230,7 +2236,7 @@ describe("s3:// url key encoding", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual([expectedPath, expectedPath, expectedPath, expectedPath]);
+    expect(JSON.parse(stdout.trim())).toEqual(Array(viaFile ? 4 : 2).fill(expectedPath));
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1786,7 +1786,8 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The S3 client honors the proxy environment; the stub is on loopback.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -2121,7 +2122,8 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The S3 client honors the proxy environment; the stub is on loopback.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1845,7 +1845,8 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The S3 client honors the proxy environment; the stub is on loopback.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -2041,7 +2042,8 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The S3 client honors the proxy environment; the stub is on loopback.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -2182,16 +2182,16 @@ describe("presigned url signature", () => {
 });
 
 describe("s3:// url key encoding", () => {
-  // fetch("s3://...") must address the same object as Bun.file("s3://...")
-  // and S3Client.file(key): the key bytes after "s3://bucket/" are taken as
-  // written and percent-encoded exactly once on the wire.
+  // fetch("s3://..."), fetch(new Request("s3://...")), Bun.file("s3://...")
+  // and S3Client.file(key) must address the same object: the key bytes after
+  // "s3://bucket/" are taken as written and percent-encoded once on the wire.
   it.each([
     ["my file.txt", "/bkt/my%20file.txt"],
     ["\u00fc.txt", "/bkt/%C3%BC.txt"],
     ["my%20file.txt", "/bkt/my%2520file.txt"],
     ["dir/../x.txt", "/bkt/dir/../x.txt"],
     ["a\tb", "/bkt/a%09b"],
-  ])("fetch, Bun.file and S3Client.file send the same path for key %j", async (key, expectedPath) => {
+  ])("fetch, Request, Bun.file and S3Client.file send the same path for key %j", async (key, expectedPath) => {
     const fixture = `
       const http = require("node:http");
       const seen = [];
@@ -2215,6 +2215,7 @@ describe("s3:// url key encoding", () => {
       const key = ${JSON.stringify(key)};
       const url = "s3://bkt/" + key;
       await (await fetch(url, { s3: options })).text();
+      await (await fetch(new Request(url), { s3: options })).text();
       await Bun.file(url, options).text();
       await new Bun.S3Client({ ...options, bucket: "bkt" }).file(key).text();
       server.close();
@@ -2229,7 +2230,7 @@ describe("s3:// url key encoding", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual([expectedPath, expectedPath, expectedPath]);
+    expect(JSON.parse(stdout.trim())).toEqual([expectedPath, expectedPath, expectedPath, expectedPath]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -2180,3 +2180,56 @@ describe("presigned url signature", () => {
     }
   });
 });
+
+describe("s3:// url key encoding", () => {
+  // fetch("s3://...") must address the same object as Bun.file("s3://...")
+  // and S3Client.file(key): the key bytes after "s3://bucket/" are taken as
+  // written and percent-encoded exactly once on the wire.
+  it.each([
+    ["my file.txt", "/bkt/my%20file.txt"],
+    ["\u00fc.txt", "/bkt/%C3%BC.txt"],
+    ["my%20file.txt", "/bkt/my%2520file.txt"],
+    ["dir/../x.txt", "/bkt/dir/../x.txt"],
+    ["a\tb", "/bkt/a%09b"],
+  ])("fetch, Bun.file and S3Client.file send the same path for key %j", async (key, expectedPath) => {
+    const fixture = `
+      const http = require("node:http");
+      const seen = [];
+      // node:http exposes the raw request target; Bun.serve normalizes it.
+      const server = http.createServer((req, res) => {
+        seen.push(req.url.split("?")[0]);
+        req.resume();
+        req.on("end", () => {
+          res.setHeader("ETag", '"x"');
+          res.end("body");
+        });
+      });
+      await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+      const options = {
+        accessKeyId: "test",
+        secretAccessKey: "test",
+        region: "eu-west-3",
+        endpoint: "http://127.0.0.1:" + server.address().port,
+        virtualHostedStyle: false,
+      };
+      const key = ${JSON.stringify(key)};
+      const url = "s3://bkt/" + key;
+      await (await fetch(url, { s3: options })).text();
+      await Bun.file(url, options).text();
+      await new Bun.S3Client({ ...options, bucket: "bkt" }).file(key).text();
+      server.close();
+      console.log(JSON.stringify(seen));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      // The S3 client honors the proxy environment; the stub is on loopback.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual([expectedPath, expectedPath, expectedPath]);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `fetch("s3://bkt/my file.txt")` sends `GET /bkt/my%2520file.txt`. `Bun.file("s3://bkt/my file.txt")` and `S3Client.file("my file.txt")` send `GET /bkt/my%20file.txt`. The same string addresses two different objects. Via `fetch` no spelling reaches a key with a space or a `%`. `dir/../x.txt` collapses to `x.txt` and a tab is dropped.
- `fetch` ran the string through the WHATWG URL serializer (`src/runtime/webcore/fetch.rs:532`), which percent-encodes the key, and the S3 signer (`src/s3_signing/credentials.rs:372`) encoded it again. `new Request("s3://...")` did the same at `src/runtime/webcore/Request.rs:1382`. `Bun.file` never URL-parses the string.

### Fix
- `bun_url::is_s3_url` is one check for an `s3://` string (case-insensitive, the same as `URL::is_s3`, which decides whether `fetch` signs the request). `fetch(string)` and the `Request` constructor skip the URL serializer when it matches and keep the key bytes as written. The signer encodes them once, the same as `Bun.file` and `S3Client.file`.
- Correct because an S3 key is a byte string, not a URL path. `S3Client.file` already works this way, and the docs present `fetch("s3://...")` and `Bun.file("s3://...")` as interchangeable.
- Wire paths before and after, for `s3://bkt/<key>` via `fetch` (`Bun.file` sends the "after" path in both versions):
  `my file.txt`: `/bkt/my%2520file.txt` -> `/bkt/my%20file.txt`
  `ü.txt`: `/bkt/%25C3%25BC.txt` -> `/bkt/%C3%BC.txt`
  `my%20file.txt`: `/bkt/my%2520file.txt` -> `/bkt/my%2520file.txt` (unchanged)
  `dir/../x.txt`: `/bkt/x.txt` -> `/bkt/dir/../x.txt`
  `a\tb`: `/bkt/ab` -> `/bkt/a%09b`
- Verified: `test/js/bun/s3/s3.test.ts` ("s3:// url key encoding", 6 cases, 5 fail on the released bun). Also the rest of `test/js/bun/s3/`, `test/js/web/fetch/fetch.test.ts` and `test/js/web/request/` (no new failures).

### Background
- SigV4 signing builds a canonical request from the percent-encoded key. `encode_uri_component` in `src/s3_signing/credentials.rs` encodes every byte except the RFC 3986 unreserved set, so a key that is already encoded is encoded twice.
- `Bun.file("s3://...")` stores the raw string. `S3::path()` in `src/jsc/webcore_types.rs` runs the non-normalizing `bun_url::URL::parse` on it and takes everything after `s3://`.
- `fetch` needs a normalized href for `http(s)://`. The `s3://` branch never uses the host or path fields. It only reads `url.s3_path()`, the bytes after the scheme.

<details><summary>Notes</summary>

- Migration note: an object written through `fetch(..., { method: "PUT" })` with a key that has a space or non-ASCII byte lives under the doubly encoded key (`report%202026.pdf` for `report 2026.pdf`). After this change `fetch` reads and writes `report 2026.pdf`, the same key `Bun.file` always used. To reach the old object, pass the doubly encoded spelling (`report%25202026.pdf`).
- `fetch(new URL("s3://bkt/a b"))` is unchanged. A `URL` object is already serialized when it reaches `fetch`.
- `fetch("S3://bkt/a b")` is covered too. `Bun.file("S3://...")` is a local path, so the uppercase test row checks `fetch` and `Request` only.
- `new Request("s3://bkt/a b").url` now returns the string as written. `Request.clone()` and `new Request(request)` carry it through.
- Edge cases checked: `s3://`, `s3://bkt` and `s3://bkt/` reject with `ERR_S3_INVALID_PATH` from both `fetch` and `Bun.file`. PUT with a string body, PUT with a `ReadableStream` body and DELETE via `fetch` all send the single-encoded path.
- Self-reviewed: 3 concerns raised, 3 addressed (the `Request` constructor path, one shared check in `bun_url`, a case-insensitive scheme match).
- `test/js/web/request/request-method-getter.test.ts` and `request-clone-leak.test.ts` time out at 5 s in this debug container with and without the change.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3.test.ts"
bun test v1.4.3 (f42e98025)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check i
... (truncated)

release without fix: 286 skipped
bun test v1.4.3-canary.1 (966da26fe)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key does not exist
(skip) R2 > s3 > Bun.S3Client > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3.test.ts"
bun test v1.4.3 (f42e98025)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check i
... (truncated)

release with fix: 286 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1034ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/38] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/38] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Request.rs | 29 +++++++----------
 src/runtime/webcore/fetch.rs   | 36 +++++++++++----------
 src/url/lib.rs                 |  6 ++++
 test/js/bun/s3/s3.test.ts      | 72 +++++++++++++++++++++++++++++++++++++++---
 4 files changed, 106 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/runtime/webcore/Request.rs      2      2     24
src/runtime/webcore/fetch.rs        5      4     24
src/url/lib.rs                      3      4     24
test/js/bun/s3/s3.test.ts           1      0     24
```

</details>

<!-- robobun:evidence:end -->