### PR TITLE
node:http2: add the hidden NGHTTP2_* and STREAM_OPTION_* constants

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1691,6 +1691,22 @@ const constants = {
   HTTP_STATUS_NOT_EXTENDED: 510,
   HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED: 511,
 };
+// Node defines these with NODE_DEFINE_HIDDEN_CONSTANT: read-only and not enumerable.
+Object.defineProperties(constants, {
+  NGHTTP2_HCAT_REQUEST: { value: 0 },
+  NGHTTP2_HCAT_RESPONSE: { value: 1 },
+  NGHTTP2_HCAT_PUSH_RESPONSE: { value: 2 },
+  NGHTTP2_HCAT_HEADERS: { value: 3 },
+  NGHTTP2_NV_FLAG_NONE: { value: 0 },
+  NGHTTP2_NV_FLAG_NO_INDEX: { value: 1 },
+  NGHTTP2_ERR_DEFERRED: { value: -508 },
+  NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE: { value: -509 },
+  NGHTTP2_ERR_INVALID_ARGUMENT: { value: -501 },
+  NGHTTP2_ERR_STREAM_CLOSED: { value: -510 },
+  NGHTTP2_ERR_NOMEM: { value: -901 },
+  STREAM_OPTION_EMPTY_PAYLOAD: { value: 1 },
+  STREAM_OPTION_GET_TRAILERS: { value: 2 },
+});
 const {
   NGHTTP2_SESSION_SERVER,
   NGHTTP2_SESSION_CLIENT,

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5976,3 +5976,37 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+it("http2.constants carries node's hidden (non-enumerable) constants", () => {
+  const { constants } = http2;
+  const hidden = {
+    NGHTTP2_HCAT_REQUEST: 0,
+    NGHTTP2_HCAT_RESPONSE: 1,
+    NGHTTP2_HCAT_PUSH_RESPONSE: 2,
+    NGHTTP2_HCAT_HEADERS: 3,
+    NGHTTP2_NV_FLAG_NONE: 0,
+    NGHTTP2_NV_FLAG_NO_INDEX: 1,
+    NGHTTP2_ERR_DEFERRED: -508,
+    NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE: -509,
+    NGHTTP2_ERR_INVALID_ARGUMENT: -501,
+    NGHTTP2_ERR_STREAM_CLOSED: -510,
+    NGHTTP2_ERR_NOMEM: -901,
+    STREAM_OPTION_EMPTY_PAYLOAD: 1,
+    STREAM_OPTION_GET_TRAILERS: 2,
+  };
+  const actual = {};
+  for (const key of Object.keys(hidden)) {
+    actual[key] = constants[key];
+  }
+  expect(actual).toEqual(hidden);
+  for (const key of Object.keys(hidden)) {
+    expect(Object.getOwnPropertyDescriptor(constants, key)).toEqual({
+      value: hidden[key],
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+  // Hidden constants stay out of Object.keys, as in node.
+  expect(Object.keys(constants)).not.toContain("NGHTTP2_ERR_STREAM_CLOSED");
+});


### PR DESCRIPTION
### Problem
- `require("http2").constants` lacks 13 entries node exports: `NGHTTP2_HCAT_REQUEST/RESPONSE/PUSH_RESPONSE/HEADERS`, `NGHTTP2_NV_FLAG_NONE/NO_INDEX`, `NGHTTP2_ERR_DEFERRED/STREAM_ID_NOT_AVAILABLE/INVALID_ARGUMENT/STREAM_CLOSED/NOMEM`, `STREAM_OPTION_EMPTY_PAYLOAD/GET_TRAILERS`. A comparison such as `code === constants.NGHTTP2_ERR_STREAM_CLOSED` reads `undefined` and never matches.
- Node defines them in `node_http2.cc` with `NODE_DEFINE_HIDDEN_CONSTANT`. They are read-only and not enumerable, so a key-by-key diff of `Object.keys` does not show them. Bun's `constants` literal in `src/js/node/http2.ts:1452` never had them.

### Fix
- Define the 13 entries on the `constants` object with `Object.defineProperties` after the literal. Each descriptor is `{ value }` only, so the property is not writable, not enumerable, and not configurable, the same as node.
- `Object.keys(constants)` stays at 240 entries, as in node v26.3.0.
- Verified: `test/js/node/http2/node-http2.test.js` (new test, fails on bun 1.4.3, passes with this change).

### Background
- `http2.constants` mirrors nghttp2's enums and node's own stream option flags. Node fills it from C++ and marks a few entries hidden so they do not show up in enumeration but still resolve by name.
- Bun's `node:http2` is a pure JS module with a hand-written `constants` literal. The literal can only express enumerable keys, so the hidden set needs `defineProperties`.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1022.52ms]
(pass) node none > Client Basics > should be able to send a POST request [724.47ms]
(pass) node none > Client Basics > constants [29.80ms]
(pass) node none > Client Basics > getDefaultSettings [10.68ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [27.93ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.86ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.87ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.65ms]
(pass) node none > Client Basics > should be able to send data using end [739.43ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [715.86ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.00ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.30ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.09ms]
(pass) node none > Client Basics > is possible to abort request [2.10ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.97ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.82ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.28ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [35.67ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (f42e98025)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1792.59ms]
(pass) node none > Client Basics > should be able to send a POST request [917.10ms]
(pass) node none > Client Basics > constants [32.59ms]
(pass) node none > Client Basics > getDefaultSettings [12.13ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [32.57ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [9.79ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [5.77ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [9.08ms]
(pass) node none > Client Basics > should be able to send data using end [970.25ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [958.27ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4f7a22f67a
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 4637ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir obj
[2/2863] mkdir pch
[3/2863] mkdir codegen
[4/2863] gen ErrorCode+*.h
[5/2863] fetch mimalloc
[mimalloc] up to date
[6/2863] fetch WebKit
[WebKit] up to date
[7/2863] gen bindgenv2
[8/2863] fetch icu
[icu] up to date
[9/2863] fetch tinycc
[tinycc] up to date
[10/2863] gen .bind.ts → GeneratedBindings.cpp
[11/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[12/2863] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[13/2863] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[14/2863] fetch zlib
[zlib] up to date
[15/2863] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[16/2863] gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  | 16 ++++++++++++++++
 test/js/node/http2/node-http2.test.js | 34 ++++++++++++++++++++++++++++++++++
 2 files changed, 50 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       1      2      5
test/js/node/http2/node-http2.test.js      0      0      4
```

</details>

<!-- robobun:evidence:end -->