### PR TITLE
bun:test: toBeInteger uses Number.isInteger semantics

### DIFF
--- a/src/runtime/test_runner/expect/simple_matchers.rs
+++ b/src/runtime/test_runner/expect/simple_matchers.rs
@@ -16,7 +16,7 @@ crate::unary_predicate_matcher!(to_be_false, "toBeFalse", |v| v.is_boolean()
     && !v.to_boolean());
 crate::unary_predicate_matcher!(to_be_falsy, "toBeFalsy", |v| !v.to_boolean());
 crate::unary_predicate_matcher!(to_be_function, "toBeFunction", |v| v.is_callable());
-crate::unary_predicate_matcher!(to_be_integer, "toBeInteger", |v| v.is_any_int());
+crate::unary_predicate_matcher!(to_be_integer, "toBeInteger", |v| v.is_integer());
 // codegen snake-cases `toBeNaN` → `to_be_na_n`
 crate::unary_predicate_matcher!(to_be_na_n, "toBeNaN", |v| v.is_number()
     && v.as_number().is_nan());

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3941,6 +3941,14 @@ describe("expect()", () => {
     expect(NaN).not.toBeInteger();
     expect("").not.toBeInteger();
     expect({}).not.toBeInteger();
+    // Number.isInteger semantics: integers outside the Int52 range still count.
+    expect(2 ** 51).toBeInteger();
+    expect(-(2 ** 51) - 1).toBeInteger();
+    expect(Number.MAX_SAFE_INTEGER).toBeInteger();
+    expect(Number.MIN_SAFE_INTEGER).toBeInteger();
+    expect(1e21).toBeInteger();
+    expect(-0).toBeInteger();
+    expect(2 ** 51 + 0.5).not.toBeInteger();
   });
 
   test("toBeObject()", () => {


### PR DESCRIPTION
### Problem
- `expect(2 ** 51).toBeInteger()` and `expect(Number.MAX_SAFE_INTEGER).toBeInteger()` fail. Every integer with |n| >= 2^51 fails the matcher. jest-extended and vitest define `toBeInteger` as `Number.isInteger(received)`.
- The cause is `src/runtime/test_runner/expect/simple_matchers.rs:19`. The predicate was `v.is_any_int()`, which is JSC's `isAnyInt` (the Int52 range), not `Number.isInteger`.

### Fix
- The predicate is now `v.is_integer()`. `JSValue::is_integer` (`src/jsc/JSValue.rs:252`) implements ECMA-262 `Number.isInteger`: an int32, or a finite double equal to its truncation.
- Verified: `test/js/bun/test/expect.test.js` (`toBeInteger()` gains 2^51, -2^51-1, MAX_SAFE_INTEGER, MIN_SAFE_INTEGER, 1e21, -0, and a non-integer double above 2^51). Stock bun fails the block. Also the rest of `expect.test.js`.

### Background
- JSC stores some integers as Int52 in registers. `isAnyInt` answers "does this value fit Int52", a storage question, not a numeric one.
- `Number.isInteger` is the spec predicate: finite and equal to its own truncation, for any magnitude.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/test/expect.test.js:
(pass) expect() > () [303.84ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.24ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.49ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.26ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.25ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.25ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.24ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.24ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.78ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.50ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) ex
... (truncated)

release without fix: 2 failed, 2 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.93ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.06ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.03ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/test/expect.test.js:
(pass) expect() > () [307.74ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.61ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.47ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.26ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.26ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.24ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.24ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.28ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.77ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.46ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.31ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.31ms]
(pass) ex
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3371ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/9] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 11s
[2/9] link testFFI
[4/9] link bun-profile
rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSSLConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80120578)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSocketConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80120578)' is 'x86_64-unknown-linux-gnu'


r
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect/simple_matchers.rs | 2 +-
 test/js/bun/test/expect.test.js                   | 8 ++++++++
 2 files changed, 9 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/runtime/test_runner/expect/simple_matchers.rs      0      0     10
test/js/bun/test/expect.test.js                        0      0     10
```

</details>

<!-- robobun:evidence:end -->