### PR TITLE
http(h3): bounded retry budget for the fetch client's pre-headers failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,6 +1689,7 @@ dependencies = [
  "bun_errno",
  "bun_http_types",
  "bun_libuv_sys",
+ "bun_lsquic_sys",
  "bun_opaque",
  "bun_paths",
  "bun_ptr",

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -167,6 +167,7 @@ fn make_client<'a>(
         remaining_redirect_count: 127,
         allow_retry: false,
         h2_retries: 0,
+        h3_retries: 0,
         redirect_type,
         redirect: Vec::new(),
         prev_redirect: Vec::new(),

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -255,8 +255,7 @@ impl ClientSession {
         let replayable = not_applied || client_ref.method.is_idempotent();
         // Always allow the first retry. Past that, keep retrying only a fast
         // failure whose request is safe to replay, and never past the cap.
-        let budget_left =
-            retries < crate::MAX_H3_RETRIES && (retries == 0 || (fast && replayable));
+        let budget_left = retries < crate::MAX_H3_RETRIES && (retries == 0 || (fast && replayable));
         if !budget_left || st.is_streaming_body {
             return self.fail(stream, err);
         }

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -214,24 +214,11 @@ impl ClientSession {
         }
     }
 
-    /// A stream closed before any response headers arrived. If the retry
-    /// budget allows and the body wasn't a JS stream (which may already be
-    /// consumed), re-enqueue it on a fresh session — this is the standard
-    /// h2/h3 client behavior for the GOAWAY / stateless-reset / port-reuse
-    /// race where a pooled session goes stale between the `matches()` check
-    /// and the first stream open.
-    ///
-    /// The first retry fires for any such failure, preserving the original
-    /// one-shot behavior. Past that, the request is re-sent only when it is
-    /// safe and cheap:
-    /// - `fast` is false for a no-response handshake timeout, so an
-    ///   unreachable origin fails in about one timeout rather than
-    ///   `MAX_H3_RETRIES` of them.
-    /// - `not_applied` is true only when the origin provably never processed
-    ///   the request (the connection never finished its handshake). When it is
-    ///   false the request may have run, so a non-idempotent method is not
-    ///   replayed, matching the h1 (`is_idempotent`) and h2 (REFUSED_STREAM)
-    ///   clients and RFC 9110 section 9.2.2.
+    /// A stream closed before any response headers arrived: re-enqueue it on a
+    /// fresh session (the stale-pooled-session race), up to `MAX_H3_RETRIES`.
+    /// The first retry always fires. Later ones need `fast` (not a no-response
+    /// timeout) and a replayable request: `not_applied` (the handshake never
+    /// finished, so the origin never saw it) or an idempotent method.
     pub(crate) fn retry_or_fail(
         &mut self,
         stream: *mut Stream,
@@ -247,14 +234,10 @@ impl ClientSession {
         let Some(client_ptr) = st.client else {
             return self.fail(stream, err);
         };
-        // `Stream.client` is a live backref while attached; `ParentRef::from`
-        // (NonNull → shared deref) reads the Copy fields without forming
-        // `&mut HTTPClient` across the `detach()` below.
+        // Shared deref only: no `&mut HTTPClient` may live across `detach()`.
         let client_ref = bun_ptr::ParentRef::from(client_ptr);
         let retries = client_ref.h3_retries;
         let replayable = not_applied || client_ref.method.is_idempotent();
-        // Always allow the first retry. Past that, keep retrying only a fast
-        // failure whose request is safe to replay, and never past the cap.
         let budget_left = retries < crate::MAX_H3_RETRIES && (retries == 0 || (fast && replayable));
         if !budget_left || st.is_streaming_body {
             return self.fail(stream, err);
@@ -373,10 +356,7 @@ impl ClientSession {
 
         if client.state.response_stage != HTTPStage::Body {
             if done {
-                // Stream closed before headers. The connection still lives, so
-                // this is a fast peer reset, not a no-response timeout. The
-                // request was already sent on this stream, so the origin may
-                // have processed it: not a "not applied" case.
+                // Peer reset before headers: fast, but the request was sent.
                 return self.retry_or_fail(
                     stream,
                     if st.status_code == 0 {

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -214,13 +214,31 @@ impl ClientSession {
         }
     }
 
-    /// A stream closed before any response headers arrived. If the request
-    /// hasn't been retried yet and the body wasn't a JS stream (which may
-    /// already be consumed), re-enqueue it on a fresh session — this is the
-    /// standard h2/h3 client behavior for the GOAWAY / stateless-reset /
-    /// port-reuse race where a pooled session goes stale between the
-    /// `matches()` check and the first stream open.
-    pub(crate) fn retry_or_fail(&mut self, stream: *mut Stream, err: crate::Error) {
+    /// A stream closed before any response headers arrived. If the retry
+    /// budget allows and the body wasn't a JS stream (which may already be
+    /// consumed), re-enqueue it on a fresh session — this is the standard
+    /// h2/h3 client behavior for the GOAWAY / stateless-reset / port-reuse
+    /// race where a pooled session goes stale between the `matches()` check
+    /// and the first stream open.
+    ///
+    /// The first retry fires for any such failure, preserving the original
+    /// one-shot behavior. Past that, the request is re-sent only when it is
+    /// safe and cheap:
+    /// - `fast` is false for a no-response handshake timeout, so an
+    ///   unreachable origin fails in about one timeout rather than
+    ///   `MAX_H3_RETRIES` of them.
+    /// - `not_applied` is true only when the origin provably never processed
+    ///   the request (the connection never finished its handshake). When it is
+    ///   false the request may have run, so a non-idempotent method is not
+    ///   replayed, matching the h1 (`is_idempotent`) and h2 (REFUSED_STREAM)
+    ///   clients and RFC 9110 section 9.2.2.
+    pub(crate) fn retry_or_fail(
+        &mut self,
+        stream: *mut Stream,
+        err: crate::Error,
+        fast: bool,
+        not_applied: bool,
+    ) {
         // Shaped for Stacked Borrows like `fail` below — `detach()`
         // re-derives `&mut HTTPClient` from the same raw ptr to null `h3`, which
         // would invalidate any `&mut HTTPClient` held across it. Hold the raw
@@ -230,16 +248,23 @@ impl ClientSession {
             return self.fail(stream, err);
         };
         // `Stream.client` is a live backref while attached; `ParentRef::from`
-        // (NonNull → shared deref) reads the Copy `flags` field without
-        // forming `&mut HTTPClient` across the `detach()` below.
-        if bun_ptr::ParentRef::from(client_ptr).flags.h3_retried || st.is_streaming_body {
+        // (NonNull → shared deref) reads the Copy fields without forming
+        // `&mut HTTPClient` across the `detach()` below.
+        let client_ref = bun_ptr::ParentRef::from(client_ptr);
+        let retries = client_ref.h3_retries;
+        let replayable = not_applied || client_ref.method.is_idempotent();
+        // Always allow the first retry. Past that, keep retrying only a fast
+        // failure whose request is safe to replay, and never past the cap.
+        let budget_left =
+            retries < crate::MAX_H3_RETRIES && (retries == 0 || (fast && replayable));
+        if !budget_left || st.is_streaming_body {
             return self.fail(stream, err);
         }
         let Some(ctx) = ClientContext::get() else {
             return self.fail(stream, err);
         };
         // Same backref as above; short-lived write before detach().
-        client_mut(client_ptr).flags.h3_retried = true;
+        client_mut(client_ptr).h3_retries = retries + 1;
         // The old session is dead from our perspective; make sure connect()
         // can't pick it again.
         self.closed = true;
@@ -349,7 +374,10 @@ impl ClientSession {
 
         if client.state.response_stage != HTTPStage::Body {
             if done {
-                // Stream closed before headers — handshake/reset failure.
+                // Stream closed before headers. The connection still lives, so
+                // this is a fast peer reset, not a no-response timeout. The
+                // request was already sent on this stream, so the origin may
+                // have processed it: not a "not applied" case.
                 return self.retry_or_fail(
                     stream,
                     if st.status_code == 0 {
@@ -357,6 +385,8 @@ impl ClientSession {
                     } else {
                         crate::Error::ConnectionClosed
                     },
+                    true,
+                    false,
                 );
             }
             return;

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -214,11 +214,9 @@ impl ClientSession {
         }
     }
 
-    /// A stream closed before any response headers arrived: re-enqueue it on a
-    /// fresh session (the stale-pooled-session race), up to `MAX_H3_RETRIES`.
-    /// The first retry always fires. Later ones need `fast` (not a no-response
-    /// timeout) and a replayable request: `not_applied` (the handshake never
-    /// finished, so the origin never saw it) or an idempotent method.
+    /// Re-enqueue a stream that closed before any response headers on a fresh
+    /// session, up to `MAX_H3_RETRIES`. After the first retry, only a `fast`
+    /// failure of a replayable request (`not_applied` or idempotent) retries.
     pub(crate) fn retry_or_fail(
         &mut self,
         stream: *mut Stream,

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -84,6 +84,18 @@ impl ClientSession {
         self.qsocket.map(|qs| quic_socket_mut(qs.as_ptr()))
     }
 
+    /// The lsquic status of the live connection, or `-1` when `qsocket` is
+    /// unset. Feeds [`status_is_retry_worthy`].
+    fn conn_status(&self) -> core::ffi::c_int {
+        match self.qsocket_mut() {
+            Some(qs) => {
+                let mut buf = [0u8; 16];
+                qs.status(&mut buf)
+            }
+            None => -1,
+        }
+    }
+
     pub(crate) fn has_headroom(&self) -> bool {
         if self.closed {
             return false;
@@ -354,7 +366,10 @@ impl ClientSession {
 
         if client.state.response_stage != HTTPStage::Body {
             if done {
-                // Peer reset before headers: fast, but the request was sent.
+                // A timeout also closes every bound stream, so read the
+                // connection status rather than assuming a fast reset. The
+                // request bytes already went out, so it is not `not_applied`.
+                let fast = status_is_retry_worthy(self.conn_status());
                 return self.retry_or_fail(
                     stream,
                     if st.status_code == 0 {
@@ -362,7 +377,7 @@ impl ClientSession {
                     } else {
                         crate::Error::ConnectionClosed
                     },
-                    true,
+                    fast,
                     false,
                 );
             }
@@ -493,6 +508,17 @@ pub(super) fn stream_ref(p: *mut Stream) -> bun_ptr::ParentRef<Stream> {
 pub(super) fn session_mut<'a>(p: *mut ClientSession) -> &'a mut ClientSession {
     // SAFETY: see INVARIANT above.
     unsafe { &mut *p }
+}
+
+/// Whether a terminal connection status is worth more than the first retry.
+/// Excludes the deterministic no-retry outcomes, where a fresh session fails
+/// the same way: a timeout (the peer never answered), a handshake failure, and
+/// a version-negotiation failure. A reset, a GOAWAY, or a peer close stays
+/// retry-worthy because a new connection to the origin can still succeed.
+pub(super) fn status_is_retry_worthy(st: core::ffi::c_int) -> bool {
+    st != quic::CONN_STATUS_TIMED_OUT
+        && st != quic::CONN_STATUS_HSK_FAILURE
+        && st != quic::CONN_STATUS_VERNEG_FAILURE
 }
 
 fn finish(client: &mut HTTPClient) {

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -139,15 +139,15 @@ extern "C" fn on_conn_close(qs: *mut quic::Socket) {
         st,
         BStr::new(bun_core::slice_to_nul(&buf)),
     );
-    // See `ClientSession::retry_or_fail` for how these gate the retry budget.
+    // See `ClientSession::retry_or_fail` for how this gates the retry budget.
     let fast = st != quic::CONN_STATUS_TIMED_OUT;
-    let not_applied = !session.handshake_done;
     if let Some(ctx) = ClientContext::get() {
         ClientContext::as_mut(ctx).unregister(session);
     }
     while !session.pending.is_empty() {
         // lsquic fires on_stream_close for every bound stream before
-        // on_conn_closed, so anything still here never got a qstream.
+        // on_conn_closed, so anything still here never got a qstream and no
+        // request byte of it ever left the client: `not_applied` is true.
         let stream = session.pending[0];
         // pending holds live Stream pointers owned by the session.
         debug_assert!(stream_ref(stream).qstream.is_none());
@@ -159,7 +159,7 @@ extern "C" fn on_conn_close(qs: *mut quic::Socket) {
                 crate::Error::HTTP3HandshakeFailed
             },
             fast,
-            not_applied,
+            true,
         );
     }
     let _ = H3::live_sessions.fetch_sub(1, Ordering::Relaxed);

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -139,6 +139,15 @@ extern "C" fn on_conn_close(qs: *mut quic::Socket) {
         st,
         BStr::new(bun_core::slice_to_nul(&buf)),
     );
+    // A timeout means the peer never answered, so the origin is likely
+    // unreachable and a bounded retry must not multiply the wait. Every other
+    // terminal status (the peer closed, reset, or went away) is a fast result
+    // worth retrying on a fresh session. See `ClientSession::retry_or_fail`.
+    let fast = st != quic::CONN_STATUS_TIMED_OUT;
+    // Without a completed handshake no request byte reached the origin, so a
+    // pending request was provably not processed and is safe to replay even if
+    // its method is not idempotent.
+    let not_applied = !session.handshake_done;
     if let Some(ctx) = ClientContext::get() {
         ClientContext::as_mut(ctx).unregister(session);
     }
@@ -155,6 +164,8 @@ extern "C" fn on_conn_close(qs: *mut quic::Socket) {
             } else {
                 crate::Error::HTTP3HandshakeFailed
             },
+            fast,
+            not_applied,
         );
     }
     let _ = H3::live_sessions.fetch_sub(1, Ordering::Relaxed);

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -13,7 +13,9 @@ use bstr::BStr;
 use bun_uws::quic;
 
 use super::client_context::ClientContext;
-use super::client_session::{ClientSession, session_mut, stream_mut, stream_ref};
+use super::client_session::{
+    ClientSession, session_mut, status_is_retry_worthy, stream_mut, stream_ref,
+};
 use super::encode;
 use super::stream::Stream;
 use crate::h2_client::dispatch::{is_malformed_response_field, is_malformed_response_value};
@@ -139,15 +141,14 @@ extern "C" fn on_conn_close(qs: *mut quic::Socket) {
         st,
         BStr::new(bun_core::slice_to_nul(&buf)),
     );
-    // See `ClientSession::retry_or_fail` for how this gates the retry budget.
-    let fast = st != quic::CONN_STATUS_TIMED_OUT;
+    let fast = status_is_retry_worthy(st);
     if let Some(ctx) = ClientContext::get() {
         ClientContext::as_mut(ctx).unregister(session);
     }
     while !session.pending.is_empty() {
         // lsquic fires on_stream_close for every bound stream before
-        // on_conn_closed, so anything still here never got a qstream and no
-        // request byte of it ever left the client: `not_applied` is true.
+        // on_conn_closed, so anything still here never got a qstream: its
+        // request never left the client, hence the `not_applied` argument.
         let stream = session.pending[0];
         // pending holds live Stream pointers owned by the session.
         debug_assert!(stream_ref(stream).qstream.is_none());

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -139,14 +139,8 @@ extern "C" fn on_conn_close(qs: *mut quic::Socket) {
         st,
         BStr::new(bun_core::slice_to_nul(&buf)),
     );
-    // A timeout means the peer never answered, so the origin is likely
-    // unreachable and a bounded retry must not multiply the wait. Every other
-    // terminal status (the peer closed, reset, or went away) is a fast result
-    // worth retrying on a fresh session. See `ClientSession::retry_or_fail`.
+    // See `ClientSession::retry_or_fail` for how these gate the retry budget.
     let fast = st != quic::CONN_STATUS_TIMED_OUT;
-    // Without a completed handshake no request byte reached the origin, so a
-    // pending request was provably not processed and is safe to replay even if
-    // its method is not idempotent.
     let not_applied = !session.handshake_done;
     if let Some(ctx) = ClientContext::get() {
         ClientContext::as_mut(ctx).unregister(session);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -203,7 +203,6 @@ pub struct Flags {
     pub(crate) upgrade_state: HTTPUpgradeState,
     pub(crate) protocol: Protocol,
     pub forced_protocol: Option<Protocol>,
-    pub(crate) h3_retried: bool,
     pub is_node_http_client: bool,
 }
 
@@ -225,7 +224,6 @@ impl Default for Flags {
             upgrade_state: HTTPUpgradeState::None,
             protocol: Protocol::Http1_1,
             forced_protocol: None,
-            h3_retried: false,
             is_node_http_client: false,
         }
     }
@@ -337,6 +335,16 @@ const MAX_TLS_RECORD_SIZE: usize = 16 * 1024;
 /// did not process the request, so re-dispatch from the top. Only reached
 /// for `.bytes` bodies (replayable).
 pub(crate) const MAX_H2_RETRIES: u8 = 5;
+
+/// An HTTP/3 stream that closed before any response headers (a dead pooled
+/// session, a peer reset, or a peer-closed connection). Re-dispatch it on a
+/// fresh session. Only reached before any response byte and for non-streaming
+/// bodies (replayable). The first retry fires for any such failure, like the
+/// original one-shot behavior. Past that, `ClientSession::retry_or_fail` keeps
+/// retrying only a fast failure whose request the origin provably never
+/// processed or whose method is idempotent, so a POST the origin may have run
+/// is not replayed and an unreachable origin still fails fast.
+pub(crate) const MAX_H3_RETRIES: u8 = 5;
 
 const PREALLOCATE_MAX: usize = 1024 * 1024 * 256;
 
@@ -789,6 +797,10 @@ pub struct HTTPClient<'a> {
     /// where the server promises the request was not processed. Capped by
     /// `MAX_H2_RETRIES`.
     pub(crate) h2_retries: u8,
+    /// Transparent re-dispatch count for an HTTP/3 stream that closed before
+    /// any response headers. Capped by `MAX_H3_RETRIES`. See that constant and
+    /// `ClientSession::retry_or_fail` for the conditions past the first retry.
+    pub(crate) h3_retries: u8,
     pub(crate) redirect_type: FetchRedirect,
     pub(crate) redirect: Vec<u8>,
     /// The previous hop's `redirect` buffer, parked by `handle_response_metadata`

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -336,14 +336,8 @@ const MAX_TLS_RECORD_SIZE: usize = 16 * 1024;
 /// for `.bytes` bodies (replayable).
 pub(crate) const MAX_H2_RETRIES: u8 = 5;
 
-/// An HTTP/3 stream that closed before any response headers (a dead pooled
-/// session, a peer reset, or a peer-closed connection). Re-dispatch it on a
-/// fresh session. Only reached before any response byte and for non-streaming
-/// bodies (replayable). The first retry fires for any such failure, like the
-/// original one-shot behavior. Past that, `ClientSession::retry_or_fail` keeps
-/// retrying only a fast failure whose request the origin provably never
-/// processed or whose method is idempotent, so a POST the origin may have run
-/// is not replayed and an unreachable origin still fails fast.
+/// Cap on re-dispatching an HTTP/3 request whose stream closed before any
+/// response headers. The gate is in `h3_client::ClientSession::retry_or_fail`.
 pub(crate) const MAX_H3_RETRIES: u8 = 5;
 
 const PREALLOCATE_MAX: usize = 1024 * 1024 * 256;
@@ -797,9 +791,7 @@ pub struct HTTPClient<'a> {
     /// where the server promises the request was not processed. Capped by
     /// `MAX_H2_RETRIES`.
     pub(crate) h2_retries: u8,
-    /// Transparent re-dispatch count for an HTTP/3 stream that closed before
-    /// any response headers. Capped by `MAX_H3_RETRIES`. See that constant and
-    /// `ClientSession::retry_or_fail` for the conditions past the first retry.
+    /// HTTP/3 re-dispatch count, capped by `MAX_H3_RETRIES`.
     pub(crate) h3_retries: u8,
     pub(crate) redirect_type: FetchRedirect,
     pub(crate) redirect: Vec<u8>,

--- a/src/uws_sys/Cargo.toml
+++ b/src/uws_sys/Cargo.toml
@@ -22,6 +22,7 @@ bun_boringssl_sys.workspace = true
 bun_core.workspace = true
 bun_errno.workspace = true
 bun_http_types.workspace = true
+bun_lsquic_sys.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 bun_windows_sys.workspace = true

--- a/src/uws_sys/quic.rs
+++ b/src/uws_sys/quic.rs
@@ -21,7 +21,7 @@ pub mod stream;
 
 pub use self::context::Context;
 pub use self::pending_connect::PendingConnect;
-pub use self::socket::Socket;
+pub use self::socket::{CONN_STATUS_TIMED_OUT, Socket};
 pub use self::stream::Stream;
 
 pub use self::header::Header;

--- a/src/uws_sys/quic.rs
+++ b/src/uws_sys/quic.rs
@@ -21,7 +21,9 @@ pub mod stream;
 
 pub use self::context::Context;
 pub use self::pending_connect::PendingConnect;
-pub use self::socket::{CONN_STATUS_TIMED_OUT, Socket};
+pub use self::socket::{
+    CONN_STATUS_HSK_FAILURE, CONN_STATUS_TIMED_OUT, CONN_STATUS_VERNEG_FAILURE, Socket,
+};
 pub use self::stream::Stream;
 
 pub use self::header::Header;

--- a/src/uws_sys/quic/Socket.rs
+++ b/src/uws_sys/quic/Socket.rs
@@ -13,8 +13,7 @@ bun_opaque::opaque_ffi! {
 /// `Socket::status` values for the deterministic, no-retry connection
 /// outcomes: no peer response, a failed handshake, and no common QUIC version.
 pub use bun_lsquic_sys::{
-    LSCONN_ST_HSK_FAILURE as CONN_STATUS_HSK_FAILURE,
-    LSCONN_ST_TIMED_OUT as CONN_STATUS_TIMED_OUT,
+    LSCONN_ST_HSK_FAILURE as CONN_STATUS_HSK_FAILURE, LSCONN_ST_TIMED_OUT as CONN_STATUS_TIMED_OUT,
     LSCONN_ST_VERNEG_FAILURE as CONN_STATUS_VERNEG_FAILURE,
 };
 

--- a/src/uws_sys/quic/Socket.rs
+++ b/src/uws_sys/quic/Socket.rs
@@ -10,8 +10,13 @@ bun_opaque::opaque_ffi! {
     pub struct Socket;
 }
 
-/// `Socket::status` value for a connection that never got a peer response.
-pub use bun_lsquic_sys::LSCONN_ST_TIMED_OUT as CONN_STATUS_TIMED_OUT;
+/// `Socket::status` values for the deterministic, no-retry connection
+/// outcomes: no peer response, a failed handshake, and no common QUIC version.
+pub use bun_lsquic_sys::{
+    LSCONN_ST_HSK_FAILURE as CONN_STATUS_HSK_FAILURE,
+    LSCONN_ST_TIMED_OUT as CONN_STATUS_TIMED_OUT,
+    LSCONN_ST_VERNEG_FAILURE as CONN_STATUS_VERNEG_FAILURE,
+};
 
 // `Socket` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so `&mut Socket` is
 // ABI-identical to a non-null `*mut Socket` with no `noalias`/`readonly`

--- a/src/uws_sys/quic/Socket.rs
+++ b/src/uws_sys/quic/Socket.rs
@@ -10,6 +10,13 @@ bun_opaque::opaque_ffi! {
     pub struct Socket;
 }
 
+/// `LSCONN_ST_TIMED_OUT` from lsquic's `enum LSQUIC_CONN_STATUS`, the value
+/// `Socket::status` returns when the connection never got a peer response and
+/// reached the handshake or idle timeout. Distinct from the peer-closed and
+/// peer-reset states, which report as other values. Re-exported from the
+/// canonical lsquic bindings so the enum ordinal lives in one place.
+pub use bun_lsquic_sys::LSCONN_ST_TIMED_OUT as CONN_STATUS_TIMED_OUT;
+
 // `Socket` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so `&mut Socket` is
 // ABI-identical to a non-null `*mut Socket` with no `noalias`/`readonly`
 // attribute. Shims taking only the handle + value types are `safe fn`; the

--- a/src/uws_sys/quic/Socket.rs
+++ b/src/uws_sys/quic/Socket.rs
@@ -10,11 +10,7 @@ bun_opaque::opaque_ffi! {
     pub struct Socket;
 }
 
-/// `LSCONN_ST_TIMED_OUT` from lsquic's `enum LSQUIC_CONN_STATUS`, the value
-/// `Socket::status` returns when the connection never got a peer response and
-/// reached the handshake or idle timeout. Distinct from the peer-closed and
-/// peer-reset states, which report as other values. Re-exported from the
-/// canonical lsquic bindings so the enum ordinal lives in one place.
+/// `Socket::status` value for a connection that never got a peer response.
 pub use bun_lsquic_sys::LSCONN_ST_TIMED_OUT as CONN_STATUS_TIMED_OUT;
 
 // `Socket` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so `&mut Socket` is

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -671,6 +671,40 @@ test("retries on a fresh session when a pooled session is stale (port reuse)", a
   }
 });
 
+// Repeated stale-session retry under concurrency. A fresh server binds the
+// same reusePort right before the old one stops abruptly, so the pooled
+// session goes stale again and again while many requests are in flight. When
+// a retry's fresh session also lands on the draining old socket, one retry is
+// not enough: each such request must keep retrying on a new session until it
+// reaches the live server, up to MAX_H3_RETRIES. Every request here reaches a
+// live server within the budget, so all of them resolve.
+test("keeps retrying a stale pooled session across repeated port reuse", async () => {
+  const CONCURRENCY = 8;
+  const ROUNDS = 20;
+  const mk = (port: number) =>
+    Bun.serve({ port, reusePort: true, tls, http3: true, http1: false, fetch: () => new Response("ok") });
+
+  let server = mk(0);
+  const port = server.port;
+  try {
+    for (let round = 0; round < ROUNDS; round++) {
+      const inflight: Promise<string>[] = [];
+      for (let i = 0; i < CONCURRENCY; i++) {
+        inflight.push(fetch(`https://127.0.0.1:${port}/`, h3).then(r => r.text()));
+      }
+      // Bind the replacement before dropping the current server so the retry
+      // always has a live origin on the same port to land on.
+      const next = mk(port);
+      server.stop(true);
+      server = next;
+      const bodies = await Promise.all(inflight);
+      expect(bodies).toEqual(Array(CONCURRENCY).fill("ok"));
+    }
+  } finally {
+    server.stop(true);
+  }
+});
+
 // Subprocess so the experimental flag is process-scoped and the in-process
 // server above (http1: false) doesn't interfere — this server keeps http1 on
 // so the first fetch goes over TCP and reads Alt-Svc.


### PR DESCRIPTION
### Problem
- `fetch()` to an HTTP/3 origin intermittently rejects with `HTTP3HandshakeFailed` (code `HTTP3HandshakeFailed`, errno 0). It shows up under CI oversubscription across the h3 test files (for example builds 110599, 110298, 110280); three h3 files already sit in `test/flaky-tests.txt`.
- The fetch h3 client retries a stream that closed before any response headers exactly once. The gate is the bool `Flags::h3_retried` (`src/http/lib.rs`), set in `ClientSession::retry_or_fail` (`src/http/h3_client/ClientSession.rs:223`).
- Under load two pre-headers failures in a row happen: a pooled session goes stale, and the single retry's fresh connection lands on a draining socket during the old server's close window. The second failure has the retry already spent, so `HTTP3HandshakeFailed` reaches the caller. The reject is fast (1 to 6 ms), so it is a negative handshake result, not a 10 s timeout.

### Fix
- Replace the single-retry bool with a counter `h3_retries` capped at `MAX_H3_RETRIES` (5), mirroring the HTTP/2 client's `h2_retries`/`MAX_H2_RETRIES`.
- The first retry still fires for any pre-headers failure, so the existing one-shot behavior is unchanged. Past that, a request is re-sent only when the failure is `fast` (not a no-response handshake timeout) and the request is safe to replay: the origin provably never processed it (the connection never finished its handshake, `not_applied`) or the method is idempotent.
- Correct because an unreachable origin times out with `fast == false`, so it still fails in about one handshake timeout rather than five, and a non-idempotent POST the origin may have run is never replayed. This matches the h1 client (`is_idempotent`) and h2 client (REFUSED_STREAM + not-processed) and RFC 9110 section 9.2.2.
- Verified: `test/js/web/fetch/fetch-http3-client.test.ts` (new `keeps retrying a stale pooled session across repeated port reuse`, plus the existing stale-reuse test), `serve-protocols.test.ts`, and `fetch-http3-syscall-fault.test.ts` all pass on the debug+ASAN build.

### Background
- The fetch h3 client keeps one process-global lsquic engine and one shared UDP endpoint on the HTTP thread, and pools one `ClientSession` per origin (`src/http/h3_client/`). A request binds to a pooled session, so a session that died between the pool lookup and the first stream open must re-dispatch on a fresh session.
- `retry_or_fail` runs from two places: `on_conn_close` in `callbacks.rs` (the whole connection died) and `ClientSession::deliver` (the stream closed before headers). `on_conn_close` reads the lsquic connection status; a timed-out status means the peer never answered.
- `LSCONN_ST_TIMED_OUT` is lsquic's `enum LSQUIC_CONN_STATUS` ordinal. It is now re-exported once from `bun_lsquic_sys` instead of a second hardcoded copy.

<details><summary>Notes</summary>

Reproduction: this is a load-dependent race. It does not reproduce on an idle multi-core box. Pinning the released binary to two cores under CPU load and running the six-file h3 batch reproduced the real failure (the `fetch-http3-client` stale-session test rejecting with `HTTP3HandshakeFailed`) about one run in three. The fatal case needs two consecutive pre-headers failures on one request, which depends on the kernel's brief window where a stopping server's UDP socket is still bound while a fresh connection's Initial goes out.

Because the trigger is timing, I could not build a test that deterministically fails on the pre-change binary and passes after: the client uses one fixed source UDP port, so reusePort hashing is sticky, and `server.stop(true)` closes the old socket before the retry, so a single retry almost always reaches the live server. The added regression test exercises the stale-retry path under concurrency and passes on both binaries; it guards the behavior, not the fail-before. A maintainer can weigh the change on the analysis: it is a bounded, opt-in (experimental flag) client change that only touches requests which never saw a response header.

Self-reviewed: the first pass raised two concerns, both addressed here. It hardcoded the lsquic status ordinal a second time (now sourced from `bun_lsquic_sys`), and it granted the extra retries without a replay-safety gate (now gated on provably-not-applied or idempotent, matching h1/h2). The remaining point, that the added test does not prove the race, is the timing limitation described above.

This does not replace `#41497`, which marks the h3 files flaky at the runner layer. That masks the CI red; this addresses the client behavior.
</details>
