### PR TITLE
test: fix the TERM race in the parallel crash-grandchild fixture

### DIFF
--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1400,7 +1400,13 @@ test.skipIf(isWindows)(
     // answer kill(pid, 0). It records its own termination instead. A shell
     // keeps its startup out of the timing; the trap is armed before the pid
     // is logged.
-    const grandchild = `trap 'echo terminated=$$ >> "$PIDS"; exit 0' TERM; echo grandchild=$$ >> "$PIDS"; while :; do sleep 60; done`;
+    //
+    // The shell must not block on a foreground child: the trap would wait for
+    // the child to exit. A `sleep` forked just before the group SIGTERM lands
+    // still has the shell's handler installed and swallows the signal, then
+    // runs for its full duration. `wait` returns as soon as a trapped signal
+    // arrives, and SIGKILL is the one signal that child cannot swallow.
+    const grandchild = `trap 'kill -9 $! 2>/dev/null; echo terminated=$$ >> "$PIDS"; exit 0' TERM; echo grandchild=$$ >> "$PIDS"; sleep 60 & wait`;
     const crasher = (how: string) => `
     import { test } from "bun:test";
     test("spawn then die", async () => {


### PR DESCRIPTION
### Problem
- `test/cli/test/parallel.test.ts` "--parallel: a worker that dies mid-file takes the processes its test spawned with it" is red on main. In build 110937 (alpine 3.23 x64) one of the two grandchild shells never logged `terminated=` within the 3 s poll, so `expect(terminated.sort()).toEqual(grandchildren.sort())` at `parallel.test.ts:1464` failed. The test landed with #41467.
- The fixture is the race. The grandchild is `sh -c 'trap ... TERM; echo grandchild=$$; while :; do sleep 60; done'`. The shell forks `sleep 60` right after it logs its pid. The coordinator's `kill(-pgid, SIGTERM)` can land while that child is still between `fork` and `exec`. The child still has the shell's trap handler, so it swallows the signal and runs `sleep` for 60 s. The parent shell got its own SIGTERM, but a shell runs a trap only after the foreground command returns. Reproduced outside bun with a 1 ms poll: 13 of 300 misses with busybox sh, 22 of 300 with dash, 6 of 300 with bash.

### Fix
- The grandchild now runs `sleep 60 & wait`. `wait` returns as soon as a trapped signal arrives (POSIX), so the trap runs at once no matter what the `sleep` child did with its copy of the signal.
- The trap sends SIGKILL to `$!` first. SIGKILL is the one signal the pre-exec child cannot swallow, so no `sleep 60` outlives the test.
- The test still exercises the same code path: the coordinator's SIGTERM to the dead worker's process group in `reap_worker`. bun 1.4.3 (no #41467) still fails it. The 3 s poll and every assertion are unchanged.
- Verified: the same stress probe gives 0 misses in 500 runs for busybox sh, 500 for dash, 300 for bash, and no leaked `sleep`. `bun bd test test/cli/test/parallel.test.ts` passes the case 6 of 6 times with busybox sh first on PATH.

### Background
- Under `--parallel` each worker leads its own process group. When a worker dies with a file in flight, the coordinator sends SIGTERM to that group so the processes the test spawned do not outlive the run (#41467).
- A shell defers a trap while a foreground command runs. It handles a trapped signal immediately only inside the `wait` builtin.
- Between `fork` and `exec` a child shares the parent's signal dispositions. A caught signal delivered in that window runs the inherited handler and is gone.

<details><summary>Notes</summary>

Stress probe (not in the repo): spawn `setsid sh -c <grandchild>`, poll the pid file every 1 ms, `kill(-pid, SIGTERM)` as soon as `grandchild=` shows, then poll 3 s for `terminated=`. Old fixture, in this container: busybox 1.38 static musl 13/300, dash 22/300, bash 6/300 misses. Every miss left a `sleep 60` with PPID 1 alive. New fixture: 0/500, 0/500, 0/300, no leaked `sleep`.

The real test polls at 10 ms in the worker and the coordinator reaps after it drains the IPC pipe, so the window is hit less often than in the probe. A loaded CI box widens it.

The `--parallel: each worker has a unique JEST_WORKER_ID` case flakes on a debug build with or without this change (its 200 ms fixture sleep is shorter than debug worker startup). #41467 recorded the same. Release lanes are not affected.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts

<!-- robobun:evidence:end -->