### PR TITLE
streams: run direct-stream pull(), close() and cancel() hooks in the stream's AsyncLocalStorage context

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1028,6 +1028,7 @@ static JSValue oneShotCallPull(JSC::VM& vm, JSGlobalObject* globalObject, JSValu
     }
     MarkedArgumentBuffer arguments;
     arguments.append(sink);
+    StreamAsyncContextScope asyncContextScope(globalObject, sink->m_stream.get());
     RELEASE_AND_RETURN(scope, JSC::call(globalObject, pullFunction, callData, jsUndefined(), arguments));
 }
 

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1706,7 +1706,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundOneShotDirectClose, (JSGlobalO
             return {};
         }
         MarkedArgumentBuffer noArguments;
-        JSC::call(globalObject, closeFunction, callData, jsUndefined(), noArguments);
+        {
+            StreamAsyncContextScope asyncContextScope(globalObject, sink->m_stream.get());
+            JSC::call(globalObject, closeFunction, callData, jsUndefined(), noArguments);
+        }
         RETURN_IF_EXCEPTION(scope, {});
     }
     MarkedArgumentBuffer noArguments;

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -817,11 +817,13 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
     bool pullIsTruthy = pull.toBoolean(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     if (!pullIsTruthy) {
+        StreamAsyncContextScope asyncContextScope(globalObject, stream);
         readDirectStreamCloseImpl(vm, globalObject, state, jsUndefined(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
         return jsUndefined();
     }
     if (!pull.isCallable()) {
+        StreamAsyncContextScope asyncContextScope(globalObject, stream);
         readDirectStreamCloseImpl(vm, globalObject, state, jsUndefined(), jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
         throwTypeError(globalObject, scope, "pull is not a function"_s);
@@ -856,7 +858,11 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
     MarkedArgumentBuffer pullArgs;
     pullArgs.append(sinkController);
     ASSERT(!pullArgs.hasOverflowed());
-    JSValue maybePromise = call(globalObject, pull, getCallData(pull), underlyingSource, pullArgs);
+    JSValue maybePromise;
+    {
+        StreamAsyncContextScope asyncContextScope(globalObject, stream);
+        maybePromise = call(globalObject, pull, getCallData(pull), underlyingSource, pullArgs);
+    }
     RETURN_IF_EXCEPTION(scope, {});
 
     if (auto* pullPromise = dynamicDowncast<JSPromise>(maybePromise)) {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -428,7 +428,7 @@ static void closeDirectSinkForError(JSC::VM& vm, JSGlobalObject* globalObject, J
 }
 
 // The Bun-only `underlyingSource.close(reason)` lifecycle callback.
-static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* underlyingSource, JSValue reason)
+static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject, JSValue asyncContext, JSObject* underlyingSource, JSValue reason)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!underlyingSource)
@@ -440,6 +440,7 @@ static void callUnderlyingSourceClose(JSC::VM& vm, JSGlobalObject* globalObject,
         return;
     MarkedArgumentBuffer args;
     args.append(reason);
+    StreamAsyncContextScope asyncContextScope(globalObject, asyncContext);
     JSC::call(globalObject, closeFunction, callData, underlyingSource, args);
     RELEASE_AND_RETURN(scope, );
 }
@@ -455,6 +456,7 @@ bool JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue
     const bool wasClosed = m_closed;
     m_closed = true;
     JSObject* underlyingSource = m_underlyingSource.get();
+    JSValue asyncContext = m_stream ? m_stream->m_asyncContext.get() : JSValue();
     directStreamControllerClearSource(this);
 
     bool delivered = false;
@@ -477,7 +479,7 @@ bool JSDirectStreamController::handleError(JSGlobalObject* globalObject, JSValue
         return delivered;
     closeDirectSinkForError(vm, globalObject, this, error);
     RETURN_IF_EXCEPTION(scope, false);
-    callUnderlyingSourceClose(vm, globalObject, underlyingSource, error);
+    callUnderlyingSourceClose(vm, globalObject, asyncContext, underlyingSource, error);
     RETURN_IF_EXCEPTION(scope, false);
     return delivered;
 }
@@ -661,6 +663,7 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
     // No "Closing" stream state exists: m_closed set here is what blocks re-entry.
     m_closed = true;
     JSObject* underlyingSource = m_underlyingSource.get();
+    JSValue asyncContext = stream->m_asyncContext.get();
     directStreamControllerClearSource(this);
 
     JSValue flushed = endDirectSink(vm, globalObject, this);
@@ -669,7 +672,7 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
     RETURN_IF_EXCEPTION(scope, );
     // The user's close(reason) hook runs once the stream is fully closed, so a throw from it
     // propagates to whoever closed with nothing left half-done.
-    RELEASE_AND_RETURN(scope, callUnderlyingSourceClose(vm, globalObject, underlyingSource, reason));
+    RELEASE_AND_RETURN(scope, callUnderlyingSourceClose(vm, globalObject, asyncContext, underlyingSource, reason));
 }
 
 // The rest of close(): hand end()'s final chunk to whoever is reading (or arm it for the next read),

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -368,12 +368,15 @@ void readableStreamDefaultReaderErrorReadRequests(JSC::JSGlobalObject*, JSReadab
 // Bun public `reader.readMany()`: returns the `{value,size,done}` object synchronously OR
 // a promise of one.
 // Restores the stream's construction-time async-context snapshot around a user
-// source callback (pull/cancel and the direct pull). Defined in WebStreamsMisc.cpp.
+// source callback (pull/cancel/close and the direct pull). Defined in WebStreamsMisc.cpp.
+// Closing or erroring the stream clears its snapshot (readableStreamClearSourceBarriers), so a
+// hook that runs after that takes the snapshot read beforehand.
 class StreamAsyncContextScope {
     WTF_MAKE_NONCOPYABLE(StreamAsyncContextScope);
 
 public:
     StreamAsyncContextScope(JSC::JSGlobalObject*, JSReadableStream*);
+    StreamAsyncContextScope(JSC::JSGlobalObject*, JSC::JSValue snapshot);
     ~StreamAsyncContextScope();
 
 private:

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -367,8 +367,8 @@ void readableStreamDefaultReaderRelease(JSC::JSGlobalObject*, JSReadableStreamDe
 void readableStreamDefaultReaderErrorReadRequests(JSC::JSGlobalObject*, JSReadableStreamDefaultReader*, JSC::JSValue error); // userJS: yes — JSReadableStreamDefaultReader.cpp
 // Bun public `reader.readMany()`: returns the `{value,size,done}` object synchronously OR
 // a promise of one.
-// Restores the stream's construction-time async-context snapshot (or one read before the
-// stream closed) around a user source callback. Defined in WebStreamsMisc.cpp.
+// Restores the stream's construction-time async-context snapshot around a user
+// source callback (pull/cancel and the direct pull). Defined in WebStreamsMisc.cpp.
 class StreamAsyncContextScope {
     WTF_MAKE_NONCOPYABLE(StreamAsyncContextScope);
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -367,10 +367,8 @@ void readableStreamDefaultReaderRelease(JSC::JSGlobalObject*, JSReadableStreamDe
 void readableStreamDefaultReaderErrorReadRequests(JSC::JSGlobalObject*, JSReadableStreamDefaultReader*, JSC::JSValue error); // userJS: yes — JSReadableStreamDefaultReader.cpp
 // Bun public `reader.readMany()`: returns the `{value,size,done}` object synchronously OR
 // a promise of one.
-// Restores the stream's construction-time async-context snapshot around a user
-// source callback (pull/cancel/close and the direct pull). Defined in WebStreamsMisc.cpp.
-// Closing or erroring the stream clears its snapshot (readableStreamClearSourceBarriers), so a
-// hook that runs after that takes the snapshot read beforehand.
+// Restores the stream's construction-time async-context snapshot (or one read before the
+// stream closed) around a user source callback. Defined in WebStreamsMisc.cpp.
 class StreamAsyncContextScope {
     WTF_MAKE_NONCOPYABLE(StreamAsyncContextScope);
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -363,9 +363,13 @@ QueuingStrategyDict convertQueuingStrategyDict(JSGlobalObject* globalObject, JSV
 // For values that are provably not thenables (undefined, internal arrays/objects we
 // created): fulfill directly instead of running the observable resolve machinery.
 StreamAsyncContextScope::StreamAsyncContextScope(JSGlobalObject* globalObject, JSReadableStream* stream)
+    : StreamAsyncContextScope(globalObject, stream ? stream->m_asyncContext.get() : JSValue())
+{
+}
+
+StreamAsyncContextScope::StreamAsyncContextScope(JSGlobalObject* globalObject, JSValue snapshot)
     : m_vm(globalObject->vm())
 {
-    JSValue snapshot = stream->m_asyncContext.get();
     if (!snapshot || snapshot.isUndefinedOrNull())
         return;
     auto* asyncContextData = globalObject->m_asyncContextData.get();

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -1032,6 +1032,91 @@ test("sync pull() under AsyncLocalStorage releases the request on end()", async 
   expect((counts.ReadableStream ?? 0) - baseline).toBeLessThan(10);
 });
 
+// The server drives a Response body's pull() natively, after the fetch handler
+// (and any AsyncLocalStorage.run() around it) has returned. The stream snapshots
+// the async context when it is constructed; the pull must run in that snapshot.
+describe("AsyncLocalStorage context of a direct Response body", () => {
+  const als = new AsyncLocalStorage<string>();
+
+  async function serveAndCollect(body: (seen: string[]) => BodyInit): Promise<{ text: string; seen: string[] }> {
+    const seen: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return als.run("request", () => new Response(body(seen)));
+      },
+    });
+    const res = await fetch(server.url);
+    const text = await res.text();
+    return { text, seen };
+  }
+
+  test("async generator body sees the store at every step", async () => {
+    const { text, seen } = await serveAndCollect(seen => {
+      async function* body() {
+        seen.push(`start:${als.getStore()}`);
+        yield "a";
+        seen.push(`after-yield:${als.getStore()}`);
+        await Bun.sleep(0);
+        seen.push(`after-await:${als.getStore()}`);
+        yield "b";
+        seen.push(`end:${als.getStore()}`);
+      }
+      return body();
+    });
+    expect({ text, seen }).toEqual({
+      text: "ab",
+      seen: ["start:request", "after-yield:request", "after-await:request", "end:request"],
+    });
+  });
+
+  test("direct stream pull() sees the store", async () => {
+    const { text, seen } = await serveAndCollect(
+      seen =>
+        new ReadableStream({
+          type: "direct",
+          async pull(c) {
+            seen.push(`pull:${als.getStore()}`);
+            await c.write("x");
+            seen.push(`after-write:${als.getStore()}`);
+            c.close();
+          },
+        }),
+    );
+    expect({ text, seen }).toEqual({ text: "x", seen: ["pull:request", "after-write:request"] });
+  });
+
+  test("a direct stream with no pull() runs cancel() in the store", async () => {
+    const { text, seen } = await serveAndCollect(
+      seen =>
+        new ReadableStream({
+          type: "direct",
+          cancel() {
+            seen.push(`cancel:${als.getStore()}`);
+          },
+        } as any),
+    );
+    expect({ text, seen }).toEqual({ text: "", seen: ["cancel:request"] });
+  });
+
+  test("a Response constructed outside any store keeps no store", async () => {
+    const seen: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        async function* body() {
+          seen.push(`start:${als.getStore()}`);
+          yield "a";
+          seen.push(`end:${als.getStore()}`);
+        }
+        return new Response(body());
+      },
+    });
+    const res = await fetch(server.url);
+    expect({ text: await res.text(), seen }).toEqual({ text: "a", seen: ["start:undefined", "end:undefined"] });
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/36940
 // close() while the sink still holds unflushed bytes deferred the final send
 // to the auto-flusher, which ended the response through uWS (writing the

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -9,6 +9,7 @@ import {
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { closeSync, createReadStream, openSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -594,6 +595,58 @@ it("ReadableStream (direct): controller.close() outside pull with a throwing clo
   expect(first.done).toBe(false);
   expect(new TextDecoder().decode(first.value)).toBe("late");
   expect((await reader.read()).done).toBe(true);
+});
+
+// A direct stream snapshots the AsyncLocalStorage context at construction. Its
+// pull() and close() hooks run in that snapshot, wherever the consumer reads from.
+it("ReadableStream (direct): pull() and close() run in the AsyncLocalStorage context of the constructor", async () => {
+  const als = new AsyncLocalStorage();
+  const seen = [];
+  let controller;
+  const pulled = Promise.withResolvers();
+  const stream = als.run("ctor", () => {
+    return new ReadableStream({
+      type: "direct",
+      pull(c) {
+        seen.push(`pull:${als.getStore()}`);
+        controller = c;
+        pulled.resolve();
+      },
+      close() {
+        seen.push(`close:${als.getStore()}`);
+      },
+    });
+  });
+  const reader = stream.getReader();
+  const pending = reader.read();
+  await pulled.promise;
+  controller.write("x");
+  controller.close();
+  expect(new TextDecoder().decode((await pending).value)).toBe("x");
+  expect((await reader.read()).done).toBe(true);
+  expect(seen).toEqual(["pull:ctor", "close:ctor"]);
+});
+
+it("ReadableStream (direct): the one-shot ArrayBuffer consumer runs pull() in the AsyncLocalStorage context of the constructor", async () => {
+  const als = new AsyncLocalStorage();
+  const seen = [];
+  const make = tag =>
+    als.run("ctor", () => {
+      return new ReadableStream({
+        type: "direct",
+        pull(c) {
+          seen.push(`${tag}:${als.getStore()}`);
+          c.write("x");
+          c.close();
+        },
+      });
+    });
+  const lengths = [
+    (await readableStreamToArrayBuffer(make("arrayBuffer"))).byteLength,
+    (await readableStreamToBytes(make("bytes"))).byteLength,
+    (await new Response(make("response")).arrayBuffer()).byteLength,
+  ];
+  expect({ lengths, seen }).toEqual({ lengths: [1, 1, 1], seen: ["arrayBuffer:ctor", "bytes:ctor", "response:ctor"] });
 });
 
 it("ReadableStream (bytes)", async () => {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -649,6 +649,31 @@ it("ReadableStream (direct): the one-shot ArrayBuffer consumer runs pull() in th
   expect({ lengths, seen }).toEqual({ lengths: [1, 1, 1], seen: ["arrayBuffer:ctor", "bytes:ctor", "response:ctor"] });
 });
 
+it("ReadableStream (direct): the one-shot ArrayBuffer consumer runs close() in the AsyncLocalStorage context of the constructor", async () => {
+  const als = new AsyncLocalStorage();
+  const seen = [];
+  let controller;
+  const pulled = Promise.withResolvers();
+  const stream = als.run("ctor", () => {
+    return new ReadableStream({
+      type: "direct",
+      pull(c) {
+        controller = c;
+        pulled.resolve();
+        return pulled.promise;
+      },
+      close() {
+        seen.push(`close:${als.getStore()}`);
+      },
+    });
+  });
+  const result = readableStreamToArrayBuffer(stream);
+  await pulled.promise;
+  controller.write("x");
+  controller.close();
+  expect({ byteLength: (await result).byteLength, seen }).toEqual({ byteLength: 1, seen: ["close:ctor"] });
+});
+
 it("ReadableStream (bytes)", async () => {
   var stream = new ReadableStream({
     start(controller) {


### PR DESCRIPTION
### Problem
- A `Bun.serve` response built from an async generator or a `{ type: "direct" }` stream inside `AsyncLocalStorage.run()` loses the store in the body. `als.getStore()` is `undefined` before the first `yield` and after every `await`. The same happens for the `close(reason)` hook of a direct stream read through a reader, and for `pull()` under `Bun.readableStreamToArrayBuffer` / `readableStreamToBytes` / `Response.arrayBuffer()`.
- The stream snapshots the async context in `JSReadableStream::finishCreation` and the spec controllers restore it with `StreamAsyncContextScope`. Five native call sites did not: the server sink pull in `readDirectStream` (`BunStreamSource.cpp:861`), its cancel-only early exit (`:820`), `oneShotCallPull` and the one-shot sink's `close` (`BunStreamConsumers.cpp:1031`, `:1709`), and `callUnderlyingSourceClose` (`JSDirectStreamController.cpp:443`). The server calls pull after the fetch handler returned, so the `run()` frame is gone by then.

### Fix
- Bracket those five calls with `StreamAsyncContextScope`, the same scope the default, byte and direct controllers already use for pull and cancel.
- The close hook runs after the stream is closed, and closing clears the snapshot (`readableStreamClearSourceBarriers`). Read the snapshot before `directStreamControllerClearSource` and pass it to a new `StreamAsyncContextScope(JSGlobalObject*, JSValue)` overload.
- Correct because the snapshot is the context the user created the stream in, and the scope is a no-op when no store is active (the common case).
- Verified: `test/js/bun/http/serve-direct-readable-stream.test.ts` (4 new tests, 3 fail on 1.4.3) and `test/js/web/streams/streams.test.js` (3 new tests, all fail on 1.4.3). Also ran all of both files and the other direct-stream suites.

### Background
- `AsyncLocalStorage` in Bun rides a per-global `$asyncContext` slot. Native code that calls user JS later has to restore the frame it captured, or the callback sees no store.
- A direct stream (`type: "direct"`, or a `Response` body built from an async iterable) has no queue. A native sink (the HTTP response, an `ArrayBufferSink`) calls `pull(controller)` once and the user writes to the controller.
- `StreamAsyncContextScope` swaps the stream's snapshot into `$asyncContext` for the scope of one call and restores the previous value on exit.

<details><summary>Notes</summary>

Probe on 1.4.3 release vs this branch (`als.run("C", ...)` around the stream constructor, consumer outside):

```
server async generator:  before-first-yield:undefined -> C, after-await:undefined -> C
reader + close():        pull:C, close:undefined -> close:C
readableStreamToArrayBuffer / toBytes / Response.arrayBuffer: pull:undefined -> C
readableStreamToText / toArray / Response.text: pull:C (already went through the direct controller)
server source with no pull(): cancel:undefined -> C
```

Suites run with the debug build: `serve-direct-readable-stream.test.ts`, `streams.test.js`, `readable-stream-terminal-barrier-release.test.ts`, `native-source-onclose-leak.test.ts`, `sync-pull-fast-path.test.ts`.

A self-review raised the close hook and the cancel-only exit. The review on the PR raised the one-shot sink's close hook. All three are in this PR.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->
