### PR TITLE
native-readable: accept a stream with no native handle

### DIFF
--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -56,8 +56,7 @@ let debugId = 0;
 function constructNativeReadable(readableStream: ReadableStream, options): NativeReadable {
   $assert(typeof readableStream === "object" && readableStream instanceof ReadableStream, "Invalid readable stream");
   const bunNativePtr = (readableStream as any).$bunNativePtr;
-  // undefined: a closed stream with nothing left to read (a subprocess pipe
-  // that ended empty before JS touched it). read() ends the Readable at once.
+  // undefined: a closed stream with nothing left to read, so read() ends at once.
   $assert(bunNativePtr === undefined || typeof bunNativePtr === "object", "Invalid native ptr");
 
   const stream = new Readable(options);

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -56,7 +56,9 @@ let debugId = 0;
 function constructNativeReadable(readableStream: ReadableStream, options): NativeReadable {
   $assert(typeof readableStream === "object" && readableStream instanceof ReadableStream, "Invalid readable stream");
   const bunNativePtr = (readableStream as any).$bunNativePtr;
-  $assert(typeof bunNativePtr === "object", "Invalid native ptr");
+  // undefined: a closed stream with nothing left to read (a subprocess pipe
+  // that ended empty before JS touched it). read() ends the Readable at once.
+  $assert(bunNativePtr === undefined || typeof bunNativePtr === "object", "Invalid native ptr");
 
   const stream = new Readable(options);
   stream._read = read;

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1254,18 +1254,7 @@ class ChildProcess extends EventEmitter {
               return stream;
             }
 
-            const nativePtr = value.$bunNativePtr;
-            let pipe;
-            if (typeof nativePtr === "object" && nativePtr !== null) {
-              pipe = require("internal/streams/native-readable").constructNativeReadable(value, {});
-            } else {
-              // No native handle: the pipe already closed empty (Readable::to_js
-              // returns ReadableStream::empty). The stream ends at once.
-              pipe = require("internal/streams/readable").fromWeb(value);
-              pipe.ref = pipe.unref = function () {
-                return this;
-              };
-            }
+            const pipe = require("internal/streams/native-readable").constructNativeReadable(value, {});
             this.#closesNeeded++;
             pipe.once("close", () => this.#maybeClose());
             if (autoResume) pipe.resume();

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1254,17 +1254,14 @@ class ChildProcess extends EventEmitter {
               return stream;
             }
 
-            // A pipe that closed with no output before JS touched it has no
-            // native handle: the native side hands out a plain closed
-            // ReadableStream. Readable.fromWeb ends that stream at once.
             const nativePtr = value.$bunNativePtr;
             let pipe;
             if (typeof nativePtr === "object" && nativePtr !== null) {
               pipe = require("internal/streams/native-readable").constructNativeReadable(value, {});
             } else {
+              // No native handle: the pipe already closed empty (Readable::to_js
+              // returns ReadableStream::empty). The stream ends at once.
               pipe = require("internal/streams/readable").fromWeb(value);
-              // The native stream has ref()/unref(). Nothing is left to keep
-              // the event loop alive here, so both are no-ops.
               pipe.ref = pipe.unref = function () {
                 return this;
               };

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1254,7 +1254,14 @@ class ChildProcess extends EventEmitter {
               return stream;
             }
 
-            const pipe = require("internal/streams/native-readable").constructNativeReadable(value, {});
+            // A pipe that closed with no output before JS touched it has no
+            // native handle: the native side hands out a plain closed
+            // ReadableStream. Readable.fromWeb ends that stream at once.
+            const nativePtr = value.$bunNativePtr;
+            const pipe =
+              typeof nativePtr === "object" && nativePtr !== null
+                ? require("internal/streams/native-readable").constructNativeReadable(value, {})
+                : require("internal/streams/readable").fromWeb(value);
             this.#closesNeeded++;
             pipe.once("close", () => this.#maybeClose());
             if (autoResume) pipe.resume();

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1258,10 +1258,17 @@ class ChildProcess extends EventEmitter {
             // native handle: the native side hands out a plain closed
             // ReadableStream. Readable.fromWeb ends that stream at once.
             const nativePtr = value.$bunNativePtr;
-            const pipe =
-              typeof nativePtr === "object" && nativePtr !== null
-                ? require("internal/streams/native-readable").constructNativeReadable(value, {})
-                : require("internal/streams/readable").fromWeb(value);
+            let pipe;
+            if (typeof nativePtr === "object" && nativePtr !== null) {
+              pipe = require("internal/streams/native-readable").constructNativeReadable(value, {});
+            } else {
+              pipe = require("internal/streams/readable").fromWeb(value);
+              // The native stream has ref()/unref(). Nothing is left to keep
+              // the event loop alive here, so both are no-ops.
+              pipe.ref = pipe.unref = function () {
+                return this;
+              };
+            }
             this.#closesNeeded++;
             pipe.once("close", () => this.#maybeClose());
             if (autoResume) pipe.resume();

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1285,6 +1285,43 @@ describe.skipIf(!isPosix)("stdout pipe backpressure", () => {
   });
 });
 
+describe.skipIf(!isPosix)("piped stdio first touched after the child exits", () => {
+  // The child writes nothing to stderr and nobody reads it. The pipe closes
+  // before JS touches child.stderr, so the native side has no handle left.
+  // The exit path constructs the stream then, and must not assert.
+  it("reaches 'close' when the unread pipe closed empty", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { spawn } = require("child_process");
+        const c = spawn("/bin/sh", ["-c", "echo hello"], { stdio: ["inherit", "pipe"] });
+        c.stdout.on("data", d => process.stdout.write("OUT:" + d));
+        c.on("close", () => console.log("closed"));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("OUT:hello\nclosed\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it("child.stderr ends and closes like an empty pipe", async () => {
+    const c = spawn("/bin/sh", ["-c", "echo hello"], { stdio: ["ignore", "pipe", "pipe"], env: bunEnv });
+    c.stdout!.resume();
+    await once(c, "close");
+    const stderr = c.stderr!;
+    expect({
+      ended: stderr.readableEnded,
+      destroyed: stderr.destroyed,
+      errored: stderr.errored,
+      exitCode: c.exitCode,
+    }).toEqual({ ended: true, destroyed: true, errored: null, exitCode: 0 });
+  });
+});
+
 // child.stdout.pause() must stop the native reader so the kernel pipe fills
 // and the child blocks on write. Previously, once the stream had flowed even
 // once the native FileReader kept the poll armed (or uv_read_start active on

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1297,13 +1297,17 @@ describe.skipIf(!isPosix)("piped stdio first touched after the child exits", () 
         `const { spawn } = require("child_process");
         const c = spawn("/bin/sh", ["-c", "echo hello"], { stdio: ["inherit", "pipe"] });
         c.stdout.on("data", d => process.stdout.write("OUT:" + d));
-        c.on("close", () => console.log("closed"));`,
+        c.on("close", () => {
+          c.stderr.unref();
+          c.stderr.ref();
+          console.log("closed", c.stderr.readableEnded, c.stderr.destroyed);
+        });`,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("OUT:hello\nclosed\n");
+    expect(stdout).toBe("OUT:hello\nclosed true true\n");
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
### Problem
- A debug build asserts after a short-lived child exits when one of its piped stdio streams was never touched: `[internal:streams/native-readable] ASSERTION FAILED: typeof bunNativePtr === "object" Invalid native ptr` at `constructNativeReadable (internal:streams/native-readable:51)`. Repro: `spawn("/bin/sh", ["-c", "echo hello"], { stdio: ["inherit", "pipe"] })`, read `stdout`, never touch `stderr`. The assertion throws out of the exit handler, so `'exit'` and `'close'` never fire. The in-tree Node test `test/js/node/test/parallel/test-stdin-from-file-spawn.js` fails under `bun bd` for this reason.
- The cause: when the child's stderr pipe closes with no output before JS reads the stream, the native side turns the pipe into an empty buffer (`subprocess.rs:on_close_io`) and `Readable::to_js` returns `ReadableStream::empty` (`subprocess/Readable.rs:235`). That stream has no `$bunNativePtr`. `#handleOnExit` in `child_process.ts` constructs the node stream at that point, and `constructNativeReadable` asserted on the missing handle.
- Release builds strip `$assert`. There, `read()` already ends a handle-less NativeReadable (`if (!ptr) push(null)`), and `destroy`, `ref`, `unref` already guard a missing handle. The only defect is the assertion.

### Fix
- `constructNativeReadable` (`src/js/internal/streams/native-readable.ts:59`) accepts `undefined` as the handle. The rest of the module already treats `undefined` as "nothing left to read".
- `child_process.ts` keeps its single construction path, so `child.stdout` and `child.stderr` stay one class.
- Verified: `test/js/node/child_process/child_process.test.ts` (new block "piped stdio first touched after the child exits", the subprocess test fails on the unfixed debug build). Also `test/js/node/child_process/`, `test/js/node/stream/`, `test/js/node/tty/`, `process-stdin.test.ts`, and 27 upstream `test-child-process-{stdio,exec,spawn}-*` and `test-stdin-from-file-spawn` files.

### Background
- `Bun.spawn` reads a `pipe` stdout/stderr into a buffered `PipeReader` until JS touches the stream. At EOF before that, the bytes move into `Readable::Buffer`. An empty buffer becomes a plain closed `ReadableStream`. A non-empty one becomes a blob-backed stream with a native handle.
- `node:child_process` wraps a native stream with `native-readable.ts`, a `Readable` whose `_read` pulls from the `$bunNativePtr` handle. With no handle, `_read` pushes `null`, so the stream ends and then closes like an empty pipe.

<details><summary>Notes</summary>

Self-reviewed: 11 concerns raised, all addressed by the rework. The first version of this PR branched in `child_process.ts` to `Readable.fromWeb` when the handle was missing, with stub `ref()`/`unref()`. The review found that shape wrong: it duplicated the `tryTransferToNativeReadable` predicate, made the stream class depend on whether EOF beat `waitpid`, and sat on the line that #36316, #39760 and #30850 rewrite (and #36316's unconditional `constructNativeReadable` call would trip the same assert). The one-line change in `native-readable.ts` covers all callers.

The second new test (in-process, state checks after `'close'`) passes on the unfixed build for every stdio shape tried (`["ignore","pipe"]`, `["ignore","pipe","pipe"]`, `["inherit","pipe"]`): inside the test runner the exit notification arrives before the pipe EOF, so the stream takes the native path. It is kept as a check of the end state, not as the fail-before proof. The subprocess test is the proof.

Pre-existing in this container, with or without the change: `child_process.test.ts` "spawn in the default shell" fails, "set env" and "extra stdio pipes are not double-closed on GC" exceed their 5 s budgets (four sequential debug-bun spawns at 1.5 s each, and 7.5 s standalone for the GC test).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->