### PR TITLE
node:os: read affinity and cgroup cpu quota on every availableParallelism() call

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "9bf28668e0b996522c94bff4761ea07abe0e9ef4";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/src/js/node/os.ts
+++ b/src/js/node/os.ts
@@ -89,9 +89,7 @@ function lazyCpus({ cpus, hostCpuCount }) {
 // all logic based on `process.platform` and `process.arch` is inlined at bundle time
 function bound(binding) {
   return {
-    availableParallelism: function () {
-      return navigator.hardwareConcurrency;
-    },
+    availableParallelism: binding.availableParallelism,
     arch: function () {
       return process.arch;
     },

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -111,39 +111,12 @@ extern "C" int32_t bun_sysconf__SC_NPROCESSORS_ONLN()
 #endif
 }
 
-#if OS(LINUX)
-#include <sched.h>
-// WTF/wtf/uv_get_constrained_memory.cpp (Bun's WebKit fork). The header is not installed.
-int uv_get_constrained_cpu();
-#endif
-
-// os.availableParallelism(): like WTF::numberOfProcessorCores() but, on Linux, read fresh on
-// every call as libuv's uv_available_parallelism() does, so an affinity change (taskset) or a
+// os.availableParallelism(): the same count as WTF::numberOfProcessorCores() but read fresh on
+// every call, as libuv's uv_available_parallelism() does, so an affinity change (taskset) or a
 // cgroup cpu.max change made after startup is observed. Thread pools keep the cached startup value.
 extern "C" int32_t Bun__availableParallelism()
 {
-#if OS(LINUX)
-    static const bool overridden = getenv("WTF_numberOfProcessorCores") != nullptr;
-    if (overridden)
-        return std::max(1, WTF::numberOfProcessorCores());
-
-    long result = sysconf(_SC_NPROCESSORS_ONLN);
-
-    cpu_set_t set;
-    CPU_ZERO(&set);
-    if (sched_getaffinity(0, sizeof(set), &set) == 0) {
-        long affinity = CPU_COUNT(&set);
-        if (affinity > 0 && (result < 1 || affinity < result))
-            result = affinity;
-    }
-
-    if (int constrained = uv_get_constrained_cpu(); constrained > 0 && (result < 1 || constrained < result))
-        result = constrained;
-
-    return result < 1 ? 1 : static_cast<int32_t>(result);
-#else
-    return std::max(1, WTF::numberOfProcessorCores());
-#endif
+    return std::max(1, WTF::numberOfProcessorCoresUncached());
 }
 
 #if OS(DARWIN) && BUN_DEBUG

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1,6 +1,8 @@
 // when we don't want to use @cInclude, we can just stick wrapper functions here
 #include "root.h"
+#include <algorithm>
 #include <cstdio>
+#include <wtf/NumberOfCores.h>
 
 #if !OS(WINDOWS)
 #include <wtf/WTFConfig.h>
@@ -106,6 +108,41 @@ extern "C" int32_t bun_sysconf__SC_NPROCESSORS_ONLN()
     return sysinfo.dwNumberOfProcessors;
 #else
     return sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+}
+
+#if OS(LINUX)
+#include <sched.h>
+// WTF/wtf/uv_get_constrained_memory.cpp (Bun's WebKit fork). The header is not installed.
+int uv_get_constrained_cpu();
+#endif
+
+// os.availableParallelism(): like WTF::numberOfProcessorCores() but, on Linux, read fresh on
+// every call as libuv's uv_available_parallelism() does, so an affinity change (taskset) or a
+// cgroup cpu.max change made after startup is observed. Thread pools keep the cached startup value.
+extern "C" int32_t Bun__availableParallelism()
+{
+#if OS(LINUX)
+    static const bool overridden = getenv("WTF_numberOfProcessorCores") != nullptr;
+    if (overridden)
+        return std::max(1, WTF::numberOfProcessorCores());
+
+    long result = sysconf(_SC_NPROCESSORS_ONLN);
+
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    if (sched_getaffinity(0, sizeof(set), &set) == 0) {
+        long affinity = CPU_COUNT(&set);
+        if (affinity > 0 && (result < 1 || affinity < result))
+            result = affinity;
+    }
+
+    if (int constrained = uv_get_constrained_cpu(); constrained > 0 && (result < 1 || constrained < result))
+        result = constrained;
+
+    return result < 1 ? 1 : static_cast<int32_t>(result);
+#else
+    return std::max(1, WTF::numberOfProcessorCores());
 #endif
 }
 

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -537,6 +537,18 @@ fn bindgen_out<T>(global: &JSGlobalObject, out: *mut T, r: bun_jsc::JsResult<T>)
     }
 }
 
+/// # Safety
+/// `out` must be a valid C++ stack out-param.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn bindgen_Node_os_dispatchAvailableParallelism1(
+    _global: *mut JSGlobalObject,
+    out: *mut i32,
+) -> bool {
+    // SAFETY: `out` is a valid C++ stack out-param. `available_parallelism()` is infallible.
+    unsafe { *out = node_os::available_parallelism() };
+    true
+}
+
 // HOST_EXPORT(bindgen_Node_os_dispatchCpus1)
 pub fn bindgen_node_os_cpus(global: &JSGlobalObject) -> bun_jsc::JsResult<JSValue> {
     node_os::cpus(global)

--- a/src/runtime/node/node_os.bind.ts
+++ b/src/runtime/node/node_os.bind.ts
@@ -2,6 +2,10 @@
 // The entrypoint for node:os is `src/js/node/os.ts`
 import { fn, t } from "bindgen";
 
+export const availableParallelism = fn({
+  args: {},
+  ret: t.i32,
+});
 export const cpus = fn({
   args: {
     global: t.globalObject,

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -9,6 +9,12 @@ use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
 unsafe extern "C" {
     safe fn bun_sysconf__SC_NPROCESSORS_ONLN() -> i32;
+    // c-bindings.cpp
+    safe fn Bun__availableParallelism() -> i32;
+}
+
+pub(crate) fn available_parallelism() -> i32 {
+    Bun__availableParallelism()
 }
 
 #[derive(Default, Clone, Copy)]
@@ -91,6 +97,7 @@ mod _impl {
         // the System V ABI on Windows-x64 and the C ABI everywhere else, matching
         // `bun_jsc::host_fn::JsHostFn`.
         bun_jsc::jsc_abi_extern! {
+            fn bindgen_Node_os_jsAvailableParallelism(g: *mut JSGlobalObject, c: *mut CallFrame) -> JSValue;
             fn bindgen_Node_os_jsCpus(g: *mut JSGlobalObject, c: *mut CallFrame) -> JSValue;
             fn bindgen_Node_os_jsFreemem(g: *mut JSGlobalObject, c: *mut CallFrame) -> JSValue;
             fn bindgen_Node_os_jsGetPriority(g: *mut JSGlobalObject, c: *mut CallFrame) -> JSValue;
@@ -124,6 +131,7 @@ mod _impl {
         )*};
     }
         create_callback! {
+            create_available_parallelism_callback, "availableParallelism", 0, bindgen_Node_os_jsAvailableParallelism;
             create_cpus_callback,               "cpus",              1, bindgen_Node_os_jsCpus;
             create_freemem_callback,            "freemem",           0, bindgen_Node_os_jsFreemem;
             create_get_priority_callback,       "getPriority",       2, bindgen_Node_os_jsGetPriority;
@@ -150,12 +158,17 @@ mod _impl {
     }
 
     pub(crate) fn create_node_os_binding(global: &JSGlobalObject) -> JsResult<JSValue> {
-        let obj = JSValue::create_empty_object(global, 14);
+        let obj = JSValue::create_empty_object(global, 15);
         // SAFETY: pure FFI getter
         obj.put(
             global,
             b"hostCpuCount",
             JSValue::js_number(1i32.max(bun_sysconf__SC_NPROCESSORS_ONLN()) as f64),
+        );
+        obj.put(
+            global,
+            b"availableParallelism",
+            gen_::create_available_parallelism_callback(global),
         );
         obj.put(global, b"cpus", gen_::create_cpus_callback(global));
         obj.put(global, b"freemem", gen_::create_freemem_callback(global));

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -231,6 +231,7 @@ it("devNull", () => {
 
 it("availableParallelism", () => {
   expect(os.availableParallelism()).toBeGreaterThan(0);
+  expect(os.availableParallelism()).toBe(navigator.hardwareConcurrency);
 });
 
 // Node reads the affinity mask and the cgroup cpu quota on every call, so a

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
@@ -232,6 +232,44 @@ it("devNull", () => {
 it("availableParallelism", () => {
   expect(os.availableParallelism()).toBeGreaterThan(0);
 });
+
+// Node reads the affinity mask and the cgroup cpu quota on every call, so a
+// `taskset` change made after startup is observed. Bun used to return the
+// value cached at startup forever.
+it.skipIf(!isLinux || !Bun.which("taskset") || os.availableParallelism() <= 2)(
+  "availableParallelism follows an affinity change made after startup",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const os = require("os");
+        const { execFileSync } = require("child_process");
+        const before = os.availableParallelism();
+        // "pid 123's current affinity list: 0-3,8-11"
+        const list = execFileSync("taskset", ["-pc", String(process.pid)], { encoding: "utf8" })
+          .split(":").pop().trim();
+        const cpus = [];
+        for (const part of list.split(",")) {
+          const [lo, hi = lo] = part.split("-").map(Number);
+          for (let i = lo; i <= hi; i++) cpus.push(i);
+        }
+        execFileSync("taskset", ["-pc", cpus.slice(0, 2).join(","), String(process.pid)], { stdio: "ignore" });
+        console.log(JSON.stringify({ before, after: os.availableParallelism() }));
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const { before, after } = JSON.parse(stdout);
+    expect(before).toBeGreaterThan(2);
+    expect(after).toBe(2);
+  },
+);
 
 it("loadavg", () => {
   const loadavg = os.loadavg();


### PR DESCRIPTION
### Problem
- `os.availableParallelism()` never changes after startup. On Linux, Node re-reads the affinity mask and the cgroup `cpu.max` quota on every call, so `taskset -pc 0-1 <pid>` or a k8s in-place CPU resize is observed. Bun returns the startup value forever: after `taskset`, bun prints `12 12`, node prints `12 2`.
- The cause: `src/js/node/os.ts:92` returned `navigator.hardwareConcurrency`, which is `WTF::numberOfProcessorCores()` (`ZigGlobalObject.cpp:1764`). That function computes the count once and caches it in a static.

### Fix
- oven-sh/WebKit#573 splits `numberOfProcessorCores()` into an exported `numberOfProcessorCoresUncached()` and a cached wrapper. The platform logic does not move or change, so there is one copy of the affinity and cgroup code. It is stacked on oven-sh/WebKit#571 (same function).
- This PR adds an `availableParallelism` binding to `node:os` (`node_os.bind.ts`, `node_os.rs`, `hw_exports.rs`). `os.ts` calls it. The binding is `Bun__availableParallelism()` in `c-bindings.cpp`: `std::max(1, WTF::numberOfProcessorCoresUncached())`, on every platform.
- `navigator.hardwareConcurrency` and thread pool sizing keep the cached startup value, as in Node. The `WTF_numberOfProcessorCores` override still applies to both.
- `WEBKIT_VERSION` points at the oven-sh/WebKit#573 branch head (`9bf28668`). Before this lands, oven-sh/WebKit#571 and #573 have to merge and `WEBKIT_VERSION` has to move to the resulting main sha.
- Verified: `test/js/node/os/os.test.js` (new test, fails on the released bun with `Expected: 2, Received: 12`). The rest of `os.test.js` passes.

### Background
- `sched_getaffinity(2)` returns the set of CPUs the scheduler may run the process on. `taskset` changes it at runtime.
- A cgroup v2 `cpu.max` file holds `quota period`. The process may use `quota / period` CPUs of time. Container runtimes and systemd write it, and they can change it while the process runs.
- On Linux, the fork's `numberOfProcessorCores()` takes the minimum of `_SC_NPROCESSORS_ONLN`, the affinity count, and the cgroup quota (`uv_get_constrained_cpu()` in `WTF/wtf/uv_get_constrained_memory.cpp`). libuv's `uv_available_parallelism()` uses the same formula.

<details><summary>Notes</summary>

- Repro: `bun -e 'const os=require("os");const a=os.availableParallelism();require("child_process").execSync("taskset -pc 0-1 "+process.pid);console.log(a, os.availableParallelism())'`. Pick CPUs from the current affinity list if 0-1 are not in it.
- The new test spawns a child bun, parses the child's own affinity list with `taskset -p`, pins it to the first two CPUs, and expects `2`. It skips when not on Linux, when `taskset` is missing, or when the host already reports 2 or fewer CPUs. The existing `availableParallelism` test also asserts the startup value equals `navigator.hardwareConcurrency`.
- Self-reviewed. The first draft copied the Linux branch of `NumberOfCores.cpp` into `c-bindings.cpp` with a forward declaration of the private `uv_get_constrained_cpu()`. The review asked for the computation to stay in the fork, so the copy is gone and the fork exports the uncached entry point instead. Two smaller concerns were also addressed: the env override is read inside the fork function, and the `>= 1` clamp lives only in `Bun__availableParallelism()`.
- #36183 adds a cached `Bun__availableParallelism` for fractional quota flooring. The fork already floors (`quota / period` in `uv_get_constrained_memory.cpp`), and that PR keeps the value in a static, so it does not fix this bug. It defines the same symbol, so one of the two has to give way.
- `userInfo` in `os.test.js` fails in this container because `$USER` is unset. That is unrelated to this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/os/os.test.js

<!-- robobun:evidence:end -->