### PR TITLE
node:zlib: treat an undefined crc32 seed as the default 0

### DIFF
--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -136,7 +136,7 @@ pub(crate) fn crc32(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
 
     let value: u32 = 'blk: {
         let value: JSValue = arguments[1];
-        if callframe.arguments_count() < 2 {
+        if callframe.arguments_count() < 2 || value.is_undefined() {
             break 'blk 0;
         }
         if !value.is_number() {

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -815,5 +815,13 @@ describe("crc32", () => {
     expect(() => zlib.crc32(undefined)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
     // Omitted second arg defaults to value=0.
     expect(zlib.crc32("hello")).toBe(zlib.crc32("hello", 0));
+    // Explicit undefined second arg takes the default too (node: `crc32(data, value = 0)`).
+    expect(zlib.crc32("hello", undefined)).toBe(zlib.crc32("hello", 0));
+    const forward = (data, value) => zlib.crc32(data, value);
+    expect(forward("abc")).toBe(891568578);
+    // null is not a number.
+    expect(() => zlib.crc32("hello", null)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+    expect(() => zlib.crc32("hello", -1)).toThrow(expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }));
+    expect(() => zlib.crc32("hello", 2 ** 32)).toThrow(expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }));
   });
 });


### PR DESCRIPTION
### Problem
- `zlib.crc32("abc", undefined)` throws `TypeError [ERR_INVALID_ARG_TYPE]: The "value" argument must be of type number. Received undefined`. Node declares the function as `crc32(data, value = 0)`, so an explicit `undefined` takes the default. Any forwarding wrapper like `(d, seed) => zlib.crc32(d, seed)` hits this when the caller omits the seed.
- Cause: the native `crc32` in `src/runtime/node/node_zlib_binding.rs:139` only applies the default when `arguments_count() < 2`. An explicit `undefined` reaches the `is_number()` check and fails it.

### Fix
- Apply the default when the second argument is `undefined`, in addition to the missing-argument case. `null`, non-integers, and out-of-range values still throw `ERR_INVALID_ARG_TYPE` or `ERR_OUT_OF_RANGE`, the same as node.
- Verified: `test/js/node/zlib/zlib.test.js` (the `crc32` block now covers `undefined`, a forwarding wrapper, `null`, `-1`, and `2 ** 32`). The whole file passes with the debug build.

### Background
- `zlib.crc32` is a native host function (`$newRustFunction("node_zlib_binding.rs", "crc32", 1)` in `src/js/node/zlib.ts`). Node does the argument validation in JS before the native call, with a JS default parameter. Bun does all of it in the host function, so the `undefined` case has to be handled there.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.3 (f42e98025)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.07ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.71ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.22ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [2.01ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.57ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.31ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.30ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.30ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [0.03ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [0.02ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate
(pass) pr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.3 (f42e98025)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.69ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.49ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [2.21ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [2.61ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.81ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.46ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.40ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.47ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 8991ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/1825] cc obj/vendor/libwebp/src/dsp/dec_mips_dsp_r2.c.o
[2/1825] cc obj/vendor/libwebp/src/dsp/cost_sse2.c.o
[3/1825] cc obj/vendor/libwebp/src/dsp/cpu.c.o
[4/1825] cc obj/vendor/libwebp/src/dsp/dec.c.o
[5/1825] cc obj/vendor/libwebp/src/dsp/dec_clip_tables.c.o
[6/1825] cc obj/vendor/libwebp/src/dsp/dec_mips32.c.o
[7/1825] cc obj/vendor/libwebp/src/dsp/dec_msa.c.o
[8/1825] cc obj/vendor/libwebp/src/dsp/dec_neon.c.o
[9/1825] cc obj/vendor/libwebp/src/dsp/dec_sse41.c.o
[10/1825] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[10/1825] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m core v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
[1m[92m   Compiling[0m enumset_derive v0.14.0
[1m[92m   Compiling[0m compiler_builtins v0.1.160 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/compi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/node_zlib_binding.rs | 2 +-
 test/js/node/zlib/zlib.test.js        | 8 ++++++++
 2 files changed, 9 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/node/node_zlib_binding.rs      3      1      6
test/js/node/zlib/zlib.test.js             1      1      6
```

</details>

**root cause** · written by the author bot

Bun's native `crc32` binding only substituted the default seed when the second argument was absent, so an explicit `undefined` fell through to the numeric validation and threw `ERR_INVALID_ARG_TYPE`, unlike Node, where the default parameter `value = 0` treats `undefined` as omitted. The fix extends the guard in `node_zlib_binding.rs` to short-circuit on `is_undefined()` as well, so `crc32(data, undefined)` now uses seed 0 while `null`, non-integer, and out-of-range values still reach the same `ERR_INVALID_ARG_TYPE` and `ERR_OUT_OF_RANGE` paths. Regression tests in `zlib.test.js` assert the …

<!-- robobun:evidence:end -->