### PR TITLE
bun:test: accept Symbol keys in a toHaveProperty array path

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4674,15 +4674,21 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
         auto* pathObject = path.toObject(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         forEachInArrayLike(globalObject, pathObject, [&](JSValue item) -> bool {
-            if (!(item.isString() || item.isNumber())) {
+            if (!(item.isString() || item.isNumber() || item.isSymbol())) {
                 currProp = {};
                 return false;
             }
 
-            JSString* propNameString = item.toString(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
-            PropertyName propName = PropertyName(propNameString->toIdentifier(globalObject));
-            RETURN_IF_EXCEPTION(scope, {});
+            Identifier propNameIdentifier;
+            if (item.isSymbol()) {
+                propNameIdentifier = Identifier::fromUid(asSymbol(item)->privateName());
+            } else {
+                JSString* propNameString = item.toString(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                propNameIdentifier = propNameString->toIdentifier(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+            PropertyName propName = PropertyName(propNameIdentifier);
 
             auto* currPropObject = currProp.toObject(globalObject);
             RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2226,6 +2226,22 @@ describe("expect()", () => {
     expect(new Date()).toHaveProperty("getTime");
   });
 
+  test("toHaveProperty() - symbol keys in an array path", () => {
+    const s = Symbol("k");
+    const other = Symbol("k");
+    expect({ [s]: 1 }).toHaveProperty([s]);
+    expect({ [s]: 1 }).toHaveProperty([s], 1);
+    expect({ [s]: 1 }).not.toHaveProperty([s], 2);
+    expect({ [s]: 1 }).not.toHaveProperty([other]);
+    expect({ [s]: undefined }).toHaveProperty([s]);
+    expect({ a: { [s]: { b: 2 } } }).toHaveProperty(["a", s]);
+    expect({ a: { [s]: { b: 2 } } }).toHaveProperty(["a", s, "b"], 2);
+    expect({ a: { [s]: { b: 2 } } }).not.toHaveProperty(["a", s, "c"]);
+    expect({ [Symbol.iterator]: 1 }).toHaveProperty([Symbol.iterator], 1);
+    expect([]).toHaveProperty([Symbol.iterator]);
+    expect({}).not.toHaveProperty([s]);
+  });
+
   test("toHaveProperty() - all", () => {
     expect({ a: 1 }).toHaveProperty("a");
     expect({ a: 1 }).toHaveProperty("a", 1);


### PR DESCRIPTION
### Problem
- `expect({ [s]: 1 }).toHaveProperty([s])` fails with `Unable to find property`, and `.not.toHaveProperty([s])` passes. Jest passes the first and fails the second: its `getPath` indexes the object with the key as given, so a Symbol works. The array form exists for keys that cannot be written in dot syntax, and a Symbol is the main such key.
- The cause is the array branch of `JSC__JSValue__getIfPropertyExistsFromPath` (`src/jsc/bindings/bindings.cpp:4677`). It rejected any path element that was not a string or a number, which made the lookup return empty.

### Fix
- A Symbol element becomes a `PropertyName` through `Identifier::fromUid(symbol->privateName())`. String and number elements keep the `toString` + `toIdentifier` path.
- Any other element type still ends the lookup as "not found", as before.
- Verified: `test/js/bun/test/expect.test.js` (`toHaveProperty() - symbol keys in an array path`: own symbol, a distinct symbol with the same description, nested `["a", s, "b"]`, `Symbol.iterator` on an array, and the `.not` forms). Stock bun fails it. Also the rest of the `toHaveProperty` tests in that file.

### Background
- `toHaveProperty(path)` accepts a dotted string (`"a.b[0]"`) or an array of keys. The string form is parsed in C++. The array form takes each element as one key.
- In JSC, a property key is a `PropertyName`. A string key becomes one through an atomized `Identifier`. A Symbol key wraps the symbol's `PrivateName` (its unique id), which is what `Identifier::fromUid` builds.

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/test/expect.test.js:
(pass) expect() > () [471.90ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [4.40ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.73ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.40ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.37ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.38ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.37ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.39ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.37ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.41ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.38ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [2.76ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.72ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.45ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.44ms]
(pass) ex
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.3-canary.1 (f9450c681)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.91ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.04ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.02ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/test/expect.test.js:
(pass) expect() > () [338.44ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.85ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.57ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.25ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.26ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.24ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.24ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.91ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.50ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.31ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.34ms]
(pass) ex
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3966ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/11] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/11] gen cpp.rs (cppbind)
[2/11] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/br
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp   | 16 +++++++++++-----
 test/js/bun/test/expect.test.js | 16 ++++++++++++++++
 2 files changed, 27 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/jsc/bindings/bindings.cpp        1      0     10
test/js/bun/test/expect.test.js      0      0     10
```

</details>

<!-- robobun:evidence:end -->