### PR TITLE
node:process: emit MaxListenersExceededWarning and follow events.defaultMaxListeners

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -59,6 +59,8 @@ let FixedQueue;
 const kEmptyObject = Object.freeze(Object.create(null));
 
 var defaultMaxListeners = 10;
+// `process` is a native EventEmitter, so the default lives in C++ too.
+const setDefaultMaxListenersNative = $newCppFunction("JSEventEmitter.cpp", "jsEventEmitterSetDefaultMaxListeners", 1);
 
 // EventEmitter must be a standard function because some old code will do weird tricks like `EventEmitter.$apply(this)`.
 function EventEmitter(opts) {
@@ -788,6 +790,7 @@ function setMaxListeners(n = defaultMaxListeners, ...eventTargets) {
   validateNumber(n, "setMaxListeners", 0);
   if (eventTargets.length === 0) {
     defaultMaxListeners = n;
+    setDefaultMaxListenersNative(n);
   } else {
     for (let i = 0; i < eventTargets.length; i++) {
       const target = eventTargets[i];
@@ -965,6 +968,7 @@ Object.defineProperties(EventEmitter, {
     set: arg => {
       validateNumber(arg, "defaultMaxListeners", 0);
       defaultMaxListeners = arg;
+      setDefaultMaxListenersNative(arg);
     },
   },
   kMaxEventTargetListeners: {

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -958,6 +958,11 @@ JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObjec
     auto arg_name = jsString->view(globalObject);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
+    RELEASE_AND_RETURN(throwScope, OUT_OF_RANGE(throwScope, globalObject, arg_name->toString(), bound_num, bound, actual));
+}
+
+JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, double bound_num, Bound bound, JSC::JSValue actual)
+{
     WTF::StringBuilder builder;
     builder.append("The value of \""_s);
     builder.append(arg_name);

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -95,6 +95,7 @@ JSC::EncodedJSValue INVALID_ARG_TYPE_INSTANCE(JSC::ThrowScope& throwScope, JSC::
 JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, double lower, double upper, JSC::JSValue actual);
 JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue arg_name, double lower, double upper, JSC::JSValue actual);
 JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue arg_name_val, double bound_num, Bound bound, JSC::JSValue actual);
+JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name, double bound_num, Bound bound, JSC::JSValue actual);
 JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue arg_name_val, const WTF::String& msg, JSC::JSValue actual);
 JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& arg_name_val, const WTF::String& msg, JSC::JSValue actual);
 JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, ASCIILiteral message);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -350,6 +350,8 @@ public:
     Ref<Bun::GlobalEventScope> globalEventScope;
     RefPtr<WebCore::MessagePort> m_nodeParentPort;
     bool m_nodeWorkerEntrySettled { false };
+    // Mirror of `events.defaultMaxListeners` for the native EventEmitter (process).
+    unsigned m_defaultMaxListeners { 10 };
 
     void resetOnEachMicrotaskTick();
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -350,8 +350,6 @@ public:
     Ref<Bun::GlobalEventScope> globalEventScope;
     RefPtr<WebCore::MessagePort> m_nodeParentPort;
     bool m_nodeWorkerEntrySettled { false };
-    // Mirror of `events.defaultMaxListeners` for the native EventEmitter (process).
-    unsigned m_defaultMaxListeners { 10 };
 
     void resetOnEachMicrotaskTick();
 

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -7,7 +7,6 @@
 #include "EventNames.h"
 #include "JSErrorHandler.h"
 #include "JSEventListener.h"
-#include "ZigGlobalObject.h"
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
@@ -73,16 +72,6 @@ bool EventEmitter::removeListener(const Identifier& eventType, EventListener& li
         return true;
     }
     return false;
-}
-
-unsigned EventEmitter::getMaxListeners() const
-{
-    if (m_maxListeners)
-        return *m_maxListeners;
-    auto* context = scriptExecutionContext();
-    if (!context)
-        return 10;
-    return defaultGlobalObject(context->jsGlobalObject())->m_defaultMaxListeners;
 }
 
 bool EventEmitter::markMaxListenersWarned(const Identifier& eventType)

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -65,12 +65,31 @@ bool EventEmitter::removeListener(const Identifier& eventType, EventListener& li
 
     if (data->eventListenerMap.remove(eventType, listener)) {
         eventListenersDidChange();
+        clearMaxListenersWarnedIfBelowLimit(eventType);
 
         if (this->onDidChangeListener)
             this->onDidChangeListener(*this, eventType, false);
         return true;
     }
     return false;
+}
+
+bool EventEmitter::markMaxListenersWarned(const Identifier& eventType)
+{
+    if (m_maxListenersWarned.contains(eventType))
+        return false;
+    m_maxListenersWarned.append(eventType);
+    return true;
+}
+
+// Node drops the `warned` flag with the array when a type is back to a single
+// listener, so the next overflow warns again.
+void EventEmitter::clearMaxListenersWarnedIfBelowLimit(const Identifier& eventType)
+{
+    if (m_maxListenersWarned.isEmpty())
+        return;
+    if (listenerCount(eventType) <= 1)
+        m_maxListenersWarned.removeFirst(eventType);
 }
 
 void EventEmitter::removeAllListenersForBindings(const Identifier& eventType)
@@ -90,6 +109,7 @@ bool EventEmitter::removeAllListeners()
     // refs, listener-count mirrors) observes the post-removal zero counts.
     Vector<Identifier> eventTypes = map.eventTypes();
     map.clear();
+    m_maxListenersWarned.clear();
     this->m_thisObject.clear();
     if (any) {
         eventListenersDidChange();
@@ -109,6 +129,7 @@ bool EventEmitter::removeAllListeners(const Identifier& eventType)
 
     if (data->eventListenerMap.removeAll(eventType)) {
         eventListenersDidChange();
+        clearMaxListenersWarnedIfBelowLimit(eventType);
         if (this->onDidChangeListener)
             this->onDidChangeListener(*this, eventType, false);
         return true;

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -7,6 +7,7 @@
 #include "EventNames.h"
 #include "JSErrorHandler.h"
 #include "JSEventListener.h"
+#include "ZigGlobalObject.h"
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
@@ -72,6 +73,16 @@ bool EventEmitter::removeListener(const Identifier& eventType, EventListener& li
         return true;
     }
     return false;
+}
+
+unsigned EventEmitter::getMaxListeners() const
+{
+    if (m_maxListeners)
+        return *m_maxListeners;
+    auto* context = scriptExecutionContext();
+    if (!context)
+        return 10;
+    return defaultGlobalObject(context->jsGlobalObject())->m_defaultMaxListeners;
 }
 
 bool EventEmitter::markMaxListenersWarned(const Identifier& eventType)

--- a/src/jsc/bindings/webcore/EventEmitter.cpp
+++ b/src/jsc/bindings/webcore/EventEmitter.cpp
@@ -82,8 +82,7 @@ bool EventEmitter::markMaxListenersWarned(const Identifier& eventType)
     return true;
 }
 
-// Node drops the `warned` flag with the array when a type is back to a single
-// listener, so the next overflow warns again.
+// Node clears `warned` once a type is back to one listener.
 void EventEmitter::clearMaxListenersWarnedIfBelowLimit(const Identifier& eventType)
 {
     if (m_maxListenersWarned.isEmpty())

--- a/src/jsc/bindings/webcore/EventEmitter.h
+++ b/src/jsc/bindings/webcore/EventEmitter.h
@@ -73,6 +73,11 @@ public:
 
     void setMaxListeners(unsigned count);
 
+    // Returns true the first time an event type goes over the max listener
+    // count. Later calls return false until the type drops back to one
+    // listener, matching node's `existing.warned` flag.
+    bool markMaxListenersWarned(const Identifier& eventType);
+
     bool fireEventListeners(const Identifier& eventName, const MarkedArgumentBuffer& arguments);
     bool isFiringEventListeners() const;
 
@@ -103,9 +108,11 @@ private:
     }
 
     bool innerInvokeEventListeners(const Identifier&, SimpleEventListenerVector, const MarkedArgumentBuffer& arguments);
+    void clearMaxListenersWarnedIfBelowLimit(const Identifier& eventType);
 
     EventEmitterData m_eventTargetData;
     unsigned m_maxListeners { 10 };
+    Vector<Identifier, 1> m_maxListenersWarned;
 
     mutable JSC::Weak<JSC::JSObject> m_thisObject { nullptr };
 };

--- a/src/jsc/bindings/webcore/EventEmitter.h
+++ b/src/jsc/bindings/webcore/EventEmitter.h
@@ -70,16 +70,12 @@ public:
 
     WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)> onDidChangeListener = WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)>(nullptr);
 
-    // The per-emitter limit, or the mirrored `events.defaultMaxListeners`
-    // when none was set, like node's `_maxListeners ?? defaultMaxListeners`.
     unsigned getMaxListeners() const { return m_maxListeners.value_or(m_defaultMaxListeners); }
 
     void setMaxListeners(unsigned count);
     void setDefaultMaxListeners(unsigned count) { m_defaultMaxListeners = count; }
 
-    // Returns true the first time an event type goes over the max listener
-    // count. Later calls return false until the type drops back to one
-    // listener, matching node's `existing.warned` flag.
+    // True on the first overflow of an event type, like node's `existing.warned`.
     bool markMaxListenersWarned(const Identifier& eventType);
 
     bool fireEventListeners(const Identifier& eventName, const MarkedArgumentBuffer& arguments);

--- a/src/jsc/bindings/webcore/EventEmitter.h
+++ b/src/jsc/bindings/webcore/EventEmitter.h
@@ -70,11 +70,12 @@ public:
 
     WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)> onDidChangeListener = WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)>(nullptr);
 
-    // The per-emitter limit, or the global's `events.defaultMaxListeners`
+    // The per-emitter limit, or the mirrored `events.defaultMaxListeners`
     // when none was set, like node's `_maxListeners ?? defaultMaxListeners`.
-    unsigned getMaxListeners() const;
+    unsigned getMaxListeners() const { return m_maxListeners.value_or(m_defaultMaxListeners); }
 
     void setMaxListeners(unsigned count);
+    void setDefaultMaxListeners(unsigned count) { m_defaultMaxListeners = count; }
 
     // Returns true the first time an event type goes over the max listener
     // count. Later calls return false until the type drops back to one
@@ -115,6 +116,7 @@ private:
 
     EventEmitterData m_eventTargetData;
     std::optional<unsigned> m_maxListeners;
+    unsigned m_defaultMaxListeners { 10 };
     Vector<Identifier, 1> m_maxListenersWarned;
 
     mutable JSC::Weak<JSC::JSObject> m_thisObject { nullptr };

--- a/src/jsc/bindings/webcore/EventEmitter.h
+++ b/src/jsc/bindings/webcore/EventEmitter.h
@@ -7,6 +7,7 @@
 #include "ContextDestructionObserver.h"
 #include "ScriptWrappable.h"
 #include <memory>
+#include <optional>
 #include <variant>
 #include <wtf/Forward.h>
 
@@ -69,7 +70,9 @@ public:
 
     WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)> onDidChangeListener = WTF::Function<void(EventEmitter&, const Identifier& eventName, bool isAdded)>(nullptr);
 
-    unsigned getMaxListeners() const { return m_maxListeners; };
+    // The per-emitter limit, or the global's `events.defaultMaxListeners`
+    // when none was set, like node's `_maxListeners ?? defaultMaxListeners`.
+    unsigned getMaxListeners() const;
 
     void setMaxListeners(unsigned count);
 
@@ -111,7 +114,7 @@ private:
     void clearMaxListenersWarnedIfBelowLimit(const Identifier& eventType);
 
     EventEmitterData m_eventTargetData;
-    unsigned m_maxListeners { 10 };
+    std::optional<unsigned> m_maxListeners;
     Vector<Identifier, 1> m_maxListenersWarned;
 
     mutable JSC::Weak<JSC::JSObject> m_thisObject { nullptr };

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -2,6 +2,7 @@
 #include "JSEventEmitter.h"
 
 #include "BunProcess.h"
+#include "NodeValidator.h"
 #include "ZigGlobalObject.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
@@ -322,19 +323,18 @@ void JSEventEmitter::emitMaxListenersExceededWarning(JSC::JSGlobalObject* lexica
             emitterName = JSObject::calculatedClassName(emitterObject);
     }
 
+    // `String(type)`: a symbol becomes "Symbol(desc)" instead of throwing.
     String typeName;
     if (type.isSymbol()) {
-        JSString* symbolString = asSymbol(type)->toString(lexicalGlobalObject);
-        RETURN_IF_EXCEPTION(scope, void());
-        typeName = symbolString->value(lexicalGlobalObject);
+        typeName = asSymbol(type)->tryGetDescriptiveString().value_or(String());
     } else {
         typeName = type.toWTFString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, void());
     }
-    RETURN_IF_EXCEPTION(scope, void());
 
     auto message = makeString("Possible EventEmitter memory leak detected. "_s, count, ' ', typeName, " listeners added to ["_s, emitterName, "]. MaxListeners is "_s, maxListeners, ". Use emitter.setMaxListeners() to increase limit"_s);
     JSObject* warning = createError(lexicalGlobalObject, message);
-    warning->putDirect(vm, vm.propertyNames->name, jsString(vm, String("MaxListenersExceededWarning"_s)), JSC::PropertyAttribute::DontEnum | 0);
+    warning->putDirect(vm, vm.propertyNames->name, jsString(vm, String("MaxListenersExceededWarning"_s)), 0);
     warning->putDirect(vm, Identifier::fromString(vm, "emitter"_s), emitter, 0);
     warning->putDirect(vm, vm.propertyNames->type, type, 0);
     warning->putDirect(vm, Identifier::fromString(vm, "count"_s), jsNumber(count), 0);
@@ -352,20 +352,17 @@ static inline JSC::EncodedJSValue jsEventEmitterPrototypeFunction_setMaxListener
 {
     auto& impl = castedThis->wrapped();
     auto throwScope = DECLARE_THROW_SCOPE(JSC::getVM(lexicalGlobalObject));
-    if (callFrame->argumentCount() == 0) {
-        return JSC::JSValue::encode(JSC::jsUndefined());
-    }
-    EnsureStillAliveScope argument0 = callFrame->uncheckedArgument(0);
-    if (!argument0.value().isNumber()) {
-        throwTypeError(lexicalGlobalObject, throwScope, "The maxListeners argument must be a number"_s);
-        return JSC::JSValue::encode(JSC::jsUndefined());
-    }
+    JSValue argument0 = callFrame->argument(0);
+    // Same check as EventEmitterPrototype.setMaxListeners in events.ts.
+    Bun::V::validateNumber(throwScope, lexicalGlobalObject, argument0, "setMaxListeners"_s, jsNumber(0), jsUndefined());
+    RETURN_IF_EXCEPTION(throwScope, {});
 
-    impl.setMaxListeners(JSEventEmitter::maxListenersFromNumber(argument0.value().asNumber()));
-    return JSC::JSValue::encode(JSC::jsUndefined());
+    impl.setMaxListeners(JSEventEmitter::maxListenersFromNumber(argument0.asNumber()));
+    return JSC::JSValue::encode(callFrame->thisValue());
 }
 
-// 0 means no limit, so a count that does not fit is the same as no limit.
+// Takes a validated non-negative number. 0 means no limit, so a count that
+// does not fit is the same as no limit.
 unsigned JSEventEmitter::maxListenersFromNumber(double n)
 {
     if (!(n < static_cast<double>(std::numeric_limits<unsigned>::max())))
@@ -374,12 +371,13 @@ unsigned JSEventEmitter::maxListenersFromNumber(double n)
 }
 
 // Called by `events.defaultMaxListeners = n` and `events.setMaxListeners(n)`
-// in events.ts, which validate `n` first.
+// in events.ts, which validate `n` first. `process` is the only native
+// EventEmitter, so the mirrored default lives on it.
 JSC_DEFINE_HOST_FUNCTION(jsEventEmitterSetDefaultMaxListeners, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     JSValue value = callFrame->argument(0);
     if (value.isNumber())
-        defaultGlobalObject(globalObject)->m_defaultMaxListeners = JSEventEmitter::maxListenersFromNumber(value.asNumber());
+        defaultGlobalObject(globalObject)->processObject()->wrapped().setDefaultMaxListeners(JSEventEmitter::maxListenersFromNumber(value.asNumber()));
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -2,6 +2,7 @@
 #include "JSEventEmitter.h"
 
 #include "BunProcess.h"
+#include "ZigGlobalObject.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "IDLTypes.h"
@@ -359,10 +360,27 @@ static inline JSC::EncodedJSValue jsEventEmitterPrototypeFunction_setMaxListener
         throwTypeError(lexicalGlobalObject, throwScope, "The maxListeners argument must be a number"_s);
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
-    unsigned maxListeners = JSC::toUInt32(argument0.value().asNumber());
 
-    impl.setMaxListeners(maxListeners);
+    impl.setMaxListeners(JSEventEmitter::maxListenersFromNumber(argument0.value().asNumber()));
     return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+// 0 means no limit, so a count that does not fit is the same as no limit.
+unsigned JSEventEmitter::maxListenersFromNumber(double n)
+{
+    if (!(n < static_cast<double>(std::numeric_limits<unsigned>::max())))
+        return 0;
+    return JSC::toUInt32(n);
+}
+
+// Called by `events.defaultMaxListeners = n` and `events.setMaxListeners(n)`
+// in events.ts, which validate `n` first.
+JSC_DEFINE_HOST_FUNCTION(jsEventEmitterSetDefaultMaxListeners, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    JSValue value = callFrame->argument(0);
+    if (value.isNumber())
+        defaultGlobalObject(globalObject)->m_defaultMaxListeners = JSEventEmitter::maxListenersFromNumber(value.asNumber());
+    return JSValue::encode(jsUndefined());
 }
 
 static inline JSC::EncodedJSValue jsEventEmitterPrototypeFunction_getMaxListenersBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSEventEmitter>::ClassParameter castedThis)

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -325,7 +325,7 @@ void JSEventEmitter::emitMaxListenersExceededWarning(JSC::JSGlobalObject* lexica
     // `String(type)`: a symbol becomes "Symbol(desc)" instead of throwing.
     String typeName;
     if (type.isSymbol()) {
-        typeName = asSymbol(type)->tryGetDescriptiveString().value_or(String());
+        typeName = asSymbol(type)->tryGetDescriptiveString().value_or("Symbol()"_s);
     } else {
         typeName = type.toWTFString(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(scope, void());

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -309,8 +309,7 @@ void JSEventEmitter::emitMaxListenersExceededWarning(JSC::JSGlobalObject* lexica
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // node prints `inspect(emitter, { depth: -1 })`, which is `[process]` for
-    // the process object. The toStringTag is the closest thing we have here.
+    // node prints `inspect(emitter, { depth: -1 })`, `[process]` here.
     String emitterName;
     if (JSObject* emitterObject = emitter.getObject()) {
         JSValue tag = emitterObject->get(lexicalGlobalObject, vm.propertyNames->toStringTagSymbol);
@@ -361,8 +360,7 @@ static inline JSC::EncodedJSValue jsEventEmitterPrototypeFunction_setMaxListener
     return JSC::JSValue::encode(callFrame->thisValue());
 }
 
-// Takes a validated non-negative number. 0 means no limit, so a count that
-// does not fit is the same as no limit.
+// 0 means no limit.
 unsigned JSEventEmitter::maxListenersFromNumber(double n)
 {
     if (!(n < static_cast<double>(std::numeric_limits<unsigned>::max())))
@@ -370,9 +368,7 @@ unsigned JSEventEmitter::maxListenersFromNumber(double n)
     return JSC::toUInt32(n);
 }
 
-// Called by `events.defaultMaxListeners = n` and `events.setMaxListeners(n)`
-// in events.ts, which validate `n` first. `process` is the only native
-// EventEmitter, so the mirrored default lives on it.
+// events.ts mirrors `defaultMaxListeners` onto process, the only native EventEmitter.
 JSC_DEFINE_HOST_FUNCTION(jsEventEmitterSetDefaultMaxListeners, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     JSValue value = callFrame->argument(0);

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "JSEventEmitter.h"
 
+#include "BunProcess.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "IDLTypes.h"
@@ -287,7 +288,58 @@ inline JSC::EncodedJSValue JSEventEmitter::addListener(JSC::JSGlobalObject* lexi
 
     vm.writeBarrier(&static_cast<JSObject&>(*castedThis), argument1.value());
     impl.setThisObject(actualThis);
+
+    // see overflowWarning in events.ts
+    unsigned maxListeners = impl.getMaxListeners();
+    if (maxListeners > 0) {
+        int count = impl.listenerCount(eventType);
+        if (count > 0 && static_cast<unsigned>(count) > maxListeners && impl.markMaxListenersWarned(eventType)) {
+            emitMaxListenersExceededWarning(lexicalGlobalObject, actualThis, argument0.value(), count, maxListeners);
+            RETURN_IF_EXCEPTION(throwScope, {});
+        }
+    }
+
     RELEASE_AND_RETURN(throwScope, JSValue::encode(actualThis));
+}
+
+void JSEventEmitter::emitMaxListenersExceededWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue emitter, JSC::JSValue type, int count, unsigned maxListeners)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // node prints `inspect(emitter, { depth: -1 })`, which is `[process]` for
+    // the process object. The toStringTag is the closest thing we have here.
+    String emitterName;
+    if (JSObject* emitterObject = emitter.getObject()) {
+        JSValue tag = emitterObject->get(lexicalGlobalObject, vm.propertyNames->toStringTagSymbol);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (tag.isString()) {
+            emitterName = tag.getString(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, void());
+        }
+        if (emitterName.isEmpty())
+            emitterName = JSObject::calculatedClassName(emitterObject);
+    }
+
+    String typeName;
+    if (type.isSymbol()) {
+        JSString* symbolString = asSymbol(type)->toString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, void());
+        typeName = symbolString->value(lexicalGlobalObject);
+    } else {
+        typeName = type.toWTFString(lexicalGlobalObject);
+    }
+    RETURN_IF_EXCEPTION(scope, void());
+
+    auto message = makeString("Possible EventEmitter memory leak detected. "_s, count, ' ', typeName, " listeners added to ["_s, emitterName, "]. MaxListeners is "_s, maxListeners, ". Use emitter.setMaxListeners() to increase limit"_s);
+    JSObject* warning = createError(lexicalGlobalObject, message);
+    warning->putDirect(vm, vm.propertyNames->name, jsString(vm, String("MaxListenersExceededWarning"_s)), JSC::PropertyAttribute::DontEnum | 0);
+    warning->putDirect(vm, Identifier::fromString(vm, "emitter"_s), emitter, 0);
+    warning->putDirect(vm, vm.propertyNames->type, type, 0);
+    warning->putDirect(vm, Identifier::fromString(vm, "count"_s), jsNumber(count), 0);
+
+    Bun::Process::emitWarningErrorInstance(lexicalGlobalObject, warning);
+    RETURN_IF_EXCEPTION(scope, void());
 }
 
 static inline JSC::EncodedJSValue jsEventEmitterPrototypeFunction_addListenerBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSEventEmitter>::ClassParameter castedThis)

--- a/src/jsc/bindings/webcore/JSEventEmitter.h
+++ b/src/jsc/bindings/webcore/JSEventEmitter.h
@@ -23,6 +23,7 @@ public:
     static void destroy(JSC::JSCell*);
 
     static inline JSC::EncodedJSValue addListener(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSEventEmitter* castedThis, bool once, bool prepend);
+    static unsigned maxListenersFromNumber(double n);
     static void emitMaxListenersExceededWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue emitter, JSC::JSValue type, int count, unsigned maxListeners);
     static inline JSC::EncodedJSValue removeListener(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSEventEmitter* castedThis);
 
@@ -74,6 +75,8 @@ template<> struct JSDOMWrapperConverterTraits<EventEmitter> {
     using WrapperClass = JSEventEmitter;
     using ToWrappedReturnType = EventEmitter*;
 };
+
+JSC_DECLARE_HOST_FUNCTION(jsEventEmitterSetDefaultMaxListeners);
 
 } // namespace WebCore
 #include "JSEventEmitterCustom.h"

--- a/src/jsc/bindings/webcore/JSEventEmitter.h
+++ b/src/jsc/bindings/webcore/JSEventEmitter.h
@@ -23,6 +23,7 @@ public:
     static void destroy(JSC::JSCell*);
 
     static inline JSC::EncodedJSValue addListener(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSEventEmitter* castedThis, bool once, bool prepend);
+    static void emitMaxListenersExceededWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue emitter, JSC::JSValue type, int count, unsigned maxListeners);
     static inline JSC::EncodedJSValue removeListener(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, JSEventEmitter* castedThis);
 
     DECLARE_INFO;

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { EventEmitter } from "node:events";
 import path from "path";
 
 describe("process.on", () => {
@@ -136,6 +137,27 @@ describe.concurrent("process MaxListenersExceededWarning", () => {
     expect(stderr).toContain("MaxListeners is 3");
     expect(JSON.parse(stdout)).toEqual(["4:3"]);
     expect(exitCode).toBe(0);
+  });
+
+  it("process.setMaxListeners validates like EventEmitter.prototype.setMaxListeners", () => {
+    for (const bad of [-1, NaN, "3", undefined]) {
+      let processError: any, emitterError: any;
+      try {
+        process.setMaxListeners(bad as number);
+      } catch (e) {
+        processError = e;
+      }
+      try {
+        new EventEmitter().setMaxListeners(bad as number);
+      } catch (e) {
+        emitterError = e;
+      }
+      expect(processError?.code).toBe(emitterError.code);
+      expect(processError?.message).toBe(emitterError.message);
+    }
+    const before = process.getMaxListeners();
+    expect(process.setMaxListeners(2.5)).toBe(process);
+    process.setMaxListeners(before);
   });
 
   it("follows events.defaultMaxListeners until process.setMaxListeners is called", async () => {

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -104,7 +104,8 @@ describe.concurrent("process MaxListenersExceededWarning", () => {
         warned.push({ name: w.name, message: w.message, type: w.type, count: w.count, emitter: w.emitter === process });
       });
       const sym = Symbol("sym");
-      for (const ev of ["SIGINT", "exit", "custom", sym]) {
+      const bare = Symbol();
+      for (const ev of ["SIGINT", "exit", "custom", sym, bare]) {
         for (let i = 0; i < 12; i++) process.on(ev, () => {});
       }
       process.nextTick(() => {
@@ -113,7 +114,7 @@ describe.concurrent("process MaxListenersExceededWarning", () => {
     `);
     expect(stderr).toContain("MaxListenersExceededWarning");
     expect(JSON.parse(stdout)).toEqual(
-      ["SIGINT", "exit", "custom", "Symbol(sym)"].map(type => ({
+      ["SIGINT", "exit", "custom", "Symbol(sym)", "Symbol()"].map(type => ({
         name: "MaxListenersExceededWarning",
         message: `Possible EventEmitter memory leak detected. 11 ${type} listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit`,
         type,

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -138,6 +138,28 @@ describe.concurrent("process MaxListenersExceededWarning", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("follows events.defaultMaxListeners until process.setMaxListeners is called", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const events = require("node:events");
+      const warned = [];
+      process.on("warning", w => warned.push(w.message.match(/(\\d+) (\\w+) listeners.*MaxListeners is (\\d+)/).slice(1).join(":")));
+      events.defaultMaxListeners = 20;
+      console.log(process.getMaxListeners(), events.getMaxListeners(process));
+      for (let i = 0; i < 15; i++) process.on("a", () => {});
+      events.setMaxListeners(12);
+      for (let i = 0; i < 13; i++) process.on("b", () => {});
+      events.defaultMaxListeners = Infinity;
+      for (let i = 0; i < 50; i++) process.on("c", () => {});
+      process.setMaxListeners(3);
+      console.log(process.getMaxListeners());
+      for (let i = 0; i < 4; i++) process.on("d", () => {});
+      process.nextTick(() => console.log(JSON.stringify(warned)));
+    `);
+    expect(stderr).not.toContain("15 a listeners");
+    expect(stdout).toBe(`20 20\n3\n${JSON.stringify(["13:b:12", "4:d:3"])}\n`);
+    expect(exitCode).toBe(0);
+  });
+
   it("warns again after the listeners are removed", async () => {
     const { stdout, exitCode } = await run(`
       let warned = 0;

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { EventEmitter } from "node:events";
 import path from "path";
 
 describe("process.on", () => {
@@ -140,25 +139,27 @@ describe.concurrent("process MaxListenersExceededWarning", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("process.setMaxListeners validates like EventEmitter.prototype.setMaxListeners", () => {
-    for (const bad of [-1, NaN, "3", undefined]) {
-      let processError: any, emitterError: any;
-      try {
-        process.setMaxListeners(bad as number);
-      } catch (e) {
-        processError = e;
+  it("process.setMaxListeners validates like EventEmitter.prototype.setMaxListeners", async () => {
+    const { stdout, exitCode } = await run(`
+      const { EventEmitter } = require("node:events");
+      const errorOf = fn => { try { fn(); return null; } catch (e) { return { code: e.code, message: e.message }; } };
+      const out = [];
+      for (const bad of [-1, NaN, "3", undefined]) {
+        const a = errorOf(() => process.setMaxListeners(bad));
+        const b = errorOf(() => new EventEmitter().setMaxListeners(bad));
+        out.push(a !== null && JSON.stringify(a) === JSON.stringify(b) ? a.code : "mismatch");
       }
-      try {
-        new EventEmitter().setMaxListeners(bad as number);
-      } catch (e) {
-        emitterError = e;
-      }
-      expect(processError?.code).toBe(emitterError.code);
-      expect(processError?.message).toBe(emitterError.message);
-    }
-    const before = process.getMaxListeners();
-    expect(process.setMaxListeners(2.5)).toBe(process);
-    process.setMaxListeners(before);
+      out.push(process.setMaxListeners(2.5) === process);
+      console.log(JSON.stringify(out));
+    `);
+    expect(JSON.parse(stdout)).toEqual([
+      "ERR_OUT_OF_RANGE",
+      "ERR_OUT_OF_RANGE",
+      "ERR_INVALID_ARG_TYPE",
+      "ERR_INVALID_ARG_TYPE",
+      true,
+    ]);
+    expect(exitCode).toBe(0);
   });
 
   it("follows events.defaultMaxListeners until process.setMaxListeners is called", async () => {

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -84,3 +84,74 @@ describe("process.on", () => {
     expect(result2.exitCode).toBe(0);
   });
 });
+
+describe.concurrent("process MaxListenersExceededWarning", () => {
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("warns once per event type when more than maxListeners are added", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const warned = [];
+      process.on("warning", w => {
+        warned.push({ name: w.name, message: w.message, type: w.type, count: w.count, emitter: w.emitter === process });
+      });
+      const sym = Symbol("sym");
+      for (const ev of ["SIGINT", "exit", "custom", sym]) {
+        for (let i = 0; i < 12; i++) process.on(ev, () => {});
+      }
+      process.nextTick(() => {
+        console.log(JSON.stringify(warned.map(w => ({ ...w, type: String(w.type) }))));
+      });
+    `);
+    expect(stderr).toContain("MaxListenersExceededWarning");
+    expect(JSON.parse(stdout)).toEqual(
+      ["SIGINT", "exit", "custom", "Symbol(sym)"].map(type => ({
+        name: "MaxListenersExceededWarning",
+        message: `Possible EventEmitter memory leak detected. 11 ${type} listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit`,
+        type,
+        count: 11,
+        emitter: true,
+      })),
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  it("respects process.setMaxListeners", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const warned = [];
+      process.on("warning", w => warned.push(w.count + ":" + w.message.match(/MaxListeners is (\\d+)/)[1]));
+      process.setMaxListeners(0);
+      for (let i = 0; i < 20; i++) process.on("a", () => {});
+      process.setMaxListeners(3);
+      for (let i = 0; i < 5; i++) process.on("b", () => {});
+      process.nextTick(() => console.log(JSON.stringify(warned)));
+    `);
+    expect(stderr).toContain("MaxListeners is 3");
+    expect(JSON.parse(stdout)).toEqual(["4:3"]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("warns again after the listeners are removed", async () => {
+    const { stdout, exitCode } = await run(`
+      let warned = 0;
+      process.on("warning", () => warned++);
+      const fns = [];
+      for (let i = 0; i < 11; i++) { const fn = () => {}; fns.push(fn); process.on("x", fn); }
+      // One warning per overflow, not per listener.
+      process.on("x", () => {});
+      for (const fn of fns) process.removeListener("x", fn);
+      process.removeAllListeners("x");
+      for (let i = 0; i < 11; i++) process.on("x", () => {});
+      process.nextTick(() => console.log(warned));
+    `);
+    expect(stdout).toBe("2\n");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `process.on()` never emits `MaxListenersExceededWarning`. Node prints `Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. MaxListeners is 10` on the 11th listener. A plain `new EventEmitter()` in bun warns, `process` does not.
- `process` is backed by the C++ `WebCore::EventEmitter`. It stores `m_maxListeners` (`src/jsc/bindings/webcore/EventEmitter.h`) but `JSEventEmitter::addListener` (`src/jsc/bindings/webcore/JSEventEmitter.cpp`) never reads it. The limit was also a fixed 10 that ignored `events.defaultMaxListeners`.
- This matters for `bun --hot`: each reload re-runs top-level `process.on("SIGINT", ...)`, and nothing flags the pile-up.

### Fix
- After a listener is added, `JSEventEmitter::addListener` compares the count with the limit. On the first overflow per event type it builds the same Error node does (`name`, `emitter`, `type`, `count`) and passes it to `Process::emitWarningErrorInstance`. So `--no-warnings`, `--trace-warnings`, and `process.on("warning")` all apply.
- The warned flag is a per-type list on `EventEmitter`. It clears when the type is back to one listener or is removed, like node's `existing.warned` on the listener array.
- `m_maxListeners` is now optional. When unset, the emitter uses `m_defaultMaxListeners`, which `events.ts` mirrors from the `defaultMaxListeners` setter and from `events.setMaxListeners(n)` with no targets. So `process.getMaxListeners()` and the warning follow `events.defaultMaxListeners`, and `process.setMaxListeners(n)` still overrides.
- `process.setMaxListeners(n)` runs the same `validateNumber(n, "setMaxListeners", 0)` check as the JS emitter and returns the emitter. This exposed a bug in `OUT_OF_RANGE` (`src/jsc/bindings/ErrorCode.cpp`): with a `String` name and one bound, the `Bound` enum converted to a double upper bound and the message read `>= 0 and <= 0`. A `String` overload of the bounded form fixes it.
- Verified: `test/js/node/process/process-on.test.ts` (5 new tests, all fail on the released bun). Also `test/js/node/events/`, `test/js/node/process/`, and the node `test-event-emitter-max-listeners*` and `test-process-warning` suites.

### Background
- `process` is not a JS `EventEmitter`. `Bun::Process` extends `JSEventEmitter`, a DOM-style wrapper over `WebCore::EventEmitter`. It is the only object that uses this C++ emitter. The max listeners logic in `src/js/node/events.ts` never runs for it.
- `events.defaultMaxListeners` is a module-level variable in `events.ts`. It is per global object (a Worker has its own copy). The mirror is written onto the process emitter of the global that loaded `events`.
- The emitter name in the message comes from `Symbol.toStringTag`, which is `process` for the process object. Node gets `[process]` from `inspect()`.

<details><summary>Notes</summary>

Self-reviewed: 5 concerns raised, 4 addressed. Bot review: 4 findings, all addressed (input validation, enumerable `name`, no new field on `ZigGlobalObject`, `tryGetDescriptiveString` for symbol names). The four were one finding: the first version used a fixed limit of 10, so `events.defaultMaxListeners = 50`, the documented way to silence this warning, would have silenced node but not bun. The second commit adds the live default. The fifth concern, that `EventTarget` has the same gap (`events.setMaxListeners(n, target)` is a no-op), is a separate follow-up.

Not changed: `events.getMaxListeners(process)` still reads `process._maxListeners ?? defaultMaxListeners` and does not see a value set with `process.setMaxListeners(n)`. That divergence exists on main.

Repro:

```js
const warned = [];
process.on("warning", w => warned.push(w.message.replace(/.*\d+ (\S+) listeners added to \[(\w+)\].*/s, "$1@$2")));
for (const ev of ["SIGINT", "exit", "message", "custom"]) for (let i = 0; i < 11; i++) process.on(ev, () => {});
const { EventEmitter } = await import("node:events");
const e = new EventEmitter(); for (let i = 0; i < 11; i++) e.on("bar", () => {});
setTimeout(() => { console.log(warned); process.exit(0); }, 100);
// node:        [SIGINT@process, exit@process, message@process, custom@process, bar@EventEmitter]
// bun 1.4.2:   [bar@EventEmitter]
// this branch: [SIGINT@process, exit@process, message@process, custom@process, bar@EventEmitter]
```
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/process/process-on.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/process/process-on.test.ts:
(pass) process.on > when called from the main thread [282.54ms]
 [165ms]  bundle  1 modules
killed 1 dangling process
33 |       stdin: "inherit",
34 |       stdout: "inherit",
35 |       stderr: "inherit",
36 |     });
37 | 
38 |     expect(result1.exitCode).toBe(0);
                                  ^
error: expect(received).toBe(expected)

Expected: 0
Received: null

      at <anonymous> (/workspace/bun/test/js/node/process/process-on.test.ts:38:30)
(fail) process.on > should work inside --compile [5289.93ms]
  ^ this test timed out after 5000ms.
[macro] call initialize
Bundled 1 module in 309ms

  out.ts  8 bytes  (entry point)

(pass) process.on > should work inside a macro [722.94ms]
132 |       for (let i = 0; i < 20; i++) process.on("a", () => {});
133 |       process.setMaxListeners(3);
134 |       for (let i = 0; i < 5; i++) process.on("b", () => {});
135 |       process.nextTick(() => console.log(JSON.stringify(warned
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/process/process-on.test.ts:
(pass) process.on > when called from the main thread [7.17ms]
   [8ms]  bundle  1 modules
[2.061s] compile  ./out
(pass) process.on > should work inside --compile [2314.00ms]
Bundled 1 module in 46ms

  out.ts  8 bytes  (entry point)

(pass) process.on > should work inside a macro [180.77ms]
132 |       for (let i = 0; i < 20; i++) process.on("a", () => {});
133 |       process.setMaxListeners(3);
134 |       for (let i = 0; i < 5; i++) process.on("b", () => {});
135 |       process.nextTick(() => console.log(JSON.stringify(warned)));
136 |     `);
137 |     expect(stderr).toContain("MaxListeners is 3");
                         ^
error: expect(received).toContain(expected)

Expected to contain: "MaxListeners is 3"
Received: ""

      at <anonymous> (/workspace/bun/test/js/node/process/process-on.test.ts:137:20)
109 |       }
110 |       process.nextTick(() => {
111 |         console.log(JSON.stringify(warned.map(w => ({ ...w, type: String(w.type) }))));
112 |       });
113 |     `);
114 |     expect(stderr).toContain("MaxListenersExceededWarning");
                         ^
error: expec
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/process/process-on.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/process/process-on.test.ts:
(pass) process.on > when called from the main thread [353.37ms]
 [148ms]  bundle  1 modules
[2.521s] compile  ./out
(pass) process.on > should work inside --compile [3564.00ms]
[macro] call initialize
Bundled 1 module in 284ms

  out.ts  8 bytes  (entry point)

(pass) process.on > should work inside a macro [1314.58ms]
(pass) process MaxListenersExceededWarning > process.setMaxListeners validates like EventEmitter.prototype.setMaxListeners [464.03ms]
(pass) process MaxListenersExceededWarning > warns once per event type when more than maxListeners are added [1138.82ms]
(pass) process MaxListenersExceededWarning > warns again after the listeners are removed [1118.52ms]
(pass) process MaxListenersExceededWarning > follows events.defaultMaxListeners until process.setMaxListeners is called [1132.64ms]
(pass) process MaxListenersExceededWarning > respects process.setMaxListeners [1185.02ms]

 8 pass
 0 fail
 18 expect() calls
Ran 8 t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3050ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/128] gen ErrorCode+*.h
[2/128] gen cpp.rs (cppbind)
[3/128] gen JS modules (bundle-modules)
Preprocess modules (11516ms)
Bundle modules (105ms)
Postprocesss modules (2242ms)
Bundle Functions (18538ms)
Generate Code (47ms)

[32.46s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/80] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[5/80] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[6/80] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[7/80] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[8/80] cxx obj/unified/UnifiedSource-src_jsc_bindings_vm-0.cpp.o
[9/80] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[10/80] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[11/80] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[12/80] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[13/80] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_http-0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/events.ts                       |   4 +
 src/jsc/bindings/ErrorCode.cpp              |   5 ++
 src/jsc/bindings/ErrorCode.h                |   1 +
 src/jsc/bindings/webcore/EventEmitter.cpp   |  20 +++++
 src/jsc/bindings/webcore/EventEmitter.h     |  12 ++-
 src/jsc/bindings/webcore/JSEventEmitter.cpp |  86 +++++++++++++++++---
 src/jsc/bindings/webcore/JSEventEmitter.h   |   4 +
 test/js/node/process/process-on.test.ts     | 117 ++++++++++++++++++++++++++++
 8 files changed, 236 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/node/events.ts                            1      0     24
src/jsc/bindings/ErrorCode.cpp                   0      0     24
src/jsc/bindings/ErrorCode.h                     0      0     24
src/jsc/bindings/webcore/EventEmitter.cpp        1      1     24
src/jsc/bindings/webcore/EventEmitter.h          1      1     24
src/jsc/bindings/webcore/JSEventEmitter.cpp      4      4     24
src/jsc/bindings/webcore/JSEventEmitter.h        0      0     24
test/js/node/process/process-on.test.ts          4      4     24
```

</details>

<!-- robobun:evidence:end -->