### PR TITLE
Index into arrays in bun pm pkg set and delete key paths

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -436,6 +436,8 @@ scripts.build              # dot notation
 contributors[0]            # array access
 workspaces.0               # dot with numeric index
 scripts[test:watch]        # bracket for special chars
+scripts[a.b]               # bracket keeps the dot in the key
+files[]                    # append to an array (set only)
 ```
 
 Examples:
@@ -451,6 +453,7 @@ bun pm pkg get scripts.build                      # nested property
 bun pm pkg set name="my-package"                  # simple property
 bun pm pkg set scripts.test="jest" version=2.0.0  # multiple properties
 bun pm pkg set private=true --json                # JSON values with --json flag
+bun pm pkg set files[2]=c.js files[]=d.js         # index into or append to an array
 
 # delete
 bun pm pkg delete description                     # single property

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -453,7 +453,7 @@ bun pm pkg get scripts.build                      # nested property
 bun pm pkg set name="my-package"                  # simple property
 bun pm pkg set scripts.test="jest" version=2.0.0  # multiple properties
 bun pm pkg set private=true --json                # JSON values with --json flag
-bun pm pkg set files[2]=c.js files[]=d.js         # index into or append to an array
+bun pm pkg set 'files[2]=c.js' 'files[]=d.js'     # index into or append to an array
 
 # delete
 bun pm pkg delete description                     # single property

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -41,8 +41,7 @@ impl SubCommand {
     }
 }
 
-/// How many `null` slots `set` may add past the end of an array for one
-/// index. A larger index is a typo, not a request for a dense array.
+/// Upper bound on the `null` slots one `set` may add past the end of an array.
 const MAX_ARRAY_EXTENSION: usize = 1024;
 
 /// One step of a `bun pm pkg` key path such as `contributors[0].name`.
@@ -537,10 +536,7 @@ impl PmPkgCommand {
     }
 
     /// Splits `a.b[0][c.d]` into `[Key("a"), Key("b"), Key("0"), Key("c.d")]`.
-    /// Text inside `[...]` is one segment, dots included. `[]` is `Append`.
-    /// Segments are sub-slices of `key`: `E::Object::put` stores keys by
-    /// reference (no copy into the AST arena), so they must outlive the
-    /// `Expr` tree, which `key` (an argv slice) does.
+    /// Segments borrow from `key` because `E::Object::put` stores keys by reference.
     fn parse_key_path(key: &[u8]) -> Result<Vec<Segment<'_>>, Error> {
         let mut segments: Vec<Segment<'_>> = Vec::new();
         let mut rest = key;
@@ -588,10 +584,7 @@ impl PmPkgCommand {
         Self::set_path(root, &path, expr)
     }
 
-    /// Walks `path` from `container`, creating missing containers, and stores
-    /// `value` at the end. Like `npm pkg set`: a numeric segment indexes an
-    /// existing array (holes become `null`), and a missing container becomes
-    /// an array when the segment after it is numeric or `[]`.
+    /// Stores `value` at `path`, with the container rules of `npm pkg set`.
     fn set_path(container: &mut Expr, path: &[Segment<'_>], value: Expr) -> Result<(), Error> {
         let (segment, rest) = path.split_first().ok_or(crate::Error::EmptyKey)?;
 
@@ -645,9 +638,7 @@ impl PmPkgCommand {
         }
     }
 
-    /// True when `next` can be stored into `expr` without replacing it. An
-    /// empty object is replaced by an array when `next` is an index, as npm
-    /// does.
+    /// An empty object is replaced by an array when `next` is an index, as npm does.
     fn is_writable_container(expr: &Expr, next: &Segment<'_>) -> bool {
         match &expr.data {
             ExprData::EArray(_) => true,
@@ -711,8 +702,7 @@ impl PmPkgCommand {
         Self::delete_path(root, &path)
     }
 
-    /// Removes the value at `path`. An index into an array removes that item
-    /// and shifts the rest down, like `npm pkg delete`.
+    /// Removes the value at `path`. An array index splices the item out.
     fn delete_path(container: &mut Expr, path: &[Segment<'_>]) -> Result<bool, Error> {
         let Some((Segment::Key(part), rest)) = path.split_first() else {
             return Ok(false);

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -535,8 +535,7 @@ impl PmPkgCommand {
         Ok(current)
     }
 
-    /// Splits `a.b[0][c.d]` into `[Key("a"), Key("b"), Key("0"), Key("c.d")]`.
-    /// Segments borrow from `key` because `E::Object::put` stores keys by reference.
+    /// Splits `a.b[0][c.d]` into `[Key("a"), Key("b"), Key("0"), Key("c.d")]`, borrowing from `key`.
     fn parse_key_path(key: &[u8]) -> Result<Vec<Segment<'_>>, Error> {
         let mut segments: Vec<Segment<'_>> = Vec::new();
         let mut rest = key;

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -41,6 +41,10 @@ impl SubCommand {
     }
 }
 
+/// How many `null` slots `set` may add past the end of an array for one
+/// index. A larger index is a typo, not a request for a dense array.
+const MAX_ARRAY_EXTENSION: usize = 1024;
+
 /// One step of a `bun pm pkg` key path such as `contributors[0].name`.
 #[derive(Copy, Clone)]
 enum Segment<'a> {
@@ -598,7 +602,15 @@ impl PmPkgCommand {
                     Segment::Key(part) => bun_core::fmt::parse_decimal::<usize>(part)
                         .ok_or(crate::Error::ExpectedObject)?,
                 };
-                if index >= arr.items.len() {
+                let len = arr.items.len();
+                if index >= len {
+                    if index - len >= MAX_ARRAY_EXTENSION {
+                        Output::err_generic(
+                            "Array index {} is too far past the end of the array ({} items)",
+                            (index, len),
+                        );
+                        Global::exit(1);
+                    }
                     arr.items.resize(index + 1, Expr::init(E::Null, Loc::EMPTY));
                 }
                 let slot = &mut arr.items[index];

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -41,6 +41,23 @@ impl SubCommand {
     }
 }
 
+/// One step of a `bun pm pkg` key path such as `contributors[0].name`.
+#[derive(Copy, Clone)]
+enum Segment<'a> {
+    Key(&'a [u8]),
+    /// `[]`: the slot after the last item of an array (set only).
+    Append,
+}
+
+impl Segment<'_> {
+    fn is_index(&self) -> bool {
+        match self {
+            Segment::Append => true,
+            Segment::Key(part) => bun_core::fmt::parse_decimal::<usize>(part).is_some(),
+        }
+    }
+}
+
 struct PackageJson {
     root: Expr,
     contents: Box<[u8]>,
@@ -494,124 +511,63 @@ impl PmPkgCommand {
             return Err(crate::Error::NotFound);
         }
 
-        let mut parts = strings::tokenize(key, b".");
         let mut current = root;
-
-        while let Some(part) = parts.next() {
-            if let Some(first_bracket) = strings::index_of(part, b"[") {
-                let mut remaining_part = part;
-
-                if first_bracket > 0 {
-                    let prop_name = &part[..first_bracket];
-                    if !matches!(current.data, ExprData::EObject(_)) {
-                        return Err(crate::Error::NotFound);
-                    }
-                    current = current.get(prop_name).ok_or(crate::Error::NotFound)?;
-                    remaining_part = &part[first_bracket..];
+        for segment in Self::parse_key_path(key)? {
+            let Segment::Key(part) = segment else {
+                return Err(crate::Error::InvalidPath);
+            };
+            match &current.data {
+                ExprData::EArray(arr) => {
+                    let index = bun_core::fmt::parse_decimal::<usize>(part)
+                        .ok_or(crate::Error::NotFound)?;
+                    current = *arr.items.get(index).ok_or(crate::Error::NotFound)?;
                 }
-
-                while let Some(bracket_start) = strings::index_of(remaining_part, b"[") {
-                    let bracket_end = strings::index_of(&remaining_part[bracket_start..], b"]")
-                        .ok_or(crate::Error::InvalidPath)?;
-                    let actual_bracket_end = bracket_start + bracket_end;
-                    let index_str = &remaining_part[bracket_start + 1..actual_bracket_end];
-
-                    if index_str.is_empty() {
-                        return Err(crate::Error::InvalidPath);
-                    }
-
-                    if let Some(index) = bun_core::fmt::parse_decimal::<usize>(index_str) {
-                        let ExprData::EArray(arr) = &current.data else {
-                            return Err(crate::Error::NotFound);
-                        };
-
-                        if index >= arr.items.len_u32() as usize {
-                            return Err(crate::Error::NotFound);
-                        }
-
-                        current = arr.items.slice()[index];
-                    } else {
-                        if !matches!(current.data, ExprData::EObject(_)) {
-                            return Err(crate::Error::NotFound);
-                        }
-                        current = current.get(index_str).ok_or(crate::Error::NotFound)?;
-                    }
-
-                    remaining_part = &remaining_part[actual_bracket_end + 1..];
-                    if remaining_part.is_empty() {
-                        break;
-                    }
-                }
-            } else {
-                if let Some(index) = bun_core::fmt::parse_decimal::<usize>(part) {
-                    match &current.data {
-                        ExprData::EArray(arr) => {
-                            if index >= arr.items.len_u32() as usize {
-                                return Err(crate::Error::NotFound);
-                            }
-                            current = arr.items.slice()[index];
-                        }
-                        ExprData::EObject(_) => {
-                            current = current.get(part).ok_or(crate::Error::NotFound)?;
-                        }
-                        _ => return Err(crate::Error::NotFound),
-                    }
-                } else {
-                    if !matches!(current.data, ExprData::EObject(_)) {
-                        return Err(crate::Error::NotFound);
-                    }
+                ExprData::EObject(_) => {
                     current = current.get(part).ok_or(crate::Error::NotFound)?;
                 }
+                _ => return Err(crate::Error::NotFound),
             }
         }
 
         Ok(current)
     }
 
-    /// Splits `a.b[0][c]` into `["a", "b", "0", "c"]`. Segments are sub-slices
-    /// of `key`: `E::Object::put` stores keys by reference (no copy into the
-    /// AST arena), so they must outlive the `Expr` tree, which `key` (an argv
-    /// slice) does. Returning owned buffers here would leave dangling keys.
-    fn parse_key_path(key: &[u8]) -> Result<Vec<&[u8]>, Error> {
-        let mut path_parts: Vec<&[u8]> = Vec::new();
+    /// Splits `a.b[0][c.d]` into `[Key("a"), Key("b"), Key("0"), Key("c.d")]`.
+    /// Text inside `[...]` is one segment, dots included. `[]` is `Append`.
+    /// Segments are sub-slices of `key`: `E::Object::put` stores keys by
+    /// reference (no copy into the AST arena), so they must outlive the
+    /// `Expr` tree, which `key` (an argv slice) does.
+    fn parse_key_path(key: &[u8]) -> Result<Vec<Segment<'_>>, Error> {
+        let mut segments: Vec<Segment<'_>> = Vec::new();
+        let mut rest = key;
 
-        let mut parts = strings::tokenize(key, b".");
-
-        while let Some(part) = parts.next() {
-            if let Some(first_bracket) = strings::index_of(part, b"[") {
-                let mut remaining_part = part;
-
-                if first_bracket > 0 {
-                    path_parts.push(&part[..first_bracket]);
-                    remaining_part = &part[first_bracket..];
-                }
-
-                while let Some(bracket_start) = strings::index_of(remaining_part, b"[") {
-                    let Some(bracket_end) =
-                        strings::index_of(&remaining_part[bracket_start..], b"]")
-                    else {
-                        return Err(crate::Error::InvalidPath);
-                    };
-                    let actual_bracket_end = bracket_start + bracket_end;
-                    let index_str = &remaining_part[bracket_start + 1..actual_bracket_end];
-
-                    if index_str.is_empty() {
-                        return Err(crate::Error::InvalidPath);
-                    }
-
-                    path_parts.push(index_str);
-
-                    remaining_part = &remaining_part[actual_bracket_end + 1..];
-                    if remaining_part.is_empty() {
-                        break;
-                    }
-                }
+        while !rest.is_empty() {
+            let Some(stop) = strings::index_of_any(rest, b".[") else {
+                segments.push(Segment::Key(rest));
+                break;
+            };
+            if stop > 0 {
+                segments.push(Segment::Key(&rest[..stop]));
+            }
+            if rest[stop] == b'.' {
+                rest = &rest[stop + 1..];
+                continue;
+            }
+            let inner = &rest[stop + 1..];
+            let close =
+                strings::index_of_char_usize(inner, b']').ok_or(crate::Error::InvalidPath)?;
+            segments.push(if close == 0 {
+                Segment::Append
             } else {
-                path_parts.push(part);
+                Segment::Key(&inner[..close])
+            });
+            rest = &inner[close + 1..];
+            if let Some(b'.') = rest.first() {
+                rest = &rest[1..];
             }
         }
 
-        Ok(path_parts)
+        Ok(segments)
     }
 
     fn set_value(root: &mut Expr, key: &[u8], value: &[u8], parse_json: bool) -> Result<(), Error> {
@@ -619,70 +575,81 @@ impl PmPkgCommand {
             return Err(crate::Error::InvalidRoot);
         }
 
-        let path_parts = Self::parse_key_path(key)?;
-
-        if path_parts.is_empty() {
+        let path = Self::parse_key_path(key)?;
+        if path.is_empty() {
             return Err(crate::Error::EmptyKey);
         }
 
-        if path_parts.len() == 1 {
-            let expr = Self::parse_value(value, parse_json)?;
-
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), path_parts[0], expr)?;
-
-            return Ok(());
-        }
-
-        Self::set_nested(root, &path_parts, value, parse_json)
+        let expr = Self::parse_value(value, parse_json)?;
+        Self::set_path(root, &path, expr)
     }
 
-    fn set_nested(
-        root: &mut Expr,
-        path: &[&[u8]],
-        value: &[u8],
-        parse_json: bool,
-    ) -> Result<(), Error> {
-        if path.is_empty() {
-            return Ok(());
+    /// Walks `path` from `container`, creating missing containers, and stores
+    /// `value` at the end. Like `npm pkg set`: a numeric segment indexes an
+    /// existing array (holes become `null`), and a missing container becomes
+    /// an array when the segment after it is numeric or `[]`.
+    fn set_path(container: &mut Expr, path: &[Segment<'_>], value: Expr) -> Result<(), Error> {
+        let (segment, rest) = path.split_first().ok_or(crate::Error::EmptyKey)?;
+
+        match &mut container.data {
+            ExprData::EArray(arr) => {
+                let index = match segment {
+                    Segment::Append => arr.items.len(),
+                    Segment::Key(part) => bun_core::fmt::parse_decimal::<usize>(part)
+                        .ok_or(crate::Error::ExpectedObject)?,
+                };
+                if index >= arr.items.len() {
+                    arr.items.resize(index + 1, Expr::init(E::Null, Loc::EMPTY));
+                }
+                let slot = &mut arr.items[index];
+                if rest.is_empty() {
+                    *slot = value;
+                    return Ok(());
+                }
+                if !Self::is_writable_container(slot, &rest[0]) {
+                    *slot = Self::new_container(&rest[0]);
+                }
+                Self::set_path(slot, rest, value)
+            }
+            ExprData::EObject(obj) => {
+                let Segment::Key(part) = segment else {
+                    return Err(crate::Error::ExpectedObject);
+                };
+                if rest.is_empty() {
+                    obj.put(dummy_bump(), part, value)?;
+                    return Ok(());
+                }
+                let mut child = match E::Object::get(obj, part) {
+                    Some(child) if Self::is_writable_container(&child, &rest[0]) => child,
+                    _ => {
+                        let child = Self::new_container(&rest[0]);
+                        obj.put(dummy_bump(), part, child)?;
+                        child
+                    }
+                };
+                Self::set_path(&mut child, rest, value)
+            }
+            _ => Err(crate::Error::ExpectedObject),
         }
+    }
 
-        let current_key = path[0];
-        let remaining_path = &path[1..];
-
-        if remaining_path.is_empty() {
-            let expr = Self::parse_value(value, parse_json)?;
-
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), current_key, expr)?;
-
-            return Ok(());
+    /// True when `next` can be stored into `expr` without replacing it. An
+    /// empty object is replaced by an array when `next` is an index, as npm
+    /// does.
+    fn is_writable_container(expr: &Expr, next: &Segment<'_>) -> bool {
+        match &expr.data {
+            ExprData::EArray(_) => true,
+            ExprData::EObject(obj) => !(next.is_index() && obj.properties.is_empty()),
+            _ => false,
         }
+    }
 
-        let mut nested_obj = root.get(current_key);
-        if nested_obj.is_none()
-            || !matches!(nested_obj.as_ref().unwrap().data, ExprData::EObject(_))
-        {
-            let new_obj = Expr::init(E::Object::default(), Loc::EMPTY);
-
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), current_key, new_obj)?;
-
-            nested_obj = root.get(current_key);
+    fn new_container(next: &Segment<'_>) -> Expr {
+        if next.is_index() {
+            Expr::init(E::Array::default(), Loc::EMPTY)
+        } else {
+            Expr::init(E::Object::default(), Loc::EMPTY)
         }
-
-        if !matches!(nested_obj.as_ref().unwrap().data, ExprData::EObject(_)) {
-            return Err(crate::Error::ExpectedObject);
-        }
-
-        let mut nested = nested_obj.unwrap();
-        Self::set_nested(&mut nested, remaining_path, value, parse_json)
     }
 
     fn parse_value(value: &[u8], parse_json: bool) -> Result<Expr, Error> {
@@ -724,60 +691,46 @@ impl PmPkgCommand {
             return Ok(false);
         }
 
-        let mut path_parts: Vec<&[u8]> = Vec::new();
-        for part in strings::tokenize(key, b".") {
-            path_parts.push(part);
-        }
-
-        if path_parts.is_empty() {
-            return Ok(false);
-        }
-
-        if path_parts.len() == 1 {
-            let exists = root.get(path_parts[0]).is_some();
-            if exists {
-                return Self::remove_property(root, path_parts[0]);
-            }
-            return Ok(false);
-        }
-
-        Self::delete_nested(root, &path_parts)
-    }
-
-    fn delete_nested(root: &mut Expr, path: &[&[u8]]) -> Result<bool, Error> {
+        let path = Self::parse_key_path(key)?;
         if path.is_empty() {
             return Ok(false);
         }
 
-        let current_key = path[0];
-        let remaining_path = &path[1..];
+        Self::delete_path(root, &path)
+    }
 
-        if remaining_path.is_empty() {
-            let exists = root.get(current_key).is_some();
-            if exists {
-                return Self::remove_property(root, current_key);
+    /// Removes the value at `path`. An index into an array removes that item
+    /// and shifts the rest down, like `npm pkg delete`.
+    fn delete_path(container: &mut Expr, path: &[Segment<'_>]) -> Result<bool, Error> {
+        let Some((Segment::Key(part), rest)) = path.split_first() else {
+            return Ok(false);
+        };
+
+        match &mut container.data {
+            ExprData::EArray(arr) => {
+                let Some(index) = bun_core::fmt::parse_decimal::<usize>(part) else {
+                    return Ok(false);
+                };
+                if index >= arr.items.len() {
+                    return Ok(false);
+                }
+                if rest.is_empty() {
+                    arr.items.remove(index);
+                    return Ok(true);
+                }
+                Self::delete_path(&mut arr.items[index], rest)
             }
-            return Ok(false);
+            ExprData::EObject(obj) => {
+                if rest.is_empty() {
+                    return Self::remove_property(container, part);
+                }
+                let Some(mut child) = E::Object::get(obj, part) else {
+                    return Ok(false);
+                };
+                Self::delete_path(&mut child, rest)
+            }
+            _ => Ok(false),
         }
-
-        let nested_obj = root.get(current_key);
-        if nested_obj.is_none()
-            || !matches!(nested_obj.as_ref().unwrap().data, ExprData::EObject(_))
-        {
-            return Ok(false);
-        }
-
-        let mut nested = nested_obj.unwrap();
-        let deleted = Self::delete_nested(&mut nested, remaining_path)?;
-
-        if deleted {
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), current_key, nested)?;
-        }
-
-        Ok(deleted)
     }
 
     fn remove_property(obj: &mut Expr, key: &[u8]) -> Result<bool, Error> {

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -344,10 +344,100 @@ describe.concurrent("bun pm pkg", () => {
       expect(await readPkg(dir)).toEqual({
         name: "x",
         version: "1.0.0",
-        contributors: { "0": "alice" },
-        nested: { deep: { "0": "value" } },
+        contributors: ["alice"],
+        nested: { deep: ["value"] },
         scripts: { lint: "eslint ." },
       });
+    });
+
+    it("should index into an existing array with a numeric segment", async () => {
+      using dir = tempDir("pm-pkg-array-index", {
+        "package.json": JSON.stringify(
+          {
+            name: "x",
+            contributors: [{ name: "ann" }, { name: "bob" }],
+            files: ["a.js", "b.js"],
+            workspaces: ["pkgs/*"],
+          },
+          null,
+          2,
+        ),
+      });
+
+      const { code } = await runPmPkg(
+        ["set", "files[2]=c.js", "workspaces[1]=apps/*", "contributors[0].name=amy", "contributors.1.name=bobby"],
+        dir,
+      );
+      expect(code).toBe(0);
+
+      expect(await readPkg(dir)).toEqual({
+        name: "x",
+        contributors: [{ name: "amy" }, { name: "bobby" }],
+        files: ["a.js", "b.js", "c.js"],
+        workspaces: ["pkgs/*", "apps/*"],
+      });
+    });
+
+    it("should fill holes with null when the index is past the end", async () => {
+      using dir = tempDir("pm-pkg-array-holes", {
+        "package.json": JSON.stringify({ name: "x", files: ["a.js"] }, null, 2),
+      });
+
+      const { code } = await runPmPkg(["set", "files[3]=d.js", "list[1].name=n"], dir);
+      expect(code).toBe(0);
+
+      expect(await readPkg(dir)).toEqual({
+        name: "x",
+        files: ["a.js", null, null, "d.js"],
+        list: [null, { name: "n" }],
+      });
+    });
+
+    it("should append with empty brackets", async () => {
+      using dir = tempDir("pm-pkg-array-append", {
+        "package.json": JSON.stringify({ name: "x", files: ["a.js", "b.js"], empty: {} }, null, 2),
+      });
+
+      const { code } = await runPmPkg(["set", "files[]=c.js", "keywords[]=k", "empty[]=e"], dir);
+      expect(code).toBe(0);
+
+      expect(await readPkg(dir)).toEqual({
+        name: "x",
+        files: ["a.js", "b.js", "c.js"],
+        keywords: ["k"],
+        empty: ["e"],
+      });
+    });
+
+    it("should treat bracketed text with dots as one key", async () => {
+      using dir = tempDir("pm-pkg-bracket-dots", {
+        "package.json": JSON.stringify({ name: "x" }, null, 2),
+      });
+
+      const { code } = await runPmPkg(["set", "scripts[c.d]=v", "deps[@scope/pkg.js]=1.0.0"], dir);
+      expect(code).toBe(0);
+      expect(await readPkg(dir)).toEqual({
+        name: "x",
+        scripts: { "c.d": "v" },
+        deps: { "@scope/pkg.js": "1.0.0" },
+      });
+
+      const { output } = await runPmPkg(["get", "scripts[c.d]"], dir);
+      expect(output.trim()).toBe('"v"');
+
+      const { code: deleteCode } = await runPmPkg(["delete", "scripts[c.d]"], dir);
+      expect(deleteCode).toBe(0);
+      expect(await readPkg(dir)).toEqual({ name: "x", scripts: {}, deps: { "@scope/pkg.js": "1.0.0" } });
+    });
+
+    it("should keep a numeric key on a non-empty object", async () => {
+      using dir = tempDir("pm-pkg-numeric-object-key", {
+        "package.json": JSON.stringify({ name: "x", config: { a: 1 } }, null, 2),
+      });
+
+      const { code } = await runPmPkg(["set", "config[0]=zero"], dir);
+      expect(code).toBe(0);
+      expect(await readPkg(dir)).toEqual({ name: "x", config: { a: 1, "0": "zero" } });
     });
 
     it("should fail with invalid key=value format", async () => {
@@ -385,6 +475,23 @@ describe.concurrent("bun pm pkg", () => {
       const { code } = await runPmPkg(["delete", "scripts.test"], dir);
       expect(code).toBe(0);
       expect((await readPkg(dir)).scripts).toEqual({ build: "echo 'build'" });
+    });
+
+    it("should delete array items by index", async () => {
+      using dir = makeTestDir();
+      const { code } = await runPmPkg(["delete", "contributors[0]", "keywords.1", "contributors[0].name"], dir);
+      expect(code).toBe(0);
+      const pkg = await readPkg(dir);
+      expect(pkg.contributors).toEqual([{}]);
+      expect(pkg.keywords).toEqual(["test"]);
+    });
+
+    it("should leave arrays alone when the index is missing or out of range", async () => {
+      using dir = makeTestDir();
+      const before = await readPkg(dir);
+      const { code } = await runPmPkg(["delete", "keywords[5]", "keywords[abc]", "keywords[]"], dir);
+      expect(code).toBe(0);
+      expect(await readPkg(dir)).toEqual(before);
     });
 
     it("should handle deleting non-existent properties", async () => {

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -393,6 +393,21 @@ describe.concurrent("bun pm pkg", () => {
       });
     });
 
+    it("should reject an index far past the end of the array", async () => {
+      using dir = tempDir("pm-pkg-array-huge-index", {
+        "package.json": JSON.stringify({ name: "x", files: ["a.js"] }, null, 2),
+      });
+
+      const { error, code } = await runPmPkg(["set", "files[1000000000]=x"], dir, false);
+      expect(error).toContain("Array index 1000000000 is too far past the end of the array (1 items)");
+      expect(code).toBe(1);
+      expect(await readPkg(dir)).toEqual({ name: "x", files: ["a.js"] });
+
+      const { code: maxCode } = await runPmPkg(["set", "files[18446744073709551615]=x"], dir, false);
+      expect(maxCode).toBe(1);
+      expect(await readPkg(dir)).toEqual({ name: "x", files: ["a.js"] });
+    });
+
     it("should append with empty brackets", async () => {
       using dir = tempDir("pm-pkg-array-append", {
         "package.json": JSON.stringify({ name: "x", files: ["a.js", "b.js"], empty: {} }, null, 2),


### PR DESCRIPTION
### Problem
- `bun pm pkg set 'files[2]=c.js'` on `"files": ["a.js", "b.js"]` writes `"files": {"2": "c.js"}`. The other items are gone. `contributors[0].name=amy` does the same to `contributors`. `files[]=c.js` fails with `InvalidPath`. `delete 'contributors[0]'` is a no-op. npm indexes the array, appends, and splices.
- `set_nested` in `src/runtime/cli/pm_pkg_command.rs` only knows objects. Any child that is not an object is replaced by a new object, and a numeric segment becomes an object key. `parse_key_path` splits on `.` before it reads brackets, so `scripts[c.d]` is split into `scripts[c` and `d]` and fails with `InvalidPath`. `delete_value` never parsed brackets at all.

### Fix
- One tokenizer, `parse_key_path`, now scans left to right. A `.` outside brackets ends a segment. Text inside `[...]` is one segment, dots included. `[]` is a `Segment::Append`. `get`, `set`, and `delete` all use it.
- `set_path` walks the tree by container type. On an array, a numeric segment indexes it and `[]` appends. An index past the end extends the array with `null`. A missing child becomes an array when the next segment is an index, else an object. An empty object also becomes an array in that case. A numeric segment on a non-empty object stays an object key. These are the rules of npm's `queryable.js` setter.
- `delete_path` removes an array item by index and shifts the rest down. A missing or non-numeric index on an array is a no-op, as before.
- Verified: `test/cli/install/bun-pm-pkg.test.ts` (7 new cases, stock bun fails 6). One existing case changed: `contributors[0]=alice` on a new key now writes `["alice"]`, the npm result, not `{"0": "alice"}`.

### Background
- `bun pm pkg` edits `package.json` through the AST that `bun_parsers::json` returns. `Expr` is a `Copy` handle. Objects and arrays are `StoreRef` pointers into the CLI arena, so a copy of a child `Expr` mutates the shared node. That is why `set_path` can recurse on a copy.
- `E::Array::items` is a `Vec<Expr, AstAlloc>`, so `resize`, `remove`, and indexing are plain `Vec` calls.
- `E::Object::put` stores keys by reference. Segments stay sub-slices of the argv key for that reason.

<details><summary>Notes</summary>

npm reference: `lib/utils/queryable.js` in npm 11.16.0. Compared on the same manifest:

```
bun pm pkg set 'files[2]=c.js' 'contributors[0].name=amy' 'newarr[0]=x' 'scripts[c.d]=v' 'files[5]=z' 'files[]=app' 'keywords[]=k' 'empty[0]=e' 'deep.list[1].name=n'
```

gives the same JSON as npm for each key: `files` is `["a.js","b.js","c.js",null,null,"z","app"]`, `newarr` and `keywords` are one-item arrays, `empty` (was `{}`) becomes `["e"]`, `deep.list` is `[null, {"name": "n"}]`, `scripts` has the key `"c.d"`.

`delete 'files[0]' 'contributors[1]' 'nope[3]' 'files[abc]'` matches too: the first two splice, the last two are no-ops with exit 0.

Not changed: `get` on an array with a non-numeric segment still returns not found. npm expands it to one entry per item. A non-numeric segment on an array in `set` still fails with `ExpectedObject`. A non-container child in the middle of a `set` path is still replaced, where npm errors with `EOVERRIDEVALUE`.

Also ran: the full `test/cli/install/bun-pm-pkg.test.ts` file (82 pass).
</details>
