### PR TITLE
docs: correct the defaults for minimumReleaseAge and coverageSkipTestFiles

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -355,10 +355,9 @@ concurrentScripts = 16 # (cpu count or GOMAXPROCS) x2
 # - configVersion = 0: "hoisted"
 linker = "hoisted"
 
-
-# minimum age config
-minimumReleaseAge = 259200 # seconds
-minimumReleaseAgeExcludes = ["@types/node", "typescript"]
+# minimum release age is off by default. To turn it on, set an age in seconds:
+# minimumReleaseAge = 259200
+# minimumReleaseAgeExcludes = ["@types/node", "typescript"]
 ```
 
 ### Configuring with environment variables

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -239,7 +239,7 @@ coverageThreshold = { lines = 0.7, functions = 0.8 }
 
 ### `test.coverageSkipTestFiles`
 
-Whether to skip test files when computing coverage statistics. Default `false`.
+Whether to skip test files when computing coverage statistics. Default `true`. Set it to `false` to include test files in the report.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]


### PR DESCRIPTION
### Problem
- `docs/pm/cli/install.mdx` introduces a bunfig sample with "These are the default values:" and lists `minimumReleaseAge = 259200` and `minimumReleaseAgeExcludes = [...]` in it. The feature is off unless the key is set (`minimum_release_age_ms: None` in the install options). The bunfig reference page already says `null` / `[]`.
- `docs/runtime/bunfig.mdx` says `coverageSkipTestFiles` defaults to `false`. Shipped builds default to `true`: `CodeCoverageOptions::default()` sets `skip_test_files: !bun_core::env::ALLOW_ASSERT` (`src/options_types/code_coverage_options.rs:44`). `docs/test/code-coverage.mdx` already says `true`.

### Fix
- Install page: show the two minimum release age keys as a commented example with a note that the feature is off by default.
- Bunfig reference: state the default as `true` and say what `false` does.
- Verified with bun 1.4.3: `bun test --coverage` on a two-file fixture lists only `lib.ts`, so the test file is skipped by default. `bun install` against a stub registry with no `minimumReleaseAge` key installs a version published seconds ago.

### Background
- `ALLOW_ASSERT` is true in debug, test, and release-safe builds. So a debug build of bun includes test files in coverage by default while a shipped binary skips them. This PR only fixes the docs for the shipped default. It does not change the code.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->