### PR TITLE
sql: do not read the environment connection URL when options name a target

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -483,7 +483,7 @@ await query;
 
 You can configure `sql` connection parameters with environment variables. The client checks them in order of precedence and detects the database type from the connection string format.
 
-The connection URL variables (`DATABASE_URL`, `POSTGRES_URL`, `MYSQL_URL`, `SQLITE_URL` and the `TLS_*` variants) are a fallback for when nothing names a target. A connection string, or an options object with `url`, `filename`, `hostname`, `host` or `path`, is used as given and these variables are not consulted.
+The connection URL variables (`DATABASE_URL`, `POSTGRES_URL`, `MYSQL_URL`, `MARIADB_URL`, `SQLITE_URL`, their aliases listed below, and the `TLS_*` variants) are a fallback for when nothing names a target. A connection string, or an options object with `url`, `filename`, `hostname`, `host` or `path`, is used as given and these variables are not consulted.
 
 ### Automatic Database Detection
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -483,6 +483,8 @@ await query;
 
 You can configure `sql` connection parameters with environment variables. The client checks them in order of precedence and detects the database type from the connection string format.
 
+The connection URL variables (`DATABASE_URL`, `POSTGRES_URL`, `MYSQL_URL`, `SQLITE_URL` and the `TLS_*` variants) are a fallback for when nothing names a target. A connection string, or an options object with `url`, `filename`, `hostname` or `host`, is used as given and these variables are not consulted.
+
 ### Automatic Database Detection
 
 When you use `Bun.sql()` without arguments, or `new SQL()` with a connection string, Bun detects the adapter from the URL format:

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -483,7 +483,7 @@ await query;
 
 You can configure `sql` connection parameters with environment variables. The client checks them in order of precedence and detects the database type from the connection string format.
 
-The connection URL variables (`DATABASE_URL`, `POSTGRES_URL`, `MYSQL_URL`, `SQLITE_URL` and the `TLS_*` variants) are a fallback for when nothing names a target. A connection string, or an options object with `url`, `filename`, `hostname` or `host`, is used as given and these variables are not consulted.
+The connection URL variables (`DATABASE_URL`, `POSTGRES_URL`, `MYSQL_URL`, `SQLITE_URL` and the `TLS_*` variants) are a fallback for when nothing names a target. A connection string, or an options object with `url`, `filename`, `hostname`, `host` or `path`, is used as given and these variables are not consulted.
 
 ### Automatic Database Detection
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1699,21 +1699,17 @@ function parseConnectionDetailsFromOptionsOrEnvironment(
 
   let optionsFilename;
   let optionsUrl;
-  if (options.adapter === "sqlite") {
-    // SQLite adapter - only check filename (not url)
-    if ("filename" in options && (optionsFilename = options.filename)) {
-      resolvedUrl = optionsFilename;
-    }
-  } else if (!options.adapter) {
-    // Unknown adapter - check both, filename first (more specific)
-    if ("filename" in options && (optionsFilename = options.filename)) {
-      resolvedUrl = optionsFilename;
-    } else if ("url" in options && (optionsUrl = options.url)) {
+  if (options.adapter && options.adapter !== "sqlite") {
+    // Known non-SQLite adapter - only check url (not filename)
+    if ("url" in options && (optionsUrl = options.url)) {
       resolvedUrl = optionsUrl;
     }
   } else {
-    // Known non-SQLite adapter - only check url (not filename)
-    if ("url" in options && (optionsUrl = options.url)) {
+    // SQLite or unknown adapter - check both, filename first (more specific).
+    // { adapter: "sqlite", url } must open the same database that { url } alone does.
+    if ("filename" in options && (optionsFilename = options.filename)) {
+      resolvedUrl = optionsFilename;
+    } else if ("url" in options && (optionsUrl = options.url)) {
       resolvedUrl = optionsUrl;
     }
   }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1705,8 +1705,7 @@ function parseConnectionDetailsFromOptionsOrEnvironment(
       resolvedUrl = optionsUrl;
     }
   } else {
-    // SQLite or unknown adapter - check both, filename first (more specific).
-    // { adapter: "sqlite", url } must open the same database that { url } alone does.
+    // SQLite or unknown adapter - filename first (more specific), then url
     if ("filename" in options && (optionsFilename = options.filename)) {
       resolvedUrl = optionsFilename;
     } else if ("url" in options && (optionsUrl = options.url)) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1640,14 +1640,14 @@ function getConnectionDetailsFromEnvironment(
 }
 
 /**
- * An options object that names where to connect (a URL, a file or a host) is
- * a complete connection target. The environment connection strings are a
- * fallback for when nothing names a target, so they must not supply the
- * adapter, the URL or the sslmode for such an object.
+ * An options object that names where to connect (a URL, a file, a host or a
+ * socket path) is a complete connection target. The environment connection
+ * strings are a fallback for when nothing names a target, so they must not
+ * supply the adapter, the URL or the sslmode for such an object.
  */
 function hasConnectionTarget(options: Bun.SQL.Options): boolean {
   const o = options as Record<string, unknown>;
-  return !!(o.url || o.filename || o.hostname || o.host);
+  return !!(o.url || o.filename || o.hostname || o.host || o.path);
 }
 
 function ensureUrlHasProtocol<T extends string | URL>(

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1639,12 +1639,7 @@ function getConnectionDetailsFromEnvironment(
   return [url, sslMode, adapter || null];
 }
 
-/**
- * An options object that names where to connect (a URL, a file, a host or a
- * socket path) is a complete connection target. The environment connection
- * strings are a fallback for when nothing names a target, so they must not
- * supply the adapter, the URL or the sslmode for such an object.
- */
+/** The environment connection URLs only apply when nothing names a target. */
 function hasConnectionTarget(options: Bun.SQL.Options): boolean {
   const o = options as Record<string, unknown>;
   return !!(o.url || o.filename || o.hostname || o.host || o.path);

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1639,6 +1639,17 @@ function getConnectionDetailsFromEnvironment(
   return [url, sslMode, adapter || null];
 }
 
+/**
+ * An options object that names where to connect (a URL, a file or a host) is
+ * a complete connection target. The environment connection strings are a
+ * fallback for when nothing names a target, so they must not supply the
+ * adapter, the URL or the sslmode for such an object.
+ */
+function hasConnectionTarget(options: Bun.SQL.Options): boolean {
+  const o = options as Record<string, unknown>;
+  return !!(o.url || o.filename || o.hostname || o.host);
+}
+
 function ensureUrlHasProtocol<T extends string | URL>(
   url: T | null,
   protocol: string,
@@ -1683,7 +1694,9 @@ function parseConnectionDetailsFromOptionsOrEnvironment(
     options = stringOrUrlOrOptions
       ? { ...stringOrUrlOrOptions, ...definitelyOptionsButMaybeEmpty }
       : definitelyOptionsButMaybeEmpty;
-    [stringOrUrl, sslMode, adapter] = getConnectionDetailsFromEnvironment(options.adapter);
+    if (!hasConnectionTarget(options)) {
+      [stringOrUrl, sslMode, adapter] = getConnectionDetailsFromEnvironment(options.adapter);
+    }
   }
 
   // Resolve URL based on adapter type

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -2,6 +2,8 @@ import { SQL } from "bun";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
 import { unlinkSync } from "js/node/fs/export-star-from";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 declare module "bun" {
   namespace SQL {
@@ -138,18 +140,33 @@ describe("SQL adapter environment variable precedence", () => {
       expect(sql.options.filename).toBe(":memory:");
     });
 
-    test.each(["sqlite://app.db", "file:data.db", ":memory:", "./relative.db"])(
-      'a url is a connection target for adapter: "sqlite" too (%s)',
-      url => {
-        const expected = new SQL(url, { adapter: "sqlite" }).options.filename;
-        expect(new SQL({ adapter: "sqlite", url }).options).toMatchObject({ adapter: "sqlite", filename: expected });
+    test('a url is a connection target for adapter: "sqlite" too', async () => {
+      using dir = tempDir("sql-sqlite-url-target", { placeholder: "" });
+      const file = (name: string) => join(String(dir), name);
+      const opened: InstanceType<typeof SQL>[] = [];
+      const filenameOf = (options: Bun.SQL.Options) => {
+        const sql = new SQL(options);
+        opened.push(sql);
+        return sql.options.filename;
+      };
+      process.env.DATABASE_URL = `sqlite://${file("env.db")}`;
+      process.env.SQLITE_URL = `sqlite://${file("env.db")}`;
 
-        process.env.DATABASE_URL = "sqlite://env.db";
-        process.env.SQLITE_URL = "sqlite://env.db";
-        expect(new SQL({ adapter: "sqlite", url }).options).toMatchObject({ adapter: "sqlite", filename: expected });
-        expect(new SQL({ adapter: "sqlite", url, filename: "wins.db" }).options.filename).toBe("wins.db");
-      },
-    );
+      try {
+        for (const [url, expected] of [
+          [`sqlite://${file("a.db")}`, file("a.db")],
+          [`sqlite:${file("b.db")}`, file("b.db")],
+          [file("c.db"), file("c.db")],
+          [":memory:", ":memory:"],
+        ]) {
+          expect(filenameOf({ adapter: "sqlite", url })).toBe(expected);
+          expect(filenameOf({ adapter: "sqlite", url, filename: file("wins.db") })).toBe(file("wins.db"));
+        }
+        expect(existsSync(file("env.db"))).toBe(false);
+      } finally {
+        await Promise.all(opened.map(sql => sql.close()));
+      }
+    });
 
     test("the host option alias is a connection target", () => {
       process.env.DATABASE_URL = ":memory:";

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -163,8 +163,15 @@ describe("SQL adapter environment variable precedence", () => {
       const withUser = new SQL({ hostname: "127.0.0.1", port: 1, username: "optuser" });
       expect(withUser.options).toMatchObject({ username: "optuser", password: "", database: "optuser" });
 
+      const withDatabase = new SQL({ hostname: "127.0.0.1", port: 1, database: "optdb" });
+      expect(withDatabase.options).toMatchObject({ username: "shelluser", password: "", database: "optdb" });
+
       // The host-agnostic per-field variables still fill in what is missing.
+      process.env.PGUSER = "pguser";
       process.env.PGPASSWORD = "pgpw";
+      const withPgUser = new SQL({ hostname: "127.0.0.1", port: 1 });
+      expect(withPgUser.options).toMatchObject({ username: "pguser", password: "pgpw", database: "pguser" });
+
       process.env.PGDATABASE = "pgdb";
       const withPgVars = new SQL({ hostname: "127.0.0.1", port: 1, username: "optuser" });
       expect(withPgVars.options).toMatchObject({ username: "optuser", password: "pgpw", database: "pgdb" });

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -138,6 +138,19 @@ describe("SQL adapter environment variable precedence", () => {
       expect(sql.options.filename).toBe(":memory:");
     });
 
+    test.each(["sqlite://app.db", "file:data.db", ":memory:", "./relative.db"])(
+      'a url is a connection target for adapter: "sqlite" too (%s)',
+      url => {
+        const expected = new SQL(url, { adapter: "sqlite" }).options.filename;
+        expect(new SQL({ adapter: "sqlite", url }).options).toMatchObject({ adapter: "sqlite", filename: expected });
+
+        process.env.DATABASE_URL = "sqlite://env.db";
+        process.env.SQLITE_URL = "sqlite://env.db";
+        expect(new SQL({ adapter: "sqlite", url }).options).toMatchObject({ adapter: "sqlite", filename: expected });
+        expect(new SQL({ adapter: "sqlite", url, filename: "wins.db" }).options.filename).toBe("wins.db");
+      },
+    );
+
     test("the host option alias is a connection target", () => {
       process.env.DATABASE_URL = ":memory:";
 

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -145,6 +145,31 @@ describe("SQL adapter environment variable precedence", () => {
       expect(sql.options).toMatchObject({ adapter: "postgres", hostname: "127.0.0.1", port: 1 });
     });
 
+    test.each(["DATABASE_URL", "POSTGRES_URL"])("credentials in %s do not go to a host named in the options", name => {
+      process.env[name] = "postgres://envuser:ENVSECRET@10.9.9.9:7/envdb";
+      process.env.USER = "shelluser";
+      delete process.env.PASSWORD;
+
+      const noCreds = new SQL({ hostname: "127.0.0.1", port: 1 });
+      expect(noCreds.options).toMatchObject({
+        adapter: "postgres",
+        hostname: "127.0.0.1",
+        port: 1,
+        username: "shelluser",
+        password: "",
+        database: "shelluser",
+      });
+
+      const withUser = new SQL({ hostname: "127.0.0.1", port: 1, username: "optuser" });
+      expect(withUser.options).toMatchObject({ username: "optuser", password: "", database: "optuser" });
+
+      // The host-agnostic per-field variables still fill in what is missing.
+      process.env.PGPASSWORD = "pgpw";
+      process.env.PGDATABASE = "pgdb";
+      const withPgVars = new SQL({ hostname: "127.0.0.1", port: 1, username: "optuser" });
+      expect(withPgVars.options).toMatchObject({ username: "optuser", password: "pgpw", database: "pgdb" });
+    });
+
     test("a unix socket path is a connection target", () => {
       process.env.SQLITE_URL = "sqlite://envfile.db";
 

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -145,7 +145,15 @@ describe("SQL adapter environment variable precedence", () => {
       expect(sql.options).toMatchObject({ adapter: "postgres", hostname: "127.0.0.1", port: 1 });
     });
 
-    test.each([{ max: 1, username: "appuser" }, { port: 9 }, { path: "/tmp/sock" }])(
+    test("a unix socket path is a connection target", () => {
+      process.env.SQLITE_URL = "sqlite://envfile.db";
+
+      const sql = new SQL({ path: "/var/run/postgresql", database: "appdb" });
+      expect(sql.options).toMatchObject({ adapter: "postgres", database: "appdb" });
+      expect(sql.options.filename).toBeUndefined();
+    });
+
+    test.each([{ max: 1, username: "appuser" }, { port: 9 }])(
       "an options object without a target (%p) still falls back to the environment",
       options => {
         process.env.MYSQL_URL = "mysql://envuser:envpw@envhost:7/envdb";

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -86,6 +86,84 @@ describe("SQL adapter environment variable precedence", () => {
     expect(options.options.username).toBe("postgres");
   });
 
+  describe("an options object that names a connection target ignores the environment connection strings", () => {
+    const byUrl = { url: "postgres://appuser:apppw@127.0.0.1:1/appdb", max: 1 };
+    const byFields = { hostname: "127.0.0.1", port: 1, username: "appuser", password: "apppw", database: "appdb" };
+
+    test.each([
+      ["MYSQL_URL", "mysql://x:y@127.0.0.1:9/x"],
+      ["MARIADB_URL", "mariadb://x:y@127.0.0.1:9/x"],
+      ["SQLITE_URL", "sqlite://envfile.db"],
+      ["DATABASE_URL", ":memory:"],
+      ["DATABASE_URL", "mysql://envuser:envpw@envhost:7/envdb"],
+      ["POSTGRES_URL", "postgres://envuser:envpw@envhost:7/envdb"],
+    ])("%s=%s does not pick the adapter or the target", (name, value) => {
+      process.env[name] = value;
+
+      for (const options of [byUrl, byFields]) {
+        const sql = new SQL(options);
+        expect(sql.options).toMatchObject({ adapter: "postgres", hostname: "127.0.0.1", port: 1, username: "appuser" });
+        expect(sql.options.database).toBe("appdb");
+        expect(sql.options.filename).toBeUndefined();
+      }
+    });
+
+    test("the explicit URL scheme picks the adapter", () => {
+      process.env.POSTGRES_URL = "postgres://x:y@127.0.0.1:9/x";
+
+      const sql = new SQL({ url: "mysql://appuser:apppw@127.0.0.1:1/appdb" });
+      expect(sql.options).toMatchObject({ adapter: "mysql", hostname: "127.0.0.1", port: 1, username: "appuser" });
+    });
+
+    test.each(["TLS_DATABASE_URL", "TLS_POSTGRES_DATABASE_URL"])("%s does not force sslmode=require", name => {
+      process.env[name] = "postgres://x:y@127.0.0.1:9/x";
+
+      expect(new SQL(byUrl).options.sslMode).toBe(0);
+      expect(new SQL(byFields).options.sslMode).toBe(0);
+    });
+
+    test("a URL copied from TLS_DATABASE_URL into options.url is an explicit URL: its own ?sslmode= applies", () => {
+      process.env.TLS_DATABASE_URL = "postgres://x:y@127.0.0.1:9/x?sslmode=require";
+
+      expect(new SQL({ url: process.env.TLS_DATABASE_URL }).options.sslMode).toBe(2);
+      process.env.TLS_DATABASE_URL = "postgres://x:y@127.0.0.1:9/x";
+      expect(new SQL({ url: process.env.TLS_DATABASE_URL }).options.sslMode).toBe(0);
+    });
+
+    test("a filename is a connection target", () => {
+      process.env.DATABASE_URL = "postgres://x:y@127.0.0.1:9/x";
+
+      const sql = new SQL({ filename: ":memory:" });
+      expect(sql.options.adapter).toBe("sqlite");
+      expect(sql.options.filename).toBe(":memory:");
+    });
+
+    test("the host option alias is a connection target", () => {
+      process.env.DATABASE_URL = ":memory:";
+
+      const sql = new SQL({ host: "127.0.0.1", port: 1 });
+      expect(sql.options).toMatchObject({ adapter: "postgres", hostname: "127.0.0.1", port: 1 });
+    });
+
+    test.each([{ max: 1, username: "appuser" }, { port: 9 }, { path: "/tmp/sock" }])(
+      "an options object without a target (%p) still falls back to the environment",
+      options => {
+        process.env.MYSQL_URL = "mysql://envuser:envpw@envhost:7/envdb";
+
+        const sql = new SQL(options);
+        expect(sql.options).toMatchObject({ adapter: "mysql", hostname: "envhost", port: options.port ?? 7 });
+      },
+    );
+
+    test("an explicit adapter without a target still reads that adapter's environment URL", () => {
+      process.env.MYSQL_URL = "mysql://envuser:envpw@envhost:7/envdb";
+      process.env.POSTGRES_URL = "postgres://pguser:pgpw@pghost:5/pgdb";
+
+      expect(new SQL({ adapter: "mysql" }).options).toMatchObject({ adapter: "mysql", hostname: "envhost", port: 7 });
+      expect(new SQL({ adapter: "postgres" }).options).toMatchObject({ adapter: "postgres", hostname: "pghost" });
+    });
+  });
+
   test("should only read PostgreSQL env vars when adapter is postgres", () => {
     process.env.PGHOST = "pg-host";
     process.env.PGUSER = "pg-user";


### PR DESCRIPTION
### Problem
- `new SQL({ url: "postgres://app@127.0.0.1/appdb" })` and `new SQL({ hostname, port, username, password, database })` take their adapter from whichever `*_URL` variable exists in the shell. `MYSQL_URL` turns them into a MySQL client that waits for a MySQL greeting at the postgres host. `SQLITE_URL=sqlite://envfile.db` or `DATABASE_URL=:memory:` turns the field form into SQLite, so queries succeed against a local file or memory and the application never reaches its database. `TLS_DATABASE_URL` forces `sslmode=require` onto the explicit config. With `DATABASE_URL=postgres://envuser:ENVSECRET@10.9.9.9/envdb`, `new SQL({ hostname: "127.0.0.1", port })` sends `envuser`, `ENVSECRET` and `envdb` to 127.0.0.1: the environment's secret goes to a different host than the one it was written for.
- The cause is `parseConnectionDetailsFromOptionsOrEnvironment` in `src/js/internal/sql/shared.ts:1697`. For every options object it calls `getConnectionDetailsFromEnvironment`, and the adapter that helper derives from the variable name is assigned before the explicit URL's scheme is looked at. #22260 (for #22147) reordered the per-field chains but left this call unconditional, so the shipped 1.4.3 still shows the bug.

### Fix
- Add `hasConnectionTarget`: an options object with `url`, `filename`, `hostname` or `host` is a complete target. Only when none is set does the resolver read the environment connection URLs. An explicit `adapter` with no target still reads that adapter's `*_URL`, as today.
- A unix socket `path` is a target too. A lone `port` is not: `{ port: 9 }` with `DATABASE_URL` set keeps the current merge (env URL plus the override).
- `{ adapter: "sqlite", url }` now honors `url` (filename first, then url), so it opens the same database that `{ url }` alone does instead of the environment URL or `:memory:`. Per-field variables (`PGUSER`, `PGHOST`, ...) are not touched. They still fill in what the explicit config leaves out.
- Verified: `test/js/sql/adapter-env-var-precedence.test.ts` (the new cases fail on 1.4.3, all 115 pass with the fix). Also `postgres-pgsslmode-env`, `sqlite-sql`, `sqlite-url-parsing`, `adapter-override`, `sql-mariadb-json`, `sql-connect-error-reporting`.

### Background
- `Bun.SQL` accepts a connection string, a `URL`, or an options object. `shared.ts` resolves all three into one `DefinedOptions` record, and that record picks the native driver (`adapter`).
- `getConnectionDetailsFromEnvironment` looks for `DATABASE_URL`, then `POSTGRES_URL`, `MYSQL_URL`, `MARIADB_URL`, `SQLITE_URL` and their `TLS_*` variants. The variable name, not the URL scheme, decides the adapter, and a `TLS_*` name also sets `sslmode=require`.
- The docs describe these variables as what applies when `Bun.sql()` is called without arguments. This change makes the code match that.

<details><summary>Notes</summary>

- Reported in an internal configuration precedence audit (invariant: explicit programmatic configuration beats the ambient environment, per field).
- `{ url: process.env.TLS_DATABASE_URL }` previously got `sslmode=require` from the variable name. It is now an explicit URL and only its own `?sslmode=` applies. A test pins this.
- Not in this PR: the database name from the URL path vs `PGDATABASE` is carried by #37811. The verify-ca / verify-full vs `NODE_TLS_REJECT_UNAUTHORIZED=0` interaction is #41589. #38427 also makes `{ adapter: "sqlite", url }` honor `url`, with the same resolution order as here, plus query-string handling for plain filenames that this PR does not touch.
- Self-reviewed: 15 concerns raised. Addressed: narrowed the target list (a lone `port` no longer suppresses the env URL), dropped the database and TLS hunks into their own PRs, pinned the `TLS_DATABASE_URL`-as-`url` case.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/sql/adapter-env-var-precedence.test.ts

<!-- robobun:evidence:end -->


