### PR TITLE
Decode a snapshot of a SharedArrayBuffer in the UTF-8 decoders

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2557,8 +2557,7 @@ impl From<ToUTF16Error> for crate::CrateError {
 /// U+FFFD. When `sentinel` is set the result
 /// includes a trailing 0 u16.
 ///
-/// `bytes` must not change during the call: the output is sized by one pass
-/// and written by a second. Copy a SharedArrayBuffer before calling.
+/// Reads `bytes` twice: copy a SharedArrayBuffer before calling.
 pub fn to_utf16_alloc(
     bytes: &[u8],
     fail_if_invalid: bool,

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2556,6 +2556,9 @@ impl From<ToUTF16Error> for crate::CrateError {
 /// `Err(InvalidByteSequence)`; otherwise invalid sequences are replaced with
 /// U+FFFD. When `sentinel` is set the result
 /// includes a trailing 0 u16.
+///
+/// `bytes` must not change during the call: the output is sized by one pass
+/// and written by a second. Copy a SharedArrayBuffer before calling.
 pub fn to_utf16_alloc(
     bytes: &[u8],
     fail_if_invalid: bool,

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -243,7 +243,16 @@ fn convert_utf8_bytes_into_utf16_with_length(
     len: U3Fast,
     remaining_len: usize,
 ) -> UTF16Replacement {
-    debug_assert!(sequence[0] > 127);
+    // The caller found a non-ASCII byte with a separate scan. `sequence` is a
+    // fresh read of the same memory. A SharedArrayBuffer can change between
+    // the two reads, so decode the snapshot as-is instead of asserting on it.
+    if sequence[0] < 0x80 {
+        return UTF16Replacement {
+            len: 1,
+            code_point: u32::from(sequence[0]),
+            ..Default::default()
+        };
+    }
     match len {
         2 => {
             debug_assert!(sequence[0] >= 0xC0);
@@ -404,7 +413,6 @@ pub(super) fn convert_utf8_bytes_into_utf16(bytes: &[u8]) -> UTF16Replacement {
         3 => [bytes[0], bytes[1], bytes[2], 0],
         _ => bytes[..4].try_into().expect("infallible: size matches"),
     };
-    debug_assert!(sequence[0] > 127);
     let sequence_length = non_ascii_sequence_length(sequence[0]);
     convert_utf8_bytes_into_utf16_with_length(sequence, sequence_length, bytes.len())
 }
@@ -649,6 +657,8 @@ pub enum ToUTF16Error {
 
 crate::oom_from_alloc!(ToUTF16Error);
 
+/// `bytes` must not change during the call: the output is sized by one pass
+/// and written by a second. Copy a SharedArrayBuffer before calling.
 pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: bool>(
     bytes: &[u8],
 ) -> Result<Option<(Vec<u16>, [u8; 3], u8)>, ToUTF16Error> {

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -243,9 +243,7 @@ fn convert_utf8_bytes_into_utf16_with_length(
     len: U3Fast,
     remaining_len: usize,
 ) -> UTF16Replacement {
-    // The caller found a non-ASCII byte with a separate scan. `sequence` is a
-    // fresh read of the same memory. A SharedArrayBuffer can change between
-    // the two reads, so decode the snapshot as-is instead of asserting on it.
+    // A shared buffer can change between the caller's scan and this read.
     if sequence[0] < 0x80 {
         return UTF16Replacement {
             len: 1,
@@ -657,8 +655,7 @@ pub enum ToUTF16Error {
 
 crate::oom_from_alloc!(ToUTF16Error);
 
-/// `bytes` must not change during the call: the output is sized by one pass
-/// and written by a second. Copy a SharedArrayBuffer before calling.
+/// Reads `bytes` twice: copy a SharedArrayBuffer before calling.
 pub fn to_utf16_alloc_maybe_buffered<const FAIL_IF_INVALID: bool, const FLUSH: bool>(
     bytes: &[u8],
 ) -> Result<Option<(Vec<u16>, [u8; 3], u8)>, ToUTF16Error> {

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -409,6 +409,8 @@ extern "C" [[ZIG_EXPORT(nothrow)]] BunString BunString__fromLatin1Unitialized(si
     return { BunStringTag::WTFStringImpl, { .wtf = impl.leakRef() } };
 }
 
+// `bytes` must not change during the call: the output is sized by one pass
+// and written by a second. Copy a SharedArrayBuffer before calling.
 extern "C" BunString BunString__fromUTF8(const char* bytes, size_t length)
 {
     ASSERT(length > 0);

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -409,8 +409,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] BunString BunString__fromLatin1Unitialized(si
     return { BunStringTag::WTFStringImpl, { .wtf = impl.leakRef() } };
 }
 
-// `bytes` must not change during the call: the output is sized by one pass
-// and written by a second. Copy a SharedArrayBuffer before calling.
+// Reads `bytes` twice: copy a SharedArrayBuffer before calling.
 extern "C" BunString BunString__fromUTF8(const char* bytes, size_t length)
 {
     ASSERT(length > 0);

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -414,6 +414,17 @@ bool Bun::rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject* globalObje
     return true;
 }
 
+std::span<const uint8_t> Bun::stableBytes(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, std::span<const uint8_t> bytes, bool shared, WTF::Vector<uint8_t>& storage)
+{
+    if (!shared) [[likely]]
+        return bytes;
+    if (!storage.tryAppend(bytes)) [[unlikely]] {
+        JSC::throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    return storage.span();
+}
+
 JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalObject* lexicalGlobalObject, char* ptr, size_t length, void* ctx, JSTypedArrayBytesDeallocator bytesDeallocator)
 {
     JSC::JSUint8Array* uint8Array = nullptr;
@@ -2148,7 +2159,13 @@ JSC::EncodedJSValue jsBufferToString(JSC::JSGlobalObject* lexicalGlobalObject, T
         length = byteLength - offset;
     }
 
-    return jsBufferToStringFromBytes(lexicalGlobalObject, scope, castedThis->span().subspan(offset, length), encoding);
+    // Only the UTF-8 decoder reads its input twice. The other encodings size
+    // their output from the byte count and read each byte once.
+    WTF::Vector<uint8_t> storage;
+    auto bytes = Bun::stableBytes(lexicalGlobalObject, scope, castedThis->span().subspan(offset, length), encoding == WebCore::BufferEncodingType::utf8 && castedThis->isShared(), storage);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return jsBufferToStringFromBytes(lexicalGlobalObject, scope, bytes, encoding);
 }
 
 // Mirrors v8::Value::IntegerValue(): NaN becomes 0 and anything outside the

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -2159,8 +2159,7 @@ JSC::EncodedJSValue jsBufferToString(JSC::JSGlobalObject* lexicalGlobalObject, T
         length = byteLength - offset;
     }
 
-    // Only the UTF-8 decoder reads its input twice. The other encodings size
-    // their output from the byte count and read each byte once.
+    // Only the UTF-8 decoder reads its input twice.
     WTF::Vector<uint8_t> storage;
     auto bytes = Bun::stableBytes(lexicalGlobalObject, scope, castedThis->span().subspan(offset, length), encoding == WebCore::BufferEncodingType::utf8 && castedThis->isShared(), storage);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -46,6 +46,13 @@ std::optional<size_t> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexica
 // RangeError `new ArrayBuffer(length)` would throw, and returns true.
 bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject*, JSC::ThrowScope&, const void* bytes, size_t length, JSTypedArrayBytesDeallocator, void* deallocatorContext);
 
+// Input for a decoder that reads its bytes more than once (a pass that sizes
+// the output, then a pass that writes it). Another thread can change a
+// SharedArrayBuffer between the passes, so when `shared` is set the bytes are
+// copied into `storage` and the copy is returned. On allocation failure this
+// throws OutOfMemoryError and returns an empty span.
+std::span<const uint8_t> stableBytes(JSC::JSGlobalObject*, JSC::ThrowScope&, std::span<const uint8_t> bytes, bool shared, WTF::Vector<uint8_t>& storage);
+
 namespace Buffer {
 
 const size_t kMaxLength = MAX_ARRAY_BUFFER_SIZE;

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -46,11 +46,8 @@ std::optional<size_t> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexica
 // RangeError `new ArrayBuffer(length)` would throw, and returns true.
 bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject*, JSC::ThrowScope&, const void* bytes, size_t length, JSTypedArrayBytesDeallocator, void* deallocatorContext);
 
-// Input for a decoder that reads its bytes more than once (a pass that sizes
-// the output, then a pass that writes it). Another thread can change a
-// SharedArrayBuffer between the passes, so when `shared` is set the bytes are
-// copied into `storage` and the copy is returned. On allocation failure this
-// throws OutOfMemoryError and returns an empty span.
+// Bytes a decoder can read more than once: a SharedArrayBuffer is copied into
+// `storage`. Throws OutOfMemoryError and returns an empty span if the copy fails.
 std::span<const uint8_t> stableBytes(JSC::JSGlobalObject*, JSC::ThrowScope&, std::span<const uint8_t> bytes, bool shared, WTF::Vector<uint8_t>& storage);
 
 namespace Buffer {

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -113,7 +113,7 @@ void JSStringDecoder::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObj
 // Checks at most 3 bytes at the end of a Buffer in order to detect an
 // incomplete multi-byte UTF-8 character. The total number of bytes (2, 3, or 4)
 // needed to complete the UTF-8 character (if applicable) are returned.
-uint8_t JSStringDecoder::utf8CheckIncomplete(uint8_t* bufPtr, uint32_t length, uint32_t i)
+uint8_t JSStringDecoder::utf8CheckIncomplete(const uint8_t* bufPtr, uint32_t length, uint32_t i)
 {
     uint32_t j = length - 1;
     if (j < i)
@@ -147,7 +147,7 @@ uint8_t JSStringDecoder::utf8CheckIncomplete(uint8_t* bufPtr, uint32_t length, u
     return 0;
 }
 
-JSC::JSString* JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
+JSC::JSString* JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const uint8_t* bufPtr, uint32_t length)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -202,7 +202,7 @@ JSC::JSString* JSStringDecoder::fillLast(JSC::VM& vm, JSC::JSGlobalObject* globa
 }
 
 // This is not the exposed text
-JSC::JSString* JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length, uint32_t offset)
+JSC::JSString* JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const uint8_t* bufPtr, uint32_t length, uint32_t offset)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
@@ -262,7 +262,7 @@ JSC::JSString* JSStringDecoder::text(JSC::VM& vm, JSC::JSGlobalObject* globalObj
     __builtin_unreachable();
 }
 
-JSC::JSString* JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
+JSC::JSString* JSStringDecoder::write(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const uint8_t* bufPtr, uint32_t length)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     if (length == 0)
@@ -325,7 +325,7 @@ ResetScope::~ResetScope()
 }
 
 JSC::JSString*
-JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, uint8_t* bufPtr, uint32_t length)
+JSStringDecoder::end(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const uint8_t* bufPtr, uint32_t length)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto resetScope = ResetScope(this);
@@ -420,7 +420,10 @@ static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_writeBody(JSC
 
         return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "buf"_s, "Buffer, TypedArray, or DataView"_s, buffer);
     }
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
+    WTF::Vector<uint8_t> storage;
+    auto bytes = Bun::stableBytes(lexicalGlobalObject, throwScope, view->span(), view->isShared(), storage);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, bytes.data(), bytes.size())));
 }
 static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_endBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSStringDecoder* castedThis)
 {
@@ -436,7 +439,10 @@ static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_endBody(JSC::
         throwVMTypeError(lexicalGlobalObject, throwScope, "Expected Uint8Array"_s);
         return {};
     }
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->end(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()), view->byteLength())));
+    WTF::Vector<uint8_t> storage;
+    auto bytes = Bun::stableBytes(lexicalGlobalObject, throwScope, view->span(), view->isShared(), storage);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->end(vm, lexicalGlobalObject, bytes.data(), bytes.size())));
 }
 static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_textBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSStringDecoder* castedThis)
 {
@@ -458,7 +464,10 @@ static inline JSC::EncodedJSValue jsStringDecoderPrototypeFunction_textBody(JSC:
     uint32_t byteLength = view->byteLength();
     if (offset < 0 || static_cast<uint32_t>(offset) > byteLength)
         RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(JSC::jsEmptyString(vm)));
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, reinterpret_cast<uint8_t*>(view->vector()) + offset, byteLength - offset)));
+    WTF::Vector<uint8_t> storage;
+    auto bytes = Bun::stableBytes(lexicalGlobalObject, throwScope, view->span().subspan(offset), view->isShared(), storage);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(castedThis->write(vm, lexicalGlobalObject, bytes.data(), bytes.size())));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsStringDecoderPrototypeFunction_write,

--- a/src/jsc/bindings/JSStringDecoder.h
+++ b/src/jsc/bindings/JSStringDecoder.h
@@ -51,8 +51,8 @@ public:
     }
 
     // These return nullptr with an exception pending on failure.
-    JSC::JSString* write(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
-    JSC::JSString* end(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
+    JSC::JSString* write(JSC::VM&, JSC::JSGlobalObject*, const uint8_t*, uint32_t);
+    JSC::JSString* end(JSC::VM&, JSC::JSGlobalObject*, const uint8_t*, uint32_t);
 
     uint8_t m_lastNeed = 0;
     uint8_t m_lastTotal = 0;
@@ -60,9 +60,9 @@ public:
     BufferEncodingType m_encoding = BufferEncodingType::utf8;
 
 private:
-    JSC::JSString* fillLast(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t);
-    JSC::JSString* text(JSC::VM&, JSC::JSGlobalObject*, uint8_t*, uint32_t, uint32_t);
-    uint8_t utf8CheckIncomplete(uint8_t*, uint32_t, uint32_t);
+    JSC::JSString* fillLast(JSC::VM&, JSC::JSGlobalObject*, const uint8_t*, uint32_t);
+    JSC::JSString* text(JSC::VM&, JSC::JSGlobalObject*, const uint8_t*, uint32_t, uint32_t);
+    uint8_t utf8CheckIncomplete(const uint8_t*, uint32_t, uint32_t);
 };
 
 class JSStringDecoderPrototype : public JSC::JSNonFinalObject {

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -4,6 +4,7 @@
 #include "DOMClientIsoSubspaces.h"
 #include "DOMIsoSubspaces.h"
 #include "ErrorCode.h"
+#include "JSBuffer.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMWrapperCache.h"
@@ -329,23 +330,31 @@ using namespace JSC;
 using WebCore::JSTextDecoderStream;
 
 // [AllowShared] BufferSource → (ptr, len); a detached buffer yields the empty sequence.
-static std::optional<std::span<const uint8_t>> textDecoderStreamBytes(JSGlobalObject* globalObject, JSValue chunk)
+// The bytes of a SharedArrayBuffer are copied into `storage` (see Bun::stableBytes).
+static std::optional<std::span<const uint8_t>> textDecoderStreamBytes(JSGlobalObject* globalObject, JSValue chunk, WTF::Vector<uint8_t>& storage)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    std::span<const uint8_t> bytes;
+    bool shared = false;
     if (auto* view = dynamicDowncast<JSArrayBufferView>(chunk)) {
-        if (view->isDetached()) [[unlikely]]
-            return std::span<const uint8_t>();
-        return std::span<const uint8_t>(static_cast<const uint8_t*>(view->vector()), view->byteLength());
-    }
-    if (auto* buffer = dynamicDowncast<JSArrayBuffer>(chunk)) {
+        if (!view->isDetached()) [[likely]] {
+            bytes = std::span<const uint8_t>(static_cast<const uint8_t*>(view->vector()), view->byteLength());
+            shared = view->isShared();
+        }
+    } else if (auto* buffer = dynamicDowncast<JSArrayBuffer>(chunk)) {
         auto* impl = buffer->impl();
-        if (!impl || impl->isDetached()) [[unlikely]]
-            return std::span<const uint8_t>();
-        return std::span<const uint8_t>(static_cast<const uint8_t*>(impl->data()), impl->byteLength());
+        if (impl && !impl->isDetached()) [[likely]] {
+            bytes = std::span<const uint8_t>(static_cast<const uint8_t*>(impl->data()), impl->byteLength());
+            shared = impl->isShared();
+        }
+    } else {
+        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "chunk"_s, "BufferSource"_s, chunk);
+        return std::nullopt;
     }
-    Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "chunk"_s, "BufferSource"_s, chunk);
-    return std::nullopt;
+    bytes = Bun::stableBytes(globalObject, scope, bytes, shared, storage);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    return bytes;
 }
 
 // The transform/flush algorithms return a promise, so a throw from decode or enqueue is that
@@ -370,7 +379,8 @@ JSPromise* textDecoderStreamTransform(JSGlobalObject* globalObject, JSTextDecode
 {
     return promiseFromSteps(globalObject, [&] -> JSPromise* {
         auto scope = DECLARE_THROW_SCOPE(getVM(globalObject));
-        std::optional<std::span<const uint8_t>> bytes = textDecoderStreamBytes(globalObject, chunk);
+        WTF::Vector<uint8_t> storage;
+        std::optional<std::span<const uint8_t>> bytes = textDecoderStreamBytes(globalObject, chunk, storage);
         RETURN_IF_EXCEPTION(scope, nullptr);
         decodeAndEnqueue(globalObject, stream, controller, bytes->data(), bytes->size(), true);
         RETURN_IF_EXCEPTION(scope, nullptr);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "ErrorCode.h"
 #include "AsyncStackTrace.h"
+#include "JSBuffer.h"
 
 #include "WebStreamsInternals.h"
 
@@ -1030,12 +1031,17 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
     // WebIDL "get a copy of the bytes held by the buffer source": a detached
     // buffer is still a BufferSource whose bytes are the empty sequence.
     std::span<const uint8_t> bytes;
+    bool shared = false;
     if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-        if (!view->isDetached())
+        if (!view->isDetached()) {
             bytes = view->span();
+            shared = view->isShared();
+        }
     } else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-        if (buffer->impl() && !buffer->impl()->isDetached())
+        if (buffer->impl() && !buffer->impl()->isDetached()) {
             bytes = buffer->impl()->span();
+            shared = buffer->impl()->isShared();
+        }
     } else {
         auto* error = createTypeError(globalObject, "Body.textStream() received a chunk that is not a BufferSource"_s);
         RETURN_IF_EXCEPTION(scope, void());
@@ -1057,6 +1063,9 @@ void textDecodeReadRequestChunkSteps(JSGlobalObject* globalObject, JSReadableStr
         }
         return;
     }
+    WTF::Vector<uint8_t> storage;
+    bytes = Bun::stableBytes(globalObject, scope, bytes, shared, storage);
+    RETURN_IF_EXCEPTION(scope, void());
     auto* decoded = streamingUTF8Decode(globalObject, bytes, controller->m_algorithms.textDecodeState, /* flush */ false);
     RETURN_IF_EXCEPTION(scope, void());
     if (!decoded || !decoded->length()) {

--- a/src/jsc/modules/NodeBufferModule.cpp
+++ b/src/jsc/modules/NodeBufferModule.cpp
@@ -3,6 +3,7 @@
 #include "BunClientData.h"
 #include "ErrorCode.h"
 #include "helpers.h"
+#include "JSBuffer.h"
 #include "JSBufferEncodingType.h"
 #include "JSDOMExceptionHandling.h"
 #include "wtf/SIMDUTF.h"
@@ -165,7 +166,9 @@ BUN_DEFINE_HOST_FUNCTION(jsBufferTranscode,
     if (length == 0)
         RELEASE_AND_RETURN(scope, JSValue::encode(WebCore::createEmptyBuffer(globalObject)));
 
-    const std::span<const uint8_t> input { view->typedVector(), length };
+    WTF::Vector<uint8_t> storage;
+    const std::span<const uint8_t> input = Bun::stableBytes(globalObject, scope, std::span<const uint8_t> { view->typedVector(), length }, view->isShared(), storage);
+    RETURN_IF_EXCEPTION(scope, {});
     const auto* data = reinterpret_cast<const char*>(input.data());
 
     // Only these two ICU statuses are producible here.

--- a/test/js/node/buffer-shared-decode-race.test.ts
+++ b/test/js/node/buffer-shared-decode-race.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// A worker flips bytes in a SharedArrayBuffer while the main thread decodes
-// it as UTF-8. The decoder must not trust a byte it read earlier: the length
-// pass and the conversion pass can see different bytes. An unfixed build
-// panics on a debug assertion or writes past the end of the output buffer.
+// A worker rewrites a SharedArrayBuffer while the main thread decodes it as
+// UTF-8. The decoder must not trust a byte it read earlier: the length pass
+// and the conversion pass can see different bytes.
 //
-// The worker leaves every byte at 0x41 ("A") except the one it is on, which
-// is briefly 0x80 (a continuation byte). The length pass counts 0x80 as
-// zero UTF-16 units, so a conversion pass that sees 0x41 there writes one
-// unit more than was allocated.
+// The worker fills the buffer with 0x80 (a continuation byte), then with
+// 0x61 ("a"). The length pass counts a 0x80 byte as zero UTF-16 units, so a
+// conversion pass that sees 0x61 there writes one unit per byte more than
+// was allocated. An unfixed build segfaults in release and reports a
+// heap-buffer-overflow under ASAN.
 const fixture = String.raw`
   import { Worker, isMainThread, workerData, parentPort } from "node:worker_threads";
   import { transcode } from "node:buffer";
@@ -17,19 +17,22 @@ const fixture = String.raw`
   if (!isMainThread) {
     const u8 = new Uint8Array(workerData);
     parentPort.postMessage("go");
-    for (let i = 0; ; i++) u8[(i >>> 1) & 63] = i & 1 ? 0x41 : 0x80;
+    for (;;) {
+      u8.fill(0x80);
+      u8.fill(0x61);
+    }
   } else {
     const mode = process.argv[2];
     const iterations = Number(process.argv[3]);
-    const sab = new SharedArrayBuffer(64);
-    const buf = Buffer.from(sab).fill(0x41);
+    const sab = new SharedArrayBuffer(4096);
+    const buf = Buffer.from(sab).fill(0x61);
     const worker = new Worker(import.meta.path, { workerData: sab });
     worker.on("message", async () => {
       let total = 0;
       if (mode === "toString") {
         for (let i = 0; i < iterations; i++) total += buf.toString("utf8").length;
       } else if (mode === "transcode") {
-        // A snapshot that holds the 0x80 byte is invalid UTF-8, which transcode rejects.
+        // A snapshot of the 0x80 fill is invalid UTF-8, which transcode rejects.
         for (let i = 0; i < iterations; i++) {
           try {
             total += transcode(buf, "utf8", "ucs2").length;
@@ -69,7 +72,7 @@ for (const mode of ["toString", "transcode", "string_decoder", "TextDecoderStrea
   test.concurrent(`${mode} on a SharedArrayBuffer that another thread writes`, async () => {
     using dir = tempDir("buffer-shared-decode-race", { "fixture.mjs": fixture });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.mjs", mode, "5000"],
+      cmd: [bunExe(), "fixture.mjs", mode, "500"],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",

--- a/test/js/node/buffer-shared-decode-race.test.ts
+++ b/test/js/node/buffer-shared-decode-race.test.ts
@@ -73,9 +73,11 @@ for (const mode of ["toString", "transcode", "string_decoder", "TextDecoderStrea
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
+      stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout).toBe("ok true\n");
-    expect(exitCode).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr carries the panic or the sanitizer report on a failing build.
+    expect(stdout, stderr).toBe("ok true\n");
+    expect(exitCode, stderr).toBe(0);
   });
 }

--- a/test/js/node/buffer-shared-decode-race.test.ts
+++ b/test/js/node/buffer-shared-decode-race.test.ts
@@ -11,9 +11,9 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // zero UTF-16 units, so a conversion pass that sees 0x41 there writes one
 // unit more than was allocated.
 const fixture = String.raw`
-  const { Worker, isMainThread, workerData, parentPort } = require("worker_threads");
-  const { transcode } = require("buffer");
-  const { StringDecoder } = require("string_decoder");
+  import { Worker, isMainThread, workerData, parentPort } from "node:worker_threads";
+  import { transcode } from "node:buffer";
+  import { StringDecoder } from "node:string_decoder";
   if (!isMainThread) {
     const u8 = new Uint8Array(workerData);
     parentPort.postMessage("go");
@@ -23,7 +23,7 @@ const fixture = String.raw`
     const iterations = Number(process.argv[3]);
     const sab = new SharedArrayBuffer(64);
     const buf = Buffer.from(sab).fill(0x41);
-    const worker = new Worker(__filename, { workerData: sab });
+    const worker = new Worker(import.meta.path, { workerData: sab });
     worker.on("message", async () => {
       let total = 0;
       if (mode === "toString") {
@@ -50,10 +50,11 @@ const fixture = String.raw`
           total += (await reader.read()).value.length;
         }
       } else if (mode === "textStream") {
+        let enqueued = 0;
         const source = new ReadableStream({
           pull(controller) {
             controller.enqueue(buf);
-            if (++total >= iterations) controller.close();
+            if (++enqueued >= iterations) controller.close();
           },
         });
         for await (const text of new Response(source).textStream()) total += text.length;
@@ -66,9 +67,9 @@ const fixture = String.raw`
 
 for (const mode of ["toString", "transcode", "string_decoder", "TextDecoderStream", "textStream"]) {
   test.concurrent(`${mode} on a SharedArrayBuffer that another thread writes`, async () => {
-    using dir = tempDir("buffer-shared-decode-race", { "fixture.cjs": fixture });
+    using dir = tempDir("buffer-shared-decode-race", { "fixture.mjs": fixture });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.cjs", mode, "5000"],
+      cmd: [bunExe(), "fixture.mjs", mode, "5000"],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",

--- a/test/js/node/buffer-shared-decode-race.test.ts
+++ b/test/js/node/buffer-shared-decode-race.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// A worker flips bytes in a SharedArrayBuffer while the main thread decodes
+// it as UTF-8. The decoder must not trust a byte it read earlier: the length
+// pass and the conversion pass can see different bytes. An unfixed build
+// panics on a debug assertion or writes past the end of the output buffer.
+//
+// The worker leaves every byte at 0x41 ("A") except the one it is on, which
+// is briefly 0x80 (a continuation byte). The length pass counts 0x80 as
+// zero UTF-16 units, so a conversion pass that sees 0x41 there writes one
+// unit more than was allocated.
+const fixture = String.raw`
+  const { Worker, isMainThread, workerData, parentPort } = require("worker_threads");
+  const { transcode } = require("buffer");
+  const { StringDecoder } = require("string_decoder");
+  if (!isMainThread) {
+    const u8 = new Uint8Array(workerData);
+    parentPort.postMessage("go");
+    for (let i = 0; ; i++) u8[(i >>> 1) & 63] = i & 1 ? 0x41 : 0x80;
+  } else {
+    const mode = process.argv[2];
+    const iterations = Number(process.argv[3]);
+    const sab = new SharedArrayBuffer(64);
+    const buf = Buffer.from(sab).fill(0x41);
+    const worker = new Worker(__filename, { workerData: sab });
+    worker.on("message", async () => {
+      let total = 0;
+      if (mode === "toString") {
+        for (let i = 0; i < iterations; i++) total += buf.toString("utf8").length;
+      } else if (mode === "transcode") {
+        // A snapshot that holds the 0x80 byte is invalid UTF-8, which transcode rejects.
+        for (let i = 0; i < iterations; i++) {
+          try {
+            total += transcode(buf, "utf8", "ucs2").length;
+          } catch (e) {
+            if (e.code !== "U_INVALID_CHAR_FOUND") throw e;
+            total += 1;
+          }
+        }
+      } else if (mode === "string_decoder") {
+        const decoder = new StringDecoder("utf8");
+        for (let i = 0; i < iterations; i++) total += decoder.write(buf).length + decoder.end(buf).length;
+      } else if (mode === "TextDecoderStream") {
+        const stream = new TextDecoderStream();
+        const writer = stream.writable.getWriter();
+        const reader = stream.readable.getReader();
+        for (let i = 0; i < iterations; i++) {
+          writer.write(buf);
+          total += (await reader.read()).value.length;
+        }
+      } else if (mode === "textStream") {
+        const source = new ReadableStream({
+          pull(controller) {
+            controller.enqueue(buf);
+            if (++total >= iterations) controller.close();
+          },
+        });
+        for await (const text of new Response(source).textStream()) total += text.length;
+      }
+      console.log("ok", total > 0);
+      worker.terminate();
+    });
+  }
+`;
+
+for (const mode of ["toString", "transcode", "string_decoder", "TextDecoderStream", "textStream"]) {
+  test.concurrent(`${mode} on a SharedArrayBuffer that another thread writes`, async () => {
+    using dir = tempDir("buffer-shared-decode-race", { "fixture.cjs": fixture });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.cjs", mode, "5000"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("ok true\n");
+    expect(exitCode).toBe(0);
+  });
+}


### PR DESCRIPTION
### Problem
- `Buffer.from(sab).toString('utf8')` while a worker rewrites the SharedArrayBuffer segfaults a release build: `panic(main thread): Segmentation fault at address 0x0`, 5/5 runs on 1.4.3-canary.1 with no sanitizer. Under ASAN it is a `heap-buffer-overflow` in `to_utf16_alloc` (`src/bun_core/string/immutable.rs:2583`), and a debug build trips `assertion failed: sequence[0] > 127` (`src/bun_core/string/immutable/unicode.rs:246`).
- The decoders read the input twice. `simdutf::utf16_length_from_utf8` sizes the output, then `convert_utf8_to_utf16le_with_errors` writes it. A byte that changes between the passes changes the unit count. `buffer.transcode`, `StringDecoder`, `TextDecoderStream`, and `Body.textStream` feed the same decoder from a view and have the same overflow.

### Fix
- Add `Bun::stableBytes` (`src/jsc/bindings/JSBuffer.h`). When the buffer is shared it copies the bytes into caller-owned storage and throws `OutOfMemoryError` if the copy fails. Non-shared input passes through untouched.
- Call it at the five entry points: `jsBufferToString` (utf8 only, the other encodings read each byte once), `jsBufferTranscode`, `StringDecoder.write/end/text`, `TextDecoderStream` transform, and `Body.textStream` chunk steps. `TextDecoder.decode` already did this (`src/runtime/webcore/TextDecoder.rs:304`).
- The per-sequence decoder in `unicode.rs` decodes its own 4-byte snapshot. An ASCII first byte becomes that code point, length 1, instead of a debug assertion.
- Verified: `test/js/node/buffer-shared-decode-race.test.ts` covers the five entry points. All five fail on a stock release binary (`USE_SYSTEM_BUN=1`, 5/5 twice) and on the unfixed ASAN build, and pass with the fix. Also `buffer.test.js`, `buffer-utf16`, `string_decoder`, `text-decoder*`, `streams.test.js`, `fetch/body*`, `fetch/wpt`, and the node `test-buffer-tostring*`, `test-icu-transcode`, `test-string-decoder*` files.

### Background
- A SharedArrayBuffer is the only JS memory another thread can change while native code reads it. A `&[u8]` or `std::span` over it is not stable.
- The decoder precondition (input must not change during the call) is now documented on `to_utf16_alloc`, `to_utf16_alloc_maybe_buffered`, and `BunString__fromUTF8`.
- #29088 (dylan-conway) fixed this before the Rust port moved the files. #33072 and #31339 landed the `TextDecoder` and HTTP parser parts. This PR covers the remaining entry points.

<details><summary>Notes</summary>

Why copy at the entry points and not in `to_utf16_alloc`: a core-level bound (reserve `bytes.len()` units) is safe but the output `Vec` becomes the external JS string with its capacity intact, up to 3x the final size for CJK text.

Why the predicate is `isShared()` only: a resizable non-shared buffer cannot change during a native call with no JS re-entry. `TextDecoder.decode` also copies on `resizable` because it reads `options.stream` (user code) before decoding.

Calibration of the test input, 4096-byte SAB, worker running `fill(0x80)` then `fill(0x61)`, 500 decode calls per mode. On a release binary with no fix every mode crashes 3/3 (segfault, or a panic in the stream path). A 64-byte SAB with a single flipping byte only reproduces under ASAN, which is why the test uses the whole-buffer rewrite.

The byte pair matters. A flip between 0x41 and 0xC3 does not overflow: both count one UTF-16 unit, so the two passes agree. A 0x80 byte counts zero units in the length pass, so an ASCII byte in its place writes one unit more than was reserved.

`Bun.JSONL.parse` on a view goes through `WTF::String::fromUTF8ReplacingInvalidSequences`, which sizes by byte count, so it is not affected. `Bun.TOML.parse` and `Bun.YAML.parse` over a shared buffer are exposed too, but one level up: they hand the view's bytes to the parser as the source text, and the lexer reads them many times. That wants a private copy of the source buffer, not a copy at the decoder, so it is out of scope here.

Self-reviewed: 8 concerns raised, 7 addressed (shared helper, fallible copy, the two stream sites, precondition docs, PR links). Not taken: a bound on the output size inside the Rust decoder, for the memory reason above.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/buffer-shared-decode-race.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/183] cxx obj/codegen/testFFI-bun_icu_decompress.cpp.o
[2/183] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/183] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[4/183] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 f
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/buffer-shared-decode-race.test.ts:
78 |       stdout: "pipe",
79 |       stderr: "pipe",
80 |     });
81 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
82 |     // stderr carries the panic or the sanitizer report on a failing build.
83 |     expect(stdout, stderr).toBe("ok true\n");
                                ^
error: 16 |     const buf = Buffer.from(sab).fill(0x61);
17 |     const worker = new Worker(import.meta.path, { workerData: sab });
18 |     worker.on("message", async () => {
19 |       let total = 0;
20 |       if (mode === "toString") {
21 |         for (let i = 0; i < iterations; i++) total += buf.toString("utf8").length;
                                                               ^
TypeError: Unknown encoding: 6.898058300144393e-307
 code: "ERR_UNKNOWN_ENCODING"

      at <anonymous> (/tmp/buffer-shared-decode-race_SvKlYD/fixture.mjs:21:59)
      at emit (node:events:100:22)
      at #onMessage (node:worker_threads:725:14)

Bun v1.4.3-canary.1+5f554969b (Linux x64)


- "ok true
- "
+ ""

- Expected  - 2
+ Received  + 1

      at 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/buffer-shared-decode-race.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/buffer-shared-decode-race.test.ts:
(pass) transcode on a SharedArrayBuffer that another thread writes [1847.83ms]
(pass) textStream on a SharedArrayBuffer that another thread writes [2145.86ms]
(pass) toString on a SharedArrayBuffer that another thread writes [2230.96ms]
(pass) TextDecoderStream on a SharedArrayBuffer that another thread writes [2311.55ms]
(pass) string_decoder on a SharedArrayBuffer that another thread writes [2395.82ms]

 5 pass
 0 fail
 10 expect() calls
Ran 5 tests across 1 file. [5.05s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 749ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/144] cxx obj/codegen/testFFI-bun_icu_decompress.cpp.o
[2/144] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/144] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[4/144] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/string/immutable.rs                   |  2 +
 src/bun_core/string/immutable/unicode.rs           | 11 ++-
 src/jsc/bindings/BunString.cpp                     |  1 +
 src/jsc/bindings/JSBuffer.cpp                      | 18 ++++-
 src/jsc/bindings/JSBuffer.h                        |  4 +
 src/jsc/bindings/JSStringDecoder.cpp               | 25 +++++--
 src/jsc/bindings/JSStringDecoder.h                 | 10 +--
 .../webcore/streams/JSTextDecoderStream.cpp        | 34 ++++++---
 .../webcore/streams/ReadableStreamOperations.cpp   | 13 +++-
 src/jsc/modules/NodeBufferModule.cpp               |  5 +-
 test/js/node/buffer-shared-decode-race.test.ts     | 86 ++++++++++++++++++++++
 11 files changed, 178 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bun_core/string/immutable.rs                              1      1     23
src/bun_core/string/immutable/unicode.rs                      4      4     23
src/jsc/bindings/BunString.cpp                                0      0     23
src/jsc/bindings/JSBuffer.cpp                                 2      4     23
src/jsc/bindings/JSBuffer.h                                   1      1     23
src/jsc/bindings/JSStringDecoder.cpp                          3      5     23
src/jsc/bindings/JSStringDecoder.h                            0      0     23
src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp      0      0     23
…c/bindings/webcore/streams/ReadableStreamOperations.cpp      0      0     23
src/jsc/modules/NodeBufferModule.cpp                          2      5     23
test/js/node/buffer-shared-decode-race.test.ts                2      5     23
```

</details>

**root cause** · written by the author bot

The UTF-8 decoder read bytes directly out of the caller's buffer, scanning once to classify each sequence and then re-reading the same bytes when decoding it, which is unsound when the memory is a SharedArrayBuffer that another thread can mutate between the two reads, producing a lead byte the decoder had already proven was non-ASCII and tripping the sequence assertion (and a replacement-character or worse outcome in release builds). The fix introduces `Bun::stableBytes`, which copies shared backing stores into a local snapshot before decoding, and routes the Buffer, StringDecoder, stream, …

<!-- robobun:evidence:end -->