### PR TITLE
glob: apply the dotfile rule per brace alternative in Glob.scan

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1758,15 +1758,25 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
 
     fn match_pattern_impl(&self, pattern_component: &Component, filepath: &[u8]) -> bool {
         log!("matchPatternImpl: {}", bstr::BStr::new(filepath));
+        if (self.is_ignored)(filepath) {
+            return false;
+        }
+
         // A pattern segment that itself starts with a literal `.` opts into
         // matching dotfiles for that segment, regardless of the `dot` flag.
+        // Brace alternatives (`{.a,*}`) and classes (`[.]a`) decide per
+        // branch, so the general matcher applies the rule itself.
         if !self.dot
             && Self::starts_with_dot(filepath)
             && !Self::starts_with_dot(pattern_component.pattern_slice(&self.pattern))
         {
-            return false;
-        }
-        if (self.is_ignored)(filepath) {
+            if pattern_component.syntax_hint == SyntaxHint::None {
+                return crate::match_no_dot(
+                    pattern_component.pattern_slice(&self.pattern),
+                    filepath,
+                )
+                .matches();
+            }
             return false;
         }
 

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1765,19 +1765,19 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
         // A pattern segment that itself starts with a literal `.` opts into
         // matching dotfiles for that segment, regardless of the `dot` flag.
         // Brace alternatives (`{.a,*}`) and classes (`[.]a`) decide per
-        // branch, so the general matcher applies the rule itself.
-        if !self.dot
-            && Self::starts_with_dot(filepath)
-            && !Self::starts_with_dot(pattern_component.pattern_slice(&self.pattern))
-        {
-            if pattern_component.syntax_hint == SyntaxHint::None {
-                return crate::matcher::match_no_dot(
-                    pattern_component.pattern_slice(&self.pattern),
-                    filepath,
-                )
-                .matches();
+        // branch, so the general matcher applies the rule itself. A negated
+        // segment (`!x`) keeps hiding dotfiles: its inner mismatch must not
+        // flip into a match.
+        if !self.dot && Self::starts_with_dot(filepath) {
+            let pattern = pattern_component.pattern_slice(&self.pattern);
+            if !Self::starts_with_dot(pattern) {
+                if pattern_component.syntax_hint == SyntaxHint::None
+                    && pattern.first() != Some(&b'!')
+                {
+                    return crate::matcher::match_no_dot(pattern, filepath).matches();
+                }
+                return false;
             }
-            return false;
         }
 
         match pattern_component.syntax_hint {

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1771,7 +1771,7 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             && !Self::starts_with_dot(pattern_component.pattern_slice(&self.pattern))
         {
             if pattern_component.syntax_hint == SyntaxHint::None {
-                return crate::match_no_dot(
+                return crate::matcher::match_no_dot(
                     pattern_component.pattern_slice(&self.pattern),
                     filepath,
                 )

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1762,8 +1762,6 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             return false;
         }
 
-        // An explicit leading `.` opts the segment into dotfiles. Braces and
-        // classes decide per branch inside the matcher.
         if !self.dot && Self::starts_with_dot(filepath) {
             let pattern = pattern_component.pattern_slice(&self.pattern);
             if !Self::starts_with_dot(pattern) {

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -1762,12 +1762,8 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
             return false;
         }
 
-        // A pattern segment that itself starts with a literal `.` opts into
-        // matching dotfiles for that segment, regardless of the `dot` flag.
-        // Brace alternatives (`{.a,*}`) and classes (`[.]a`) decide per
-        // branch, so the general matcher applies the rule itself. A negated
-        // segment (`!x`) keeps hiding dotfiles: its inner mismatch must not
-        // flip into a match.
+        // An explicit leading `.` opts the segment into dotfiles. Braces and
+        // classes decide per branch inside the matcher.
         if !self.dot && Self::starts_with_dot(filepath) {
             let pattern = pattern_component.pattern_slice(&self.pattern);
             if !Self::starts_with_dot(pattern) {

--- a/src/glob/lib.rs
+++ b/src/glob/lib.rs
@@ -6,7 +6,7 @@ pub mod matcher;
 
 // `match` is a Rust keyword; re-export with raw identifier.
 pub use crate::glob_walker as walk;
-pub use crate::matcher::{MatchResult, r#match};
+pub use crate::matcher::{MatchResult, r#match, match_no_dot};
 pub use walk::GlobWalker;
 
 // `ignore_filter_fn` is a runtime fn-pointer field supplied at `init()` rather than a type

--- a/src/glob/lib.rs
+++ b/src/glob/lib.rs
@@ -6,7 +6,7 @@ pub mod matcher;
 
 // `match` is a Rust keyword; re-export with raw identifier.
 pub use crate::glob_walker as walk;
-pub use crate::matcher::{MatchResult, r#match, match_no_dot};
+pub use crate::matcher::{MatchResult, r#match};
 pub use walk::GlobWalker;
 
 // `ignore_filter_fn` is a runtime fn-pointer field supplied at `init()` rather than a type

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -158,13 +158,17 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
     match_with_dot(glob, path, true)
 }
 
-/// Like [`match`](r#match), but a `.` at the start of a path segment only
-/// matches an explicit `.`, `\.`, or `[.]` at that position in the pattern.
-/// Wildcards (`*`, `?`, other `[...]` classes) do not consume it. This is
-/// minimatch's `dot: false` rule, applied per brace alternative, so
-/// `{.a,*}` matches `.a` but `{*,x}` does not.
-pub fn match_no_dot(glob: &[u8], path: &[u8]) -> MatchResult {
-    match_with_dot(glob, path, false)
+/// Like [`match`](r#match) for one path segment (`name` holds no separator),
+/// but a leading `.` only matches an explicit `.`, `\.`, or `[.]` at that
+/// position in the pattern. Wildcards (`*`, `?`, other `[...]` classes) do
+/// not consume it. This is minimatch's `dot: false` rule, applied per brace
+/// alternative, so `{.a,*}` matches `.a` but `{*,x}` does not.
+///
+/// One segment only: on a full path, a `**` that restarts on a later hidden
+/// segment would be rejected instead of matching zero segments there.
+pub(crate) fn match_no_dot(glob: &[u8], name: &[u8]) -> MatchResult {
+    debug_assert!(strings::index_of_any(name, b"/\\").is_none());
+    match_with_dot(glob, name, false)
 }
 
 fn match_with_dot(glob: &[u8], path: &[u8], dot: bool) -> MatchResult {
@@ -216,12 +220,14 @@ fn glob_match_impl(
         if (state.glob_index as usize) < glob.len() {
             'fallthrough: {
                 let ch = glob[state.glob_index as usize];
+                // Nothing before a segment start can backtrack into it, so
+                // this branch is dead rather than retried.
                 if !state.dot
                     && !matches!(ch, b'{' | b',' | b'}')
                     && at_hidden_segment_start(path, state.path_index)
                     && !is_explicit_dot(glob, state.glob_index)
                 {
-                    break 'fallthrough;
+                    return false;
                 }
                 'to_else: {
                     match ch {

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -167,7 +167,8 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
 /// One segment only: on a full path, a `**` that restarts on a later hidden
 /// segment would be rejected instead of matching zero segments there.
 pub(crate) fn match_no_dot(glob: &[u8], name: &[u8]) -> MatchResult {
-    debug_assert!(strings::index_of_any(name, b"/\\").is_none());
+    debug_assert!(!strings::contains_char(name, b'/'));
+    debug_assert!(!cfg!(windows) || !strings::contains_char(name, b'\\'));
     match_with_dot(glob, name, false)
 }
 

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -82,6 +82,10 @@ struct State {
     globstar: Wildcard,
 
     brace_depth: u8,
+
+    /// When false, a `.` at the start of a path segment may only be matched
+    /// by an explicit `.`, `\.`, or `[.]` in the pattern (minimatch `dot: false`).
+    dot: bool,
 }
 
 impl State {
@@ -151,7 +155,23 @@ struct Wildcard {
 // TODO: consider just taking arena and resetting to initial state,
 // all usages of this function pass in Arena.arena()
 pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
-    let mut state = State::default();
+    match_with_dot(glob, path, true)
+}
+
+/// Like [`match`](r#match), but a `.` at the start of a path segment only
+/// matches an explicit `.`, `\.`, or `[.]` at that position in the pattern.
+/// Wildcards (`*`, `?`, other `[...]` classes) do not consume it. This is
+/// minimatch's `dot: false` rule, applied per brace alternative, so
+/// `{.a,*}` matches `.a` but `{*,x}` does not.
+pub fn match_no_dot(glob: &[u8], path: &[u8]) -> MatchResult {
+    match_with_dot(glob, path, false)
+}
+
+fn match_with_dot(glob: &[u8], path: &[u8], dot: bool) -> MatchResult {
+    let mut state = State {
+        dot,
+        ..State::default()
+    };
 
     let mut negated = false;
     while (state.glob_index as usize) < glob.len() && glob[state.glob_index as usize] == b'!' {
@@ -196,6 +216,13 @@ fn glob_match_impl(
         if (state.glob_index as usize) < glob.len() {
             'fallthrough: {
                 let ch = glob[state.glob_index as usize];
+                if !state.dot
+                    && !matches!(ch, b'{' | b',' | b'}')
+                    && at_hidden_segment_start(path, state.path_index)
+                    && !is_explicit_dot(glob, state.glob_index)
+                {
+                    break 'fallthrough;
+                }
                 'to_else: {
                     match ch {
                         b'*' => {
@@ -597,6 +624,25 @@ fn find_brace_end(glob: &[u8], open_idx: u32) -> u32 {
 }
 
 use bun_paths::is_sep_native as is_separator;
+
+/// Is `path[path_index]` a `.` that begins a path segment?
+#[inline(always)]
+fn at_hidden_segment_start(path: &[u8], path_index: u32) -> bool {
+    let i = path_index as usize;
+    i < path.len() && path[i] == b'.' && (i == 0 || is_separator(path[i - 1]))
+}
+
+/// Does the pattern at `glob_index` spell out a literal `.`: `.`, `\.`, or `[.]`?
+#[inline(always)]
+fn is_explicit_dot(glob: &[u8], glob_index: u32) -> bool {
+    let rest = &glob[glob_index as usize..];
+    match rest.first() {
+        Some(b'.') => true,
+        Some(b'\\') => rest.get(1) == Some(&b'.'),
+        Some(b'[') => rest.starts_with(b"[.]"),
+        _ => false,
+    }
+}
 
 #[inline(always)]
 fn unescape(c: &mut u8, glob: &[u8], glob_index: &mut u32) -> bool {

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -157,8 +157,7 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
     match_with_dot(glob, path, true)
 }
 
-/// [`match`](r#match) for one path segment with minimatch's `dot: false` rule:
-/// a leading `.` only matches an explicit `.`, `\.`, or `[.]`, per brace branch.
+/// One path segment. A leading `.` needs an explicit `.`, `\.`, or `[.]` in its branch.
 pub(crate) fn match_no_dot(glob: &[u8], name: &[u8]) -> MatchResult {
     debug_assert!(!strings::contains_char(name, b'/'));
     debug_assert!(!cfg!(windows) || !strings::contains_char(name, b'\\'));

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -83,8 +83,7 @@ struct State {
 
     brace_depth: u8,
 
-    /// When false, a `.` at the start of a path segment may only be matched
-    /// by an explicit `.`, `\.`, or `[.]` in the pattern (minimatch `dot: false`).
+    /// False: a leading `.` in a segment needs an explicit `.`, `\.`, or `[.]`.
     dot: bool,
 }
 
@@ -158,14 +157,8 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
     match_with_dot(glob, path, true)
 }
 
-/// Like [`match`](r#match) for one path segment (`name` holds no separator),
-/// but a leading `.` only matches an explicit `.`, `\.`, or `[.]` at that
-/// position in the pattern. Wildcards (`*`, `?`, other `[...]` classes) do
-/// not consume it. This is minimatch's `dot: false` rule, applied per brace
-/// alternative, so `{.a,*}` matches `.a` but `{*,x}` does not.
-///
-/// One segment only: on a full path, a `**` that restarts on a later hidden
-/// segment would be rejected instead of matching zero segments there.
+/// [`match`](r#match) for one path segment with minimatch's `dot: false` rule:
+/// a leading `.` only matches an explicit `.`, `\.`, or `[.]`, per brace branch.
 pub(crate) fn match_no_dot(glob: &[u8], name: &[u8]) -> MatchResult {
     debug_assert!(!strings::contains_char(name, b'/'));
     debug_assert!(!cfg!(windows) || !strings::contains_char(name, b'\\'));
@@ -221,8 +214,6 @@ fn glob_match_impl(
         if (state.glob_index as usize) < glob.len() {
             'fallthrough: {
                 let ch = glob[state.glob_index as usize];
-                // Nothing before a segment start can backtrack into it, so
-                // this branch is dead rather than retried.
                 if !state.dot
                     && !matches!(ch, b'{' | b',' | b'}')
                     && at_hidden_segment_start(path, state.path_index)

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1011,10 +1011,19 @@ describe("explicit dotfile segments match without dot:true", () => {
     ["flat/{*,?a}", ["flat/a.b", "flat/c"]],
     ["flat/{[!x],c}a", []],
     ["flat/[.a]a", []],
+    // A negated segment never opts dotfiles in.
+    ["flat/!*", []],
+    ["flat/!{.a,c}", ["flat/a.b"]],
   ])("pattern %j applies the dotfile rule per brace alternative", (pattern, expected) => {
     using dir = tempDir("glob-scan-brace-dot", braceFiles);
     const result = Array.from(new Glob(pattern).scanSync({ cwd: String(dir) }));
     expect(norm(result)).toEqual(expected.sort());
+  });
+
+  test.skipIf(isWindows)("a dotfile with a backslash in its name is one segment", () => {
+    using dir = tempDir("glob-scan-brace-dot-backslash", { "flat/.a\\b": "x", "flat/c": "x" });
+    const result = Array.from(new Glob("flat/{.a*,c}").scanSync({ cwd: String(dir) }));
+    expect(result.sort()).toEqual(["flat/.a\\b", "flat/c"]);
   });
 });
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -987,6 +987,35 @@ describe("explicit dotfile segments match without dot:true", () => {
     const result = await Array.fromAsync(new Glob(".dotdir/inner.txt").scan({ cwd: String(dir) }));
     expect(norm(result)).toEqual([".dotdir/inner.txt"]);
   });
+
+  // The explicit-dot rule applies per brace alternative, like minimatch
+  // after brace expansion: `{.a,*}` is `.a` (explicit) or `*` (hidden).
+  const braceFiles = {
+    "flat/.a": "x",
+    "flat/.b": "x",
+    "flat/.ca": "x",
+    "flat/a.b": "x",
+    "flat/c": "x",
+  };
+
+  test.each([
+    ["flat/{.a,.b}", ["flat/.a", "flat/.b"]],
+    ["flat/{c,.a}", ["flat/.a", "flat/c"]],
+    ["flat/{*,.a}", ["flat/.a", "flat/a.b", "flat/c"]],
+    ["flat/{.,}a", ["flat/.a"]],
+    ["flat/{.c,x}*", ["flat/.ca"]],
+    ["flat/{a,.c}?", ["flat/.ca"]],
+    ["flat/[.]a", ["flat/.a"]],
+    ["flat/{**,.a}", ["flat/.a", "flat/a.b", "flat/c"]],
+    // No alternative spells out the dot: dotfiles stay hidden.
+    ["flat/{*,?a}", ["flat/a.b", "flat/c"]],
+    ["flat/{[!x],c}a", []],
+    ["flat/[.a]a", []],
+  ])("pattern %j applies the dotfile rule per brace alternative", (pattern, expected) => {
+    using dir = tempDir("glob-scan-brace-dot", braceFiles);
+    const result = Array.from(new Glob(pattern).scanSync({ cwd: String(dir) }));
+    expect(norm(result)).toEqual(expected.sort());
+  });
 });
 
 // `followSymlinks` controls whether wildcard traversal descends through


### PR DESCRIPTION
### Problem
- `Bun.Glob.scan` and `scanSync` with the default `dot: false` hide a dotfile even when the pattern spells it out inside a brace group. `new Glob("flat/{.a,.b}").scanSync()` returns `[]`. `flat/{c,.a}` returns only `flat/c`. `flat/[.]a` returns `[]`. Node `fs.globSync` and minimatch return the dotfiles for all three.
- The cause is `match_pattern_impl` in `src/glob/GlobWalker.rs:1764`. It only asks whether the whole pattern segment starts with `.`. A segment that starts with `{` or `[` never passes, so the dotfile rule from #32853 is not applied per alternative.

### Fix
- `src/glob/matcher.rs` gets a `dot` flag on the matcher state and a crate-private `match_no_dot(glob, name)` entry. In that mode a `.` at the start of the name only matches an explicit `.`, `\.`, or `[.]` at that point in the pattern. Any other token at that position fails the branch. Brace control tokens are exempt, so each alternative is tried on its own.
- The walker calls `match_no_dot` for a hidden entry whose segment needs the general matcher (`SyntaxHint::None`: braces, classes). Every other segment kind keeps the old `starts_with_dot` check. `r#match`, and so `Bun.Glob.match`, is unchanged: it always passes `dot = true`.
- This is minimatch's rule after brace expansion: `{.a,*}` is `.a` (explicit) or `*` (hidden). The 11 new patterns produce the same sets as node v26 `fs.globSync`, including the three negatives (`{*,?a}`, `{[!x],c}a`, `[.a]a`).
- Verified: `test/js/bun/glob/scan.test.ts` (new `test.each` block, 8 of 11 rows fail on bun 1.4.3). Also `test/js/bun/glob/match.test.ts`.

### Background
- `GlobWalker` splits the pattern on `/` into components and tags each with a `SyntaxHint`. Literal and `*.ext` components take fast paths. Anything with braces or classes goes to the general backtracking matcher in `matcher.rs`.
- `dot: false` means wildcards do not match a leading `.`. An explicit `.` in the pattern opts in. #32853 added that rule for whole segments. This change applies it per brace alternative.
- The matcher is shared by `Bun.Glob.match`, `bun pm pack`, and the bundler. For those callers the new check is one boolean short-circuit per token.

<details><summary>Notes</summary>

This is a parity follow-on found by a fuzz census against node and minimatch. There is no user report for it. Scope is `Bun.Glob.scan` and `scanSync` only. `bun run --filter` passes `dot: true`, and `node:fs.glob` in bun is a separate minimatch port.

Two known gaps stay as they are:

- `flat/\.a` still returns `[]`. The walker classifies `\.a` as a literal and compares it byte for byte. That is the backslash escape gap tracked by #32876, not this rule.
- `flat/{**,.a}` does not yield `flat` itself. Node does, because `**` can match zero segments there. That is the existing `**` dialect of the walker.

`match_no_dot` is single segment only. The walker always passes one directory entry name. On a full path a `**` that restarts on a later hidden segment would be rejected instead of matching zero segments there, so the function is `pub(crate)` and asserts that the name holds no separator in debug builds.

The `glob.match` recursive tests in `scan.test.ts` scan the whole `test/` tree and time out at 30 s under ASAN in a small container. They time out the same way on main there. CI machines pass them.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->