### PR TITLE
install: remove the staging directory after an extraction replaces a cache entry

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -593,6 +593,8 @@ pub fn do_patch_commit(
         Output::err(e, "failed renaming patch file to patches dir", ());
         Global::crash();
     }
+    // After an exchange the temporary name holds the patch file that was replaced.
+    let _ = sys::unlinkat(tmpdir, tempfile_name);
 
     let patchfile_path: Box<[u8]> = Box::<[u8]>::from(path_in_patches_dir.as_bytes());
     let _ = sys::unlink(resolve_path::join_z::<platform::Auto>(&[

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -697,6 +697,8 @@ impl ExtractTarball {
                     );
                     return Err(crate::Error::InstallFailed);
                 }
+                // After an exchange the temporary name holds the cache entry that was replaced.
+                let _ = tmpdir.delete_tree(tmpname.as_bytes());
             }
 
             // We return a resolved absolute absolute file path to the cache dir.

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -596,6 +596,8 @@ impl PatchTask {
             );
             return Ok(());
         }
+        // After an exchange the temporary name holds the cache entry that was replaced.
+        let _ = sys::Dir::borrow(&system_tmpdir).delete_tree(path_in_tmpdir.as_bytes());
         Ok(())
     }
 

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -951,3 +951,63 @@ test("streaming extract skips a damaged header block and extracts the entries af
   }
   expect(exitCode).toBe(0);
 });
+
+// -------------------------------------------------------------------
+// A tarball is extracted into a staging directory under the temp dir
+// and then renamed into the cache. When the cache already holds that
+// entry, the rename swaps the two directories, so the staging name now
+// holds the replaced cache entry. It must be removed, or every warm
+// install leaves a full package copy behind in $TMPDIR.
+// -------------------------------------------------------------------
+test("extracting over an existing cache entry leaves nothing behind in the temp dir", async () => {
+  const pkgJson = Buffer.from(JSON.stringify({ name: "warm-pkg", version: "1.0.0", main: "index.js" }) + "\n");
+  const body = Buffer.from("module.exports = 1;\n");
+  const tar = Buffer.concat([
+    tarHeader("package/package.json", pkgJson.length, "0"),
+    pkgJson,
+    pad512(pkgJson.length),
+    tarHeader("package/index.js", body.length, "0"),
+    body,
+    pad512(body.length),
+    Buffer.alloc(1024, 0),
+  ]);
+  const tgz = gzipSync(tar);
+
+  const manifest = JSON.stringify({
+    name: "app",
+    version: "1.0.0",
+    dependencies: { "warm-pkg": "file:../warm-pkg.tgz" },
+  });
+  using dir = tempDir("warm-cache-tmp", {
+    "a/package.json": manifest,
+    "b/package.json": manifest,
+    "tmp/.keep": "",
+  });
+  writeFileSync(join(String(dir), "warm-pkg.tgz"), tgz);
+
+  const tmp = join(String(dir), "tmp");
+  const env = {
+    BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"),
+    BUN_TMPDIR: tmp,
+    TMPDIR: tmp,
+    TEMP: tmp,
+    TMP: tmp,
+  };
+
+  // Cold cache: the staging dir is renamed into the cache.
+  const cold = await runInstall(join(String(dir), "a"), env);
+  expect(cold.stderr).not.toContain("error:");
+  expect(cold.exitCode).toBe(0);
+  expect(await readdirSorted(tmp)).toEqual([".keep"]);
+
+  // Warm cache, no lockfile: the tarball is extracted again and the new
+  // extraction replaces the cache entry.
+  const warm = await runInstall(join(String(dir), "b"), env);
+  expect(warm.stderr).not.toContain("error:");
+  expect(warm.exitCode).toBe(0);
+  expect(await readdirSorted(tmp)).toEqual([".keep"]);
+
+  expect(readFileSync(join(String(dir), "b", "node_modules", "warm-pkg", "index.js"), "utf8")).toBe(
+    "module.exports = 1;\n",
+  );
+});

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,6 +1,6 @@
 import { $, ShellOutput } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { lstatSync, readFileSync } from "fs";
+import { lstatSync, readdirSync, readFileSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDir, VerdaccioRegistry } from "harness";
 import { isAbsolute, join, sep } from "path";
 
@@ -1230,5 +1230,60 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
     // name-only argument exercises the name-and-version lookup path
     const patchKey = await expectPatchFlowWorks(String(dir), env, "pkg-to-patch");
     expect(patchKey).toBe("pkg-to-patch@./dep.tgz");
+  });
+
+  // The patch file is written under the temp dir and renamed into patches/.
+  // When the patch file already exists the rename is an exchange, so the
+  // temporary name then holds the old patch file. It must be removed.
+  test("committing a patch a second time leaves nothing behind in the temp dir", async () => {
+    await using dir = tempDir("patch-commit-twice", {
+      "package.json": JSON.stringify({
+        name: "test-patch-twice",
+        dependencies: { "pkg-to-patch": "file:./dep.tgz" },
+      }),
+      "tarball-src": {
+        "package": {
+          "package.json": JSON.stringify({ name: "pkg-to-patch", version: "1.0.0" }),
+          "index.js": `module.exports = "original";\n`,
+        },
+      },
+      "tmp/.keep": "",
+    });
+
+    await using tarProc = Bun.spawn({
+      cmd: ["tar", "-czf", join(String(dir), "dep.tgz"), "-C", join(String(dir), "tarball-src"), "package"],
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(await tarProc.exited).toBe(0);
+
+    const tmp = join(String(dir), "tmp");
+    const env = {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+      BUN_TMPDIR: tmp,
+      TMPDIR: tmp,
+      TEMP: tmp,
+      TMP: tmp,
+    };
+
+    await expectPatchFlowWorks(String(dir), env, "pkg-to-patch");
+    expect(readdirSync(tmp)).toEqual([".keep"]);
+
+    {
+      const { stderr, exitCode } = await runBun(String(dir), env, "patch", "pkg-to-patch");
+      expect(exitCode, `bun patch failed: ${stderr}`).toBe(0);
+    }
+    await Bun.write(join(String(dir), "node_modules", "pkg-to-patch", "index.js"), `module.exports = "again";\n`);
+    {
+      const { stderr, exitCode } = await runBun(String(dir), env, "patch", "--commit", "pkg-to-patch");
+      expect(exitCode, `bun patch --commit failed: ${stderr}`).toBe(0);
+    }
+
+    const pkg = await Bun.file(join(String(dir), "package.json")).json();
+    const [, patchPath] = Object.entries(pkg.patchedDependencies)[0] as [string, string];
+    expect(await Bun.file(join(String(dir), patchPath)).text()).toContain('+module.exports = "again";');
+    expect(readdirSync(tmp)).toEqual([".keep"]);
   });
 });


### PR DESCRIPTION
### Problem
- `bun install` of a `file:` tarball dependency on a warm cache leaves a full copy of the package behind in `$TMPDIR` on every install. The leftover is named `.<16 hex>-1.<pkg>`. Six installs of a two-tarball project leave twelve directories.
- The cause is in `move_to_cache_directory` (`src/install/extract_tarball.rs:678`). The extraction lands in a staging directory under the temp dir. `renameat_concurrently` then moves it into the cache. When the cache already holds the entry, the move is a `RENAME_EXCHANGE`, so the staging name now holds the replaced cache entry. Nothing deleted it.

### Fix
- After the rename succeeds, delete the staging name in the temp dir. After a plain rename the name is gone and the delete is a no-op. After an exchange it removes the old cache entry.
- This matches what the Windows arm of the same function already does (it renames the old entry back into the temp dir and deletes it) and what `git_runner.rs` does after its publish rename.
- Verified: `test/cli/install/bun-install-streaming-extract.test.ts` (new test, stock bun fails it with one leftover directory). Also ran all of that file, `bun-install-hardlink-fallback.test.ts` and `bun-install-tarball-integrity.test.ts`.

### Background
- A `file:` tarball dependency is extracted during resolution when there is no lockfile, because bun has to read its `package.json` to learn the name and version. So a warm cache still extracts.
- `renameat_concurrently` (`src/sys/lib.rs:8989`) tries `renameat2(RENAME_NOREPLACE)`, then `renameat2(RENAME_EXCHANGE)`, then delete plus rename. The exchange arm is the one that swaps the two directories.
- Installed files are hardlinks of the cache entry. Deleting the old entry does not affect a project that already links to it.

<details><summary>Notes</summary>

Repro with the released bun (1.4.2):

```
T=$(mktemp -d); export BUN_INSTALL_CACHE_DIR=$T/cache TMPDIR=$T/tmp BUN_TMPDIR=$T/tmp; mkdir -p $T/tmp $T/pk $T/a $T/b
printf '{"name":"dep","version":"1.0.0","main":"index.js"}' > $T/pk/package.json; echo 'module.exports=1' > $T/pk/index.js; (cd $T/pk && bun pm pack --quiet)
for p in a b; do printf '{"name":"%s","dependencies":{"dep":"file:../pk/dep-1.0.0.tgz"}}' $p > $T/$p/package.json; done
(cd $T/a && bun install); ls -A $T/tmp | wc -l    # 0
(cd $T/b && bun install); ls -A $T/tmp            # .<hex>-1.dep
```

The same Zig code had the same omission, so this is not a regression. The comment above the rename call already described step "2b. Delete the temporary directory version", which was never implemented on POSIX.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-patch.test.ts

<!-- robobun:evidence:end -->