### PR TITLE
bun test: wait for done() when the callback also returns a fulfilled promise

### DIFF
--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1241,7 +1241,7 @@ impl BunTest {
                     }
                     PromiseStatus::Fulfilled => {
                         // Do not register a then callback when it's already fulfilled.
-                        return Some(cfg_data);
+                        // Fall through: a pending done callback still has to be awaited.
                     }
                     PromiseStatus::Rejected => {
                         let value = bun_jsc::JSPromise::opaque_mut(promise).result(global_this.vm());
@@ -1251,6 +1251,7 @@ impl BunTest {
 
                         // We previously marked it as handled above.
 
+                        // Fail fast without waiting for done(), like bun_test_catch.
                         return Some(cfg_data);
                     }
                 }

--- a/test/js/bun/test/done-async.test.ts
+++ b/test/js/bun/test/done-async.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
@@ -27,4 +27,54 @@ test("done() causes the test to fail when it should", async () => {
   expect(result.exitCode).toBe(1);
   expect(result.stderr.toString()).toContain(" 7 fail\n");
   expect(result.stderr.toString()).toContain(" 0 pass\n");
+});
+
+// A test that takes `done` and returns a promise completes when both settle.
+// An already-fulfilled promise must not end the test before done() is called.
+describe.each(["serial", "--concurrent"])("a returned fulfilled promise still waits for done() (%s)", mode => {
+  test("done() is awaited and done(err) fails its own test", async () => {
+    using dir = tempDir("done-and-promise", {
+      "done.test.ts": `
+        import { test, expect } from "bun:test";
+        test("never calls done", done => {
+          return Promise.resolve(1);
+        }, 50);
+        test("late done(err)", done => {
+          return Promise.resolve().then(() => {
+            setTimeout(() => {
+              try { expect(1).toBe(2); done(); } catch (e) { done(e); }
+            }, 10);
+          });
+        });
+        test("late done()", done => {
+          return Promise.resolve().then(() => {
+            setTimeout(() => done(), 10);
+          });
+        });
+        test("innocent", async () => {
+          await new Promise(resolve => setTimeout(resolve, 100));
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...(mode === "serial" ? [] : [mode]), "done.test.ts"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const lines = stderr.split("\n").filter(line => /^\((pass|fail)\)/.test(line));
+    // Under --concurrent a late done(err) is still reported between tests, not
+    // against its own test. That attribution is a separate fix.
+    const results = lines.map(line => line.replace(/ \[[\d.]+m?s\]$/, "")).sort();
+    expect(mode === "serial" ? results : results.filter(line => !line.endsWith("late done(err)"))).toEqual(
+      mode === "serial"
+        ? ["(fail) late done(err)", "(fail) never calls done", "(pass) innocent", "(pass) late done()"]
+        : ["(fail) never calls done", "(pass) innocent", "(pass) late done()"],
+    );
+    expect(stderr).toContain("timed out after 50ms, before its done callback was called");
+    expect(stderr).toContain("Expected: 2");
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/test/done-async.test.ts
+++ b/test/js/bun/test/done-async.test.ts
@@ -59,7 +59,7 @@ describe.each(["serial", "--concurrent"])("a returned fulfilled promise still wa
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", ...(mode === "serial" ? [] : [mode]), "done.test.ts"],
       cwd: String(dir),
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
       env: bunEnv,
     });


### PR DESCRIPTION
### Problem
- A test that takes a `done` parameter and returns an already-fulfilled promise passes at once. `done()` is never awaited. `test("x", done => Promise.resolve(1))` prints `(pass)`. A `done(err)` that arrives later is blamed on whichever test is running then: with `test("late", done => Promise.resolve().then(() => setTimeout(() => done(new Error("boom")), 30)))` the next test in the file fails and `late` passes.
- Cause: `BunTest::run_test_callback` (`src/runtime/test_runner/bun_test.rs:1242`). The `Fulfilled` arm returned `Some(cfg_data)` before the tail check at line 1260 that waits for the done callback. #22928 (0ea4ce1bb4) added that early return. Before it every returned promise went through `.then()` with the shared ref, so a fulfilled promise waited for `done()`.

### Fix
- Make the `Fulfilled` arm fall through to the existing tail check: `if dcb_ref.is_some() { return None }`. The done callback holds the only ref and adds the result when it is called, the same path a sync test body with a later `done()` takes.
- The `Rejected` arm is unchanged and now says so: it fails fast like `bun_test_catch`. A late `done(err)` after a rejection is an attribution problem in `bun_test_done_callback`, which #39112 fixes.
- Behaviour change: a test that takes `done`, returns a fulfilled promise, and never calls `done()` goes from an instant pass to the existing failure `timed out ..., before its done callback was called. If a done callback was not intended, remove the last parameter from the test callback function`. Jest rejects a test that takes `done` and returns a value. node's test runner fails it. Bun's documented shape (`test/js/bun/test/bun_test.fixture.ts`, "done combined with promise") is to wait for both.
- Verified: `test/js/bun/test/done-async.test.ts`, a new `describe.each` over serial and `--concurrent`. Both fail on main (the two broken tests print `(pass)`, `innocent` prints `(fail)`). Also ran `bun_test.test.ts`, `test-error-code-done-callback.test.ts`, `test-failing.test.ts`, `jest-hooks.test.ts`, `concurrent.test.ts`, and `test/js/node/test_runner/node-test.test.ts`.

### Background
- `RefData` is the runner's handle for "this test is still running". `run_test_callback` creates one when the callback takes `done` and returns a value. `bun_test_done_callback` and `bun_test_then_or_catch` each check `has_one_ref()` and only the last holder adds the result.
- Under `--concurrent` a late `done(err)` is still printed as `Unhandled error between tests` instead of failing its own test. That is the attribution bug #39112 fixes. The test here asserts only the exit code and the error text for that mode.

<details><summary>Notes</summary>

Repro on main:

```ts
import { test, expect } from "bun:test";
test("never_calls_done", done => { return Promise.resolve(1); });
test("late_done_err", done => {
  return Promise.resolve().then(() => {
    setTimeout(() => { try { expect(1).toBe(2); done(); } catch (e) { done(e); } }, 30);
  });
});
test("innocent", async () => { await new Promise(r => setTimeout(r, 100)); });
```

main: `(pass) never_calls_done`, `(pass) late_done_err`, `(fail) innocent`. With this branch: `never_calls_done` times out before its done callback, `late_done_err` fails with the `expect` error, `innocent` passes.

Self-reviewed: 3 concerns raised, 3 addressed (fall through to the tail check instead of a second guard, leave `Rejected` fail-fast with a comment, cite #22928 and #39112).
</details>
