### PR TITLE
test: make sourcetextmodule-leak detect a retained module and run in seconds

### DIFF
--- a/test/js/node/vm/sourcetextmodule-leak.test.ts
+++ b/test/js/node/vm/sourcetextmodule-leak.test.ts
@@ -1,41 +1,58 @@
 const vm = require("vm");
 const { describe, it, expect } = require("bun:test");
-const { isASAN, isDebug, rss } = require("harness");
+const { isASAN, isDebug, rss, expectMaxObjectTypeCount } = require("harness");
+const { heapStats } = require("bun:jsc");
 
-// 50k×50KB ≈ 2.5 GB of source text — if module records leak their source we
-// blow past the threshold. Debug builds parse/link ~50× slower, so scale down.
-// ASAN's quarantine raises the RSS floor; keep a wide-but-bounded ceiling there.
-const ITERATIONS = isDebug ? 2_000 : 50_000;
-const THRESHOLD_MB = isDebug ? (isASAN ? 1500 : 300) : isASAN ? 3500 : 3000;
+// Each module carries ~50 KB of source, so a module record that keeps its
+// source alive shows up in RSS. A full GC after every batch keeps the no-leak
+// RSS near one batch of outstanding work instead of the allocator's high-water
+// mark over the whole run. Without it, 50k iterations with every module
+// retained (2.8 GB) and with none retained both stayed under the old 3 GB bound.
+//
+// The object count at the end is the exact signal for a retained module record.
+// It does not depend on RSS, so ASAN's quarantine, which holds freed pages and
+// hides RSS deltas, cannot mask it.
+const ITERATIONS = isDebug ? 200 : 8_000;
+const BATCH = isDebug ? 50 : 500;
+// No-leak RSS settles near 90 MB on release and 25 MB on debug. A retained
+// module adds ~55 KB each (~440 MB at 8k iterations). ASAN's quarantine raises
+// the floor by up to 256 MB regardless of leak state.
+const THRESHOLD_MB = isASAN ? 600 : 256;
 
 describe("vm.SourceTextModule", () => {
-  it(
-    "shouldn't leak memory",
-    async () => {
-      const initialUsage = rss();
+  it("shouldn't leak memory", async () => {
+    const baseline = heapStats().objectTypeCounts.NodeVMSourceTextModule ?? 0;
+    const initialUsage = rss();
 
-      {
-        const source = `/*\n${Buffer.alloc(50_000, " * aaaaa\n").toString("utf8")}\n*/ Buffer.alloc(10, 'hello');`;
+    {
+      const source = `/*\n${Buffer.alloc(50_000, " * aaaaa\n").toString("utf8")}\n*/ export const result = Buffer.alloc(10, 'hello').toString();`;
 
-        async function go(i) {
-          const mod = new vm.SourceTextModule(source + "//" + i, {
-            identifier: Buffer.alloc(64, i.toString()).toString("utf8"),
-          });
-          await mod.link(() => {});
-          await mod.evaluate();
-        }
-
-        for (let i = 0; i < ITERATIONS; ++i) {
-          await go(i);
-        }
+      let last;
+      async function go(i) {
+        const mod = new vm.SourceTextModule(source + "//" + i, {
+          identifier: Buffer.alloc(64, i.toString()).toString("utf8"),
+        });
+        await mod.link(() => {});
+        await mod.evaluate();
+        last = mod;
       }
 
-      Bun.gc(true);
+      for (let i = 0; i < ITERATIONS; ++i) {
+        await go(i);
+        if ((i + 1) % BATCH === 0) Bun.gc(true);
+      }
 
-      const finalUsage = rss();
-      const megabytes = Math.round(((finalUsage - initialUsage) / 1024 / 1024) * 100) / 100;
-      expect(megabytes).toBeLessThan(THRESHOLD_MB);
-    },
-    isDebug ? 60_000 : 30_000,
-  );
+      expect(last.status).toBe("evaluated");
+      expect(last.namespace.result).toBe("hellohello");
+      last = undefined;
+    }
+
+    Bun.gc(true);
+
+    const finalUsage = rss();
+    const megabytes = Math.round(((finalUsage - initialUsage) / 1024 / 1024) * 100) / 100;
+    expect(megabytes).toBeLessThan(THRESHOLD_MB);
+
+    await expectMaxObjectTypeCount(expect, "NodeVMSourceTextModule", baseline + 10, 100);
+  });
 });


### PR DESCRIPTION
### Problem
- `test/js/node/vm/sourcetextmodule-leak.test.ts` went red on the x64-asan lane in build 111088: `vm.SourceTextModule > shouldn't leak memory [49144.51ms] ^ this test timed out after 30000ms`. It runs 50k modules in about 20 s on that lane under its own 30 s timeout. One slow agent trips it (every file on that shard ran 1.65x slower).
- The test cannot detect the leak it was written for. With all 50k modules retained, release RSS reads 2776 MB, under the 3000 MB bound. The loop never runs a GC.
- No code change caused this. #41330 (JSC from source) was the suspect. The asan lane took 21 s to 22.7 s before it and 18.9 s to 22.7 s across ten builds after it.

### Fix
- Run a full GC after every batch (500 modules, 50 on debug). No-leak RSS stays near one batch: 90 MB release, 25 MB debug. 8k retained modules read 437 MB against a 256 MB bound (600 MB under ASAN).
- Assert the exact `NodeVMSourceTextModule` count with `expectMaxObjectTypeCount`. This catches a retained record on debug ASAN too, where the quarantine hides the RSS delta.
- Assert the last module's `status` and exported `namespace.result`. Drop the explicit timeout. The test runs 1.7 s on release and 2 s on debug ASAN.
- Verified: `bun bd test test/js/node/vm/sourcetextmodule-leak.test.ts` and `USE_SYSTEM_BUN=1 bun test`, 3 runs each. A copy with `leaked.push(mod)` fails on the RSS bound (release) and on the object count (debug ASAN).

### Background
- Each `vm.SourceTextModule` is one `NodeVMSourceTextModule` cell (`src/jsc/bindings/NodeVMSourceTextModule.cpp`). `bun:jsc`'s `heapStats().objectTypeCounts` reports live cells per class after a GC.
- ASAN holds freed allocations in a 256 MB quarantine, so RSS on sanitized builds under-reports frees.
- `scripts/runner.node.mjs` passes `--timeout` per lane (3x on ASAN). A timeout argument in the test file replaces it.
- Supersedes #35917 (same design, predates the harness `rss()` helper).

<details><summary>Notes</summary>

Lane timing, this file, x64-asan test shards (from the job logs):

| build | base vs #41330 | time |
| --- | --- | --- |
| 110841 | before | 22.71 s |
| 110878 | before | 21.05 s |
| 110912 | before | 21.88 s |
| 111088 | after | 49.37 s (timed out, every file on the shard 1.65x slower than the same shard in 111116) |
| 111116 | after | 18.89 s |
| 111079, 111133, 111139, 111146, 111150, 111155, 111158, 111159 | after | 19.5 s to 22.7 s |

Old test, release bun 1.4.3, `rss()` delta: nothing retained 305 MB, all 50k retained 2776 MB, both under the 3000 MB bound. Both runs about 12 s.

New test, release: nothing retained 90 MB in 1.7 s, all 8k retained 437 MB (fails the 256 MB bound, object count 8000).

New test, debug ASAN (`bun bd`): nothing retained 24 MB in 2 s, all 200 retained 17 MB (RSS passes, object count 200 fails the bound of 10). `maxWait` for the object-count poll is 100 ms so a failure reports the count instead of tripping the 5 s default timeout in a local run.

Other leak tests on build 111088 (`inspect-error-leak`, `setInterval`, `require-cache`, `test-crypto-dh-leak`) ran on other shards and are outside this change.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/vm/sourcetextmodule-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/vm/sourcetextmodule-leak.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/vm/sourcetextmodule-leak.test.ts:
(pass) vm.SourceTextModule > shouldn't leak memory [2731.62ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [5.10s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/vm/sourcetextmodule-leak.test.ts | 81 ++++++++++++++++-----------
 1 file changed, 49 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/node/vm/sourcetextmodule-leak.test.ts      2      3     10
```

</details>

<!-- robobun:evidence:end -->