### PR TITLE
test(grpc-js): give waitForReady a deadline the ASAN build can meet

### DIFF
--- a/test/js/third_party/grpc-js/test-client.test.ts
+++ b/test/js/third_party/grpc-js/test-client.test.ts
@@ -18,6 +18,7 @@ import grpc from "@grpc/grpc-js";
 import { Client, Server, ServerCredentials } from "@grpc/grpc-js/build/src";
 import { ConnectivityState } from "@grpc/grpc-js/build/src/connectivity-state";
 import { afterAll, beforeAll, describe, it } from "bun:test";
+import { isASAN, isDebug } from "harness";
 import assert from "node:assert";
 
 const clientInsecureCreds = grpc.credentials.createInsecure();
@@ -43,18 +44,30 @@ describe("Client", () => {
     server.tryShutdown(done);
   });
 
-  it("should call the waitForReady callback only once, when channel connectivity state is READY", done => {
-    const deadline = Date.now() + 100;
+  it("should call the waitForReady callback only once, when channel connectivity state is READY", async () => {
+    // The channel arms a deadline timer while it connects and must clear it
+    // when it reaches READY. The deadline only has to outlast the connect:
+    // upstream uses 100 ms, which a sanitizer or debug build cannot meet (the
+    // first connect takes about 1 s on a debug build). Wait for READY first,
+    // then for the deadline to pass, and only then count the calls.
+    const deadline = Date.now() + (isASAN || isDebug ? 2000 : 100);
+    const ready = Promise.withResolvers<void>();
     let calledTimes = 0;
     client.waitForReady(deadline, err => {
-      assert.ifError(err);
-      assert.equal(client.getChannel().getConnectivityState(true), ConnectivityState.READY);
       calledTimes += 1;
+      try {
+        assert.ifError(err);
+        assert.equal(client.getChannel().getConnectivityState(true), ConnectivityState.READY);
+        ready.resolve();
+      } catch (e) {
+        ready.reject(e);
+      }
     });
-    setTimeout(() => {
-      assert.equal(calledTimes, 1);
-      done();
-    }, deadline - Date.now());
+    await ready.promise;
+    // A deadline timer that was not cleared expires at `deadline`. Timers run
+    // in expiry order, so sleeping past the deadline runs it first.
+    await Bun.sleep(deadline - Date.now() + 1);
+    assert.equal(calledTimes, 1);
   });
 });
 


### PR DESCRIPTION
### Problem
- `test/js/third_party/grpc-js/test-client.test.ts` went red in the x64-asan parallel batch (builds 110898 and 111047, both on shard 1). The first case fails with `ifError got unwanted exception: Failed to connect before the deadline`, then `0 == 1` and `Channel has been shut down` fail the next two cases.
- The cause is the 100 ms connect deadline at `test-client.test.ts:47`. The ASAN build connects in 50 to 130 ms inside a 7-wide batch, and the batch got heavier neighbours (`webpack.test.ts`, `bundler/cli.test.ts`) when new test files shifted the shard boundaries. No bun change is involved: the same file passed in 400 builds before, and a debug build here always fails it (the first connect takes about 1 s).
- The two follow-on failures are a cascade. The upstream test asserts inside a bare `setTimeout`, so the `0 == 1` throw lands in the next test, and that test's leftover callback then calls a closed client during the third.

### Fix
- The test waits for READY through a promise, then sleeps until the deadline has passed, then counts the calls. Errors from the grpc callback reject the test's own promise, so a failure cannot spill into another test.
- The deadline is 2 s on an ASAN or debug build and stays at 100 ms on a release build.
- The check still catches the regression it was written for. With `clearTimeout` removed from grpc-js `updateState`, the test fails with `3 == 1` and the other four cases still pass.
- Verified: `bun bd test test/js/third_party/grpc-js/test-client.test.ts` (3 of 3 runs pass, 0 of 3 before). Also `USE_SYSTEM_BUN=1` on the same file.

### Background
- `client.waitForReady(deadline, cb)` watches the channel state. Each state change (IDLE, CONNECTING, READY) re-arms a timer that expires at `deadline` and calls `cb` with an error. Reaching READY must clear that timer, or `cb` fires twice.
- Timers fire in expiry order, so a sleep that ends one ms after the deadline runs after any uncleared deadline timer.

<details><summary>Notes</summary>

Measured first-connect times for `waitForReady` on a local server:

- release bun: 15 to 21 ms
- debug ASAN build in this container: 892 to 1286 ms (8 samples)
- CI x64-asan (release with ASAN) inside the batch: the whole file ran in 0.40 s in build 110630 and the failing case ran for 130.91 ms in build 111047

Shard 1 in build 111047 ran 74 files in parallel, 7 wide, with `test/js/third_party/webpack/webpack.test.ts` and `test/js/bun/webview/*.test.ts` in the batch. Those files were in a different shard in build 110630. Most files in the shard ran 10 to 30 percent slower than in 110630.

Scan of 500 builds (109657 to 111140): the file failed only in 110898 and 111047, both on the x64-asan lane, both in the parallel batch.

Suites run: `test/js/third_party/grpc-js/test-client.test.ts` with `bun bd test` and with `USE_SYSTEM_BUN=1 bun test`.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/third_party/grpc-js/test-client.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/third_party/grpc-js/test-client.test.ts
bun test v1.4.3 (f42e98025)

test/js/third_party/grpc-js/test-client.test.ts:
(node:30992) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Client > should call the waitForReady callback only once, when channel connectivity state is READY [2044.45ms]
(pass) Client without a server > should fail multiple calls to the nonexistent server [536.48ms]
(pass) Client without a server > close should force calls to end [38.94ms]
(pass) Client with a nonexistent target domain > should fail multiple calls [53.07ms]
(pass) Client with a nonexistent target domain > close should force calls to end [22.32ms]

 5 pass
 0 fail
Ran 5 tests across 1 file. [14.71s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/third_party/grpc-js/test-client.test.ts | 29 ++++++++++++++++++-------
 1 file changed, 21 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/js/third_party/grpc-js/test-client.test.ts      1      4      7
```

</details>

**root cause** · written by the author bot

The "waitForReady callback only once" case used a fixed 100 ms connect deadline and a bare setTimeout, so on slow ASAN and debug builds under batch load the first connection took around a second, the deadline expired with "Failed to connect before the deadline", and the stray assertion then leaked into the two following cases. The fix is test-only: it waits for READY through a promise, sleeps past the deadline before counting callback invocations, and raises the deadline to 2 s on ASAN and debug builds while keeping 100 ms on release. This removes the timing dependence without weakening the…

<!-- robobun:evidence:end -->