### PR TITLE
redis: treat an empty REDIS_URL or VALKEY_URL as unset

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -491,7 +491,8 @@ impl JSValkeyClient {
             arguments[0].to_bun_string(&global_object)?
         } else {
             let env = vm_ref.env_loader();
-            match env.get(b"REDIS_URL").or_else(|| env.get(b"VALKEY_URL")) {
+            let from_env = |key: &[u8]| env.get(key).filter(|url| !url.is_empty());
+            match from_env(b"REDIS_URL").or_else(|| from_env(b"VALKEY_URL")) {
                 Some(url) => BunString::borrow_utf8(url),
                 None => BunString::static_("valkey://localhost:6379"),
             }

--- a/test/js/valkey/valkey-env-url.test.ts
+++ b/test/js/valkey/valkey-env-url.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The default client resolves its URL as: explicit argument > REDIS_URL > VALKEY_URL > valkey://localhost:6379.
+// An empty environment variable counts as unset, the same as PORT for Bun.serve and DATABASE_URL for Bun.SQL.
+describe.concurrent("RedisClient: empty URL environment variables", () => {
+  test("REDIS_URL='' falls back to the default URL", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          import { redis, RedisClient } from "bun";
+          new RedisClient();
+          console.log(typeof Bun.redis.connect, typeof redis.connect);
+        `,
+      ],
+      env: { ...bunEnv, REDIS_URL: "", VALKEY_URL: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("function function\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("REDIS_URL='' falls back to VALKEY_URL", async () => {
+    const { promise: connected, resolve } = Promise.withResolvers<void>();
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          resolve();
+          socket.end();
+        },
+        data() {},
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const client = new Bun.RedisClient(undefined, { autoReconnect: false });
+          await client.connect().catch(() => {});
+          console.log("done");
+        `,
+      ],
+      env: { ...bunEnv, REDIS_URL: "", VALKEY_URL: `redis://127.0.0.1:${server.port}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done\n");
+    expect(exitCode).toBe(0);
+    await connected;
+  });
+});

--- a/test/js/valkey/valkey-env-url.test.ts
+++ b/test/js/valkey/valkey-env-url.test.ts
@@ -26,13 +26,13 @@ describe.concurrent("RedisClient: empty URL environment variables", () => {
   });
 
   test("REDIS_URL='' falls back to VALKEY_URL", async () => {
-    const { promise: connected, resolve } = Promise.withResolvers<void>();
+    let connections = 0;
     using server = Bun.listen({
       hostname: "127.0.0.1",
       port: 0,
       socket: {
         open(socket) {
-          resolve();
+          connections++;
           socket.end();
         },
         data() {},
@@ -57,6 +57,6 @@ describe.concurrent("RedisClient: empty URL environment variables", () => {
     expect(stderr).toBe("");
     expect(stdout).toBe("done\n");
     expect(exitCode).toBe(0);
-    await connected;
+    expect(connections).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- With `REDIS_URL` set to the empty string, `Bun.redis`, `new RedisClient()`, and a read of `redis` from `import { redis } from "bun"` throw `TypeError: Invalid URL format`. The `VALKEY_URL` fallback and the default `valkey://localhost:6379` are skipped.
- The cause is the env lookup in `create_no_js_no_pubsub` (`src/runtime/valkey_jsc/js_valkey.rs:494`). `env.get(b"REDIS_URL")` returns `Some("")` for an empty variable, so the `or_else` chain stops there and the empty string reaches the URL parser.

### Fix
- Filter empty values out of the `REDIS_URL` and `VALKEY_URL` lookups. An empty variable now counts as unset. The resolution order is unchanged: explicit argument, then `REDIS_URL`, then `VALKEY_URL`, then the default.
- This matches the other clients. `Bun.serve` ignores an empty `PORT`. `Bun.SQL` ignores an empty `DATABASE_URL` and the `PG*` variables.
- An explicit empty string argument (`new RedisClient("")`) still throws `Invalid URL format`. Only the environment lookup changes.
- Verified: `test/js/valkey/valkey-env-url.test.ts` (2 tests, both fail on the released bun, no server needed). Also `test/regression/issue/24385.test.ts` and `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`.

### Background
- `Bun.redis` is a lazy property. Its first read builds the default client with no URL argument, so the URL comes from the environment. `new RedisClient()` with no argument takes the same path.
- `EnvLoader::get` returns the raw value of a variable. It does not distinguish an empty value from a missing one. Each caller decides what an empty value means.

<details><summary>Notes</summary>

- Repro on the released bun: `REDIS_URL= bun -e 'Bun.redis'` throws `TypeError: Invalid URL format` with `code: "ERR_INVALID_ARG_TYPE"`.
- The second test points `VALKEY_URL` at a `Bun.listen` server on port 0 and asserts that the child connects to it. The client is built with `autoReconnect: false`, because the default client reconnects forever when the server closes the socket, and `connect()` never settles.
- #41418 moves the same lookup into a stored `url` field. The two changes touch the same lines, so one of them needs a small rebase after the other lands.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/valkey/valkey-env-url.test.ts
bun test v1.4.3 (f42e98025)

test/js/valkey/valkey-env-url.test.ts:
18 |       env: { ...bunEnv, REDIS_URL: "", VALKEY_URL: "" },
19 |       stdout: "pipe",
20 |       stderr: "pipe",
21 |     });
22 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
23 |     expect(stderr).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "1 | 
+ 2 |           import { redis, RedisClient } from "bun";
+               ^
+ TypeError: Invalid URL format
+  code: "ERR_INVALID_ARG_TYPE"
+ 
+       at /workspace/bun/[eval]:2:11
+ 
+ Bun v1.4.3-debug+f42e98025 (Linux x64)
+ "

- Expected  - 1
+ Received  + 10

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-env-url.test.ts:23:20)
(fail) RedisClient: empty URL environment variables > REDIS_URL='' falls back to the default URL [282.72ms]
52 |       env: { ...bunEnv, REDIS_URL: "", VALKEY_URL: `redis://127.0.0.1:${server.port}` },
53 |       stdout: "pipe",
54 |       
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/valkey/valkey-env-url.test.ts:
18 |       env: { ...bunEnv, REDIS_URL: "", VALKEY_URL: "" },
19 |       stdout: "pipe",
20 |       stderr: "pipe",
21 |     });
22 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
23 |     expect(stderr).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "1 | 
+ 2 |           import { redis, RedisClient } from "bun";
+               ^
+ TypeError: Invalid URL format
+  code: "ERR_INVALID_ARG_TYPE"
+ 
+       at /workspace/bun/[eval]:2:11
+ 
+ Bun v1.4.3-canary.1+f42e98025 (Linux x64)
+ "

- Expected  - 1
+ Received  + 10

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-env-url.test.ts:23:20)
(fail) RedisClient: empty URL environment variables > REDIS_URL='' falls back to the default URL [8.94ms]
52 |       env: { ...bunEnv, REDIS_URL: "", VALKEY_URL: `redis://127.0.0.1:${server.port}` },
53 |       stdout: "pipe",
54 |       stderr: "pipe",
55 |     });
56 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
57 |     expe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/valkey/valkey-env-url.test.ts
bun test v1.4.3 (f42e98025)

test/js/valkey/valkey-env-url.test.ts:
(pass) RedisClient: empty URL environment variables > REDIS_URL='' falls back to the default URL [294.78ms]
(pass) RedisClient: empty URL environment variables > REDIS_URL='' falls back to VALKEY_URL [298.19ms]

 2 pass
 0 fail
 7 expect() calls
Ran 2 tests across 1 file. [2.75s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ba58b6ee7d
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 2017ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir obj
[2/2863] mkdir pch
[3/2863] mkdir codegen
[4/2863] gen ErrorCode+*.h
[5/2863] fetch mimalloc
[mimalloc] up to date
[6/2863] fetch WebKit
[WebKit] up to date
[7/2863] fetch icu
[icu] up to date
[8/2863] fetch tinycc
[tinycc] up to date
[9/2863] gen bindgenv2
[10/2863] mkdir stamps
[11/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[12/2863] gen .bind.ts → GeneratedBindings.cpp
[13/2863] fetch zlib
[zlib] up to date
[14/2863] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[15/2863] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[16/2863] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSB
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey.rs   |  3 +-
 test/js/valkey/valkey-env-url.test.ts | 62 +++++++++++++++++++++++++++++++++++
 2 files changed, 64 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/valkey_jsc/js_valkey.rs        1      1      9
test/js/valkey/valkey-env-url.test.ts      1      2      9
```

</details>

**root cause** · written by the author bot

The default Redis client resolved its URL by checking whether REDIS_URL or VALKEY_URL was set rather than whether it was non-empty, so an empty REDIS_URL short-circuited the fallback chain and handed an empty string to the URL parser, which threw "Invalid URL format". The fix filters empty values out of both environment lookups in js_valkey.rs, so resolution proceeds as explicit argument, then non-empty REDIS_URL, then non-empty VALKEY_URL, then the localhost default. An explicit `new RedisClient("")` still reaches the parser unchanged, and new tests confirm both the default fallback and th…

<!-- robobun:evidence:end -->