### PR TITLE
streams: restore the native source ref when a new reader locks a released stream

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -232,14 +232,16 @@ impl PosixBufferedReader {
         }
     }
 
-    pub fn update_ref(&mut self, value: bool) {
+    /// Returns the previous ref state.
+    pub fn update_ref(&mut self, value: bool) -> bool {
+        let previous = self.flags.contains(PosixFlags::KEEP_ALIVE);
         // Remember the ref state so a poll created later (lazy start) honours
         // an unref() that preceded the first registration.
         self.flags.set(PosixFlags::KEEP_ALIVE, value);
-        let Some(poll) = self.handle.get_poll() else {
-            return;
-        };
-        poll.set_keeping_process_alive(self.vtable.event_loop(), value);
+        if let Some(poll) = self.handle.get_poll() {
+            poll.set_keeping_process_alive(self.vtable.event_loop(), value);
+        }
+        previous
     }
 
     #[inline]
@@ -1013,13 +1015,18 @@ bitflags::bitflags! {
         /// When true, wait for the file operation callback before calling done().
         /// Used to ensure proper cleanup ordering when closing during cancellation.
         const DEFER_DONE_CALLBACK      = 1 << 9;
+        const KEEP_ALIVE               = 1 << 10; // default true
     }
 }
 
 #[cfg(windows)]
 impl WindowsFlags {
     pub(crate) const fn new() -> Self {
-        Self::from_bits_truncate(WindowsFlags::CLOSE_HANDLE.bits() | WindowsFlags::IS_PAUSED.bits())
+        Self::from_bits_truncate(
+            WindowsFlags::CLOSE_HANDLE.bits()
+                | WindowsFlags::IS_PAUSED.bits()
+                | WindowsFlags::KEEP_ALIVE.bits(),
+        )
     }
 }
 
@@ -1098,7 +1105,10 @@ impl WindowsBufferedReader {
         }
     }
 
-    pub fn update_ref(&mut self, value: bool) {
+    /// Returns the previous ref state.
+    pub fn update_ref(&mut self, value: bool) -> bool {
+        let previous = self.flags.contains(WindowsFlags::KEEP_ALIVE);
+        self.flags.set(WindowsFlags::KEEP_ALIVE, value);
         if let Some(source) = self.source.as_mut() {
             if value {
                 source.ref_();
@@ -1106,6 +1116,7 @@ impl WindowsBufferedReader {
                 source.unref();
             }
         }
+        previous
     }
 
     pub fn disable_keeping_process_alive<C>(&mut self, _: C) {

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -64,6 +64,11 @@ public:
     // Body.textStream(): the native source adapter decodes each chunk as UTF-8
     // text before enqueue.
     bool m_nativeTextMode : 1 { false };
+    // Bun: releasing a reader calls updateRef(false) on the native source so an
+    // abandoned stream does not keep the process alive. The next reader to lock
+    // the stream restores that ref. Only a release sets this, so a source that was
+    // unref'd on purpose (proc.unref(), process.stdin.unref()) stays unref'd.
+    bool m_nativeRefDroppedOnRelease : 1 { false };
 
     // [[reader]] — a default reader, a BYOB reader, or null (undefined).
     JSC::WriteBarrier<JSReadableStreamReaderBase> m_reader;

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -64,10 +64,8 @@ public:
     // Body.textStream(): the native source adapter decodes each chunk as UTF-8
     // text before enqueue.
     bool m_nativeTextMode : 1 { false };
-    // Bun: releasing a reader calls updateRef(false) on the native source so an
-    // abandoned stream does not keep the process alive. The next reader to lock
-    // the stream restores that ref. Only a release sets this, so a source that was
-    // unref'd on purpose (proc.unref(), process.stdin.unref()) stays unref'd.
+    // Bun: reader release called updateRef(false) on the native source; the next
+    // reader lock calls updateRef(true). A deliberate unref() never sets this.
     bool m_nativeRefDroppedOnRelease : 1 { false };
 
     // [[reader]] — a default reader, a BYOB reader, or null (undefined).

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -64,8 +64,7 @@ public:
     // Body.textStream(): the native source adapter decodes each chunk as UTF-8
     // text before enqueue.
     bool m_nativeTextMode : 1 { false };
-    // Bun: reader release called updateRef(false) on the native source; the next
-    // reader lock calls updateRef(true). A deliberate unref() never sets this.
+    // Bun: a reader release unref'd the native source; the next reader lock re-refs it.
     bool m_nativeRefDroppedOnRelease : 1 { false };
 
     // [[reader]] — a default reader, a BYOB reader, or null (undefined).

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -477,6 +477,33 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
     return result;
 }
 
+// Bun: calls `updateRef(value)` on the native source handle of a default-controller stream.
+// A no-op for every other stream.
+static void updateNativeSourceRef(JSGlobalObject* globalObject, JSReadableStream* stream, bool value)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (stream->m_controllerKind != ControllerKind::Default)
+        return;
+    auto* controller = defaultControllerOf(stream);
+    if (controller->m_algorithms.kind != SourceKind::Native)
+        return;
+    const auto* adapter = uncheckedDowncast<WebCore::JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
+    auto* handle = adapter->handle();
+    if (!handle)
+        return;
+    JSValue updateRef = handle->getIfPropertyExists(globalObject, builtinNames(vm).updateRefPublicName());
+    RETURN_IF_EXCEPTION(scope, void());
+    if (!updateRef || !updateRef.isCallable())
+        return;
+    auto callData = JSC::getCallData(updateRef);
+    MarkedArgumentBuffer args;
+    args.append(jsBoolean(value));
+    ASSERT(!args.hasOverflowed());
+    JSC::call(globalObject, updateRef, callData, handle, args);
+    RETURN_IF_EXCEPTION(scope, void());
+}
+
 // ReadableStreamReaderGenericInitialize(reader, stream)
 void readableStreamReaderGenericInitialize(JSGlobalObject* globalObject, JSReadableStreamReaderBase* reader, JSReadableStream* stream)
 {
@@ -487,6 +514,13 @@ void readableStreamReaderGenericInitialize(JSGlobalObject* globalObject, JSReada
     switch (stream->m_state) {
     case ReadableStreamState::Readable:
         reader->m_closedPromise.set(vm, reader, JSPromise::create(vm, globalObject->promiseStructure()));
+        // Bun: the previous reader's release dropped the native source's event-loop ref.
+        // This reader is going to read, so put it back.
+        if (stream->m_nativeRefDroppedOnRelease) {
+            stream->m_nativeRefDroppedOnRelease = false;
+            updateNativeSourceRef(globalObject, stream, true);
+            RETURN_IF_EXCEPTION(scope, void());
+        }
         return;
     case ReadableStreamState::Closed: {
         auto* closedPromise = promiseFulfilledWith(globalObject, JSC::jsUndefined());
@@ -546,20 +580,11 @@ void readableStreamReaderGenericRelease(JSGlobalObject* globalObject, JSReadable
         auto* controller = defaultControllerOf(stream);
         controller->releaseSteps();
         // Bun: drop the native handle's event-loop ref when its consumer releases the lock.
+        // The next reader to lock the stream restores it (readableStreamReaderGenericInitialize).
         if (controller->m_algorithms.kind == SourceKind::Native) {
-            const auto* adapter = uncheckedDowncast<WebCore::JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
-            if (auto* handle = adapter->handle()) {
-                JSValue updateRef = handle->getIfPropertyExists(globalObject, builtinNames(vm).updateRefPublicName());
-                RETURN_IF_EXCEPTION(scope, void());
-                if (updateRef && updateRef.isCallable()) {
-                    auto callData = JSC::getCallData(updateRef);
-                    MarkedArgumentBuffer args;
-                    args.append(jsBoolean(false));
-                    ASSERT(!args.hasOverflowed());
-                    JSC::call(globalObject, updateRef, callData, handle, args);
-                    RETURN_IF_EXCEPTION(scope, void());
-                }
-            }
+            stream->m_nativeRefDroppedOnRelease = true;
+            updateNativeSourceRef(globalObject, stream, false);
+            RETURN_IF_EXCEPTION(scope, void());
         }
         break;
     }

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -477,8 +477,7 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
     return result;
 }
 
-// Bun: `updateRef(value)` on a default-controller native source handle. Returns whether the
-// source held a ref before the call; false when there is no such handle.
+// Bun: `updateRef(value)` on the native source handle, if any; returns the previous ref state.
 static bool updateNativeSourceRef(JSGlobalObject* globalObject, JSReadableStream* stream, bool value)
 {
     auto& vm = getVM(globalObject);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -477,8 +477,7 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
     return result;
 }
 
-// Bun: calls `updateRef(value)` on the native source handle of a default-controller stream.
-// A no-op for every other stream.
+// Bun: `updateRef(value)` on a default-controller native source handle; no-op otherwise.
 static void updateNativeSourceRef(JSGlobalObject* globalObject, JSReadableStream* stream, bool value)
 {
     auto& vm = getVM(globalObject);
@@ -514,8 +513,7 @@ void readableStreamReaderGenericInitialize(JSGlobalObject* globalObject, JSReada
     switch (stream->m_state) {
     case ReadableStreamState::Readable:
         reader->m_closedPromise.set(vm, reader, JSPromise::create(vm, globalObject->promiseStructure()));
-        // Bun: the previous reader's release dropped the native source's event-loop ref.
-        // This reader is going to read, so put it back.
+        // Bun: restore the event-loop ref that the previous reader's release dropped.
         if (stream->m_nativeRefDroppedOnRelease) {
             stream->m_nativeRefDroppedOnRelease = false;
             updateNativeSourceRef(globalObject, stream, true);
@@ -580,7 +578,6 @@ void readableStreamReaderGenericRelease(JSGlobalObject* globalObject, JSReadable
         auto* controller = defaultControllerOf(stream);
         controller->releaseSteps();
         // Bun: drop the native handle's event-loop ref when its consumer releases the lock.
-        // The next reader to lock the stream restores it (readableStreamReaderGenericInitialize).
         if (controller->m_algorithms.kind == SourceKind::Native) {
             stream->m_nativeRefDroppedOnRelease = true;
             updateNativeSourceRef(globalObject, stream, false);

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -477,30 +477,32 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
     return result;
 }
 
-// Bun: `updateRef(value)` on a default-controller native source handle; no-op otherwise.
-static void updateNativeSourceRef(JSGlobalObject* globalObject, JSReadableStream* stream, bool value)
+// Bun: `updateRef(value)` on a default-controller native source handle. Returns whether the
+// source held a ref before the call; false when there is no such handle.
+static bool updateNativeSourceRef(JSGlobalObject* globalObject, JSReadableStream* stream, bool value)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (stream->m_controllerKind != ControllerKind::Default)
-        return;
+        return false;
     auto* controller = defaultControllerOf(stream);
     if (controller->m_algorithms.kind != SourceKind::Native)
-        return;
+        return false;
     const auto* adapter = uncheckedDowncast<WebCore::JSNativeStreamSourceAdapter>(controller->m_algorithms.algorithmContext.get());
     auto* handle = adapter->handle();
     if (!handle)
-        return;
+        return false;
     JSValue updateRef = handle->getIfPropertyExists(globalObject, builtinNames(vm).updateRefPublicName());
-    RETURN_IF_EXCEPTION(scope, void());
+    RETURN_IF_EXCEPTION(scope, false);
     if (!updateRef || !updateRef.isCallable())
-        return;
+        return false;
     auto callData = JSC::getCallData(updateRef);
     MarkedArgumentBuffer args;
     args.append(jsBoolean(value));
     ASSERT(!args.hasOverflowed());
-    JSC::call(globalObject, updateRef, callData, handle, args);
-    RETURN_IF_EXCEPTION(scope, void());
+    JSValue previous = JSC::call(globalObject, updateRef, callData, handle, args);
+    RETURN_IF_EXCEPTION(scope, false);
+    return previous.isTrue();
 }
 
 // ReadableStreamReaderGenericInitialize(reader, stream)
@@ -578,10 +580,11 @@ void readableStreamReaderGenericRelease(JSGlobalObject* globalObject, JSReadable
         auto* controller = defaultControllerOf(stream);
         controller->releaseSteps();
         // Bun: drop the native handle's event-loop ref when its consumer releases the lock.
+        // A source the user already unref'd has nothing to drop, so nothing gets restored later.
         if (controller->m_algorithms.kind == SourceKind::Native) {
-            stream->m_nativeRefDroppedOnRelease = true;
-            updateNativeSourceRef(globalObject, stream, false);
+            bool wasRef = updateNativeSourceRef(globalObject, stream, false);
             RETURN_IF_EXCEPTION(scope, void());
+            stream->m_nativeRefDroppedOnRelease = wasRef;
         }
         break;
     }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -866,11 +866,12 @@ impl FileReader {
         Vec::<u8>::move_from_list(mem::take(self.reader().buffer()))
     }
 
-    pub(crate) fn set_ref_or_unref(&self, enable: bool) {
+    /// Returns the previous ref state. A finished reader has none.
+    pub(crate) fn set_ref_or_unref(&self, enable: bool) -> bool {
         if self.done.get() {
-            return;
+            return false;
         }
-        self.reader().update_ref(enable);
+        self.reader().update_ref(enable)
     }
 
     fn consume_reader_buffer(&self) {
@@ -1091,7 +1092,7 @@ impl readable_stream::SourceContext for FileReader {
     fn finalize_detach(&mut self) -> bool {
         Self::finalize_detach(self)
     }
-    fn set_ref_unref(&mut self, e: bool) {
+    fn set_ref_unref(&mut self, e: bool) -> bool {
         Self::set_ref_or_unref(self, e)
     }
     fn drain_internal_buffer(&mut self) -> Vec<u8> {

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -805,8 +805,10 @@ pub trait SourceContext: Sized {
     /// sweep: no JS. `ByteStream` tells a parked producer nobody can read it now.
     fn wrapper_finalized(&mut self) {}
 
-    /// `setRefUnrefFn` — default no-op.
-    fn set_ref_unref(&mut self, _enable: bool) {}
+    /// `setRefUnrefFn` — returns the previous ref state. Default no-op with no ref.
+    fn set_ref_unref(&mut self, _enable: bool) -> bool {
+        false
+    }
 
     /// `drainInternalBuffer` — default returns empty.
     fn drain_internal_buffer(&mut self) -> Vec<u8> {
@@ -1097,9 +1099,12 @@ impl<C: SourceContext> NewSource<C> {
         unsafe { &mut *Self::new(init) }
     }
 
-    pub fn set_ref(&mut self, value: bool) {
+    /// Returns the previous ref state.
+    pub fn set_ref(&mut self, value: bool) -> bool {
         if C::SUPPORTS_REF {
-            self.context.set_ref_unref(value);
+            self.context.set_ref_unref(value)
+        } else {
+            false
         }
     }
 
@@ -1502,8 +1507,8 @@ impl<C: SourceContext> NewSource<C> {
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let ref_or_unref = call_frame.argument(0).to_boolean();
-        self.set_ref(ref_or_unref);
-        Ok(JSValue::UNDEFINED)
+        // The previous state, so a caller can restore only what it changed.
+        Ok(JSValue::js_boolean(self.set_ref(ref_or_unref)))
     }
 
     pub fn finalize(self: Box<Self>) {

--- a/test/js/bun/console/console-iterator.test.ts
+++ b/test/js/bun/console/console-iterator.test.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 describe("should work for static input", () => {
   const inputs = [
@@ -73,4 +73,130 @@ it("can use the console iterator more than once", async () => {
 
   expect(await stdout.text()).toBe('["hello","world"]["another"]');
   proc.kill(0);
+});
+
+// Bun.stdin.stream() is one stream per process. Releasing its reader (which the
+// console iterator does when the loop breaks) unrefs the native stdin reader so
+// an abandoned stream does not keep the process alive. The next reader on that
+// stream must ref it again, or the process exits with code 0 while a read is
+// still pending. No top-level await in the child: it would keep the loop alive
+// and hide the bug.
+describe("a later stdin consumer keeps the process alive after the reader is released", () => {
+  const afterConsoleBreak = `
+    (async () => {
+      for await (const line of console) {
+        console.log("ITER " + line);
+        break;
+      }
+      console.log("READY");
+      for await (const chunk of Bun.stdin.stream()) {
+        console.log("STREAM " + new TextDecoder().decode(chunk).trim());
+        break;
+      }
+      console.log("DONE");
+    })();
+  `;
+
+  const afterReleaseLock = `
+    (async () => {
+      const decoder = new TextDecoder();
+      const first = Bun.stdin.stream().getReader();
+      console.log("FIRST " + decoder.decode((await first.read()).value).trim());
+      first.releaseLock();
+      console.log("READY");
+      const second = Bun.stdin.stream().getReader();
+      console.log("SECOND " + decoder.decode((await second.read()).value).trim());
+      second.releaseLock();
+      console.log("DONE");
+    })();
+  `;
+
+  async function runWithPipe(script: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", script],
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let output = "";
+    async function waitFor(marker: string) {
+      while (!output.includes(marker)) {
+        const { value, done } = await reader.read();
+        if (done) throw new Error(`stdout ended before ${JSON.stringify(marker)}; output=${JSON.stringify(output)}`);
+        output += decoder.decode(value, { stream: true });
+      }
+    }
+
+    proc.stdin.write("first\n");
+    proc.stdin.flush();
+    await waitFor("READY\n");
+    proc.stdin.write("second\n");
+    proc.stdin.flush();
+    await waitFor("DONE\n");
+    for (let { value, done } = await reader.read(); !done; { value, done } = await reader.read()) {
+      output += decoder.decode(value, { stream: true });
+    }
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return output;
+  }
+
+  async function runWithTerminal(script: string) {
+    const decoder = new TextDecoder();
+    let output = "";
+    let waiting: { marker: string; resolve: () => void } | undefined;
+    function waitFor(marker: string) {
+      return new Promise<void>((resolve, reject) => {
+        waiting = { marker, resolve };
+        proc.exited.then(code =>
+          reject(
+            new Error(`child exited with ${code} before ${JSON.stringify(marker)}; output=${JSON.stringify(output)}`),
+          ),
+        );
+        if (output.includes(marker)) resolve();
+      });
+    }
+    const proc = spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      terminal: {
+        data(_terminal, chunk) {
+          output += decoder.decode(chunk, { stream: true });
+          if (waiting && output.includes(waiting.marker)) waiting.resolve();
+        },
+      },
+    });
+    const terminal = proc.terminal!;
+    terminal.write("first\n");
+    await waitFor("READY");
+    terminal.write("second\n");
+    await waitFor("DONE");
+    expect(await proc.exited).toBe(0);
+    terminal.close();
+    return output;
+  }
+
+  it("Bun.stdin.stream() after the console iterator breaks (pipe)", async () => {
+    expect(await runWithPipe(afterConsoleBreak)).toBe("ITER first\nREADY\nSTREAM second\nDONE\n");
+  });
+
+  it("a second reader after releaseLock() (pipe)", async () => {
+    expect(await runWithPipe(afterReleaseLock)).toBe("FIRST first\nREADY\nSECOND second\nDONE\n");
+  });
+
+  it.skipIf(isWindows)("Bun.stdin.stream() after the console iterator breaks (tty)", async () => {
+    const output = await runWithTerminal(afterConsoleBreak);
+    expect(output).toContain("ITER first");
+    expect(output).toContain("STREAM second");
+  });
+
+  it.skipIf(isWindows)("a second reader after releaseLock() (tty)", async () => {
+    const output = await runWithTerminal(afterReleaseLock);
+    expect(output).toContain("FIRST first");
+    expect(output).toContain("SECOND second");
+  });
 });

--- a/test/js/bun/console/console-iterator.test.ts
+++ b/test/js/bun/console/console-iterator.test.ts
@@ -149,6 +149,17 @@ describe("a later stdin consumer keeps the process alive after the reader is rel
     const decoder = new TextDecoder();
     let output = "";
     let waiting: { marker: string; resolve: () => void } | undefined;
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      terminal: {
+        data(_terminal, chunk) {
+          output += decoder.decode(chunk, { stream: true });
+          if (waiting && output.includes(waiting.marker)) waiting.resolve();
+        },
+      },
+    });
+    await using terminal = proc.terminal!;
     function waitFor(marker: string) {
       return new Promise<void>((resolve, reject) => {
         waiting = { marker, resolve };
@@ -160,23 +171,11 @@ describe("a later stdin consumer keeps the process alive after the reader is rel
         if (output.includes(marker)) resolve();
       });
     }
-    const proc = spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      terminal: {
-        data(_terminal, chunk) {
-          output += decoder.decode(chunk, { stream: true });
-          if (waiting && output.includes(waiting.marker)) waiting.resolve();
-        },
-      },
-    });
-    const terminal = proc.terminal!;
     terminal.write("first\n");
     await waitFor("READY");
     terminal.write("second\n");
     await waitFor("DONE");
     expect(await proc.exited).toBe(0);
-    terminal.close();
     return output;
   }
 

--- a/test/js/bun/console/console-iterator.test.ts
+++ b/test/js/bun/console/console-iterator.test.ts
@@ -198,4 +198,39 @@ describe("a later stdin consumer keeps the process alive after the reader is rel
     expect(output).toContain("FIRST first");
     expect(output).toContain("SECOND second");
   });
+
+  // Only a ref that the release itself dropped comes back. A source the user
+  // unref'd on purpose stays unref'd across a releaseLock()/getReader() cycle.
+  it("a second reader does not undo an explicit unref()", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const child = Bun.spawn({
+          cmd: [${JSON.stringify(bunExe())}, "-e", "console.log('hi'); setTimeout(() => {}, 60_000)"],
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "ignore",
+        });
+        process.on("exit", () => child.kill());
+        child.unref();
+        const first = child.stdout.getReader();
+        await first.read();
+        first.releaseLock();
+        const second = child.stdout.getReader();
+        second.read().then(() => console.log("unexpected second read"));
+        console.log("DONE");
+        `,
+      ],
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("DONE\n");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- After `for await (const line of console) { break; }`, a later `for await (const chunk of Bun.stdin.stream())` never sees the next line. The process exits with code 0 while that read is still pending. A plain `getReader()` / `read()` / `releaseLock()` / `getReader()` / `read()` sequence fails the same way. Pipe and tty stdin both reproduce.
- `Bun.stdin.stream()` is one `ReadableStream` per process (`Blob.rs:1212` caches it for fd-backed blobs). `readableStreamReaderGenericRelease` (`src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp:548`) calls `updateRef(false)` on the native source when a reader releases its lock. Nothing called `updateRef(true)` again, so the stdin poll no longer kept the event loop alive for the next reader. `process.stdin` was not affected because its `own()` calls `updateRef(true)` itself.

### Fix
- `updateRef(value)` on a native source handle now returns the previous ref state (`BufferedReader::update_ref` on both platforms, through `FileReader::set_ref_or_unref` and `NewSource::update_ref_from_js`).
- `readableStreamReaderGenericRelease` records on the stream that it dropped a held ref (new bit `m_nativeRefDroppedOnRelease` in `JSReadableStream.h`). `readableStreamReaderGenericInitialize` clears that bit when a new reader locks a still-readable stream and calls `updateRef(true)`. Both share the helper `updateNativeSourceRef`.
- A source that was already unref'd on purpose (`proc.unref()` before reading `proc.stdout`, `process.stdin.unref()`) has nothing for the release to drop, so a later reader leaves it unref'd.
- Verified: `test/js/bun/console/console-iterator.test.ts` (5 new cases: pipe and tty, console iterator and plain reader, and the explicit `unref()` case; the first 4 fail on bun 1.4.3). Also ran spawn, terminal, process.stdin, web streams and node stdin fixture suites, and `cargo check` for the Windows target.

### Background
- A native `ReadableStream` source (here `FileReader` in `src/runtime/webcore/FileReader.rs`) owns a `FilePoll` on the fd. `updateRef(true/false)` tells the poll whether it keeps the event loop alive. With the ref dropped and nothing else active, Bun exits as soon as the JS stack unwinds, even with a `read()` promise pending.
- The release-time unref exists so an abandoned `Bun.stdin.stream()` reader does not hold the process open. It dates from the original `process.stdin` work (c8305df5c2) and was carried into the C++ streams rewrite (#33193). This change keeps it and adds the missing other half.
- The console async iterator (`src/js/builtins/ConsoleObject.ts`) releases its reader in `finally`, so `break` or `throw` in the loop is the common way to hit this.

<details><summary>Notes</summary>

- The handoff that led here described two fds competing for the same pty. That is not what happens: there is one cached stream and one `FileReader`. The symptom (lines typed after the first loop never reach the next consumer) is the early exit.
- Top-level `await` in the child hides the bug because the pending module promise keeps the loop alive. The new tests use an async IIFE.
- The Windows reader had no stored ref state (`update_ref` called `uv_ref`/`uv_unref` directly). It now keeps a `KEEP_ALIVE` flag like the POSIX reader so it can report the previous state. `WindowsBufferedReader::from` already copies flags, so a `proc.unref()` before the stdout stream exists is preserved.
- `test/js/node/process/stdin/stdin-fixtures.test.ts` fails under this debug (ASAN) build with and without the change: its 1 s auto-kill timer is shorter than the 1.6 s `process.stdin` bootstrap under ASAN. With the timer raised locally all 6 pass.
- Self-reviewed: 14 concerns raised, none survived. A later review asked for the previous-state check (done in 848c5f630a).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/console/console-iterator.test.ts

<!-- robobun:evidence:end -->