### PR TITLE
Use simdutf for Latin-1 to UTF-8 encoding in TextEncoder and Buffer.from

### DIFF
--- a/bench/snippets/encode-into.mjs
+++ b/bench/snippets/encode-into.mjs
@@ -7,4 +7,39 @@ bench("encodeInto", () => {
   encoder.encodeInto("Hello World!", buffer);
 });
 
+// The same Latin-1 text held by the engine as 8-bit and as 16-bit.
+const N = 1 << 20;
+const latin1Dense8 = Buffer.alloc(N, 0xe9).toString("latin1");
+const latin1Dense16 = (() => {
+  const w = Buffer.alloc(N * 2);
+  for (let i = 0; i < N; i++) w.writeUInt16LE(0xe9, 2 * i);
+  return w.toString("utf16le");
+})();
+const latin1Mixed8 = (() => {
+  const b = Buffer.alloc(N);
+  for (let i = 0; i < N; i++) b[i] = i % 3 === 0 ? 0xe9 : 0x61;
+  return b.toString("latin1");
+})();
+const ascii8 = Buffer.alloc(N, 0x61).toString("latin1");
+// Exact-size destinations, the shape WebSocket and TextEncoderStream use.
+const denseDest = new Uint8Array(N * 2);
+const mixedDest = new Uint8Array(encoder.encode(latin1Mixed8).byteLength);
+const asciiDest = new Uint8Array(N);
+
+bench(`encodeInto ${N} ascii 8-bit`, () => {
+  encoder.encodeInto(ascii8, asciiDest);
+});
+
+bench(`encodeInto ${N} latin1 dense 8-bit`, () => {
+  encoder.encodeInto(latin1Dense8, denseDest);
+});
+
+bench(`encodeInto ${N} latin1 dense 16-bit`, () => {
+  encoder.encodeInto(latin1Dense16, denseDest);
+});
+
+bench(`encodeInto ${N} latin1 mixed 8-bit (exact fit)`, () => {
+  encoder.encodeInto(latin1Mixed8, mixedDest);
+});
+
 await run();

--- a/bench/snippets/text-encoder.mjs
+++ b/bench/snippets/text-encoder.mjs
@@ -30,4 +30,52 @@ bench(`${longUTF16.length} utf8`, () => {
   encoder.encode(longUTF16);
 });
 
+// The same Latin-1 text held by the engine as 8-bit and as 16-bit.
+const N = 1 << 20;
+const latin1Dense8 = Buffer.alloc(N, 0xe9).toString("latin1");
+const latin1Dense16 = (() => {
+  const w = Buffer.alloc(N * 2);
+  for (let i = 0; i < N; i++) w.writeUInt16LE(0xe9, 2 * i);
+  return w.toString("utf16le");
+})();
+const latin1Mixed8 = (() => {
+  const b = Buffer.alloc(N);
+  for (let i = 0; i < N; i++) b[i] = i % 3 === 0 ? 0xe9 : 0x61;
+  return b.toString("latin1");
+})();
+const ascii8 = Buffer.alloc(N, 0x61).toString("latin1");
+const shortLatin1 = "héllo wörld";
+
+bench(`${shortLatin1.length} latin1`, () => {
+  encoder.encode(shortLatin1);
+});
+
+bench(`${N} ascii 8-bit`, () => {
+  encoder.encode(ascii8);
+});
+
+bench(`${N} latin1 dense 8-bit`, () => {
+  encoder.encode(latin1Dense8);
+});
+
+bench(`${N} latin1 dense 16-bit`, () => {
+  encoder.encode(latin1Dense16);
+});
+
+bench(`${N} latin1 mixed 8-bit`, () => {
+  encoder.encode(latin1Mixed8);
+});
+
+bench(`Buffer.from ${N} ascii 8-bit`, () => {
+  Buffer.from(ascii8);
+});
+
+bench(`Buffer.from ${N} latin1 dense 8-bit`, () => {
+  Buffer.from(latin1Dense8);
+});
+
+bench(`Buffer.from ${N} latin1 dense 16-bit`, () => {
+  Buffer.from(latin1Dense16);
+});
+
 await run();

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1591,36 +1591,26 @@ pub(crate) mod strings_impl {
     }
 
     /// Port of `allocateLatin1IntoUTF8WithList`.
-    /// Uses `first_non_ascii` (simdutf SIMD) for the ASCII-span scan.
     pub fn allocate_latin1_into_utf8_with_list(
         mut list: Vec<u8>,
         offset_into_list: usize,
         latin1: &[u8],
     ) -> Vec<u8> {
         list.truncate(offset_into_list);
-        list.reserve(latin1.len());
-        let mut rest = latin1;
-        while !rest.is_empty() {
-            match first_non_ascii_usize(rest) {
-                None => {
-                    list.extend_from_slice(rest);
-                    break;
-                }
-                Some(i) => {
-                    list.extend_from_slice(&rest[..i]);
-                    rest = &rest[i..];
-                    while let Some(&c) = rest.first() {
-                        if c < 0x80 {
-                            break;
-                        }
-                        list.reserve(2);
-                        let [a, b] = latin1_to_codepoint_bytes_assume_not_ascii(c);
-                        list.push(a);
-                        list.push(b);
-                        rest = &rest[1..];
-                    }
-                }
-            }
+        let (ascii, rest) = match first_non_ascii_usize(latin1) {
+            None => (latin1, &[][..]),
+            Some(i) => latin1.split_at(i),
+        };
+        list.reserve(ascii.len() + element_length_latin1_into_utf8(rest));
+        list.extend_from_slice(ascii);
+        if !rest.is_empty() {
+            // SAFETY: the reserve above sized the spare slice for the whole
+            // conversion; simdutf writes only initialized bytes and reports the count.
+            unsafe {
+                crate::vec::fill_spare(&mut list, 0, |spare| {
+                    (simdutf::convert::latin1::to::utf8(rest, spare), ())
+                })
+            };
         }
         list
     }
@@ -1819,9 +1809,29 @@ pub(crate) mod strings_impl {
     }
 
     /// Port of `copyLatin1IntoUTF8` — encode Latin-1 into a fixed-size UTF-8 buffer.
-    #[inline]
+    ///
+    /// A Latin-1 byte encodes to at most 2 UTF-8 bytes, so the next
+    /// `remaining_buf / 2` input bytes always fit. Those go through simdutf,
+    /// and each round at least halves the space left, so only a short tail
+    /// takes the bounded scalar loop.
     pub fn copy_latin1_into_utf8(buf: &mut [u8], latin1: &[u8]) -> EncodeIntoResult {
-        copy_latin1_into_utf8_stop_on_non_ascii::<false>(buf, latin1)
+        let mut read = 0usize;
+        let mut written = 0usize;
+        loop {
+            let head = ((buf.len() - written) / 2).min(latin1.len() - read);
+            if head < 16 {
+                break;
+            }
+            written +=
+                simdutf::convert::latin1::to::utf8(&latin1[read..read + head], &mut buf[written..]);
+            read += head;
+        }
+        let tail =
+            copy_latin1_into_utf8_stop_on_non_ascii::<false>(&mut buf[written..], &latin1[read..]);
+        EncodeIntoResult {
+            read: (read + tail.read as usize) as u32,
+            written: (written + tail.written as usize) as u32,
+        }
     }
 
     #[inline]

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1811,11 +1811,8 @@ pub(crate) mod strings_impl {
     }
 
     /// Port of `copyLatin1IntoUTF8` — encode Latin-1 into a fixed-size UTF-8 buffer.
-    ///
-    /// A Latin-1 byte encodes to at most 2 UTF-8 bytes, so the next
-    /// `remaining_buf / 2` input bytes always fit. Those go through simdutf,
-    /// and each round at least halves the space left, so only a short tail
-    /// takes the bounded scalar loop.
+    /// simdutf converts the `remaining_buf / 2` bytes that are sure to fit per
+    /// round; the scalar loop takes the short tail.
     pub fn copy_latin1_into_utf8(buf: &mut [u8], latin1: &[u8]) -> EncodeIntoResult {
         let mut read = 0usize;
         let mut written = 0usize;

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1604,8 +1604,10 @@ pub(crate) mod strings_impl {
         list.reserve(ascii.len() + element_length_latin1_into_utf8(rest));
         list.extend_from_slice(ascii);
         if !rest.is_empty() {
-            // SAFETY: the reserve above sized the spare slice for the whole
-            // conversion; simdutf writes only initialized bytes and reports the count.
+            // SAFETY: the reserve above sized the spare slice for
+            // `element_length_latin1_into_utf8(rest)` bytes, which is what
+            // the conversion writes; simdutf writes only initialized bytes
+            // and reports the count.
             unsafe {
                 crate::vec::fill_spare(&mut list, 0, |spare| {
                     (simdutf::convert::latin1::to::utf8(rest, spare), ())
@@ -1822,8 +1824,11 @@ pub(crate) mod strings_impl {
             if head < 16 {
                 break;
             }
-            written +=
-                simdutf::convert::latin1::to::utf8(&latin1[read..read + head], &mut buf[written..]);
+            // SAFETY: `head <= (buf.len() - written) / 2`, and each Latin-1
+            // byte expands to at most 2 bytes, so the output always fits.
+            written += unsafe {
+                simdutf::convert::latin1::to::utf8(&latin1[read..read + head], &mut buf[written..])
+            };
             read += head;
         }
         let tail =

--- a/src/parsers/benches/support/simdutf_shim.cpp
+++ b/src/parsers/benches/support/simdutf_shim.cpp
@@ -35,6 +35,10 @@ size_t simdutf__utf8_length_from_latin1(const char* input, size_t length) {
   return simdutf::utf8_length_from_latin1(input, length);
 }
 
+size_t simdutf__convert_latin1_to_utf8(const char* input, size_t length, char* output) {
+  return simdutf::convert_latin1_to_utf8(input, length, output);
+}
+
 size_t simdutf__utf16_length_from_utf8(const char* input, size_t length) {
   return simdutf::utf16_length_from_utf8(input, length);
 }

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -4,6 +4,7 @@ use bun_core::strings;
 use bun_jsc::HostReturn as _;
 use bun_jsc::js_string::Iterator as JSStringIterator;
 use bun_jsc::{ArrayBuffer, JSGlobalObject, JSString, JSType, JSValue, JsResult};
+use bun_simdutf_sys::simdutf;
 
 // `const TextEncoder = @This();` — file is a namespace of exported fns; no wrapper struct needed.
 
@@ -43,9 +44,8 @@ unsafe extern "C" fn TextEncoder__encode8(
         return JSValue::ZERO;
     };
     debug_assert!(array_buffer.len == utf8_len);
-    let result = strings::copy_latin1_into_utf8(array_buffer.byte_slice_mut(), slice);
-    debug_assert!(result.written as usize == utf8_len);
-    debug_assert!(result.read as usize == slice.len());
+    let written = simdutf::convert::latin1::to::utf8(slice, array_buffer.byte_slice_mut());
+    debug_assert!(written == utf8_len);
     uint8array
 }
 

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -44,7 +44,10 @@ unsafe extern "C" fn TextEncoder__encode8(
         return JSValue::ZERO;
     };
     debug_assert!(array_buffer.len == utf8_len);
-    let written = simdutf::convert::latin1::to::utf8(slice, array_buffer.byte_slice_mut());
+    // SAFETY: the array was allocated with exactly `utf8_len` bytes, the
+    // number the conversion writes.
+    let written =
+        unsafe { simdutf::convert::latin1::to::utf8(slice, array_buffer.byte_slice_mut()) };
     debug_assert!(written == utf8_len);
     uint8array
 }

--- a/src/simdutf_sys/bun-simdutf.cpp
+++ b/src/simdutf_sys/bun-simdutf.cpp
@@ -79,6 +79,11 @@ size_t simdutf__utf8_length_from_latin1(const char* input, size_t length)
     return simdutf::utf8_length_from_latin1(input, length);
 }
 
+size_t simdutf__convert_latin1_to_utf8(const char* input, size_t length, char* output)
+{
+    return simdutf::convert_latin1_to_utf8(input, length, output);
+}
+
 size_t simdutf__base64_encode(const char* input, size_t length, char* output, int is_urlsafe)
 {
     return simdutf::binary_to_base64(input, length, output, is_urlsafe ? simdutf::base64_url : simdutf::base64_default);

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -155,12 +155,15 @@ pub mod convert {
         use super::*;
         pub mod to {
             use super::*;
-            /// Returns the number of UTF-8 bytes written. `output` must hold at
-            /// least `length::utf8::from::latin1(input)` bytes (at most
-            /// `2 * input.len()`).
-            pub fn utf8(input: &[u8], output: &mut [u8]) -> usize {
+            /// Returns the number of UTF-8 bytes written.
+            ///
+            /// # Safety
+            /// `output` must hold at least `length::utf8::from::latin1(input)`
+            /// bytes (at most `2 * input.len()`). simdutf writes that many
+            /// bytes without a bound check.
+            pub unsafe fn utf8(input: &[u8], output: &mut [u8]) -> usize {
                 debug_assert!(output.len() >= length::utf8::from::latin1(input));
-                // SAFETY: caller guarantees output capacity is sufficient.
+                // SAFETY: the caller upholds the capacity contract above.
                 unsafe {
                     simdutf__convert_latin1_to_utf8(
                         input.as_ptr(),

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -58,6 +58,11 @@ unsafe extern "C" {
     ) -> usize;
     pub fn simdutf__utf16_length_from_utf8(input: *const u8, length: usize) -> usize;
     pub fn simdutf__utf8_length_from_latin1(input: *const u8, length: usize) -> usize;
+    pub(crate) fn simdutf__convert_latin1_to_utf8(
+        input: *const u8,
+        length: usize,
+        utf8_output: *mut u8,
+    ) -> usize;
 }
 
 pub mod validate {
@@ -141,6 +146,27 @@ pub mod convert {
                             output.as_mut_ptr(),
                         )
                     }
+                }
+            }
+        }
+    }
+
+    pub mod latin1 {
+        use super::*;
+        pub mod to {
+            use super::*;
+            /// Returns the number of UTF-8 bytes written. `output` must hold at
+            /// least `length::utf8::from::latin1(input)` bytes (at most
+            /// `2 * input.len()`).
+            pub fn utf8(input: &[u8], output: &mut [u8]) -> usize {
+                debug_assert!(output.len() >= length::utf8::from::latin1(input));
+                // SAFETY: caller guarantees output capacity is sufficient.
+                unsafe {
+                    simdutf__convert_latin1_to_utf8(
+                        input.as_ptr(),
+                        input.len(),
+                        output.as_mut_ptr(),
+                    )
                 }
             }
         }

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -158,9 +158,8 @@ pub mod convert {
             /// Returns the number of UTF-8 bytes written.
             ///
             /// # Safety
-            /// `output` must hold at least `length::utf8::from::latin1(input)`
-            /// bytes (at most `2 * input.len()`). simdutf writes that many
-            /// bytes without a bound check.
+            /// `output` must hold `length::utf8::from::latin1(input)` bytes
+            /// (at most `2 * input.len()`); simdutf does not bound-check.
             pub unsafe fn utf8(input: &[u8], output: &mut [u8]) -> usize {
                 debug_assert!(output.len() >= length::utf8::from::latin1(input));
                 // SAFETY: the caller upholds the capacity contract above.

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -683,3 +683,140 @@ describe("TextEncoder UTF-16 exact-size path", () => {
     }
   });
 });
+
+describe("TextEncoder latin1 non-ASCII runs", () => {
+  const encoder = new TextEncoder();
+  const N = 1 << 20;
+
+  // The same text, held by JSC as 8-bit (Latin-1) and as 16-bit.
+  const latin1Dense8 = Buffer.alloc(N, 0xe9).toString("latin1");
+  const latin1Dense16 = (() => {
+    const w = Buffer.alloc(N * 2);
+    for (let i = 0; i < N; i++) w.writeUInt16LE(0xe9, 2 * i);
+    return w.toString("utf16le");
+  })();
+
+  it("8-bit and 16-bit backings of the same text encode to the same bytes", () => {
+    expect(latin1Dense8).toBe(latin1Dense16);
+    expect(encoder.encode(latin1Dense8)).toEqual(encoder.encode(latin1Dense16));
+    expect(Buffer.from(latin1Dense8)).toEqual(Buffer.from(latin1Dense16));
+    const dest8 = new Uint8Array(N * 2);
+    const dest16 = new Uint8Array(N * 2);
+    expect(encoder.encodeInto(latin1Dense8, dest8)).toEqual({ read: N, written: N * 2 });
+    expect(encoder.encodeInto(latin1Dense16, dest16)).toEqual({ read: N, written: N * 2 });
+    expect(dest8).toEqual(dest16);
+  });
+
+  it("encodeInto stops at the right byte for every destination size around a non-ASCII run", () => {
+    const mixed = Buffer.from([0x61, 0x62, 0xe9, 0xfc, 0xff, 0xa0, 0x63, 0xe9, 0x64, 0xe9, 0xe9]);
+    const text = mixed.toString("latin1");
+    const expected = utf8Reference(text);
+    for (let size = 0; size <= expected.length + 1; size++) {
+      const dest = new Uint8Array(size).fill(0xaa);
+      const { read, written } = encoder.encodeInto(text, dest);
+      expect({ size, bytes: Array.from(dest.subarray(0, written)) }).toEqual({
+        size,
+        bytes: Array.from(expected.subarray(0, written)),
+      });
+      expect({ size, written, read }).toEqual({
+        size,
+        written: utf8Reference(text.slice(0, read)).length,
+        read,
+      });
+      // The next character did not fit.
+      if (read < text.length) {
+        expect(written + (text.charCodeAt(read) >= 0x80 ? 2 : 1)).toBeGreaterThan(size);
+      }
+      expect(Array.from(dest.subarray(written))).toEqual(new Array(size - written).fill(0xaa));
+    }
+  });
+
+  it("encodeInto handles a long mixed latin1 string for destination sizes across the simd rounds", () => {
+    const bytes = Buffer.alloc(4096);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 3 === 0 ? 0xe9 : 0x61 + (i % 7);
+    const text = bytes.toString("latin1");
+    const expected = utf8Reference(text);
+    for (const size of [
+      15,
+      16,
+      17,
+      31,
+      32,
+      33,
+      63,
+      64,
+      65,
+      100,
+      1000,
+      2047,
+      2048,
+      2049,
+      expected.length - 1,
+      expected.length,
+    ]) {
+      const dest = new Uint8Array(size);
+      const { read, written } = encoder.encodeInto(text, dest);
+      expect({
+        size,
+        read,
+        written,
+        ok: Buffer.compare(dest.subarray(0, written), expected.subarray(0, written)),
+      }).toEqual({
+        size,
+        read,
+        written: utf8Reference(text.slice(0, read)).length,
+        ok: 0,
+      });
+      expect(size - written).toBeLessThan(2);
+    }
+  });
+
+  it("encodeInto with an ASCII first half and a non-ASCII second half around the exact output size", () => {
+    const bytes = Buffer.concat([Buffer.alloc(2048, 0x61), Buffer.alloc(2048, 0xe9)]);
+    const text = bytes.toString("latin1");
+    const expected = utf8Reference(text);
+    for (const size of [expected.length - 1, expected.length, expected.length + 1]) {
+      const dest = new Uint8Array(size);
+      const result = encoder.encodeInto(text, dest);
+      const fits = size >= expected.length;
+      expect({
+        size,
+        ...result,
+        ok: Buffer.compare(dest.subarray(0, result.written), expected.subarray(0, result.written)),
+      }).toEqual({
+        size,
+        read: fits ? text.length : text.length - 1,
+        written: fits ? expected.length : expected.length - 2,
+        ok: 0,
+      });
+    }
+  });
+
+  it("8-bit backed non-ASCII text encodes about as fast as 16-bit backed text", () => {
+    const dest = new Uint8Array(N * 2);
+    const ops = {
+      encode: s => encoder.encode(s),
+      encodeInto: s => encoder.encodeInto(s, dest),
+      "Buffer.from": s => Buffer.from(s),
+    };
+    const time = f => {
+      let best = Infinity;
+      for (let trial = 0; trial < 5; trial++) {
+        const t = performance.now();
+        for (let k = 0; k < 4; k++) f();
+        best = Math.min(best, performance.now() - t);
+      }
+      return best;
+    };
+    const ratios = {};
+    for (const [name, f] of Object.entries(ops)) {
+      const ms16 = time(() => f(latin1Dense16));
+      const ms8 = time(() => f(latin1Dense8));
+      ratios[name] = ms8 / ms16;
+    }
+    // Before the simdutf path, 8-bit dense Latin-1 was 20x to 40x slower than 16-bit.
+    for (const [name, ratio] of Object.entries(ratios)) {
+      expect({ name, ratio, ok: ratio < 8 }).toEqual({ name, ratio, ok: true });
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- `TextEncoder.encode`, `encodeInto` and `Buffer.from(string)` are about 20x slower when JSC holds a string as 8-bit (Latin-1) than when it holds the same text as 16-bit, once the text is dense in U+0080..U+00FF. On bun 1.4.2, 1 MiB of `é`: encode 10.0 ms vs 0.53 ms, encodeInto 10.0 ms vs 0.24 ms. Output bytes are identical, only speed differs.
- The cause is `copy_latin1_into_utf8_stop_on_non_ascii` (`src/bun_core/lib.rs:1845`). After each 2-byte write it calls `copy_ascii_prefix` again, which dispatches into `bun_highway` whenever 64 or more bytes remain. Dense non-ASCII text pays one SIMD dispatch per byte. The pre-port Zig code re-entered an inline SWAR scan, so the port made this a regression.

### Fix
- Add a `simdutf__convert_latin1_to_utf8` shim and `simdutf::convert::latin1::to::utf8` next to the existing `utf8_length_from_latin1` binding.
- `copy_latin1_into_utf8` converts the input that is guaranteed to fit (`remaining_buf / 2` bytes, since a Latin-1 byte is at most 2 UTF-8 bytes) with simdutf, in rounds that halve the space left. Only a tail under 16 bytes takes the old scalar loop, which is unchanged. `TextEncoder__encode8` calls simdutf directly because its buffer is exact size. `allocate_latin1_into_utf8_with_list` copies the ASCII prefix as before, then sizes the rest once and converts it in one call.
- Correct because simdutf produces the same bytes as the scalar loop, and the `read`/`written` contract of `EncodeIntoResult` is unchanged: every destination size from 0 to full is covered by the new tests.
- Verified: `test/js/web/encoding/text-encoder.test.js` (5 new tests, the timing one fails on 1.4.2). Also text-encoder-stream, buffer, string-decoder and bunshell suites.

### Background
- JSC stores a string as 8-bit when every char is at most U+00FF, so accented Western text and `Buffer#toString("latin1")` output take this path.
- `copy_latin1_into_utf8` is the shared helper behind `encodeInto`, `TextEncoderStream`, WebSocket text frames and `fmt`. `allocate_latin1_into_utf8_with_list` is behind `Buffer.from`, shell output and `PipeWriter`.
- simdutf is the vendored SIMD transcoding library with runtime CPU dispatch. The 16-bit path already used it. The Latin-1 length function was bound, the converter was not.

<details><summary>Notes</summary>

Release build on this container (Xeon 8375C), 1 MiB inputs, `bench/snippets/text-encoder.mjs` and `encode-into.mjs`:

| case | bun 1.4.2 | this PR | 16-bit twin | node 26.3 |
| --- | --- | --- | --- | --- |
| encode, dense 8-bit | 10.01 ms | 454 µs | 524 µs | 463 µs |
| encode, mixed (1 in 3) 8-bit | 4.05 ms | 249 µs | | 328 µs |
| encode, ASCII 8-bit | 213 µs | 203 µs | | 260 µs |
| encodeInto exact fit, dense 8-bit | 10.03 ms | 116 µs | 237 µs | 115 µs |
| encodeInto exact fit, mixed 8-bit | 3.35 ms | 93 µs | | 127 µs |
| encodeInto, ASCII 8-bit | 73 µs | 74 µs | | 89 µs |
| Buffer.from, dense 8-bit | 2.39 ms | 480 µs | 476 µs | 339 µs |
| Buffer.from, ASCII 8-bit | 219 µs | 180 µs | | 240 µs |

The timing test asserts the 8-bit time is under 8x the 16-bit time, min of 5 trials. It measured 0.3x to 0.9x on release and about 0.5x on the debug build. On 1.4.2 it measures 19x to 40x.

The pure-ASCII path through `allocate_latin1_into_utf8_with_list` keeps its one scan plus memcpy. The bench rows above show it did not get slower.

Self-review: 6 concerns raised, 5 addressed (exact-fit encodeInto still hit the scalar loop, a drain loop inside the generic that #37622 rewrites, no bench rows, pure-ASCII `Buffer.from` unmeasured, a missing ASCII-then-non-ASCII encodeInto case). One rejected: dropping the timing test. It is the only assertion that fails without the fix, and it is coarse enough (8x bound on a ratio that moves from 20x to under 1x) to not flake.

Related open PRs that touch the same code: #37622 (refactor of the STOP generic, the generic is untouched here), #40244 (TextEncoderStream encoder), #40321 (test file restructure).

`copy_cp1252_into_utf16` in `src/bun_core/string/immutable/unicode.rs` has the same per-byte re-scan. It is a separate follow-up.
</details>
