### PR TITLE
test(serve-body-leak): run the fixture without the ASAN quarantine and with eager page release

### DIFF
--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -147,7 +147,24 @@ describe.each([false, true])("request body leak (http2: %p)", http2 => {
     fixture = Bun.spawn(
       [bunExe(), "--smol", join(import.meta.dirname, "body-leak-test-fixture.ts"), ...(http2 ? ["--http2"] : [])],
       {
-        env: bunEnv,
+        env: {
+          ...bunEnv,
+          // Under ASAN, freed memory stays resident: the quarantine pins up to
+          // 256 MB of freed blocks, and the allocator hands free pages back to
+          // the OS at most every 5 s. With no leak at all, RSS then jittered by
+          // 60-90 MB between two samples taken 2000 requests apart, over the
+          // 64 MB allowance below. Make the fixture free memory eagerly so its
+          // RSS tracks live memory. A retained 64 KB chunk per request still
+          // measures ~120 MB, a retained body over 1 GB. Inert off ASAN.
+          ASAN_OPTIONS: [
+            bunEnv.ASAN_OPTIONS,
+            "quarantine_size_mb=0",
+            "thread_local_quarantine_size_kb=0",
+            "allocator_release_to_os_interval_ms=0",
+          ]
+            .filter(Boolean)
+            .join(":"),
+        },
         stdout: "inherit",
         stderr: "inherit",
         stdin: "ignore",


### PR DESCRIPTION
### Problem
- `test/js/bun/http/serve-body-leak.test.ts` fails on the x64-asan lane: `expect(report.leak).toBeLessThanOrEqual(64)` received 83 (build #110910, "streaming the body incompletely"). Two earlier x64-asan hits on other PRs measured 70 and 80 ("streaming the body"). No hit on main in the 125 main builds before. No single culprit commit: the flake is allocator noise with no margin.
- The cause is how ASAN frees memory in the fixture process. The quarantine pins up to 256 MB of freed blocks, and the allocator returns free pages to the OS at most every 5 s. `report.leak` is the difference of two RSS samples 2000 requests apart. With no leak, that difference moved by 60 to 90 MB (`serve-body-leak.test.ts:125`).

### Fix
- Spawn the fixture with `quarantine_size_mb=0`, `thread_local_quarantine_size_kb=0` and `allocator_release_to_os_interval_ms=0` in `ASAN_OPTIONS`. Freed memory leaves RSS at once, so RSS tracks live memory. The options are inert off ASAN.
- This is the same idiom that `archive.test.ts`, `fetch-leak.test.ts` and `harness.ts` (`expectRssDeltaBelow`) use for RSS leak checks under ASAN. No bound changes.
- The test still detects a leak. With these options and a fixture that retains one chunk per streaming request, `leak` measured 124 MB (incomplete streaming) and 1043 MB (full streaming), against the 64 MB bound.
- Verified: `bun bd test test/js/bun/http/serve-body-leak.test.ts` (debug ASAN, 15 pass, max leak 4). Before the change, the same build measured leak 63 and 64 with the default options.

### Background
- The fixture is one `Bun.serve` process. `/report` runs `Bun.gc(true)`, sleeps 50 ms and returns its RSS. The test sends batches of 512 KB bodies and samples RSS every 1000 requests.
- ASAN's allocator does not reuse freed memory at once. Freed blocks wait in a FIFO quarantine (256 MB by default on x86_64) so a use after free can be caught. Free pages of the size-class regions are given back to the kernel only on a timer.
- Related: #40088 rewrites this test and its fixture (fewer requests, a settle loop, a 32 MB quarantine). This PR is the minimal change to stop the failure on main.

<details><summary>Notes</summary>

Measurements on the local debug ASAN build, `leak` in MB per scenario run (each run is 3000 streaming requests, the statistic is the last sample minus the first one):

- default ASAN options, 10 runs: 27, 41, 0, 0, 36, 64, 0, 0, 20, 0 (max 64). Full test file runs: 36, 39, 63 for the streaming scenarios.
- `quarantine_size_mb=0:thread_local_quarantine_size_kb=0`, 10 runs: 0, 57, 28, 0, 0, 46, 39, 0, 0, 44 (max 57).
- plus `allocator_release_to_os_interval_ms=0`, 10 runs: 3, 0, 0, 12, 0, 6, 0, 17, 3, 0 (max 17). Two full test file runs: max 1 and max 37. `bun bd test` after rebuild at HEAD: max 4.
- positive control with the final options, fixture patched to retain every streaming chunk: streaming 1043, incomplete streaming 124.
- A settle loop in the fixture (repeat `Bun.gc(true)` + 50 ms until RSS stops falling) did not reduce the residual noise (max 42 over 10 runs), so it is not part of this change.
- `process.memoryUsage()` in the fixture at each sample shows heapUsed under 20 MB while RSS moves by 40 to 50 MB, so the residual noise is native allocator state, not JS heap.

CI scan: 400 builds between 2026-09-03 and 2026-09-06 on all branches, 3 failures of this file, all on x64-asan (leak 70, 80, 83). 125 main builds between 2026-08-20 and 2026-09-03: none.

CI on this PR (build #111033, x64-asan release): the file passes, 15 tests in 38 s. The fixture's RSS baseline dropped from 495 to 650 MB (build #110910) to 290 to 340 MB. `leak` per scenario: 0, 0, 3, 0, 35, 0, 0 over HTTP/1, then 0, 0, 0, 0, 2, 0, 0 over HTTP/2. The remaining 35 is in the streaming scenario (samples 300 and 343 MB, end 338 MB).
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-body-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/serve-body-leak.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/serve-body-leak.test.ts:
http://localhost:37263/
{
  leak: 2,
  start_memory: 404037632,
  peak_memory: 404037632,
  end_memory: 381464576,
  memory_examples: [ 379367424, 381464576 ],
}
(pass) request body leak (http2: false) > #10265 should not leak memory when ignoring the body [4853.32ms]
{
  leak: 0,
  start_memory: 381464576,
  peak_memory: 395354112,
  end_memory: 391725056,
  memory_examples: [ 391958528, 395354112 ],
}
(pass) request body leak (http2: false) > should not leak memory when buffering the body [9318.45ms]
{
  leak: 2,
  start_memory: 391725056,
  peak_memory: 411160576,
  end_memory: 411074560,
  memory_examples: [ 408842240, 411160576 ],
}
(pass) request body leak (http2: false) > should not leak memory when buffering a JSON body [35991.25ms]
{
  leak: 1,
  start_memory: 411074560,
  peak_memory: 411074560,
  end_memory: 400551936,
  memory_examples: [ 399282176, 400252928 ],
}
(pass) request body leak (http2: false) > should not leak memory when buffering the body and accessing req.body [12506.48ms]
{
  leak: 10,
  start_memory: 400551936,
  peak_memory: 467083264,
  end_memory: 438861824,
  memory_examples: [ 428195840, 467083264 ],
}
(pass) request body leak (http2: false) > should not leak memory when streaming the body [13434.39ms]
{
  leak: 0,
  start_memory: 438861824,
  peak_memory: 513155072,
  end_memory: 476024832,
  memory_examples: [ 493940736, 513155072 ],
}
(pass) request body leak (http2: false) > should not leak memory when streaming the body incompletely [10455.30ms]
{
  leak: 2,
  start_memory: 476024832,
  peak_memory: 476024832,
  end_memory: 392167424,
  memory_examples: [ 390070272, 391118848 ],
}
(pass) request body leak (http2: false) > should not leak memory when streaming the body and echoing it back [8365.58ms]
https://localhost:39051/
{
  l
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/serve-body-leak.test.ts | 19 ++++++++++++++++++-
 1 file changed, 18 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/bun/http/serve-body-leak.test.ts      1      2     10
```

</details>

**root cause** · written by the author bot

The test's `leak` value is the difference between two RSS samples taken from a fixture process running under ASAN's default allocator settings, where freed blocks sit in a 256 MB quarantine and pages are only returned to the OS every 5 seconds, so this deferred freeing alone shifted the measurement by 60 to 90 MB on the x64-asan lane and tripped the 64 MB bound with no real leak present. The fix spawns the fixture with `quarantine_size_mb=0`, `thread_local_quarantine_size_kb=0`, and `allocator_release_to_os_interval_ms=0` appended to `ASAN_OPTIONS`, the same idiom used in `harness.ts` and o…

<!-- robobun:evidence:end -->
