### PR TITLE
Bun.serve: close the connection when a body stream fails before its first flush

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2309,6 +2309,25 @@ where
             .response_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
 
+        // A direct stream's synchronous `controller.close(error)`: the sink
+        // dropped its buffered prefix, and the stream is already errored and
+        // unlocked, so it must not fall through to `render_missing()`.
+        if response_stream.sink.is_failed() {
+            stream_log!("failed");
+            response_stream.sink.on_first_write = None;
+            response_stream.sink.ctx = None;
+            ResponseStreamJSSink::<SSL_ENABLED>::detach(
+                &mut response_stream.sink.source,
+                global_this,
+            );
+            response_stream.sink.finalize();
+            this.sink.set(None);
+            Self::destroy_sink(response_stream_ptr);
+            readable_ref.deinit();
+            this.close_incomplete_stream();
+            return;
+        }
+
         let is_in_progress = response_stream.sink.has_backpressure
             || !(response_stream.sink.wrote == 0 && response_stream.sink.buffer.len() == 0);
 
@@ -2891,6 +2910,7 @@ where
 
         let mut wrote_anything = false;
         let mut ended_response = false;
+        let mut failed = false;
         if let Some(wrapper) = self.sink_mut() {
             let wrapper_ptr = self
                 .sink
@@ -2900,6 +2920,7 @@ where
             self.flags.set_aborted(aborted);
             wrote_anything = wrapper.sink.wrote > 0;
             ended_response = wrapper.sink.ended_response;
+            failed = wrapper.sink.is_failed();
             if ended_response {
                 // `resp` may be freed; the sink already resumed it. Clear these
                 // before `detach()` below re-enters JS so any drain callback /
@@ -2950,6 +2971,12 @@ where
         // alive here and its still-armed onAborted must be disarmed.
         if !MUX && ended_response {
             self.end_already_responded_stream();
+            return;
+        }
+        // A direct stream's `controller.close(error)` fails the sink but
+        // resolves the pump, so the failure is only visible on the sink.
+        if failed {
+            self.close_incomplete_stream();
             return;
         }
         if !self.flags.has_written_status() {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2309,9 +2309,7 @@ where
             .response_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
 
-        // A direct stream's synchronous `controller.close(error)`: the sink
-        // dropped its buffered prefix, and the stream is already errored and
-        // unlocked, so it must not fall through to `render_missing()`.
+        // A synchronous `controller.close(error)` on a direct stream.
         if response_stream.sink.is_failed() {
             stream_log!("failed");
             response_stream.sink.on_first_write = None;
@@ -2973,8 +2971,7 @@ where
             self.end_already_responded_stream();
             return;
         }
-        // A direct stream's `controller.close(error)` fails the sink but
-        // resolves the pump, so the failure is only visible on the sink.
+        // A direct stream's `controller.close(error)` resolves the pump.
         if failed {
             self.close_incomplete_stream();
             return;

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1809,8 +1809,10 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
     /// body that never completes, so they must not go out: a clean `end()`
     /// would `try_end` them with a `Content-Length`, and the client would
     /// take the truncated body for a complete 200. Drop them and stop. The
-    /// owning `RequestContext` reads `is_failed()` and closes the connection
-    /// without a terminator.
+    /// owning `RequestContext` then closes the connection without a
+    /// terminator: through `handle_reject_stream` when the pump rejects, or
+    /// through `is_failed()` when a direct stream's `controller.close(error)`
+    /// resolves it instead.
     pub(crate) fn fail(&mut self) {
         bun_core::scoped_log!(HTTPServerWritableLog, "fail()");
 
@@ -1825,6 +1827,9 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
                 res.clear_on_writable();
             }
         }
+        // A parked `flush(true)`/`write()` promise could only settle from the
+        // drain callback cleared above; settle it here, as `abort` does.
+        self.flush_promise();
         self.source.close(None);
         self.finalize();
     }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -987,12 +987,10 @@ impl SourceHandle {
 // HTTPServerWritable
 // ──────────────────────────────────────────────────────────────────────────
 
-/// `Done`, `Failed` and `Aborted` are all "done" (no further sends).
-/// `Failed` records that the source failed while bytes were still buffered
-/// here, so the response must be closed as incomplete; `Aborted` records
-/// that the peer went away. `start()` (reachable again through a
-/// `type: "direct"` stream's controller) moves `Done` back to `Writing`; it
-/// bails out first on `Failed` and `Aborted`, which nothing leaves.
+/// `Done`, `Failed` and `Aborted` are all "done" (no further sends). `Failed`:
+/// the source failed, close the response as incomplete. `Aborted`: the peer
+/// went away. `start()` moves `Done` back to `Writing`; nothing leaves the
+/// other two.
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum HTTPServerWritableState {
     Writing,
@@ -1199,8 +1197,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         self.state == HTTPServerWritableState::Failed
     }
 
-    /// `Failed` and `Aborted` are already done and keep their state; callers
-    /// still read `is_failed()` / `is_aborted()` afterwards.
+    /// `Failed` and `Aborted` keep their state.
     pub(crate) fn set_done(&mut self) {
         if self.state == HTTPServerWritableState::Writing {
             self.state = HTTPServerWritableState::Done;
@@ -1805,14 +1802,9 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         bun_sys::Result::Ok(())
     }
 
-    /// The source failed. The bytes still buffered here are the prefix of a
-    /// body that never completes, so they must not go out: a clean `end()`
-    /// would `try_end` them with a `Content-Length`, and the client would
-    /// take the truncated body for a complete 200. Drop them and stop. The
-    /// owning `RequestContext` then closes the connection without a
-    /// terminator: through `handle_reject_stream` when the pump rejects, or
-    /// through `is_failed()` when a direct stream's `controller.close(error)`
-    /// resolves it instead.
+    /// The source failed. Drop the buffered prefix instead of ending with it
+    /// (`end()` would `try_end` it as a complete body with a `Content-Length`).
+    /// The owning `RequestContext` closes the connection without a terminator.
     pub(crate) fn fail(&mut self) {
         bun_core::scoped_log!(HTTPServerWritableLog, "fail()");
 
@@ -1827,8 +1819,8 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
                 res.clear_on_writable();
             }
         }
-        // A parked `flush(true)`/`write()` promise could only settle from the
-        // drain callback cleared above; settle it here, as `abort` does.
+        // The drain callback cleared above was the only thing left to settle a
+        // parked `flush(true)` promise.
         self.flush_promise();
         self.source.close(None);
         self.finalize();

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -987,14 +987,17 @@ impl SourceHandle {
 // HTTPServerWritable
 // ──────────────────────────────────────────────────────────────────────────
 
-/// `Done` and `Aborted` are both "done" (no further sends); `Aborted`
-/// additionally records that the peer went away. `start()` (reachable again
-/// through a `type: "direct"` stream's controller) moves `Done` back to
-/// `Writing`; it bails out first on `Aborted`, which nothing leaves.
+/// `Done`, `Failed` and `Aborted` are all "done" (no further sends).
+/// `Failed` records that the source failed while bytes were still buffered
+/// here, so the response must be closed as incomplete; `Aborted` records
+/// that the peer went away. `start()` (reachable again through a
+/// `type: "direct"` stream's controller) moves `Done` back to `Writing`; it
+/// bails out first on `Failed` and `Aborted`, which nothing leaves.
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum HTTPServerWritableState {
     Writing,
     Done,
+    Failed,
     Aborted,
 }
 
@@ -1192,8 +1195,12 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         self.state == HTTPServerWritableState::Aborted
     }
 
-    /// `Aborted` is already done and stays `Aborted`; callers still read
-    /// `is_aborted()` afterwards.
+    pub(crate) fn is_failed(&self) -> bool {
+        self.state == HTTPServerWritableState::Failed
+    }
+
+    /// `Failed` and `Aborted` are already done and keep their state; callers
+    /// still read `is_failed()` / `is_aborted()` afterwards.
     pub(crate) fn set_done(&mut self) {
         if self.state == HTTPServerWritableState::Writing {
             self.state = HTTPServerWritableState::Done;
@@ -1485,7 +1492,11 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
     }
 
     pub(crate) fn start(&mut self, stream_start: &Start) -> bun_sys::Result<()> {
-        if self.is_aborted() || self.res.is_none() || self.any_res().unwrap().has_responded() {
+        if self.is_aborted()
+            || self.is_failed()
+            || self.res.is_none()
+            || self.any_res().unwrap().has_responded()
+        {
             self.mark_done();
             self.source.close(None);
             return bun_sys::Result::Ok(());
@@ -1794,6 +1805,30 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         bun_sys::Result::Ok(())
     }
 
+    /// The source failed. The bytes still buffered here are the prefix of a
+    /// body that never completes, so they must not go out: a clean `end()`
+    /// would `try_end` them with a `Content-Length`, and the client would
+    /// take the truncated body for a complete 200. Drop them and stop. The
+    /// owning `RequestContext` reads `is_failed()` and closes the connection
+    /// without a terminator.
+    pub(crate) fn fail(&mut self) {
+        bun_core::scoped_log!(HTTPServerWritableLog, "fail()");
+
+        if !self.is_done() {
+            self.state = HTTPServerWritableState::Failed;
+            self.unregister_auto_flusher();
+            self.buffer.clear();
+            self.offset = 0;
+            self.requested_end = true;
+            self.end_len = 0;
+            if let Some(res) = self.any_res() {
+                res.clear_on_writable();
+            }
+        }
+        self.source.close(None);
+        self.finalize();
+    }
+
     pub(crate) fn end_from_js(&mut self, global_this: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         bun_core::scoped_log!(HTTPServerWritableLog, "endFromJS()");
 
@@ -2073,6 +2108,15 @@ impl<const SSL: bool> crate::webcore::sink::JsSinkType for HTTPServerWritable<SS
         // `destroy` frees it (never the inherent `finalize`), so the `&mut`
         // scoped to this call stays valid throughout.
         unsafe { (*this).finalize() }
+    }
+    unsafe fn close_with_error(
+        this: *mut Self,
+        _global: &JSGlobalObject,
+        _reason: JSValue,
+    ) -> bun_sys::Result<()> {
+        // SAFETY: caller contract; `fail` does not free the sink.
+        unsafe { (*this).fail() };
+        bun_sys::Result::Ok(())
     }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         Self::end_from_js(self, global)

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -102,6 +102,45 @@ const sources: Record<string, () => ReadableStream> = {
         c.close();
       },
     }),
+  // A direct stream that fails through its own controller, synchronously:
+  // the write is still buffered in the sink when close(error) arrives.
+  "direct-close-error": () =>
+    new ReadableStream({
+      type: "direct",
+      pull(c) {
+        c.write('{"rows":[1,');
+        c.close(new Error("boom"));
+      },
+    }),
+  // Same, after the first chunk is already on the wire. The second write is
+  // still buffered when close(error) arrives.
+  "direct-mid-stream-close-error": () =>
+    new ReadableStream({
+      type: "direct",
+      async pull(c) {
+        const reached = chunkReachedClient();
+        c.write("chunk-a");
+        await reached;
+        c.write("chunk-b");
+        c.close(new Error("boom"));
+      },
+    }),
+  // A flush() promise is still parked when close(error) arrives. The failed
+  // sink must settle it, or the request waits on it until the client goes
+  // away. The parked flush is resolved, so the pull itself completes.
+  "direct-flush-then-close-error": () =>
+    new ReadableStream({
+      type: "direct",
+      async pull(c) {
+        const reached = chunkReachedClient();
+        c.write("chunk-a");
+        await reached;
+        c.write(Buffer.alloc(16 * 1024 * 1024, "b"));
+        const flushed = c.flush(true);
+        c.close(new Error("boom"));
+        await flushed;
+      },
+    }),
   // highWaterMark: 0 defers the first pull() until the server's own reader
   // asks for data, so the stream is still readable when the server commits to
   // streaming and only errors inside the microtask drain that follows.

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -75,6 +75,33 @@ const sources: Record<string, () => ReadableStream> = {
         throw new Error("boom");
       },
     }),
+  // The first pull() hands the sink some body bytes and returns; the second
+  // throws in the same turn, before the sink has flushed anything. The sink
+  // used to end cleanly with the buffered prefix as a complete body:
+  // `200 OK` with `Content-Length: 11`.
+  "enqueue-then-pull-throw": () => {
+    let pulls = 0;
+    return new ReadableStream({
+      pull(c) {
+        if (pulls++ === 0) {
+          c.enqueue(new TextEncoder().encode('{"rows":[1,'));
+          return;
+        }
+        throw new Error("boom");
+      },
+    });
+  },
+  // Same window, but the failure is the pump's: the second chunk is not a
+  // string or BufferSource, so the sink's write() rejects it.
+  "enqueue-then-bad-chunk": () =>
+    new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode('{"rows":[1,'));
+        c.enqueue(12345 as any);
+        c.enqueue(new TextEncoder().encode("2,3]}"));
+        c.close();
+      },
+    }),
   // highWaterMark: 0 defers the first pull() until the server's own reader
   // asks for data, so the stream is still readable when the server commits to
   // streaming and only errors inside the microtask drain that follows.

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -111,6 +111,34 @@ for (const flags of [[], ["development"]]) {
   );
 }
 
+// A direct stream fails through its own `controller.close(error)`. That
+// resolves the pump instead of rejecting it, so the failure is only visible
+// on the sink. Before the fix the synchronous close went out as a complete
+// empty 200, and the mid-stream close framed the still-buffered second write
+// as a complete body.
+//
+// No stderr assertion: close(error) is the source's own action, and its
+// reason goes to the source's cancel(), not to the error reporter.
+test.concurrent.each([
+  ["direct-close-error", "", ""],
+  ["direct-mid-stream-close-error", "HTTP/1.1 200 OK", "7\r\nchunk-a\r\n"],
+  ["direct-flush-then-close-error", "HTTP/1.1 200 OK", "7\r\nchunk-a\r\n"],
+])("%s: the body is not terminated as complete", async (variant, statusLine, bodyPrefix) => {
+  const { stdout, exitCode } = await runFixture(variant);
+  const { body, ...result } = JSON.parse(stdout);
+  expect({ result, exitCode }).toEqual({
+    result: {
+      statusLine,
+      cleanChunkedTerminator: false,
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+  expect(body).toStartWith(bodyPrefix);
+});
+
 // The headers are already on the wire (the first pull() was still pending
 // when the server flushed them) and the source then errors without ever
 // producing a chunk. The 200 is irrevocable, so the connection is closed

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -76,6 +76,41 @@ test.concurrent("pull-throw in development mode: the connection is closed withou
   expect(exitCode).toBe(0);
 });
 
+// The source hands the sink some body bytes and then fails in the same turn,
+// before the sink's first flush. The sink used to end cleanly with the
+// buffered prefix as a complete body: `200 OK`, `Content-Length: 11`, and a
+// keep-alive client could not tell the truncated body from a complete one.
+// Now the sink drops the prefix and the connection is closed, the same as
+// when the source fails before producing anything.
+//
+// [variant, what stderr must name]
+const bufferedPrefixFailures = [
+  ["enqueue-then-pull-throw", "boom"],
+  ["enqueue-then-bad-chunk", "write() expects a string, ArrayBufferView, or ArrayBuffer"],
+] as const;
+
+for (const flags of [[], ["development"]]) {
+  const mode = flags.length ? "development" : "production";
+  test.concurrent.each(bufferedPrefixFailures)(
+    `%s in ${mode} mode: the buffered prefix is not sent as a complete response`,
+    async (variant, reported) => {
+      const { stdout, stderr, exitCode } = await runFixture(variant, ...flags);
+      expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+        result: {
+          statusLine: "",
+          cleanChunkedTerminator: false,
+          body: "",
+          errorCb: 0,
+          unhandled: 0,
+          secondStatusLine: "HTTP/1.1 200 OK",
+        },
+        exitCode: 0,
+      });
+      expect(stderr).toContain(reported);
+    },
+  );
+}
+
 // The headers are already on the wire (the first pull() was still pending
 // when the server flushed them) and the source then errors without ever
 // producing a chunk. The 200 is irrevocable, so the connection is closed


### PR DESCRIPTION
### Problem
- A `Bun.serve` Response body backed by a `ReadableStream` that produces some bytes and then fails in the same turn (before the sink's first flush) is sent as a complete `HTTP/1.1 200 OK` with `Content-Length: <bytes so far>`. The error is printed (`error: db cursor failed`, or `TypeError: write() expects a string, ArrayBufferView, or ArrayBuffer` for a non-BufferSource chunk), but a keep-alive client sees a well formed, truncated body. A cache stores it.
- Cause: the pump closes the sink with the error (`rsisAbrupt` in `src/jsc/bindings/webcore/streams/BunStreamSource.cpp:994`). `HTTPServerWritable` used the trait default `close_with_error` (`src/runtime/webcore/Sink.rs:326`), which is a clean `end(None)`. That parks the buffered prefix as a pending `try_end`, and the auto flusher sends it with a `Content-Length` before `handle_reject_stream` runs. Once a flush has happened, the same failure already closes the connection without a terminator (#40596).
- A direct stream's `controller.close(error)` reaches the same sink close, but resolves the pump instead of rejecting it. `handle_resolve_stream` then ended the response cleanly.

### Fix
- `HTTPServerWritable` overrides `close_with_error` with `fail()`: it drops the buffered prefix, unregisters the auto flusher, settles a parked `flush(true)` promise, and enters a new `Failed` state that sends nothing and never ends the uWS response.
- A pump rejection reaches `handle_reject_stream`, which already calls `close_incomplete_stream()` and force closes the socket. `handle_resolve_stream`, and the synchronous path in `do_render_stream`, now read `is_failed()` and do the same for a direct stream's `close(error)`. The client gets a reset, the same as a body that fails after its first flush.
- This is the per-sink override shape that #40669 used for `NetworkSink` and `RewriterPipe`. `start()` refuses to restart a `Failed` sink, as it does an `Aborted` one.
- Verified: `test/js/bun/http/serve-stream-body-error.test.ts` (five new fixture variants, seven new tests, all fail on 1.4.3). Also `serve.test.ts`, `serve-direct-readable-stream`, `async-iterator-stream`, `bun-server.test.ts`, the sink leak tests, and `test/js/web/streams/`.

### Background
- `HTTPServerWritable` (`src/runtime/webcore/streams.rs`) is the native sink behind `HTTPResponseSink`. It buffers small writes up to a high water mark and a deferred auto flusher sends them at the end of the microtask drain.
- `end()` with buffered bytes sets `requested_end` and `end_len`. The next send then uses uWS `try_end`, which writes the bytes as a complete body with a `Content-Length` header.
- `close_with_error` is the `JsSinkType` hook the pump calls when the source fails. Its default is a clean end, for sinks whose owner handles the pump rejection before anything goes out. The HTTP sink is not one of those: the auto flusher runs first.
- `close_incomplete_stream` (`src/runtime/server/RequestContext.rs`) closes a response whose body failed after the status line was committed. It never writes the terminating chunk.

<details><summary>Notes</summary>

Wire before the fix, for both the `pull()` throw and the `enqueue(12345)` case:

```
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 11

{"rows":[1,HTTP/1.1 200 OK        <- next response on the same socket
```

After the fix the client gets `ECONNRESET` and nothing on the wire: the status line is still in the cork buffer when the force close runs, which is what the existing `pull-throw` variants already assert.

Direct streams before the fix: a synchronous `write(); close(error)` went out as `200 OK` with `Content-Length: 0`. A `close(error)` after an earlier flush, with a second write still buffered, went out with a clean terminating chunk (on 1.4.3 the buffered write was framed with `Content-Length` and a second terminator followed it).

The `is_failed()` checks in `RequestContext.rs` exist because `readDirectStreamCloseImpl` resolves the pump on `close(error)`. That pump behavior also affects `Response.text()`, `Bun.write()` and `fetch(body:)` with a direct stream, and is tracked separately. When the pump rejects instead, those checks become unreachable and can go.

Self-reviewed: 2 concerns raised, 2 addressed (the sink half confirmed as is, the direct stream handling reworked to read the sink state in the owner's resolve path and to settle a parked flush).

Suites run: `test/js/bun/http/serve-stream-body-error.test.ts`, `serve.test.ts` (2 pre-existing environment failures: root port range, `/bun:info` loopback), `serve-direct-readable-stream.test.ts`, `async-iterator-stream.test.ts`, `serve-async-stream-client-abort.test.ts`, `serve-error-handler-stream.test.ts`, `serve-response-stream-sink-leak.test.ts`, `serve-stream-reject-flush-leak.test.ts`, `bun-server.test.ts` (1 pre-existing IPv6 failure), `serve-http3.test.ts`, `test/js/web/streams/streams.test.js`, `native-source-onclose-leak.test.ts`, `sync-pull-fast-path.test.ts`.
</details>
