### PR TITLE
Bun.serve: keep static, file and negative routes on a reload() without a routes object

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1478,10 +1478,10 @@ pub struct FromJSOptions {
     pub(crate) is_fetch_required: bool,
     /// What the running server keeps answering with when a `reload()` config
     /// names no handler, as `on_reload_from_zig` applies it: `fetch` stays
-    /// unless the new config replaces it, and callback routes stay as long as
-    /// the new config has no `routes` object at all (`routes: {}` replaces
-    /// them). Static routes and the node:http handler are replaced on every
-    /// reload, so they count for nothing here. Both are false for `Bun.serve()`.
+    /// unless the new config replaces it, and routes (callback and static)
+    /// stay as long as the new config has no `routes` object at all
+    /// (`routes: {}` replaces them). The node:http handler is cleared on every
+    /// reload, so it counts for nothing here. Both are false for `Bun.serve()`.
     pub(crate) previous_fetch: bool,
     pub(crate) previous_routes: bool,
 }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2150,12 +2150,14 @@ where
             dev_server.html_router.fallback = None;
         }
 
-        // NOTE: `Vec<StaticRouteEntry>` impls `Drop`, so
-        // a move-assign frees the old `static_routes`.
-        self.config.static_routes = core::mem::take(&mut new_config.static_routes);
-        self.config.negative_routes = core::mem::take(&mut new_config.negative_routes);
-
+        // A reload without a `routes` object keeps every kind of route, like
+        // it keeps `fetch` and `error`. `set_routes` registers the kept
+        // static routes again on the cleared app.
         if new_config.had_routes_object {
+            // NOTE: `Vec<StaticRouteEntry>` impls `Drop`, so
+            // a move-assign frees the old `static_routes`.
+            self.config.static_routes = core::mem::take(&mut new_config.static_routes);
+            self.config.negative_routes = core::mem::take(&mut new_config.negative_routes);
             self.config.user_routes_to_build =
                 core::mem::take(&mut new_config.user_routes_to_build);
             // `UserRoute`'s owned `RouteDeclaration` drops via `Vec::clear`.
@@ -2217,7 +2219,8 @@ where
                 allow_bake_config: false,
                 is_fetch_required: true,
                 previous_fetch: !self.config.on_request.is_empty_or_undefined_or_null(),
-                previous_routes: !self.user_routes.is_empty(),
+                previous_routes: !self.user_routes.is_empty()
+                    || !self.config.static_routes.is_empty(),
             },
         )?;
 

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1,7 +1,8 @@
 import type { BunRequest, ServeOptions, Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import net from "node:net";
+import { join } from "node:path";
 
 describe("path parameters", () => {
   let server: Server;
@@ -616,6 +617,60 @@ describe("route reloading", () => {
     const res = await fetch(`${server.url}test`);
     expect(await res.text()).toBe("fallback");
   });
+
+  // A reload without a routes object used to keep the callback routes but
+  // drop the static, file, and negative routes, so those fell through to the
+  // new fetch handler.
+  it("keeps every kind of route on a reload without a routes object", async () => {
+    using dir = tempDir("bun-serve-routes-reload-keeps-static", { "file.txt": "file" });
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("fetch v1", { status: 404 }),
+      routes: {
+        "/static": new Response("static"),
+        "/fn": () => new Response("fn"),
+        "/p/:x": () => new Response("param"),
+        "/file": Bun.file(join(String(dir), "file.txt")),
+        "/negative": false,
+      },
+    });
+    const probe = async () => {
+      const result: Record<string, [number, string]> = {};
+      for (const path of ["/static", "/fn", "/p/1", "/file", "/negative", "/missing"]) {
+        const res = await fetch(new URL(path, server.url));
+        result[path] = [res.status, await res.text()];
+      }
+      return result;
+    };
+    expect(await probe()).toEqual({
+      "/static": [200, "static"],
+      "/fn": [200, "fn"],
+      "/p/1": [200, "param"],
+      "/file": [200, "file"],
+      "/negative": [404, "fetch v1"],
+      "/missing": [404, "fetch v1"],
+    });
+
+    server.reload({ fetch: () => new Response("fetch v2", { status: 404 }) } as ServeOptions);
+    expect(await probe()).toEqual({
+      "/static": [200, "static"],
+      "/fn": [200, "fn"],
+      "/p/1": [200, "param"],
+      "/file": [200, "file"],
+      "/negative": [404, "fetch v2"],
+      "/missing": [404, "fetch v2"],
+    });
+
+    server.reload({ fetch: () => new Response("fetch v3", { status: 404 }), routes: {} } as ServeOptions);
+    expect(await probe()).toEqual({
+      "/static": [404, "fetch v3"],
+      "/fn": [404, "fetch v3"],
+      "/p/1": [404, "fetch v3"],
+      "/file": [404, "fetch v3"],
+      "/negative": [404, "fetch v3"],
+      "/missing": [404, "fetch v3"],
+    });
+  });
 });
 
 describe("reload() keeps the server able to answer", () => {
@@ -659,18 +714,25 @@ describe("reload() keeps the server able to answer", () => {
     expect(await (await fetch(server.url)).text()).toBe("fetch");
   });
 
-  // Unlike callback routes, static routes are replaced by every reload, even
-  // one without a routes object, so they cannot stand in for a missing handler.
-  it("rejects a reload that names no handler on a server whose only routes are static", async () => {
+  it("allows a reload that names no handler at all on a static-routes-only server", async () => {
     using server = Bun.serve({
       port: 0,
       routes: { "/": new Response("static") },
     });
-    expect(() => server.reload({ development: false } as ServeOptions)).toThrow("Bun.serve() needs either:");
+    server.reload({ development: false } as ServeOptions);
     expect(await (await fetch(server.url)).text()).toBe("static");
   });
 
-  // Same for node:http's request handler: a reload that omits it clears it.
+  it("rejects routes: {} on a static-routes-only server, and keeps serving the old routes", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: { "/": new Response("static") },
+    });
+    expect(() => server.reload({ routes: {} } as ServeOptions)).toThrow("Bun.serve() needs either:");
+    expect(await (await fetch(server.url)).text()).toBe("static");
+  });
+
+  // node:http's request handler is cleared by a reload that omits it.
   it("rejects a reload that names no handler on a server whose only handler is onNodeHTTPRequest", () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### Problem
- `server.reload({ fetch })` on a server with a `routes` object kept the callback routes and dropped every other kind. Static `Response` routes, `Bun.file` routes, HTML imports and `false` routes all fell through to the new `fetch` after the reload. A later `reload({ routes })` brought them back.
- The cause is `on_reload_from_zig` (`src/runtime/server/server_body.rs:2153`). It moved `static_routes` and `negative_routes` out of the new config on every reload, but replaced `user_routes_to_build` only under `if new_config.had_routes_object`. A reload config without a `routes` key has empty static and negative lists, so the move emptied them.

### Fix
- A reload without a `routes` object now keeps all route kinds. The three lists and `user_routes` are replaced together, only when the new config has a `routes` object. `set_routes` registers the kept static routes again on the cleared app, the same way `reload_static_routes` already does.
- The no-handler check in `ServerConfig::from_js` now counts kept static routes as a handler (`previous_routes` in `on_reload`). So `reload({ development: false })` on a static-routes-only server goes through and keeps serving, like it already did on a callback-routes-only server. `reload({ routes: {} })` on such a server still throws.
- This flips one pinned case in `bun-serve-routes.test.ts` from #38697, which documented the static-routes drop as is. The docs say a reload updates `fetch`, `error`, `routes` and `websocket`. Omitting `routes` now keeps them, like omitting `fetch` keeps it.
- Verified: `test/js/bun/http/bun-serve-routes.test.ts` (two new cases fail on bun 1.4.3). Also bun-serve-static, bun-serve-file, bun-serve-html, bun-serve-html-hot-reload-drop, serve-directory-routes, bun-server and the reload cases in serve.test.ts.

### Background
- `ServerConfig` holds routes in three lists. `user_routes_to_build` are callback routes. `static_routes` are `Response`, `Bun.file`, directory and HTML routes. `negative_routes` are paths mapped to `false`, which fall through to `fetch`.
- `reload()` parses the new options with the same `ServerConfig::from_js` as `Bun.serve()`, then `on_reload_from_zig` copies the fields it applies into the running server's config and calls `set_routes` to register the routes on the uWS app.
- `had_routes_object` is true when the reload options had a `routes` (or `static`) key. `routes: {}` sets it and removes all routes. A missing key leaves it false.
