### PR TITLE
Blob: report the shared store bytes to the GC once, not per slice

### DIFF
--- a/bench/snippets/blob.mjs
+++ b/bench/snippets/blob.mjs
@@ -23,6 +23,13 @@ bench("blob.slice()", function () {
   return small.slice();
 });
 
+// slice() shares the source's bytes, so this only differs from the small case
+// by what each new Blob tells the GC.
+var large = new Blob([new Uint8Array(8 * 1024 * 1024)]);
+bench("blob.slice() (8 MiB blob)", function () {
+  return large.slice();
+});
+
 if ((await small.text()) !== JSON.stringify("hello world ")) {
   throw new Error("blob.text() failed");
 }

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -3,6 +3,7 @@
 
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(JSC::JSGlobalObject* globalObject, void* impl);
 extern "C" void Blob__setAsFile(void* impl, const BunString* filename);
+extern "C" void Blob__calculateEstimatedByteSize(void* impl);
 
 namespace WebCore {
 
@@ -11,7 +12,11 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
     BunString filename = Bun::toString(impl.fileName());
     Blob__setAsFile(impl.impl(), &filename);
 
-    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    // The dupe shares impl's store, so what Blob__create reports to the GC
+    // must be computed for the dupe, not copied from impl.
+    void* dupe = Blob__dupe(impl.impl());
+    Blob__calculateEstimatedByteSize(dupe);
+    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, dupe));
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4095,6 +4095,11 @@ pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
 }
 
 #[unsafe(no_mangle)]
+pub(crate) extern "C" fn Blob__calculateEstimatedByteSize(this: &Blob) {
+    this.calculate_estimated_byte_size();
+}
+
+#[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
     this.get_name_string()
         .map_or(BunString::EMPTY, Clone::clone)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3416,11 +3416,12 @@ impl BlobExt for Blob {
             match &store.data {
                 store::Data::Bytes(bytes) => {
                     size += bytes.stored_name.len();
-                    size += if self.size.get() != MAX_SIZE {
-                        self.size.get() as usize
-                    } else {
-                        bytes.len() as usize
-                    };
+                    // The bytes belong to the shared store, not to this view.
+                    // Count them once, for the sole owner. A slice shares the
+                    // store and allocates nothing.
+                    if store.has_one_ref() {
+                        size += bytes.len() as usize;
+                    }
                 }
                 store::Data::File(file) => size += file.pathlike.estimated_size(),
                 store::Data::S3(s3) => size += s3.estimated_size(),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3416,9 +3416,7 @@ impl BlobExt for Blob {
             match &store.data {
                 store::Data::Bytes(bytes) => {
                     size += bytes.stored_name.len();
-                    // The bytes belong to the shared store, not to this view.
-                    // Count them once, for the sole owner. A slice shares the
-                    // store and allocates nothing.
+                    // Slices share the store. Its bytes count once, for the sole owner.
                     if store.has_one_ref() {
                         size += bytes.len() as usize;
                     }

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -845,3 +845,39 @@ test("Blob.slice() does not report the shared bytes as extra memory", () => {
   expect(slices.length).toBe(100);
   expect(delta).toBeLessThan(size);
 });
+
+describe("a Blob that shares another Blob's bytes does not report them to the GC as newly allocated", () => {
+  const PAYLOAD = 1024 * 1024;
+  const COUNT = 256;
+  const source = new Blob([new Uint8Array(PAYLOAD)]);
+  const bytes = new Uint8Array(PAYLOAD);
+  const formData = new FormData();
+  formData.append("f", source, "f.bin");
+
+  // Right after a full GC, JSC allows at least 8 MiB of reported allocation
+  // before it collects again. COUNT wrappers that report only their own struct
+  // stay far below that, so none of them is collected. COUNT wrappers that each
+  // report PAYLOAD cross it every few iterations, and only the last few survive.
+  async function blobsSurviving(make: () => unknown): Promise<number> {
+    Bun.gc(true);
+    const before = heapStats().objectTypeCounts.Blob ?? 0;
+    for (let i = 0; i < COUNT; i++) await make();
+    return (heapStats().objectTypeCounts.Blob ?? 0) - before;
+  }
+
+  test.each([
+    ["blob.slice()", () => source.slice()],
+    ["new Blob([blob])", () => new Blob([source])],
+    ["formData.get()", () => formData.get("f")],
+    ["new Response(blob).blob()", () => new Response(source).blob()],
+  ])("%s", async (_, make) => {
+    expect(await blobsSurviving(make)).toBe(COUNT);
+  });
+
+  test.each([
+    ["new Blob([bytes])", () => new Blob([bytes])],
+    ["new Response(bytes).blob()", () => new Response(bytes).blob()],
+  ])("%s owns its bytes and still reports them", async (_, make) => {
+    expect(await blobsSurviving(make)).toBeLessThan(COUNT);
+  });
+});

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -825,3 +825,19 @@ test.each([
   const blob = new Blob(["abc"], { type });
   expect(blob.slice(0, 1).type).toBe(expected);
 });
+
+// A slice shares the parent's bytes. It must not report them to the GC as a
+// new allocation, or each slice of a large Blob triggers a collection.
+test("Blob.slice() does not report the shared bytes as extra memory", () => {
+  const { heapStats } = require("bun:jsc");
+  const size = 1 << 20;
+  const blob = new Blob([new Uint8Array(size)]);
+  const before = heapStats().extraMemorySize;
+  const slices: Blob[] = [];
+  for (let i = 0; i < 100; i++) {
+    slices.push(blob.slice(0, size));
+  }
+  const delta = heapStats().extraMemorySize - before;
+  expect(slices.length).toBe(100);
+  expect(delta).toBeLessThan(size);
+});

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -829,15 +829,19 @@ test.each([
 
 // A slice shares the parent's bytes. It must not report them to the GC as a
 // new allocation, or each slice of a large Blob triggers a collection.
+// extraMemorySize is summed during marking, so a full GC precedes each sample.
 test("Blob.slice() does not report the shared bytes as extra memory", () => {
   const size = 1 << 20;
   const blob = new Blob([new Uint8Array(size)]);
+  Bun.gc(true);
   const before = heapStats().extraMemorySize;
   const slices: Blob[] = [];
   for (let i = 0; i < 100; i++) {
     slices.push(blob.slice(0, size));
   }
+  Bun.gc(true);
   const delta = heapStats().extraMemorySize - before;
+  expect(blob.size).toBe(size);
   expect(slices.length).toBe(100);
   expect(delta).toBeLessThan(size);
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,3 +1,4 @@
+import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import type { BlobOptions } from "node:buffer";
@@ -829,7 +830,6 @@ test.each([
 // A slice shares the parent's bytes. It must not report them to the GC as a
 // new allocation, or each slice of a large Blob triggers a collection.
 test("Blob.slice() does not report the shared bytes as extra memory", () => {
-  const { heapStats } = require("bun:jsc");
   const size = 1 << 20;
   const blob = new Blob([new Uint8Array(size)]);
   const before = heapStats().extraMemorySize;


### PR DESCRIPTION
### Problem
- `Blob.slice()` gets slower with the slice length although it copies nothing: 300k slices of a 3 MB Blob take 62 ms at 10 bytes and 11.6 s at 3 MB (bun 1.4.3), because JSC collects every few slices. Same for `new Blob([blob])`, `formData.get()`, `new Response(blob).blob()`.
- Cause: `calculate_estimated_byte_size` (`src/runtime/webcore/Blob.rs:3410`) counts the viewed bytes for every Blob, and each new wrapper passes that number to `Heap::reportExtraMemoryAllocated`. N views of one store look like N allocations.

### Fix
- Count the store bytes only when the Blob is the sole owner of the store (`Store::has_one_ref()`, the rule `Store::memory_cost` already uses). A Blob that shares a store reports its own struct.
- `formData.get()` reported the estimate copied from the entry. `toJS(Blob&)` (`src/jsc/bindings/blob.cpp`) now computes it for the dupe it wraps.
- The same cached number feeds `visitChildren`, so live views stop multiplying the store in JSC's heap size too. When the owner dies first, no view reports the store, which errs toward collecting sooner.
- Verified: `test/js/web/fetch/blob.test.ts` (7 new tests, 5 fail on 1.4.3), `heap-snapshot` (FormData), `FormData`, `blob-cow`. Self-reviewed: 1 concern (a Blob made from `blob.stream()` keeps the struct-only estimate), accepted, see Notes.

### Background
- A `Blob` is a view (offset, size) over a refcounted `Store` that owns the bytes. `slice()`, `new Blob([blob])`, FormData entries and Response bodies dupe the view and bump the refcount.
- JSC sees memory outside its heap through two reports: `reportExtraMemoryAllocated` at wrapper creation decides when the next collection runs, `reportExtraMemoryVisited` at each mark sizes the next cycle. Blob computes one number for both at wrapper creation and caches it in `reported_estimated_size`, because marking threads read it.

<details><summary>Notes</summary>

Repro (bun 1.4.3, one core):

```js
const [N, S, L] = process.argv.slice(2).map(Number);
const b = new Blob(['x'.repeat(S)]);
const t0 = performance.now(); let z = 0;
for (let i = 0; i < N; i++) z += b.slice(0, L).size;
console.log({ N, S, L, ms: performance.now() - t0 });
```

`N=300000 S=3000000`: L=10 62 ms, L=10k 204 ms, L=100k 1305 ms, L=1M 6460 ms, L=3M 11658 ms. With the fix the loop time no longer depends on L.

#38562 fixed the same over-reporting with the same `has_one_ref()` rule, but only for the creation-time report, through a generated `JS<T>::reportExtraMemoryAllocated(vm)` and a `newlyAllocatedSize` opt-in in `.classes.ts` (10 files). It was closed in favor of this PR. Its bench case (`bench/snippets/blob.mjs`, `blob.slice() (8 MiB blob)`), its survivor-count tests and the `formData.get()` path were folded in here.

The survivor-count tests create 256 Blobs right after `Bun.gc(true)` and count live `Blob` cells with `heapStats().objectTypeCounts`. Bun sets `largeHeapSize` to 8 MiB, so 256 wrappers that report only their struct cannot trigger a collection and all 256 are still counted. On 1.4.3: `slice()` 16 to 40 of 256, `new Blob([blob])` about 25, `formData.get()` 16 to 40, `new Response(blob).blob()` 25. The two `owns its bytes` rows check that a Blob with its own store still reports it (under 10 of 256 survive before and after). They also pass with `BUN_GARBAGE_COLLECTOR_LEVEL=1` as the CI runner sets it.

`formData.get()` detail: `FormData.append(name, blob)` stores a native dupe whose cached estimate is copied from the JS Blob, which keeps `estimateShallowMemoryUsageOf(formData)` and the heap snapshot FormData size including the bytes (`heap-snapshot.test.ts` "FormData" passes). Only the JS wrapper that `get()` creates recomputes, and it shares the store, so it reports its struct. Without the `blob.cpp` change the `formData.get()` row fails with 40 of 256.

Paths where the new JS Blob shares its store with a native holder rather than another JS Blob (`response.clone()` bodies, `Bun.serve` static routes, the object URL registry, `Bun.embeddedFiles`) now report only the struct as well. Before, each such wrapper reported the full view every time.

Self-review concern, accepted: `Bun.readableStreamToBlob(blob.stream())` and `new Response(blob.stream()).blob()` go through `Any::to_blob`, which dupes the store while the local `Any::Blob` still holds its ref, so the resulting Blob is computed at refcount 2 and keeps the struct-only estimate even if it ends up the sole owner. No bytes are allocated on that path (the store already existed and was reported by the Blob that created it), and `Any::to_blob` has to keep its ref because `StaticRoute` serves from the same `Any::Blob` repeatedly. The effect is a smaller retained-size estimate for that Blob, which makes JSC collect sooner, not later.

The old code used `self.size` (the view length) when set, else `bytes.len()`. A sole owner now reports `bytes.len()`, which is what the store holds.

The debug-build timeouts of the `URL (heap size reporting bug)` and `Headers` cases in `heap-snapshot.test.ts` are pre-existing and unrelated (#37835).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->
