### PR TITLE
Bump WebKit so a refused GC, collector or VMTraps thread does not abort the process

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-569-53a8b74f";
+export const WEBKIT_VERSION = "autobuild-preview-pr-569-0ef78c6f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-569-674a5c68";
+export const WEBKIT_VERSION = "autobuild-preview-pr-569-53a8b74f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-569-674a5c68";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/test/js/bun/jsc/thread-limit.test.ts
+++ b/test/js/bun/jsc/thread-limit.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+import { readdirSync, readFileSync } from "node:fs";
+
+// On Linux, threads count toward RLIMIT_NPROC (the same counter a cgroup
+// pids.max enforces). The kernel does not enforce the limit for root, so a
+// root test runner drops to `nobody` through runuser.
+const isRoot = process.getuid?.() === 0;
+const hasPrlimit = isLinux && !!Bun.which("prlimit");
+const nobodyUid = (() => {
+  if (!isLinux || !isRoot || !Bun.which("runuser")) return undefined;
+  const uid = readFileSync("/etc/passwd", "utf8")
+    .split("\n")
+    .find(line => line.startsWith("nobody:"))
+    ?.split(":")[2];
+  return uid === undefined ? undefined : Number(uid);
+})();
+const canLimitThreads = hasPrlimit && (!isRoot || nobodyUid !== undefined);
+
+/** Threads that already belong to `uid`. RLIMIT_NPROC is per uid, not per process. */
+function threadsOwnedBy(uid: number): number {
+  let total = 0;
+  for (const pid of readdirSync("/proc")) {
+    if (!/^\d+$/.test(pid)) continue;
+    let status: string;
+    try {
+      status = readFileSync(`/proc/${pid}/status`, "utf8");
+    } catch {
+      continue;
+    }
+    const owner = status.match(/^Uid:\s+(\d+)/m);
+    if (!owner || Number(owner[1]) !== uid) continue;
+    const threads = status.match(/^Threads:\s+(\d+)/m);
+    total += threads ? Number(threads[1]) : 1;
+  }
+  return total;
+}
+
+function spawnWithThreadLimit(extraThreads: number, script: string) {
+  const uid = isRoot ? nobodyUid! : process.getuid!();
+  const limit = threadsOwnedBy(uid) + extraThreads;
+  const cmd = [Bun.which("prlimit")!, `--nproc=${limit}`, bunExe(), "-e", script];
+  if (isRoot) cmd.unshift(Bun.which("runuser")!, "-u", "nobody", "--");
+  return Bun.spawn({
+    cmd,
+    env: {
+      ...bunEnv,
+      // `nobody` has no writable home.
+      HOME: "/tmp",
+      // LeakSanitizer needs a tracer thread at exit, which this limit refuses.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+test.skipIf(!canLimitThreads)("a GC under a thread limit does not abort the process", async () => {
+  // Room for the main thread only. The GC's parallel markers get no thread,
+  // so a synchronous GC has to finish on the main thread. The heap has to be
+  // big enough for the collector to ask for markers.
+  await using proc = spawnWithThreadLimit(
+    1,
+    `
+    let keep = [];
+    for (let i = 0; i < 200; i++) {
+      keep.push(new Array(10000).fill({ i }));
+      if (i % 50 === 0) keep = [];
+    }
+    Bun.gc(true);
+    console.log("ok");
+  `,
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(exitCode, stderr).toBe(0);
+});
+
+test.skipIf(!canLimitThreads)("new Worker throws ERR_WORKER_INIT_FAILED when the OS refuses the thread", async () => {
+  await using proc = spawnWithThreadLimit(
+    6,
+    `
+    const workers = [];
+    let failure;
+    for (let i = 0; i < 40 && !failure; i++) {
+      try {
+        workers.push(new Worker("data:text/javascript,postMessage(1)"));
+      } catch (e) {
+        failure = { code: e.code, message: e.message, name: e.name };
+      }
+    }
+    console.log(JSON.stringify(failure));
+    for (const w of workers) w.terminate();
+  `,
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(JSON.parse(stdout)).toEqual({
+    code: "ERR_WORKER_INIT_FAILED",
+    message: "EAGAIN",
+    name: "Error",
+  });
+  expect(exitCode, stderr).toBe(0);
+});


### PR DESCRIPTION
Stacked on #41675 (the Worker `ERR_WORKER_INIT_FAILED` change). Draft until oven-sh/WebKit#569 lands on `main`; then `WEBKIT_VERSION` moves to that sha.

### Problem
- A process at its cgroup `pids.max` or `RLIMIT_NPROC` limit aborts with `panic: abort() called` ("oh no: Bun has crashed") on the first GC and on `worker.terminate()`. `ulimit -u 6; bun -e 'Bun.gc(true)'` on the main thread is enough, no workers needed.
- The cause is in WebKit: `WTF::Thread::create` has `RELEASE_ASSERT(success)` on `pthread_create` EAGAIN (`Heap::runBeginPhase -> ParallelHelperClient::setTask -> AutomaticThread::start -> Thread::create`), libpas has the same assert for its scavenger, and `VMTraps::queue()` creates a `WorkQueue` thread on the first `terminate()`.

### Fix
- Bump `WEBKIT_VERSION` to the preview tarball of oven-sh/WebKit#569. The GC helper pool, the collector thread, the JIT worklist and the block warm-up helper retry instead of crashing, the mutator runs the collection itself when no collector thread can start, and the VMTraps sender and the libpas scavenger start later.
- Verified: `test/js/bun/jsc/thread-limit.test.ts`. A synchronous GC with room for the main thread only (aborts on main), and Worker churn with `terminate()` under the limit (aborts on main, throws `ERR_WORKER_INIT_FAILED` and exits 0 here).

### Background
- On Linux every thread counts toward `RLIMIT_NPROC`, and a cgroup v2 `pids.max` counts threads too. Root is exempt from `RLIMIT_NPROC`, so the test drops to `nobody` through `runuser` and sets the limit with `prlimit --nproc`.
- JSC starts most of its threads on demand and lets them exit when idle: the GC markers on a mark phase, the collector thread when the mutator hands off a collection, the libpas scavenger when memory becomes eligible for decommit, the `VMTraps` signal sender on the first trap. So any of them can be the `pthread_create` that fails after the limit is reached.

<details><summary>Notes</summary>

- History: a July attempt (#34705 + oven-sh/WebKit#311) and an August one (oven-sh/WebKit#489) existed. #569 carries #489's Heap and JIT design forward on the current WebKit main and adds the libpas, RunLoop/WorkQueue and VMTraps parts. Both old PRs are closed with pointers.
- The preview tarballs are not built with the release flags of the `autobuild-<sha>` releases, so the binary-size lane reports large deltas until `WEBKIT_VERSION` points at the merged sha.
- The test needs `prlimit` (util-linux) and, as root, `runuser` and a `nobody` entry in `/etc/passwd`. It skips otherwise. The limited child runs with `detect_leaks=0`: LeakSanitizer needs a tracer thread at exit.
- Residual on the WebKit side: the Wasm worklist keeps the crash (a synchronous compile would otherwise hang). Bun's own HTTP, IO and thread pool threads under the same limit are #39864 and a separate ThreadPool fix.
</details>
