### PR TITLE
test(fetch): speed up body-stream.test.ts and tighten its assertions

### DIFF
--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -1,10 +1,50 @@
-// @ts-nocheck
-import { ServeOptions } from "bun";
-import { afterAll, describe, expect, it, test } from "bun:test";
+import type { Server } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { tls } from "harness";
 
-const port = 0;
+type BodyInput = ArrayBuffer | ArrayBufferView | Blob;
+type Position = "begin" | "end";
+type Mode = "reader" | "direct" | "web";
+
 const globalFetch = fetch;
+
+// One macrotask. The "end" position attaches the body reader only after the
+// event loop ran once, so the request body can already be buffered.
+const nextTick = () => new Promise<void>(resolve => setImmediate(resolve));
+
+function bytesOf(input: Exclude<BodyInput, Blob>): Uint8Array {
+  if (input instanceof ArrayBuffer) return new Uint8Array(input);
+  return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+}
+
+function repeat(bytes: Uint8Array, times: number): Uint8Array {
+  const out = new Uint8Array(bytes.byteLength * times);
+  for (let i = 0; i < times; i++) out.set(bytes, i * bytes.byteLength);
+  return out;
+}
+
+function fillRepeating(dstBuffer: Uint8Array, start: number, end: number) {
+  let len = dstBuffer.length,
+    sLen = end - start,
+    p = sLen;
+  while (p < len) {
+    if (p + sLen > len) sLen = len - p;
+    dstBuffer.copyWithin(p, start, sLen);
+    p += sLen;
+    sLen <<= 1;
+  }
+}
+
+// The headers the server saw on the request, echoed back as JSON so the
+// client can assert them with one toEqual.
+function seenRequestHeaders(req: Request): string {
+  return JSON.stringify({
+    "content-length": req.headers.get("content-length"),
+    "content-type": req.headers.get("content-type"),
+    "user-agent": req.headers.get("user-agent"),
+    "x-custom": req.headers.get("x-custom"),
+  });
+}
 
 // Run the entire suite once over plain HTTP/1.1 and once over HTTP/3 so the
 // streaming-body matrix exercises both transports end-to-end. The http/3 row
@@ -18,608 +58,361 @@ describe.each([
     ? (input, init) => globalFetch(input, { ...init, protocol: "http3", tls: { rejectUnauthorized: false } } as any)
     : globalFetch;
 
-  test("Should receive the response body when direct stream is properly flushed", async () => {
-    var called = false;
-    await runInServer(
-      {
-        async fetch() {
-          var stream = new ReadableStream({
-            type: "direct",
-            async pull(controller) {
-              controller.write("hey");
-              await Bun.sleep(1);
-              await controller.end();
-            },
-          });
+  let server: Server;
+  let url: string;
+  let syncPull: { controller: any; pulled: PromiseWithResolvers<void> } | undefined;
 
-          return new Response(stream);
-        },
-      },
-      async url => {
-        called = true;
-        expect(await fetch(url).then(res => res.text())).toBe("hey");
-      },
-    );
-
-    expect(called).toBe(true);
-  });
-
-  for (let doClone of [true, false]) {
-    const BodyMixin = [
-      Request.prototype.arrayBuffer,
-      Request.prototype.bytes,
-      Request.prototype.blob,
-      Request.prototype.text,
-      Request.prototype.json,
-    ];
-    const useRequestObjectValues = [true, false];
-
-    test("Should not crash when not returning a promise when stream is in progress", async () => {
-      var called = false;
-      let controller;
-      const pulled = Promise.withResolvers();
-      await runInServer(
-        {
-          async fetch() {
-            var stream = new ReadableStream({
-              type: "direct",
-              pull(c) {
-                c.write("hey");
-                controller = c;
-                pulled.resolve();
-              },
-            });
-
-            return new Response(stream);
-          },
-        },
-        async url => {
-          called = true;
-          const responsePromise = fetch(url);
-          await pulled.promise;
-          controller.end();
-          // the response stays open until controller.end() is called
-          expect(await responsePromise.then(res => res.text())).toBe("hey");
-        },
-      );
-
-      expect(called).toBe(true);
-    });
-
-    for (let RequestPrototypeMixin of BodyMixin) {
-      for (let useRequestObject of useRequestObjectValues) {
-        // When you do req.body
-        // We go through Bun.readableStreamTo${Method}(stream)
-        for (let forceReadableStreamConversionFastPath of [true, false]) {
-          describe(`Request.prototoype.${RequestPrototypeMixin.name}() ${
-            useRequestObject
-              ? "fetch(req)"
-              : "fetch(url)" +
-                (forceReadableStreamConversionFastPath ? " (force fast ReadableStream conversion)" : "") +
-                (doClone ? " (clone)" : "")
-          }`, () => {
-            const inputFixture = [
-              [JSON.stringify("Hello World"), JSON.stringify("Hello World")],
-              [JSON.stringify("Hello World 123"), Buffer.from(JSON.stringify("Hello World 123")).buffer],
-              [JSON.stringify("Hello World 456"), Buffer.from(JSON.stringify("Hello World 456"))],
-              [
-                JSON.stringify("EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100)),
-                Buffer.from(
-                  JSON.stringify("EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100)),
-                ),
-              ],
-              [
-                JSON.stringify(
-                  "EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100),
-                ),
-                Buffer.from(
-                  JSON.stringify(
-                    "EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100),
-                  ),
-                ),
-              ],
-            ];
-
-            for (const [name, input] of inputFixture) {
-              test(`${name.slice(0, Math.min(name.length ?? name.byteLength, 64))}`, async () => {
-                await runInServer(
-                  {
-                    async fetch(req) {
-                      if (forceReadableStreamConversionFastPath) {
-                        req.body;
-                      }
-
-                      var result;
-                      for (const request of doClone ? [req.clone(), req] : [req]) {
-                        result = await RequestPrototypeMixin.call(request);
-                        if (RequestPrototypeMixin === Request.prototype.json) {
-                          result = JSON.stringify(result);
-                        }
-                        if (typeof result === "string") {
-                          expect(result.length).toBe(name.length);
-                          expect(result).toBe(name);
-                        } else if (result && result instanceof Blob) {
-                          expect(result.size).toBe(new TextEncoder().encode(name).byteLength);
-                          expect(await result.text()).toBe(name);
-                        } else {
-                          expect(result.byteLength).toBe(Buffer.from(input).byteLength);
-                          expect(Bun.SHA1.hash(result, "base64")).toBe(Bun.SHA1.hash(input, "base64"));
-                        }
-                      }
-                      return new Response(result, {
-                        headers: req.headers,
-                      });
-                    },
-                  },
-                  async url => {
-                    var response;
-
-                    // once, then batch of 5
-
-                    if (useRequestObject) {
-                      response = await fetch(
-                        new Request({
-                          body: input,
-                          method: "POST",
-                          url: url,
-                          headers: {
-                            "content-type": "text/plain",
-                          },
-                        }),
-                      );
-                    } else {
-                      response = await fetch(url, {
-                        body: input,
-                        method: "POST",
-                        headers: {
-                          "content-type": "text/plain",
-                        },
-                      });
-                    }
-
-                    if (forceReadableStreamConversionFastPath) {
-                      response.body;
-                    }
-
-                    const originalResponse = response;
-
-                    if (doClone) {
-                      response = response.clone();
-                    }
-
-                    expect(response.status).toBe(200);
-                    expect(response.headers.get("content-length")).toBe(String(Buffer.from(input).byteLength));
-                    expect(response.headers.get("content-type")).toBe("text/plain");
-                    const initialResponseText = await response.text();
-                    expect(initialResponseText).toBe(name);
-
-                    if (doClone) {
-                      expect(await originalResponse.text()).toBe(name);
-                    }
-
-                    let promises = Array.from({ length: 5 }).map((_, i) => {
-                      if (useRequestObject) {
-                        return fetch(
-                          new Request({
-                            body: input,
-                            method: "POST",
-                            url: url,
-                            headers: {
-                              "content-type": "text/plain",
-                              "x-counter": i,
-                            },
-                          }),
-                        );
-                      } else {
-                        return fetch(url, {
-                          body: input,
-                          method: "POST",
-                          headers: {
-                            "content-type": "text/plain",
-                            "x-counter": i,
-                          },
-                        });
-                      }
-                    });
-
-                    promises = await Promise.all(promises);
-
-                    await Promise.all(
-                      promises.map(async (originalResponse, i) => {
-                        if (forceReadableStreamConversionFastPath) {
-                          originalResponse.body;
-                        }
-
-                        for (let response of doClone
-                          ? [originalResponse.clone(), originalResponse]
-                          : [originalResponse]) {
-                          expect(response.status).toBe(200);
-                          expect(response.headers.get("content-length")).toBe(String(Buffer.from(input).byteLength));
-                          expect(response.headers.get("content-type")).toBe("text/plain");
-                          expect(response.headers.get("x-counter")).toBe(String(i));
-                          const responseText = await response.text();
-                          expect(responseText).toBe(name);
-                        }
-                      }),
-                    );
-                  },
-                );
-              });
-            }
-          });
-        }
-      }
-    }
-  }
-
-  var existingServer;
-  async function runInServer(opts: ServeOptions, cb: (url: string) => void | Promise<void>) {
-    var server;
-    const handler = {
-      ...opts,
+  // A single server for the whole matrix. Each request selects its case
+  // with the path and the x-* headers, so the tests can run concurrently.
+  beforeAll(() => {
+    server = Bun.serve({
       port: 0,
       ...(http3 ? { tls, http3: true, http1: false } : {}),
-      fetch(req) {
-        try {
-          return opts.fetch(req);
-        } catch (e) {
-          console.error(e.message);
-          console.log(e.stack);
-          throw e;
+      async fetch(request) {
+        const { pathname } = new URL(request.url);
+        const doClone = request.headers.get("x-clone") === "1";
+        const fast = request.headers.get("x-fast") === "1";
+        const position = request.headers.get("x-position") as Position;
+        const responseHeaders = {
+          "content-type": request.headers.get("content-type") ?? "",
+          "x-counter": request.headers.get("x-counter") ?? "",
+          "x-request-headers": seenRequestHeaders(request),
+        };
+
+        if (pathname === "/flush") {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(controller) {
+                controller.write("hey");
+                await nextTick();
+                await controller.end();
+              },
+            }),
+          );
         }
-      },
-      error(err) {
-        console.log(err.message);
-        console.log(err.stack);
-        throw err;
-      },
-    };
 
-    if (!existingServer) {
-      existingServer = server = Bun.serve(handler);
-    } else {
-      server = existingServer;
-      server.reload(handler);
-    }
+        if (pathname === "/sync-pull") {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              pull(controller) {
+                controller.write("hey");
+                syncPull!.controller = controller;
+                syncPull!.pulled.resolve();
+              },
+            }),
+          );
+        }
 
-    const scheme = http3 ? "https" : "http";
-    try {
-      await cb(`${scheme}://${server.hostname}:${server.port}`);
-    } catch (e) {
-      throw e;
-    } finally {
-    }
-  }
+        if (pathname === "/mixin") {
+          if (fast) {
+            // Going through req.body first makes the mixin read from a
+            // ReadableStream via Bun.readableStreamTo${Method}(stream).
+            request.body;
+          }
+          const requests = doClone ? [request.clone(), request] : [request];
+          const mixin = request.headers.get("x-mixin") as "arrayBuffer" | "bytes" | "blob" | "text" | "json";
+          const parts: BlobPart[] = [];
+          for (const req of requests) {
+            let result = await req[mixin]();
+            if (mixin === "json") result = JSON.stringify(result);
+            parts.push(result as BlobPart);
+          }
+          // One part per read. The client expects the input repeated once
+          // per request it asked the server to read.
+          return new Response(new Blob(parts), { headers: responseHeaders });
+        }
 
-  afterAll(() => {
-    existingServer && existingServer.stop();
-    existingServer = null;
-  });
+        const mode = request.headers.get("x-mode") as Mode;
+        const requests = doClone ? [request.clone(), request] : [request];
+        const readers: ReadableStreamDefaultReader<Uint8Array>[] = [];
+        for (const req of requests) {
+          if (position === "end") await nextTick();
+          readers.push(req.body!.getReader());
+        }
 
-  function fillRepeating(dstBuffer, start, end) {
-    let len = dstBuffer.length,
-      sLen = end - start,
-      p = sLen;
-    while (p < len) {
-      if (p + sLen > len) sLen = len - p;
-      dstBuffer.copyWithin(p, start, sLen);
-      p += sLen;
-      sLen <<= 1;
-    }
-  }
-
-  function gc() {
-    Bun.gc(true);
-  }
-
-  for (let doClone of [true, false]) {
-    describe("reader" + (doClone ? " (clone)" : ""), function () {
-      for (let forceReadableStreamConversionFastPath of [true, false]) {
-        for (let withDelay of [false, true]) {
-          try {
-            // - 1 byte
-            // - less than the InlineBlob limit
-            // - multiple chunks
-            // - backpressure
-
-            // The 1 MB / 2 MB rows fan out to 8–16 MB typed arrays; over QUIC
-            // in a debug+ASAN build the per-packet cost pushes those past the
-            // default timeout without exercising any path the smaller sizes
-            // don't already cover.
-            const inputLengths = http3
-              ? [1, 2, 12, 95, 1024, 64 * 1024]
-              : [1, 2, 12, 95, 1024, 1024 * 1024, 1024 * 1024 * 2];
-            for (let inputLength of inputLengths) {
-              var bytes = new Uint8Array(inputLength);
-              {
-                const chunk = Math.min(bytes.length, 256);
-                for (var i = 0; i < chunk; i++) {
-                  bytes[i] = 255 - i;
-                }
-              }
-
-              if (bytes.length > 255) fillRepeating(bytes, 0, bytes.length);
-
-              // On the 1 MB / 2 MB rows, element-per-byte construction balloons
-              // the multi-byte-element bodies to 4-16 MB. View `bytes.buffer`
-              // instead (same element types, byteLength == inputLength).
-              const isLargeRow = inputLength >= 1024 * 1024;
-              const Float64 = isLargeRow ? new Float64Array(bytes.buffer) : new Float64Array(bytes);
-              const Uint16 = isLargeRow ? new Uint16Array(bytes.buffer) : new Uint16Array(bytes);
-              const Uint32 = isLargeRow ? new Uint32Array(bytes.buffer) : new Uint32Array(bytes);
-              const Int16 = () => (isLargeRow ? new Int16Array(bytes.buffer) : new Int16Array(bytes));
-              const Int32 = () => (isLargeRow ? new Int32Array(bytes.buffer) : new Int32Array(bytes));
-              const Float32 = () => (isLargeRow ? new Float32Array(bytes.buffer) : new Float32Array(bytes));
-
-              for (const huge_ of [
-                bytes,
-                bytes.buffer,
-                new DataView(bytes.buffer),
-                new Int8Array(bytes),
-                new Blob([bytes]),
-                Float64,
-
-                Uint16,
-                Uint32,
-                Int16(),
-                Int32(),
-
-                // make sure we handle subarray() as expected when reading
-                // typed arrays from native code
-                Int16().subarray(1),
-                Int16().subarray(0, Int16().byteLength - 1),
-                Int32().subarray(1),
-                Int32().subarray(0, Int32().byteLength - 1),
-                Int16().subarray(0, 1),
-                Int32().subarray(0, 1),
-                Float32().subarray(0, 1),
-              ]) {
-                const thisArray = huge_;
-                if (Number(thisArray.byteLength ?? thisArray.size) === 0) continue;
-
-                it(
-                  `works with ${thisArray.constructor.name}(${
-                    thisArray.byteLength ?? thisArray.size
-                  }:${inputLength}) via req.body.getReader() in chunks` +
-                    (withDelay ? " with delay" : "") +
-                    (forceReadableStreamConversionFastPath ? " (force ReadableStream conversion)" : ""),
-                  async () => {
-                    var huge = thisArray;
-                    var called = false;
-
-                    const expectedHash =
-                      huge instanceof Blob
-                        ? Bun.SHA1.hash(await huge.bytes(), "base64")
-                        : Bun.SHA1.hash(huge, "base64");
-                    const expectedSize = huge instanceof Blob ? huge.size : huge.byteLength;
-
-                    const out = await runInServer(
-                      {
-                        async fetch(request) {
-                          try {
-                            if (withDelay) await 1;
-
-                            const run = async function (req) {
-                              expect(req.headers.get("x-custom")).toBe("hello");
-                              expect(req.headers.get("content-type")).toBe("text/plain");
-                              expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-
-                              expect(req.headers.get("x-custom")).toBe("hello");
-                              expect(req.headers.get("content-type")).toBe("text/plain");
-                              expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-
-                              let reader = req.body.getReader();
-                              called = true;
-                              let buffers = [];
-                              while (true) {
-                                let { done, value } = await reader.read();
-                                if (done) break;
-                                buffers.push(value);
-                              }
-                              let out = new Blob(buffers);
-                              expect(out.size).toBe(expectedSize);
-                              expect(Bun.SHA1.hash(await out.arrayBuffer(), "base64")).toBe(expectedHash);
-                              expect(req.headers.get("x-custom")).toBe("hello");
-                              expect(req.headers.get("content-type")).toBe("text/plain");
-                              expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-                              return out;
-                            };
-
-                            let out;
-                            for (let req of doClone ? [request.clone(), request] : [request]) {
-                              out = await run(req);
-                            }
-
-                            return new Response(out, {
-                              headers: request.headers,
-                            });
-                          } catch (e) {
-                            console.error(e);
-                            throw e;
-                          }
-                        },
-                      },
-                      async url => {
-                        if (withDelay) await 1;
-                        const pendingResponse = await fetch(url, {
-                          body: huge,
-                          method: "POST",
-                          headers: {
-                            "content-type": "text/plain",
-                            "x-custom": "hello",
-                            "x-typed-array": thisArray.constructor.name,
-                          },
-                        });
-                        if (withDelay) {
-                          await 1;
-                        }
-                        let response = await pendingResponse;
-                        if (forceReadableStreamConversionFastPath) {
-                          response.body;
-                        }
-                        let originalResponse = response;
-                        if (doClone) {
-                          response = response.clone();
-                        }
-                        huge = undefined;
-                        expect(response.status).toBe(200);
-                        for (let body of doClone ? [response, originalResponse] : [response]) {
-                          const response_body = await body.bytes();
-                          expect(response_body.byteLength).toBe(expectedSize);
-                          expect(Bun.SHA1.hash(response_body, "base64")).toBe(expectedHash);
-                        }
-
-                        expect(response.headers.get("content-type")).toBe("text/plain");
-                      },
-                    );
-                    expect(called).toBe(true);
-
-                    return out;
-                  },
-                );
-
-                for (let isDirectStream of [true, false]) {
-                  const positions = ["begin", "end"];
-                  const inner = thisArray => {
-                    for (let position of positions) {
-                      it(
-                        `streaming back ${thisArray.constructor.name}(${
-                          thisArray.byteLength ?? thisArray.size
-                        }:${inputLength}) starting request.body.getReader() at ${position}` +
-                          (forceReadableStreamConversionFastPath ? " (force ReadableStream conversion)" : ""),
-                        async () => {
-                          var huge = thisArray;
-                          var called = false;
-
-                          const expectedHash =
-                            huge instanceof Blob
-                              ? Bun.SHA1.hash(await huge.bytes(), "base64")
-                              : Bun.SHA1.hash(huge, "base64");
-                          const expectedSize = huge instanceof Blob ? huge.size : huge.byteLength;
-
-                          const out = await runInServer(
-                            {
-                              async fetch(request) {
-                                try {
-                                  var reader;
-
-                                  if (withDelay) await 1;
-
-                                  for (let req of doClone ? [request.clone(), request] : [request]) {
-                                    if (position === "begin") {
-                                      reader = req.body.getReader();
-                                    }
-
-                                    if (position === "end") {
-                                      await 1;
-                                      reader = req.body.getReader();
-                                    }
-
-                                    expect(req.headers.get("x-custom")).toBe("hello");
-                                    expect(req.headers.get("content-type")).toBe("text/plain");
-                                    expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-                                  }
-
-                                  const direct = {
-                                    type: "direct",
-                                    async pull(controller) {
-                                      if (withDelay) await 1;
-
-                                      while (true) {
-                                        const { done, value } = await reader.read();
-                                        if (done) {
-                                          called = true;
-                                          controller.end();
-
-                                          return;
-                                        }
-                                        controller.write(value);
-                                      }
-                                    },
-                                  };
-
-                                  const web = {
-                                    async start() {
-                                      if (withDelay) await 1;
-                                    },
-                                    async pull(controller) {
-                                      while (true) {
-                                        const { done, value } = await reader.read();
-                                        if (done) {
-                                          called = true;
-                                          controller.close();
-                                          return;
-                                        }
-                                        controller.enqueue(value);
-                                      }
-                                    },
-                                  };
-
-                                  return new Response(new ReadableStream(isDirectStream ? direct : web), {
-                                    headers: request.headers,
-                                  });
-                                } catch (e) {
-                                  console.error(e);
-                                  throw e;
-                                }
-                              },
-                            },
-                            async url => {
-                              let response = await fetch(url, {
-                                body: huge,
-                                method: "POST",
-                                headers: {
-                                  "content-type": "text/plain",
-                                  "x-custom": "hello",
-                                  "x-typed-array": thisArray.constructor.name,
-                                },
-                              });
-                              huge = undefined;
-                              expect(response.status).toBe(200);
-                              if (forceReadableStreamConversionFastPath) {
-                                response.body;
-                              }
-
-                              const originalResponse = response;
-                              if (doClone) {
-                                response = response.clone();
-                              }
-
-                              for (let body of doClone ? [response, originalResponse] : [response]) {
-                                const response_body = await body.bytes();
-                                expect(response_body.byteLength).toBe(expectedSize);
-                                expect(Bun.SHA1.hash(response_body, "base64")).toBe(expectedHash);
-                              }
-
-                              if (!response.headers.has("content-type")) {
-                                console.error(Object.fromEntries(response.headers.entries()));
-                              }
-
-                              expect(response.headers.get("content-type")).toBe("text/plain");
-                            },
-                          );
-                          expect(called).toBe(true);
-
-                          return out;
-                        },
-                      );
-                    }
-                  };
-
-                  if (isDirectStream) {
-                    describe(" direct stream", () => inner(thisArray));
-                  } else {
-                    describe("default stream", () => inner(thisArray));
-                  }
-                }
-              }
+        if (mode === "reader") {
+          const parts: Uint8Array[] = [];
+          for (const reader of readers) {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              parts.push(value);
             }
-          } catch (e) {
-            console.error(e);
-            throw e;
+          }
+          return new Response(new Blob(parts), { headers: responseHeaders });
+        }
+
+        async function pump(write: (chunk: Uint8Array) => unknown) {
+          for (const reader of readers) {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              write(value);
+            }
           }
         }
-      }
+
+        const stream =
+          mode === "direct"
+            ? new ReadableStream({
+                type: "direct",
+                async pull(controller) {
+                  await pump(chunk => controller.write(chunk));
+                  controller.end();
+                },
+              })
+            : new ReadableStream({
+                async pull(controller) {
+                  await pump(chunk => controller.enqueue(chunk));
+                  controller.close();
+                },
+              });
+        return new Response(stream, { headers: responseHeaders });
+      },
+      error(err) {
+        console.error(err);
+        return new Response(String(err), { status: 500 });
+      },
     });
+    url = `${http3 ? "https" : "http"}://${server.hostname}:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  // A buffered response carries an exact content-length. A streamed response
+  // carries content-length only when the whole body was ready before the
+  // headers were flushed, otherwise HTTP/1.1 uses chunked transfer encoding.
+  // HTTP/3 has no transfer-encoding header at all.
+  function expectFraming(response: Response, byteLength: number, streamed: boolean) {
+    const contentLength = response.headers.get("content-length");
+    const transferEncoding = response.headers.get("transfer-encoding");
+    if (!streamed) {
+      expect(contentLength).toBe(String(byteLength));
+      expect(transferEncoding).toBeNull();
+    } else if (http3) {
+      expect(contentLength === null || contentLength === String(byteLength)).toBe(true);
+      expect(transferEncoding).toBeNull();
+    } else if (contentLength !== null) {
+      expect(contentLength).toBe(String(byteLength));
+      expect(transferEncoding).toBeNull();
+    } else {
+      expect(transferEncoding).toBe("chunked");
+    }
+  }
+
+  test("Should receive the response body when direct stream is properly flushed", async () => {
+    const response = await fetch(`${url}/flush`);
+    expect(await response.text()).toBe("hey");
+    expect(response.status).toBe(200);
+  });
+
+  test("Should not crash when not returning a promise when stream is in progress", async () => {
+    syncPull = { controller: undefined, pulled: Promise.withResolvers<void>() };
+    const responsePromise = fetch(`${url}/sync-pull`);
+    await syncPull.pulled.promise;
+    syncPull.controller.end();
+    // the response stays open until controller.end() is called
+    const response = await responsePromise;
+    expect(await response.text()).toBe("hey");
+    expect(response.status).toBe(200);
+  });
+
+  const mixinFixtures: [name: string, input: string | ArrayBuffer | Buffer][] = [
+    [JSON.stringify("Hello World"), JSON.stringify("Hello World")],
+    [JSON.stringify("Hello World 123"), Buffer.from(JSON.stringify("Hello World 123")).buffer],
+    [JSON.stringify("Hello World 456"), Buffer.from(JSON.stringify("Hello World 456"))],
+    [
+      JSON.stringify("EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100)),
+      Buffer.from(JSON.stringify("EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100))),
+    ],
+    [
+      JSON.stringify("EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100)),
+      Buffer.from(
+        JSON.stringify("EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100)),
+      ),
+    ],
+  ];
+
+  for (const doClone of [true, false]) {
+    for (const mixin of ["arrayBuffer", "bytes", "blob", "text", "json"] as const) {
+      for (const useRequestObject of [true, false]) {
+        for (const forceReadableStreamConversionFastPath of [true, false]) {
+          describe(
+            `Request.prototype.${mixin}() ${useRequestObject ? "fetch(req)" : "fetch(url)"}` +
+              (forceReadableStreamConversionFastPath ? " (force fast ReadableStream conversion)" : "") +
+              (doClone ? " (clone)" : ""),
+            () => {
+              const reads = doClone ? 2 : 1;
+              const headers = {
+                "content-type": "text/plain",
+                "x-clone": doClone ? "1" : "0",
+                "x-fast": forceReadableStreamConversionFastPath ? "1" : "0",
+                "x-mixin": mixin,
+              };
+              const send = (input: string | ArrayBuffer | Buffer, counter?: number) => {
+                const init = {
+                  body: input,
+                  method: "POST",
+                  headers: counter === undefined ? headers : { ...headers, "x-counter": String(counter) },
+                };
+                return useRequestObject
+                  ? fetch(new Request({ url: `${url}/mixin`, ...init } as any))
+                  : fetch(`${url}/mixin`, init);
+              };
+              const check = async (response: Response, name: string, byteLength: number, counter: string) => {
+                if (forceReadableStreamConversionFastPath) {
+                  response.body;
+                }
+                for (const res of doClone ? [response.clone(), response] : [response]) {
+                  const text = await res.text();
+                  expect(text).toBe(name.repeat(reads));
+                  expect(res.status).toBe(200);
+                  expectFraming(res, byteLength * reads, false);
+                  expect(res.headers.get("content-type")).toBe("text/plain");
+                  expect(res.headers.get("x-counter")).toBe(counter);
+                  expect(JSON.parse(res.headers.get("x-request-headers")!)).toEqual({
+                    "content-length": String(byteLength),
+                    "content-type": "text/plain",
+                    "user-agent": navigator.userAgent,
+                    "x-custom": null,
+                  });
+                }
+              };
+
+              for (const [name, input] of mixinFixtures) {
+                test.concurrent(name.slice(0, 64), async () => {
+                  const byteLength = Buffer.from(input as any).byteLength;
+                  // once, then a batch of 5
+                  await check(await send(input), name, byteLength, "");
+                  const responses = await Promise.all(Array.from({ length: 5 }, (_, i) => send(input, i)));
+                  await Promise.all(responses.map((response, i) => check(response, name, byteLength, String(i))));
+                });
+              }
+            },
+          );
+        }
+      }
+    }
+  }
+
+  // Sizes: one byte, a few bytes, under one socket read, a few KiB, a 64 KiB
+  // chunk boundary, and one body large enough to need backpressure both ways.
+  // Over QUIC in a debug+ASAN build the 1 MiB row does not fit in the
+  // timeout and exercises no path the 64 KiB row does not.
+  const inputLengths = http3 ? [1, 12, 95, 1024, 64 * 1024] : [1, 12, 95, 1024, 64 * 1024, 1024 * 1024];
+
+  for (const doClone of [true, false]) {
+    for (const forceReadableStreamConversionFastPath of [true, false]) {
+      describe(
+        "reader" +
+          (doClone ? " (clone)" : "") +
+          (forceReadableStreamConversionFastPath ? " (force ReadableStream conversion)" : ""),
+        () => {
+          const reads = doClone ? 2 : 1;
+
+          for (const inputLength of inputLengths) {
+            const bytes = new Uint8Array(inputLength);
+            for (let i = 0; i < Math.min(bytes.length, 256); i++) {
+              bytes[i] = 255 - i;
+            }
+            if (bytes.length > 255) fillRepeating(bytes, 0, bytes.length);
+
+            // On the 1 MiB row, element-per-byte construction balloons the
+            // multi-byte-element bodies to 2-8 MiB. View `bytes.buffer`
+            // instead (same element types, byteLength == inputLength).
+            const isLargeRow = inputLength >= 1024 * 1024;
+            const Int16 = () => (isLargeRow ? new Int16Array(bytes.buffer) : new Int16Array(bytes));
+            const Int32 = () => (isLargeRow ? new Int32Array(bytes.buffer) : new Int32Array(bytes));
+            const Float32 = () => (isLargeRow ? new Float32Array(bytes.buffer) : new Float32Array(bytes));
+            const Float64 = () => (isLargeRow ? new Float64Array(bytes.buffer) : new Float64Array(bytes));
+
+            // Every shape the native side reads differently: a plain byte
+            // view, a bare ArrayBuffer, a DataView, a Blob, views whose
+            // element count differs from their byte length, and subarray()
+            // views with a non-zero byteOffset or a byteLength shorter than
+            // the buffer. Signed and unsigned views of the same width produce
+            // identical bytes, so only one of each width is here.
+            const shapes: [label: string, input: BodyInput][] = [
+              ["Uint8Array", bytes],
+              ["ArrayBuffer", bytes.buffer],
+              ["DataView", new DataView(bytes.buffer)],
+              ["Blob", new Blob([bytes])],
+              ["Float64Array", Float64()],
+              ["Int16Array", Int16()],
+              ["Int32Array", Int32()],
+              ["Int16Array.subarray(1)", Int16().subarray(1)],
+              ["Int32Array.subarray(1)", Int32().subarray(1)],
+              ["Int16Array.subarray(0, -1)", Int16().subarray(0, -1)],
+              ["Int32Array.subarray(0, -1)", Int32().subarray(0, -1)],
+            ];
+            if (inputLength === 12) {
+              // A one-element view over a larger buffer. The bytes are the
+              // same on every row, so it runs once.
+              shapes.push(
+                ["Int16Array.subarray(0, 1)", Int16().subarray(0, 1)],
+                ["Int32Array.subarray(0, 1)", Int32().subarray(0, 1)],
+                ["Float32Array.subarray(0, 1)", Float32().subarray(0, 1)],
+              );
+            }
+
+            for (const [label, input] of shapes) {
+              const byteLength = input instanceof Blob ? input.size : input.byteLength;
+              if (byteLength === 0) continue;
+              const expected = input instanceof Blob ? bytes : bytesOf(input);
+              const expectedResponse = repeat(expected, reads);
+
+              async function roundTrip(mode: Mode, position: Position) {
+                const response = await fetch(`${url}/echo`, {
+                  body: input,
+                  method: "POST",
+                  headers: {
+                    "content-type": "text/plain",
+                    "x-custom": "hello",
+                    "x-clone": doClone ? "1" : "0",
+                    "x-fast": forceReadableStreamConversionFastPath ? "1" : "0",
+                    "x-mode": mode,
+                    "x-position": position,
+                  },
+                });
+                if (forceReadableStreamConversionFastPath) {
+                  response.body;
+                }
+                for (const res of doClone ? [response.clone(), response] : [response]) {
+                  const body = await res.bytes();
+                  expect(res.status).toBe(200);
+                  expect(body.byteLength).toBe(expectedResponse.byteLength);
+                  expect(body).toEqual(expectedResponse);
+                  expectFraming(res, expectedResponse.byteLength, mode !== "reader");
+                  expect(res.headers.get("content-type")).toBe("text/plain");
+                  expect(JSON.parse(res.headers.get("x-request-headers")!)).toEqual({
+                    "content-length": String(byteLength),
+                    "content-type": "text/plain",
+                    "user-agent": navigator.userAgent,
+                    "x-custom": "hello",
+                  });
+                }
+              }
+
+              const title = `${label}(${byteLength}:${inputLength})`;
+              for (const position of ["begin", "end"] as const) {
+                test.concurrent(`works with ${title} via req.body.getReader() at ${position}`, () =>
+                  roundTrip("reader", position),
+                );
+                test.concurrent(`streaming back ${title} via direct stream, getReader() at ${position}`, () =>
+                  roundTrip("direct", position),
+                );
+                test.concurrent(`streaming back ${title} via default stream, getReader() at ${position}`, () =>
+                  roundTrip("web", position),
+                );
+              }
+            }
+          }
+        },
+      );
+    }
   }
 });

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -383,9 +383,9 @@ describe.each([
                 }
                 for (const res of doClone ? [response.clone(), response] : [response]) {
                   const body = await res.bytes();
-                  expect(res.status).toBe(200);
                   expect(body.byteLength).toBe(expectedResponse.byteLength);
                   expect(body).toEqual(expectedResponse);
+                  expect(res.status).toBe(200);
                   expectFraming(res, expectedResponse.byteLength, mode !== "reader");
                   expect(res.headers.get("content-type")).toBe("text/plain");
                   expect(JSON.parse(res.headers.get("x-request-headers")!)).toEqual({

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -23,16 +23,16 @@ function repeat(bytes: Uint8Array, times: number): Uint8Array {
   return out;
 }
 
-function fillRepeating(dstBuffer: Uint8Array, start: number, end: number) {
-  let len = dstBuffer.length,
-    sLen = end - start,
-    p = sLen;
-  while (p < len) {
-    if (p + sLen > len) sLen = len - p;
-    dstBuffer.copyWithin(p, start, sLen);
-    p += sLen;
-    sLen <<= 1;
+// A 255..0 gradient tiled across the whole body, so a byte-exact compare
+// also catches corruption past the first 256 bytes.
+function pattern(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  const seed = Math.min(length, 256);
+  for (let i = 0; i < seed; i++) bytes[i] = 255 - i;
+  for (let filled = seed; filled < length; filled *= 2) {
+    bytes.copyWithin(filled, 0, Math.min(filled, length - filled));
   }
+  return bytes;
 }
 
 // The headers the server saw on the request, echoed back as JSON so the
@@ -315,11 +315,7 @@ describe.each([
           const reads = doClone ? 2 : 1;
 
           for (const inputLength of inputLengths) {
-            const bytes = new Uint8Array(inputLength);
-            for (let i = 0; i < Math.min(bytes.length, 256); i++) {
-              bytes[i] = 255 - i;
-            }
-            if (bytes.length > 255) fillRepeating(bytes, 0, bytes.length);
+            const bytes = pattern(inputLength);
 
             // On the 1 MiB row, element-per-byte construction balloons the
             // multi-byte-element bodies to 2-8 MiB. View `bytes.buffer`


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/body-stream.test.ts` takes 67s on the debian 13 x64-asan lane (build 110747). Nested loops expand 5 `test()` call sites into 9086 cases. Each case calls `server.reload()` and runs one fetch round trip in series.
- The matrix has exact duplicates. `Int8Array(bytes)` sends the same bytes as `Uint8Array`. `Uint16Array` and `Uint32Array` send the same bytes as `Int16Array` and `Int32Array`. `subarray(0, byteLength - 1)` clamps to the full view. The one-element `subarray(0, 1)` views repeat the same 2 or 4 bytes on every size row. The `withDelay` rows differ only by one `await 1`, which is what the `position: "end"` rows already test.

### Fix
- One `Bun.serve` per transport in `beforeAll`. The request path and `x-*` headers select the case. All matrix tests are `test.concurrent`.
- Sizes are `1, 12, 95, 1024, 64 KiB, 1 MiB` (HTTP/1.1) and the same minus 1 MiB (HTTP/3). The 2 byte and 2 MiB rows covered no path the 1 byte and 1 MiB rows do not. `withDelay` folds into `position: begin | end`. The `end` position now waits one macrotask (`setImmediate`), so the reader attaches after body bytes can arrive. `Bun.sleep(1)` in the flush test is now the same macrotask wait.
- Assertions: the client compares the full response bytes with `toEqual` (was SHA1). The body is a 255..0 gradient tiled across its whole length. The old `fillRepeating(bytes, 0, bytes.length)` call never ran its loop, so every byte past 256 was zero. The server echoes the request headers it saw as JSON and the client checks them with one `toEqual`, including an exact `content-length`. Buffered responses must carry an exact `content-length` and no `transfer-encoding`. Streamed responses must carry exactly one of the two on HTTP/1.1, and never `transfer-encoding` on HTTP/3. With `clone`, the server reads both requests and returns the concatenation, so the client checks both reads byte for byte. The old streaming rows never consumed the clone reader, and the old clone checks lived inside the server handler.
- Verified: `bun bd test test/js/web/fetch/body-stream.test.ts`. Local debug ASAN build, same machine, back to back: 9086 tests in 234s before, 3260 tests in 77s after. Runs at `--max-concurrency` 1, 5, and 20 all pass.

### Background
- The file sends a request body of many shapes (typed arrays, `ArrayBuffer`, `DataView`, `Blob`, `subarray` views) to `Bun.serve`, reads it there through `req.body.getReader()` or a body mixin, and streams or buffers it back. The native side reads every typed array and `DataView` through one path (`JSC__JSValue__asArrayBuffer`), which only looks at the view's element size, byte offset, and byte length.
- Bun sends a streamed response with `content-length` when the whole body is ready before the headers flush, and with `transfer-encoding: chunked` otherwise. The test accepts either, but pins the exact value when `content-length` is present.

<details><summary>Notes</summary>

Case count per transport: 2 single tests, 200 mixin tests (clone x mixin x request form x fast path x 5 fixtures), and 1560 (HTTP/1.1) or 1296 (HTTP/3) body tests: 65 or 54 unique body shapes x 6 modes (reader, direct stream, default stream, each at begin and end) x clone x fast path.

Body shapes per size: `Uint8Array`, `ArrayBuffer`, `DataView`, `Blob`, `Float64Array`, `Int16Array`, `Int32Array`, `Int16Array.subarray(1)`, `Int32Array.subarray(1)`, `Int16Array.subarray(0, -1)`, `Int32Array.subarray(0, -1)`. The `subarray(0, -1)` rows replace the old `subarray(0, byteLength - 1)` rows, which clamped to the full view and tested nothing new. The one-element `subarray(0, 1)` views of `Int16Array`, `Int32Array`, and `Float32Array` run once, on the 12 byte row.

The server chunk count is not pinned. Loopback delivery can split a small body across reads, so an exact count would flake.

Local timing is noisy on a shared host (load average above 150). Runs of the new file ranged from 75s to 101s. The 234s and 77s numbers come from one back to back run.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/body-stream.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/body-stream.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/fetch/body-stream.test.ts:
(pass) body-stream over http/1.1 > Should receive the response body when direct stream is properly flushed [141.71ms]
(pass) body-stream over http/1.1 > Should not crash when not returning a promise when stream is in progress [23.93ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (force fast ReadableStream conversion) (clone) > "Hello World 123" [705.14ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (force fast ReadableStream conversion) (clone) > "Hello World 456" [706.78ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (force fast ReadableStream conversion) (clone) > "EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT [707.11ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (force fast ReadableStream conversion) (clone) > "EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WON [707.05ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (force fast ReadableStream conversion) (clone) > "Hello World" [775.55ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (clone) > "Hello World" [644.36ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (clone) > "Hello World 123" [644.29ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (clone) > "Hello World 456" [645.11ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (clone) > "EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT [646.18ms]
(pass) body-stream over http/1.1 > Request.prototype.arrayBuffer() fetch(req) (clone) > "EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WON [836.37ms]
(pass) body-st
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/body-stream.test.ts | 939 +++++++++++++---------------------
 1 file changed, 364 insertions(+), 575 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
test/js/web/fetch/body-stream.test.ts      4      2     27
```

</details>

**root cause** · written by the author bot

The test helper `fillRepeating(bytes, 0, bytes.length)` was a no-op because its tiling loop starts at `end - start`, which equalled the buffer length, so request bodies larger than 256 bytes were the seeded gradient followed entirely by zeros rather than the intended repeating pattern. That left the new byte-exact `toEqual` assertions unable to detect corruption or zero-padding past offset 256 in the 1 KiB, 64 KiB, and 1 MiB cases. The fix replaces the call with a `pattern(length)` helper that seeds the 256-byte gradient and tiles it across the whole buffer via doubling `copyWithin`, so eve…

<!-- robobun:evidence:end -->
