### PR TITLE
Do not treat st_size 0 of a regular file as an empty body

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -263,9 +263,10 @@ pub trait BlobExt {
     fn get_size(&self, _: &JSGlobalObject) -> JSValue;
     fn resolve_size(&self);
     /// [`resolve_size`] for a blob that is about to become a `ReadableStream`.
-    /// A file-backed blob is left as it is: its `st_size` is not a byte
-    /// budget (0 on procfs, the directory size on sysfs), so an unsliced file
-    /// keeps `MAX_SIZE` and the stream reads to EOF, like `Blob.stream()`.
+    /// A file or S3 blob is left as it is: a file's `st_size` is not a byte
+    /// budget (0 on procfs, the directory size on sysfs) and an S3 object has
+    /// no local size, so an unsliced one keeps `MAX_SIZE` and the stream reads
+    /// to the end, like `Blob.stream()`.
     ///
     /// [`resolve_size`]: Self::resolve_size
     fn resolve_size_for_stream(&self);
@@ -2228,7 +2229,7 @@ impl BlobExt for Blob {
     }
 
     fn resolve_size_for_stream(&self) {
-        if self.needs_to_read_file() {
+        if self.needs_to_read_file() || self.is_s3() {
             return;
         }
         self.resolve_size();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -262,6 +262,13 @@ pub trait BlobExt {
     fn get_stat(&self, global_this: &JSGlobalObject, callback: &CallFrame) -> JsResult<JSValue>;
     fn get_size(&self, _: &JSGlobalObject) -> JSValue;
     fn resolve_size(&self);
+    /// [`resolve_size`] for a blob that is about to become a `ReadableStream`.
+    /// A file-backed blob is left as it is: its `st_size` is not a byte
+    /// budget (0 on procfs, the directory size on sysfs), so an unsliced file
+    /// keeps `MAX_SIZE` and the stream reads to EOF, like `Blob.stream()`.
+    ///
+    /// [`resolve_size`]: Self::resolve_size
+    fn resolve_size_for_stream(&self);
     fn resolved_size(&self) -> (SizeType, SizeType);
     fn constructor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<*mut Blob>
     where
@@ -2218,6 +2225,13 @@ impl BlobExt for Blob {
             }
             store::DataTag::S3 => self.size.set(0),
         }
+    }
+
+    fn resolve_size_for_stream(&self) {
+        if self.needs_to_read_file() {
+            return;
+        }
+        self.resolve_size();
     }
 
     /// Non-mutating variant of [`resolve_size`]: returns the `(offset, size)` that

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -784,7 +784,7 @@ impl Value {
             Value::InternalBlob(_) | Value::Blob(_) | Value::WTFStringImpl(_) => {
                 // `deinit` must run on every exit incl. `?` paths.
                 let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
-                blob.resolve_size();
+                blob.resolve_size_for_stream();
                 let blob_size = blob.size.get();
                 let value = ReadableStream::from_blob_copy_ref(global_this, &blob, blob_size)?;
 
@@ -842,7 +842,7 @@ impl Value {
             Value::Blob(_) => {
                 let stream = {
                     let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
-                    blob.resolve_size();
+                    blob.resolve_size_for_stream();
                     if blob.needs_to_read_file() || blob.is_s3() {
                         let blob_size = blob.size.get();
                         let bytes =

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -743,15 +743,8 @@ impl ReadFile {
             return self.on_finish();
         }
 
-        // Special files might report a size of > 0, and be wrong.
-        // so we should check specifically that its a regular file before trusting the size.
-        if self.size == 0 && bun_sys::is_regular_file(self.file_store.mode) {
-            self.buffer = Vec::new();
-
-            self.on_finish();
-            return;
-        }
-
+        // No shortcut for a regular file with `st_size == 0`: procfs files report that and
+        // still have content, so read until EOF (one `read()` for a truly empty file).
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if !self.could_block || (self.size > 0 && self.size != MAX_SIZE) {
             let want = (self.size as usize).saturating_add(16);

--- a/src/runtime/webcore/wasm_streaming.rs
+++ b/src/runtime/webcore/wasm_streaming.rs
@@ -136,7 +136,7 @@ fn get_body_stream_or_bytes_for_wasm_streaming(
         };
         // `defer blob.detach()` — RAII via scopeguard.
         let blob = scopeguard::guard(blob, |b: Blob| b.detach());
-        blob.resolve_size();
+        blob.resolve_size_for_stream();
         let size = blob.size.get();
         return ReadableStream::from_blob_copy_ref(this, &blob, size);
     }

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -381,6 +381,32 @@ for (const { body, fn } of bodyTypes) {
           expect(fn(file).body).toBeInstanceOf(ReadableStream);
           expect(await file.text()).toBe(expected);
         });
+
+        // clone() stats the file to learn whether it can be read twice. That
+        // cached stat (a regular file, st_size 0) must not turn the buffered
+        // read of either copy, or of the Bun.file() itself, into "".
+        test("clone() reads the whole file on both copies", async () => {
+          const expected = await Bun.file(path).text();
+          const file = Bun.file(path);
+          const original = fn(file);
+          const clone = original.clone();
+          const streamed = fn(Bun.file(path));
+          expect(streamed.body).toBeInstanceOf(ReadableStream);
+          const streamedClone = streamed.clone();
+          expect({
+            clone: await clone.text(),
+            original: await original.text(),
+            "clone after .body": await streamedClone.text(),
+            "original after .body": await streamed.text(),
+            "Bun.file() afterwards": await file.text(),
+          }).toEqual({
+            clone: expected,
+            original: expected,
+            "clone after .body": expected,
+            "original after .body": expected,
+            "Bun.file() afterwards": expected,
+          });
+        });
       });
 
       // An S3 object has no local size either, so the body stream must fetch

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
+import { bunEnv, bunExe, exampleSite, isLinux, tempDir } from "harness";
 import net from "net";
 
 const exampleServer = exampleSite("http");
@@ -347,6 +347,39 @@ for (const { body, fn } of bodyTypes) {
           const subject = fn(Bun.file(`${dir}/data.txt`).slice(3, 8));
           expect(subject.body).toBeInstanceOf(ReadableStream);
           expect([Buffer.from(await subject.bytes()).toString(), subject.bodyUsed]).toEqual(["defgh", true]);
+        });
+      });
+
+      // procfs files are regular files whose st_size is 0, so a stream that
+      // trusts stat as a byte budget ends before it reads anything. The body
+      // getter must read to EOF like Bun.file().stream() does.
+      describe.skipIf(!isLinux)("made from a procfs Bun.file()", () => {
+        const path = "/proc/version";
+
+        test("the body stream reads the whole file", async () => {
+          const expected = await Bun.file(path).text();
+          expect(expected.length).toBeGreaterThan(0);
+          const drain = async (stream: ReadableStream<Uint8Array>) => {
+            let text = "";
+            for await (const chunk of stream) text += Buffer.from(chunk).toString();
+            return text;
+          };
+          expect({
+            "for await": await drain(fn(Bun.file(path)).body!),
+            "Bun.readableStreamToText": await Bun.readableStreamToText(fn(Bun.file(path)).body!),
+            "new Response(body).text()": await new Response(fn(Bun.file(path)).body).text(),
+          }).toEqual({
+            "for await": expected,
+            "Bun.readableStreamToText": expected,
+            "new Response(body).text()": expected,
+          });
+        });
+
+        test("the body getter does not make a later text() on the same Bun.file() empty", async () => {
+          const expected = await Bun.file(path).text();
+          const file = Bun.file(path);
+          expect(fn(file).body).toBeInstanceOf(ReadableStream);
+          expect(await file.text()).toBe(expected);
         });
       });
     });

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,4 +1,4 @@
-import { file, spawn, version, type Socket } from "bun";
+import { file, S3Client, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, exampleSite, isLinux, tempDir } from "harness";
 import net from "net";
@@ -380,6 +380,34 @@ for (const { body, fn } of bodyTypes) {
           const file = Bun.file(path);
           expect(fn(file).body).toBeInstanceOf(ReadableStream);
           expect(await file.text()).toBe(expected);
+        });
+      });
+
+      // An S3 object has no local size either, so the body stream must fetch
+      // the whole object, not a zero-length range. (A Response made from an
+      // S3 file is a redirect by design, so only Request applies.)
+      describe.skipIf(body !== Request)("made from an S3 file", () => {
+        test("the body stream downloads the whole object", async () => {
+          const payload = Buffer.alloc(100, "0123456789").toString();
+          const ranges: (string | null)[] = [];
+          using server = Bun.serve({
+            port: 0,
+            fetch(req) {
+              const range = req.headers.get("range");
+              ranges.push(range);
+              const match = range && /^bytes=(\d+)-(\d*)$/.exec(range);
+              if (!match) return new Response(payload, { headers: { "Content-Type": "text/plain" } });
+              const start = Number(match[1]);
+              const end = match[2] === "" ? payload.length - 1 : Number(match[2]);
+              return new Response(payload.slice(start, end + 1), {
+                status: 206,
+                headers: { "Content-Type": "text/plain", "Content-Range": `bytes ${start}-${end}/${payload.length}` },
+              });
+            },
+          });
+          const s3 = new S3Client({ endpoint: server.url.href, accessKeyId: "x", secretAccessKey: "y", bucket: "b" });
+          const text = await Bun.readableStreamToText(fn(s3.file("key")).body!);
+          expect({ text, ranges }).toEqual({ text: payload, ranges: [null] });
         });
       });
     });


### PR DESCRIPTION
### Problem
- `new Response(Bun.file("/proc/version")).body` is an empty stream, while `.text()` and `Bun.file(p).stream()` return the content. Since #42053, `new Response(Bun.file(p)).clone()` also makes both copies read `""`.
- Two sites treat `st_size == 0` of a regular file as "empty". `Body::Value::to_readable_stream` (`Body.rs:759`, also `textStream()` and `wasm_streaming.rs:139`) calls `resolve_size()` first, so the `FileReader` gets `max_size: Some(0)`. `ReadFile::run_async_with_fd` (`blob/read_file.rs:748`) returns an empty buffer when `fstat` says 0 bytes and the store's cached mode says regular file. `clone()` now fills that cache through `store_reads_repeatably`.

### Fix
- Add `Blob::resolve_size_for_stream`: it sizes an in-memory blob and leaves a file or S3 blob at `MAX_SIZE`, so the reader runs to EOF and an S3 download requests the whole object. A `.slice()` keeps its bound. `Blob.prototype.stream()` already works this way.
- Drop the empty-file shortcut in `ReadFile`. A regular file whose `fstat` reports 0 bytes is read until EOF: one `read()` for a truly empty file, which still reads as `""`.
- Verified: `test/js/web/fetch/body.test.ts`, "made from a procfs Bun.file()" (skipped off Linux) and "made from an S3 file". They fail with `src/` at main and pass here.

### Background
- Every `Blob` over a `Bun.file()` shares one `File` store. `resolve_file_stat` caches `st_size`, mode and `seekable` on it; `resolve_size` copies the size onto a blob, whose `size` is otherwise `MAX_SIZE` ("unknown").
- `FileReader` (streams) and `ReadFile` (`.text()`, `.bytes()`) stop at the blob's size unless it is `MAX_SIZE`.
- procfs, sysfs and cgroupfs files are regular files whose `st_size` is 0 or a page size. Their content only exists on `read()`.

<details><summary>Notes</summary>

Before and after on main at b5ba14b61 (`/proc/self/status`, about 1.5 KB):

```
                                        before   after
Bun.file(P).text()                      1535     1535
new Response(Bun.file(P)).body          0        1535
f.text() after touching .body           0        1535
r.clone().text() / r.text()             0 / 0    1535 / 1535
f.text() after new Response(f).clone()  0        1535
```

The tests cover, for both `Request` and `Response`: draining `.body` three ways, `text()` on the same `Bun.file()` after `.body`, and `clone()` before and after `.body` with both copies and the `Bun.file()` read afterwards.

Other suites run locally: `body-clone`, `body-stream`, `blob`, `bun-serve-file`, `bun-write`, `fs.test.ts`, `bun-file-exists`.

The S3 sibling: `resolve_size` sets an S3 blob's size to 0, so `new Request(url, { body: s3file }).body` sent `Range: bytes=0-0` and streamed one byte. It now sends no `Range` and streams the object. `new Response(s3file)` is a 302 redirect by design and does not reach this path.

Still open, by design of this PR: `f.size` and `await f.exists()` copy the cached `st_size == 0` onto the blob itself, so a later `f.text()` on that same `Bun.file` reads `""` (the read runs with `max_length` 0). That is the `.size` / `exists()` half of the problem; #33360 is the broader open PR that separates "bytes the view spans" from "read budget" for every read path, FormData and fetch upload included.

`WebAssembly.compileStreaming(new Response(Bun.file("/proc/version")))` now fails with "doesn't start with the magic number" instead of "expected a module of at least 8 bytes", which shows the wasm site reads the content too.

Windows keeps its `ReadFileUV` shortcut: it tests the mode from the `fstat` it just ran, and NTFS regular files do not under-report their size.
</details>
