### PR TITLE
FileSink: report a write error that arrived while no promise was pending

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -739,6 +739,7 @@ writeStreamPrototype._destroy = function (err, cb) {
     try {
       end = sink.end(err);
     } catch (e) {
+      this.fd = null;
       cb(err || e);
       return;
     }

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -343,7 +343,13 @@ function close(stream, err, cb) {
   const fastPath: FileSink | true = stream[kWriteStreamFastPath];
   if (fastPath && fastPath !== true) {
     stream.fd = null;
-    const maybePromise = fastPath.end(err);
+    let maybePromise;
+    try {
+      maybePromise = fastPath.end(err);
+    } catch (e) {
+      cb(err || e);
+      return;
+    }
     thenIfPromise(maybePromise, () => {
       cb(err);
     });
@@ -729,7 +735,13 @@ writeStreamPrototype._writev = function (data, cb) {
 writeStreamPrototype._destroy = function (err, cb) {
   const sink = this[kWriteStreamFastPath];
   if (sink && sink !== true) {
-    const end = sink.end(err);
+    let end;
+    try {
+      end = sink.end(err);
+    } catch (e) {
+      cb(err || e);
+      return;
+    }
     if ($isPromise(end)) {
       end.then(() => cb(err), cb);
       return;

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -64,6 +64,11 @@ pub struct FileSink {
     /// Bytes accepted since `pipe_stream` (`written` counts buffered bytes again when flushed).
     pub(crate) stream_bytes: Cell<Option<u64>>,
 
+    /// A write failure that arrived while no `write()`/`flush()`/`end()` promise was pending
+    /// to carry it (the writer dropped buffered bytes on an async error). The next
+    /// `write`/`flush`/`end` from JS takes it.
+    undelivered_error: JsCell<Option<sys::Error>>,
+
     /// Strong reference to the JS wrapper object to prevent GC from collecting it
     /// while an async operation is pending. This is set when endFromJS returns a
     /// pending Promise and cleared when the operation completes.
@@ -466,19 +471,21 @@ impl FileSink {
         // SAFETY: caller contract — `this` is live with write+dealloc provenance.
         unsafe {
             (*this).record_stream_error(streams::StreamError::Error(err.clone()));
-            if (*this).pending.get().state == streams::PendingState::Pending {
-                (*this)
-                    .pending
-                    .with_mut(|p| p.result = streams::Writable::Err(err));
-                if let Some(vm) = (*this).js_vm() {
-                    if vm.is_inside_deferred_task_queue.get() {
-                        (*this).run_pending_later();
-                        return;
-                    }
-                }
-
-                FileSink::run_pending(this);
+            if (*this).pending.get().state != streams::PendingState::Pending {
+                (*this).undelivered_error.set(Some(err));
+                return;
             }
+            (*this)
+                .pending
+                .with_mut(|p| p.result = streams::Writable::Err(err));
+            if let Some(vm) = (*this).js_vm() {
+                if vm.is_inside_deferred_task_queue.get() {
+                    (*this).run_pending_later();
+                    return;
+                }
+            }
+
+            FileSink::run_pending(this);
         }
     }
 
@@ -879,6 +886,8 @@ impl FileSink {
                         (*this)
                             .pending
                             .with_mut(|p| p.result = streams::Writable::Err(err));
+                    } else {
+                        (*this).undelivered_error.set(Some(err));
                     }
                     (*this).writer.with_mut(|w| w.end());
                     (*this).run_pending_later();
@@ -928,6 +937,10 @@ impl FileSink {
             if let streams::WritableFuture::Promise { strong, .. } = &self.pending.get().future {
                 return sys::Result::Ok(strong.value());
             }
+        }
+
+        if let Some(err) = self.undelivered_error.take() {
+            return sys::Result::Err(err);
         }
 
         if self.done.get() {
@@ -1047,6 +1060,9 @@ impl FileSink {
     }
 
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
+        if let Some(err) = self.undelivered_error.take() {
+            return streams::Writable::Err(err);
+        }
         if self.done.get() {
             return streams::Writable::Done;
         }
@@ -1083,6 +1099,9 @@ impl FileSink {
     }
 
     pub(crate) fn write_latin1(&self, data: &streams::Result) -> streams::Writable {
+        if let Some(err) = self.undelivered_error.take() {
+            return streams::Writable::Err(err);
+        }
         if self.done.get() {
             return streams::Writable::Done;
         }
@@ -1100,6 +1119,9 @@ impl FileSink {
     }
 
     pub(crate) fn write_utf16(&self, data: &streams::Result) -> streams::Writable {
+        if let Some(err) = self.undelivered_error.take() {
+            return streams::Writable::Err(err);
+        }
         if self.done.get() {
             return streams::Writable::Done;
         }
@@ -1233,7 +1255,15 @@ impl FileSink {
                     return sys::Result::Ok(strong.value());
                 }
             }
+            if let Some(err) = self.undelivered_error.take() {
+                return sys::Result::Err(err);
+            }
             return sys::Result::Ok(JSValue::js_number(self.written.get() as f64));
+        }
+
+        if let Some(err) = self.undelivered_error.take() {
+            self.done.set(true);
+            return sys::Result::Err(err);
         }
 
         // SAFETY(JsCell): `IOWriter::flush` is pure I/O; no JS while held.
@@ -1494,6 +1524,7 @@ impl FileSink {
             stream_done: JsCell::new(bun_jsc::JSPromiseStrong::empty()),
             stream_error: JsCell::new(None),
             stream_bytes: Cell::new(None),
+            undelivered_error: JsCell::new(None),
             js_sink_ref: JsCell::new(bun_jsc::strong::Optional::empty()),
         }
     }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -65,8 +65,8 @@ pub struct FileSink {
     pub(crate) stream_bytes: Cell<Option<u64>>,
 
     /// A write failure that arrived while no `write()`/`flush()`/`end()` promise was pending
-    /// to carry it (the writer dropped buffered bytes on an async error). The next
-    /// `write`/`flush`/`end` from JS takes it.
+    /// to carry it (the writer dropped buffered bytes on an async error) and no stream drives
+    /// the sink. The next `write`/`flush`/`end` from JS takes it.
     undelivered_error: JsCell<Option<sys::Error>>,
 
     /// Strong reference to the JS wrapper object to prevent GC from collecting it
@@ -472,7 +472,7 @@ impl FileSink {
         unsafe {
             (*this).record_stream_error(streams::StreamError::Error(err.clone()));
             if (*this).pending.get().state != streams::PendingState::Pending {
-                (*this).undelivered_error.set(Some(err));
+                (*this).latch_undelivered_error(err);
                 return;
             }
             (*this)
@@ -887,7 +887,7 @@ impl FileSink {
                             .pending
                             .with_mut(|p| p.result = streams::Writable::Err(err));
                     } else {
-                        (*this).undelivered_error.set(Some(err));
+                        (*this).latch_undelivered_error(err);
                     }
                     (*this).writer.with_mut(|w| w.end());
                     (*this).run_pending_later();
@@ -1095,6 +1095,15 @@ impl FileSink {
     fn record_stream_error(&self, err: streams::StreamError) {
         if self.stream_error.get().is_none() {
             self.stream_error.set(Some(err));
+        }
+    }
+
+    /// A stream that drives the sink reports the failure through its own pump; only a sink
+    /// written from JS has nobody else to tell.
+    fn latch_undelivered_error(&self, err: sys::Error) {
+        // SAFETY(JsCell): `Strong::has` only reads the GC root.
+        if !unsafe { self.readable_stream.get_mut() }.has() {
+            self.undelivered_error.set(Some(err));
         }
     }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -64,9 +64,7 @@ pub struct FileSink {
     /// Bytes accepted since `pipe_stream` (`written` counts buffered bytes again when flushed).
     pub(crate) stream_bytes: Cell<Option<u64>>,
 
-    /// A write failure that arrived while no `write()`/`flush()`/`end()` promise was pending
-    /// to carry it (the writer dropped buffered bytes on an async error) and no stream drives
-    /// the sink. The next `write`/`flush`/`end` from JS takes it.
+    /// An async write error with no pending promise to reject; the next JS call takes it.
     undelivered_error: JsCell<Option<sys::Error>>,
 
     /// Strong reference to the JS wrapper object to prevent GC from collecting it
@@ -1098,8 +1096,7 @@ impl FileSink {
         }
     }
 
-    /// A stream that drives the sink reports the failure through its own pump; only a sink
-    /// written from JS has nobody else to tell.
+    /// A stream driving the sink reports failures through its pump, not here.
     fn latch_undelivered_error(&self, err: sys::Error) {
         // SAFETY(JsCell): `Strong::has` only reads the GC root.
         if !unsafe { self.readable_stream.get_mut() }.has() {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -938,6 +938,149 @@ describe("FileSink flush() from a 'beforeExit' listener", () => {
   });
 });
 
+// A write that `write(2)` would not take yet is buffered and reported as
+// written; the writer drains it later from a poll callback. When that drain
+// fails, the failure has nowhere to go if no write()/flush() Promise is pending
+// at that moment. It must reach the next call instead of being dropped with the
+// bytes: flush() and end() throw it, write() rejects with it.
+describe.skipIf(!isPosix)("FileSink reports a write error that arrived while nothing was pending", () => {
+  async function setup() {
+    const [readFd, writeFd] = createSocketPair();
+    // createSocketPair() hands out non-blocking fds: fill the socket so the
+    // next write has to be buffered.
+    const filler = Buffer.alloc(64 * 1024, 0x61);
+    try {
+      while (true) fs.writeSync(writeFd, filler);
+    } catch (e: any) {
+      if (e.code !== "EAGAIN") throw e;
+    }
+    const sink = Bun.file(writeFd).writer();
+    expect(sink.write("marker")).toBe(6);
+    // Let the sink's own end-of-tick flush try the fd and leave the bytes
+    // pending on the poll.
+    await new Promise(resolve => setImmediate(resolve));
+    // The peer goes away: the poll reports the fd, the drain fails with
+    // EPIPE, and the writer drops the buffered bytes.
+    fs.closeSync(readFd);
+    return { sink, writeFd };
+  }
+
+  // The poll callback runs on a later loop turn. Keep yielding until the
+  // sink has seen the error (it reports it) or the deadline passes.
+  async function until<T>(attempt: () => T | undefined): Promise<T | undefined> {
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setImmediate(resolve));
+      const result = attempt();
+      if (result !== undefined) return result;
+    }
+    return undefined;
+  }
+
+  it.concurrent("flush() throws it", async () => {
+    const { sink, writeFd } = await setup();
+    try {
+      const code = await until(() => {
+        try {
+          sink.flush();
+        } catch (e: any) {
+          return e.code;
+        }
+      });
+      expect(code).toBe("EPIPE");
+    } finally {
+      fs.closeSync(writeFd);
+    }
+  });
+
+  it.concurrent("end() throws it", async () => {
+    const { sink, writeFd } = await setup();
+    try {
+      const code = await until(() => {
+        try {
+          sink.end();
+        } catch (e: any) {
+          return e.code;
+        }
+      });
+      expect(code).toBe("EPIPE");
+    } finally {
+      fs.closeSync(writeFd);
+    }
+  });
+
+  it.concurrent("write() rejects with it", async () => {
+    const { sink, writeFd } = await setup();
+    try {
+      const code = await until(() => {
+        const result = sink.write("more");
+        if (result instanceof Promise) return result.then(() => "resolved", (e: any) => e.code);
+      });
+      expect(await code).toBe("EPIPE");
+    } finally {
+      fs.closeSync(writeFd);
+    }
+  });
+
+  // Once delivered, the error is spent: end() on the dead sink is the no-op
+  // it is after end().
+  it.concurrent("the error is reported once", async () => {
+    const { sink, writeFd } = await setup();
+    try {
+      const code = await until(() => {
+        try {
+          sink.flush();
+        } catch (e: any) {
+          return e.code;
+        }
+      });
+      expect(code).toBe("EPIPE");
+      expect(typeof sink.end()).toBe("number");
+    } finally {
+      fs.closeSync(writeFd);
+    }
+  });
+
+  // process.stdout is an fs.WriteStream over the same sink. Its end() flushes
+  // the sink from _final, so the error has to come out as the stream's
+  // 'error' event, the way Node reports EPIPE on stdout. The child's stdout
+  // is a full socket whose peer is already closed, so the end-of-tick flush
+  // of the buffered write is what fails.
+  it.concurrent("process.stdout.end() reports it as an 'error' event", async () => {
+    const [readFd, writeFd] = createSocketPair();
+    const filler = Buffer.alloc(64 * 1024, 0x61);
+    try {
+      while (true) fs.writeSync(writeFd, filler);
+    } catch (e: any) {
+      if (e.code !== "EAGAIN") throw e;
+    }
+    fs.closeSync(readFd);
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            process.stdout.on("error", e => console.error("error " + e.code));
+            process.stdout.on("finish", () => console.error("finish"));
+            process.stdout.write("marker");
+            await new Promise(resolve => setImmediate(resolve));
+            process.stdout.end();
+          `,
+        ],
+        env: bunEnv,
+        stdout: writeFd,
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("error EPIPE\n");
+      expect(exitCode).toBe(0);
+    } finally {
+      fs.closeSync(writeFd);
+    }
+  });
+});
+
 it("fs.promises.writeFile with iterables under GC pressure does not crash", async () => {
   const dir = tmpdirSync();
   await using proc = Bun.spawn({

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1014,7 +1014,11 @@ describe.skipIf(!isPosix)("FileSink reports a write error that arrived while not
     try {
       const code = await until(() => {
         const result = sink.write("more");
-        if (result instanceof Promise) return result.then(() => "resolved", (e: any) => e.code);
+        if (result instanceof Promise)
+          return result.then(
+            () => "resolved",
+            (e: any) => e.code,
+          );
       });
       expect(await code).toBe("EPIPE");
     } finally {
@@ -1036,45 +1040,6 @@ describe.skipIf(!isPosix)("FileSink reports a write error that arrived while not
       });
       expect(code).toBe("EPIPE");
       expect(typeof sink.end()).toBe("number");
-    } finally {
-      fs.closeSync(writeFd);
-    }
-  });
-
-  // process.stdout is an fs.WriteStream over the same sink. Its end() flushes
-  // the sink from _final, so the error has to come out as the stream's
-  // 'error' event, the way Node reports EPIPE on stdout. The child's stdout
-  // is a full socket whose peer is already closed, so the end-of-tick flush
-  // of the buffered write is what fails.
-  it.concurrent("process.stdout.end() reports it as an 'error' event", async () => {
-    const [readFd, writeFd] = createSocketPair();
-    const filler = Buffer.alloc(64 * 1024, 0x61);
-    try {
-      while (true) fs.writeSync(writeFd, filler);
-    } catch (e: any) {
-      if (e.code !== "EAGAIN") throw e;
-    }
-    fs.closeSync(readFd);
-    try {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
-            process.stdout.on("error", e => console.error("error " + e.code));
-            process.stdout.on("finish", () => console.error("finish"));
-            process.stdout.write("marker");
-            await new Promise(resolve => setImmediate(resolve));
-            process.stdout.end();
-          `,
-        ],
-        env: bunEnv,
-        stdout: writeFd,
-        stderr: "pipe",
-      });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("error EPIPE\n");
-      expect(exitCode).toBe(0);
     } finally {
       fs.closeSync(writeFd);
     }


### PR DESCRIPTION
### Problem
- A `FileSink` write that `write(2)` does not take yet is buffered and reported as written. The writer drains it later from a poll callback or from the end-of-tick auto-flush. When that drain fails (EPIPE, the reader is gone), and no `write()`/`flush()`/`end()` promise is pending at that moment, the error goes nowhere. The bytes are dropped and the next `flush()` returns `undefined`, `end()` returns the byte count, and `write()` returns `true`.
- Cause: `FileSink::on_error` and the `Err` arm of `on_auto_flush` (`src/runtime/webcore/FileSink.rs`) only reject the pending promise. With no pending promise they record the error for the `Bun.write(file, stream)` pipe path (`stream_error`) and return. Nothing reads that record on the JS side.

### Fix
- Add `undelivered_error` to `FileSink`. `on_error` and `on_auto_flush` set it when no promise is pending. The next `write()`, `flush()`, or `end()` from JS takes it: `flush()` and `end()` throw it (their existing synchronous error shape), `write()` returns `Writable::Err`, which becomes a rejected promise (its existing error shape). The error is delivered once. After that the sink behaves like an ended sink.
- `fs.WriteStream`'s fast path (`src/js/internal/fs/streams.ts`, used by `process.stdout` and `child_process` stdin) now catches a throw from `sink.end()` in `_destroy` and `close` and passes it to the callback. `end()` could already throw there on a synchronous flush failure. This keeps the throw inside the stream's error path.
- Verified: `test/js/bun/util/filesink.test.ts`, new block "FileSink reports a write error that arrived while nothing was pending" (4 tests, each fails on bun 1.4.3 with `Received: undefined`). Also green: the rest of `filesink.test.ts`, `spawn.test.ts`, `spawn-stdin-readable-stream.test.ts`, `process-stdio.test.ts`, `process-stdout-write-after-end.test.ts`, `child-process-stdio.test.js`, `fs.test.ts`, and `cargo check` for `x86_64-pc-windows-msvc`.

### Background
- `FileSink` is the native writer behind `Bun.file(x).writer()`, `Bun.stdout.writer()`, `proc.stdin`, and the `fs.WriteStream` fast path. It wraps an `IOWriter` (`src/io/PipeWriter.rs`) that buffers bytes below a chunk size and drains them from a poll on the fd.
- `pending` is the one slot for a promise handed to JS. `write()` returns it when the fd is backed up, `flush()` and `end()` hand back the same promise. Callbacks settle it through `run_pending`. The bug is the case where no such promise exists.
- `stream_error` is the error slot for `Bun.write(file, readableStream)`. `settle_stream_done` consumes it into the pipe's promise. It is not visible to a JS caller of the sink's own methods.

<details><summary>Notes</summary>

- Self-review raised three concerns. The `JsSinkType::get_pending_error` hook (checked by the generic `JSSink` glue) was not used on purpose: it throws synchronously at every entry point, including `js_close`, which would skip the sink's own close when the stream pump closes a failed sink, and it has no `global` to build a rejected promise for `write()`. A second concern, latching EPIPE in `on_attached_process_exit` when a child exits with unsent stdin bytes, was dropped from this PR: it is a `proc.stdin.end()` behaviour change that overlaps #37128 and has no deterministic test. The third, the untested `streams.ts` try/catch, is kept as a defensive change and is described above.
- Repro without the test harness: fill one end of a socketpair until `EAGAIN`, `Bun.file(writeFd).writer().write("marker")` (returns 6), yield one loop turn, close the read end, then call `flush()` repeatedly. Before: `undefined` forever. After: throws `EPIPE` on the turn after the poll fires.
- `process.stdout` is not affected by the dropped-error path: its writes reach the fd at once and a backed-up write always returns a promise, so the error always has a promise to reject. The `Bun.spawn` case from the report (`head -c 100` exiting between two `send()` calls) is a synchronous EPIPE that `write()` already reports through the promise it returns, and is unchanged here.
- Debug-build test runs on this container are slow. `spawn.test.ts` "stdout can be read" and two leak tests in `spawn-stdin-readable-stream.test.ts` exceed 5s here and pass with `--timeout 60000`. They do not touch this code path.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->