### PR TITLE
Report FormData native memory to the GC

### DIFF
--- a/src/jsc/DOMFormData.rs
+++ b/src/jsc/DOMFormData.rs
@@ -33,6 +33,7 @@ unsafe extern "C" {
         arg4: &EncodedSlice,
     );
     safe fn WebCore__DOMFormData__count(arg0: &mut DOMFormData) -> usize;
+    safe fn WebCore__DOMFormData__reportMemoryCost(value: JSValue);
 }
 
 impl DOMFormData {
@@ -80,5 +81,11 @@ impl DOMFormData {
 
     pub fn count(&mut self) -> usize {
         WebCore__DOMFormData__count(self)
+    }
+
+    /// Report the native byte cost of the wrapper to the GC. Call after a batch
+    /// of native appends so the allocation-driven GC trigger can see the bytes.
+    pub fn report_memory_cost(value: JSValue) {
+        WebCore__DOMFormData__reportMemoryCost(value);
     }
 }

--- a/src/jsc/DOMFormData.rs
+++ b/src/jsc/DOMFormData.rs
@@ -83,8 +83,7 @@ impl DOMFormData {
         WebCore__DOMFormData__count(self)
     }
 
-    /// Report the native byte cost of the wrapper to the GC. Call after a batch
-    /// of native appends so the allocation-driven GC trigger can see the bytes.
+    /// Report the wrapper's native byte cost to the GC after native appends.
     pub fn report_memory_cost(value: JSValue) {
         WebCore__DOMFormData__reportMemoryCost(value);
     }

--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -197,11 +197,9 @@ size_t DOMFormData::memoryCost() const
     size_t cost = m_items.capacity() * sizeof(Item);
     for (auto& item : m_items) {
         cost += stringMemoryCost(item.name);
-        if (auto value = std::get_if<RefPtr<Blob>>(&item.data)) {
-            cost += value->get()->memoryCost();
-        } else if (auto value = std::get_if<String>(&item.data)) {
+        // A Blob entry's store is reported by the JSBlob wrapper that get() creates.
+        if (auto value = std::get_if<String>(&item.data))
             cost += stringMemoryCost(*value);
-        }
     }
 
     return cost;

--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -194,13 +194,13 @@ std::optional<KeyValuePair<String, DOMFormData::FormDataEntryValue>> DOMFormData
 
 size_t DOMFormData::memoryCost() const
 {
-    size_t cost = m_items.sizeInBytes();
+    size_t cost = m_items.capacity() * sizeof(Item);
     for (auto& item : m_items) {
-        cost += item.name.sizeInBytes();
+        cost += stringMemoryCost(item.name);
         if (auto value = std::get_if<RefPtr<Blob>>(&item.data)) {
             cost += value->get()->memoryCost();
         } else if (auto value = std::get_if<String>(&item.data)) {
-            cost += value->sizeInBytes();
+            cost += stringMemoryCost(*value);
         }
     }
 

--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -192,14 +192,24 @@ std::optional<KeyValuePair<String, DOMFormData::FormDataEntryValue>> DOMFormData
     return makeKeyValuePair(item.name, item.data);
 }
 
-size_t DOMFormData::memoryCost() const
+size_t DOMFormData::reportableMemoryCost() const
 {
     size_t cost = m_items.capacity() * sizeof(Item);
     for (auto& item : m_items) {
         cost += stringMemoryCost(item.name);
-        // A Blob entry's store is reported by the JSBlob wrapper that get() creates.
         if (auto value = std::get_if<String>(&item.data))
             cost += stringMemoryCost(*value);
+    }
+
+    return cost;
+}
+
+size_t DOMFormData::memoryCost() const
+{
+    size_t cost = reportableMemoryCost();
+    for (auto& item : m_items) {
+        if (auto value = std::get_if<RefPtr<Blob>>(&item.data))
+            cost += value->get()->memoryCost();
     }
 
     return cost;

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -75,7 +75,7 @@ public:
     void set(const String& name, RefPtr<Blob>, const String& filename = {});
 
     size_t count() const { return m_items.size(); }
-    // Native bytes the entries hold, including each StringImpl header.
+    // Native bytes the string entries hold, including each StringImpl header.
     size_t memoryCost() const;
     static size_t stringMemoryCost(const String& string)
     {

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -75,9 +75,7 @@ public:
     void set(const String& name, RefPtr<Blob>, const String& filename = {});
 
     size_t count() const { return m_items.size(); }
-    // Heap bytes the entries hold outside the JS heap. Counts each StringImpl
-    // header, not just its characters: a body of a million tiny pairs is
-    // dominated by per-entry overhead.
+    // Native bytes the entries hold, including each StringImpl header.
     size_t memoryCost() const;
     static size_t stringMemoryCost(const String& string)
     {

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -75,11 +75,8 @@ public:
     void set(const String& name, RefPtr<Blob>, const String& filename = {});
 
     size_t count() const { return m_items.size(); }
-    // All native bytes the entries hold, for heap snapshots.
-    size_t memoryCost() const;
-    // The subset no other JS cell reports: a Blob entry's store belongs to
-    // the JSBlob wrapper that get() creates.
-    size_t reportableMemoryCost() const;
+    size_t memoryCost() const; // every entry, for heap snapshots
+    size_t reportableMemoryCost() const; // excludes Blob stores, which their JSBlob wrapper reports
     static size_t stringMemoryCost(const String& string)
     {
         auto* impl = string.impl();

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -75,8 +75,11 @@ public:
     void set(const String& name, RefPtr<Blob>, const String& filename = {});
 
     size_t count() const { return m_items.size(); }
-    // Native bytes the string entries hold, including each StringImpl header.
+    // All native bytes the entries hold, for heap snapshots.
     size_t memoryCost() const;
+    // The subset no other JS cell reports: a Blob entry's store belongs to
+    // the JSBlob wrapper that get() creates.
+    size_t reportableMemoryCost() const;
     static size_t stringMemoryCost(const String& string)
     {
         auto* impl = string.impl();

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -75,7 +75,15 @@ public:
     void set(const String& name, RefPtr<Blob>, const String& filename = {});
 
     size_t count() const { return m_items.size(); }
+    // Heap bytes the entries hold outside the JS heap. Counts each StringImpl
+    // header, not just its characters: a body of a million tiny pairs is
+    // dominated by per-entry overhead.
     size_t memoryCost() const;
+    static size_t stringMemoryCost(const String& string)
+    {
+        auto* impl = string.impl();
+        return impl ? impl->sizeInBytes() : 0;
+    }
 
     String toURLEncodedString();
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6331,7 +6331,16 @@ CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__createFromURLQuery(JSC::JSGlo
         return Bun::ERR::STRING_TOO_LONG(scope, globalObject);
     }
     auto formData = DOMFormData::create(globalObject->scriptExecutionContext(), WTF::move(str));
-    return JSValue::encode(toJSNewlyCreated(arg0, globalObject, WTF::move(formData)));
+    auto jsValue = toJSNewlyCreated(arg0, globalObject, WTF::move(formData));
+    if (auto* wrapper = dynamicDowncast<WebCore::JSDOMFormData>(jsValue))
+        wrapper->computeMemoryCost();
+    return JSValue::encode(jsValue);
+}
+
+CPP_DECL void WebCore__DOMFormData__reportMemoryCost(JSC::EncodedJSValue value)
+{
+    if (auto* wrapper = dynamicDowncast<WebCore::JSDOMFormData>(JSC::JSValue::decode(value)))
+        wrapper->computeMemoryCost();
 }
 
 CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__create(JSC::JSGlobalObject* arg0)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -61,6 +61,7 @@ CPP_DECL void WebCore__DOMFormData__appendBlob(WebCore::DOMFormData* arg0, JSC::
 CPP_DECL size_t WebCore__DOMFormData__count(WebCore::DOMFormData* arg0);
 CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__create(JSC::JSGlobalObject* arg0);
 CPP_DECL JSC::EncodedJSValue WebCore__DOMFormData__createFromURLQuery(JSC::JSGlobalObject* arg0, const EncodedSlice* arg1);
+CPP_DECL void WebCore__DOMFormData__reportMemoryCost(JSC::EncodedJSValue value);
 CPP_DECL WebCore::DOMFormData* _fromJS(JSC::EncodedJSValue JSValue0);
 
 #pragma mark - WebCore::FetchHeaders

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -244,13 +244,6 @@ void JSDOMFormData::computeMemoryCost()
     }
 }
 
-void JSDOMFormData::reportAppendedEntry(size_t bytes)
-{
-    size_t cost = bytes + sizeof(DOMFormData::Item);
-    m_memoryCost += cost;
-    globalObject()->vm().heap.reportExtraMemoryAllocated(this, cost);
-}
-
 JSObject* JSDOMFormData::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {
     auto* structure = JSDOMFormDataPrototype::createStructure(vm, &globalObject, globalObject.objectPrototype());
@@ -297,10 +290,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append1Body(JSC
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto value = convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    size_t entryBytes = DOMFormData::stringMemoryCost(name) + DOMFormData::stringMemoryCost(value);
-    impl.append(WTF::move(name), WTF::move(value));
-    castedThis->reportAppendedEntry(entryBytes);
-    return JSValue::encode(jsUndefined());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTF::move(name), WTF::move(value)); })));
 }
 
 extern "C" BunString Blob__getFileNameString(void* impl);
@@ -331,10 +321,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC
     auto filename = argument2.value().isUndefined() ? Blob__getFileNameString(blobValue->impl()).transferToWTFString() : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    size_t entryBytes = DOMFormData::stringMemoryCost(name) + blobValue->memoryCost();
-    impl.append(WTF::move(name), WTF::move(blobValue), WTF::move(filename));
-    castedThis->reportAppendedEntry(entryBytes);
-    return JSValue::encode(jsUndefined());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
 }
 
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_appendOverloadDispatcher(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)
@@ -373,9 +360,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_deleteBody(JSC:
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto name = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    impl.remove(WTF::move(name));
-    castedThis->computeMemoryCost();
-    return JSValue::encode(jsUndefined());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.remove(WTF::move(name)); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDOMFormDataPrototypeFunction_delete, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -470,9 +455,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set1Body(JSC::J
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto value = convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    impl.set(WTF::move(name), WTF::move(value));
-    castedThis->computeMemoryCost();
-    return JSValue::encode(jsUndefined());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.set(WTF::move(name), WTF::move(value)); })));
 }
 
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set2Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)
@@ -501,9 +484,7 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set2Body(JSC::J
     auto filename = argument2.value().isUndefined() ? Blob__getFileNameString(blobValue->impl()).transferToWTFString() : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    impl.set(WTF::move(name), WTF::move(blobValue), WTF::move(filename));
-    castedThis->computeMemoryCost();
-    return JSValue::encode(jsUndefined());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.set(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
 }
 
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_setOverloadDispatcher(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -244,6 +244,13 @@ void JSDOMFormData::computeMemoryCost()
     }
 }
 
+void JSDOMFormData::reportAppendedEntry(size_t bytes)
+{
+    size_t cost = bytes + sizeof(DOMFormData::Item);
+    m_memoryCost += cost;
+    globalObject()->vm().heap.reportExtraMemoryAllocated(this, cost);
+}
+
 JSObject* JSDOMFormData::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {
     auto* structure = JSDOMFormDataPrototype::createStructure(vm, &globalObject, globalObject.objectPrototype());
@@ -290,7 +297,10 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append1Body(JSC
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto value = convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTF::move(name), WTF::move(value)); })));
+    size_t entryBytes = DOMFormData::stringMemoryCost(name) + DOMFormData::stringMemoryCost(value);
+    impl.append(WTF::move(name), WTF::move(value));
+    castedThis->reportAppendedEntry(entryBytes);
+    return JSValue::encode(jsUndefined());
 }
 
 extern "C" BunString Blob__getFileNameString(void* impl);
@@ -321,7 +331,10 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_append2Body(JSC
     auto filename = argument2.value().isUndefined() ? Blob__getFileNameString(blobValue->impl()).transferToWTFString() : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.append(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
+    size_t entryBytes = DOMFormData::stringMemoryCost(name) + blobValue->memoryCost();
+    impl.append(WTF::move(name), WTF::move(blobValue), WTF::move(filename));
+    castedThis->reportAppendedEntry(entryBytes);
+    return JSValue::encode(jsUndefined());
 }
 
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_appendOverloadDispatcher(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)
@@ -360,7 +373,9 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_deleteBody(JSC:
     EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
     auto name = convert<IDLUSVString>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.remove(WTF::move(name)); })));
+    impl.remove(WTF::move(name));
+    castedThis->computeMemoryCost();
+    return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDOMFormDataPrototypeFunction_delete, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -455,7 +470,9 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set1Body(JSC::J
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
     auto value = convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.set(WTF::move(name), WTF::move(value)); })));
+    impl.set(WTF::move(name), WTF::move(value));
+    castedThis->computeMemoryCost();
+    return JSValue::encode(jsUndefined());
 }
 
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set2Body(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)
@@ -484,7 +501,9 @@ static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_set2Body(JSC::J
     auto filename = argument2.value().isUndefined() ? Blob__getFileNameString(blobValue->impl()).transferToWTFString() : convert<IDLUSVString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.set(WTF::move(name), WTF::move(blobValue), WTF::move(filename)); })));
+    impl.set(WTF::move(name), WTF::move(blobValue), WTF::move(filename));
+    castedThis->computeMemoryCost();
+    return JSValue::encode(jsUndefined());
 }
 
 static inline JSC::EncodedJSValue jsDOMFormDataPrototypeFunction_setOverloadDispatcher(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSDOMFormData>::ClassParameter castedThis)

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -237,7 +237,7 @@ void JSDOMFormData::finishCreation(VM& vm)
 void JSDOMFormData::computeMemoryCost()
 {
     size_t previousCost = m_memoryCost;
-    m_memoryCost = wrapped().memoryCost();
+    m_memoryCost = wrapped().reportableMemoryCost();
     int64_t diff = static_cast<int64_t>(m_memoryCost) - static_cast<int64_t>(previousCost);
     if (diff > 0) {
         globalObject()->vm().heap.reportExtraMemoryAllocated(this, static_cast<uint64_t>(diff));

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -234,6 +234,16 @@ void JSDOMFormData::finishCreation(VM& vm)
     // static_assert(!std::is_base_of<ActiveDOMObject, DOMFormData>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
 }
 
+void JSDOMFormData::computeMemoryCost()
+{
+    size_t previousCost = m_memoryCost;
+    m_memoryCost = wrapped().memoryCost();
+    int64_t diff = static_cast<int64_t>(m_memoryCost) - static_cast<int64_t>(previousCost);
+    if (diff > 0) {
+        globalObject()->vm().heap.reportExtraMemoryAllocated(this, static_cast<uint64_t>(diff));
+    }
+}
+
 JSObject* JSDOMFormData::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {
     auto* structure = JSDOMFormDataPrototype::createStructure(vm, &globalObject, globalObject.objectPrototype());
@@ -724,5 +734,16 @@ size_t JSDOMFormData::estimatedSize(JSCell* cell, JSC::VM& vm)
     auto& wrapped = uncheckedDowncast<JSDOMFormData>(cell)->wrapped();
     return Base::estimatedSize(cell, vm) + wrapped.memoryCost();
 }
+
+template<typename Visitor>
+void JSDOMFormData::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<JSDOMFormData>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    visitor.reportExtraMemoryVisited(thisObject->m_memoryCost);
+}
+
+DEFINE_VISIT_CHILDREN(JSDOMFormData);
 
 }

--- a/src/jsc/bindings/webcore/JSDOMFormData.h
+++ b/src/jsc/bindings/webcore/JSDOMFormData.h
@@ -60,10 +60,7 @@ public:
     static size_t estimatedSize(JSCell* cell, JSC::VM& vm);
 
     size_t m_memoryCost { 0 };
-    // Recompute from the wrapped object (O(entries)). Use after a bulk fill
-    // or an O(entries) mutation such as set or delete.
-    void computeMemoryCost();
-    // Add one appended entry without walking the whole list.
+    void computeMemoryCost(); // O(entries); append uses reportAppendedEntry
     void reportAppendedEntry(size_t bytes);
 
 protected:

--- a/src/jsc/bindings/webcore/JSDOMFormData.h
+++ b/src/jsc/bindings/webcore/JSDOMFormData.h
@@ -60,7 +60,11 @@ public:
     static size_t estimatedSize(JSCell* cell, JSC::VM& vm);
 
     size_t m_memoryCost { 0 };
+    // Recompute from the wrapped object (O(entries)). Use after a bulk fill
+    // or an O(entries) mutation such as set or delete.
     void computeMemoryCost();
+    // Add one appended entry without walking the whole list.
+    void reportAppendedEntry(size_t bytes);
 
 protected:
     JSDOMFormData(JSC::Structure*, JSDOMGlobalObject&, Ref<DOMFormData>&&);

--- a/src/jsc/bindings/webcore/JSDOMFormData.h
+++ b/src/jsc/bindings/webcore/JSDOMFormData.h
@@ -60,8 +60,7 @@ public:
     static size_t estimatedSize(JSCell* cell, JSC::VM& vm);
 
     size_t m_memoryCost { 0 };
-    void computeMemoryCost(); // O(entries); append uses reportAppendedEntry
-    void reportAppendedEntry(size_t bytes);
+    void computeMemoryCost();
 
 protected:
     JSDOMFormData(JSC::Structure*, JSDOMGlobalObject&, Ref<DOMFormData>&&);

--- a/src/jsc/bindings/webcore/JSDOMFormData.h
+++ b/src/jsc/bindings/webcore/JSDOMFormData.h
@@ -41,6 +41,7 @@ public:
     static void destroy(JSC::JSCell*);
 
     DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {
@@ -57,6 +58,9 @@ public:
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm);
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
     static size_t estimatedSize(JSCell* cell, JSC::VM& vm);
+
+    size_t m_memoryCost { 0 };
+    void computeMemoryCost();
 
 protected:
     JSDOMFormData(JSC::Structure*, JSDOMGlobalObject&, Ref<DOMFormData>&&);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3435,10 +3435,6 @@ impl BlobExt for Blob {
     }
 
     fn estimated_size(&self) -> usize {
-        // A natively held Blob (a multipart file part) has no wrapper, so `to_js` has not run.
-        if self.reported_estimated_size.get() == 0 {
-            self.calculate_estimated_byte_size();
-        }
         self.reported_estimated_size.get()
     }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3435,9 +3435,7 @@ impl BlobExt for Blob {
     }
 
     fn estimated_size(&self) -> usize {
-        // A Blob held natively (a multipart FormData file part) has no JS
-        // wrapper yet, so `to_js` has not computed the size. Compute it here so
-        // the owner can report the store bytes.
+        // A natively held Blob (a multipart file part) has no wrapper, so `to_js` has not run.
         if self.reported_estimated_size.get() == 0 {
             self.calculate_estimated_byte_size();
         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3435,6 +3435,12 @@ impl BlobExt for Blob {
     }
 
     fn estimated_size(&self) -> usize {
+        // A Blob held natively (a multipart FormData file part) has no JS
+        // wrapper yet, so `to_js` has not computed the size. Compute it here so
+        // the owner can report the store bytes.
+        if self.reported_estimated_size.get() == 0 {
+            self.calculate_estimated_byte_size();
+        }
         self.reported_estimated_size.get()
     }
 

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -235,6 +235,7 @@ pub(crate) fn to_js_from_multipart_data(
         }
     }
 
+    DOMFormData::report_memory_cost(form_data_value);
     Ok(form_data_value)
 }
 

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1005,27 +1005,27 @@ describe("USVString conversion of lone surrogates", () => {
   });
 });
 
-// A parsed FormData stores its entries as native WTF::String bytes outside the
-// JS heap. The JS wrapper must report those bytes to the GC, otherwise the
-// allocation-driven GC trigger never fires and the native memory accumulates
-// while requests keep arriving. See ledger #23371.
+// A FormData stores its entries as native WTF::String bytes outside the JS
+// heap. The JS wrapper must report those bytes to the GC, otherwise the
+// allocation-driven GC trigger never fires and a server that parses one body
+// per request accumulates native memory until the idle collector runs.
 describe.concurrent("FormData native memory is reported to the GC", () => {
-  async function extraMemoryDelta(buildBody: string, contentType: string, count: number): Promise<number> {
+  // `create` is the source of an async function that returns one FormData.
+  async function extraMemoryDelta(create: string, count: number): Promise<number> {
     const script = `
       const { heapStats } = require("bun:jsc");
-      const headers = { "content-type": ${JSON.stringify(contentType)} };
-      const buildBody = ${buildBody};
+      const create = ${create};
 
       Bun.gc(true);
       const before = heapStats().extraMemorySize;
 
       const live = [];
       for (let i = 0; i < ${count}; i++) {
-        live.push(await new Response(buildBody(), { headers }).formData());
+        live.push(await create());
       }
 
-      // Collect the transient request bodies. Only the referenced FormData
-      // objects and their reported native bytes remain.
+      // Collect the transient inputs. Only the referenced FormData objects and
+      // their reported native bytes remain.
       Bun.gc(true);
       const after = heapStats().extraMemorySize;
       process.stdout.write(String(after - before));
@@ -1040,30 +1040,50 @@ describe.concurrent("FormData native memory is reported to the GC", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     const delta = Number(stdout);
-    expect({ stderr, exitCode, delta }).toEqual({ stderr: expect.any(String), exitCode: 0, delta: expect.any(Number) });
+    expect(stderr).toBe("");
+    expect({ exitCode, delta }).toEqual({ exitCode: 0, delta: expect.any(Number) });
     expect(Number.isFinite(delta)).toBe(true);
     return delta;
   }
 
-  // Each body has one 8 MB field value, parsed into a native WTF::String entry
-  // the FormData owns. After the fix the GC sees those bytes and they survive a
-  // collection while the FormData is referenced. Without the fix the delta is
-  // near zero. A few large entries keep the debug+ASAN parse fast.
+  // Each FormData holds one 8 MB field value as a native WTF::String. After
+  // the fix the GC sees those bytes and they survive a collection while the
+  // FormData is referenced. Without the fix the delta is near zero. A few
+  // large entries keep the debug+ASAN parse fast.
   const valueSize = 8 * 1024 * 1024;
   const count = 2;
+  const value = `Buffer.alloc(${valueSize}, "x").toString()`;
 
   test("urlencoded entries report their bytes", async () => {
-    const buildBody = `() => "a=" + Buffer.alloc(${valueSize}, "x").toString()`;
-    const delta = await extraMemoryDelta(buildBody, "application/x-www-form-urlencoded", count);
-    expect(delta).toBeGreaterThan(count * valueSize * 0.5);
+    const create = `async () => new Response("a=" + ${value}, {
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    }).formData()`;
+    expect(await extraMemoryDelta(create, count)).toBeGreaterThan(count * valueSize * 0.5);
   });
 
   test("multipart string fields report their bytes", async () => {
-    const buildBody = `() => {
-      const value = Buffer.alloc(${valueSize}, "x").toString();
-      return "--X\\r\\nContent-Disposition: form-data; name=\\"a\\"\\r\\n\\r\\n" + value + "\\r\\n--X--\\r\\n";
+    const create = `async () => new Response(
+      "--X\\r\\nContent-Disposition: form-data; name=\\"a\\"\\r\\n\\r\\n" + ${value} + "\\r\\n--X--\\r\\n",
+      { headers: { "content-type": "multipart/form-data; boundary=X" } },
+    ).formData()`;
+    expect(await extraMemoryDelta(create, count)).toBeGreaterThan(count * valueSize * 0.5);
+  });
+
+  test("multipart file parts report their store bytes", async () => {
+    const create = `async () => new Response(
+      "--X\\r\\nContent-Disposition: form-data; name=\\"a\\"; filename=\\"a.txt\\"\\r\\n\\r\\n" + ${value} + "\\r\\n--X--\\r\\n",
+      { headers: { "content-type": "multipart/form-data; boundary=X" } },
+    ).formData()`;
+    expect(await extraMemoryDelta(create, count)).toBeGreaterThan(count * valueSize * 0.5);
+  });
+
+  test("append and set report their bytes", async () => {
+    const create = `async () => {
+      const fd = new FormData();
+      fd.append("a", ${value});
+      fd.set("b", ${value});
+      return fd;
     }`;
-    const delta = await extraMemoryDelta(buildBody, "multipart/form-data; boundary=X", count);
-    expect(delta).toBeGreaterThan(count * valueSize * 0.5);
+    expect(await extraMemoryDelta(create, count)).toBeGreaterThan(count * 2 * valueSize * 0.5);
   });
 });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1013,7 +1013,7 @@ describe.concurrent("FormData native memory is reported to the GC", () => {
   // `create` is the source of an async function that returns one FormData.
   async function extraMemoryDelta(create: string, count: number): Promise<number> {
     const script = `
-      const { heapStats } = require("bun:jsc");
+      import { heapStats } from "bun:jsc";
       const create = ${create};
 
       Bun.gc(true);
@@ -1067,23 +1067,5 @@ describe.concurrent("FormData native memory is reported to the GC", () => {
       { headers: { "content-type": "multipart/form-data; boundary=X" } },
     ).formData()`;
     expect(await extraMemoryDelta(create, count)).toBeGreaterThan(count * valueSize * 0.5);
-  });
-
-  test("multipart file parts report their store bytes", async () => {
-    const create = `async () => new Response(
-      "--X\\r\\nContent-Disposition: form-data; name=\\"a\\"; filename=\\"a.txt\\"\\r\\n\\r\\n" + ${value} + "\\r\\n--X--\\r\\n",
-      { headers: { "content-type": "multipart/form-data; boundary=X" } },
-    ).formData()`;
-    expect(await extraMemoryDelta(create, count)).toBeGreaterThan(count * valueSize * 0.5);
-  });
-
-  test("append and set report their bytes", async () => {
-    const create = `async () => {
-      const fd = new FormData();
-      fd.append("a", ${value});
-      fd.set("b", ${value});
-      return fd;
-    }`;
-    expect(await extraMemoryDelta(create, count)).toBeGreaterThan(count * 2 * valueSize * 0.5);
   });
 });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1004,3 +1004,66 @@ describe("USVString conversion of lone surrogates", () => {
     expect(formData.get("\uFFFD")).toBeNull();
   });
 });
+
+// A parsed FormData stores its entries as native WTF::String bytes outside the
+// JS heap. The JS wrapper must report those bytes to the GC, otherwise the
+// allocation-driven GC trigger never fires and the native memory accumulates
+// while requests keep arriving. See ledger #23371.
+describe.concurrent("FormData native memory is reported to the GC", () => {
+  async function extraMemoryDelta(buildBody: string, contentType: string, count: number): Promise<number> {
+    const script = `
+      const { heapStats } = require("bun:jsc");
+      const headers = { "content-type": ${JSON.stringify(contentType)} };
+      const buildBody = ${buildBody};
+
+      Bun.gc(true);
+      const before = heapStats().extraMemorySize;
+
+      const live = [];
+      for (let i = 0; i < ${count}; i++) {
+        live.push(await new Response(buildBody(), { headers }).formData());
+      }
+
+      // Collect the transient request bodies. Only the referenced FormData
+      // objects and their reported native bytes remain.
+      Bun.gc(true);
+      const after = heapStats().extraMemorySize;
+      process.stdout.write(String(after - before));
+      if (live.length !== ${count}) throw new Error("unreachable");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const delta = Number(stdout);
+    expect({ stderr, exitCode, delta }).toEqual({ stderr: expect.any(String), exitCode: 0, delta: expect.any(Number) });
+    expect(Number.isFinite(delta)).toBe(true);
+    return delta;
+  }
+
+  // Each body has one 8 MB field value, parsed into a native WTF::String entry
+  // the FormData owns. After the fix the GC sees those bytes and they survive a
+  // collection while the FormData is referenced. Without the fix the delta is
+  // near zero. A few large entries keep the debug+ASAN parse fast.
+  const valueSize = 8 * 1024 * 1024;
+  const count = 2;
+
+  test("urlencoded entries report their bytes", async () => {
+    const buildBody = `() => "a=" + Buffer.alloc(${valueSize}, "x").toString()`;
+    const delta = await extraMemoryDelta(buildBody, "application/x-www-form-urlencoded", count);
+    expect(delta).toBeGreaterThan(count * valueSize * 0.5);
+  });
+
+  test("multipart string fields report their bytes", async () => {
+    const buildBody = `() => {
+      const value = Buffer.alloc(${valueSize}, "x").toString();
+      return "--X\\r\\nContent-Disposition: form-data; name=\\"a\\"\\r\\n\\r\\n" + value + "\\r\\n--X--\\r\\n";
+    }`;
+    const delta = await extraMemoryDelta(buildBody, "multipart/form-data; boundary=X", count);
+    expect(delta).toBeGreaterThan(count * valueSize * 0.5);
+  });
+});


### PR DESCRIPTION
### Problem
- A server that runs `await req.formData()` on an `application/x-www-form-urlencoded` body is a request-reachable denial of service under default limits when the body arrives slowly. One 10 Mbit/s client drives RSS from 186 MB to 1374 MB in 60 s on 1.4.2 (19 requests, monotonic). Fifty keep-alive connections reach 9.4 GB in 16 s.
- A parsed `FormData` keeps its entries as native `WTF::String` bytes in the C++ `DOMFormData` (`src/jsc/bindings/DOMFormData.cpp`), outside the JS heap. `JSDOMFormData` only implemented `estimatedSize()`, which JSC reads for heap snapshots. It never called `reportExtraMemoryAllocated`, so the allocation-driven GC trigger never saw the bytes. A body that arrives in one write materialises a reported Blob first, which is why whole-body load sawtooths and trickled load does not.

### Fix
- `JSDOMFormData` gets `computeMemoryCost()`, which reports the `memoryCost()` delta with `reportExtraMemoryAllocated`, and a `visitChildren` that reports it again with `reportExtraMemoryVisited`. This is the `JSFetchHeaders` pattern. The urlencoded and multipart parse paths call it after they fill the entries.
- `DOMFormData::memoryCost()` counts each `StringImpl` header and the vector capacity, not only the characters. A million tiny pairs cost about 75 B each (measured 75 to 85 B on 1.4.2). The old count gave 26 B. A Blob entry's store is left to the `JSBlob` wrapper that `get()` creates, so it is not counted twice.
- Result on a release build of this branch, same scripts: trickle peaks at 194 MB and settles at 119 MB. Burst peaks at 514 MB and holds about 375 MB.
- Verified: `test/js/web/html/FormData.test.ts`, two new tests. Bun 1.4.2 reports about 4 KB for 16 MB of entries, the fixed build reports 16 MB and the bytes survive `Bun.gc(true)` while the object is referenced. Full file: 151 pass.

### Background
- JSC tracks "extra memory", native bytes owned by a JS cell. `reportExtraMemoryAllocated(cell, size)` adds to the counter and can trigger a collection. `reportExtraMemoryVisited(size)` from `visitChildren` rebuilds the counter during marking so it survives a GC cycle. Both calls are required.
- `String::sizeInBytes()` counts characters only. `StringImpl::sizeInBytes()` adds the header. For a 1 char string the header is the cost.
- The multipart path builds the wrapper empty, then appends from Rust, so it reports through a small FFI entry point after the loop.

<details><summary>Notes</summary>

Measurement cells (release build of this branch vs `/usr/local/bin/bun` 1.4.2, 1e6-pair 3.8 MB body, handler `await req.formData()`):

- Trickle, one connection at 10 Mbit/s, 60 s: 1.4.2 186, 271, 535, 870, 1120, 1374 MB at 10 s steps. Fixed: 34, 34, 33, 194, 118, 119 MB.
- Burst, 50 keep-alive connections flat out: 1.4.2 938, 4420, 7358, 9477 MB at 4 s steps (141 requests). Fixed: 269, 514, 368, 375 MB (100 requests).

Not in this PR: the store bytes of a multipart file part that nobody has called `get()` on. Those stay bounded at 1 to 2.5x body today and belong with the Blob ownership work. The JS `append` path shares its `StringImpl` with the source JSString, which JSC counts, so it is also left alone. `JSURLSearchParams` and `JSCookieMap` have the same missing report and are follow-ups.

The test uses two 8 MB values per process because a many-tiny-entries parse takes about 100 us per pair under ASAN.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [6.30ms]
(pass) FormData > should be able to append a Blob [14.38ms]
(pass) FormData > should be able to set a Blob [12.06ms]
(pass) FormData > should be able to set a string [5.28ms]
(pass) FormData > should get filename from file [7.57ms]
(pass) FormData > should use the correct filenames [9.15ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [28.09ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [69.28ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [6.45ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [11.70ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [5.13ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [7.69ms]
(pass) FormData > should parse multipart/form-data (
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.12ms]
(pass) FormData > should be able to append a Blob [0.22ms]
(pass) FormData > should be able to set a Blob [0.12ms]
(pass) FormData > should be able to set a string [0.07ms]
(pass) FormData > should get filename from file [0.07ms]
(pass) FormData > should use the correct filenames [0.09ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.43ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [1.78ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.07ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.06ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.03ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [5.75ms]
(pass) FormData > should be able to append a Blob [14.14ms]
(pass) FormData > should be able to set a Blob [9.86ms]
(pass) FormData > should be able to set a string [4.06ms]
(pass) FormData > should get filename from file [5.01ms]
(pass) FormData > should use the correct filenames [7.73ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [20.91ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [47.26ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [4.54ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.73ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [2.04ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.61ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3169ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/27] cxx obj/src/jsc/bindings/BunObject.cpp.o
[2/27] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[3/27] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[4/27] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[5/27] cxx obj/src/jsc/bindings/bindings.cpp.o
[6/27] gen cpp.rs (cppbind)
[6/27] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/DOMFormData.rs                     |  6 +++
 src/jsc/bindings/DOMFormData.cpp           | 20 ++++++---
 src/jsc/bindings/DOMFormData.h             |  8 +++-
 src/jsc/bindings/bindings.cpp              | 11 ++++-
 src/jsc/bindings/headers.h                 |  1 +
 src/jsc/bindings/webcore/JSDOMFormData.cpp | 21 ++++++++++
 src/jsc/bindings/webcore/JSDOMFormData.h   |  4 ++
 src/runtime/webcore/FormData.rs            |  1 +
 test/js/web/html/FormData.test.ts          | 65 ++++++++++++++++++++++++++++++
 9 files changed, 129 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/DOMFormData.rs                          1      2     28
src/jsc/bindings/DOMFormData.cpp                1      1     28
src/jsc/bindings/DOMFormData.h                  1      1     28
src/jsc/bindings/bindings.cpp                   1      1     28
src/jsc/bindings/headers.h                      1      1     28
src/jsc/bindings/webcore/JSDOMFormData.cpp      4      5     28
src/jsc/bindings/webcore/JSDOMFormData.h        1      3     28
src/runtime/webcore/FormData.rs                 1      1     28
test/js/web/html/FormData.test.ts               2      6     28
```

</details>

**root cause** · written by the author bot

FormData objects built from URL-encoded or multipart request bodies held their parsed string storage in native memory without reporting it to the JavaScript garbage collector, so a single client streaming large bodies could drive RSS to gigabytes while the heap saw only a few small wrappers and never triggered collection. The fix makes DOMFormData compute the size of its vector and string storage, has JSDOMFormData cache that cost, report increases to the VM heap, and include it during child visitation, and wires the Rust and C++ creation paths to invoke that reporting. With the native allo…

<!-- robobun:evidence:end -->