### PR TITLE
test: clear the stale stack slot that keeps the last abandoned fetch body alive

### DIFF
--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -269,11 +269,9 @@ describe("an abandoned fetch body stream is collected and its fetch is aborted",
         }
         for (let i = 0; i < N; i++) await abandonOne();
 
-        // The native frames under this function (the microtask that ran the last stream's read)
-        // still hold that stream's controller in a stale slot, and the conservative stack scan
-        // keeps the stream alive through every collection below. Only the same code path writes
-        // that slot again: read one chunk of a throwaway body and cancel it, so the slot holds a
-        // stream nobody cares about before each collection.
+        // The JSC::runInternalMicrotask frame under this function keeps the last stream's
+        // controller in a stale slot (heap snapshot and lldb evidence in #41607), which the stack
+        // scan marks. Reading another body through the same path writes that slot again.
         async function scrub() {
           const reader = (await fetch(new URL("/scrub", server.url))).body!.getReader();
           await reader.read();

--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -240,7 +240,8 @@ describe("an abandoned fetch body stream is collected and its fetch is aborted",
         using server = Bun.serve({
           port: 0,
           fetch(req) {
-            req.signal.addEventListener("abort", () => aborted++);
+            // `/scrub` bodies are read and cancelled on purpose below; only the abandoned ones count.
+            if (new URL(req.url).pathname !== "/scrub") req.signal.addEventListener("abort", () => aborted++);
             return new Response(
               new ReadableStream({
                 async pull(controller) {
@@ -268,15 +269,25 @@ describe("an abandoned fetch body stream is collected and its fetch is aborted",
         }
         for (let i = 0; i < N; i++) await abandonOne();
 
+        // The native frames under this function (the microtask that ran the last stream's read)
+        // still hold that stream's controller in a stale slot, and the conservative stack scan
+        // keeps the stream alive through every collection below. Only the same code path writes
+        // that slot again: read one chunk of a throwaway body and cancel it, so the slot holds a
+        // stream nobody cares about before each collection.
+        async function scrub() {
+          const reader = (await fetch(new URL("/scrub", server.url))).body!.getReader();
+          await reader.read();
+          await reader.cancel();
+        }
         // Bounds the failing case only; the fixed build is done in well under a second.
         const deadline = performance.now() + (isASAN || isDebug ? 15_000 : 3000);
         while (aborted < N && performance.now() < deadline) {
+          await scrub();
           Bun.gc(true);
           await Bun.sleep(10);
         }
-        // A few can survive a collection through stale stack slots (conservative scanning);
-        // the rest must go. Unfixed, none of them do.
-        expect(N - aborted).toBeLessThan(N / 4);
+        // Unfixed, none of them are aborted: the fetch keeps its stream rooted until the body ends.
+        expect(aborted).toBe(N);
       },
       30_000,
     );


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/fetch-stream-cancel-leak.test.ts` > "one read() after it parked" went red on darwin aarch64 in builds 110683 and 110902: `expect(N - aborted).toBeLessThan(N / 4)`, `Expected: < 5`, `Received: 5`. Up to 4 of the 20 abandoned bodies were allowed to survive the 3 s wait, and 5 did.
- The survivors are not rooted by bun. After the last body's final `read()`, its `ReadableStreamDefaultController` stays in a stale slot of the `JSC::runInternalMicrotask` frame that ran that read. The wait loop resumes through that same frame, so the conservative stack scan marks the controller, and through it the stream, on every `Bun.gc(true)`. Nothing in the loop writes that slot again, so the stream lives until unrelated work does, about one second later on an idle box, and past the deadline on the CI lane.

### Fix
- Before each collection the loop reads one chunk of a throwaway body from a `/scrub` route of the same origin and cancels it. That runs the same fetch-body code path, so the stale slot then holds a stream nobody cares about. `/scrub` aborts do not count.
- With the slot cleared, the assertion is exact: `expect(aborted).toBe(N)`. Unfixed (#39590 reverted), none of the bodies are aborted, so the test still fails.
- The test still exercises the same paths: park on 256 KiB unread, `read()` after the park, unpark, re-park, collect, abort from the sweep.
- Verified: the file 15 of 15 times on darwin aarch64 with the CI build of 110902 (release and profile), 6 of 6 with the release build on linux x64, 3 of 3 with `bun bd test` (ASAN). The stall is gone in all of them.

### Background
- A fetch body that nothing reads is parked once it holds 256 KiB (#39590): the transport pauses and the tasklet stops rooting the stream, so the GC can collect it and the sweep aborts the fetch. The test counts those aborts at the origin.
- JSC scans the native stack conservatively: every word between the stack pointer and the stack base that looks like a cell pointer keeps that cell alive. A stale word inside a live frame is not sanitized.
- `runInternalMicrotask` is JSC's dispatcher for internal microtasks. Promise reactions of the stream machinery and async-function resumes both run through it, at the same depth, but they spill different values into the same frame area.

<details><summary>Notes</summary>

**How the retainer was found.** A standalone copy of the "dropped while a reader holds the lock" shape stalls for about 1 s in 25 to 45 % of runs on darwin and linux release builds. During the stall: the origin's socket has a full send queue, the client socket a full receive queue (`netstat`, `ss -tnie`: `rwnd_limited`), the HTTP thread does no `recvfrom` on that socket (`fs_usage`), and the JS thread sends no wakeup to the HTTP thread (a `DYLD_INSERT_LIBRARIES` interposer on `mach_msg`). So the stream is parked and the transport paused, and the only thing missing is the collection.

`generateHeapSnapshotForDebugging()` taken after `Bun.gc(true)` during the stall: the stream, its controller, reader, `BytesInternalReadableStreamSource` and `NativeStreamSourceAdapter` form a cluster with no incoming edge from outside it and no `roots` entry.

`lldb` on the profile build of 110902, stopped from inside the stall: the controller's cell address `0x45b98648e70` is on the main thread stack at `0x16fdfdc38`, inside frame #10 `JSC::runInternalMicrotask` (fp `0x16fdfdd20`) of the chain `drainWithUseCallOnEachMicrotask` > `runInternalMicrotask` > `asyncModuleExecutionResume` > the script's continuation > `Bun.gc`. The fp chain was walked by hand so JIT frames do not stop it. `/proc/self/mem` on linux finds the same controller address in the `[stack]` mapping.

**Why a throwaway fetch and not a throwaway `ReadableStream`.** A JS-source stream or a `Bun.file().stream()` read before each collection did not help (stalls in 16 to 19 of 20 runs, they spill into other slots). A throwaway fetch body read made 30 of 30 runs collect everything within 100 ms on darwin and 20 of 20 on linux. One throwaway fetch read in the middle of a stall collects the retained stream within 20 ms in 12 of 12 stalled runs.

**Why the 1 s on an idle box.** Not measured to the instruction. The slot is overwritten only by the same microtask path, and the origin's own stream microtasks stop while it is backpressured. The next unrelated work on the JS thread clears it.

**The CI count.** 5 survivors did not reproduce locally, with or without CPU load, under the release or the profile build. The mechanism is the same for every survivor that the heap snapshot cannot explain, and the scrub re-runs the whole path (tasklet progress task, `ByteStream::on_data`, the pull microtasks, the read request), so it overwrites the slots of each of those frames.

**Related.** #41111 rewrites this file and waits on `WeakRef`s with an exact count. It notes the same ~970 ms stall. The scrub applies there too.

Suites run: this file under the darwin release and profile builds of 110902 (15 runs), the linux release build (6 runs), and `bun bd test` ASAN (3 runs).
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/fetch-stream-cancel-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/fetch-stream-cancel-leak.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/fetch/fetch-stream-cancel-leak.test.ts:
(pass) ReadableStream from fetch should be GC'd after reader.cancel() [915.97ms]
(pass) ReadableStream from fetch should be GC'd after body.cancel() [831.24ms]
(pass) response.body.cancel() on a never-read body aborts the underlying fetch [418.98ms]
(pass) an abandoned fetch body stream is collected and its fetch is aborted > res.body touched [535.51ms]
(pass) an abandoned fetch body stream is collected and its fetch is aborted > one read(), then releaseLock() [677.89ms]
(pass) an abandoned fetch body stream is collected and its fetch is aborted > dropped while a reader holds the lock [578.03ms]
(pass) an abandoned fetch body stream is collected and its fetch is aborted > one read() after it parked [3602.14ms]
(pass) a proxied fetch body is aborted once the response's client is gone > new Response(upstream.body), client leaves while reading [140.51ms]
(pass) a proxied fetch body is aborted once the response's client is gone > new Response(upstream.body), client leaves without reading [231.04ms]
(pass) a proxied fetch body is aborted once the response's client is gone > the upstream Response itself, client leaves while reading [80.22ms]
(pass) a proxied fetch body is aborted once the response's client is gone > the upstream Response itself, client leaves without reading [199.19ms]

 11 pass
 0 fail
 15 expect() calls
Ran 11 tests across 1 file. [12.39s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/fetch-stream-cancel-leak.test.ts | 17 +++++++++++++----
 1 file changed, 13 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
test/js/web/fetch/fetch-stream-cancel-leak.test.ts      2      3     11
```

</details>

<!-- robobun:evidence:end -->