### PR TITLE
Walk the timer pairing heap without recursion

### DIFF
--- a/src/io/heap.rs
+++ b/src/io/heap.rs
@@ -78,59 +78,69 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
 
     /// Count the number of elements in the heap. This is an O(N) operation.
     pub unsafe fn count(&self) -> usize {
+        let mut result: usize = 0;
         // SAFETY: all reachable nodes from `self.root` are valid for the heap's lifetime.
-        Self::count_internal(self.root)
-    }
-
-    unsafe fn count_internal(node: *mut T) -> usize {
-        if node.is_null() {
-            return 0;
-        }
-        let current = node;
-        let mut result: usize = 1;
-
-        // Count children
-        // SAFETY: `current` is non-null and valid (checked above / invariant).
-        result += Self::count_internal((*current).heap().child);
-
-        // Count siblings
-        result += Self::count_internal((*current).heap().next);
-
+        self.for_each(|_| result += 1);
         result
     }
 
     /// Look at the next maximum value but do not remove it. This is an O(N) operation.
     pub unsafe fn find_max(&self) -> *mut T {
-        if self.root.is_null() {
-            return ptr::null_mut();
-        }
-        let root = self.root;
-        // SAFETY: `root` is non-null and valid.
-        Self::find_max_internal(&self.context, root, root)
+        let mut max_so_far = self.root;
+        // SAFETY: all reachable nodes from `self.root` are valid for the heap's lifetime.
+        self.for_each(|node| {
+            if self.context.less(max_so_far, node) {
+                max_so_far = node;
+            }
+        });
+        max_so_far
     }
 
-    unsafe fn find_max_internal(ctx: &Context, node: *mut T, current_max: *mut T) -> *mut T {
-        let mut max_so_far = current_max;
-
-        // Update max if current node is greater
-        if ctx.less(max_so_far, node) {
-            max_so_far = node;
+    /// Visit every node in depth-first order without recursion. The walk
+    /// climbs back up through the `prev` links, so it runs in constant stack
+    /// space. Inserts in decreasing order build one chain of `child` links
+    /// (and inserts in increasing order one chain of `next` links), so a
+    /// recursive walk overflows the stack at a few hundred thousand nodes.
+    ///
+    /// # Safety
+    /// All nodes reachable from `self.root` must be valid.
+    unsafe fn for_each(&self, mut f: impl FnMut(*mut T)) {
+        let mut node = self.root;
+        if node.is_null() {
+            return;
         }
+        'walk: loop {
+            f(node);
 
-        // Traverse children
-        // SAFETY: `node` is a valid heap node (caller invariant).
-        let child = (*node).heap().child;
-        if !child.is_null() {
-            max_so_far = Self::find_max_internal(ctx, child, max_so_far);
+            // SAFETY: `node` is non-null and valid (invariant).
+            let child = (*node).heap().child;
+            if !child.is_null() {
+                node = child;
+                continue;
+            }
+
+            loop {
+                let next = (*node).heap().next;
+                if !next.is_null() {
+                    node = next;
+                    continue 'walk;
+                }
+
+                // `prev` is the left sibling, or the parent for the leftmost
+                // sibling. Every sibling to the left is already visited, so
+                // walk left to the leftmost one, step up to the parent, and
+                // try the parent's own `next`.
+                let mut prev = (*node).heap().prev;
+                while !prev.is_null() && (*prev).heap().child != node {
+                    node = prev;
+                    prev = (*node).heap().prev;
+                }
+                if prev.is_null() {
+                    return;
+                }
+                node = prev;
+            }
         }
-
-        // Traverse siblings
-        let next_sibling = (*node).heap().next;
-        if !next_sibling.is_null() {
-            max_so_far = Self::find_max_internal(ctx, next_sibling, max_so_far);
-        }
-
-        max_so_far
     }
 
     /// Delete the minimum value from the heap and return it.

--- a/src/io/heap.rs
+++ b/src/io/heap.rs
@@ -96,11 +96,8 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
         max_so_far
     }
 
-    /// Visit every node in depth-first order without recursion. The walk
-    /// climbs back up through the `prev` links, so it runs in constant stack
-    /// space. Inserts in decreasing order build one chain of `child` links
-    /// (and inserts in increasing order one chain of `next` links), so a
-    /// recursive walk overflows the stack at a few hundred thousand nodes.
+    /// Visit every node depth-first in constant stack space. A heap can be
+    /// one chain as long as the element count, so the walk must not recurse.
     ///
     /// # Safety
     /// All nodes reachable from `self.root` must be valid.
@@ -126,10 +123,8 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
                     continue 'walk;
                 }
 
-                // `prev` is the left sibling, or the parent for the leftmost
-                // sibling. Every sibling to the left is already visited, so
-                // walk left to the leftmost one, step up to the parent, and
-                // try the parent's own `next`.
+                // `prev` is the left sibling, or the parent of the leftmost one.
+                // Climb to the parent and try its `next`.
                 let mut prev = (*node).heap().prev;
                 while !prev.is_null() && (*prev).heap().child != node {
                     node = prev;

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,7 +1,7 @@
 import { RedisClient, SQL } from "bun";
 import { heapStats } from "bun:jsc";
 import { setSystemTime } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { spawnSync as childProcessSpawnSync } from "node:child_process";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -194,6 +194,40 @@ describe("getTimerCount", () => {
   test("throws error if fake timers not active", () => {
     expect(() => vi.getTimerCount()).toThrow("Fake timers are not active");
   });
+
+  // Timers inserted with decreasing deadlines form one long chain of child
+  // links in the pairing heap. getTimerCount() and runOnlyPendingTimers()
+  // walk every node, and that walk used to recurse once per node, so a few
+  // hundred thousand timers overflowed the 8 MB main stack (SIGSEGV, no
+  // trace). The child runs with a 1 MB stack so that 60k timers are enough.
+  test.skipIf(isWindows)(
+    "walks a deep timer heap without overflowing the stack",
+    async () => {
+      const N = 60_000;
+      const script = `
+        import { jest } from "bun:test";
+        jest.useFakeTimers();
+        let fired = 0;
+        const N = ${N};
+        for (let i = 0; i < N; i++) setTimeout(() => fired++, N - i);
+        console.log("count", jest.getTimerCount());
+        jest.runOnlyPendingTimers();
+        console.log("fired", fired, "left", jest.getTimerCount());
+        jest.useRealTimers();
+      `;
+      await using proc = Bun.spawn({
+        cmd: ["sh", "-c", 'ulimit -s 1024 && exec "$0" -e "$1"', bunExe(), script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe(`count ${N}\nfired ${N} left 0\n`);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    60_000,
+  );
 });
 describe("clearAllTimers", () => {
   test("clears all pending timers", () => {


### PR DESCRIPTION
### Problem
- `jest.getTimerCount()` and `jest.runOnlyPendingTimers()` die with a silent `Segmentation fault` (exit 139, no crash banner) once a few hundred thousand fake timers are pending. An ASAN build reports `AddressSanitizer: stack-overflow` in `Intrusive::count_internal` (`src/io/heap.rs:94`) and `Intrusive::find_max_internal` (`src/io/heap.rs:124`).
- Both walkers recursed once per node. Timers inserted with decreasing deadlines build one chain of `child` links in the pairing heap, so the recursion depth equals the timer count. With increasing deadlines the chain runs along `next` links instead. The release build overflows the 8 MB main stack at about 240k timers.

### Fix
- `count()` and `find_max()` now share one iterative depth-first walk, `Intrusive::for_each`. It descends through `child` and `next`, and climbs back through `prev` links. The walk uses constant stack space.
- The climb is correct because every non-root node's `prev` points at its left sibling, or at its parent when it is the leftmost child, and `meld`, `combine_siblings`, and `remove` keep that invariant. So `prev.child == node` tells the walk that it reached the parent.
- Verified: `test/js/bun/test/fake-timers/fake-timers.test.ts` (new test: 60k decreasing timers under a 1 MB stack, stock bun segfaults). Also `test/js/bun/test/test-timers.test.ts`, `test/js/node/timers`, and the sinonjs fake-timers port.
- Overlaps #40187, which rewrites the same `heap.rs` region with a `Vec`-stack `for_each`. Either walk fixes the crash. This PR is the small step: if #40187 lands first, this one reduces to its test. If this lands first, #40187 takes its own `for_each` on rebase and keeps the test.

### Background
- `src/io/heap.rs` is an intrusive pairing heap. Each node embeds an `IntrusiveField` with `child`, `next`, and `prev` pointers. `child` is the leftmost child, `next` the right sibling, `prev` the left sibling or (for the leftmost child) the parent.
- The fake-timer clock in `src/runtime/test_runner/timers/FakeTimers.rs` keeps pending timers in this heap. `getTimerCount` calls `count()`. `runOnlyPendingTimers` calls `find_max()` to find the deadline it must run up to.
- The real event-loop timer heap (`src/runtime/timer/mod.rs`) is the same type, so it gets the same walk.

<details><summary>Notes</summary>

- Stock bun (1.4.3-canary f42e98025) with the ledger repro: 1e6 decreasing timers, `getTimerCount()` → SIGSEGV. `runOnlyPendingTimers()` with 300k decreasing timers → SIGSEGV. Increasing order survives on the release build because the `next` leg of the old recursion is a tail position that the optimizer turned into a loop.
- Release overflow thresholds measured with `ulimit -s`: at 512 KB between 14k and 16k timers (about 35 bytes per frame). The debug ASAN build overflows between 100k and 200k timers at 8 MB.
- The test spawns through `sh -c 'ulimit -s 1024 && exec ...'` so that 60k timers are enough. 60k timers take about 8 s on the debug ASAN build, almost all of it in `setTimeout` creation and firing. A 256 KB stack is too small for the debug build to boot the VM.
- `insert`, `meld`, `delete_min`, `remove`, and `combine_siblings` are already loop based. Nothing else in the file recurses.
- Self-reviewed: 9 concerns raised. The one that survived is the overlap with #40187, addressed by the cross-reference above. Rejected: making `for_each` public and retargeting the two teardown walks in `src/runtime/timer/mod.rs` onto it (those walks belong to #40187's refactor, and this PR stays a crash fix).
- The walker was checked in a throwaway crate against a brute-force expectation after every insert, every third `remove`, and ten `delete_min` calls, in decreasing, increasing, and scrambled insert orders, plus a 2M-node chain. That test cannot live in `bun_io` because the crate does not link standalone under `cargo test`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/fake-timers/fake-timers.test.ts

<!-- robobun:evidence:end -->