### PR TITLE
css: emit @layer statements that precede @import before the imported files

### DIFF
--- a/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
+++ b/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
@@ -145,16 +145,23 @@ pub(crate) fn find_imported_files_in_css_order<'a>(
             };
             let top_level_rules = &repr.rules;
 
-            // TODO: should we even do this? @import rules have to be the first rules in the stylesheet, why even allow pre-import layers?
-            // Any pre-import layers come first
-            // if len(repr.AST.LayersPreImport) > 0 {
-            //     order = append(order, cssImportOrder{
-            //         kind:                   cssImportLayers,
-            //         layers:                 repr.AST.LayersPreImport,
-            //         conditions:             wrappingConditions,
-            //         conditionImportRecords: wrappingImportRecords,
-            //     })
-            // }
+            // `@layer` statements may precede `@import` (css-cascade-5) so
+            // that a file can pin the order of the layers its imports create.
+            // Emit them before the imported files.
+            if !repr.layers_pre_import.is_empty() {
+                // See the LayerName nominal-type note at `Layers::borrow`.
+                let layers_ptr =
+                    core::ptr::NonNull::from(&repr.layers_pre_import).cast::<Vec<LayerName>>();
+                self.order.push(CssImportOrder {
+                    kind: CssImportOrderKind::Layers(Layers::borrow(layers_ptr)),
+                    // SAFETY: arena-backed `Vec` header; `CssImportOrder`
+                    // suppresses `Drop` on it (see the note at `bitwise_copy`),
+                    // so the aliased buffer is freed once with the arena.
+                    conditions: unsafe { bitwise_copy(wrapping_conditions) },
+                    // SAFETY: same single-free invariant as `conditions`.
+                    condition_import_records: unsafe { bitwise_copy(wrapping_import_records) },
+                });
+            }
 
             // `visited.pop()` happens at the end of this function; the early
             // return above intentionally skips it.

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -349,12 +349,13 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                     };
 
                     {
-                        // Strip leading "@import" and ".ignored" rules. Any
-                        // "@layer" statement rules interleaved with them are
-                        // preserved, because they carry layer ordering
-                        // information that is not re-emitted elsewhere by
-                        // the bundler (e.g. Tailwind's
-                        // `@layer theme, base, components, utilities;`).
+                        // Strip leading "@import" and ".ignored" rules, and
+                        // the "@layer" statements that precede the first
+                        // "@import": those are `layers_pre_import`, which
+                        // `find_imported_files_in_css_order` already emitted
+                        // as a `Layers` entry ahead of the imported files.
+                        // "@layer" statements after an "@import" are kept,
+                        // because nothing else re-emits them.
                         //
                         // IMPORTANT: `ast` is only a shallow copy of the
                         // per-source stylesheet, so `ast.rules.v.items` still
@@ -368,35 +369,45 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                         //
                         // Regression: #28914
                         let original_rules = ast.rules.v.as_slice();
-                        let mut layer_count: usize = 0;
+                        let mut seen_import = false;
+                        let mut kept_layer_count: usize = 0;
                         let mut prefix_end: usize = original_rules.len();
                         'prefix_scan: for (idx, rule) in original_rules.iter().enumerate() {
                             match rule {
-                                BundlerCssRule::Import(_) | BundlerCssRule::Ignored => {}
-                                BundlerCssRule::LayerStatement(_) => layer_count += 1,
+                                BundlerCssRule::Import(_) => seen_import = true,
+                                BundlerCssRule::Ignored => {}
+                                BundlerCssRule::LayerStatement(_) => {
+                                    if seen_import {
+                                        kept_layer_count += 1;
+                                    }
+                                }
                                 _ => {
                                     prefix_end = idx;
                                     break 'prefix_scan;
                                 }
                             }
                         }
-                        let dropped = prefix_end - layer_count;
+                        let dropped = prefix_end - kept_layer_count;
 
                         if dropped == 0 {
-                            // Prefix is all "@layer" (or empty). Nothing to
-                            // strip — leave `ast.rules.v` untouched.
+                            // Nothing to strip — leave `ast.rules.v` untouched.
                         } else {
-                            // Interleaved case: allocate a fresh rules list
-                            // so we don't mutate the shared backing array.
-                            // Preserve the "@layer" statements from the
-                            // prefix and append the remaining tail.
+                            // Allocate a fresh rules list so we don't mutate
+                            // the shared backing array. Preserve the kept
+                            // "@layer" statements from the prefix and append
+                            // the remaining tail.
                             let mut new_rules: ArenaVec<BundlerCssRule> =
                                 ArenaVec::with_capacity_in(
-                                    layer_count + (original_rules.len() - prefix_end),
+                                    kept_layer_count + (original_rules.len() - prefix_end),
                                     bump,
                                 );
+                            let mut seen_import = false;
                             for rule in &original_rules[0..prefix_end] {
-                                if matches!(rule, BundlerCssRule::LayerStatement(_)) {
+                                if matches!(rule, BundlerCssRule::Import(_)) {
+                                    seen_import = true;
+                                }
+                                if seen_import && matches!(rule, BundlerCssRule::LayerStatement(_))
+                                {
                                     // SAFETY: bitwise duplicate of a rule. The copy goes into
                                     // an `arena_rule_list` slab installed in `css_chunk.asts[i]`,
                                     // whose elements never run `Drop` (see `arena_rule_list` /

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -680,6 +680,9 @@ pub trait CustomAtRuleParser {
 
     fn on_import_rule(this: &mut Self, import_rule: &mut ImportRule, start: u32, end: u32);
     fn on_layer_rule(this: &mut Self, layers: &SmallList<LayerName, 1>);
+    /// A top-level `@layer a, b;` statement that precedes every `@import`.
+    /// These go to `StyleSheet.layers_pre_import`, not `layer_names`.
+    fn on_layer_statement_before_import(this: &mut Self, layers: &SmallList<LayerName, 1>);
     fn enclosing_layer_length(this: &mut Self) -> u32;
     fn push_to_enclosing_layer(this: &mut Self, name: LayerName);
     fn reset_enclosing_layer(this: &mut Self, len: u32);
@@ -690,6 +693,10 @@ pub trait CustomAtRuleParser {
     /// `StyleSheet.layer_names`; this is a trait hook with a
     /// default no-op for parsers that don't track layers.
     fn take_layer_names(_this: &mut Self) -> Vec<LayerName> {
+        Vec::new()
+    }
+
+    fn take_layers_pre_import(_this: &mut Self) -> Vec<LayerName> {
         Vec::new()
     }
 }
@@ -728,6 +735,7 @@ pub struct BundlerAtRuleParser<'a> {
     /// soundly under Stacked Borrows.
     pub(crate) import_records: *mut Vec<ImportRecord>,
     pub(crate) layer_names: Vec<LayerName>,
+    pub(crate) layers_pre_import: Vec<LayerName>,
     /// Having _named_ layers nested inside of an _anonymous_ layer has no
     /// effect. See: https://drafts.csswg.org/css-cascade-5/#example-787042b6
     pub(crate) anon_layer_count: u32,
@@ -830,6 +838,18 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
         }
     }
 
+    fn on_layer_statement_before_import(this: &mut Self, layers: &SmallList<LayerName, 1>) {
+        if !this.track_layers_and_imports {
+            return;
+        }
+        this.layers_pre_import
+            .ensure_unused_capacity(layers.len() as usize);
+        for layer in layers.slice() {
+            this.layers_pre_import
+                .append_assume_capacity(layer.deep_clone(this.arena));
+        }
+    }
+
     fn enclosing_layer_length(this: &mut Self) -> u32 {
         this.enclosing_layer.v.len()
     }
@@ -843,6 +863,10 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
 
     fn take_layer_names(this: &mut Self) -> Vec<LayerName> {
         core::mem::take(&mut this.layer_names)
+    }
+
+    fn take_layers_pre_import(this: &mut Self) -> Vec<LayerName> {
+        core::mem::take(&mut this.layers_pre_import)
     }
 
     fn reset_enclosing_layer(this: &mut Self, len: u32) {
@@ -1343,12 +1367,24 @@ mod rule_parsers {
                     ));
                     Ok(())
                 }
-                layer @ AtRulePrelude::Layer(_) => {
-                    if (this.state as u8) <= (TopLevelState::Layers as u8) {
-                        this.state = TopLevelState::Layers;
-                    } else {
-                        this.state = TopLevelState::Body;
+                AtRulePrelude::Layer(layer)
+                    if (this.state as u8) <= (TopLevelState::Layers as u8) =>
+                {
+                    if layer.len() == 0 {
+                        return Err(());
                     }
+                    this.state = TopLevelState::Layers;
+                    AtRuleParserT::on_layer_statement_before_import(this.at_rule_parser, &layer);
+                    this.rules
+                        .v
+                        .push(CssRule::LayerStatement(LayerStatementRule {
+                            names: layer,
+                            loc,
+                        }));
+                    Ok(())
+                }
+                layer @ AtRulePrelude::Layer(_) => {
+                    this.state = TopLevelState::Body;
                     let mut nested_parser = this.nested();
                     <NestedRuleParser<'_, AtRuleParserT> as AtRuleParser>::rule_without_block(
                         &mut nested_parser,
@@ -2323,7 +2359,10 @@ pub struct StyleSheet<AtRule> {
     pub source_map_urls: Vec<Option<Box<[u8]>>>,
     pub license_comments: Vec<&'static [u8]>, // TODO: lifetime — arena
     pub options: ParserOptions<'static>,      // TODO: lifetime
+    /// Every `@layer` name seen after the first `@import`, in cascade order.
     pub layer_names: Vec<LayerName>,
+    /// The names of the `@layer` statements that precede every `@import`.
+    pub layers_pre_import: Vec<LayerName>,
 
     /// Used when css modules is enabled. Maps `local name string` -> `Ref`.
     pub local_scope: LocalScope,
@@ -2343,6 +2382,7 @@ impl<AtRule> StyleSheet<AtRule> {
             license_comments: Vec::new(),
             options: ParserOptions::default(None),
             layer_names: Vec::new(),
+            layers_pre_import: Vec::new(),
             local_scope: LocalScope::default(),
             local_properties: LocalPropertyUsage::default(),
             composes: ComposesMap::default(),
@@ -2552,6 +2592,7 @@ mod stylesheet_impl {
                 track_layers_and_imports: false,
                 import_records: core::ptr::null_mut(),
                 layer_names: Vec::new(),
+                layers_pre_import: Vec::new(),
                 anon_layer_count: 0,
                 enclosing_layer: LayerName::default(),
             };
@@ -2653,6 +2694,7 @@ mod stylesheet_impl {
             // (default = empty; `BundlerAtRuleParser` overrides to move its list
             // out) so the accumulated layer ordering isn't silently dropped.
             let layer_names = P::take_layer_names(at_rule_parser);
+            let layers_pre_import = P::take_layers_pre_import(at_rule_parser);
 
             Ok((
                 Self {
@@ -2662,6 +2704,7 @@ mod stylesheet_impl {
                     license_comments,
                     options,
                     layer_names,
+                    layers_pre_import,
                     local_scope: parser_extra.local_scope,
                     local_properties,
                     composes,
@@ -2773,6 +2816,7 @@ mod stylesheet_impl {
                 track_layers_and_imports: true,
                 import_records: import_records_ptr.as_ptr(),
                 layer_names: Vec::new(),
+                layers_pre_import: Vec::new(),
                 anon_layer_count: 0,
                 enclosing_layer: LayerName::default(),
             };

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -2116,6 +2116,90 @@ c {
     outfile: "/out.css",
   });
 
+  // "@layer" statements may precede "@import" so that a file can pin the
+  // order of the layers its imports create. They have to come out before the
+  // imported files, not after them with the rest of the importer's body.
+  itBundled("css/CSSAtLayerStatementBeforeAtImport", {
+    files: {
+      "/entry.css": /* css */ `
+        @layer first;
+        @import "./imported.css" layer(second);
+        @layer third { .t { c: d } }
+      `,
+      "/imported.css": `.i { c: d }`,
+    },
+    outfile: "/out.css",
+    onAfterBundle(api) {
+      api.expectFile("/out.css").toEqualIgnoringWhitespace(/* css */ `
+        @layer first;
+
+        /* imported.css */
+        @layer second {
+          .i {
+            c: d;
+          }
+        }
+
+        /* entry.css */
+        @layer third {
+          .t {
+            c: d;
+          }
+        }
+      `);
+    },
+  });
+
+  itBundled("css/CSSAtLayerStatementBeforeAtImportTailwind", {
+    files: {
+      "/entry.css": /* css */ `
+        @import "./tailwind/index.css";
+        @layer components { .card { c: e } }
+      `,
+      "/tailwind/index.css": /* css */ `
+        @layer theme, base, components, utilities;
+        @import "./theme.css" layer(theme);
+        @import "./utilities.css" layer(utilities);
+      `,
+      "/tailwind/theme.css": `:root { --x: 1 }`,
+      "/tailwind/utilities.css": `.u { c: d }`,
+    },
+    outfile: "/out.css",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      api
+        .expectFile("/out.css")
+        .toEqualIgnoringWhitespace(
+          "@layer theme,base,components,utilities;@layer theme{:root{--x:1}}@layer utilities{.u{c:d}}@layer components{.card{c:e}}",
+        );
+    },
+  });
+
+  itBundled("css/CSSAtLayerStatementBeforeAtImportNested", {
+    files: {
+      "/entry.css": /* css */ `
+        @layer outer;
+        @import "./mid.css" layer(wrap) supports(display: flex);
+      `,
+      "/mid.css": /* css */ `
+        @layer inner;
+        @import "./leaf.css" layer(leafy);
+        @layer after;
+        .mid { c: d }
+      `,
+      "/leaf.css": `.leaf { c: d }`,
+    },
+    outfile: "/out.css",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      api
+        .expectFile("/out.css")
+        .toEqualIgnoringWhitespace(
+          "@layer outer;@supports (display:flex){@layer wrap{@layer inner;}}@supports (display:flex){@layer wrap{@layer leafy{.leaf{c:d}}}}@supports (display:flex){@layer wrap{@layer after;.mid{c:d}}}",
+        );
+    },
+  });
+
   // This test mainly just makes sure that this scenario doesn't crash
   itBundled("css/CSSAndJavaScriptCodeSplittingESBuildIssue1064", {
     files: {

--- a/test/regression/issue/28914.test.ts
+++ b/test/regression/issue/28914.test.ts
@@ -106,9 +106,8 @@ describe.concurrent("issue #28914 - bundler preserves top-level @layer statement
     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const out = await Bun.file(`${dir}/out/entry.css`).text();
-    expect(out).toContain("@layer theme;");
-    expect(out).toContain("@layer base;");
-    expect(out).toContain("@layer components;");
+    // Statements that precede every @import are merged into one, in order.
+    expect(out).toContain("@layer theme, base, components;");
     expect(out).toContain(".foo");
     expect(stdout).toContain("Bundled");
     expect(exitCode).toBe(0);


### PR DESCRIPTION
### Problem
- `@layer` statements that precede a layered `@import` come out after the imported block. `@layer first; @import "i1.css" layer(second);` bundles to `@layer second{...}@layer first;`, so the cascade order of `first` and `second` flips. esbuild and lightningcss print `@layer first;@layer second{...}`.
- Tailwind v4 has this shape: its `index.css` starts with `@layer theme, base, components, utilities;` and then imports each layer. bun emits that statement after the `theme` and `utilities` blocks, so a user's `@layer components {}` lands above `utilities` in the cascade.
- Cause: `find_imported_files_in_css_order` (`src/bundler/linker_context/findImportedFilesInCSSOrder.rs:148`) places every imported file before the importer's body. The branch that emits pre-import layers first was commented out with a TODO.

### Fix
- The parser records the top-level `@layer` statements seen before the first `@import` in `StyleSheet.layers_pre_import` (`src/css/css_parser.rs`). `layer_names` now holds only the names seen after that point, the set the duplicate-import logic keys on.
- The order visitor emits `layers_pre_import` as a `Layers` entry ahead of the file's imports, under the same wrapping conditions. The existing passes then dedupe and merge it like any other layer entry.
- `prepare_css_asts_for_chunk` drops those statements from the file's rule prefix so they are not printed a second time. Statements after an `@import` are kept, as before.
- Verified: `test/bundler/esbuild/css.test.ts` (three new `css/CSSAtLayerStatementBeforeAtImport*` cases, all fail on the released build). `test/regression/issue/28914.test.ts` updated: the three separate statements now merge into one `@layer theme, base, components;`. Also `test/bundler/css/`, `test/js/bun/css/css.test.ts` and `bundler_html.test.ts`.

### Background
- A cascade layer's precedence is fixed by the first time its name is seen. A `@layer a, b;` statement with no block exists only to pin that order. css-cascade-5 allows these statements before `@import` so a file can order the layers its imports create.
- The bundler flattens `@import` by visiting files depth first. The output is a list of entries: a source file, an external import, or a bare layer list. Layer entries exist so a file that is imported twice still contributes its layer names at the first position.
- `prepare_css_asts_for_chunk` strips the `@import` rules from each file's rule prefix before printing, because the imported content is already inlined above it.

<details><summary>Notes</summary>

Repro on bun 1.4.3:

```
printf '@layer first;\n@import "i1.css" layer(second);\n@layer third{.t{c:d}}\n' > a.css
printf '.i1{c:d}\n' > i1.css
bun build ./a.css --minify
# @layer second{.i1{c:d}}@layer first;@layer third{.t{c:d}}
```

With the fix: `@layer first;@layer second{.i1{c:d}}@layer third{.t{c:d}}`.

Other shapes checked with the fix:

- `@layer x; @layer first, other; @import ... layer(second);` prints `@layer x,first,other;@layer second{...}` (adjacent layer entries merge).
- `@layer a; @import "http://x/e.css";` keeps `@layer a;` ahead of the hoisted external import, which css-cascade-5 allows.
- A file imported twice with `@layer p1; @import ...; @layer p2;` prints `@layer p1;@layer p2;` once, before the first copy.
- `@import ...; @layer post;` is unchanged: `post` stays in the file body.

The parser change is in `TopLevelRuleParser::rule_without_block`: while the top-level state is still `Start` or `Layers`, a `@layer` statement is recorded through the new `on_layer_statement_before_import` hook instead of `on_layer_rule`. The rule itself is still pushed, so the non-bundling printer output is unchanged.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/css.test.ts "test/regression/issue/28914.test.ts"
bun test v1.4.3 (b99371011)

test/regression/issue/28914.test.ts:
(pass) issue #28914 - bundler preserves top-level @layer statements > bare @layer statement survives the bundle [309.83ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > @layer statement followed by an unlayered rule [291.81ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > Tailwind-style @layer statement with a @layer block [452.93ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > duplicate imports of a layered source don't corrupt the shared AST [299.90ms]
105 | 
106 |     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
107 | 
108 |     const out = await Bun.file(`${dir}/out/entry.css`).text();
109 |     // Statements that precede every @import are merged into one, in order.
110 |     expect(out).toContain("@layer theme, base, components;");
                      ^
error: expect
... (truncated)

release without fix: 4 failed, 1 skipped
bun test v1.4.3-canary.1 (b99371011)

test/regression/issue/28914.test.ts:
(pass) issue #28914 - bundler preserves top-level @layer statements > Tailwind-style @layer statement with a @layer block [14.18ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > @layer statement followed by an unlayered rule [9.86ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > bare @layer statement survives the bundle [10.79ms]
105 | 
106 |     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
107 | 
108 |     const out = await Bun.file(`${dir}/out/entry.css`).text();
109 |     // Statements that precede every @import are merged into one, in order.
110 |     expect(out).toContain("@layer theme, base, components;");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "@layer theme, base, components;"
Received: "/* entry.css */\n@layer theme;\n@layer base;\n@layer components;\n\n.foo {\n  color: red;\n}\n"

      at <anonymous> (/workspace/bun/test/regression/issue/28914.test.ts:110:17)
(fail) issue #28914 - bundler preserves top-level @layer statements > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/css.test.ts "test/regression/issue/28914.test.ts"
bun test v1.4.3 (b99371011)

test/regression/issue/28914.test.ts:
(pass) issue #28914 - bundler preserves top-level @layer statements > bare @layer statement survives the bundle [303.28ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > @layer statement followed by an unlayered rule [309.69ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > Tailwind-style @layer statement with a @layer block [447.09ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > multiple individual @layer statements are all preserved [387.86ms]
(pass) issue #28914 - bundler preserves top-level @layer statements > duplicate imports of a layered source don't corrupt the shared AST [412.72ms]

test/bundler/esbuild/css.test.ts:
(pass) bundler > css/CSSEntryPoint [786.58ms]
(pass) bundler > css/CSSEntryPointEmpty [130.06ms]
(pass) bundler > css/CSSNesting [130.62ms]
(pass) bundler > css/CSSAtImportMissing [140.23ms]
(pass) bundler > css
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 724ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/findImportedFilesInCSSOrder.rs  | 23 +++---
 .../linker_context/prepareCssAstsForChunk.rs       | 46 +++++-------
 src/css/css_parser.rs                              | 53 ++++++++++++--
 test/bundler/esbuild/css.test.ts                   | 84 ++++++++++++++++++++++
 test/regression/issue/28914.test.ts                |  5 +-
 5 files changed, 165 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…c/bundler/linker_context/findImportedFilesInCSSOrder.rs      4      2     36
src/bundler/linker_context/prepareCssAstsForChunk.rs          4      2     36
src/css/css_parser.rs                                         5     10     36
test/bundler/esbuild/css.test.ts                              5      6     35
test/regression/issue/28914.test.ts                           1      2      7
```

</details>

<!-- robobun:evidence:end -->