### PR TITLE
bundler: run plugin onResolve, onLoad and onEnd hooks in the AsyncLocalStorage context of their registration

### DIFF
--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -5,9 +5,9 @@ type AnyFunction = (...args: any[]) => any;
  * @see `JSBundlerPlugin.h`
  */
 interface BundlerPlugin {
-  onLoad: Map<string, [RegExp, OnLoadCallback][]>;
-  onResolve: Map<string, [RegExp, OnResolveCallback][]>;
-  onEndCallbacks: Array<(build: Bun.BuildOutput) => void | Promise<void>> | undefined;
+  onLoad: Map<string, [RegExp, OnLoadCallback, asyncContext: unknown][]>;
+  onResolve: Map<string, [RegExp, OnResolveCallback, asyncContext: unknown][]>;
+  onEndCallbacks: Array<[(build: Bun.BuildOutput) => void | Promise<void>, asyncContext: unknown]> | undefined;
   /** Binding to `JSBundlerPlugin__onLoadAsync` */
   onLoadAsync(
     internalID,
@@ -115,10 +115,11 @@ export function runOnEndCallbacks(
   const callbacks = this.onEndCallbacks;
   if (!callbacks) return;
   const promises: PromiseLike<unknown>[] = [];
+  const runInFrame = require("internal/async_context_frame").run;
 
-  for (const callback of callbacks) {
+  for (const [callback, asyncContext] of callbacks) {
     try {
-      const result = callback(buildResult);
+      const result = runInFrame(asyncContext, callback, undefined, buildResult);
 
       if (result && $isPromise(result)) {
         $arrayPush(promises, result);
@@ -163,8 +164,8 @@ export function runSetupFunction(
   isBake: boolean,
 ): Promise<Promise<any>[]> | Promise<any>[] | undefined {
   this.promises = promises;
-  var onLoadPlugins = new Map<string, [filter: RegExp, callback: OnLoadCallback][]>();
-  var onResolvePlugins = new Map<string, [filter: RegExp, OnResolveCallback][]>();
+  var onLoadPlugins = new Map<string, [filter: RegExp, callback: OnLoadCallback, asyncContext: unknown][]>();
+  var onResolvePlugins = new Map<string, [filter: RegExp, OnResolveCallback, asyncContext: unknown][]>();
   var onBeforeParsePlugins = new Map<
     string,
     [RegExp, napiModule: unknown, symbol: string, external?: undefined | unknown][]
@@ -218,10 +219,15 @@ export function runSetupFunction(
 
     var callbacks = map.$get(namespace);
 
+    // The bundle thread dispatches onLoad/onResolve later, outside any JS frame. Capture the
+    // async context at registration so the callback runs in it (AsyncLocalStorage).
+    var entry = isOnBeforeParse
+      ? [filter, callback, symbol, external]
+      : [filter, callback, $getInternalField($asyncContext, 0)];
     if (!callbacks) {
-      map.$set(namespace, [isOnBeforeParse ? [filter, callback, symbol, external] : [filter, callback]]);
+      map.$set(namespace, [entry]);
     } else {
-      $arrayPush(callbacks, isOnBeforeParse ? [filter, callback, symbol, external] : [filter, callback]);
+      $arrayPush(callbacks, entry);
     }
   }
 
@@ -273,7 +279,7 @@ export function runSetupFunction(
 
     if (!self.onEndCallbacks) self.onEndCallbacks = [];
 
-    $arrayPush(self.onEndCallbacks, callback);
+    $arrayPush(self.onEndCallbacks, [callback, $getInternalField($asyncContext, 0)]);
 
     return this;
   }
@@ -308,7 +314,7 @@ export function runSetupFunction(
         this.onResolve = onResolvePlugins;
       } else {
         for (let [namespace, callbacks] of onResolvePlugins.entries()) {
-          var existing = onResolveObject.$get(namespace) as [RegExp, AnyFunction][];
+          var existing = onResolveObject.$get(namespace) as [RegExp, AnyFunction, unknown][];
 
           if (!existing) {
             onResolveObject.$set(namespace, callbacks);
@@ -325,7 +331,7 @@ export function runSetupFunction(
         this.onLoad = onLoadPlugins;
       } else {
         for (let [namespace, callbacks] of onLoadPlugins.entries()) {
-          var existing = onLoadObject.$get(namespace) as [RegExp, AnyFunction][];
+          var existing = onLoadObject.$get(namespace) as [RegExp, AnyFunction, unknown][];
 
           if (!existing) {
             onLoadObject.$set(namespace, callbacks);
@@ -408,10 +414,11 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
       this.onResolveAsync(internalID, null, null, null);
       return null;
     }
+    const runInFrame = require("internal/async_context_frame").run;
 
-    for (let [filter, callback] of results) {
+    for (let [filter, callback, asyncContext] of results) {
       if (filter.test(inputPath)) {
-        var result = callback({
+        var result = runInFrame(asyncContext, callback, undefined, {
           path: inputPath,
           importer,
           namespace: inputNamespace,
@@ -515,10 +522,11 @@ export function runOnLoadPlugins(
       this.onLoadAsync(internalID, null, null);
       return null;
     }
+    const runInFrame = require("internal/async_context_frame").run;
 
-    for (let [filter, callback] of results) {
+    for (let [filter, callback, asyncContext] of results) {
       if (filter.test(path)) {
-        var result = callback({
+        var result = runInFrame(asyncContext, callback, undefined, {
           path,
           namespace,
           // suffix

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -219,8 +219,7 @@ export function runSetupFunction(
 
     var callbacks = map.$get(namespace);
 
-    // The bundle thread dispatches onLoad/onResolve later, outside any JS frame. Capture the
-    // async context at registration so the callback runs in it (AsyncLocalStorage).
+    // The bundle thread dispatches the hook later, outside any async frame.
     var entry = isOnBeforeParse
       ? [filter, callback, symbol, external]
       : [filter, callback, $getInternalField($asyncContext, 0)];

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -219,7 +219,6 @@ export function runSetupFunction(
 
     var callbacks = map.$get(namespace);
 
-    // The bundle thread dispatches the hook later, outside any async frame.
     var entry = isOnBeforeParse
       ? [filter, callback, symbol, external]
       : [filter, callback, $getInternalField($asyncContext, 0)];

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -715,7 +715,6 @@ extern "C" JSC::EncodedJSValue JSBundlerPlugin__runOnEndCallbacks(Bun::JSBundler
     arguments.append(JSValue::decode(encodedBuildResult));
     arguments.append(JSValue::decode(encodedRejection));
 
-    // TODO: use AsyncContextFrame?
     auto result
         = JSC::profiledCall(globalObject, ProfilingReason::API, runOnEndCallbacksFn, callData, plugin, arguments);
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { AsyncLocalStorage } from "node:async_hooks";
 import path, { dirname, join, resolve } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -1893,4 +1894,52 @@ describe("bundler", () => {
       }).toEqual({ success: true, logs: [], outputs: ["second-name.js"] });
     });
   }
+
+  // The bundle thread dispatches onResolve/onLoad/onEnd back to JS after the
+  // setup() call has returned. Each hook runs in the AsyncLocalStorage context
+  // that was active when it was registered.
+  test.concurrent("plugin/hooks run in the AsyncLocalStorage context of their registration", async () => {
+    using dir = tempDir("plugin-async-local-storage", {
+      "entry.ts": `import x from "./dep.magic"; console.log(x);`,
+      "dep.ts": `export default 1;`,
+    });
+    const als = new AsyncLocalStorage<string>();
+    const seen: string[] = [];
+    const result = await als.run("build", () =>
+      Bun.build({
+        entrypoints: [join(String(dir), "entry.ts")],
+        throw: false,
+        plugins: [
+          {
+            name: "als",
+            setup(build) {
+              build.onStart(() => {
+                seen.push(`onStart:${als.getStore()}`);
+              });
+              build.onResolve({ filter: /\.magic$/ }, () => {
+                seen.push(`onResolve:${als.getStore()}`);
+                return { path: join(String(dir), "dep.ts") };
+              });
+              build.onLoad({ filter: /dep\.ts$/ }, async () => {
+                seen.push(`onLoad:${als.getStore()}`);
+                await Bun.sleep(0);
+                seen.push(`onLoad-after-await:${als.getStore()}`);
+                return { contents: "export default 2;", loader: "ts" };
+              });
+              als.run("registration", () => {
+                build.onEnd(() => {
+                  seen.push(`onEnd:${als.getStore()}`);
+                });
+              });
+            },
+          },
+        ],
+      }),
+    );
+    expect({ success: result.success, logs: result.logs.map(log => log.message), seen }).toEqual({
+      success: true,
+      logs: [],
+      seen: ["onStart:build", "onResolve:build", "onLoad:build", "onLoad-after-await:build", "onEnd:registration"],
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- A `Bun.build()` plugin registered inside `AsyncLocalStorage.run()` sees `als.getStore() === undefined` in `onResolve`, `onLoad` and `onEnd`. Only the synchronous `onStart` sees the store.
- The bundle thread hands each request to the JS thread through `JSBundlerPlugin__matchOnLoad` / `matchOnResolve` / `runOnEndCallbacks` (`src/jsc/bindings/JSBundlerPlugin.cpp`), outside any async frame. `src/js/builtins/BundlerPlugin.ts` stored the bare callbacks and called them as is.

### Fix
- `runSetupFunction` now stores `$getInternalField($asyncContext, 0)` next to each `onLoad` / `onResolve` / `onEnd` callback at registration. `runOnResolvePlugins`, `runOnLoadPlugins` and `runOnEndCallbacks` run the callback through `internal/async_context_frame`'s `run`, which swaps the frame in for the call and restores it after.
- The capture point is the registration call, not the `Bun.build()` call, so an `onEnd` registered inside a nested `run()` in `setup()` sees that inner store. For a plain `setup()` the two are the same frame.
- Runtime `Bun.plugin()` hooks (`BunPlugin.cpp`) are dispatched at import time with the importer's context and are not changed.
- Removes the `TODO: use AsyncContextFrame?` in `JSBundlerPlugin__runOnEndCallbacks`.
- Verified: `test/bundler/bundler_plugin.test.ts` (1 new test, fails on 1.4.3). Also ran all of `bundler_plugin.test.ts`, `bundler_plugin_chain.test.ts`, `plugin-error-nested-throw.test.ts`, `plugin-sync-exception-fallback.test.ts`.

### Background
- `AsyncLocalStorage` in Bun rides a per-global `$asyncContext` internal field. Built-in JS that calls user code later captures that field and restores it around the call. `node/_http_client.ts`, `node/http2.ts` and `ProcessObjectInternals.ts` use the same pattern.
- The plugin hooks live in tuples `[filter, callback]` in per-namespace maps on the `BundlerPlugin` object. Every reader destructures them by position, so the extra element is invisible to the other consumers (Bake, the serve HTML bundler).

<details><summary>Notes</summary>

Probe on 1.4.3 (`als.run("C", () => Bun.build({...}))`):

```
setup:C onStart:C onResolve:undefined onLoad:undefined onLoad-after-await:undefined onEnd:undefined
```

With this PR every hook reports `C`. An async `onLoad` keeps the store across its own `await`, since the continuation restores the frame that was active at the await.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->