### PR TITLE
Bun.serve: keep the chunk routes of a built html route across server.reload()

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -158,10 +158,8 @@ pub struct Route {
     pub(crate) dev_server_id: Cell<Option<route_bundle::Index>>,
     /// When state == .pending, incomplete responses are stored here.
     pending_responses: JsCell<Vec<PendingResponse>>,
-    /// The static routes the last successful bundle appended to the server:
-    /// the js and css chunks, and the page at its output path. They live on
-    /// the server's static route list, which `server.reload()` replaces, so
-    /// the route keeps its own copy for `adopt_built_state`.
+    /// The static routes the last successful bundle appended to the server.
+    /// `server.reload()` replaces that list; `adopt_assets` carries these over.
     assets: JsCell<Vec<(Box<[u8]>, RefPtr<StaticRoute>)>>,
 }
 
@@ -209,16 +207,10 @@ impl Route {
         })
     }
 
-    /// `server.reload()` builds a fresh `Route` for every html import in the
-    /// new config and drops the old static route list with the chunk routes
-    /// the old route's bundle appended. A fresh route for the same
-    /// `HTMLBundle` takes those chunk routes from the old route here, so the
-    /// chunk urls in a document a client already holds stay served until the
-    /// next build replaces them. The page itself is not taken: the next
-    /// request to it bundles again, as before. Returns the chunk routes for
-    /// the caller to append to the new config. Empty when the routes are for
-    /// different files, the old route never finished a build, or this route
-    /// already adopted.
+    /// Takes the chunk routes of `old`, the route for the same `HTMLBundle`
+    /// in the config that `server.reload()` replaces, so the chunk urls in a
+    /// document a client already holds stay served until the next build.
+    /// Returns them for the caller to append to the new config.
     pub(crate) fn adopt_assets(&self, old: &Route) -> Vec<(Box<[u8]>, RefPtr<StaticRoute>)> {
         if !std::ptr::eq(self.bundle.as_ptr(), old.bundle.as_ptr()) || !self.assets.get().is_empty()
         {

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -665,11 +665,9 @@ impl Route {
                 let (mut html_route, html_route_path) =
                     this_html_route.expect("the loop above visited html_index");
                 let html_route_clone = html_route.clone(global_this);
-                // The page is also served at its output path, unless an html
-                // route is mounted there: a static route at the same path
-                // would replace it in the route list, and the page would
-                // never bundle again. Not an asset either way, so a reload
-                // drops it and the new html route bundles.
+                // Not an asset: a reload drops this alias so the page bundles
+                // again. An html route mounted at this path would be replaced
+                // by the alias in the route list and never bundle again.
                 let html_path_has_html_route =
                     server.config().static_routes.iter().any(|entry| {
                         matches!(entry.route, AnyRoute::Html(_))

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -158,7 +158,7 @@ pub struct Route {
     pub(crate) dev_server_id: Cell<Option<route_bundle::Index>>,
     /// When state == .pending, incomplete responses are stored here.
     pending_responses: JsCell<Vec<PendingResponse>>,
-    /// The static routes the last successful bundle appended to the server.
+    /// The chunk routes the last successful bundle appended to the server.
     /// `server.reload()` replaces that list; `adopt_assets` carries these over.
     assets: JsCell<Vec<(Box<[u8]>, RefPtr<StaticRoute>)>>,
 }
@@ -225,7 +225,7 @@ impl Route {
         assets
     }
 
-    /// Registers one output of the bundle on the server and records it in
+    /// Registers one chunk of the bundle on the server and records it in
     /// `assets`.
     fn append_asset(&self, server: AnyServer, path: &[u8], route: StaticRoute) {
         let route = RefPtr::new(route);
@@ -665,7 +665,23 @@ impl Route {
                 let (mut html_route, html_route_path) =
                     this_html_route.expect("the loop above visited html_index");
                 let html_route_clone = html_route.clone(global_this);
-                self.append_asset(server, &html_route_path, html_route);
+                // The page is also served at its output path, unless an html
+                // route is mounted there: a static route at the same path
+                // would replace it in the route list, and the page would
+                // never bundle again. Not an asset either way, so a reload
+                // drops it and the new html route bundles.
+                let html_path_has_html_route =
+                    server.config().static_routes.iter().any(|entry| {
+                        matches!(entry.route, AnyRoute::Html(_))
+                            && *entry.path == *html_route_path
+                    });
+                if !html_path_has_html_route {
+                    bun_core::handle_oom(server.append_static_route(
+                        &html_route_path,
+                        AnyRoute::Static(RefPtr::new(html_route)),
+                        MethodOptional::Any,
+                    ));
+                }
                 self.state.set(State::Html(html_route_clone));
 
                 if !bun_core::handle_oom(server.reload_static_routes()) {

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -220,8 +220,7 @@ impl Route {
     /// different files, the old route never finished a build, or this route
     /// already adopted.
     pub(crate) fn adopt_assets(&self, old: &Route) -> Vec<(Box<[u8]>, RefPtr<StaticRoute>)> {
-        if !std::ptr::eq(self.bundle.as_ptr(), old.bundle.as_ptr())
-            || !self.assets.get().is_empty()
+        if !std::ptr::eq(self.bundle.as_ptr(), old.bundle.as_ptr()) || !self.assets.get().is_empty()
         {
             return Vec::new();
         }

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -668,11 +668,9 @@ impl Route {
                 // Not an asset: a reload drops this alias so the page bundles
                 // again. An html route mounted at this path would be replaced
                 // by the alias in the route list and never bundle again.
-                let html_path_has_html_route =
-                    server.config().static_routes.iter().any(|entry| {
-                        matches!(entry.route, AnyRoute::Html(_))
-                            && *entry.path == *html_route_path
-                    });
+                let html_path_has_html_route = server.config().static_routes.iter().any(|entry| {
+                    matches!(entry.route, AnyRoute::Html(_)) && *entry.path == *html_route_path
+                });
                 if !html_path_has_html_route {
                     bun_core::handle_oom(server.append_static_route(
                         &html_route_path,

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -158,6 +158,11 @@ pub struct Route {
     pub(crate) dev_server_id: Cell<Option<route_bundle::Index>>,
     /// When state == .pending, incomplete responses are stored here.
     pending_responses: JsCell<Vec<PendingResponse>>,
+    /// The static routes the last successful bundle appended to the server:
+    /// the js and css chunks, and the page at its output path. They live on
+    /// the server's static route list, which `server.reload()` replaces, so
+    /// the route keeps its own copy for `adopt_built_state`.
+    assets: JsCell<Vec<(Box<[u8]>, RefPtr<StaticRoute>)>>,
 }
 
 pub enum State {
@@ -200,7 +205,42 @@ impl Route {
             server: Cell::new(None),
             state: JsCell::new(State::Pending),
             dev_server_id: Cell::new(None),
+            assets: JsCell::new(Vec::new()),
         })
+    }
+
+    /// `server.reload()` builds a fresh `Route` for every html import in the
+    /// new config and drops the old static route list with the chunk routes
+    /// the old route's bundle appended. A fresh route for the same
+    /// `HTMLBundle` takes those chunk routes from the old route here, so the
+    /// chunk urls in a document a client already holds stay served until the
+    /// next build replaces them. The page itself is not taken: the next
+    /// request to it bundles again, as before. Returns the chunk routes for
+    /// the caller to append to the new config. Empty when the routes are for
+    /// different files, the old route never finished a build, or this route
+    /// already adopted.
+    pub(crate) fn adopt_assets(&self, old: &Route) -> Vec<(Box<[u8]>, RefPtr<StaticRoute>)> {
+        if !std::ptr::eq(self.bundle.as_ptr(), old.bundle.as_ptr())
+            || !self.assets.get().is_empty()
+        {
+            return Vec::new();
+        }
+        let assets = old.assets.get().clone();
+        self.assets.set(assets.clone());
+        assets
+    }
+
+    /// Registers one output of the bundle on the server and records it in
+    /// `assets`.
+    fn append_asset(&self, server: AnyServer, path: &[u8], route: StaticRoute) {
+        let route = RefPtr::new(route);
+        self.assets
+            .with_mut(|assets| assets.push((Box::<[u8]>::from(path), route.clone())));
+        bun_core::handle_oom(server.append_static_route(
+            path,
+            AnyRoute::Static(route),
+            MethodOptional::Any,
+        ));
     }
 
     pub(crate) fn on_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse) {
@@ -551,6 +591,7 @@ impl Route {
                 // needs it by `&mut` before it is shared. Static routes are keyed
                 // by `dest_path`, so registration order is immaterial.
                 let mut this_html_route: Option<(StaticRoute, Box<[u8]>)> = None;
+                self.assets.set(Vec::new());
 
                 // Create static routes for each output file
                 // Index loop because the SourceMap branch reads a sibling entry.
@@ -623,21 +664,13 @@ impl Route {
                         continue;
                     }
 
-                    bun_core::handle_oom(server.append_static_route(
-                        route_path,
-                        AnyRoute::Static(RefPtr::new(static_route)),
-                        MethodOptional::Any,
-                    ));
+                    self.append_asset(server, route_path, static_route);
                 }
 
                 let (mut html_route, html_route_path) =
                     this_html_route.expect("the loop above visited html_index");
                 let html_route_clone = html_route.clone(global_this);
-                bun_core::handle_oom(server.append_static_route(
-                    &html_route_path,
-                    AnyRoute::Static(RefPtr::new(html_route)),
-                    MethodOptional::Any,
-                ));
+                self.append_asset(server, &html_route_path, html_route);
                 self.state.set(State::Html(html_route_clone));
 
                 if !bun_core::handle_oom(server.reload_static_routes()) {

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -191,6 +191,10 @@ impl Route {
         cost += mem::size_of::<Route>();
         cost += self.pending_responses.get().len() * mem::size_of::<PendingResponse>();
         cost += self.state.get().memory_cost();
+        // The `StaticRoute`s themselves are counted through the server's static route list.
+        for (path, _) in self.assets.get().iter() {
+            cost += mem::size_of::<(Box<[u8]>, RefPtr<StaticRoute>)>() + path.len();
+        }
         cost
     }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2150,10 +2150,7 @@ where
             dev_server.html_router.fallback = None;
         }
 
-        // The old static route list goes away below, with the chunk routes
-        // each built html route appended to it. A new html route for the same
-        // file takes the chunks from the old one, so the chunk urls stay
-        // served until its own build replaces them.
+        // Carry the chunk routes of each built html route into the new list.
         let mut adopted_assets = Vec::new();
         for new_entry in new_config.static_routes.iter() {
             let AnyRoute::Html(new_route) = &new_entry.route else {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2150,6 +2150,29 @@ where
             dev_server.html_router.fallback = None;
         }
 
+        // The old static route list goes away below, with the chunk routes
+        // each built html route appended to it. A new html route for the same
+        // file takes the chunks from the old one, so the chunk urls stay
+        // served until its own build replaces them.
+        let mut adopted_assets = Vec::new();
+        for new_entry in new_config.static_routes.iter() {
+            let AnyRoute::Html(new_route) = &new_entry.route else {
+                continue;
+            };
+            for old_entry in self.config.static_routes.iter() {
+                if let AnyRoute::Html(old_route) = &old_entry.route {
+                    adopted_assets.extend(new_route.adopt_assets(old_route));
+                }
+            }
+        }
+        for (path, route) in adopted_assets {
+            bun_core::handle_oom(new_config.append_static_route(
+                &path,
+                AnyRoute::Static(route),
+                server_config::MethodOptional::Any,
+            ));
+        }
+
         // NOTE: `Vec<StaticRouteEntry>` impls `Drop`, so
         // a move-assign frees the old `static_routes`.
         self.config.static_routes = core::mem::take(&mut new_config.static_routes);

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1103,16 +1103,21 @@ test.concurrent("server.reload() while an html route's first bundle is still in 
 // held fell through to fetch() until some client requested the page again.
 // The page itself still bundles again on the next request after a reload, so
 // a reload picks up an edit on disk. The chunks of the previous build stay
-// served next to the new ones until the following reload.
-describe.each([false, { hmr: false }])(
-  "server.reload() keeps the chunks of a built html route (development: %p)",
-  development => {
-    const files = {
-      "index.html": `<!DOCTYPE html><html><head><link rel="stylesheet" href="./style.css"></head><body><script type="module" src="./app.ts"></script></body></html>`,
-      "style.css": `body { color: red; }`,
-      "app.ts": `console.log("app v1");`,
-    };
-    const serveHead = /*ts*/ `
+// served next to the new ones until the following reload. "/index.html" is
+// also the bundler's output path for the page, so that route checks that the
+// previous page does not shadow the new route.
+describe.each([
+  { development: false, route: "/" },
+  { development: false, route: "/index.html" },
+  { development: { hmr: false }, route: "/" },
+  { development: { hmr: false }, route: "/index.html" },
+])("server.reload() keeps the chunks of a built html route (%p)", ({ development, route }) => {
+  const files = {
+    "index.html": `<!DOCTYPE html><html><head><link rel="stylesheet" href="./style.css"></head><body><script type="module" src="./app.ts"></script></body></html>`,
+    "style.css": `body { color: red; }`,
+    "app.ts": `console.log("app v1");`,
+  };
+  const serveHead = /*ts*/ `
     import html from "./index.html";
     import { writeFileSync } from "node:fs";
 
@@ -1120,10 +1125,11 @@ describe.each([false, { hmr: false }])(
       port: 0,
       hostname: "127.0.0.1",
       development: ${JSON.stringify(development)},
-      routes: { "/": html },
+      routes: { ${JSON.stringify(route)}: html },
       fetch: () => new Response("fallback", { status: 404 }),
     });
     const server = Bun.serve(options());
+    const route = ${JSON.stringify(route)};
     const get = async (path) => {
       const res = await fetch(new URL(path, server.url));
       return { status: res.status, body: await res.text() };
@@ -1132,62 +1138,61 @@ describe.each([false, { hmr: false }])(
     const chunks = (page) => [/src="([^"]+\\.js)"/.exec(page)[1], /href="([^"]+\\.css)"/.exec(page)[1]];
   `;
 
-    test.concurrent("chunk urls stay served after reload until the page is requested again", async () => {
-      using dir = tempDir("bun-serve-html-reload-chunks", {
-        ...files,
-        "serve.ts": /*ts*/ `
+  test.concurrent("chunk urls stay served after reload until the page is requested again", async () => {
+    using dir = tempDir("bun-serve-html-reload-chunks", {
+      ...files,
+      "serve.ts": /*ts*/ `
         ${serveHead}
-        const [js, css] = chunks((await get("/")).body);
+        const [js, css] = chunks((await get(route)).body);
 
         const before = [await status(js), await status(css)];
         server.reload(options());
         const afterReload = [await status(js), await status(css)];
-        const pageAfterReload = await status("/");
+        const pageAfterReload = await status(route);
         const afterPage = [await status(js), await status(css)];
 
         console.log(JSON.stringify({ before, afterReload, pageAfterReload, afterPage }));
         server.stop(true);
       `,
-      });
-      const { stdout, stderr, exitCode } = await runServeFixture(dir);
-      expect({ stdout, exitCode }, stderr).toEqual({
-        stdout: JSON.stringify({
-          before: [200, 200],
-          afterReload: [200, 200],
-          pageAfterReload: 200,
-          afterPage: [200, 200],
-        }),
-        exitCode: 0,
-      });
     });
+    const { stdout, stderr, exitCode } = await runServeFixture(dir);
+    expect({ stdout, exitCode }, stderr).toEqual({
+      stdout: JSON.stringify({
+        before: [200, 200],
+        afterReload: [200, 200],
+        pageAfterReload: 200,
+        afterPage: [200, 200],
+      }),
+      exitCode: 0,
+    });
+  });
 
-    test.concurrent("the page bundles again after reload and the previous chunks stay served", async () => {
-      using dir = tempDir("bun-serve-html-reload-rebuild", {
-        ...files,
-        "serve.ts": /*ts*/ `
+  test.concurrent("the page bundles again after reload and the previous chunks stay served", async () => {
+    using dir = tempDir("bun-serve-html-reload-rebuild", {
+      ...files,
+      "serve.ts": /*ts*/ `
         ${serveHead}
-        const [js1] = chunks((await get("/")).body);
+        const [js1] = chunks((await get(route)).body);
         const v1 = (await get(js1)).body.includes("app v1");
 
         writeFileSync("app.ts", 'console.log("app v2");');
         server.reload(options());
 
-        const [js2] = chunks((await get("/")).body);
+        const [js2] = chunks((await get(route)).body);
         const v2 = (await get(js2)).body.includes("app v2");
         const oldChunkAfterRebuild = await status(js1);
 
         console.log(JSON.stringify({ v1, v2, sameChunk: js1 === js2, oldChunkAfterRebuild }));
         server.stop(true);
       `,
-      });
-      const { stdout, stderr, exitCode } = await runServeFixture(dir);
-      expect({ stdout, exitCode }, stderr).toEqual({
-        stdout: JSON.stringify({ v1: true, v2: true, sameChunk: false, oldChunkAfterRebuild: 200 }),
-        exitCode: 0,
-      });
     });
-  },
-);
+    const { stdout, stderr, exitCode } = await runServeFixture(dir);
+    expect({ stdout, exitCode }, stderr).toEqual({
+      stdout: JSON.stringify({ v1: true, v2: true, sameChunk: false, oldChunkAfterRebuild: 200 }),
+      exitCode: 0,
+    });
+  });
+});
 
 // process.chdir() leaves the cached top-level directory with a trailing slash,
 // which the dev server then used as its root. Reporting a bundle failure

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1097,6 +1097,98 @@ test.concurrent("server.reload() while an html route's first bundle is still in 
   });
 });
 
+// server.reload() replaces the server's static route list with the one from the
+// new config. The js and css chunk routes of a built html route lived only on
+// that list, so after a reload the chunk urls in a document a client already
+// held fell through to fetch() until some client requested the page again.
+// The page itself still bundles again on the next request after a reload, so
+// a reload picks up an edit on disk. The chunks of the previous build stay
+// served next to the new ones until the following reload.
+describe.each([false, { hmr: false }])(
+  "server.reload() keeps the chunks of a built html route (development: %p)",
+  development => {
+    const files = {
+      "index.html": `<!DOCTYPE html><html><head><link rel="stylesheet" href="./style.css"></head><body><script type="module" src="./app.ts"></script></body></html>`,
+      "style.css": `body { color: red; }`,
+      "app.ts": `console.log("app v1");`,
+    };
+    const serveHead = /*ts*/ `
+    import html from "./index.html";
+    import { writeFileSync } from "node:fs";
+
+    const options = () => ({
+      port: 0,
+      hostname: "127.0.0.1",
+      development: ${JSON.stringify(development)},
+      routes: { "/": html },
+      fetch: () => new Response("fallback", { status: 404 }),
+    });
+    const server = Bun.serve(options());
+    const get = async (path) => {
+      const res = await fetch(new URL(path, server.url));
+      return { status: res.status, body: await res.text() };
+    };
+    const status = async (path) => (await get(path)).status;
+    const chunks = (page) => [/src="([^"]+\\.js)"/.exec(page)[1], /href="([^"]+\\.css)"/.exec(page)[1]];
+  `;
+
+    test.concurrent("chunk urls stay served after reload until the page is requested again", async () => {
+      using dir = tempDir("bun-serve-html-reload-chunks", {
+        ...files,
+        "serve.ts": /*ts*/ `
+        ${serveHead}
+        const [js, css] = chunks((await get("/")).body);
+
+        const before = [await status(js), await status(css)];
+        server.reload(options());
+        const afterReload = [await status(js), await status(css)];
+        const pageAfterReload = await status("/");
+        const afterPage = [await status(js), await status(css)];
+
+        console.log(JSON.stringify({ before, afterReload, pageAfterReload, afterPage }));
+        server.stop(true);
+      `,
+      });
+      const { stdout, stderr, exitCode } = await runServeFixture(dir);
+      expect({ stdout, exitCode }, stderr).toEqual({
+        stdout: JSON.stringify({
+          before: [200, 200],
+          afterReload: [200, 200],
+          pageAfterReload: 200,
+          afterPage: [200, 200],
+        }),
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("the page bundles again after reload and the previous chunks stay served", async () => {
+      using dir = tempDir("bun-serve-html-reload-rebuild", {
+        ...files,
+        "serve.ts": /*ts*/ `
+        ${serveHead}
+        const [js1] = chunks((await get("/")).body);
+        const v1 = (await get(js1)).body.includes("app v1");
+
+        writeFileSync("app.ts", 'console.log("app v2");');
+        server.reload(options());
+
+        const [js2] = chunks((await get("/")).body);
+        const v2 = (await get(js2)).body.includes("app v2");
+        const oldChunkAfterRebuild = await status(js1);
+
+        console.log(JSON.stringify({ v1, v2, sameChunk: js1 === js2, oldChunkAfterRebuild }));
+        server.stop(true);
+      `,
+      });
+      const { stdout, stderr, exitCode } = await runServeFixture(dir);
+      expect({ stdout, exitCode }, stderr).toEqual({
+        stdout: JSON.stringify({ v1: true, v2: true, sameChunk: false, oldChunkAfterRebuild: 200 }),
+        exitCode: 0,
+      });
+    });
+  },
+);
+
 // process.chdir() leaves the cached top-level directory with a trailing slash,
 // which the dev server then used as its root. Reporting a bundle failure
 // relativizes the failing file against that root and hit a debug assertion


### PR DESCRIPTION
### Problem
- After `server.reload()`, the hashed `/chunk-*.js` and `/chunk-*.css` urls of an html import route answer 404 (they fall through to `fetch`) until some client requests the html page again. A client that holds the document, or that races a reload between the document and its subresources, loses the app's script and style. Seen with `development: false` and `{ hmr: false }` on 1.3.14 through 1.4.3 and main.
- The cause: `on_reload_from_zig` (`src/runtime/server/server_body.rs:2178`) replaces `config.static_routes` with the new config's list, and `html_route_from_js` gives the new config a fresh `Route` in `State::Pending`. The chunk routes that the old route's bundle appended in `on_complete` (`src/runtime/server/HTMLBundle.rs`) lived only on the replaced list.

### Fix
- `html_bundle::Route` records the static routes its bundle appends (`assets`). `on_complete` goes through `append_asset` for every output and resets the list at the start of each successful build.
- On reload, a new html route for the same `HTMLBundle` takes the old route's chunk routes (`adopt_assets`) and the reload appends them to the new config before it replaces the list.
- The page itself is not carried over. The next request to it bundles again, as before, so a reload still picks up an edit on disk. The chunks of the previous build stay served next to the new ones until the following reload.
- Verified: `test/js/bun/http/bun-serve-html.test.ts`, two new cases for `development: false` and `{ hmr: false }`, each at `/` and at `/index.html` (eight tests, all fail on 1.4.3). Also the other `bun-serve-html-*` files and `bun-serve-routes.test.ts`.

### Background
- An html import route is a `html_bundle::Route`. The first request to it runs the bundler. `on_complete` turns each output into a `StaticRoute`, appends it to `config.static_routes`, and re-registers every route on the uws app.
- `config.static_routes` is input state. `server.reload()` replaces it with the list parsed from the new config. Function routes and html routes come from that new config. The chunk routes have no source in it.
- The dev server (`development: true`) keys its route bundles on the html file and is not affected.

<details><summary>Notes</summary>

- Reported by a fuzz soak, not a tracker issue: 9 of about 110k asset fetches 404'd, each within 0.5 s of a `server.reload()`.
- Probe against the fix: 8 concurrent clients fetching a chunk while the server reloads every 10 ms for 5 s. 3589 fetches, 0 with status 404, 244 reloads. Before the fix the same probe produced 404s after every reload.
- Adoption keys on `HTMLBundle` pointer identity. A reload with a different `HTMLBundle` object for the same file (for example after `bun --hot` re-evaluates the import) does not adopt. The next page request bundles and registers the chunks as before.
- `adopt_assets` adopts once per new route. The same route can appear under several paths in one config (the `dedupe_html_bundle_map` in `html_route_from_js`), so the loop in `on_reload_from_zig` sees it more than once.
- The page is also registered at its bundler output path (`/index.html`). It is not an asset: a reload drops it so the page bundles again. When an html route is mounted at that same path, the alias replaced the html route in the list after the first build (`normalize_static_routes_list` keeps the later entry), so the page never bundled again and a reload had no old route to take the chunks from. The alias is now skipped in that case.
- Self-reviewed. The first draft also carried the built page over, so a production reload with the same `HTMLBundle` never bundled again. That is a semantic change the docs do not describe (`docs/runtime/http/routing.mdx` says `server.reload()` is how static routes are refreshed). The draft was narrowed to carry only the chunk routes.
- Two related findings from the same soak are not in this PR. `reload({ fetch })` without a `routes` key drops static and html routes but keeps function routes. A failed bundle answers 500 once, then 200 with an empty body (the `State::Err` arm of `on_any_request`).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_UZo6a2 {
  "/": "/tmp/html-css-js_UZo6a2/index.html",
  "/dashboard": "/tmp/html-css-js_UZo6a2/dashboard.html",
}
[0.07ms] bundle index.html 1.09 KB
[0.05ms] bundle dashboard.html 1.27 KB
(pass) serve html [690.30ms]
waitForServer /tmp/bun-serve-html-txt_wHKnRp {
  "/": "/tmp/bun-serve-html-txt_wHKnRp/index.html",
}
[0.69ms] bundle index.html 0.40 KB
HASH rq3x286y
(pass) serve plugins > basic plugin [1367.99ms]
waitForServer /tmp/html-css-js-failing-plugin_fZVSK9 {
  "/": "/tmp/html-css-js-failing-plugin_fZVSK9/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_fZVSK9/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_fZVSK9/styles.css:0
(pass) serve plugins > serve html with failing plugin [593.55ms]
waitForServer /tmp/html-css-js-empty-plugins_flMHUW {
  "/": "/tmp/html-css-js-empty-plugins_flMHUW/index.html",
}
[0.18ms] bu
... (truncated)

release without fix: 8 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_wMqAY8 {
  "/": "/tmp/html-css-js_wMqAY8/index.html",
  "/dashboard": "/tmp/html-css-js_wMqAY8/dashboard.html",
}
[0.01ms] bundle index.html 1.09 KB
[0.00ms] bundle dashboard.html 1.27 KB
(pass) serve html [29.88ms]
waitForServer /tmp/bun-serve-html-txt_ZxAUMc {
  "/": "/tmp/bun-serve-html-txt_ZxAUMc/index.html",
}
[0.02ms] bundle index.html 0.40 KB
HASH rq3x286y
(pass) serve plugins > basic plugin [75.39ms]
waitForServer /tmp/html-css-js-failing-plugin_jbrbPN {
  "/": "/tmp/html-css-js-failing-plugin_jbrbPN/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_jbrbPN/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_jbrbPN/styles.css:0
(pass) serve plugins > serve html with failing plugin [63.12ms]
waitForServer /tmp/html-css-js-empty-plugins_zNclD6 {
  "/": "/tmp/html-css-js-empty-plugins_zNclD6/index.html",
}
[0.02ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [58.01ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_0stm1T {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_N3g4wz {
  "/": "/tmp/html-css-js_N3g4wz/index.html",
  "/dashboard": "/tmp/html-css-js_N3g4wz/dashboard.html",
}
[0.11ms] bundle index.html 1.09 KB
[0.08ms] bundle dashboard.html 1.27 KB
(pass) serve html [897.83ms]
waitForServer /tmp/bun-serve-html-txt_64GmvE {
  "/": "/tmp/bun-serve-html-txt_64GmvE/index.html",
}
[0.16ms] bundle index.html 0.40 KB
HASH rq3x286y
(pass) serve plugins > basic plugin [890.11ms]
waitForServer /tmp/html-css-js-failing-plugin_4xXZ9a {
  "/": "/tmp/html-css-js-failing-plugin_4xXZ9a/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_4xXZ9a/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_4xXZ9a/styles.css:0
(pass) serve plugins > serve html with failing plugin [1033.61ms]
waitForServer /tmp/html-css-js-empty-plugins_B4P3qO {
  "/": "/tmp/html-css-js-empty-plugins_B4P3qO/index.html",
}
[0.12ms] bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 7442ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 57s
[3/8] link bun-profile
rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSSLConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80179190)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSocketConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80179190)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: L
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/HTMLBundle.rs        | 60 ++++++++++++++++----
 src/runtime/server/server_body.rs       | 20 +++++++
 test/js/bun/http/bun-serve-html.test.ts | 97 +++++++++++++++++++++++++++++++++
 3 files changed, 167 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/server/HTMLBundle.rs             3      5     24
src/runtime/server/server_body.rs            2      2     24
test/js/bun/http/bun-serve-html.test.ts      4      1     23
```

</details>

**root cause** · written by the author bot

HTML routes only registered their bundled JS and CSS chunk paths as static routes from the bundle-completion path triggered by a request to the HTML route, and `server.reload()` rebuilt the static route list from the new config, so the previously appended chunk routes were dropped until the next request to the HTML path re-ran the cached completion. The fix makes each HTML route record its built chunk assets on the route object itself, and on reload any matching HTML route in the new config adopts those assets and re-appends them to the static route list so the chunk URLs keep serving witho…

<!-- robobun:evidence:end -->