### PR TITLE
node:zlib: expose the flat ZSTD_* constant aliases on the module

### DIFF
--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -915,53 +915,9 @@ ObjectDefineProperties(zlib, {
 
 // These should be considered deprecated
 // expose all the zlib constants
-{
-  // prettier-ignore
-  const { Z_OK, Z_STREAM_END, Z_NEED_DICT, Z_ERRNO, Z_STREAM_ERROR, Z_DATA_ERROR, Z_MEM_ERROR, Z_BUF_ERROR, Z_VERSION_ERROR, Z_NO_COMPRESSION, Z_BEST_SPEED, Z_BEST_COMPRESSION, Z_DEFAULT_COMPRESSION, Z_FILTERED, Z_HUFFMAN_ONLY, Z_RLE, ZLIB_VERNUM, Z_MAX_CHUNK, Z_DEFAULT_LEVEL } = constants;
-  ObjectDefineProperty(zlib, "Z_NO_FLUSH", { value: Z_NO_FLUSH });
-  ObjectDefineProperty(zlib, "Z_PARTIAL_FLUSH", { value: Z_PARTIAL_FLUSH });
-  ObjectDefineProperty(zlib, "Z_SYNC_FLUSH", { value: Z_SYNC_FLUSH });
-  ObjectDefineProperty(zlib, "Z_FULL_FLUSH", { value: Z_FULL_FLUSH });
-  ObjectDefineProperty(zlib, "Z_FINISH", { value: Z_FINISH });
-  ObjectDefineProperty(zlib, "Z_BLOCK", { value: Z_BLOCK });
-  ObjectDefineProperty(zlib, "Z_OK", { value: Z_OK });
-  ObjectDefineProperty(zlib, "Z_STREAM_END", { value: Z_STREAM_END });
-  ObjectDefineProperty(zlib, "Z_NEED_DICT", { value: Z_NEED_DICT });
-  ObjectDefineProperty(zlib, "Z_ERRNO", { value: Z_ERRNO });
-  ObjectDefineProperty(zlib, "Z_STREAM_ERROR", { value: Z_STREAM_ERROR });
-  ObjectDefineProperty(zlib, "Z_DATA_ERROR", { value: Z_DATA_ERROR });
-  ObjectDefineProperty(zlib, "Z_MEM_ERROR", { value: Z_MEM_ERROR });
-  ObjectDefineProperty(zlib, "Z_BUF_ERROR", { value: Z_BUF_ERROR });
-  ObjectDefineProperty(zlib, "Z_VERSION_ERROR", { value: Z_VERSION_ERROR });
-  ObjectDefineProperty(zlib, "Z_NO_COMPRESSION", { value: Z_NO_COMPRESSION });
-  ObjectDefineProperty(zlib, "Z_BEST_SPEED", { value: Z_BEST_SPEED });
-  ObjectDefineProperty(zlib, "Z_BEST_COMPRESSION", { value: Z_BEST_COMPRESSION });
-  ObjectDefineProperty(zlib, "Z_DEFAULT_COMPRESSION", { value: Z_DEFAULT_COMPRESSION });
-  ObjectDefineProperty(zlib, "Z_FILTERED", { value: Z_FILTERED });
-  ObjectDefineProperty(zlib, "Z_HUFFMAN_ONLY", { value: Z_HUFFMAN_ONLY });
-  ObjectDefineProperty(zlib, "Z_RLE", { value: Z_RLE });
-  ObjectDefineProperty(zlib, "Z_FIXED", { value: Z_FIXED });
-  ObjectDefineProperty(zlib, "Z_DEFAULT_STRATEGY", { value: Z_DEFAULT_STRATEGY });
-  ObjectDefineProperty(zlib, "ZLIB_VERNUM", { value: ZLIB_VERNUM });
-  ObjectDefineProperty(zlib, "DEFLATE", { value: DEFLATE });
-  ObjectDefineProperty(zlib, "INFLATE", { value: INFLATE });
-  ObjectDefineProperty(zlib, "GZIP", { value: GZIP });
-  ObjectDefineProperty(zlib, "GUNZIP", { value: GUNZIP });
-  ObjectDefineProperty(zlib, "DEFLATERAW", { value: DEFLATERAW });
-  ObjectDefineProperty(zlib, "INFLATERAW", { value: INFLATERAW });
-  ObjectDefineProperty(zlib, "UNZIP", { value: UNZIP });
-  ObjectDefineProperty(zlib, "Z_MIN_WINDOWBITS", { value: Z_MIN_WINDOWBITS });
-  ObjectDefineProperty(zlib, "Z_MAX_WINDOWBITS", { value: Z_MAX_WINDOWBITS });
-  ObjectDefineProperty(zlib, "Z_DEFAULT_WINDOWBITS", { value: Z_DEFAULT_WINDOWBITS });
-  ObjectDefineProperty(zlib, "Z_MIN_CHUNK", { value: Z_MIN_CHUNK });
-  ObjectDefineProperty(zlib, "Z_MAX_CHUNK", { value: Z_MAX_CHUNK });
-  ObjectDefineProperty(zlib, "Z_DEFAULT_CHUNK", { value: Z_DEFAULT_CHUNK });
-  ObjectDefineProperty(zlib, "Z_MIN_MEMLEVEL", { value: Z_MIN_MEMLEVEL });
-  ObjectDefineProperty(zlib, "Z_MAX_MEMLEVEL", { value: Z_MAX_MEMLEVEL });
-  ObjectDefineProperty(zlib, "Z_DEFAULT_MEMLEVEL", { value: Z_DEFAULT_MEMLEVEL });
-  ObjectDefineProperty(zlib, "Z_MIN_LEVEL", { value: Z_MIN_LEVEL });
-  ObjectDefineProperty(zlib, "Z_MAX_LEVEL", { value: Z_MAX_LEVEL });
-  ObjectDefineProperty(zlib, "Z_DEFAULT_LEVEL", { value: Z_DEFAULT_LEVEL });
+for (const bkey of ObjectKeys(constants)) {
+  if (bkey.startsWith("BROTLI")) continue;
+  ObjectDefineProperty(zlib, bkey, { value: constants[bkey] });
 }
 
 export default zlib;

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -817,3 +817,48 @@ describe("crc32", () => {
     expect(zlib.crc32("hello")).toBe(zlib.crc32("hello", 0));
   });
 });
+
+describe("flat constant aliases", () => {
+  // Node defines every non-BROTLI key of zlib.constants as a non-enumerable,
+  // read-only property on the module itself. Non-enumerable keys are not part
+  // of the ESM namespace, in node either, so this uses require().
+  const zlib = require("node:zlib");
+
+  it("exposes the ZSTD_* constants on the module", () => {
+    expect([
+      zlib.ZSTD_e_end,
+      zlib.ZSTD_c_compressionLevel,
+      zlib.ZSTD_CLEVEL_DEFAULT,
+      zlib.ZSTD_COMPRESS,
+      zlib.ZSTD_btultra2,
+      zlib.ZSTD_d_windowLogMax,
+    ]).toEqual([
+      zlib.constants.ZSTD_e_end,
+      zlib.constants.ZSTD_c_compressionLevel,
+      zlib.constants.ZSTD_CLEVEL_DEFAULT,
+      zlib.constants.ZSTD_COMPRESS,
+      zlib.constants.ZSTD_btultra2,
+      zlib.constants.ZSTD_d_windowLogMax,
+    ]);
+    expect(zlib.ZSTD_e_end).toBe(2);
+    expect(zlib.ZSTD_c_compressionLevel).toBe(100);
+    expect(zlib.ZSTD_CLEVEL_DEFAULT).toBe(3);
+  });
+
+  it("mirrors every non-BROTLI key of zlib.constants, non-enumerable and read-only", () => {
+    const missing = [];
+    for (const key of Object.keys(zlib.constants)) {
+      const desc = Object.getOwnPropertyDescriptor(zlib, key);
+      if (key.startsWith("BROTLI")) {
+        expect(desc).toBeUndefined();
+        continue;
+      }
+      if (!desc) {
+        missing.push(key);
+        continue;
+      }
+      expect(desc).toEqual({ value: zlib.constants[key], writable: false, enumerable: false, configurable: false });
+    }
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Problem
- `require("zlib").ZSTD_e_end`, `zlib.ZSTD_c_compressionLevel`, `zlib.ZSTD_CLEVEL_DEFAULT` and the other 60 flat `ZSTD_*` names read `undefined`. Node v26.3.0 returns `2`, `100`, `3`. Code that passes the flat spelling as a `flush` or `params` value gets `undefined`.
- Node defines every non-`BROTLI` key of `zlib.constants` as a non-enumerable, read-only property on the module. Bun had a hand-written list in `src/js/node/zlib.ts:918` that covered the `Z_*` and mode names only.

### Fix
- Replace the hand-written list with the same loop node uses: for each key of `constants` that does not start with `BROTLI`, define it on the module with `{ value }` (not writable, not enumerable, not configurable).
- The key sets of `zlib.constants` in bun and node v26.3.0 are identical (170 keys), so the loop exposes the same 107 flat names as node.
- Verified: `test/js/node/zlib/zlib.test.js` (two new tests, both fail on bun 1.4.3). The whole file passes: 390 pass, 2 skip.

### Background
- Node's `lib/zlib.js` ends with a loop over `ObjectKeys(constants)` that skips `BROTLI*` and calls `ObjectDefineProperty(zlib, key, { value })`. The flat names exist for compatibility with code that predates `zlib.constants`.
- The flat names are not enumerable, so the ESM namespace (`import * as zlib`) does not carry them, in node either. The new tests use `require()`.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.3 (f42e98025)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [3.82ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [3.20ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [2.50ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [3.82ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.81ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.46ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.40ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.47ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release without fix: 2 failed, 2 skipped
bun test v1.4.3-canary.1 (4f7a22f67)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [0.02ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate
(pass) prototype a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.3 (f42e98025)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.24ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.14ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.52ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.55ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.48ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.64ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.26ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.30ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 6222ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen JS modules (bundle-modules)
Preprocess modules (11485ms)
Bundle modules (91ms)
Postprocesss modules (401ms)
Bundle Functions (998ms)
Generate Code (38ms)

[13.02s] Bundled "src/js" for production
  2591 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/10] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/zlib.ts            | 50 +++---------------------------------------
 test/js/node/zlib/zlib.test.js | 45 +++++++++++++++++++++++++++++++++++++
 2 files changed, 48 insertions(+), 47 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/js/node/zlib.ts                 1      0      7
test/js/node/zlib/zlib.test.js      0      0      7
```

</details>

<!-- robobun:evidence:end -->