### PR TITLE
WebSocket: cap the 101 handshake head on the completed parse path

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -704,6 +704,14 @@ where
         };
 
         match parsed {
+            // The completed head must also respect the cap. `head_len` is the
+            // header size alone, so pipelined WebSocket frames after the head
+            // are not counted. Without this, a head larger than the cap is
+            // accepted whenever no single `recv` boundary lands inside the
+            // incomplete header (the only place the `ShortRead` arm checks).
+            Ok(HeadParse::Done { head_len, .. }) if head_len > bun_http::max_http_header_size() => {
+                HeadParse::Invalid
+            }
             Ok(done) => done,
             Err(picohttp::ParseResponseError::MalformedHttpResponse) => HeadParse::Invalid,
             Err(picohttp::ParseResponseError::ShortRead) => {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -704,8 +704,6 @@ where
         };
 
         match parsed {
-            // Cap the completed head by `head_len`, not `full.len()`, so
-            // pipelined frames after the head are not counted.
             Ok(HeadParse::Done { head_len, .. }) if head_len > bun_http::max_http_header_size() => {
                 HeadParse::Invalid
             }

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -704,11 +704,8 @@ where
         };
 
         match parsed {
-            // The completed head must also respect the cap. `head_len` is the
-            // header size alone, so pipelined WebSocket frames after the head
-            // are not counted. Without this, a head larger than the cap is
-            // accepted whenever no single `recv` boundary lands inside the
-            // incomplete header (the only place the `ShortRead` arm checks).
+            // Cap the completed head by `head_len`, not `full.len()`, so
+            // pipelined frames after the head are not counted.
             Ok(HeadParse::Done { head_len, .. }) if head_len > bun_http::max_http_header_size() => {
                 HeadParse::Invalid
             }

--- a/test/js/web/websocket/websocket-client-short-read.test.ts
+++ b/test/js/web/websocket/websocket-client-short-read.test.ts
@@ -197,6 +197,67 @@ describe("WebSocket upgrade split across reads", () => {
     }
   });
 
+  test("completed header larger than the cap is rejected even when split under the cap", async () => {
+    // A full 101 head (terminated with \r\n\r\n) whose total size is over the
+    // default cap (16384). The server splits it so the first write stays under
+    // the cap. The old code only checked the cap in the ShortRead arm, so the
+    // head completed on the second read with no size check and was accepted.
+    using server = Bun.listen<{ buf: string; done: boolean }>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = { buf: "", done: false };
+        },
+        data(socket, chunk) {
+          const st = socket.data;
+          if (st.done) return;
+          st.buf += chunk.toString("latin1");
+          if (!st.buf.includes("\r\n\r\n")) return;
+          st.done = true;
+          const m = /Sec-WebSocket-Key:\s*(\S+)/i.exec(st.buf);
+          if (!m) {
+            socket.end();
+            return;
+          }
+          const accept = makeAccept(m[1]);
+          const head =
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n` +
+            "X-Pad: " +
+            Buffer.alloc(21000, "p").toString("latin1") + // head_len > 16384
+            "\r\n\r\n";
+          const bytes = Buffer.from(head, "latin1");
+          // First write stays under the cap so the ShortRead arm never rejects.
+          socket.write(bytes.subarray(0, 16000));
+          socket.flush();
+          setTimeout(() => {
+            socket.write(bytes.subarray(16000));
+            socket.flush();
+          }, 50);
+        },
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const ws = new globalThis.WebSocket(`ws://127.0.0.1:${server.port}`);
+    ws.onopen = () => reject(new Error("unexpected open"));
+    ws.onmessage = () => reject(new Error("unexpected message"));
+    ws.onerror = ev => resolve((ev as ErrorEvent).message ?? "error");
+    ws.onclose = ev => {
+      if (ev.wasClean) reject(new Error("unexpected clean close"));
+    };
+
+    try {
+      const msg = await promise;
+      expect(msg).toContain("Invalid response");
+    } finally {
+      ws.close();
+    }
+  });
+
   test("incomplete header larger than the cap is still rejected", async () => {
     // >16KB of header bytes with no terminating blank line must still fail.
     using server = Bun.listen<{ buf: string; done: boolean }>({

--- a/test/js/web/websocket/websocket-client-short-read.test.ts
+++ b/test/js/web/websocket/websocket-client-short-read.test.ts
@@ -200,8 +200,7 @@ describe("WebSocket upgrade split across reads", () => {
   test("completed header larger than the cap is rejected even when split under the cap", async () => {
     // A full 101 head (terminated with \r\n\r\n) whose total size is over the
     // default cap (16384). The server splits it so the first write stays under
-    // the cap. The old code only checked the cap in the ShortRead arm, so the
-    // head completed on the second read with no size check and was accepted.
+    // the cap, so no single read of an incomplete head exceeds the cap.
     using server = Bun.listen<{ buf: string; done: boolean }>({
       hostname: "127.0.0.1",
       port: 0,
@@ -230,7 +229,6 @@ describe("WebSocket upgrade split across reads", () => {
             Buffer.alloc(21000, "p").toString("latin1") + // head_len > 16384
             "\r\n\r\n";
           const bytes = Buffer.from(head, "latin1");
-          // First write stays under the cap so the ShortRead arm never rejects.
           socket.write(bytes.subarray(0, 16000));
           socket.flush();
           setTimeout(() => {


### PR DESCRIPTION
### Problem
- `new WebSocket()` accepts a 101 handshake head larger than the cap (`--max-http-header-size`, default 16 KB) whenever no `recv()` boundary lands inside the incomplete head. A 60 KB head split so the first read stays under the cap opens the connection.
- The cap is checked only in the `ShortRead` arm of `buffer_and_parse_head` (`src/http_jsc/websocket_client/WebSocketUpgradeClient.rs:717`). The `Ok(done)` arm, which runs when the head parse completes, never checks the size. So the bound depends on read segmentation, not on the head size.

### Fix
- Check the cap in the `Ok(done)` arm too. Compare `head_len` (the header size alone), so pipelined WebSocket frames after the head are not counted.
- Correct because the cap now applies to the header bytes on every path, not only when a read boundary splits an incomplete head. This matches the existing `ShortRead` check and Node and undici, which enforce a fixed 16 KB regardless of segmentation.
- Verified: `test/js/web/websocket/websocket-client-short-read.test.ts` (new case, stock bun opens the connection and fails). Also ran the other 4 cases in that file, including the pipelined large-frame case that must still open.

### Background
- A WebSocket client first sends an HTTP/1.1 upgrade request, then reads the 101 response head. `buffer_and_parse_head` accumulates bytes and runs `picohttp::Response::parse`.
- `parse` returns `ShortRead` while no `\r\n\r\n` is found, and `Done` once the head is complete. `head_len` (`response.bytes_read`) is the head size. Bytes after it are pipelined WebSocket frames.
- `max_http_header_size` (default 16 KB) bounds the head so a peer cannot force unbounded buffering.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-client-short-read.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/websocket/websocket-client-short-read.test.ts:
(pass) WebSocket > short read on payload length [99.64ms]
(pass) WebSocket upgrade split across reads > large frame pipelined after split 101 header is not counted against the header-size cap [108.04ms]
239 |       },
240 |     });
241 | 
242 |     const { promise, resolve, reject } = Promise.withResolvers<string>();
243 |     const ws = new globalThis.WebSocket(`ws://127.0.0.1:${server.port}`);
244 |     ws.onopen = () => reject(new Error("unexpected open"));
                                       ^
error: unexpected open
      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-client-short-read.test.ts:244:34)
(fail) WebSocket upgrade split across reads > completed header larger than the cap is rejected even when split under the cap [102.86ms]
(pass) WebSocket upgrade split across reads > incomplete header larger than the cap is still rejected [84.91ms]
(pass) WebSocket buffered 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/websocket/websocket-client-short-read.test.ts:
(pass) WebSocket > short read on payload length [2.92ms]
(pass) WebSocket upgrade split across reads > large frame pipelined after split 101 header is not counted against the header-size cap [51.35ms]
239 |       },
240 |     });
241 | 
242 |     const { promise, resolve, reject } = Promise.withResolvers<string>();
243 |     const ws = new globalThis.WebSocket(`ws://127.0.0.1:${server.port}`);
244 |     ws.onopen = () => reject(new Error("unexpected open"));
                                       ^
error: unexpected open
      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-client-short-read.test.ts:244:34)
(fail) WebSocket upgrade split across reads > completed header larger than the cap is rejected even when split under the cap [53.38ms]
(pass) WebSocket upgrade split across reads > incomplete header larger than the cap is still rejected [51.21ms]
(pass) WebSocket buffered handshake data > terminating the client from its open handler while handshake bytes are buffered shuts down cleanly [13.24ms]

 4 pass
 1 fail
 5 expect() calls
Ran 5 tests across 1 fi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-client-short-read.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/websocket/websocket-client-short-read.test.ts:
(pass) WebSocket > short read on payload length [81.49ms]
(pass) WebSocket upgrade split across reads > large frame pipelined after split 101 header is not counted against the header-size cap [1390.69ms]
(pass) WebSocket upgrade split across reads > completed header larger than the cap is rejected even when split under the cap [80.45ms]
(pass) WebSocket upgrade split across reads > incomplete header larger than the cap is still rejected [83.33ms]
(pass) WebSocket buffered handshake data > terminating the client from its open handler while handshake bytes are buffered shuts down cleanly [595.38ms]

 5 pass
 0 fail
 6 expect() calls
Ran 5 tests across 1 file. [8.24s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 7283ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/2355] host-cxx deps/icu/host-obj/source/i18n/reldtfmt.cpp.o
[2/2355] host-cxx deps/icu/host-obj/source/i18n/regexcmp.cpp.o
[3/2355] host-cxx deps/icu/host-obj/source/i18n/regeximp.cpp.o
[4/2355] host-cxx deps/icu/host-obj/source/i18n/regexst.cpp.o
[5/2355] host-cxx deps/icu/host-obj/source/i18n/regextxt.cpp.o
[6/2355] host-cxx deps/icu/host-obj/source/i18n/remtrans.cpp.o
[7/2355] host-cxx deps/icu/host-obj/source/i18n/rematch.cpp.o
[8/2355] host-cxx deps/icu/host-obj/source/i18n/rbnf.cpp.o
[9/2355] host-cxx deps/icu/host-obj/source/i18n/region.cpp.o
[10/2355] host-cxx deps/icu/host-obj/source/i18n/rbtz.cpp.o
[11/2355] host-cxx deps/icu/host-obj/source/i18n/reldatefmt.cpp.o
[12/2355] host-cxx deps/icu/host-obj/source/i18n/repattrn.cpp.o
[13/2355] host-cxx deps/icu/host-obj/source/i18n/selfmt.cpp.o
[14/2355] host-cxx deps/icu/host-obj/source/i18n/scriptset.cpp.o
[15/2355] host-cxx deps/icu/host-obj/source/i18n/scientificnumberformatter.cpp.o
[16/2355] host-cxx deps/icu/host-obj/source/i18n/sharedbreakite
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../websocket_client/WebSocketUpgradeClient.rs     |  3 ++
 .../websocket/websocket-client-short-read.test.ts  | 59 ++++++++++++++++++++++
 2 files changed, 62 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs       5      3      5
…st/js/web/websocket/websocket-client-short-read.test.ts      2      3      5
```

</details>

<!-- robobun:evidence:end -->