### PR TITLE
js_parser: drop a TypeScript import whose clause binds nothing

### DIFF
--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -118,9 +118,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut items = bun_alloc::ArenaVec::<ClauseItem>::new_in(p.arena);
         p.lexer.expect(T::TOpenBrace)?;
         let mut is_single_line = !p.lexer.has_newline_before;
-        // this variable should not exist if we're not in a typescript file
-        // Declared unconditionally — dead-store elim removes it when !TS.
-        let mut had_type_only_imports = false;
 
         while p.lexer.token != T::TCloseBrace {
             // The alias may be a keyword;
@@ -160,7 +157,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if p.lexer.token == T::TIdentifier {
                             // "import { type as as as } from 'mod'"
                             // "import { type as as foo } from 'mod'"
-                            had_type_only_imports = true;
                             p.lexer.next()?;
                         } else {
                             // "import { type as as } from 'mod'"
@@ -173,8 +169,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             });
                         }
                     } else if p.lexer.token == T::TIdentifier {
-                        had_type_only_imports = true;
-
                         // "import { type as xxx } from 'mod'"
                         original_name = p.lexer.identifier;
                         name = LocRef {
@@ -220,7 +214,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // An import where the name is a keyword must have an alias
                         p.lexer.expected_string(b"\"as\"")?;
                     }
-                    had_type_only_imports = true;
                 }
             } else {
                 if p.lexer.is_contextual_keyword(b"as") {
@@ -280,11 +273,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ImportClause {
             items: items.into_bump_slice_mut(),
             is_single_line,
-            had_type_only_imports: if TYPESCRIPT {
-                had_type_only_imports
-            } else {
-                false
-            },
         })
     }
 

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1463,7 +1463,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 let import_clause = p.parse_import_clause()?;
                 if Self::IS_TYPESCRIPT_ENABLED {
-                    if import_clause.had_type_only_imports && import_clause.items.is_empty() {
+                    // tsc drops a clause that binds nothing. Only a bare `import "x"` runs for effect.
+                    if import_clause.items.is_empty() {
                         p.lexer.expect_contextual_keyword(b"from")?;
                         let _ = p.parse_path()?;
                         p.lexer.expect_or_insert_semicolon()?;

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1330,7 +1330,6 @@ pub(crate) struct ImportClause<'a> {
     /// (`S::Import.items: StoreSlice<ClauseItem>`).
     pub(crate) items: &'a mut [js_ast::ClauseItem],
     pub(crate) is_single_line: bool,
-    pub(crate) had_type_only_imports: bool,
 }
 
 pub struct PropertyOpts {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -445,6 +445,39 @@ describe("Bun.Transpiler", () => {
       exp("export import type = require('mod'); type", 'export const type = require("mod");\n');
     });
 
+    it("an import clause with no bindings is dropped like tsc does", async () => {
+      const exp = ts.expectPrinted_;
+
+      // tsc keeps only the bare `import "x"` form as a side-effect import
+      exp("import {} from 'bar'; x", "x;\n");
+      exp("import { } from 'bar'; x", "x;\n");
+      exp("import {} from 'bar';\nimport 'bar'; x", 'import"bar";\nx;\n');
+      exp("import foo, {} from 'bar'; foo", 'import foo from "bar";\nfoo;\n');
+      exp("import 'bar'; x", 'import"bar";\nx;\n');
+
+      // JavaScript has no type-only bindings, so the statement is kept
+      const js = new Bun.Transpiler({ loader: "js" });
+      expect(js.transformSync("import {} from 'bar'; x")).toBe('import"bar";\nx;\n');
+
+      using dir = tempDir("ts-empty-import-clause", {
+        "polyfill.ts": `(globalThis as any).__polyfilled = true; export {};`,
+        "index.ts": `
+          import {} from "./polyfill.ts";
+          console.log("polyfilled:", (globalThis as any).__polyfilled === true);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("polyfilled: false\n");
+      expect(exitCode).toBe(0);
+    });
+
     it("runs TypeScript that tsc accepts at these parse edges", async () => {
       using dir = tempDir("ts-parse-edges", {
         "mod.ts": "export default 'default export';",


### PR DESCRIPTION
### Problem
- In a `.ts` file, `import {} from "./polyfill.ts"` is kept and the module runs. tsc and esbuild drop it. The same sources behave differently under `bun run` and under a tsc or esbuild build.
- tsc drops an import declaration that has an import clause with no value bindings. Only the bare `import "x"` form is a side-effect import. bun already drops `import { type T } from "x"`, but an empty clause fell through to the side-effect path (`parse_stmt.rs`, the `T::TOpenBrace` arm of `t_import`).

### Fix
- An empty import clause in a TypeScript file is now treated like a type-only clause: the statement parses to `S::TypeScript` and emits nothing. `import foo, {} from "x"` is unchanged, since the default binding decides it.
- JavaScript files are unchanged. They have no type-only bindings, so `import {} from "x"` still runs the module, as esbuild does.
- The `had_type_only_imports` field of `ImportClause` had no other reader, so it is removed.
- Verified: `test/bundler/transpiler/transpiler.test.js` (new `an import clause with no bindings is dropped like tsc does` test, fails on 1.4.3). Also `test/bundler/esbuild/ts.test.ts`, `test/bundler/esbuild/importstar_ts.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/js/bun/typescript/`.

### Background
- TypeScript cannot tell a value import from a type import without a checker, so its isolated emit drops any import whose bindings are all unused or type-only. An empty clause is the degenerate case of that rule.
- esbuild tracks "had a clause" separately from "has items" and drops the statement in TypeScript files. bun's `S::Import` stores only the items, so the decision moves to the parser, next to the existing type-only elision.

<details><summary>Notes</summary>

Repro from the report:

```ts
// polyfill.ts
(globalThis as any).__polyfilled = true; export {};
// main.ts
import {} from "./polyfill.ts";
console.log("polyfilled:", (globalThis as any).__polyfilled === true);
```

tsc 6.0.3 + node and esbuild 0.28.1: `polyfilled: false`. bun 1.4.3: `polyfilled: true`. bun with this change: `polyfilled: false`.

`Bun.Transpiler` output for the covered forms (loader `ts`):

```
import {} from 'bar'; x            ->  x;
import { } from 'bar'; x           ->  x;
import {} from 'bar'; import 'bar' ->  import"bar";
import foo, {} from 'bar'; foo     ->  import foo from "bar"; foo;
import 'bar'; x                    ->  import"bar"; x;
```
</details>
