### PR TITLE
bun:test: format test.each titles with Jest's placeholder semantics

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -349,19 +349,19 @@ test.each([
 
 Use these specifiers to format the test title:
 
-| Specifier | Description                        |
-| --------- | ---------------------------------- |
-| `%p`      | pretty-format                      |
-| `%s`      | String                             |
-| `%d`      | Number                             |
-| `%i`      | Integer (`parseInt`)               |
-| `%f`      | Floating point (`parseFloat`)      |
-| `%j`      | JSON                               |
-| `%o`      | Object                             |
-| `%O`      | pretty-format                      |
-| `%#`      | Index of the test case (0-based)   |
-| `%$`      | Number of the test case (1-based)  |
-| `%%`      | Single percent sign (%)            |
+| Specifier | Description                       |
+| --------- | --------------------------------- |
+| `%p`      | pretty-format                     |
+| `%s`      | String                            |
+| `%d`      | Number                            |
+| `%i`      | Integer (`parseInt`)              |
+| `%f`      | Floating point (`parseFloat`)     |
+| `%j`      | JSON                              |
+| `%o`      | Object                            |
+| `%O`      | pretty-format                     |
+| `%#`      | Index of the test case (0-based)  |
+| `%$`      | Number of the test case (1-based) |
+| `%%`      | Single percent sign (%)           |
 
 In the `$variable` form, `$#` is the index of the test case.
 

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -349,17 +349,21 @@ test.each([
 
 Use these specifiers to format the test title:
 
-| Specifier | Description             |
-| --------- | ----------------------- |
-| `%p`      | pretty-format           |
-| `%s`      | String                  |
-| `%d`      | Number                  |
-| `%i`      | Integer                 |
-| `%f`      | Floating point          |
-| `%j`      | JSON                    |
-| `%o`      | Object                  |
-| `%#`      | Index of the test case  |
-| `%%`      | Single percent sign (%) |
+| Specifier | Description                        |
+| --------- | ---------------------------------- |
+| `%p`      | pretty-format                      |
+| `%s`      | String                             |
+| `%d`      | Number                             |
+| `%i`      | Integer (`parseInt`)               |
+| `%f`      | Floating point (`parseFloat`)      |
+| `%j`      | JSON                               |
+| `%o`      | Object                             |
+| `%O`      | pretty-format                      |
+| `%#`      | Index of the test case (0-based)   |
+| `%$`      | Number of the test case (1-based)  |
+| `%%`      | Single percent sign (%)            |
+
+In the `$variable` form, `$#` is the index of the test case.
 
 #### Examples
 

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -357,7 +357,7 @@ Use these specifiers to format the test title:
 | `%i`      | Integer (`parseInt`)              |
 | `%f`      | Floating point (`parseFloat`)     |
 | `%j`      | JSON                              |
-| `%o`      | Object                            |
+| `%o`      | pretty-format                     |
 | `%O`      | pretty-format                     |
 | `%#`      | Index of the test case (0-based)  |
 | `%$`      | Number of the test case (1-based) |

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2270,9 +2270,7 @@ impl JSValue {
         host_fn::from_js_host_call_generic(global, || Bun__JSValue__toNumber(self, global))
     }
 
-    /// `parseInt(value, radix)`: `ToString` the value, then JSC's parser. A
-    /// radix of 0 means "not given" (decimal, or hex after a `0x` prefix).
-    /// A Symbol gives NaN, as `util.format("%i")` does, instead of throwing.
+    /// `parseInt(value, radix)`; radix 0 means "not given". A Symbol gives NaN.
     pub fn parse_int(self, global: &JSGlobalObject, radix: i32) -> JsResult<f64> {
         if self.is_symbol() {
             return Ok(f64::NAN);
@@ -2281,8 +2279,7 @@ impl JSValue {
         Ok(Bun__parseInt(&string, radix))
     }
 
-    /// `parseFloat(value)`: `ToString` the value, then JSC's parser.
-    /// A Symbol gives NaN, as `util.format("%f")` does, instead of throwing.
+    /// `parseFloat(value)`. A Symbol gives NaN.
     pub fn parse_float(self, global: &JSGlobalObject) -> JsResult<f64> {
         if self.is_symbol() {
             return Ok(f64::NAN);

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2270,6 +2270,27 @@ impl JSValue {
         host_fn::from_js_host_call_generic(global, || Bun__JSValue__toNumber(self, global))
     }
 
+    /// `parseInt(value, radix)`: `ToString` the value, then JSC's parser. A
+    /// radix of 0 means "not given" (decimal, or hex after a `0x` prefix).
+    /// A Symbol gives NaN, as `util.format("%i")` does, instead of throwing.
+    pub fn parse_int(self, global: &JSGlobalObject, radix: i32) -> JsResult<f64> {
+        if self.is_symbol() {
+            return Ok(f64::NAN);
+        }
+        let string = self.to_bun_string(global)?;
+        Ok(Bun__parseInt(&string, radix))
+    }
+
+    /// `parseFloat(value)`: `ToString` the value, then JSC's parser.
+    /// A Symbol gives NaN, as `util.format("%f")` does, instead of throwing.
+    pub fn parse_float(self, global: &JSGlobalObject) -> JsResult<f64> {
+        if self.is_symbol() {
+            return Ok(f64::NAN);
+        }
+        let string = self.to_bun_string(global)?;
+        Ok(Bun__parseFloat(&string))
+    }
+
     /// `JSValue.toPortNumber` — Node `validatePort` semantics:
     /// numeric, non-NaN, integer-truncated `0..=65535`, else `ERR_SOCKET_BAD_PORT`.
     pub fn to_port_number(self, global: &JSGlobalObject) -> JsResult<u16> {
@@ -2697,6 +2718,10 @@ unsafe extern "C" {
         global: &JSGlobalObject,
     ) -> bool;
     safe fn Bun__JSValue__toNumber(this: JSValue, global: &JSGlobalObject) -> f64;
+    /// `parseInt(str, radix)` on an already-converted string (ParseInt.h).
+    safe fn Bun__parseInt(str: &bun_core::String, radix: core::ffi::c_int) -> f64;
+    /// `parseFloat(str)` on an already-converted string.
+    safe fn Bun__parseFloat(str: &bun_core::String) -> f64;
     safe fn JSC__JSValue__toObject(this: JSValue, global: &JSGlobalObject) -> *mut JSObject;
     safe fn JSC__JSValue__unwrapBoxedPrimitive(global: &JSGlobalObject, this: JSValue) -> JSValue;
     safe fn JSC__JSValue__getPrototype(this: JSValue, global: &JSGlobalObject) -> JSValue;

--- a/src/jsc/bindings/DoubleFormatter.cpp
+++ b/src/jsc/bindings/DoubleFormatter.cpp
@@ -30,8 +30,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] double Bun__parseInt(const BunString* str, in
     return JSC::parseInt(str->toWTFString(BunString::ZeroCopy), radix);
 }
 
-/// `parseFloat(string)` on an already-converted string. Mirrors the static
-/// `parseFloat` in JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp.
+/// `parseFloat(string)`, as JSGlobalObjectFunctions.cpp implements it.
 template<typename CharacterType>
 static double parseFloatSpan(std::span<const CharacterType> data)
 {

--- a/src/jsc/bindings/DoubleFormatter.cpp
+++ b/src/jsc/bindings/DoubleFormatter.cpp
@@ -2,6 +2,8 @@
 #include "wtf/dtoa.h"
 #include "wtf/text/StringView.h"
 #include "JavaScriptCore/JSGlobalObjectFunctions.h"
+#include "JavaScriptCore/ParseInt.h"
+#include "BunString.h"
 #include <cstring>
 
 using namespace WTF;
@@ -20,4 +22,57 @@ extern "C" [[ZIG_EXPORT(nothrow)]] size_t WTF__dtoa(char* buf_124_bytes, double 
 extern "C" [[ZIG_EXPORT(nothrow)]] double JSC__jsToNumber(const char* latin1_ptr, size_t len)
 {
     return JSC::jsToNumber(WTF::StringView(latin1_ptr, len, true));
+}
+
+/// `parseInt(string, radix)` on an already-converted string.
+extern "C" [[ZIG_EXPORT(nothrow)]] double Bun__parseInt(const BunString* str, int radix)
+{
+    return JSC::parseInt(str->toWTFString(BunString::ZeroCopy), radix);
+}
+
+/// `parseFloat(string)` on an already-converted string. Mirrors the static
+/// `parseFloat` in JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp.
+template<typename CharacterType>
+static double parseFloatSpan(std::span<const CharacterType> data)
+{
+    size_t i = 0;
+    while (i < data.size() && JSC::isStrWhiteSpace(data[i]))
+        i++;
+    data = data.subspan(i);
+    if (data.empty())
+        return JSC::PNaN;
+
+    size_t parsedLength = 0;
+    double number = WTF::parseDouble(data, parsedLength);
+    if (parsedLength)
+        return number;
+
+    auto isInfinity = [](std::span<const CharacterType> s) {
+        static constexpr std::array<char, 8> infinity { 'I', 'n', 'f', 'i', 'n', 'i', 't', 'y' };
+        if (s.size() < infinity.size())
+            return false;
+        for (size_t j = 0; j < infinity.size(); j++) {
+            if (s[j] != static_cast<CharacterType>(infinity[j]))
+                return false;
+        }
+        return true;
+    };
+    switch (data[0]) {
+    case 'I':
+        return isInfinity(data) ? std::numeric_limits<double>::infinity() : JSC::PNaN;
+    case '+':
+        return isInfinity(data.subspan(1)) ? std::numeric_limits<double>::infinity() : JSC::PNaN;
+    case '-':
+        return isInfinity(data.subspan(1)) ? -std::numeric_limits<double>::infinity() : JSC::PNaN;
+    default:
+        return JSC::PNaN;
+    }
+}
+
+extern "C" [[ZIG_EXPORT(nothrow)]] double Bun__parseFloat(const BunString* str)
+{
+    WTF::String string = str->toWTFString(BunString::ZeroCopy);
+    if (string.is8Bit())
+        return parseFloatSpan(string.span8());
+    return parseFloatSpan(string.span16());
 }

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -653,8 +653,7 @@ pub(crate) mod on_unhandled_rejection {
     }
 }
 
-/// Skips the leading whitespace that `parseInt` / `parseFloat` ignore
-/// (ECMA-262 WhiteSpace and LineTerminator, as UTF-8).
+/// Skips the leading whitespace (ECMA-262 WhiteSpace and LineTerminator) that `parseInt` / `parseFloat` ignore.
 fn trim_js_leading_whitespace(s: &[u8]) -> &[u8] {
     let mut i = 0;
     while i < s.len() {
@@ -725,8 +724,7 @@ fn js_parse_float(s: &[u8]) -> f64 {
     bun_core::fmt::parse_double(s).unwrap_or(f64::NAN)
 }
 
-/// Pretty-prints `value` on one line through the matcher formatter
-/// (`1`, `-0`, `10n`, `"x"`, `Symbol(x)`, `null`, `{ a: 1 }`).
+/// Pretty-prints `value` on one line; a string keeps its quotes.
 fn write_pretty_value(
     global_this: &JSGlobalObject,
     value: JSValue,
@@ -737,8 +735,7 @@ fn write_pretty_value(
     formatter.format_value::<false>(value, list)
 }
 
-/// Writes `value` the way `String(value)` reads in a title: a primitive
-/// string as its raw text, anything else pretty-printed.
+/// Writes `value` as `String(value)` reads in a title: raw text for a string, pretty-printed otherwise.
 fn write_title_value(
     global_this: &JSGlobalObject,
     value: JSValue,
@@ -752,10 +749,7 @@ fn write_title_value(
     write_pretty_value(global_this, value, list)
 }
 
-/// Writes one positional argument for a `%<spec>` placeholder with the
-/// `util.format` coercions Jest applies: `%s` is `String()`, `%d` is
-/// `Number()`, `%i` is `parseInt()`, `%f` is `parseFloat()`, `%j`/`%o` are
-/// `JSON.stringify()`, `%p`/`%O` pretty-print.
+/// Writes one positional argument with the `util.format` coercion Jest applies to `%<spec>`.
 fn write_placeholder_arg(
     global_this: &JSGlobalObject,
     spec: u8,

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -653,24 +653,121 @@ pub(crate) mod on_unhandled_rejection {
     }
 }
 
-fn consume_arg(
-    global_this: &JSGlobalObject,
-    should_write: bool,
-    str_idx: &mut usize,
-    args_idx: &mut usize,
-    array_list: &mut Vec<u8>,
-    arg: JSValue,
-    fallback: &[u8],
-) -> JsResult<()> {
-    if should_write {
-        let owned_slice = arg.to_utf8(global_this)?;
-        array_list.extend_from_slice(owned_slice.slice());
-    } else {
-        array_list.extend_from_slice(fallback);
+/// Skips the leading whitespace that `parseInt` / `parseFloat` ignore
+/// (ECMA-262 WhiteSpace and LineTerminator, as UTF-8).
+fn trim_js_leading_whitespace(s: &[u8]) -> &[u8] {
+    let mut i = 0;
+    while i < s.len() {
+        let rest = &s[i..];
+        let skip = match rest {
+            [b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c, ..] => 1,
+            [0xc2, 0xa0, ..] => 2,
+            [0xe1, 0x9a, 0x80, ..] => 3,
+            [0xe2, 0x80, 0x80..=0x8a | 0xa8 | 0xa9 | 0xaf, ..] => 3,
+            [0xe2, 0x81, 0x9f, ..] => 3,
+            [0xe3, 0x80, 0x80, ..] => 3,
+            [0xef, 0xbb, 0xbf, ..] => 3,
+            _ => 0,
+        };
+        if skip == 0 {
+            break;
+        }
+        i += skip;
     }
-    *str_idx += 1;
-    *args_idx += 1;
+    &s[i..]
+}
+
+/// `parseInt(s)` with no radix argument.
+fn js_parse_int(s: &[u8]) -> f64 {
+    let s = trim_js_leading_whitespace(s);
+    let (neg, s) = match s {
+        [b'-', rest @ ..] => (true, rest),
+        [b'+', rest @ ..] => (false, rest),
+        _ => (false, s),
+    };
+    let (radix, s) = match s {
+        [b'0', b'x' | b'X', rest @ ..] => (16u32, rest),
+        _ => (10u32, s),
+    };
+    let digits_len = s
+        .iter()
+        .take_while(|&&c| (c as char).is_digit(radix))
+        .count();
+    if digits_len == 0 {
+        return f64::NAN;
+    }
+    let digits = &s[..digits_len];
+    let magnitude = if radix == 10 {
+        bun_core::fmt::parse_double(digits).unwrap_or(f64::NAN)
+    } else {
+        digits.iter().fold(0.0f64, |acc, &c| {
+            acc * 16.0 + f64::from((c as char).to_digit(16).unwrap_or(0))
+        })
+    };
+    if neg {
+        -magnitude
+    } else {
+        magnitude
+    }
+}
+
+/// `parseFloat(s)`.
+fn js_parse_float(s: &[u8]) -> f64 {
+    let s = trim_js_leading_whitespace(s);
+    let (neg, unsigned) = match s {
+        [b'-', rest @ ..] => (true, rest),
+        [b'+', rest @ ..] => (false, rest),
+        _ => (false, s),
+    };
+    if unsigned.starts_with(b"Infinity") {
+        return if neg { f64::NEG_INFINITY } else { f64::INFINITY };
+    }
+    bun_core::fmt::parse_double(s).unwrap_or(f64::NAN)
+}
+
+/// Writes `value` the way the title formatter renders a substituted value:
+/// a primitive string as its raw text, anything else through the matcher
+/// formatter (`1`, `-0`, `10n`, `Symbol(x)`, `null`, `{ a: 1 }`).
+fn write_title_value(
+    global_this: &JSGlobalObject,
+    value: JSValue,
+    list: &mut Vec<u8>,
+) -> JsResult<()> {
+    if value.is_string() {
+        let owned_slice = value.to_utf8(global_this)?;
+        list.extend_from_slice(owned_slice.slice());
+    } else {
+        let mut formatter = crate::test_runner::expect::make_formatter(global_this);
+        formatter.single_line = true;
+        formatter.format_value::<false>(value, list)?;
+    }
     Ok(())
+}
+
+/// Writes one positional argument for a `%<spec>` placeholder with the
+/// `util.format` coercions Jest applies: `%s` is `String()`, `%d` is
+/// `Number()`, `%i` is `parseInt()`, `%f` is `parseFloat()`, `%j`/`%o` are
+/// `JSON.stringify()`, `%p`/`%O` pretty-print.
+fn write_placeholder_arg(
+    global_this: &JSGlobalObject,
+    spec: u8,
+    arg: JSValue,
+    list: &mut Vec<u8>,
+) -> JsResult<()> {
+    let number = match spec {
+        b's' | b'p' | b'O' => return write_title_value(global_this, arg, list),
+        b'j' | b'o' => {
+            let str = arg.json_stringify_fast(global_this)?;
+            list.extend_from_slice(&str.to_owned_slice());
+            return Ok(());
+        }
+        b'd' | b'i' if arg.is_big_int() => return write_title_value(global_this, arg, list),
+        _ if arg.is_symbol() => f64::NAN,
+        b'd' => arg.to_number(global_this)?,
+        b'i' => js_parse_int(&arg.to_utf8(global_this)?),
+        _ => js_parse_float(&arg.to_utf8(global_this)?),
+    };
+    write_title_value(global_this, JSValue::js_number(number), list)
 }
 
 /// Generate test label by positionally injecting parameters with printf formatting
@@ -693,10 +790,15 @@ pub(crate) fn format_label(
             && function_args[0].is_object()
         {
             let var_start = idx + 1;
-            let mut var_end = var_start;
 
-            if bun_js_parser::js_lexer::is_identifier_start(label[var_end] as i32) {
-                var_end += 1;
+            if label[var_start] == b'#' {
+                write!(&mut list, "{}", test_idx).unwrap();
+                idx = var_start + 1;
+                continue;
+            }
+
+            if bun_js_parser::js_lexer::is_identifier_start(label[var_start] as i32) {
+                let mut var_end = var_start + 1;
 
                 while var_end < label.len() {
                     let c = label[var_end];
@@ -720,109 +822,49 @@ pub(crate) fn format_label(
                     global_this,
                     bun_string_jsc::create_utf8_for_js(global_this, var_path)?,
                 )?;
-                if !value.is_empty_or_undefined_or_null() {
-                    // For primitive strings, use toString() to avoid adding quotes
-                    // This matches Jest's behavior (https://github.com/jestjs/jest/issues/7689)
-                    if value.is_string() {
-                        let owned_slice = value.to_utf8(global_this)?;
-                        list.extend_from_slice(owned_slice.slice());
-                    } else {
-                        let mut formatter = crate::test_runner::expect::make_formatter(global_this);
-                        // formatter cleanup handled by Drop.
-                        formatter.format_value::<false>(value, &mut list)?;
-                    }
-                    idx = var_end;
-                    continue;
+                // An empty value means the property does not exist: the
+                // placeholder stays literal. An existing null/undefined is
+                // rendered, as in Jest.
+                if value.is_empty() {
+                    list.extend_from_slice(&label[idx..var_end]);
+                } else {
+                    write_title_value(global_this, value, &mut list)?;
                 }
-            } else {
-                while var_end < label.len()
-                    && (bun_js_parser::js_lexer::is_identifier_continue(label[var_end] as i32)
-                        && label[var_end] != b'$')
-                {
-                    var_end += 1;
-                }
+                idx = var_end;
+                continue;
             }
 
             list.push(b'$');
-            list.extend_from_slice(&label[var_start..var_end]);
-            idx = var_end;
-        } else if char == b'%' && (idx + 1 < label.len()) && !(args_idx >= function_args.len()) {
-            let current_arg = function_args[args_idx];
+            idx += 1;
+            continue;
+        }
 
-            match label[idx + 1] {
-                b's' => {
-                    consume_arg(
-                        global_this,
-                        !current_arg.is_empty() && current_arg.js_type().is_string(),
-                        &mut idx,
-                        &mut args_idx,
-                        &mut list,
-                        current_arg,
-                        b"%s",
-                    )?;
-                }
-                b'i' => {
-                    consume_arg(
-                        global_this,
-                        current_arg.is_any_int(),
-                        &mut idx,
-                        &mut args_idx,
-                        &mut list,
-                        current_arg,
-                        b"%i",
-                    )?;
-                }
-                b'd' => {
-                    consume_arg(
-                        global_this,
-                        current_arg.is_number(),
-                        &mut idx,
-                        &mut args_idx,
-                        &mut list,
-                        current_arg,
-                        b"%d",
-                    )?;
-                }
-                b'f' => {
-                    consume_arg(
-                        global_this,
-                        current_arg.is_number(),
-                        &mut idx,
-                        &mut args_idx,
-                        &mut list,
-                        current_arg,
-                        b"%f",
-                    )?;
-                }
-                b'j' | b'o' => {
-                    // Use jsonStringifyFast for SIMD-optimized serialization
-                    let str = current_arg.json_stringify_fast(global_this)?;
-                    let owned_slice = str.to_owned_slice();
-                    list.extend_from_slice(&owned_slice);
-                    idx += 1;
+        if char == b'%' && idx + 1 < label.len() {
+            let spec = label[idx + 1];
+            match spec {
+                b'%' => list.push(b'%'),
+                b'#' => write!(&mut list, "{}", test_idx).unwrap(),
+                b'$' => write!(&mut list, "{}", test_idx + 1).unwrap(),
+                b's' | b'd' | b'i' | b'f' | b'j' | b'o' | b'O' | b'p'
+                    if args_idx < function_args.len() =>
+                {
+                    let arg = function_args[args_idx];
                     args_idx += 1;
+                    write_placeholder_arg(global_this, spec, arg, &mut list)?;
                 }
-                b'p' => {
-                    let mut formatter = crate::test_runner::expect::make_formatter(global_this);
-                    formatter.format_value::<false>(current_arg, &mut list)?;
-                    idx += 1;
-                    args_idx += 1;
-                }
-                b'#' => {
-                    write!(&mut list, "{}", test_idx).unwrap();
-                    idx += 1;
-                }
-                b'%' => {
+                // Not a placeholder (or no argument left for it): the text
+                // stays as written.
+                _ => {
                     list.push(b'%');
                     idx += 1;
-                }
-                _ => {
-                    // ignore unrecognized fmt
+                    continue;
                 }
             }
-        } else {
-            list.push(char);
+            idx += 2;
+            continue;
         }
+
+        list.push(char);
         idx += 1;
     }
 

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -687,8 +687,8 @@ fn write_placeholder_arg(
 ) -> JsResult<()> {
     let number = match spec {
         b's' => return write_title_value(global_this, arg, list),
-        b'p' | b'O' => return write_pretty_value(global_this, arg, list),
-        b'j' | b'o' => {
+        b'p' | b'o' | b'O' => return write_pretty_value(global_this, arg, list),
+        b'j' => {
             let str = arg.json_stringify_fast(global_this)?;
             list.extend_from_slice(&str.to_owned_slice());
             return Ok(());

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -725,9 +725,20 @@ fn js_parse_float(s: &[u8]) -> f64 {
     bun_core::fmt::parse_double(s).unwrap_or(f64::NAN)
 }
 
-/// Writes `value` the way the title formatter renders a substituted value:
-/// a primitive string as its raw text, anything else through the matcher
-/// formatter (`1`, `-0`, `10n`, `Symbol(x)`, `null`, `{ a: 1 }`).
+/// Pretty-prints `value` on one line through the matcher formatter
+/// (`1`, `-0`, `10n`, `"x"`, `Symbol(x)`, `null`, `{ a: 1 }`).
+fn write_pretty_value(
+    global_this: &JSGlobalObject,
+    value: JSValue,
+    list: &mut Vec<u8>,
+) -> JsResult<()> {
+    let mut formatter = crate::test_runner::expect::make_formatter(global_this);
+    formatter.single_line = true;
+    formatter.format_value::<false>(value, list)
+}
+
+/// Writes `value` the way `String(value)` reads in a title: a primitive
+/// string as its raw text, anything else pretty-printed.
 fn write_title_value(
     global_this: &JSGlobalObject,
     value: JSValue,
@@ -736,12 +747,9 @@ fn write_title_value(
     if value.is_string() {
         let owned_slice = value.to_utf8(global_this)?;
         list.extend_from_slice(owned_slice.slice());
-    } else {
-        let mut formatter = crate::test_runner::expect::make_formatter(global_this);
-        formatter.single_line = true;
-        formatter.format_value::<false>(value, list)?;
+        return Ok(());
     }
-    Ok(())
+    write_pretty_value(global_this, value, list)
 }
 
 /// Writes one positional argument for a `%<spec>` placeholder with the
@@ -755,7 +763,8 @@ fn write_placeholder_arg(
     list: &mut Vec<u8>,
 ) -> JsResult<()> {
     let number = match spec {
-        b's' | b'p' | b'O' => return write_title_value(global_this, arg, list),
+        b's' => return write_title_value(global_this, arg, list),
+        b'p' | b'O' => return write_pretty_value(global_this, arg, list),
         b'j' | b'o' => {
             let str = arg.json_stringify_fast(global_this)?;
             list.extend_from_slice(&str.to_owned_slice());

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -653,77 +653,6 @@ pub(crate) mod on_unhandled_rejection {
     }
 }
 
-/// Skips the leading whitespace (ECMA-262 WhiteSpace and LineTerminator) that `parseInt` / `parseFloat` ignore.
-fn trim_js_leading_whitespace(s: &[u8]) -> &[u8] {
-    let mut i = 0;
-    while i < s.len() {
-        let rest = &s[i..];
-        let skip = match rest {
-            [b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c, ..] => 1,
-            [0xc2, 0xa0, ..] => 2,
-            [0xe1, 0x9a, 0x80, ..] => 3,
-            [0xe2, 0x80, 0x80..=0x8a | 0xa8 | 0xa9 | 0xaf, ..] => 3,
-            [0xe2, 0x81, 0x9f, ..] => 3,
-            [0xe3, 0x80, 0x80, ..] => 3,
-            [0xef, 0xbb, 0xbf, ..] => 3,
-            _ => 0,
-        };
-        if skip == 0 {
-            break;
-        }
-        i += skip;
-    }
-    &s[i..]
-}
-
-/// `parseInt(s)` with no radix argument.
-fn js_parse_int(s: &[u8]) -> f64 {
-    let s = trim_js_leading_whitespace(s);
-    let (neg, s) = match s {
-        [b'-', rest @ ..] => (true, rest),
-        [b'+', rest @ ..] => (false, rest),
-        _ => (false, s),
-    };
-    let (radix, s) = match s {
-        [b'0', b'x' | b'X', rest @ ..] => (16u32, rest),
-        _ => (10u32, s),
-    };
-    let digits_len = s
-        .iter()
-        .take_while(|&&c| (c as char).is_digit(radix))
-        .count();
-    if digits_len == 0 {
-        return f64::NAN;
-    }
-    let digits = &s[..digits_len];
-    let magnitude = if radix == 10 {
-        bun_core::fmt::parse_double(digits).unwrap_or(f64::NAN)
-    } else {
-        digits.iter().fold(0.0f64, |acc, &c| {
-            acc * 16.0 + f64::from((c as char).to_digit(16).unwrap_or(0))
-        })
-    };
-    if neg {
-        -magnitude
-    } else {
-        magnitude
-    }
-}
-
-/// `parseFloat(s)`.
-fn js_parse_float(s: &[u8]) -> f64 {
-    let s = trim_js_leading_whitespace(s);
-    let (neg, unsigned) = match s {
-        [b'-', rest @ ..] => (true, rest),
-        [b'+', rest @ ..] => (false, rest),
-        _ => (false, s),
-    };
-    if unsigned.starts_with(b"Infinity") {
-        return if neg { f64::NEG_INFINITY } else { f64::INFINITY };
-    }
-    bun_core::fmt::parse_double(s).unwrap_or(f64::NAN)
-}
-
 /// Pretty-prints `value` on one line; a string keeps its quotes.
 fn write_pretty_value(
     global_this: &JSGlobalObject,
@@ -765,10 +694,10 @@ fn write_placeholder_arg(
             return Ok(());
         }
         b'd' | b'i' if arg.is_big_int() => return write_title_value(global_this, arg, list),
-        _ if arg.is_symbol() => f64::NAN,
+        b'd' if arg.is_symbol() => f64::NAN,
         b'd' => arg.to_number(global_this)?,
-        b'i' => js_parse_int(&arg.to_utf8(global_this)?),
-        _ => js_parse_float(&arg.to_utf8(global_this)?),
+        b'i' => arg.parse_int(global_this, 0)?,
+        _ => arg.parse_float(global_this)?,
     };
     write_title_value(global_this, JSValue::js_number(number), list)
 }

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -825,9 +825,7 @@ pub(crate) fn format_label(
                     global_this,
                     bun_string_jsc::create_utf8_for_js(global_this, var_path)?,
                 )?;
-                // An empty value means the property does not exist: the
-                // placeholder stays literal. An existing null/undefined is
-                // rendered, as in Jest.
+                // Empty means the property does not exist; null/undefined render.
                 if value.is_empty() {
                     list.extend_from_slice(&label[idx..var_end]);
                 } else {
@@ -855,8 +853,6 @@ pub(crate) fn format_label(
                     args_idx += 1;
                     write_placeholder_arg(global_this, spec, arg, &mut list)?;
                 }
-                // Not a placeholder (or no argument left for it): the text
-                // stays as written.
                 _ => {
                     list.push(b'%');
                     idx += 1;

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -970,7 +970,7 @@ describe("bun test", () => {
         input: `
           import { test, expect } from "bun:test";
 
-          test.each(${JSON.stringify(input)})("with an object: %o", (o) => {
+          test.each(${JSON.stringify(input)})("with an object: %j", (o) => {
             expect(o).toBe(o);
           });
         `,
@@ -999,7 +999,7 @@ describe("bun test", () => {
           });
         `,
       });
-      expect(stderr).toContain(`with an object: ${JSON.stringify(input[0])}`);
+      expect(stderr).toContain(`with an object: { foo: "bar", nested: { again: { a: 2 } } }`);
     });
     test("check formatting for %#", () => {
       const numbers = [

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1059,6 +1059,7 @@ describe("bun test", () => {
           test.each([[1]])("%s %s %d", () => {});
           test.each([[]])("empty %s %% %#", () => {});
           test.each([[1, "x%sy", 3]])("%s %s %s", () => {});
+          test.each([["x", { a: "y" }]])("p=%p O=%O", () => {});
         `,
       });
       const titles = stderr
@@ -1097,6 +1098,7 @@ describe("bun test", () => {
         "1 %s %d",
         "empty %s % 0",
         "1 x%sy 3",
+        'p="x" O={ a: "y" }',
       ]);
     });
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1042,6 +1042,63 @@ describe("bun test", () => {
       expect(stderr).toContain(`%`);
     });
     test.todo("check formatting for %p", () => {});
+    test("formats titles with Jest's printf coercions, escapes and index placeholders", () => {
+      const stderr = runTest({
+        args: [],
+        input: `
+          import { test } from "bun:test";
+          test.each([[1, 2, 3]])("%s + %s = %s", () => {});
+          test.each([["3.9"], [2 ** 53], [1e21], ["0x1f"], ["  -42abc"], ["abc"]])("i=%i", () => {});
+          test.each([["3.9e2"], ["-Infinity"], ["abc"]])("f=%f", () => {});
+          test.each([["3"], [true], [null], [{}], [10n], [Symbol("s")], [-0]])("d=%d", () => {});
+          test.each([[{ a: 1 }], [[1, 2]], [null], [undefined], [10n], [Symbol("s")], [-0]])("s=%s", () => {});
+          test.each([[7]])("%i then %# (%$ of %%)", () => {});
+          test.each([[1]])("%d is 100%%", () => {});
+          test.each([[1]])("odd %z num=%$", () => {});
+          test.each([[1]])("trailing %", () => {});
+          test.each([[1]])("%s %s %d", () => {});
+          test.each([[]])("empty %s %% %#", () => {});
+          test.each([[1, "x%sy", 3]])("%s %s %s", () => {});
+        `,
+      });
+      const titles = stderr
+        .split("\n")
+        .filter(line => line.startsWith("(pass) "))
+        .map(line => line.slice("(pass) ".length).replace(/ \[[\d.]+ms\]$/, ""));
+      expect(titles).toEqual([
+        "1 + 2 = 3",
+        "i=3",
+        "i=9007199254740992",
+        "i=1",
+        "i=31",
+        "i=-42",
+        "i=NaN",
+        "f=390",
+        "f=-Infinity",
+        "f=NaN",
+        "d=3",
+        "d=1",
+        "d=0",
+        "d=NaN",
+        "d=10n",
+        "d=NaN",
+        "d=-0",
+        "s={ a: 1 }",
+        "s=[ 1, 2 ]",
+        "s=null",
+        "s=undefined",
+        "s=10n",
+        "s=Symbol(s)",
+        "s=-0",
+        "7 then 0 (1 of %)",
+        "1 is 100%",
+        "odd %z num=1",
+        "trailing %",
+        "1 %s %d",
+        "empty %s % 0",
+        "1 x%sy 3",
+      ]);
+    });
 
     describe("$variable syntax", () => {
       test("should replace $variables with object properties in test names", () => {
@@ -1244,12 +1301,7 @@ describe("bun test", () => {
           `,
         });
 
-        expect(stderr).toContain("underscore");
-        expect(stderr).toContain("dollar");
-        expect(stderr).toContain("mix");
-        expect(stderr).toContain("$123invalid");
-        expect(stderr).toContain("$hasdash");
-        expect(stderr).toContain("$hasspace");
+        expect(stderr).toContain("Edge: underscore | dollar | mix | $123invalid | $has-dash | $has space");
       });
 
       test("handles deeply nested properties with arrays", () => {
@@ -1345,7 +1397,35 @@ describe("bun test", () => {
           `,
         });
 
-        expect(stderr).toContain("1 | $missing| $a.b.c| 1");
+        expect(stderr).toContain("1 | $missing | $a.b.c | 1");
+      });
+
+      test("renders null and undefined values, $# and a literal $ without eating the next character", () => {
+        const stderr = runTest({
+          args: [],
+          input: `
+            import { test } from "bun:test";
+            test.each([{ a: null, b: 5 }])("a=$a|b=$b|", () => {});
+            test.each([{ a: undefined, b: 5 }])("a=$a|b=$b|", () => {});
+            test.each([{ a: 1 }, { a: 2 }])("idx=$# end", () => {});
+            test.each([{ a: 1 }])("\${a} braces", () => {});
+            test.each([{ a: 1 }])("$5 USD $a", () => {});
+            test.each([{ a: 1 }])("100%% $a", () => {});
+          `,
+        });
+        const titles = stderr
+          .split("\n")
+          .filter(line => line.startsWith("(pass) "))
+          .map(line => line.slice("(pass) ".length).replace(/ \[[\d.]+ms\]$/, ""));
+        expect(titles).toEqual([
+          "a=null|b=5|",
+          "a=undefined|b=5|",
+          "idx=0 end",
+          "idx=1 end",
+          "${a} braces",
+          "$5 USD 1",
+          "100% 1",
+        ]);
       });
     });
   });


### PR DESCRIPTION
Fixes #37821

### Problem
- `test.each` and `describe.each` titles diverge from Jest in three ways. A placeholder only substitutes when the argument already has the matching type (`%s` needs a string, `%d`/`%f` a number, `%i` an Int52), otherwise the literal token stays and the argument is still consumed: `test.each([[1, 2, 3]])("%s + %s = %s")` gives `%s + %s = %s`. `%#` and `%%` stop working once the positional arguments run out, and an unknown token loses its `%` (`%z` prints `z`). In the `$var` form, a null or undefined value, `$#`, `${a}` and `$5` each skip the character after the token (`a=$a|b=$b|` gives `a=$ab=5|`).
- The cause is `format_label` in `src/runtime/test_runner/jest.rs`. The `%` arm was guarded by `args_idx < args.len()`, each specifier had a type gate, the `_` arm dropped the `%`, and the `$var` fallback fell through to the loop's `idx += 1`.
- Titles feed `-t` filtering, JUnit names and snapshot keys, so a wrong title is not only cosmetic. A suite that had a wrong title recorded in a `.snap` file gets a new key after this change.

### Fix
- `%s`, `%d`, `%i`, `%f` apply the `util.format` coercions Jest uses: `String()`, `Number()`, `parseInt()`, `parseFloat()`. `%i` and `%f` go through JSC's own parsers (`ParseInt.h`, and the `parseFloat` logic of `JSGlobalObjectFunctions.cpp`), exposed as `JSValue::parse_int` and `JSValue::parse_float`. A BigInt prints as `10n`, a Symbol gives `NaN` for the numeric specifiers. `%j`/`%o` stay `JSON.stringify`, `%p` and `%O` pretty-print.
- `%%`, `%#` and `%$` (1-based index, Jest 30) always apply. A `%` with no argument left, or with an unknown letter, stays as written. `$#` is the row index. A `$` that does not start an identifier is literal and the next character is kept. An existing null/undefined property renders as `null`/`undefined`; a missing property stays literal.
- Non-string values in a title print on one line (`{ a: 1 }`), so a title never spans lines. `docs/test/writing-tests.mdx` lists `%O`, `%$` and `$#`.
- Verified: `test/cli/test/bun-test.test.ts` (two new tests, two existing expectations that encoded the eaten character are corrected). Stock bun fails 4 tests. Also `jest-each.test.ts`, `jest-each-gc-root.test.ts`, `isolation`, `test-shard`.

### Background
- Jest formats a title in `jest-each/src/table/array.ts`: `%%` becomes `%`, `%#`/`%$` are replaced first, then each row value consumes the first remaining `%[sdifjoOp]` through `util.format`. Object rows use `interpolation.ts`: `$key[.path]` renders the value, `$#` the index.
- Self-reviewed: 5 concerns raised, 4 addressed (string quoting for `%p`/`%O`, JSC-backed parsers, docs rows, lineage below). Not taken: hoisting Jest's template-vs-printf mode decision out of the per-row loop. Bun has always applied both forms in one pass, and changing that is a separate behaviour change.

Supersedes #38831 (the `%s` gate, by @deepshekhardas) and #34977 (the `$var` null/undefined case), and covers item 3 of #32817.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->