### PR TITLE
css: print :nth-col(1) and :nth-last-col(1) in functional form

### DIFF
--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -2553,11 +2553,9 @@ impl NthSelectorData {
         })
     }
 
-    /// Whether the selector prints in functional form. `0n+1` collapses to
-    /// `:first-child` and friends, but `:nth-col()` and `:nth-last-col()` have
-    /// no such shorthand.
     pub(crate) fn is_function_(&self) -> bool {
         match self.ty {
+            // No `:first-col` shorthand exists.
             NthType::Col | NthType::LastCol => true,
             NthType::OnlyChild | NthType::OnlyOfType => false,
             _ => self.a != 0 || self.b != 1,

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -2553,8 +2553,15 @@ impl NthSelectorData {
         })
     }
 
+    /// Whether the selector prints in functional form. `0n+1` collapses to
+    /// `:first-child` and friends, but `:nth-col()` and `:nth-last-col()` have
+    /// no such shorthand.
     pub(crate) fn is_function_(&self) -> bool {
-        self.a != 0 || self.b != 1
+        match self.ty {
+            NthType::Col | NthType::LastCol => true,
+            NthType::OnlyChild | NthType::OnlyOfType => false,
+            _ => self.a != 0 || self.b != 1,
+        }
     }
 
     fn number_sign(num: i32) -> &'static str {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5291,7 +5291,10 @@ describe("css tests", () => {
     minify_test(":nth-col(1) {width: 20px}", ":nth-col(1){width:20px}");
     minify_test(":nth-col(0n+1) {width: 20px}", ":nth-col(1){width:20px}");
     minify_test(":nth-last-col(1) {width: 20px}", ":nth-last-col(1){width:20px}");
-    minify_test(":nth-col(1) {c: d} :nth-last-col(1) {e: f} .after {g: h}", ":nth-col(1){c:d}:nth-last-col(1){e:f}.after{g:h}");
+    minify_test(
+      ":nth-col(1) {c: d} :nth-last-col(1) {e: f} .after {g: h}",
+      ":nth-col(1){c:d}:nth-last-col(1){e:f}.after{g:h}",
+    );
     minify_test(":nth-child(odd) {width: 20px}", ":nth-child(odd){width:20px}");
     minify_test(":nth-child(2n) {width: 20px}", ":nth-child(2n){width:20px}");
     minify_test(":nth-child(2n+1) {width: 20px}", ":nth-child(odd){width:20px}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5287,6 +5287,11 @@ describe("css tests", () => {
     minify_test(":nth-last-col(-n+2) {width: 20px}", ":nth-last-col(-n+2){width:20px}");
     minify_test(":nth-last-col(even) {width: 20px}", ":nth-last-col(2n){width:20px}");
     minify_test(":nth-last-col(odd) {width: 20px}", ":nth-last-col(odd){width:20px}");
+    // `0n+1` has no `:first-col` shorthand, unlike `:nth-child(1)`.
+    minify_test(":nth-col(1) {width: 20px}", ":nth-col(1){width:20px}");
+    minify_test(":nth-col(0n+1) {width: 20px}", ":nth-col(1){width:20px}");
+    minify_test(":nth-last-col(1) {width: 20px}", ":nth-last-col(1){width:20px}");
+    minify_test(":nth-col(1) {c: d} :nth-last-col(1) {e: f} .after {g: h}", ":nth-col(1){c:d}:nth-last-col(1){e:f}.after{g:h}");
     minify_test(":nth-child(odd) {width: 20px}", ":nth-child(odd){width:20px}");
     minify_test(":nth-child(2n) {width: 20px}", ":nth-child(2n){width:20px}");
     minify_test(":nth-child(2n+1) {width: 20px}", ":nth-child(odd){width:20px}");


### PR DESCRIPTION
### Problem
- `:nth-col(1){c:d}` prints as `:nth-col({c:d}`, an unterminated function. bun rejects its own output with `error: Unexpected end of input`. `:nth-last-col(1)` does the same. A browser consumes the rest of the sheet while it looks for the `)`.
- Cause: `NthSelectorData::is_function_` (`src/css/selectors/parser.rs:2556`) returns `false` for `0n+1` regardless of the pseudo-class, because `:nth-child(1)` collapses to `:first-child`. `write_start` has no shorthand for the column pseudo-classes, so it writes `:nth-col(` and the printer (`src/css/selectors/selector.rs:1580`) then skips the argument and the closing parenthesis.

### Fix
- `is_function_` now depends on the pseudo-class: `:nth-col()` and `:nth-last-col()` always print in functional form, `:only-child` and `:only-of-type` never do, and the `0n+1` shorthand applies to the rest as before.
- Correct because the shorthand table in `write_start` already encodes which types have a non-functional form. The predicate now agrees with it.
- Verified: `test/js/bun/css/css.test.ts` (four new `minify_test` cases under `selectors`, all fail on the released build). Also the rest of `test/js/bun/css/` and `test/bundler/css/`.

### Background
- `:nth-col(An+B)` and `:nth-last-col(An+B)` (Selectors 4) select table columns. They accept the same An+B argument as `:nth-child()`, but there is no `:first-col` shorthand.
- The printer stores every nth pseudo-class as one `NthSelectorData { ty, a, b }` and decides the output form from `a` and `b`. lightningcss has the same bug.

<details><summary>Notes</summary>

Repro on bun 1.4.3:

```
printf ':nth-col(1){c:d}\n:nth-last-col(1){e:f}\n.after{g:h}\n' > a.css
bun build ./a.css --minify
# :nth-col({c:d}:nth-last-col({e:f}.after{g:h}
```

With the fix: `:nth-col(1){c:d}:nth-last-col(1){e:f}.after{g:h}`.

`:nth-col(2)`, `(2n+1)`, `(even)` and `(odd)` were already correct because their `a`/`b` are not `0`/`1`.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.20ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.26ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.06ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release without fix: 4 failed, 67 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.16ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [20.24ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [2.39ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.99ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3989ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/selectors/parser.rs | 7 ++++++-
 test/js/bun/css/css.test.ts | 8 ++++++++
 2 files changed, 14 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/css/selectors/parser.rs      2      2     12
test/js/bun/css/css.test.ts      2      4     12
```

</details>

<!-- robobun:evidence:end -->