### PR TITLE
test(bundler): speed up bundler_compile_autoload.test.ts and tighten its assertions

### DIFF
--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -1,173 +1,270 @@
 import { describe } from "bun:test";
 import { itBundled } from "./expectBundled";
 
+// One entry point probes every source a standalone executable can autoload
+// at run time: .env, bunfig.toml (through its preload), tsconfig.json paths
+// and package.json exports. Each case compiles it with one flag set, runs it
+// in a directory that holds all four files, and pins the exact set it loaded.
+// The import specifiers are built at run time so the bundler cannot resolve
+// them and the runtime resolver has to.
+const probeEntry = {
+  "/entry.ts": /* ts */ `
+    const tsconfigPath = "@utils/" + "helper";
+    const packagePath = "runtime-pkg/" + "utils";
+    const tryImport = (specifier: string) => import(specifier).then(m => m.default, e => e.code);
+    console.log("dotenv: " + (process.env.TEST_VAR ?? "not found"));
+    console.log("tsconfig: " + (await tryImport(tsconfigPath)));
+    console.log("packageJson: " + (await tryImport(packagePath)));
+    console.log("execArgv: " + JSON.stringify(process.execArgv));
+  `,
+};
+
+// Written after the build, so only the executable sees them.
+const autoloadFiles = {
+  "/.env": `TEST_VAR=from_dotenv`,
+  "/bunfig.toml": `preload = ["./preload.ts"]`,
+  "/preload.ts": `console.log("bunfig: preload ran");`,
+  "/tsconfig.json": JSON.stringify({
+    compilerOptions: {
+      baseUrl: ".",
+      paths: {
+        "@utils/*": ["./src/utils/*"],
+      },
+    },
+  }),
+  "/src/utils/helper.ts": `export default "helper-from-tsconfig-paths";`,
+  "/node_modules/runtime-pkg/package.json": JSON.stringify({
+    name: "runtime-pkg",
+    exports: {
+      "./utils": "./lib/utils.js",
+    },
+  }),
+  "/node_modules/runtime-pkg/lib/utils.js": `export default "utils-from-package-exports";`,
+};
+
+function probeOutput(loaded: {
+  dotenv: "from_dotenv" | "from_shell" | "not found";
+  bunfig: boolean;
+  tsconfig: boolean;
+  packageJson: boolean;
+  execArgv?: string[];
+}): string {
+  return [
+    ...(loaded.bunfig ? ["bunfig: preload ran"] : []),
+    `dotenv: ${loaded.dotenv}`,
+    `tsconfig: ${loaded.tsconfig ? "helper-from-tsconfig-paths" : "ERR_MODULE_NOT_FOUND"}`,
+    `packageJson: ${loaded.packageJson ? "utils-from-package-exports" : "ERR_MODULE_NOT_FOUND"}`,
+    `execArgv: ${JSON.stringify(loaded.execArgv ?? [])}`,
+  ].join("\n");
+}
+
 // Not describe.concurrent: the backend:"cli" cases each spawn a full
 // `bun build --compile` link (hundreds of MB on disk) and running eight of
 // those at once SIGTERMs on the linux lanes. expectBundled already forces
 // backend:"api" cases to it.serial, so only the CLI cases would overlap.
 describe("bundler", () => {
-  // Test that .env files are loaded by default in standalone executables
-  itBundled("compile/AutoloadDotenvDefault", {
+  // Defaults: .env and bunfig.toml load, tsconfig.json and package.json do not.
+  // The second run checks that the process environment wins over .env.
+  itBundled("compile/AutoloadDefaults", {
     compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_dotenv",
-      setCwd: true,
-    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
+    run: [
+      {
+        stdout: probeOutput({ dotenv: "from_dotenv", bunfig: true, tsconfig: false, packageJson: false }),
+        stderr: "",
+        setCwd: true,
+      },
+      {
+        stdout: probeOutput({ dotenv: "from_shell", bunfig: true, tsconfig: false, packageJson: false }),
+        stderr: "",
+        setCwd: true,
+        env: {
+          TEST_VAR: "from_shell",
+        },
+      },
+    ],
   });
 
-  // Test that .env files can be disabled with autoloadDotenv: false
   itBundled("compile/AutoloadDotenvDisabled", {
     compile: {
       autoloadDotenv: false,
     },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
     run: {
-      stdout: "not found",
+      stdout: probeOutput({ dotenv: "not found", bunfig: true, tsconfig: false, packageJson: false }),
+      stderr: "",
       setCwd: true,
     },
   });
 
-  // Test that .env files can be explicitly enabled with autoloadDotenv: true
-  itBundled("compile/AutoloadDotenvEnabledExplicitly", {
-    compile: {
-      autoloadDotenv: true,
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_dotenv",
-      setCwd: true,
-    },
-  });
-
-  // Test that process environment variables take precedence over .env files
-  itBundled("compile/AutoloadDotenvWithExistingEnv", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_shell",
-      setCwd: true,
-      env: {
-        TEST_VAR: "from_shell",
-      },
-    },
-  });
-
-  // Test that bunfig.toml is loaded by default (preload is executed)
-  itBundled("compile/AutoloadBunfigDefault", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "PRELOAD\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that bunfig.toml can be disabled with autoloadBunfig: false
   itBundled("compile/AutoloadBunfigDisabled", {
     compile: {
       autoloadBunfig: false,
     },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
     run: {
-      // When bunfig is disabled, preload should NOT execute
-      stdout: "ENTRY",
+      stdout: probeOutput({ dotenv: "from_dotenv", bunfig: false, tsconfig: false, packageJson: false }),
+      stderr: "",
       setCwd: true,
     },
   });
 
-  // Test that bunfig.toml can be explicitly enabled with autoloadBunfig: true
-  itBundled("compile/AutoloadBunfigEnabled", {
+  itBundled("compile/AutoloadTsconfigEnabled", {
     compile: {
-      autoloadBunfig: true,
+      autoloadTsconfig: true,
     },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
     run: {
-      stdout: "PRELOAD\nENTRY",
+      stdout: probeOutput({ dotenv: "from_dotenv", bunfig: true, tsconfig: true, packageJson: false }),
+      stderr: "",
       setCwd: true,
     },
   });
 
-  // Test CLI backend with autoloadDotenv: false
-  itBundled("compile/AutoloadDotenvDisabledCLI", {
+  itBundled("compile/AutoloadPackageJsonEnabled", {
+    compile: {
+      autoloadPackageJson: true,
+    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
+    run: {
+      stdout: probeOutput({ dotenv: "from_dotenv", bunfig: true, tsconfig: false, packageJson: true }),
+      stderr: "",
+      setCwd: true,
+    },
+  });
+
+  // Every flag explicitly true. execArgv must not change what loads.
+  itBundled("compile/AutoloadAllEnabledWithExecArgv", {
+    compile: {
+      autoloadDotenv: true,
+      autoloadBunfig: true,
+      autoloadTsconfig: true,
+      autoloadPackageJson: true,
+      execArgv: ["--smol"],
+    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
+    run: {
+      stdout: probeOutput({
+        dotenv: "from_dotenv",
+        bunfig: true,
+        tsconfig: true,
+        packageJson: true,
+        execArgv: ["--smol"],
+      }),
+      stderr: "",
+      setCwd: true,
+    },
+  });
+
+  // Every flag explicitly false. With execArgv present, bunfig.toml used to
+  // load anyway (#25640).
+  itBundled("compile/AutoloadAllDisabledWithExecArgv", {
     compile: {
       autoloadDotenv: false,
+      autoloadBunfig: false,
+      autoloadTsconfig: false,
+      autoloadPackageJson: false,
+      execArgv: ["--smol"],
+    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
+    run: {
+      stdout: probeOutput({
+        dotenv: "not found",
+        bunfig: false,
+        tsconfig: false,
+        packageJson: false,
+        execArgv: ["--smol"],
+      }),
+      stderr: "",
+      setCwd: true,
+    },
+  });
+
+  // The CLI maps each --compile-autoload-* flag to its own bit. The two mixed
+  // cases flip one default-on flag off and one default-off flag on, so a flag
+  // that lands on the wrong bit shows up in the probe.
+  itBundled("compile/AutoloadDotenvDisabledTsconfigEnabledCLI", {
+    compile: {
+      autoloadDotenv: false,
+      autoloadTsconfig: true,
     },
     backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
     run: {
-      stdout: "not found",
+      stdout: probeOutput({ dotenv: "not found", bunfig: true, tsconfig: true, packageJson: false }),
+      stderr: "",
+      setCwd: true,
+    },
+  });
+
+  itBundled("compile/AutoloadBunfigDisabledPackageJsonEnabledCLI", {
+    compile: {
+      autoloadBunfig: false,
+      autoloadPackageJson: true,
+    },
+    backend: "cli",
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
+    run: {
+      stdout: probeOutput({ dotenv: "from_dotenv", bunfig: false, tsconfig: false, packageJson: true }),
+      stderr: "",
+      setCwd: true,
+    },
+  });
+
+  itBundled("compile/AutoloadAllEnabledWithExecArgvCLI", {
+    compile: {
+      autoloadDotenv: true,
+      autoloadBunfig: true,
+      autoloadTsconfig: true,
+      autoloadPackageJson: true,
+      execArgv: ["--smol"],
+    },
+    backend: "cli",
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
+    run: {
+      stdout: probeOutput({
+        dotenv: "from_dotenv",
+        bunfig: true,
+        tsconfig: true,
+        packageJson: true,
+        execArgv: ["--smol"],
+      }),
+      stderr: "",
+      setCwd: true,
+    },
+  });
+
+  // --no-compile-autoload-bunfig with --compile-exec-argv is the CLI shape of #25640.
+  itBundled("compile/AutoloadAllDisabledWithExecArgvCLI", {
+    compile: {
+      autoloadDotenv: false,
+      autoloadBunfig: false,
+      autoloadTsconfig: false,
+      autoloadPackageJson: false,
+      execArgv: ["--smol"],
+    },
+    backend: "cli",
+    files: probeEntry,
+    runtimeFiles: autoloadFiles,
+    run: {
+      stdout: probeOutput({
+        dotenv: "not found",
+        bunfig: false,
+        tsconfig: false,
+        packageJson: false,
+        execArgv: ["--smol"],
+      }),
+      stderr: "",
       setCwd: true,
     },
   });
@@ -182,16 +279,18 @@ console.log("PRELOAD");
       "/entry.ts": /* js */ `
         import { rmSync } from "fs";
 
+        // Remove the source so the Worker has to come from the embedded graph.
         rmSync("./worker.ts", { force: true });
 
         const worker = new Worker("./worker.ts");
-        console.log(await new Promise(resolve => {
+        console.log("worker: " + await new Promise(resolve => {
           worker.onmessage = event => resolve(event.data);
         }));
         worker.terminate();
+        console.log("main: " + (process.env.TEST_VAR ?? "not found"));
       `,
       "/worker.ts": /* js */ `
-        postMessage(process.env.TEST_VAR || "not found");
+        postMessage(process.env.TEST_VAR ?? "not found");
       `,
     },
     entryPointsRaw: ["./entry.ts", "./worker.ts"],
@@ -200,411 +299,9 @@ console.log("PRELOAD");
       "/.env": `TEST_VAR=from_dotenv`,
     },
     run: {
-      stdout: "not found",
+      stdout: "worker: not found\nmain: not found",
+      stderr: "",
       file: "dist/out",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadDotenv: true
-  itBundled("compile/AutoloadDotenvEnabledCLI", {
-    compile: {
-      autoloadDotenv: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_dotenv",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadBunfig: false
-  itBundled("compile/AutoloadBunfigDisabledCLI", {
-    compile: {
-      autoloadBunfig: false,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "ENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadBunfig: true
-  itBundled("compile/AutoloadBunfigEnabledCLI", {
-    compile: {
-      autoloadBunfig: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "PRELOAD\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadTsconfig: true using tsconfig paths
-  itBundled("compile/AutoloadTsconfigPathsCLI", {
-    compile: {
-      autoloadTsconfig: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* ts */ `
-        const modulePath = "@lib/" + "mymodule";
-        import(modulePath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@lib/*": ["./lib/*"],
-          },
-        },
-      }),
-      "/lib/mymodule.ts": `export default "mymodule-from-cli-tsconfig";`,
-    },
-    run: {
-      stdout: "mymodule-from-cli-tsconfig",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadPackageJson: true using package.json exports
-  itBundled("compile/AutoloadPackageJsonExportsCLI", {
-    compile: {
-      autoloadPackageJson: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.js": /* js */ `
-        const pkgName = "cli-pkg";
-        const subpath = "feature";
-        import(pkgName + "/" + subpath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/node_modules/cli-pkg/package.json": JSON.stringify({
-        name: "cli-pkg",
-        exports: {
-          "./feature": "./features/main.js",
-        },
-      }),
-      "/node_modules/cli-pkg/features/main.js": `export default "feature-from-cli-package-exports";`,
-    },
-    run: {
-      stdout: "feature-from-cli-package-exports",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend for autoloadBunfig: false with execArgv (regression test for #25640)
-  itBundled("compile/AutoloadBunfigDisabledWithExecArgvCLI", {
-    compile: {
-      autoloadBunfig: false,
-      execArgv: ["--smol"],
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "ENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that both flags can be disabled together without interference
-  itBundled("compile/AutoloadBothDisabled", {
-    compile: {
-      autoloadDotenv: false,
-      autoloadBunfig: false,
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "not found\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that tsconfig.json paths are loaded at runtime when autoloadTsconfig: true
-  // Uses a dynamic import path that the bundler cannot resolve at compile time
-  itBundled("compile/AutoloadTsconfigPathsEnabled", {
-    compile: {
-      autoloadTsconfig: true,
-    },
-    files: {
-      "/entry.ts": /* ts */ `
-        // Use a dynamic path that can't be resolved at compile time
-        // This forces runtime resolution using the runtime tsconfig.json
-        const modulePath = "@utils/" + "helper";
-        import(modulePath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@utils/*": ["./src/utils/*"],
-          },
-        },
-      }),
-      "/src/utils/helper.ts": `export default "helper-from-tsconfig-paths";`,
-    },
-    run: {
-      stdout: "helper-from-tsconfig-paths",
-      setCwd: true,
-    },
-  });
-
-  // Test that tsconfig.json paths are NOT loaded when autoloadTsconfig: false (default)
-  // The import should fail because @utils/helper cannot be resolved without tsconfig paths
-  itBundled("compile/AutoloadTsconfigPathsDisabled", {
-    compile: {
-      autoloadTsconfig: false,
-    },
-    files: {
-      "/entry.ts": /* ts */ `
-        // Without runtime tsconfig.json, @utils/helper cannot be resolved
-        const modulePath = "@utils/" + "helper";
-        import(modulePath)
-          .then(m => console.log(m.default))
-          .catch(() => console.log("import-failed-as-expected"));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@utils/*": ["./src/utils/*"],
-          },
-        },
-      }),
-      "/src/utils/helper.ts": `export default "helper-from-tsconfig-paths";`,
-    },
-    run: {
-      stdout: "import-failed-as-expected",
-      setCwd: true,
-    },
-  });
-
-  // Test that package.json exports are loaded at runtime when autoloadPackageJson: true
-  // Uses a dynamic import path that the bundler cannot resolve at compile time
-  itBundled("compile/AutoloadPackageJsonExportsEnabled", {
-    compile: {
-      autoloadPackageJson: true,
-    },
-    files: {
-      "/entry.js": /* js */ `
-        // Use a dynamic path that can't be resolved at compile time
-        const pkgName = "my-runtime-pkg";
-        const subpath = "utils";
-        import(pkgName + "/" + subpath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/node_modules/my-runtime-pkg/package.json": JSON.stringify({
-        name: "my-runtime-pkg",
-        exports: {
-          "./utils": "./lib/utilities.js",
-        },
-      }),
-      "/node_modules/my-runtime-pkg/lib/utilities.js": `export default "utilities-from-package-exports";`,
-    },
-    run: {
-      stdout: "utilities-from-package-exports",
-      setCwd: true,
-    },
-  });
-
-  // Test that package.json exports are NOT loaded when autoloadPackageJson: false (default)
-  // The import should fail because my-runtime-pkg/utils cannot be resolved without package.json exports
-  itBundled("compile/AutoloadPackageJsonExportsDisabled", {
-    compile: {
-      autoloadPackageJson: false,
-    },
-    files: {
-      "/entry.js": /* js */ `
-        // Without runtime package.json, my-runtime-pkg/utils cannot be resolved
-        const pkgName = "my-runtime-pkg";
-        const subpath = "utils";
-        import(pkgName + "/" + subpath)
-          .then(m => console.log(m.default))
-          .catch(() => console.log("import-failed-as-expected"));
-      `,
-    },
-    runtimeFiles: {
-      "/node_modules/my-runtime-pkg/package.json": JSON.stringify({
-        name: "my-runtime-pkg",
-        exports: {
-          "./utils": "./lib/utilities.js",
-        },
-      }),
-      "/node_modules/my-runtime-pkg/lib/utilities.js": `export default "utilities-from-package-exports";`,
-    },
-    run: {
-      stdout: "import-failed-as-expected",
-      setCwd: true,
-    },
-  });
-
-  // Test that autoloadBunfig: false works with execArgv (regression test for #25640)
-  // When execArgv is present, bunfig should still be disabled if autoloadBunfig: false
-  itBundled("compile/AutoloadBunfigDisabledWithExecArgv", {
-    compile: {
-      autoloadBunfig: false,
-      execArgv: ["--smol"],
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      // When bunfig is disabled, preload should NOT execute even with execArgv
-      stdout: "ENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that autoloadBunfig: true with execArgv still loads bunfig
-  itBundled("compile/AutoloadBunfigEnabledWithExecArgv", {
-    compile: {
-      autoloadBunfig: true,
-      execArgv: ["--smol"],
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "PRELOAD\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that both tsconfig and package.json can be enabled together
-  itBundled("compile/AutoloadBothTsconfigAndPackageJson", {
-    compile: {
-      autoloadTsconfig: true,
-      autoloadPackageJson: true,
-    },
-    files: {
-      "/entry.ts": /* ts */ `
-        // Both imports require runtime config files
-        const tsconfigPath = "@utils/" + "helper";
-        const pkgPath = "runtime-pkg/" + "utils";
-        Promise.all([import(tsconfigPath), import(pkgPath)])
-          .then(([helper, utils]) => console.log(helper.default + " " + utils.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@utils/*": ["./src/utils/*"],
-          },
-        },
-      }),
-      "/src/utils/helper.ts": `export default "tsconfig-helper";`,
-      "/node_modules/runtime-pkg/package.json": JSON.stringify({
-        name: "runtime-pkg",
-        exports: {
-          "./utils": "./lib/utils.js",
-        },
-      }),
-      "/node_modules/runtime-pkg/lib/utils.js": `export default "package-utils";`,
-    },
-    run: {
-      stdout: "tsconfig-helper package-utils",
       setCwd: true,
     },
   });


### PR DESCRIPTION
### Problem
- `test/bundler/bundler_compile_autoload.test.ts` compiles one executable per case: 23 `--compile` links, each a copy of the bun binary (800 MB in a debug build). It takes 63 s on the windows aarch64 lane and 107 s in a local debug run.
- Most cases share a flag set and differ only in which autoload file sits next to the executable. Each case checks one line of stdout and nothing else, so a flag that also changed another autoload source would pass.

### Fix
- One probe entry point reports every autoload source at run time: `.env` (`TEST_VAR`), `bunfig.toml` (its preload prints a line), `tsconfig.json` paths and `package.json` exports (both through a dynamic import the bundler cannot resolve), and `process.execArgv`. Every case compiles it with one flag set, runs it in a directory that holds all four files, and pins the full output plus an empty stderr.
- 23 compiles become 12. The API side keeps the default set, each default-on flag turned off alone, each default-off flag turned on alone, all four explicitly on, and all four explicitly off. The CLI side has the two mixed cases (one default-on flag off with one default-off flag on, so a flag that lands on the wrong bit shows in the probe), all on, all off, and the worker case. Both all-on and all-off cases carry `--compile-exec-argv`, which covers #25640 (bunfig disabled with execArgv) and the `--no-compile-autoload-tsconfig` and `--no-compile-autoload-package-json` flags that no case exercised before.
- Assertions: 23 `expect()` calls become 26, each on the full four-line probe output, a pinned `execArgv`, and an empty stderr. The default case also pins that the shell environment wins over `.env`. The worker case prints the main thread's value too.
- Verified: `bun bd test test/bundler/bundler_compile_autoload.test.ts`, 12 pass. Local debug ASAN build: 106.7 s (23 cases) to 48.7 s (12 cases). CI (build 111094, against `test/expected-durations.json`): windows aarch64 63.4 s to 33.1 s, x64 asan 22.6 s to 13.6 s, debian x64 7.4 s to 3.4 s.

### Background
- A `--compile` executable stores four autoload bits in its embedded module graph (`StandaloneModuleGraph::Flags`). `bun build` sets them from `--compile-autoload-*` flags (`src/runtime/cli/build_command.rs:921`) and `Bun.build` from `compile.autoload*` (`src/runtime/api/js_bundle_completion_task.rs:391`). The executable reads them at startup, so the flag set is fixed per compile and which files exist is decided by the cwd at run time.
- `itBundled` writes `runtimeFiles` after the build, so the bundler never sees them. The `run` array runs the same executable several times with different env.
- The API backend of `itBundled` is `it.serial`, and concurrent links exhaust CI memory. The compile count is the lever.

<details><summary>Notes</summary>

- Per-case cost in a local debug build is 3.2 to 5.4 s, nearly all of it the link. The run of the executable is about 0.25 s.
- Old to new mapping. `AutoloadDotenvDefault`, `AutoloadDotenvWithExistingEnv`, `AutoloadBunfigDefault`: `AutoloadDefaults` (two runs). `AutoloadDotenvEnabledExplicitly`, `AutoloadBunfigEnabled`, `AutoloadBunfigEnabledWithExecArgv`, `AutoloadBothTsconfigAndPackageJson`: `AutoloadAllEnabledWithExecArgv`. `AutoloadBothDisabled`, `AutoloadTsconfigPathsDisabled`, `AutoloadPackageJsonExportsDisabled`, `AutoloadBunfigDisabledWithExecArgv`: `AutoloadAllDisabledWithExecArgv`. `AutoloadDotenvDisabledCLI`, `AutoloadTsconfigPathsCLI`: `AutoloadDotenvDisabledTsconfigEnabledCLI`. `AutoloadBunfigDisabledCLI`, `AutoloadPackageJsonExportsCLI`: `AutoloadBunfigDisabledPackageJsonEnabledCLI`. `AutoloadDotenvEnabledCLI`, `AutoloadBunfigEnabledCLI`: `AutoloadAllEnabledWithExecArgvCLI`. `AutoloadBunfigDisabledWithExecArgvCLI`: `AutoloadAllDisabledWithExecArgvCLI`. `AutoloadDotenvDisabled`, `AutoloadBunfigDisabled`, `AutoloadTsconfigPathsEnabled` (now `AutoloadTsconfigEnabled`), `AutoloadPackageJsonExportsEnabled` (now `AutoloadPackageJsonEnabled`) and `AutoloadDotenvDisabledWorkerCLI` keep their shape.
- The failed import is reported by `e.code` (`ERR_MODULE_NOT_FOUND`) and not the message, which carries the `/$bunfs/root/out` path and differs per platform.
- `process.execArgv` in a compiled executable is the `--compile-exec-argv` list, `["--smol"]` here, which proves the execArgv was embedded in the #25640 cases.
- Not done: `describe.concurrent`. The file comment explains why: eight CLI links at once SIGTERM on the linux lanes. #39649 adds a slot gate for `bundler_compile.test.ts` that could cover this file later.
- #41506 inserts one case (`AutoloadDotenvProductionSuffix`) into this file. It applies on top of this rewrite as a new case with its own compile.
- Timings: local debug ASAN build, 23 cases, `Ran 23 tests across 1 file. [106.73s]`. This branch, `Ran 12 tests across 1 file. [48.74s]`. `USE_SYSTEM_BUN=1` (release 1.4.3) on linux: 3.02 s. Windows x64 with the canary build: old file 8.59 s, new file 4.09 s. CI build 111094, file run first on its shard: windows 11 aarch64 33.06 s, windows 2019 x64 12.50 s, debian 13 x64-asan 13.62 s, debian 13 x64 3.44 s. The expected durations on main are 63.4 s, 13.5 s, 22.6 s and 7.4 s.
- CI build 111094 failed on lanes this diff does not touch: `verify-baseline` on x64 and x64-musl (an `INVLPGB` decode in `llint_op_wide16`, passes on main build 111080 at the same base commit), `test-crypto-dh-leak.js` on asan (pre-existing), and `fetch-backpressure.test.ts` on windows aarch64 (timeout). This file passed on every lane. The retriggered build 111312 finished with the same two `verify-baseline` lanes red (main build 110907 hit it on x64-musl too) and `test-crypto-dh-leak.js` red on asan, which also fails on main. Every test lane that ran this file passed, including both Windows lanes.
</details>

