### PR TITLE
Stop the multipart name/filename quote scan at the first double quote

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -319,26 +319,22 @@ pub(crate) fn for_each_multipart_entry<C>(
                         value = &value[1..];
                     }
 
-                    let mut field_value = value;
-                    {
-                        let mut i: usize = 0;
-                        while i < field_value.len() {
-                            match field_value[i] {
-                                b'"' => {
-                                    field_value = &field_value[..i];
-                                    break;
-                                }
-                                b'\\' => {
-                                    i += (field_value.len() > i + 1 && field_value[i + 1] == b'"')
-                                        as usize;
-                                }
-                                // the spec requires a end quote, but some browsers don't send it
-                                _ => {}
-                            }
-                            i += 1;
+                    // The multipart/form-data serializer (HTML spec, browsers, undici)
+                    // percent-encodes `"`, CR and LF and writes `\` verbatim, so the
+                    // first `"` always ends the value: there are no quoted-pairs here.
+                    let field_value = match strings::index_of_char_usize(value, b'"') {
+                        Some(end) => {
+                            let field_value = &value[..end];
+                            value = &value[end + 1..];
+                            field_value
                         }
-                        value = &value[(i + 1).min(value.len())..];
-                    }
+                        // the spec requires an end quote, but some browsers don't send it
+                        None => {
+                            let field_value = value;
+                            value = b"";
+                            field_value
+                        }
+                    };
 
                     if strings::eql_case_insensitive_ascii(eql_key, b"name", true) {
                         name = subslicer.sub(field_value).value();

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -319,9 +319,7 @@ pub(crate) fn for_each_multipart_entry<C>(
                         value = &value[1..];
                     }
 
-                    // The multipart/form-data serializer (HTML spec, browsers, undici)
-                    // percent-encodes `"`, CR and LF and writes `\` verbatim, so the
-                    // first `"` always ends the value: there are no quoted-pairs here.
+                    // No quoted-pairs: the serializer percent-encodes `"` and writes `\` as is.
                     let field_value = match strings::index_of_char_usize(value, b'"') {
                         Some(end) => {
                             let field_value = &value[..end];

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -339,6 +339,54 @@ describe("FormData", () => {
     }
   });
 
+  // The multipart serializer writes `\` verbatim and percent-encodes `"`, so a
+  // `\` right before the closing quote is part of the value, not an escape.
+  describe("Content-Disposition: backslash before the closing quote", () => {
+    const boundary = "BX8";
+    const headers = { "Content-Type": `multipart/form-data; boundary=${boundary}` };
+    const describeEntry = (v: FormDataEntryValue) =>
+      typeof v === "string" ? { kind: "string", value: v } : { kind: "file", name: v.name, size: v.size };
+
+    for (const C of [Response, Request] as const) {
+      const make = (body: BodyInit) =>
+        C === Response ? new Response(body, { headers }) : new Request("http://x/", { method: "POST", body, headers });
+
+      it(`${C.name}: raw body`, async () => {
+        const body =
+          `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="dir\\"; filename="a.bin"\r\n` +
+          `Content-Type: application/octet-stream\r\n\r\n` +
+          `\x01\x02\x03\r\n` +
+          `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="note\\"\r\n\r\n` +
+          `plain value\r\n` +
+          `--${boundary}\r\n` +
+          `Content-Disposition: form-data; name="f2"; filename="C:\\tmp\\"\r\n\r\n` +
+          `x\r\n` +
+          `--${boundary}--\r\n`;
+        const fd = await make(body).formData();
+        expect([...fd.entries()].map(([k, v]) => [k, describeEntry(v)])).toEqual([
+          ["dir\\", { kind: "file", name: "a.bin", size: 3 }],
+          ["note\\", { kind: "string", value: "plain value" }],
+          ["f2", { kind: "file", name: "C:\\tmp\\", size: 1 }],
+        ]);
+      });
+    }
+
+    it("round-trips bun's own serializer output", async () => {
+      const fd = new FormData();
+      fd.append("dir\\", new File([new Uint8Array([1, 2, 3])], "a.bin", { type: "application/octet-stream" }));
+      fd.append("note\\", "plain value");
+      fd.append("f2", new File(["x"], "C:\\tmp\\", { type: "text/plain" }));
+      const parsed = await new Response(fd).formData();
+      expect([...parsed.entries()].map(([k, v]) => [k, describeEntry(v)])).toEqual([
+        ["dir\\", { kind: "file", name: "a.bin", size: 3 }],
+        ["note\\", { kind: "string", value: "plain value" }],
+        ["f2", { kind: "file", name: "C:\\tmp\\", size: 1 }],
+      ]);
+    });
+  });
+
   test("FormData.from (URLSearchParams)", () => {
     expect(
       // @ts-expect-error


### PR DESCRIPTION
### Problem
- `Response.formData()` mis-parses a multipart part whose `name=` or `filename=` ends in a backslash. `name="dir\"; filename="a.bin"` becomes a text entry named `dir\"; filename=` and the file is lost. `filename="C:\tmp\"` becomes `C:\tmp\"`. Bun cannot round-trip its own serializer output. undici parses the same bytes correctly.
- The cause is the quote scan in `for_each_multipart_entry` (`src/runtime/webcore/FormData.rs:322`). It skipped `\"` as an escaped quote while it looked for the closing quote, but it never unescaped the value. The serializer (HTML spec, browsers, undici, bun) writes `\` verbatim and percent-encodes `"`, so `\"` on the wire is always a backslash followed by the closing quote.

### Fix
- The scan now ends at the first `"`. The value is the bytes before it. With no closing quote, the value runs to the end of the line, as before.
- This matches the WHATWG multipart/form-data parsing algorithm and undici, which collect bytes up to the first `"` and have no quoted-pair rule.
- Verified: `test/js/web/html/FormData.test.ts` (new `backslash before the closing quote` block, 3 tests, all fail on the released bun). Also `FormData-multipart-serialization.test.ts`, `fetch/body.test.ts`, `fetch/form-data-boundary-crash.test.ts`.

### Background
- A multipart body carries one `Content-Disposition: form-data; name="..."; filename="..."` header per part. The parser reads the parameters from that line to decide the entry name and whether the entry is a `File`.
- RFC 2183 allows quoted-pairs (`\"`) inside a quoted-string. The HTML form-data serializer does not use them. It percent-encodes `"`, CR and LF instead, and leaves `\` alone. Parsers that follow the HTML/WHATWG side therefore stop at the first `"`.

<details><summary>Notes</summary>

Repro on bun 1.4.2 and main:

```js
const fd = new FormData();
fd.append('dir\\', new File([new Uint8Array([1,2,3])], 'a.bin'));
fd.append('note\\', 'plain value');
fd.append('f2', new File(['x'], 'C:\\tmp\\'));
for (const [k, v] of await new Response(fd).formData()) console.log(JSON.stringify(k), v);
```

Before: `"dir\\\"; filename="` (string), `"note\\\""` (string), `"f2"` File name `C:\tmp\"`.
After: `"dir\\"` File `a.bin`, `"note\\"` string, `"f2"` File `C:\tmp\`. Same as node v26.

A related gap is out of scope here: the parser does not percent-decode `%22`, `%0A`, `%0D` in name/filename as the WHATWG algorithm does. It is tracked separately.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [6.61ms]
(pass) FormData > should be able to append a Blob [14.41ms]
(pass) FormData > should be able to set a Blob [10.84ms]
(pass) FormData > should be able to set a string [5.10ms]
(pass) FormData > should get filename from file [7.26ms]
(pass) FormData > should use the correct filenames [9.14ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [25.73ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [53.39ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [4.17ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [10.61ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [2.77ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [6.04ms]
(pass) FormData > should parse multipart/form-data (
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.11ms]
(pass) FormData > should be able to append a Blob [0.20ms]
(pass) FormData > should be able to set a Blob [0.11ms]
(pass) FormData > should be able to set a string [0.06ms]
(pass) FormData > should get filename from file [0.08ms]
(pass) FormData > should use the correct filenames [0.12ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.43ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.96ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.07ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.06ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.05ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [5.56ms]
(pass) FormData > should be able to append a Blob [13.09ms]
(pass) FormData > should be able to set a Blob [9.87ms]
(pass) FormData > should be able to set a string [4.46ms]
(pass) FormData > should get filename from file [7.05ms]
(pass) FormData > should use the correct filenames [8.10ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [23.08ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [49.79ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.81ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [8.34ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [2.42ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [5.22ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 7046ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 07s
[3/8] link bun-profile
rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSSLConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80120094)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSocketConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80120094)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: L
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/FormData.rs   | 32 +++++++++++---------------
 test/js/web/html/FormData.test.ts | 48 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 61 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/FormData.rs        2      3      6
test/js/web/html/FormData.test.ts      1      1      5
```

</details>

**root cause** · written by the author bot

The multipart Content-Disposition parameter scanner in FormData.rs treated `\"` as an escaped quote while searching for the closing quote, but it never unescaped the value, even though the HTML multipart serializer used by Bun, undici, and browsers writes `\` verbatim and percent-encodes `"`, so a name or filename ending in a backslash caused the parser to run past the real closing quote, swallowing the following `; filename=` into the name and demoting File parts to text entries. The fix replaces the half-implemented quoted-pair loop with a lookup for the first `"`, which is always the ter…

<!-- robobun:evidence:end -->