### PR TITLE
ci(windows): turn off Smart App Control on the Windows 11 test runners

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -665,6 +665,7 @@ function Install-Buildkite {
 
 function Optimize-System {
   Disable-Windows-Defender
+  Disable-Smart-App-Control
   Disable-Windows-Threat-Protection
   Disable-Windows-Services
   Disable-Power-Management
@@ -678,6 +679,24 @@ function Disable-Windows-Defender {
   Write-Output "Disabling Windows Defender..."
   Set-MpPreference -DisableRealtimeMonitoring $true
   Add-MpPreference -ExclusionPath "C:\", "D:\"
+}
+
+# Windows 11 ships Smart App Control in evaluation mode (Server has no such
+# policy). It hashes every unsigned executable on its first launch and asks the
+# cloud for its reputation: 2 to 3.5 seconds per `bun build --compile` output,
+# which the compile test suites launch by the dozen. Defender exclusions do not
+# cover it, and tamper protection does not guard this key. The change takes
+# effect after `CiTool --refresh` or a reboot, and cannot be undone without a
+# reinstall, which is fine for a CI image.
+function Disable-Smart-App-Control {
+  $itemPath = "HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy"
+  if (Test-Path $itemPath) {
+    Write-Output "Disabling Smart App Control..."
+    Set-ItemProperty -Path $itemPath -Name "VerifiedAndReputablePolicyState" -Value 0 -Type DWORD
+    if (Get-Command CiTool -ErrorAction SilentlyContinue) {
+      CiTool --refresh -json | Out-Null
+    }
+  }
 }
 
 function Disable-Windows-Threat-Protection {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -3502,8 +3502,12 @@ function escapeXml(str) {
  * at 220 to 290 seconds against the 300 second per-file cap. Turning the policy
  * off takes effect at once and needs no reboot. scripts/bootstrap.ps1 does the
  * same at image bake time; this covers images baked before that change.
+ *
+ * Only on Buildkite: the policy cannot be turned on again without a reinstall,
+ * so a developer's machine running with CI=true must not get this.
  */
 async function disableSmartAppControl() {
+  if (!isBuildkite) return;
   const script = [
     "$p = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\CI\\Policy'",
     "if (-not (Test-Path $p)) { exit 0 }",

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -3494,6 +3494,35 @@ function escapeXml(str) {
     .replace(/'/g, "&apos;");
 }
 
+/**
+ * Windows 11 ships Smart App Control in evaluation mode. In that mode the kernel
+ * hashes every unsigned executable on its first launch and asks the cloud for
+ * its reputation, which costs 2 to 3.5 seconds for a 77 MB `bun build --compile`
+ * output. bundler_compile.test.ts launches about 85 of those, which puts the file
+ * at 220 to 290 seconds against the 300 second per-file cap. Turning the policy
+ * off takes effect at once and needs no reboot. scripts/bootstrap.ps1 does the
+ * same at image bake time; this covers images baked before that change.
+ */
+async function disableSmartAppControl() {
+  const script = [
+    "$p = 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\CI\\Policy'",
+    "if (-not (Test-Path $p)) { exit 0 }",
+    "$state = (Get-ItemProperty $p).VerifiedAndReputablePolicyState",
+    "if ($null -eq $state -or $state -eq 0) { exit 0 }",
+    "Set-ItemProperty $p -Name VerifiedAndReputablePolicyState -Value 0 -Type DWord",
+    "if (Get-Command CiTool -ErrorAction SilentlyContinue) { CiTool --refresh -json | Out-Null }",
+    'Write-Output "Smart App Control: state $state -> 0"',
+  ].join("; ");
+  const { ok, error } = await spawnSafe({
+    command: "pwsh",
+    args: ["-NoProfile", "-Command", script],
+    timeout: 60_000,
+  });
+  if (!ok) {
+    console.warn(`Failed to disable Smart App Control: ${error}`);
+  }
+}
+
 export async function main() {
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.on(signal, () => onExit(signal));
@@ -3511,6 +3540,7 @@ export async function main() {
       "-Command",
       "Set-DnsClientServerAddress -InterfaceAlias 'Ethernet 4' -ServerAddresses ('8.8.8.8','8.8.4.4')",
     ]);
+    await disableSmartAppControl();
   }
 
   let doRunTests = true;


### PR DESCRIPTION
### Problem
- `test/bundler/bundler_compile.test.ts` reports `timeout on :windows: 11 aarch64` (builds 110724, 110766, 110870). The output stops after a different test each time and no per-test timeout fires. The file is not hung. It takes 286 to 293 s in the passing runs and the runner caps it at 300 s (`integrationTimeout`, `scripts/runner.node.mjs:90`).
- The cost is Smart App Control. Windows 11 ships it in evaluation mode. On the first launch of an unsigned executable it hashes the file and asks the cloud for its reputation. A 77 MB `bun build --compile` output pays 2.3 s for that on the aarch64 VM, more in canadaeast and switzerlandnorth. The file launches about 85 such binaries.
- `scripts/bootstrap.ps1` tries to disable Defender, but tamper protection blocks `DisableRealtimeMonitoring` on Windows 11, `Uninstall-WindowsFeature` does not exist there, and the `C:\` exclusion does not cover Smart App Control.

### Fix
- `scripts/runner.node.mjs`: at job start on Windows, set `HKLM\SYSTEM\CurrentControlSet\Control\CI\Policy\VerifiedAndReputablePolicyState` to 0 and run `CiTool --refresh`. This takes effect at once, with no reboot. It runs next to the existing `Set-DnsClientServerAddress` step, which already needs the same rights.
- `scripts/bootstrap.ps1`: `Disable-Smart-App-Control` in `Optimize-System`, so the next image bake has it off from the start. No `# Version` bump and no `[publish images]`: the runner step covers the current v23 images.
- Verified on a Windows 11 aarch64 VM from the CI image: the file takes 205 s with the policy in evaluation mode and 28 s with it off (85 pass both times). The runner step logs `Smart App Control: state 2 -> 0` and is a no-op once the value is 0.

### Background
- Smart App Control is a Windows 11 code integrity policy. Evaluation mode is the default on a fresh install. It does not block anything, but it still evaluates every new unsigned binary. Once turned off it cannot be turned on again without a reinstall.
- The runner has two per-file caps: 3 min, and 5 min for files matched by the integration list (`bundler_compile` is on it). A file that passes the cap is reported as `timeout` and retried once.
- Only the Windows 11 aarch64 lane is affected. The Windows 2019 x64 lane has Defender uninstalled and has no Smart App Control.

<details><summary>Notes</summary>

There is no single culprit commit. The file has grown to 85 tests (#41263 and #40816 added the latest ones) and the per-launch cost depends on the Azure region the spot VM lands in. The three failures ran in canadaeast and switzerlandnorth.

How the cause was found:

- The runner log for the three failures ends after a different compile test each time (the "8+ entry points" test in 110724, the last test in 110766 and 110870), followed by `EPERM` from the runner's `rmSync` of the temp dir: the killed test's child was still running. No `bun test` per-test timeout fired, so nothing was stuck, the file was cut off mid-run.
- Shard 1 of the Windows 11 aarch64 lane, durations of the file in passing builds (job log "Ran 85 tests across 1 file"): 219 to 226 s on eastus2 and swedencentral VMs, 286 to 293 s on canadaeast VMs. The NAT gateway IP of the agent maps to the region.
- On the dev VM (same image lineage, Windows 11 26100, buildkite-agent service present): first launch of a fresh compiled exe 2300 ms, second launch 17 ms. A copy of the same file pays the 2300 ms again. A 50 KB `where.exe` with 77 MB of random bytes appended (not mapped by the loader) pays 2600 ms. A copy of the signed `node.exe` (89 MB) pays 800 ms. Defender exclusions for `C:\` and `D:\` were already in place.
- `Get-MpComputerStatus` shows `SmartAppControlState: Eval` and the Code Integrity log lists the `VerifiedAndReputableDesktopEvaluation` policy as active. After `VerifiedAndReputablePolicyState = 0` and `CiTool --refresh`: state `Off`, first launch 154 ms, full file 28 s.

Suites run on the dev VM after the change: `bundler_compile.test.ts` (85 pass), `bundler_compile_autoload.test.ts`, `bundler_compile_splitting.test.ts`, `transpiler/property.test.ts` through `runner.node.mjs`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->