### PR TITLE
js_parser: omit the jsxDEV self argument inside a derived class constructor

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -258,8 +258,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) fn_or_arrow_data_parse: FnOrArrowDataParse,
     pub(crate) fn_or_arrow_data_visit: FnOrArrowDataVisit,
     pub(crate) fn_only_data_visit: FnOnlyDataVisit,
-    /// Set by `visit_class` just before it visits the `constructor` of a class
-    /// with an `extends` clause. `visit_func` takes it.
+    /// Handoff from `visit_class` to `visit_func` for a derived `constructor`.
     pub(crate) next_fn_is_derived_class_ctor: bool,
     pub(crate) allocated_names: List<'a, &'a [u8]>,
     // allocated_names: ListManaged(string) = ListManaged(string).init(bun.default_allocator),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -258,6 +258,9 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) fn_or_arrow_data_parse: FnOrArrowDataParse,
     pub(crate) fn_or_arrow_data_visit: FnOrArrowDataVisit,
     pub(crate) fn_only_data_visit: FnOnlyDataVisit,
+    /// Set by `visit_class` just before it visits the `constructor` of a class
+    /// with an `extends` clause. `visit_func` takes it.
+    pub(crate) next_fn_is_derived_class_ctor: bool,
     pub(crate) allocated_names: List<'a, &'a [u8]>,
     // allocated_names: ListManaged(string) = ListManaged(string).init(bun.default_allocator),
     // allocated_names_pool: ?*AllocatedNamesPool.Node = null,
@@ -9727,6 +9730,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             fn_or_arrow_data_parse,
             fn_or_arrow_data_visit: FnOrArrowDataVisit::default(),
             fn_only_data_visit: FnOnlyDataVisit::default(),
+            next_fn_is_derived_class_ctor: false,
             allocated_names: BumpVec::new_in(arena),
             latest_arrow_arg_loc: bun_ast::Loc::EMPTY,
             forbid_suffix_after_as_loc: bun_ast::Loc::EMPTY,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1301,10 +1301,8 @@ pub struct FnOnlyDataVisit {
     /// has been shadowed and is now inaccessible.
     pub(crate) is_this_nested: bool,
 
-    /// "this" belongs to the `constructor` of a class with an `extends` clause.
-    /// It is in its temporal dead zone until `super()` returns, so generated
-    /// code must not read it. Arrow functions share the constructor's "this",
-    /// so they inherit this flag.
+    /// "this" is the `constructor` of a class with an `extends` clause, so it
+    /// is in its temporal dead zone until `super()` returns.
     pub(crate) is_derived_class_ctor: bool,
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1277,6 +1277,12 @@ pub struct FnOrArrowDataVisit {
     pub(crate) is_inside_switch: bool,
     pub(crate) is_outside_fn_or_arrow: bool,
 
+    /// The body of a `constructor` in a class with an `extends` clause. `this`
+    /// is in its temporal dead zone until `super()` runs, so generated code
+    /// must not read it. Arrow functions inside the constructor reset this,
+    /// as in esbuild.
+    pub(crate) is_derived_class_ctor: bool,
+
     /// This is used to silence unresolvable imports due to "require" calls inside
     /// a try/catch statement. The assumption is that the try/catch statement is
     /// there to handle the case where the reference to "require" crashes. Counts

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1277,12 +1277,6 @@ pub struct FnOrArrowDataVisit {
     pub(crate) is_inside_switch: bool,
     pub(crate) is_outside_fn_or_arrow: bool,
 
-    /// The body of a `constructor` in a class with an `extends` clause. `this`
-    /// is in its temporal dead zone until `super()` runs, so generated code
-    /// must not read it. Arrow functions inside the constructor reset this,
-    /// as in esbuild.
-    pub(crate) is_derived_class_ctor: bool,
-
     /// This is used to silence unresolvable imports due to "require" calls inside
     /// a try/catch statement. The assumption is that the try/catch statement is
     /// there to handle the case where the reference to "require" crashes. Counts
@@ -1306,6 +1300,12 @@ pub struct FnOnlyDataVisit {
     /// or a class declaration). That means the top-level module scope "this" value
     /// has been shadowed and is now inaccessible.
     pub(crate) is_this_nested: bool,
+
+    /// "this" belongs to the `constructor` of a class with an `extends` clause.
+    /// It is in its temporal dead zone until `super()` returns, so generated
+    /// code must not read it. Arrow functions share the constructor's "this",
+    /// so they inherit this flag.
+    pub(crate) is_derived_class_ctor: bool,
 }
 
 /// Due to ES6 destructuring patterns, there are many cases where it's

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1155,6 +1155,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 if let Some(val) = property.value {
                     self.next_fn_is_derived_class_ctor = is_derived_class
+                        && property.kind == PropertyKind::Normal
                         && property.flags.contains(flags::Property::IsMethod)
                         && !property.flags.contains(flags::Property::IsStatic)
                         && !property.flags.contains(flags::Property::IsComputed)

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1115,6 +1115,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // The value of "this" is shadowed inside property values
                 let old_is_this_captured = self.fn_only_data_visit.is_this_nested;
                 self.fn_only_data_visit.is_this_nested = true;
+                let old_is_derived_class_ctor = self.fn_only_data_visit.is_derived_class_ctor;
+                self.fn_only_data_visit.is_derived_class_ctor = false;
 
                 // We need to explicitly assign the name to the property initializer if it
                 // will be transformed such that it is no longer an inline initializer.
@@ -1222,6 +1224,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // manual restore for the two `defer`s above
                 self.vis_scope().forbid_arguments = false;
                 self.fn_only_data_visit.is_this_nested = old_is_this_captured;
+                self.fn_only_data_visit.is_derived_class_ctor = old_is_derived_class_ctor;
             }
 
             if Self::IS_TYPESCRIPT_ENABLED {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -91,6 +91,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let old_fn_or_arrow_data = self.fn_or_arrow_data_visit;
         let old_fn_only_data = core::mem::take(&mut self.fn_only_data_visit);
         self.fn_or_arrow_data_visit = FnOrArrowDataVisit {
+            is_derived_class_ctor: core::mem::take(&mut self.next_fn_is_derived_class_ctor),
             ..Default::default()
         };
         self.fn_only_data_visit = FnOnlyDataVisit {
@@ -1047,6 +1048,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .expect("unreachable");
 
             let mut constructor_function: Option<bun_ast::StoreRef<E::Function>> = None;
+            let is_derived_class = class.extends.is_some();
             let properties: &mut [G::Property] = class.properties.slice_mut();
             for property in properties.iter_mut() {
                 if property.kind == PropertyKind::ClassStaticBlock {
@@ -1153,6 +1155,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if let Some(val) = property.value {
+                    self.next_fn_is_derived_class_ctor = is_derived_class
+                        && property.flags.contains(flags::Property::IsMethod)
+                        && !property.flags.contains(flags::Property::IsStatic)
+                        && !property.flags.contains(flags::Property::IsComputed)
+                        && matches!(val.data, ExprData::EFunction(_))
+                        && matches!(
+                            property.key.map(|k| k.data),
+                            Some(ExprData::EString(s)) if s.eql_comptime(b"constructor")
+                        );
                     if let Some(name) = name_to_keep {
                         let was_anon = val.is_anonymous_named();
                         let prev_dcn = self.decorator_class_name;
@@ -1171,6 +1182,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     } else {
                         self.visit_expr(property.value.as_mut().unwrap());
                     }
+                    self.next_fn_is_derived_class_ctor = false;
 
                     if Self::IS_TYPESCRIPT_ENABLED {
                         if constructor_function_.is_some() {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -91,12 +91,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let old_fn_or_arrow_data = self.fn_or_arrow_data_visit;
         let old_fn_only_data = core::mem::take(&mut self.fn_only_data_visit);
         self.fn_or_arrow_data_visit = FnOrArrowDataVisit {
-            is_derived_class_ctor: core::mem::take(&mut self.next_fn_is_derived_class_ctor),
             ..Default::default()
         };
         self.fn_only_data_visit = FnOnlyDataVisit {
             is_this_nested: true,
-            ..Default::default()
+            is_derived_class_ctor: core::mem::take(&mut self.next_fn_is_derived_class_ctor),
         };
 
         if let Some(name) = func.name {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -646,9 +646,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         );
 
                         VecExt::append(&mut args, p.new_expr(E::Undefined {}, expr.loc));
-                        // `this` is unreadable in a derived constructor until
-                        // `super()` has run. Omit the `self` argument there,
-                        // as Babel does.
+                        // `this` is in its TDZ before `super()`: no `self` argument there.
                         if !p.fn_only_data_visit.is_derived_class_ctor {
                             VecExt::append(
                                 &mut args,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -646,16 +646,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         );
 
                         VecExt::append(&mut args, p.new_expr(E::Undefined {}, expr.loc));
-                        // `this` is in its TDZ before `super()`: no `self` argument there.
-                        if !p.fn_only_data_visit.is_derived_class_ctor {
-                            VecExt::append(
-                                &mut args,
-                                Expr {
-                                    data: prefill::data::THIS,
-                                    loc: expr.loc,
-                                },
-                            );
-                        }
+                        // `this` is in its TDZ before `super()`: pass `undefined` as `self` there.
+                        let self_arg = if p.fn_only_data_visit.is_derived_class_ctor {
+                            Data::EUndefined(E::Undefined {})
+                        } else {
+                            prefill::data::THIS
+                        };
+                        VecExt::append(
+                            &mut args,
+                            Expr {
+                                data: self_arg,
+                                loc: expr.loc,
+                            },
+                        );
                     }
 
                     let jsx_target = p.jsx_import_automatic(expr.loc, is_static_jsx);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -646,13 +646,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         );
 
                         VecExt::append(&mut args, p.new_expr(E::Undefined {}, expr.loc));
-                        VecExt::append(
-                            &mut args,
-                            Expr {
-                                data: prefill::data::THIS,
-                                loc: expr.loc,
-                            },
-                        );
+                        // `this` is unreadable in a derived constructor until
+                        // `super()` has run. Omit the `self` argument there,
+                        // as esbuild and Babel do.
+                        if !p.fn_or_arrow_data_visit.is_derived_class_ctor {
+                            VecExt::append(
+                                &mut args,
+                                Expr {
+                                    data: prefill::data::THIS,
+                                    loc: expr.loc,
+                                },
+                            );
+                        }
                     }
 
                     let jsx_target = p.jsx_import_automatic(expr.loc, is_static_jsx);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -648,8 +648,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         VecExt::append(&mut args, p.new_expr(E::Undefined {}, expr.loc));
                         // `this` is unreadable in a derived constructor until
                         // `super()` has run. Omit the `self` argument there,
-                        // as esbuild and Babel do.
-                        if !p.fn_or_arrow_data_visit.is_derived_class_ctor {
+                        // as Babel does.
+                        if !p.fn_only_data_visit.is_derived_class_ctor {
                             VecExt::append(
                                 &mut args,
                                 Expr {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1390,9 +1390,12 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
           this.nested = function () {
             return <e />;
           }.call(this);
+          this.inner = new (class {
+            field = <f />;
+          })();
         }
         method() {
-          return <f />;
+          return <g />;
         }
       }
       const d = new Derived();
@@ -1403,6 +1406,7 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
           after: d.after.self,
           arrow: d.arrow.self,
           nested: d.nested.self === d,
+          innerField: d.inner.field.self === d.inner,
           method: d.method().self === d,
         }),
       );
@@ -1420,11 +1424,11 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual({ nested: true, method: true });
+    expect(JSON.parse(stdout)).toEqual({ nested: true, innerField: true, method: true });
     expect(exitCode).toBe(0);
   });
 
-  test("the self argument is omitted only where this is the derived constructor's", async () => {
+  test("the self argument is undefined only where this is the derived constructor's", async () => {
     using dir = tempDir("jsx-derived-ctor-out", files);
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", "--no-bundle", "index.tsx"],
@@ -1435,17 +1439,17 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const selfArgs = [...stdout.matchAll(/jsxDEV\w*\("(\w)", \{\}, undefined, false, undefined(, this)?\)/g)].map(m => [
-      m[1],
-      m[2] === ", this",
-    ]);
+    const selfArgs = [...stdout.matchAll(/jsxDEV\w*\("(\w)", \{\}, undefined, false, undefined, (this|undefined)\)/g)].map(
+      m => [m[1], m[2]],
+    );
     expect(selfArgs).toEqual([
-      ["a", false],
-      ["b", false],
-      ["c", false],
-      ["d", false],
-      ["e", true],
-      ["f", true],
+      ["a", "undefined"],
+      ["b", "undefined"],
+      ["c", "undefined"],
+      ["d", "undefined"],
+      ["e", "this"],
+      ["f", "this"],
+      ["g", "this"],
     ]);
     expect(exitCode).toBe(0);
   });

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1363,3 +1363,85 @@ describe("bundler", () => {
     });
   });
 });
+
+// `this` is in its temporal dead zone inside a derived class constructor until
+// `super()` returns. The jsxDEV `self` argument must not read it there.
+describe.concurrent("jsx/derivedClassCtorSelf", () => {
+  const files = {
+    "node_modules/react/package.json": `{ "name": "react" }`,
+    "node_modules/react/jsx-dev-runtime.js": /* js */ `
+      export function jsxDEV(type, props, key, isStaticChildren, source, self) {
+        return { type, self };
+      }
+    `,
+    "index.tsx": /* tsx */ `
+      class Base {
+        constructor(el) {
+          this.el = el;
+        }
+      }
+      class Derived extends Base {
+        constructor() {
+          super(<a />);
+          this.after = <b />;
+          this.arrow = (() => <c />)();
+          this.nested = function () {
+            return <d />;
+          }.call(this);
+        }
+        method() {
+          return <e />;
+        }
+      }
+      const d = new Derived();
+      console.log(
+        JSON.stringify({
+          ctor: d.el.self,
+          after: d.after.self,
+          arrow: d.arrow.self === d,
+          nested: d.nested.self === d,
+          method: d.method().self === d,
+        }),
+      );
+    `,
+  };
+
+  test("super(<jsx/>) runs in development", async () => {
+    using dir = tempDir("jsx-derived-ctor", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.tsx"],
+      env: { ...bunEnv, NODE_ENV: "development" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ arrow: true, nested: true, method: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test("the self argument is omitted only inside the derived constructor", async () => {
+    using dir = tempDir("jsx-derived-ctor-out", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "index.tsx"],
+      env: { ...bunEnv, NODE_ENV: "development" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const selfArgs = [...stdout.matchAll(/jsxDEV\w*\("(\w)", \{\}, undefined, false, undefined(, this)?\)/g)].map(
+      m => [m[1], m[2] === ", this"],
+    );
+    expect(selfArgs).toEqual([
+      ["a", false],
+      ["b", false],
+      ["c", true],
+      ["d", true],
+      ["e", true],
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1439,9 +1439,9 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const selfArgs = [...stdout.matchAll(/jsxDEV\w*\("(\w)", \{\}, undefined, false, undefined, (this|undefined)\)/g)].map(
-      m => [m[1], m[2]],
-    );
+    const selfArgs = [
+      ...stdout.matchAll(/jsxDEV\w*\("(\w)", \{\}, undefined, false, undefined, (this|undefined)\)/g),
+    ].map(m => [m[1], m[2]]);
     expect(selfArgs).toEqual([
       ["a", "undefined"],
       ["b", "undefined"],

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1365,7 +1365,8 @@ describe("bundler", () => {
 });
 
 // `this` is in its temporal dead zone inside a derived class constructor until
-// `super()` returns. The jsxDEV `self` argument must not read it there.
+// `super()` returns. The jsxDEV `self` argument must not read it there, and an
+// arrow function shares the constructor's `this`.
 describe.concurrent("jsx/derivedClassCtorSelf", () => {
   const files = {
     "node_modules/react/package.json": `{ "name": "react" }`,
@@ -1376,29 +1377,31 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
     `,
     "index.tsx": /* tsx */ `
       class Base {
-        constructor(el) {
+        constructor(el, items) {
           this.el = el;
+          this.items = items;
         }
       }
       class Derived extends Base {
         constructor() {
-          super(<a />);
-          this.after = <b />;
-          this.arrow = (() => <c />)();
+          super(<a />, [1].map(x => <b />));
+          this.after = <c />;
+          this.arrow = (() => <d />)();
           this.nested = function () {
-            return <d />;
+            return <e />;
           }.call(this);
         }
         method() {
-          return <e />;
+          return <f />;
         }
       }
       const d = new Derived();
       console.log(
         JSON.stringify({
           ctor: d.el.self,
+          ctorArrow: d.items[0].self,
           after: d.after.self,
-          arrow: d.arrow.self === d,
+          arrow: d.arrow.self,
           nested: d.nested.self === d,
           method: d.method().self === d,
         }),
@@ -1417,11 +1420,11 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual({ arrow: true, nested: true, method: true });
+    expect(JSON.parse(stdout)).toEqual({ nested: true, method: true });
     expect(exitCode).toBe(0);
   });
 
-  test("the self argument is omitted only inside the derived constructor", async () => {
+  test("the self argument is omitted only where this is the derived constructor's", async () => {
     using dir = tempDir("jsx-derived-ctor-out", files);
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build", "--no-bundle", "index.tsx"],
@@ -1438,9 +1441,10 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
     expect(selfArgs).toEqual([
       ["a", false],
       ["b", false],
-      ["c", true],
-      ["d", true],
+      ["c", false],
+      ["d", false],
       ["e", true],
+      ["f", true],
     ]);
     expect(exitCode).toBe(0);
   });

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1435,9 +1435,10 @@ describe.concurrent("jsx/derivedClassCtorSelf", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const selfArgs = [...stdout.matchAll(/jsxDEV\w*\("(\w)", \{\}, undefined, false, undefined(, this)?\)/g)].map(
-      m => [m[1], m[2] === ", this"],
-    );
+    const selfArgs = [...stdout.matchAll(/jsxDEV\w*\("(\w)", \{\}, undefined, false, undefined(, this)?\)/g)].map(m => [
+      m[1],
+      m[2] === ", this",
+    ]);
     expect(selfArgs).toEqual([
       ["a", false],
       ["b", false],


### PR DESCRIPTION
### Problem
- In development mode, `super(<a />)` inside a class with an `extends` clause throws `ReferenceError: 'super()' must be called in derived constructor before accessing |this|`. The same file runs fine with `NODE_ENV=production`.
- The cause: the automatic runtime lowers every element to `jsxDEV(type, props, key, isStatic, source, this)` (`src/js_parser/visit/visit_expr.rs:649`), and `this` is in its temporal dead zone until `super()` returns.

### Fix
- `visit_class` marks the `constructor` of a derived class before it visits it. `visit_func` moves that mark into `FnOnlyDataVisit.is_derived_class_ctor`.
- The jsxDEV lowering passes `undefined` as `self` when that flag is set. The call keeps its six arguments, which the React Compiler's decoder expects. Arrow functions share the constructor's `this`, so `super(xs.map(x => <li />))` is covered too. Nested functions, methods, and the fields of a class nested in the constructor have their own `this` and still pass it.
- This is the rule Babel's `jsx-self` plugin uses. esbuild omits the argument for the constructor body but not for arrows inside it. tsc has the same bug as bun had.
- Verified: `test/bundler/bundler_jsx.test.ts` (`jsx/derivedClassCtorSelf`, both tests fail on stock bun). Also the rest of `bundler_jsx.test.ts`, `transpiler.test.js`, `jsx-production.test.ts`, `jsx-tsconfig-react-jsx.test.ts`, and `react-compiler.test.ts`.

### Background
- `jsxDEV(type, props, key, isStaticChildren, source, self)` is the development entry of the automatic JSX runtime. `self` is the `this` at the element's position. React 18 stores it as `_self` for DevTools, React 19 ignores it. Bun already passes `undefined` for `source`.
- `FnOnlyDataVisit` (`src/js_parser/parser.rs`) is the per-function visit state that tracks what `this` means. `visit_func` saves and replaces it for a function body. Arrow functions do not, because they share the enclosing `this`.
- `next_fn_is_derived_class_ctor` on the parser is a one-shot handoff from `visit_class` to `visit_func`. The class visitor knows which method is the constructor and whether the class has an `extends` clause. The function visitor does not.

<details><summary>Notes</summary>

Repro:

```tsx
class B { constructor(x) { this.x = x } }
class K extends B { constructor() { super(<a/>) } }
new K();
```

`bun run` with `NODE_ENV` unset (jsxDEV) throws. `NODE_ENV=production bun run` works.

esbuild 0.28.1 output for the same file (`--jsx=automatic --jsx-dev`) omits the trailing `this` inside the constructor body and keeps it in methods. Bun passes `undefined` instead of dropping the argument, so the call shape stays `jsxDEV(type, props, key, isStatic, source, self)` for the React Compiler's JSX decoder (`src/react_compiler/lowering/build_hir/jsx.rs`). esbuild keeps `this` in an arrow inside the constructor (its flag lives on the per-function-or-arrow state). That still throws at runtime when the arrow runs before `super()`, for example in `super(<ul>{xs.map(x => <li/>)}</ul>)`, so this PR follows Babel and lets arrows inherit the flag.

The flag is only read by the jsxDEV lowering. Nothing else changes for non-derived constructors, for `jsx()`/`jsxs()`, or for the classic runtime.

Found by a JSX fidelity comparison against tsc 6.0.3 and esbuild 0.28.1.
</details>

