### PR TITLE
Clamp the WTF_numberOfProcessorCores override to [1, 1024] (WebKit bump)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "d195f4077981197ca7220c0b4ea9aa6cc9248d74";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1368,8 +1368,9 @@ jsimd_ycc_rgb_convert_avx2.return                    [AVX, AVX2]
 # decoded as AVX and as RDPMC), so a ceiling has nothing to bound. On ELF each
 # opcode handler has its own symbol, so layout shifts can move the desync
 # between llint_op_* siblings; add them here as they trip.
-# (3 symbols)
+# (4 symbols)
 # ----------------------------------------------------------------------------
 llint_op_enter_wide32
 llint_op_jmp_wide32
+llint_op_wide16
 llint_op_wide16_wide16

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
@@ -231,6 +231,44 @@ it("devNull", () => {
 
 it("availableParallelism", () => {
   expect(os.availableParallelism()).toBeGreaterThan(0);
+});
+
+describe("WTF_numberOfProcessorCores override", () => {
+  const script = `
+    const os = require("os");
+    require("crypto").pbkdf2("p", "s", 1000, 32, "sha256", err => {
+      if (err) throw err;
+      console.log(JSON.stringify([os.availableParallelism(), navigator.hardwareConcurrency]));
+    });
+  `;
+  async function run(value) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, WTF_numberOfProcessorCores: value },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  it.concurrent("0 is clamped to 1", async () => {
+    expect(await run("0")).toEqual([1, 1]);
+  });
+
+  it.concurrent("999999 is capped to 1024", async () => {
+    expect(await run("999999")).toEqual([1024, 1024]);
+  });
+
+  it.concurrent("4294967295 does not wrap negative", async () => {
+    expect(await run("4294967295")).toEqual([1024, 1024]);
+  });
+
+  it.concurrent("3 is honored", async () => {
+    expect(await run("3")).toEqual([3, 3]);
+  });
 });
 
 it("loadavg", () => {


### PR DESCRIPTION
### Problem
- `WTF_numberOfProcessorCores` is the WTF environment override for the CPU count. Bun uses it unvalidated. `WTF_numberOfProcessorCores=0` makes `os.availableParallelism()` and `navigator.hardwareConcurrency` return 0. `=999999` passes through. `=4294967295` wraps to -1.
- In a debug or ASAN build `=0` aborts at startup with `ASSERTION FAILED: cpusToUse >= 1` in `JSC::Options::computeNumberOfWorkerThreads` (`Source/JavaScriptCore/runtime/Options.cpp:441`).
- The only read of the variable is `WTF::numberOfProcessorCores()` in `Source/WTF/wtf/NumberOfCores.cpp`. Bun has no copy of that logic, so the fix lives in oven-sh/WebKit.

### Fix
- oven-sh/WebKit#571 clamps the parsed override to `[1, 1024]`. The cap keeps the value in `int` range and matches the `UV_THREADPOOL_SIZE` cap. A value that does not parse still warns and falls back to the detected count.
- This PR points `WEBKIT_VERSION` at that PR's branch head (`d195f407`). Before this lands, oven-sh/WebKit#571 has to merge and `WEBKIT_VERSION` has to move to the resulting main sha.
- Test: `test/js/node/os/os.test.js`, block "WTF_numberOfProcessorCores override". It spawns bun with the override set to `0`, `3`, `999999` and `4294967295`, runs a `pbkdf2` so the crypto pool sizes itself, and expects `[1, 1]`, `[3, 3]`, `[1024, 1024]` and `[1024, 1024]`.
- Fail-before: with bun 1.4.x (`USE_SYSTEM_BUN=1`) the `0`, `999999` and `4294967295` cases fail with `[0, 0]`, `[999999, 999999]` and `[-1, -1]`. With the current debug build the `0` and `4294967295` cases abort on the assertion. With this pin all four pass. The rest of `os.test.js` passes except `userInfo`, which fails on this machine without the pin too (`$USER` is unset).

### Background
- `WTF::numberOfProcessorCores()` is WebKit's cached CPU count. On Linux bun's fork takes the minimum of `_SC_NPROCESSORS_ONLN`, the affinity mask and the cgroup cpu quota. The env override replaces that detection, for tests that want to simulate a core count.
- Bun reports that number from `navigator.hardwareConcurrency` (`src/jsc/bindings/ZigGlobalObject.cpp:1764`) and `os.availableParallelism()` (`src/js/node/os.ts:92`). `bun_core::util::get_thread_count` (`src/bun_core/util.rs:2816`) already clamps it to at least 1 for bun's own pools. JSC reads it directly when it sizes its JIT worklist threads, which is where the debug assertion fires.
- Since #41330 the build compiles WebKit from source at `WEBKIT_VERSION`, so a branch sha is enough to test the change. No preview tarball is needed.

<details><summary>Notes</summary>

Probe against the fixed debug build (host reports 12 through affinity):

```
0          => 1 1
1          => 1 1
12         => 12 12
1024       => 1024 1024
1025       => 1024 1024
999999     => 1024 1024
4294967295 => 1024 1024
5000000000 => WARNING: failed to parse WTF_numberOfProcessorCores=5000000000 12 12
-1         => WARNING: failed to parse WTF_numberOfProcessorCores=-1 12 12
```

The cap is a constant rather than the host count because the override exists to simulate a count the host does not have. `UV_THREADPOOL_SIZE` and `GOMAXPROCS` are parsed by `get_thread_count` with the same `[2, 1024]` window.

The gate that reverts `src/` and `packages/` cannot show a fail-before for this PR: the change is in `scripts/build/deps/webkit.ts`, which both gate runs share.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/os/os.test.js

<!-- robobun:evidence:end -->