### PR TITLE
node:tty: fix WriteStream prototype, isTTY, and prevent fs.WriteStream prototype contamination

### DIFF
--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -102,7 +102,12 @@ Object.defineProperty(ReadStream, "prototype", {
       return this;
     };
 
-    Prototype.constructor = ReadStream;
+    Object.defineProperty(Prototype, "constructor", {
+      value: ReadStream,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
 
     Object.defineProperty(ReadStream, "prototype", { value: Prototype });
 
@@ -134,7 +139,12 @@ $toClass(WriteStream, "WriteStream", fs.WriteStream);
 Object.defineProperty(WriteStream, "prototype", {
   get() {
     const Prototype = Object.create(fs.WriteStream.prototype);
-    Prototype.constructor = WriteStream;
+    Object.defineProperty(Prototype, "constructor", {
+      value: WriteStream,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
     Prototype.isTTY = true;
 
     Prototype._refreshSize = function () {

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -102,6 +102,8 @@ Object.defineProperty(ReadStream, "prototype", {
       return this;
     };
 
+    Prototype.constructor = ReadStream;
+
     Object.defineProperty(ReadStream, "prototype", { value: Prototype });
 
     return Prototype;
@@ -116,9 +118,8 @@ function WriteStream(fd): void {
   const stream = fs.WriteStream.$call(this, null, { fd, $fastPath: true, autoClose: false });
   stream.columns = undefined;
   stream.rows = undefined;
-  stream.isTTY = isatty(stream.fd);
 
-  if (stream.isTTY) {
+  if (isatty(fd)) {
     const windowSizeArray = [0, 0];
     if (_getWindowSize(fd, windowSizeArray) === true) {
       stream.columns = windowSizeArray[0];
@@ -128,13 +129,15 @@ function WriteStream(fd): void {
 
   return stream;
 }
+$toClass(WriteStream, "WriteStream", fs.WriteStream);
 
 Object.defineProperty(WriteStream, "prototype", {
   get() {
-    const Real = fs.WriteStream.prototype;
-    Object.defineProperty(WriteStream, "prototype", { value: Real });
+    const Prototype = Object.create(fs.WriteStream.prototype);
+    Prototype.constructor = WriteStream;
+    Prototype.isTTY = true;
 
-    WriteStream.prototype._refreshSize = function () {
+    Prototype._refreshSize = function () {
       const oldCols = this.columns;
       const oldRows = this.rows;
       const windowSizeArray = [0, 0];
@@ -147,30 +150,30 @@ Object.defineProperty(WriteStream, "prototype", {
       }
     };
 
-    WriteStream.prototype.clearLine = function (dir, cb) {
+    Prototype.clearLine = function (dir, cb) {
       return require("node:readline").clearLine(this, dir, cb);
     };
 
-    WriteStream.prototype.clearScreenDown = function (cb) {
+    Prototype.clearScreenDown = function (cb) {
       return require("node:readline").clearScreenDown(this, cb);
     };
 
-    WriteStream.prototype.cursorTo = function (x, y, cb) {
+    Prototype.cursorTo = function (x, y, cb) {
       return require("node:readline").cursorTo(this, x, y, cb);
     };
 
     // The `getColorDepth` API got inspired by multiple sources such as
     // https://github.com/chalk/supports-color,
     // https://github.com/isaacs/color-support.
-    WriteStream.prototype.getColorDepth = function (env = process.env) {
+    Prototype.getColorDepth = function (env = process.env) {
       return require("internal/tty").getColorDepth(env);
     };
 
-    WriteStream.prototype.getWindowSize = function () {
+    Prototype.getWindowSize = function () {
       return [this.columns, this.rows];
     };
 
-    WriteStream.prototype.hasColors = function (count, env) {
+    Prototype.hasColors = function (count, env) {
       if (env === undefined && (count === undefined || (typeof count === "object" && count !== null))) {
         env = count;
         count = 16;
@@ -181,13 +184,13 @@ Object.defineProperty(WriteStream, "prototype", {
       return count <= 2 ** this.getColorDepth(env);
     };
 
-    WriteStream.prototype.moveCursor = function (dx, dy, cb) {
+    Prototype.moveCursor = function (dx, dy, cb) {
       return require("node:readline").moveCursor(this, dx, dy, cb);
     };
 
     // Add Symbol.asyncIterator to make tty.WriteStream compatible with code
     // that expects stdout/stderr to be async iterable (like in Node.js where they're Duplex)
-    WriteStream.prototype[Symbol.asyncIterator] = function () {
+    Prototype[Symbol.asyncIterator] = function () {
       // Since WriteStream is write-only, we return an empty async iterator
       // This matches the behavior of Node.js Duplex streams used for stdout/stderr
       return (async function* () {
@@ -195,7 +198,9 @@ Object.defineProperty(WriteStream, "prototype", {
       })();
     };
 
-    return Real;
+    Object.defineProperty(WriteStream, "prototype", { value: Prototype });
+
+    return Prototype;
   },
   enumerable: true,
   configurable: true,

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 import fs from "node:fs";
+import os from "node:os";
 import { ReadStream, WriteStream } from "node:tty";
 
 describe("ReadStream.prototype.setRawMode", () => {
@@ -329,8 +330,24 @@ describe("tty prototype and compatibility (issue #29019)", () => {
   });
 
   test("plain fs.WriteStream instance does not have hasColors", () => {
-    const stream = fs.createWriteStream("/dev/null");
+    const stream = fs.createWriteStream(os.devNull);
     expect((stream as any).hasColors).toBeUndefined();
     stream.close();
+  });
+
+  test("tty.WriteStream.prototype.constructor is non-enumerable", () => {
+    const desc = Object.getOwnPropertyDescriptor(WriteStream.prototype, "constructor");
+    expect(desc?.enumerable).toBe(false);
+    expect(desc?.writable).toBe(true);
+    expect(desc?.configurable).toBe(true);
+    expect(Object.keys(WriteStream.prototype).includes("constructor")).toBe(false);
+  });
+
+  test("tty.ReadStream.prototype.constructor is non-enumerable", () => {
+    const desc = Object.getOwnPropertyDescriptor(ReadStream.prototype, "constructor");
+    expect(desc?.enumerable).toBe(false);
+    expect(desc?.writable).toBe(true);
+    expect(desc?.configurable).toBe(true);
+    expect(Object.keys(ReadStream.prototype).includes("constructor")).toBe(false);
   });
 });

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
-import { WriteStream } from "node:tty";
+import fs from "node:fs";
+import { ReadStream, WriteStream } from "node:tty";
 
 describe("ReadStream.prototype.setRawMode", () => {
   // Regression: on Windows, the `fd === 0` branch returned early on success
@@ -299,5 +300,37 @@ describe("WriteStream.prototype.getColorDepth", () => {
 
   it("empty", () => {
     expect(WriteStream.prototype.getColorDepth.call(undefined, {})).toBe(isWindows ? 24 : 1);
+  });
+});
+
+describe("tty prototype and compatibility (issue #29019)", () => {
+  test("tty.WriteStream.prototype.isTTY is true", () => {
+    expect(WriteStream.prototype.isTTY).toBe(true);
+  });
+
+  test("tty.WriteStream.prototype does not mutate fs.WriteStream.prototype", () => {
+    expect(WriteStream.prototype !== fs.WriteStream.prototype).toBe(true);
+    expect((fs.WriteStream.prototype as any).hasColors).toBeUndefined();
+    expect(typeof WriteStream.prototype.hasColors).toBe("function");
+  });
+
+  test("tty.WriteStream.prototype.constructor is WriteStream", () => {
+    expect(WriteStream.prototype.constructor).toBe(WriteStream);
+  });
+
+  test("tty.ReadStream.prototype.constructor is ReadStream", () => {
+    expect(ReadStream.prototype.constructor).toBe(ReadStream);
+  });
+
+  test("new tty.WriteStream inherits isTTY: true from prototype without own property", () => {
+    const ws = new WriteStream(1);
+    expect(ws.isTTY).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(ws, "isTTY")).toBe(false);
+  });
+
+  test("plain fs.WriteStream instance does not have hasColors", () => {
+    const stream = fs.createWriteStream("/dev/null");
+    expect((stream as any).hasColors).toBeUndefined();
+    stream.close();
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #29019

- **Fix `tty.WriteStream.prototype.isTTY`**: Node.js documents that `writeStream.isTTY` is a boolean that is always `true` for `tty.WriteStream` instances (`WriteStream.prototype.isTTY = true`). In Bun, `tty.WriteStream.prototype.isTTY` was `undefined`.
- **Prevent `fs.WriteStream.prototype` contamination**: In `src/js/node/tty.ts`, `WriteStream.prototype` was previously assigned directly to `fs.WriteStream.prototype` (`const Real = fs.WriteStream.prototype; Object.defineProperty(WriteStream, "prototype", { value: Real })`), polluting `fs.WriteStream.prototype` with TTY-specific methods like `hasColors`, `clearLine`, `cursorTo`, `getColorDepth`, and `getWindowSize`. Now `WriteStream.prototype` is cleanly created via `Object.create(fs.WriteStream.prototype)`.
- **Define `constructor` as non-enumerable**: Used `Object.defineProperty(Prototype, "constructor", { value: ..., writable: true, enumerable: false, configurable: true })` on both `ReadStream` and `WriteStream` prototypes to match standard JS class prototypes and Node.js behavior where `constructor` does not enumerate in `Object.keys()`.
- **Add `$toClass` binding**: Added `$toClass(WriteStream, "WriteStream", fs.WriteStream)` matching `ReadStream`.
- **Clean up instance property**: Removed manual assignment `stream.isTTY = isatty(...)` on `WriteStream` instances so `isTTY: true` is inherited cleanly from `WriteStream.prototype.isTTY` without polluting instances as an own property, matching Node.js behavior.
- **Cross-platform test resilience**: Used `os.devNull` for filesystem stream test fixture creation so tests run portably across POSIX and Windows.

### How did you verify your code works?

1. **Reproduction script**: Verified before and after against Node.js v22.14.0 and Bun debug build:
   - Before: Failing assertions in Bun (including `tty.WriteStream.prototype.isTTY === undefined`, `tty.WriteStream.prototype === fs.WriteStream.prototype`, `fs.WriteStream.prototype.hasColors` being defined, and `constructor` enumerability).
   - After: 10/10 assertions pass, producing identical behavior to Node.js.
2. **Automated tests in `test/js/node/tty.test.ts`**:
   - Added test suite verifying `tty.WriteStream.prototype.isTTY`, prototype isolation from `fs.WriteStream.prototype`, non-enumerable constructor property descriptors, and `fs.WriteStream.prototype.hasColors === undefined`.
   - Ran `bun test test/js/node/tty.test.ts` (15 pass, 0 fail).
3. **Regression tests**:
   - Ran `bun test test/js/node/tty.test.ts test/js/node/fs/fs.test.ts test/js/node/nodettywrap.test.ts test/regression/issue/tty-readstream-ref-unref.test.ts` (573 pass, 16 skip, 0 fail).
4. **Static checks**:
   - Ran `bun run prettier --write` and `bun run lint src/js/node/tty.ts test/js/node/tty.test.ts` (0 errors, 0 warnings).
   - Ran `bun run rust:check` (0 errors).