### PR TITLE
js_printer: keep the space between a non-ASCII identifier and a keyword

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1662,10 +1662,8 @@ pub(crate) mod __gated_printer {
         pub(crate) prev_op_end: i32,
         pub(crate) prev_num_end: i32,
         pub(crate) prev_reg_exp_end: i32,
-        /// End offset of the last printed identifier whose final code point is not
-        /// ASCII (printed raw as UTF-8 or as a `\u{...}` escape). `prev_char()` sees
-        /// a UTF-8 continuation byte or `}` there, which `is_identifier_continue`
-        /// rejects, so a following keyword (`of`, `in`, `instanceof`) would be glued on.
+        /// End of the last identifier whose final byte is not an ASCII identifier byte
+        /// (raw UTF-8 or a `\u{...}` escape), so `prev_char()` cannot tell.
         pub(crate) prev_identifier_end: i32,
         pub(crate) call_target: Option<ExprData>,
         pub(crate) writer: W,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1662,8 +1662,6 @@ pub(crate) mod __gated_printer {
         pub(crate) prev_op_end: i32,
         pub(crate) prev_num_end: i32,
         pub(crate) prev_reg_exp_end: i32,
-        /// End of the last identifier whose final byte is not an ASCII identifier byte
-        /// (raw UTF-8 or a `\u{...}` escape), so `prev_char()` cannot tell.
         pub(crate) prev_identifier_end: i32,
         pub(crate) call_target: Option<ExprData>,
         pub(crate) writer: W,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1662,6 +1662,11 @@ pub(crate) mod __gated_printer {
         pub(crate) prev_op_end: i32,
         pub(crate) prev_num_end: i32,
         pub(crate) prev_reg_exp_end: i32,
+        /// End offset of the last printed identifier whose final code point is not
+        /// ASCII (printed raw as UTF-8 or as a `\u{...}` escape). `prev_char()` sees
+        /// a UTF-8 continuation byte or `}` there, which `is_identifier_continue`
+        /// rejects, so a following keyword (`of`, `in`, `instanceof`) would be glued on.
+        pub(crate) prev_identifier_end: i32,
         pub(crate) call_target: Option<ExprData>,
         pub(crate) writer: W,
 
@@ -2108,7 +2113,8 @@ pub(crate) mod __gated_printer {
             // byte precedes a keyword (e.g. `x instanceof y` minified to `xinstanceof y`).
             if self.writer.written() >= 0
                 && (lexer::is_identifier_continue(self.writer.prev_char() as i32)
-                    || self.writer.written() == self.prev_reg_exp_end)
+                    || self.writer.written() == self.prev_reg_exp_end
+                    || self.writer.written() == self.prev_identifier_end)
             {
                 self.print(b" ");
             }
@@ -6828,6 +6834,9 @@ pub(crate) mod __gated_printer {
                 self.print_identifier_ascii_only(identifier);
             } else {
                 self.print(identifier);
+                if identifier.last().is_some_and(|&b| b >= 0x80) {
+                    self.prev_identifier_end = self.writer.written();
+                }
             }
         }
 
@@ -6867,6 +6876,8 @@ pub(crate) mod __gated_printer {
 
             if is_ascii {
                 self.print(&identifier[ascii_start..]);
+            } else {
+                self.prev_identifier_end = self.writer.written();
             }
         }
 
@@ -7016,6 +7027,7 @@ pub(crate) mod __gated_printer {
                 prev_op_end: -1,
                 prev_num_end: -1,
                 prev_reg_exp_end: -1,
+                prev_identifier_end: -1,
                 call_target: None,
                 writer,
                 renamer,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4672,7 +4672,7 @@ pub(crate) mod __gated_printer {
             let key: &[u8] = key.get();
             if lexer::is_identifier(key) {
                 self.print(b".");
-                self.print(key);
+                self.print_identifier(key);
             } else {
                 self.print(b"[");
                 self.print_string_literal_utf8(key, false);

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1574,6 +1574,61 @@ describe("bundler", () => {
     },
   });
 
+  // An identifier can end in a code point that is ID_Continue but not ID_Start
+  // (ZWNJ, a combining mark, a non-ASCII digit) or in any non-ASCII letter. The
+  // printer must still put a space between it and a following keyword, whether
+  // the identifier is printed as raw UTF-8 or as a `\u{...}` escape.
+  const nonAsciiIdentifierSource = /* js */ `
+    var _\u200C = 1;
+    var caf\u00E9 = 2;
+    var x\u0967 = 3;
+    var \u2118q = 4;
+    var \u03C0 = "k";
+    class \u00D1 {
+      #\u00E9 = 1;
+      static has(o) {
+        return #\u00E9 in o;
+      }
+    }
+    var out = [];
+    for (_\u200C of [4]) out.push(_\u200C);
+    for (caf\u00E9 in { 2: 1 }) out.push(caf\u00E9);
+    for (x\u0967 of [5]) out.push(x\u0967);
+    for (\u2118q of [6]) out.push(\u2118q);
+    out.push(caf\u00E9 in { 2: 1 }, x\u0967 instanceof Number, _\u200C in { 4: 1 });
+    out.push(\u03C0 in { k: 1 }, \u00D1.has(new \u00D1()), new \u00D1() instanceof \u00D1);
+    console.log(JSON.stringify(out));
+  `;
+  const nonAsciiIdentifierStdout = '[4,"2",5,6,true,false,true,true,true,true]';
+  itBundled("minify/SpaceBetweenNonAsciiIdentifierAndKeyword", {
+    files: { "/entry.js": nonAsciiIdentifierSource },
+    minifyWhitespace: true,
+    target: "browser",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("_\u200C of[4]");
+      expect(code).toContain("caf\u00E9 in{");
+      expect(code).toContain("x\u0967 instanceof Number");
+      expect(code).toContain("#\u00E9 in o");
+      expect(code).toContain("new \u00D1 instanceof \u00D1");
+    },
+    run: { stdout: nonAsciiIdentifierStdout },
+  });
+  itBundled("minify/SpaceBetweenEscapedIdentifierAndKeyword", {
+    files: { "/entry.js": nonAsciiIdentifierSource },
+    minifyWhitespace: true,
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("_\\u{200c} of[4]");
+      expect(code).toContain("caf\\u{e9} in{");
+      expect(code).toContain("x\\u{967} instanceof Number");
+      expect(code).toContain("#\\u{e9} in o");
+      expect(code).toContain("new \\u{d1} instanceof \\u{d1}");
+    },
+    run: { stdout: nonAsciiIdentifierStdout },
+  });
+
   // Without minifySyntax the block body must be preserved verbatim.
   itBundled("minify/ArrowReturnNotCollapsedWithoutMinifySyntax", {
     files: {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1597,11 +1597,22 @@ describe("bundler", () => {
     for (\u2118q of [6]) out.push(\u2118q);
     out.push(caf\u00E9 in { 2: 1 }, x\u0967 instanceof Number, _\u200C in { 4: 1 });
     out.push(\u03C0 in { k: 1 }, \u00D1.has(new \u00D1()), new \u00D1() instanceof \u00D1);
+    out.push(lib.check({ k: 1 }));
     console.log(JSON.stringify(out));
   `;
-  const nonAsciiIdentifierStdout = '[4,"2",5,6,true,false,true,true,true,true]';
+  // A wrapped CommonJS module prints `exports.café` for this export. That path
+  // prints the name on its own, so it needs the same space handling.
+  const nonAsciiIdentifierFiles = {
+    "/entry.js": `import lib from "./lib.cjs";\n${nonAsciiIdentifierSource}`,
+    "/lib.cjs": /* js */ `
+      exports.caf\u00E9 = "k";
+      exports.check = function (o) { return exports.caf\u00E9 in o; };
+      module.exports = module.exports;
+    `,
+  };
+  const nonAsciiIdentifierStdout = '[4,"2",5,6,true,false,true,true,true,true,true]';
   itBundled("minify/SpaceBetweenNonAsciiIdentifierAndKeyword", {
-    files: { "/entry.js": nonAsciiIdentifierSource },
+    files: nonAsciiIdentifierFiles,
     minifyWhitespace: true,
     target: "browser",
     onAfterBundle(api) {
@@ -1611,11 +1622,12 @@ describe("bundler", () => {
       expect(code).toContain("x\u0967 instanceof Number");
       expect(code).toContain("#\u00E9 in o");
       expect(code).toContain("new \u00D1 instanceof \u00D1");
+      expect(code).toContain("exports.caf\u00E9 in o");
     },
     run: { stdout: nonAsciiIdentifierStdout },
   });
   itBundled("minify/SpaceBetweenEscapedIdentifierAndKeyword", {
-    files: { "/entry.js": nonAsciiIdentifierSource },
+    files: nonAsciiIdentifierFiles,
     minifyWhitespace: true,
     target: "bun",
     onAfterBundle(api) {
@@ -1625,6 +1637,7 @@ describe("bundler", () => {
       expect(code).toContain("x\\u{967} instanceof Number");
       expect(code).toContain("#\\u{e9} in o");
       expect(code).toContain("new \\u{d1} instanceof \\u{d1}");
+      expect(code).toContain("exports.caf\\u{e9} in o");
     },
     run: { stdout: nonAsciiIdentifierStdout },
   });


### PR DESCRIPTION
### Problem
- `bun build --minify-whitespace` prints `for(_‌of[4])`, `éin{}`, `x१instanceof Number`, `#éin o` and `new Ñinstanceof Ñ`. The keyword is glued to the identifier, so the output is a SyntaxError. The build exits 0. Under `--target=bun` the same happens with the escaped form: `caf\u{e9}of[`.
- The cause is `print_space_before_identifier` (`src/js_printer/lib.rs:2105`). It only looks at the last written byte. For an identifier that ends in a non-ASCII code point that byte is a UTF-8 continuation byte, or the `}` of a `\u{...}` escape. `is_identifier_continue` rejects both, so no space is printed.

### Fix
- Add `prev_identifier_end` to the printer. `print_identifier` sets it when the identifier ends in a non-ASCII byte (raw UTF-8) or in an escape (ASCII-only mode). `print_space_before_identifier` prints a space when the write position equals it, the same way it handles `prev_reg_exp_end` after a regex literal.
- `print_commonjs_export_identifier` printed an export name raw. It now goes through `print_identifier`, so `exports.café in o` in a wrapped CommonJS module gets the space too, and the name is escaped in ASCII-only mode like every other identifier.
- ASCII identifiers are unchanged: the last byte passes `is_identifier_continue` as before, and the hot path only adds one byte compare.
- Verified: `test/bundler/bundler_minify.test.ts` (two new cases, both fail on 1.4.3). Also ran all of `bundler_minify.test.ts` and `test/bundler/transpiler/transpiler.test.js`.

### Background
- The printer tracks "what did I just write" with byte offsets, not tokens. `prev_reg_exp_end` is the existing example: a regex literal can end in a letter (`/a/g`), so a following identifier needs a space even though the byte check alone would not know that.
- With `--target=bun` the printer runs in ASCII-only mode and prints a non-ASCII code point in an identifier as `\u{e9}`. With `--target=node|browser` it prints the raw UTF-8 bytes. Both forms end in a byte that is not an ASCII identifier byte.

<details><summary>Notes</summary>

The bug is independent of minify-identifiers. It shows under `--minify-whitespace`, `--minify-syntax --minify-whitespace`, `--no-bundle --minify-whitespace` and `Bun.Transpiler` with `minifyWhitespace`. Full `--minify` hides it for names the renamer can rename, and shows it for the rest (an exported top-level `café` in a lifted module, for example).

Affected contexts are the ones where a keyword follows an identifier with nothing in between: `ID in`, `ID instanceof`, `for (... ID of|in ...)`, `#ID in o`, and `new ID() instanceof C` (the `()` removal creates the adjacency). Keyword-before-identifier contexts (`typeof é`, `new é`, `import é from`, `export { é as e }`) print their space on another path and were never affected.

`print_identifier_utf16` is only used for property keys, which are always followed by `:` or `(`, so it does not set the marker.

Repro:

```js
// id.mjs
var _‌=1;var é=2;var x१=3;for(_‌ of [4]){}console.log(JSON.stringify([_‌,é in {2:1},x१ instanceof Number]));
```

```
bun build id.mjs --minify-whitespace --outfile o.mjs && node o.mjs
before: SyntaxError: Unexpected token ')'
after:  [4,true,false]
```

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.3 (367d939d9)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [728.84ms]
(pass) bundler > minify/TemplateStringFolding [184.66ms]
(pass) bundler > minify/StringAdditionFolding [115.54ms]
(pass) bundler > minify/FunctionExpressionRemoveName [98.80ms]
(pass) bundler > minify/KeepNamesPreservesNames [135.45ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [99.50ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1160.37ms]
(pass) bundler > minify/MergeAdjacentVars [347.70ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [400.61ms]
(pass) bundler > minify/Infinity [108.18ms]
(pass) bundler > minify+whitespace/Infinity [102.90ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [363.01ms]
(pass) bundler > minify/SameTargetDestructuringAfterOtherDecl [370.89ms]
(pass) bundler > minify/SameTargetDestructuringMultipleRuns [405.80ms]
(pass) bundler > minify/SameTargetDestructuringStopsWhenTargetRebound [3
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (8d5174148)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [38.90ms]
(pass) bundler > minify/TemplateStringFolding [7.40ms]
(pass) bundler > minify/StringAdditionFolding [4.54ms]
(pass) bundler > minify/FunctionExpressionRemoveName [4.42ms]
(pass) bundler > minify/KeepNamesPreservesNames [6.25ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [4.04ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [16.59ms]
(pass) bundler > minify/MergeAdjacentVars [12.88ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [15.38ms]
(pass) bundler > minify/Infinity [6.18ms]
(pass) bundler > minify+whitespace/Infinity [5.41ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [12.38ms]
(pass) bundler > minify/SameTargetDestructuringAfterOtherDecl [15.20ms]
(pass) bundler > minify/SameTargetDestructuringMultipleRuns [12.72ms]
(pass) bundler > minify/SameTargetDestructuringStopsWhenTargetRebound [11.36ms]
(pass) bundler > minify/SameTargetDestructuringSkipsRedeclaredTarget [14.53ms]
(pass) bundler > minify/SameTargetDestructuringSkipsRedeclaredTargetWithoutMinify [12.32ms]

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.3 (367d939d9)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [747.56ms]
(pass) bundler > minify/TemplateStringFolding [143.91ms]
(pass) bundler > minify/StringAdditionFolding [111.55ms]
(pass) bundler > minify/FunctionExpressionRemoveName [107.00ms]
(pass) bundler > minify/KeepNamesPreservesNames [137.71ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [84.61ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1073.74ms]
(pass) bundler > minify/MergeAdjacentVars [397.22ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [419.82ms]
(pass) bundler > minify/Infinity [103.24ms]
(pass) bundler > minify+whitespace/Infinity [109.10ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [342.81ms]
(pass) bundler > minify/SameTargetDestructuringAfterOtherDecl [351.31ms]
(pass) bundler > minify/SameTargetDestructuringMultipleRuns [420.83ms]
(pass) bundler > minify/SameTargetDestructuringStopsWhenTargetRebound [
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     864322c5a8
  features     lto, baseline

23 deps, 131 codegen, 1176 objects in 747ms

ninja: Entering directory `/workspace/bun/build/release'
[1/13] install /workspace/bun
bun install v1.4.3-canary.1 (8d5174148)

Checked 22 installs across 61 packages (no changes) [3.00ms]
[2/13] esbuild runtime.out.js

  build/release/codegen/runtime.out.js  5.6kb

⚡ Done in 3ms
[3/13] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 12ms
[4/13] gen compressed/codegen/bun-error/bun-error.css.zst
[5/13] gen compressed/codegen/bun-error/index.js.zst
[6/13] gen cpp.rs (cppbind)
[6/13] cargo bun_runtime → libbun_runtime.a
[1m[33mwarning[0m[1m: binary `bun_shim_impl` should have a kebab-case name[0m
   [1m[94m|[0m
[1m[94m 1[0m [1m[94m|[0m /workspace/bun/build/release/rust-target/.../bun_shim_impl
   [1m[94m|[0m                                              [1m[33m^^^^^^^^^^^^^[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs               | 12 +++++--
 test/bundler/bundler_minify.test.ts | 68 +++++++++++++++++++++++++++++++++++++
 2 files changed, 78 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js_printer/lib.rs                    4      9     12
test/bundler/bundler_minify.test.ts      2      5     12
```

</details>

<!-- robobun:evidence:end -->