### PR TITLE
node:http2: normalize outbound header objects like node

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1210,20 +1210,19 @@ class Http2ServerResponse extends Stream {
     const linkHeaderValue = validateLinkHeaderValue(hints.link);
     for (const key of ObjectKeys(hints)) {
       if (key !== "link") {
-        headers[key] = hints[key];
+        const name = key.trim().toLowerCase();
+        assertValidHeader(name, hints[key]);
+        if (!checkIsHttpToken(name)) {
+          throw $ERR_INVALID_HTTP_TOKEN("Header name", name);
+        }
+        headers[name] = hints[key];
       }
     }
     if (linkHeaderValue.length === 0) {
       return false;
     }
-    const stream = this[kStream];
-    if (stream.headersSent || this[kState].closed) return false;
-    stream.additionalHeaders({
-      ...headers,
-      [HTTP2_HEADER_STATUS]: HTTP_STATUS_EARLY_HINTS,
-      "Link": linkHeaderValue,
-    });
-    return true;
+    headers.Link = linkHeaderValue;
+    return this.writeInformation(HTTP_STATUS_EARLY_HINTS, headers);
   }
 }
 
@@ -2398,6 +2397,7 @@ class Http2Stream extends Duplex {
     // symbol keys, and deleting it here would flip the object into dictionary mode,
     // pessimizing every later property access on it.
     const sensitiveNames = buildSensitiveNames(headers, sensitives);
+    assertNoConnectionHeaders(headers);
     // node keeps the never-index list visible on sentTrailers (symbol keys are not iterated by
     // the wire-encoding path, so re-attaching is safe).
     if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
@@ -3466,6 +3466,7 @@ class ServerHttp2Stream extends Http2Stream {
     // Pre-validate single-value headers in JS so a throwing additionalHeaders() leaves no partial
     // state in the shared HPACK table (same rule request() applies).
     if (this[bunHTTP2Session]?.[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+    assertNoConnectionHeaders(headers);
     let hasStatus = true;
     if (headers[HTTP2_HEADER_STATUS] === undefined) {
       headers[HTTP2_HEADER_STATUS] = 200;
@@ -3577,6 +3578,7 @@ class ServerHttp2Stream extends Http2Stream {
     // Pre-validate single-value headers in JS so a throwing respond() leaves no partial state in
     // the shared HPACK table (same rule request() applies).
     if (session[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+    assertNoConnectionHeaders(headers);
     // node keeps the never-index list visible on sentHeaders (symbol keys are not iterated by the
     // wire-encoding path, so re-attaching is safe).
     if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
@@ -3758,13 +3760,21 @@ const kForbiddenConnectionHeaders = new SafeSet([
   "proxy-connection",
   "transfer-encoding",
 ]);
+// RFC 9113 §8.2.2 with node's mapToHeaders field rules. Only a `te` value is read, so a user
+// toString() runs once, in the native walk.
 function assertNoConnectionHeaders(headers): void {
-  for (const name in headers) {
-    const lower = name.toLowerCase();
-    if (kForbiddenConnectionHeaders.has(lower) || (lower === "te" && headers[name] !== "trailers")) {
-      const err = new TypeError(`HTTP/1 Connection specific headers are forbidden: "${lower}"`);
-      err.code = "ERR_HTTP2_INVALID_CONNECTION_HEADERS";
-      throw err;
+  const keys = ObjectKeys(headers);
+  for (let i = 0; i < keys.length; i++) {
+    let value = headers[keys[i]];
+    if (value === undefined || ($isArray(value) && value.length === 0)) continue;
+    const lower = keys[i].toLowerCase();
+    let forbidden = kForbiddenConnectionHeaders.has(lower);
+    if (!forbidden && lower === "te") {
+      if ($isArray(value) && value.length === 1) value = value[0];
+      forbidden = `${value}` !== "trailers";
+    }
+    if (forbidden) {
+      throw $ERR_HTTP2_INVALID_CONNECTION_HEADERS(`HTTP/1 Connection specific headers are forbidden: "${lower}"`);
     }
   }
 }
@@ -6031,7 +6041,8 @@ class ClientHttp2Session extends Http2Session {
         const headerNames = ObjectKeys(headers);
         for (let i = 0; i < headerNames.length; i++) {
           const name = headerNames[i];
-          if (name === "") continue;
+          // node's mapToHeaders skips an undefined value before it looks at the name.
+          if (name === "" || headers[name] === undefined) continue;
           if (name.charCodeAt(0) === 0x3a /* ':' */) {
             // Unknown pseudo-header names throw synchronously (node's mapToHeaders); known ones
             // are still re-checked by the native encoder at submission time.
@@ -6046,6 +6057,7 @@ class ClientHttp2Session extends Http2Session {
       // Validate single-value constraints before anything is encoded (a mid-encode throw would
       // desync the shared HPACK table from the peer).
       if (this[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+      assertNoConnectionHeaders(headers);
       // node keeps the never-index list visible on the request's sentHeaders (symbol keys are
       // not iterated by the wire-encoding path, so re-attaching is safe).
       if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
@@ -6113,14 +6125,18 @@ class ClientHttp2Session extends Http2Session {
         } else if (options.endStream === undefined) {
           options = { ...options, endStream: true };
         }
-        // nghttp2 refuses content-length on a request whose HEADERS carry END_STREAM (no payload
-        // can follow): reset with PROTOCOL_ERROR after creation (an async stream error, not a
-        // throw). An explicit endStream:false keeps the body legal, so only the ended case rejects.
+        // nghttp2 refuses a nonzero content-length on a request whose HEADERS carry END_STREAM
+        // (no payload can follow): reset with PROTOCOL_ERROR after creation (an async stream
+        // error, not a throw). `content-length: 0` matches the empty payload and goes through.
+        // An explicit endStream:false keeps the body legal, so only the ended case rejects.
         if (options.endStream) {
           for (const key of Object.keys(headers)) {
             if (key.toLowerCase() === "content-length") {
-              rejectContentLengthOnNoPayload = true;
-              break;
+              const value = headers[key];
+              if (value !== undefined && String(value) !== "0") {
+                rejectContentLengthOnNoPayload = true;
+                break;
+              }
             }
           }
         }

--- a/src/jsc/JSPropertyIterator.rs
+++ b/src/jsc/JSPropertyIterator.rs
@@ -7,9 +7,10 @@ use crate::{JSGlobalObject, JSObject, JSValue, JsResult};
 /// Runtime flag set passed to [`JSPropertyIterator::init`].
 ///
 /// `Default` is `own_properties_only = true`,
-/// `observable = true`, `only_non_index_properties = false`.
+/// `observable = true`, `only_non_index_properties = false`,
+/// `include_symbols = false`.
 // Runtime flags (not const generics) because the branches gate per-property work, not a
-// hot inner loop, and the monomorphization fan-out would be 32 instantiations. Profile
+// hot inner loop, and the monomorphization fan-out would be 64 instantiations. Profile
 // if hot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JSPropertyIteratorOptions {
@@ -18,10 +19,14 @@ pub struct JSPropertyIteratorOptions {
     pub own_properties_only: bool,
     pub observable: bool,
     pub only_non_index_properties: bool,
+    /// Also yield Symbol-keyed properties. The yielded name is the symbol's
+    /// description, not a property key, so this is only for callers that
+    /// count or display properties. Off by default, like `Object.keys`.
+    pub include_symbols: bool,
 }
 
 impl JSPropertyIteratorOptions {
-    /// Shorthand for the most common call-site shape; the remaining three
+    /// Shorthand for the most common call-site shape; the remaining
     /// options take the [`Default`] values.
     pub const fn new(skip_empty_name: bool, include_value: bool) -> Self {
         Self {
@@ -30,6 +35,7 @@ impl JSPropertyIteratorOptions {
             own_properties_only: true,
             observable: true,
             only_non_index_properties: false,
+            include_symbols: false,
         }
     }
 }
@@ -43,11 +49,12 @@ impl Default for JSPropertyIteratorOptions {
             own_properties_only: true,
             observable: true,
             only_non_index_properties: false,
+            include_symbols: false,
         }
     }
 }
 
-/// Two-field shorthand of [`JSPropertyIteratorOptions`]; the remaining three options
+/// Two-field shorthand of [`JSPropertyIteratorOptions`]; the remaining options
 /// take the default values via the `From` conversion.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PropertyIteratorOptions {
@@ -142,6 +149,7 @@ impl<'a> JSPropertyIterator<'a> {
             &mut len,
             options.own_properties_only,
             options.only_non_index_properties,
+            options.include_symbols,
         )?;
         if cfg!(debug_assertions) {
             if len > 0 {
@@ -250,6 +258,7 @@ impl JSPropertyIteratorImpl {
         count: &mut usize,
         own_properties_only: bool,
         only_non_index_properties: bool,
+        include_symbols: bool,
     ) -> JsResult<Option<NonNull<JSPropertyIteratorImpl>>> {
         // may return null without an exception
         let raw = from_js_host_call_generic(global_object, || {
@@ -259,6 +268,7 @@ impl JSPropertyIteratorImpl {
                 count,
                 own_properties_only,
                 only_non_index_properties,
+                include_symbols,
             )
         })?;
         Ok(NonNull::new(raw))
@@ -311,6 +321,7 @@ unsafe extern "C" {
         count: &mut usize,
         own_properties_only: bool,
         only_non_index_properties: bool,
+        include_symbols: bool,
     ) -> *mut JSPropertyIteratorImpl;
     safe fn Bun__JSPropertyIterator__getNameAndValue(
         iter: &mut JSPropertyIteratorImpl,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6445,6 +6445,7 @@ impl VirtualMachine {
                     own_properties_only: true,
                     observable: false,
                     only_non_index_properties: true,
+                    include_symbols: true,
                 },
             )?;
             let longest_name = iterator.get_longest_property_name().min(10);

--- a/src/jsc/bindings/JSPropertyIterator.cpp
+++ b/src/jsc/bindings/JSPropertyIterator.cpp
@@ -36,7 +36,7 @@ public:
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSPropertyIterator);
 };
 
-extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, size_t* count, bool own_properties_only, bool only_non_index_properties)
+extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, size_t* count, bool own_properties_only, bool only_non_index_properties, bool include_symbols)
 {
     auto& vm = JSC::getVM(globalObject);
     JSC::JSValue value = JSValue::decode(encodedValue);
@@ -45,7 +45,11 @@ extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObje
     ASSERT(count);
 
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::PropertyNameArrayBuilder array(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+    // The iterator yields every name as a string. A Symbol key has no string
+    // name: its impl() is the description, so `Symbol.for("s")` would come
+    // out as the key "s". Only callers that merely count or display
+    // properties opt in to symbols.
+    JSC::PropertyNameArrayBuilder array(vm, include_symbols ? PropertyNameMode::StringsAndSymbols : PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
 
     if (object->hasNonReifiedStaticProperties()) [[unlikely]] {
         object->reifyAllStaticProperties(globalObject);

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -148,6 +148,7 @@ const PROP_ITER_OPTS: JSPropertyIteratorOptions = JSPropertyIteratorOptions {
     own_properties_only: true,
     observable: true,
     only_non_index_properties: false,
+    include_symbols: false,
 };
 
 impl Config {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5777,7 +5777,7 @@ impl H2FrameParser {
         let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
 
         while let Some((header_name, js_value)) = iter.next()? {
-            if header_name.length() == 0 {
+            if header_name.length() == 0 || js_value.is_undefined() {
                 continue;
             }
 
@@ -5795,13 +5795,6 @@ impl H2FrameParser {
                 return Err(global_object.throw_value(exception));
             }
 
-            if js_value.is_undefined_or_null() {
-                let exception = global_object.to_type_error(
-                    bun_jsc::ErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                    format_args!("Invalid value for header \"{}\"", BStr::new(name)),
-                );
-                return Err(global_object.throw_value(exception));
-            }
             let validated_name = match Self::to_valid_header_name(name, &mut name_buffer[..]) {
                 Ok(n) => n,
                 Err(_) => {
@@ -5849,17 +5842,6 @@ impl H2FrameParser {
                 }
 
                 while let Some(item) = value_iter.next()? {
-                    if item.is_empty_or_undefined_or_null() {
-                        let exception = global_object.to_type_error(
-                            bun_jsc::ErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                            format_args!(
-                                "Invalid value for header \"{}\"",
-                                BStr::new(validated_name)
-                            ),
-                        );
-                        return Err(global_object.throw_value(exception));
-                    }
-
                     let value_view = item.to_js_string_view(global_object)?;
 
                     // All-digit names can't be passed to get_truthy (integer-index-like names
@@ -5906,6 +5888,23 @@ impl H2FrameParser {
                 let value_bytes = header_value_bytes(&value_view);
                 collect(value_bytes.as_ref(), never_index)?;
             }
+        }
+
+        // Every field was skipped (undefined values): nghttp2 peers reject a zero-length header
+        // block, so end the stream the way noTrailers() does, with an empty DATA frame.
+        if pending.fields.is_empty() {
+            stream.wait_for_trailers = false;
+            let _ = this.send_data(
+                &mut stream,
+                b"",
+                JSValue::UNDEFINED,
+                SendDataOptions {
+                    close: true,
+                    suppress_half_closed_local_dispatch: false,
+                    defer_write_callback: false,
+                },
+            );
+            return Ok(JSValue::UNDEFINED);
         }
 
         let mut encoded_headers: Vec<u8> = Vec::new();
@@ -6236,7 +6235,7 @@ impl H2FrameParser {
                 },
             )?;
             while let Some((header_name, js_value)) = iter.next()? {
-                if header_name.length() == 0 {
+                if header_name.length() == 0 || js_value.is_undefined() {
                     continue;
                 }
                 let name_slice = header_name.to_utf8();
@@ -6270,9 +6269,6 @@ impl H2FrameParser {
                             .throw());
                     }
                 } else if ignore_pseudo_headers == 0 {
-                    continue;
-                }
-                if js_value.is_empty_or_undefined_or_null() {
                     continue;
                 }
                 // All-digit names can't be passed to get_truthy (integer-index-like names trip
@@ -6323,17 +6319,6 @@ impl H2FrameParser {
                         single_value_headers[idx] = true;
                     }
                     while let Some(item) = value_iter.next()? {
-                        if item.is_empty_or_undefined_or_null() {
-                            return Err(global_object
-                                .err(
-                                    JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                    format_args!(
-                                        "Invalid value for header \"{}\"",
-                                        BStr::new(validated_name)
-                                    ),
-                                )
-                                .throw());
-                        }
                         collect_value(item)?;
                     }
                 } else {
@@ -6789,7 +6774,7 @@ impl H2FrameParser {
             )?;
 
             while let Some((header_name, js_value)) = iter.next()? {
-                if header_name.length() == 0 {
+                if header_name.length() == 0 || js_value.is_undefined() {
                     continue;
                 }
 
@@ -6844,14 +6829,6 @@ impl H2FrameParser {
                     continue;
                 }
 
-                if js_value.is_undefined_or_null() {
-                    let exception = global_object.to_type_error(
-                        bun_jsc::ErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                        format_args!("Invalid value for header \"{}\"", BStr::new(name)),
-                    );
-                    return Err(global_object.throw_value(exception));
-                }
-
                 if js_value.js_type().is_array() {
                     bun_output::scoped_log!(H2FrameParser, "array header {}", BStr::new(name));
                     let mut value_iter = js_value.array_iterator(global_object)?;
@@ -6871,18 +6848,6 @@ impl H2FrameParser {
                     }
 
                     while let Some(item) = value_iter.next()? {
-                        if item.is_empty_or_undefined_or_null() {
-                            return Err(global_object
-                                .err(
-                                    JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                    format_args!(
-                                        "Invalid value for header \"{}\"",
-                                        BStr::new(validated_name)
-                                    ),
-                                )
-                                .throw());
-                        }
-
                         let value_view = item.to_js_string_view(global_object)?;
 
                         let never_index = if Self::is_index_like_name(validated_name) {
@@ -6912,7 +6877,7 @@ impl H2FrameParser {
                                 .throw(format_args!("Failed to allocate header buffer")));
                         }
                     }
-                } else if !js_value.is_empty_or_undefined_or_null() {
+                } else {
                     bun_output::scoped_log!(H2FrameParser, "single header {}", BStr::new(name));
                     if let Some(idx) = this.single_value_index_checked(validated_name) {
                         if single_value_headers[idx] {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1333,6 +1333,7 @@ impl Expect {
                     own_properties_only: false,
                     observable: true,
                     only_non_index_properties: false,
+                    include_symbols: false,
                 },
             )?;
 

--- a/src/runtime/test_runner/expect/toBeEmpty.rs
+++ b/src/runtime/test_runner/expect/toBeEmpty.rs
@@ -54,6 +54,9 @@ pub(crate) fn to_be_empty(
                         skip_empty_name: false,
                         own_properties_only: false,
                         include_value: true,
+                        // jest-extended compares against `{}` with an equality
+                        // that sees enumerable Symbol keys, so count them too.
+                        include_symbols: true,
                         // FIXME: can we do this?
                         ..Default::default()
                     },

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -12,6 +12,7 @@ import defaultMacro, {
   identity as identity1,
   identity as identity2,
   ireturnapromise,
+  symbolKeys,
 } from "./macro.ts" assert { type: "macro" };
 
 import * as macros from "./macro.ts" assert { type: "macro" };
@@ -36,6 +37,14 @@ test("type coercion", () => {
   expect(identity(1.5)).toBe(1.5);
   expect(identity(1)).toBe(1);
   expect(identity(true)).toBe(true);
+});
+
+// A Symbol key has no source form. The inlined object keeps the string keys
+// only, like JSON.stringify, instead of a string key named by the description.
+test("object with Symbol keys", () => {
+  const value = symbolKeys();
+  expect(value).toEqual({ v: 2 });
+  expect(Reflect.ownKeys(value)).toEqual(["v"]);
 });
 
 test("escaping", () => {

--- a/test/bundler/transpiler/macro.ts
+++ b/test/bundler/transpiler/macro.ts
@@ -23,3 +23,7 @@ export async function ireturnapromise() {
   setTimeout(() => resolve("aaa"), 100);
   return promise;
 }
+
+export function symbolKeys() {
+  return { v: 2, [Symbol.for("s")]: 1, [Symbol("d")]: 3, [Symbol()]: 4 };
+}

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
-import { test } from "bun:test";
-import { bunExe } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("spawn env", async () => {
   const env = {};
@@ -21,4 +21,18 @@ test("spawn env", async () => {
       });
     } catch (e) {}
   }
+});
+
+// A Symbol key is not an environment variable name. It used to reach the
+// child as a variable named by the symbol description.
+test("spawn env skips Symbol keys", async () => {
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", "console.log(JSON.stringify([process.env.SYMKEY ?? null, process.env.PLAIN]))"],
+    env: { ...bunEnv, PLAIN: "1", [Symbol("SYMKEY")]: "leaked" },
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe('[null,"1"]\n');
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -4302,8 +4302,8 @@ refs:
           normalKey: "normal value",
           symbolValue: sym,
         };
-        // Symbol keys are not enumerable, symbol values are undefined
-        expect(YAML.stringify(obj, null, 2)).toBe("normalKey: normal value\ntest: symbol key value");
+        // Symbol keys are skipped (like JSON.stringify), symbol values are undefined
+        expect(YAML.stringify(obj, null, 2)).toBe("normalKey: normal value");
       });
 
       test("handles WeakMap and WeakSet", () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1799,6 +1799,39 @@ it("sensitive headers should work", async () => {
   }
 });
 
+// The never-index list lives under a Symbol key of the headers object. The
+// native header walk must skip Symbol keys. It used to send them as headers
+// named by the symbol description ("nodejs.http2.sensitiveheaders: cookie").
+it("Symbol keys of the headers object are not sent as headers", async () => {
+  const server = http2.createServer((req, res) => {
+    res.end(JSON.stringify(Object.keys(req.headers).filter(name => !name.startsWith(":"))));
+  });
+  let client;
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    server.listen(0, () => {
+      client = http2.connect(`http://localhost:${server.address().port}`);
+      client.on("error", reject);
+      const req = client.request({
+        ":path": "/",
+        cookie: "a=b",
+        [http2.sensitiveHeaders]: ["cookie"],
+        [Symbol("local")]: "v",
+      });
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", chunk => (body += chunk));
+      req.on("end", () => resolve(body));
+      req.on("error", reject);
+      req.end();
+    });
+    expect(JSON.parse(await promise)).toEqual(["cookie"]);
+  } finally {
+    server.close();
+    client?.close?.();
+  }
+});
+
 it("http2 session.goaway() validates input types", async done => {
   const { mustCall } = createCallCheckCtx(done);
   const server = http2.createServer((req, res) => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4487,6 +4487,9 @@ it("http2 pushStream sends each element of a single-value header when strictSing
   ]);
 });
 
+// The first push is rejected after a valid field ("ok") was already walked. The rejected
+// block must not advance the shared HPACK table, or the second push (the same "ok", node
+// stringifies null like `${null}`) fails the session with COMPRESSION_ERROR.
 it("http2 pushStream reports an unsendable array element through the callback", async () => {
   const results = [];
   const blocks = await pushedHeaderBlocks(stream => {
@@ -4515,8 +4518,16 @@ it("http2 pushStream reports an unsendable array element through the callback", 
     code: "ERR_HTTP2_INVALID_HEADER_VALUE",
     message: 'Invalid value for header "x-custom"',
   };
-  expect(results).toEqual([invalidValue, invalidValue]);
-  expect(blocks).toEqual([]);
+  expect(results).toEqual([invalidValue, "pushed"]);
+  expect(blocks).toEqual([
+    {
+      id: 4,
+      path: "/pushed",
+      sensitive: [],
+      headers: { "x-custom": "ok, null" },
+      fields: ["x-custom", "ok", "x-custom", "null"],
+    },
+  ]);
 });
 
 // Every kind of field name the native header-block materializer distinguishes, in one request and
@@ -6036,15 +6047,13 @@ describe("http2 a header call that throws leaves the HPACK encoder in sync with 
       error: "ERR_HTTP2_INVALID_HEADER_VALUE",
     },
     "invalid name": { headers: { "x-a": "AAAA", "x-b": "BBBB", "bad name": "v" }, error: "ERR_INVALID_HTTP_TOKEN" },
-    "null value": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-n": null }, error: "ERR_HTTP2_INVALID_HEADER_VALUE" },
     "symbol value": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-s": Symbol("s") }, error: "TypeError" },
     "throwing toString": { headers: { "x-a": "AAAA", "x-b": "BBBB", "x-t": throwingToString }, error: "BOOM" },
   };
   const kinds = Object.keys(poisons);
   // respond() drops a string value with CR/LF/NUL instead of throwing, so those two kinds do not
-  // apply to it. pushStream() skips a null value (node's mapToHeaders does the same).
+  // apply to it.
   const respondKinds = kinds.filter(k => k !== "invalid value" && k !== "invalid array element");
-  const pushKinds = kinds.filter(k => k !== "null value");
   const errorOf = err => err.code ?? err.constructor.name;
   const cleanResponse = { ":status": 200, "x-clean": "clean-value", "content-type": "text/plain" };
 
@@ -6262,7 +6271,7 @@ describe("http2 a header call that throws leaves the HPACK encoder in sync with 
     );
   });
 
-  it.each(pushKinds)("pushStream() that fails on an %s", async kind => {
+  it.each(kinds)("pushStream() that fails on an %s", async kind => {
     const pushErrors = [];
     await withServer(
       (stream, headers) => {
@@ -6330,5 +6339,182 @@ describe("http2 a header call that throws leaves the HPACK encoder in sync with 
         expect(sessionErrors).toEqual([]);
       },
     );
+  });
+});
+
+// Header-object faces node's mapToHeaders normalizes in JS before nghttp2 sees the block:
+// undefined skipped, null and array items stringified, connection-specific fields rejected up
+// front. The sensitiveHeaders row checks the marked field itself still arrives.
+describe("header object normalization matches node", () => {
+  const nonPseudo = headers =>
+    Object.fromEntries(Object.entries(headers).filter(([k]) => !k.startsWith(":") && k !== "date"));
+
+  async function roundTrip({ respond, request = {}, trailers }) {
+    const server = http2.createServer();
+    let requestHeaders;
+    server.on("stream", (stream, headers) => {
+      requestHeaders = nonPseudo(headers);
+      stream.respond(respond ?? { ":status": 200 }, trailers ? { waitForTrailers: true } : undefined);
+      if (trailers) stream.on("wantTrailers", () => stream.sendTrailers(trailers));
+      stream.end("ok");
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      try {
+        const req = client.request({ ":path": "/", ...request });
+        const { promise, resolve, reject } = Promise.withResolvers();
+        let responseHeaders;
+        let trailerHeaders;
+        req.on("response", h => (responseHeaders = nonPseudo(h)));
+        req.on("trailers", h => (trailerHeaders = nonPseudo(h)));
+        req.on("error", reject);
+        req.resume();
+        req.on("end", resolve);
+        req.end();
+        await promise;
+        return { requestHeaders, responseHeaders, trailerHeaders };
+      } finally {
+        client.destroy();
+      }
+    } finally {
+      server.close();
+    }
+  }
+
+  const faces = {
+    "x-undefined": undefined,
+    "x-null": null,
+    "x-array": ["1", undefined, null, "2"],
+    "x-empty-array": [],
+    "x-secret": "s3cret",
+    [http2.sensitiveHeaders]: ["x-secret"],
+    "x-ok": "ok",
+  };
+  const expected = {
+    "x-null": "null",
+    "x-array": "1, undefined, null, 2",
+    "x-secret": "s3cret",
+    "x-ok": "ok",
+  };
+
+  it("client.request() headers", async () => {
+    const { requestHeaders } = await roundTrip({ request: faces });
+    expect(requestHeaders).toEqual(expected);
+  });
+
+  it("stream.respond() headers", async () => {
+    const { responseHeaders } = await roundTrip({ respond: { ":status": 200, ...faces } });
+    expect(responseHeaders).toEqual(expected);
+  });
+
+  it("stream.sendTrailers() headers", async () => {
+    const { trailerHeaders } = await roundTrip({ trailers: faces });
+    expect(trailerHeaders).toEqual(expected);
+  });
+
+  it("a trailer object whose every value is undefined ends the stream without a trailer block", async () => {
+    const { trailerHeaders, responseHeaders } = await roundTrip({ trailers: { "grpc-message": undefined } });
+    expect(responseHeaders).toEqual({});
+    expect(trailerHeaders).toBeUndefined();
+  });
+
+  it("an undefined value or an empty array is not a field, whatever the name", async () => {
+    const { requestHeaders } = await roundTrip({
+      request: { "bad name": undefined, ":bogus": undefined, connection: [], te: [], "x-ok": "ok" },
+    });
+    expect(requestHeaders).toEqual({ "x-ok": "ok" });
+  });
+
+  // The rejected block had already walked "x-a: ok". It must not advance the shared HPACK
+  // table, or the next request (which repeats "x-a: ok") fails the session with COMPRESSION_ERROR.
+  it("a request rejected for an invalid value leaves the session usable", async () => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      try {
+        const outcome = headers =>
+          new Promise(resolve => {
+            const req = client.request({ ":path": "/", ...headers });
+            let status;
+            req.on("response", h => (status = h[":status"]));
+            req.on("error", e => resolve(e.code));
+            req.on("end", () => resolve(status));
+            req.resume();
+            req.end();
+          });
+        expect(await outcome({ "x-a": "ok", "x-b": "a\nb" })).toBe("ERR_HTTP2_INVALID_HEADER_VALUE");
+        expect(await outcome({ "x-a": "ok" })).toBe(200);
+        expect(await outcome({ "x-a": "ok" })).toBe(200);
+      } finally {
+        client.destroy();
+      }
+    } finally {
+      server.close();
+    }
+  });
+
+  it("content-length: 0 on a GET is sent as is", async () => {
+    const { requestHeaders } = await roundTrip({ request: { "content-length": 0 } });
+    expect(requestHeaders).toEqual({ "content-length": "0" });
+  });
+
+  it("connection-specific headers throw ERR_HTTP2_INVALID_CONNECTION_HEADERS synchronously", async () => {
+    const server = http2.createServer();
+    const serverErrors = [];
+    server.on("stream", stream => {
+      for (const headers of [{ connection: "close" }, { te: "gzip" }, { te: ["trailers", "gzip"] }]) {
+        try {
+          stream.respond({ ":status": 200, ...headers });
+          serverErrors.push("no error");
+        } catch (e) {
+          serverErrors.push(e.code);
+        }
+      }
+      stream.respond({ ":status": 200, te: "trailers" });
+      stream.end("ok");
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      try {
+        const clientErrors = [];
+        for (const headers of [
+          { Connection: "keep-alive" },
+          { upgrade: "h2c" },
+          { "transfer-encoding": "chunked" },
+          { te: "gzip" },
+        ]) {
+          try {
+            client.request({ ":path": "/", ...headers });
+            clientErrors.push("no error");
+          } catch (e) {
+            clientErrors.push(e.code);
+          }
+        }
+        expect(clientErrors).toEqual(Array(4).fill("ERR_HTTP2_INVALID_CONNECTION_HEADERS"));
+
+        const req = client.request({ ":path": "/", te: "trailers" });
+        const { promise, resolve, reject } = Promise.withResolvers();
+        let status;
+        req.on("response", h => (status = h[":status"]));
+        req.on("error", reject);
+        req.resume();
+        req.on("end", resolve);
+        req.end();
+        await promise;
+        expect(status).toBe(200);
+        expect(serverErrors).toEqual(Array(3).fill("ERR_HTTP2_INVALID_CONNECTION_HEADERS"));
+      } finally {
+        client.destroy();
+      }
+    } finally {
+      server.close();
+    }
   });
 });


### PR DESCRIPTION
Stacked on #41520 (the base branch of this PR). Merge #41520 first. The first commit is a cherry-pick of #41910 (already on main) and disappears once the base branch is rebased past it.

### Problem
- The native header walks in `src/runtime/api/bun/h2_frame_parser.rs` (`request`, `push_promise`, `send_trailers`) read the user's header object field by field. Node normalizes the whole object in JS first (`mapToHeaders`). Three results differ from node v26: an `undefined` value throws `ERR_HTTP2_INVALID_HEADER_VALUE` (node skips the field), `null` throws (node sends `"null"`), and an array item that is `undefined` or `null` throws (node sends `"undefined"` or `"null"`). A node client gets `ERR_HTTP2_INVALID_HEADER_VALUE` or a 500 where node to node gets a 200.
- Three smaller drifts: connection-specific headers (`connection`, `te: gzip`) go on the wire and the peer resets the stream (node throws `ERR_HTTP2_INVALID_CONNECTION_HEADERS` at once), a client request with `content-length: 0` is reset before it is sent (`http2.ts` rejected every content-length on an ended request, nghttp2 rejects only a nonzero one), and `writeEarlyHints` accepted `undefined` values and invalid tokens.

### Fix
- The walks skip an `undefined` value and stringify `null` and array items the way `${value}` does. A trailer object whose every value is `undefined` ends the stream with an empty DATA frame (the `noTrailers()` shape), because nghttp2 peers reject a zero-length header block.
- `assertNoConnectionHeaders` has node's `te` rules (an empty array is no field, a one-element array is its element, only a `te` value is read) and runs from `request()`, `respond()`, `additionalHeaders()` and `sendTrailers()`. The content-length check reads the value. `writeEarlyHints` validates like node v26.
- Correct because each case now produces the bytes node v26.3.0 produces, with node as the observing peer in both directions (probe table in the notes).
- Verified: `test/js/node/http2/node-http2.test.js` (8 new tests, all fail on 1.4.3). Also the rest of `test/js/node/http2/`, `h2-conformance.test.ts`, and node's 256 `test-http2-*.js` files.

### Background
- `mapToHeaders` (`lib/internal/http2/util.js` in node) is the one JS function that turns a header object into the flat list nghttp2 encodes. It skips `undefined` and empty arrays, stringifies everything else, and rejects connection-specific fields (RFC 9113 §8.2.2) before anything reaches the encoder.
- The HPACK dynamic table is shared by every stream on a connection. #41520 makes the walks collect and validate every field before the first encode. This PR needs that: with per-field encoding, a field stringified or skipped after an earlier field was encoded could leave the table ahead of the peer when a later field throws.
- `http2.sensitiveHeaders` is a symbol key on the header object. #41910 keeps symbol keys off the wire, so this PR no longer carries its own iterator option.

Supersedes #37953 (undefined values) and #33458 (connection headers), both closed. This PR also records the `null` decision: `null` is sent as `"null"`, like node, which retires the pushStream exception noted in #37579.

<details><summary>Notes</summary>

Probe: `stream.respond()` / `client.request()` with each header face, node v26.3.0 against bun 1.4.3 and this branch, bun to bun and bun client to node server.

| face | node | bun 1.4.3 | this PR |
| --- | --- | --- | --- |
| `{"x-a": undefined, "x-b": "ok"}` | `x-b: ok` | throws `ERR_HTTP2_INVALID_HEADER_VALUE` | `x-b: ok` |
| `{"x-a": null}` | `x-a: null` | throws | `x-a: null` |
| `{"x-a": ["1", undefined, "2"]}` | `1, undefined, 2` | throws | `1, undefined, 2` |
| `{connection: "keep-alive"}` | throws `ERR_HTTP2_INVALID_CONNECTION_HEADERS` | peer RST, `ERR_HTTP2_STREAM_ERROR` | throws |
| `{te: "gzip"}` | throws | peer RST | throws |
| `{connection: []}`, `{te: []}` | no field | no field | no field |
| GET with `content-length: 0` | 200 | `ERR_HTTP2_STREAM_ERROR` (rst 1) | 200 |
| GET with `content-length: 5` | `ERR_HTTP2_STREAM_ERROR` (rst 1) | same | same |
| `sendTrailers({"grpc-message": undefined})` | stream ends, no trailers | throws | stream ends, no trailers |

The one remaining difference is a value with CR, LF or NUL on `client.request()`: node sends it and the receiving nghttp2 drops the field, bun throws `ERR_HTTP2_INVALID_HEADER_VALUE`. That is an existing decision (see the pushStream CR/LF test) and this PR keeps it.

The pushStream test "reports an unsendable array element through the callback" used `["ok", null]` as a second poison. Under node semantics that push succeeds with `x-custom: ok` and `x-custom: null`, and the test now asserts the pushed block. The `"null value"` row of the #41520 poison matrix is removed for the same reason.

The raw `[name, value, ...]` header form of `request()` keeps its current rule (an `undefined` or `null` value skips the pair). Node has no raw form for `request()`.

Review history: an all-undefined trailer object produced a zero-length HEADERS frame (now the empty DATA path), `{connection: []}` threw (an empty array is now no field for any name), the request() name pre-check ran on undefined values (now skipped first, like mapToHeaders), the error bypassed the `$ERR_` codegen (now uses it), and the JS check coerced every value so a user `toString()` ran twice (now only a `te` value is read; `h2-conformance.test.ts` covers the single call).

Earlier shape: this branch first carried its own `include_symbols` iterator option and a duplicate of the collect-then-encode change. Both were dropped in favour of #41910 and #41520.

Suites run with the debug build: `bun bd test test/js/node/http2/` and node's `test/js/node/test/parallel/test-http2-*.js` (256 pass).
</details>
