### PR TITLE
bun:sqlite: release native state when a Database is collected or closed

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -320,7 +320,9 @@ declare module "bun:sqlite" {
     /**
      * The underlying `sqlite3` database handle
      *
-     * In native code, this is not a file descriptor, but an index into an array of database handles
+     * In native code, this is not a file descriptor, but an index into an array of database handles.
+     * The index is released once the `Database` is closed and garbage collected, and a later
+     * `Database` can receive the same value.
      */
     readonly handle: number;
 

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -126,7 +126,7 @@ interface CppSQL {
     openFlags: number,
     deserializeFlags: number,
     db: Database,
-  ): TODO;
+  ): number;
   fcntl(handle: TODO, ...args: TODO[]): TODO;
   close(handle: TODO, throwOnError: boolean): void;
   setCustomSQLite(path: string): void;

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -121,7 +121,12 @@ interface CppSQL {
   isInTransaction(handle: TODO): boolean;
   loadExtension(handle: TODO, name: string, entryPoint: string): void;
   serialize(handle: TODO, name: string): Buffer;
-  deserialize(serialized: NodeJS.TypedArray | ArrayBufferLike, openFlags: number, deserializeFlags: number): TODO;
+  deserialize(
+    serialized: NodeJS.TypedArray | ArrayBufferLike,
+    openFlags: number,
+    deserializeFlags: number,
+    db: Database,
+  ): TODO;
   fcntl(handle: TODO, ...args: TODO[]): TODO;
   close(handle: TODO, throwOnError: boolean): void;
   setCustomSQLite(path: string): void;
@@ -369,7 +374,7 @@ class Database implements SqliteTypes.Database {
           }
         }
 
-        this.#handle = Database.#deserialize(filenameGiven, this.#internalFlags, deserializeFlags);
+        this.#handle = Database.#deserialize(filenameGiven, this.#internalFlags, deserializeFlags, this);
         this.filename = ":memory:";
 
         return;
@@ -452,12 +457,17 @@ class Database implements SqliteTypes.Database {
     return SQL.serialize(this.#handle, optionalName || "main");
   }
 
-  static #deserialize(serialized: NodeJS.TypedArray | ArrayBufferLike, openFlags: number, deserializeFlags: number) {
+  static #deserialize(
+    serialized: NodeJS.TypedArray | ArrayBufferLike,
+    openFlags: number,
+    deserializeFlags: number,
+    finalizationTarget: Database,
+  ) {
     if (!SQL) {
       initializeSQL();
     }
 
-    return SQL.deserialize(serialized, openFlags, deserializeFlags);
+    return SQL.deserialize(serialized, openFlags, deserializeFlags, finalizationTarget);
   }
 
   static deserialize(

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -241,8 +241,7 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 class SQLiteSingleton {
 public:
     Vector<VersionSqlite3*> databases;
-    // Handles whose entry was freed. Reused by the next registerDatabase so the
-    // vector does not grow by one slot per Database ever opened.
+    // Indices of freed entries, reused by registerDatabase.
     Vector<size_t> freeHandles;
 };
 
@@ -295,10 +294,7 @@ static VersionSqlite3* databaseForHandle(int32_t handle)
     return dbs[static_cast<size_t>(handle)];
 }
 
-// Registers a freshly opened connection. The JS Database object that owns the
-// handle is the finalization target: its GC finalizer drops the entry's initial
-// ref, so a Database that is dropped without close() still releases the
-// connection.
+// The finalization target is the JS Database object; its GC finalizer drops the entry's initial ref.
 static size_t registerDatabase(JSC::VM& vm, sqlite3* db, JSC::JSValue finalizationTarget)
 {
     auto* versionDB = new VersionSqlite3(db, &vm);
@@ -311,9 +307,7 @@ static size_t registerDatabase(JSC::VM& vm, sqlite3* db, JSC::JSValue finalizati
     return index;
 }
 
-// The last ref is always dropped on the owning VM's thread: the JS Database
-// finalizer and every JSSQLStatement destructor run there. Once it is gone no
-// JS object can name this handle, so the entry is freed and the handle reused.
+// The last ref drops on the owning VM's thread after no JS object can name this handle.
 void VersionSqlite3::release()
 {
     ASSERT(reference_count > 0);

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -213,7 +213,10 @@ public:
     // (Bun__closeAllSQLiteDatabasesForTermination).
     JSC::VM* const vm;
     std::atomic<uint64_t> version;
+    // One ref for the JS Database object (dropped by its GC finalizer), one per JSSQLStatement.
     size_t reference_count;
+    // Index of this entry in the registry; the JS-visible handle.
+    size_t handleIndex = 0;
     WTF::HashSet<WebCore::JSSQLStatement*> statements;
     // close(false) with live db.prepare() statements: JS-visible closed, sqlite3_close deferred until they drain.
     bool closed = false;
@@ -229,12 +232,8 @@ public:
     // Defined after JSSQLStatement: needs its definition to inspect `stmt`.
     void closeIfDrained();
 
-    void release()
-    {
-        ASSERT(reference_count > 0);
-        if (--reference_count == 0)
-            closeHandle();
-    };
+    // Defined after the registry: frees this entry and recycles its handle.
+    void release();
 };
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
@@ -242,35 +241,55 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 class SQLiteSingleton {
 public:
     Vector<VersionSqlite3*> databases;
+    // Handles whose entry was freed. Reused by the next registerDatabase so the
+    // vector does not grow by one slot per Database ever opened.
+    Vector<size_t> freeHandles;
 };
 
 static SQLiteSingleton* _instance = nullptr;
 static WTF::Lock databasesLock;
 
-static Vector<VersionSqlite3*>& databases()
+static SQLiteSingleton& registry()
 {
     if (!_instance) {
         _instance = new SQLiteSingleton();
-        _instance->databases = Vector<VersionSqlite3*>();
         _instance->databases.reserveInitialCapacity(4);
     }
 
-    return _instance->databases;
+    return *_instance;
 }
 
 static size_t registerDatabase(VersionSqlite3* versionDB)
 {
     WTF::Locker locker { databasesLock };
-    auto& dbs = databases();
-    size_t index = dbs.size();
-    dbs.append(versionDB);
+    auto& instance = registry();
+    size_t index;
+    if (!instance.freeHandles.isEmpty()) {
+        index = instance.freeHandles.takeLast();
+        ASSERT(!instance.databases[index]);
+        instance.databases[index] = versionDB;
+    } else {
+        index = instance.databases.size();
+        instance.databases.append(versionDB);
+    }
+    versionDB->handleIndex = index;
     return index;
+}
+
+static void unregisterDatabase(VersionSqlite3* versionDB)
+{
+    WTF::Locker locker { databasesLock };
+    auto& instance = registry();
+    size_t index = versionDB->handleIndex;
+    ASSERT(index < instance.databases.size() && instance.databases[index] == versionDB);
+    instance.databases[index] = nullptr;
+    instance.freeHandles.append(index);
 }
 
 static VersionSqlite3* databaseForHandle(int32_t handle)
 {
     WTF::Locker locker { databasesLock };
-    auto& dbs = databases();
+    auto& dbs = registry().databases;
     if (handle < 0 || static_cast<size_t>(handle) >= dbs.size())
         return nullptr;
     return dbs[static_cast<size_t>(handle)];
@@ -290,6 +309,19 @@ static size_t registerDatabase(JSC::VM& vm, sqlite3* db, JSC::JSValue finalizati
         });
     }
     return index;
+}
+
+// The last ref is always dropped on the owning VM's thread: the JS Database
+// finalizer and every JSSQLStatement destructor run there. Once it is gone no
+// JS object can name this handle, so the entry is freed and the handle reused.
+void VersionSqlite3::release()
+{
+    ASSERT(reference_count > 0);
+    if (--reference_count != 0)
+        return;
+    closeHandle();
+    unregisterDatabase(this);
+    delete this;
 }
 
 // Shared with node:sqlite's termination path (Bun__closeAllNodeSqliteDatabasesForTermination):
@@ -317,7 +349,7 @@ extern "C" void Bun__closeAllSQLiteDatabasesForTermination(JSC::JSGlobalObject* 
     auto& dbs = _instance->databases;
 
     for (auto& db : dbs) {
-        if (db->vm != exitingVM)
+        if (!db || db->vm != exitingVM)
             continue;
         if (db->db) {
             Bun__sqliteCheckpointForTermination(db->db);

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -276,6 +276,22 @@ static VersionSqlite3* databaseForHandle(int32_t handle)
     return dbs[static_cast<size_t>(handle)];
 }
 
+// Registers a freshly opened connection. The JS Database object that owns the
+// handle is the finalization target: its GC finalizer drops the entry's initial
+// ref, so a Database that is dropped without close() still releases the
+// connection.
+static size_t registerDatabase(JSC::VM& vm, sqlite3* db, JSC::JSValue finalizationTarget)
+{
+    auto* versionDB = new VersionSqlite3(db, &vm);
+    size_t index = registerDatabase(versionDB);
+    if (finalizationTarget.isObject()) {
+        vm.heap.addFinalizer(finalizationTarget.getObject(), [versionDB](JSC::JSCell*) -> void {
+            versionDB->release();
+        });
+    }
+    return index;
+}
+
 // Shared with node:sqlite's termination path (Bun__closeAllNodeSqliteDatabasesForTermination):
 // with unfinalized statements close_v2 only zombifies the connection and
 // defers the WAL checkpoint to a finalize that never comes, so flush the WAL
@@ -1324,8 +1340,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementDeserialize, (JSC::JSGlobalObject * lexic
         return {};
     }
 
-    auto count = registerDatabase(new VersionSqlite3(db, &vm));
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(count)));
+    auto index = registerDatabase(vm, db, callFrame->argument(3));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(index)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSerialize, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
@@ -1805,13 +1821,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
     if (status != SQLITE_OK) {
         // TODO: log a warning here that defensive mode is unsupported.
     }
-    auto* versionDB = new VersionSqlite3(db, &vm);
-    auto index = registerDatabase(versionDB);
-    if (finalizationTarget.isObject()) {
-        vm.heap.addFinalizer(finalizationTarget.getObject(), [versionDB](JSC::JSCell* ptr) -> void {
-            versionDB->release();
-        });
-    }
+    auto index = registerDatabase(vm, db, finalizationTarget);
     RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(index)));
 }
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2809,3 +2809,56 @@ it("a deserialized Database that is never closed releases its connection when co
   // Unfixed: every dropped 1 MB image stays allocated, about 230 MiB. Fixed: under 5 MiB.
   await expectRssDeltaBelow(["-e", code], { release: 60, debug: 80 });
 });
+
+// Every Database owns one entry in a process-wide native registry, indexed by
+// `db.handle`. The entry used to live for the rest of the process even after
+// close() and GC, so each new Database cost a little native memory forever.
+// A freed entry's handle is reused, which is what these tests observe.
+describe("native registry entry is released", () => {
+  async function expectHandleReuse(openOne, highest) {
+    // GC sweeps (and the finalizers they run) are not synchronous with Bun.gc;
+    // poll with a deadline instead of waiting a fixed time.
+    const deadline = Date.now() + 3_000;
+    let handle;
+    do {
+      Bun.gc(true);
+      await Bun.sleep(1);
+      const db = openOne();
+      handle = db.handle;
+      db.close();
+    } while (handle > highest && Date.now() < deadline);
+    expect(handle).toBeLessThanOrEqual(highest);
+  }
+
+  it("after close() and GC of the Database", async () => {
+    function openAndClose() {
+      const db = new Database(":memory:");
+      db.exec("create table t(a)");
+      db.close();
+      return db.handle;
+    }
+    let highest = -1;
+    for (let i = 0; i < 1000; i++) {
+      highest = Math.max(highest, openAndClose());
+    }
+    await expectHandleReuse(() => new Database(":memory:"), highest);
+  });
+
+  it("after GC of a deserialized Database that was never closed", async () => {
+    const src = new Database(":memory:");
+    src.exec("create table t(a)");
+    const serialized = src.serialize();
+    src.close();
+
+    function openAndDrop() {
+      const db = Database.deserialize(serialized);
+      db.exec("insert into t values (1)");
+      return db.handle;
+    }
+    let highest = -1;
+    for (let i = 0; i < 1000; i++) {
+      highest = Math.max(highest, openAndDrop());
+    }
+    await expectHandleReuse(() => Database.deserialize(serialized), highest);
+  });
+});

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2,7 +2,7 @@ import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, expectRssDeltaBelow, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -2771,4 +2771,41 @@ it("exec/run with an embedded NUL byte in the SQL string does not hang", async (
     signalCode: null,
     exitCode: 0,
   });
+});
+
+it("a deserialized Database that is never closed releases its connection when collected", async () => {
+  const code = /* js */ `
+    import { Database } from "bun:sqlite";
+    const src = new Database(":memory:");
+    src.exec("create table t(a)");
+    for (let i = 0; i < 1000; i++) src.exec("insert into t values (randomblob(1000))");
+    const serialized = src.serialize();
+    src.close();
+
+    function dropOne() {
+      const db = Database.deserialize(serialized);
+      db.query("select count(*) from t").get();
+    }
+    async function settle() {
+      for (let i = 0; i < 3; i++) {
+        Bun.gc(true);
+        await Bun.sleep(1);
+      }
+    }
+    // Collect after every few drops so the assertion sees steady state and not
+    // the peak of 100 live images, which the allocator would keep mapped.
+    async function batch(n) {
+      for (let i = 0; i < n; i++) {
+        for (let j = 0; j < 5; j++) dropOne();
+        await settle();
+      }
+    }
+    await batch(4);
+    const before = process.memoryUsage.rss();
+    await batch(20);
+    console.log(JSON.stringify({ deltaMiB: (process.memoryUsage.rss() - before) / 1024 / 1024 }));
+  `;
+
+  // Unfixed: every dropped 1 MB image stays allocated, about 230 MiB. Fixed: under 5 MiB.
+  await expectRssDeltaBelow(["-e", code], { release: 60, debug: 80 });
 });


### PR DESCRIPTION
### Problem
- `Database.deserialize()` registered its native entry without the GC finalizer that `open()` installs (`jsSQLStatementDeserialize` in `src/jsc/bindings/sqlite/JSSQLStatement.cpp`). Its refcount never reached zero. A deserialized Database dropped without `close()` kept its whole in-memory image forever: 100 drops of a 1 MB database grow RSS by 226 MiB on bun 1.4.3.
- `new Database()` then `close()` also leaks on every cycle. `VersionSqlite3::release()` closed the sqlite3 handle but never deleted the entry, and the process-global `databases` vector never reused a slot. On 1.4.3 RSS grows 52 to 73 B per cycle with a flat JS heap, and `db.handle` reads 300000 after 300k cycles. `node:sqlite` in the same binary is flat.

### Fix
- Commit 1: one `registerDatabase(vm, db, finalizationTarget)` helper serves `open` and `deserialize`. `sqlite.ts` passes the Database object as the fourth argument to `SQL.deserialize`, so GC of the object releases the connection.
- Commit 2: when the last ref drops, `release()` closes the handle, nulls the slot, pushes the index onto a free list, and deletes the entry. `registerDatabase` takes a free index before it grows the vector. The termination walk skips freed slots.
- The last ref is always dropped on the owning VM's thread (the Database finalizer or a `JSSQLStatement` destructor), after the JS object is gone. So a reused handle cannot alias a live Database. Statements hold a ref, so a statement that outlives its Database keeps the entry alive.
- `db.handle` can now repeat across Databases in one process. The type comment in `packages/bun-types/sqlite.d.ts` says so.
- Verified: `test/js/bun/sqlite/sqlite.test.js`, three new tests (an RSS delta for the deserialize leak, handle reuse for open and deserialize). All three fail on 1.4.3. Also `test/js/bun/sqlite/`, `test/js/sql/sqlite-*.test.ts`, `test/regression/issue/14709.test.ts`, `test/js/web/workers/worker-terminate-funnels.test.ts`.

### Background
- `VersionSqlite3` is the native record behind one `bun:sqlite` Database: the `sqlite3*`, the owning VM, a version counter, a refcount, and the set of live `JSSQLStatement`s. The JS side holds only an integer handle, the index into the registry vector.
- The refcount is one for the JS Database object plus one per prepared statement. `vm.heap.addFinalizer` runs the Database's release when the GC collects the JS object.
- `Bun__closeAllSQLiteDatabasesForTermination` walks the registry at VM exit and closes the connections that VM opened.

<details><summary>Notes</summary>

- Found by a create/destroy leak census over native object kinds. The deserialize leak was found while reading the code for the first one.
- Open/close repro on 1.4.3: 300k cycles, RSS 45 to 55 MB, handle 300000. With the fix: flat, handle 52721 (slots of cycles the GC had not collected yet).
- Deserialize repro: 1 MB image, `deserialize` then `query().get()`, drop, GC every 5 drops. 100 drops: +226 MiB on 1.4.3, +4 MiB with the fix (debug ASAN build, quarantine off).
- The RSS test collects after every 5 drops. Measuring after 100 live images sees the allocator's peak, which it keeps mapped, not a leak.
- The handle reuse tests observe the free list directly. The per-cycle leak is about 64 bytes, which is below RSS noise.
- Self-reviewed. The review asked to split the two fixes, to test the deserialize leak directly, and to state the `db.handle` change. All three done. It also suggested a larger redesign: replace the integer registry with a JSC cell that owns the connection, as `node:sqlite`'s `JSDatabaseSync` does. That is a follow-up, not part of this PR.
- `#13082` in the same test file takes 7 s on an unmodified ASAN build in the build container (5 s default timeout). Not related to this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->