### PR TITLE
Bun.serve: register HTML import outputs under their percent-encoded path

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -617,14 +617,15 @@ impl Route {
                     {
                         route_path = &route_path[1..];
                     }
+                    let route_path = crate::server::percent_encode_route_path(route_path);
 
                     if i == html_index {
-                        this_html_route = Some((static_route, Box::<[u8]>::from(route_path)));
+                        this_html_route = Some((static_route, Box::<[u8]>::from(&*route_path)));
                         continue;
                     }
 
                     bun_core::handle_oom(server.append_static_route(
-                        route_path,
+                        &route_path,
                         AnyRoute::Static(RefPtr::new(static_route)),
                         MethodOptional::Any,
                     ));

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -161,6 +161,35 @@ pub(crate) fn write_status<const SSL: bool>(resp: *mut uws_sys::NewAppResponse<S
 }
 
 // ─── AnyRoute ────────────────────────────────────────────────────────────────
+
+/// An output file's path as a browser puts it on the request line: every
+/// byte in the WHATWG URL path percent-encode set is escaped. The URL written
+/// into the page is the raw name, and the browser encodes it before the
+/// request, so the route must be registered under the encoded form.
+pub(crate) fn percent_encode_route_path(path: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+    fn needs_escape(byte: u8) -> bool {
+        byte < 0x20
+            || byte >= 0x7F
+            || matches!(
+                byte,
+                b' ' | b'"' | b'#' | b'<' | b'>' | b'?' | b'`' | b'{' | b'}'
+            )
+    }
+    if !path.iter().copied().any(needs_escape) {
+        return std::borrow::Cow::Borrowed(path);
+    }
+    let mut out = Vec::with_capacity(path.len() + 16);
+    for &byte in path {
+        if needs_escape(byte) {
+            let hex = bun_core::fmt::hex2_upper(byte);
+            out.extend_from_slice(&[b'%', hex[0], hex[1]]);
+        } else {
+            out.push(byte);
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
 /// The route table's ref on each route.
 pub enum AnyRoute {
     /// Serve a static file — `"/robots.txt": new Response(...)`

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -627,7 +627,7 @@ impl AnyRoute {
         if !relative_path.starts_with(b"/") {
             builder.push(b'/');
         }
-        builder.extend_from_slice(relative_path);
+        builder.extend_from_slice(&super::percent_encode_route_path(relative_path));
 
         let Some(headers_js) = argument.get(init_ctx.global, b"headers")? else {
             return Ok(None);

--- a/test/bundler/bundler_html_server.test.ts
+++ b/test/bundler/bundler_html_server.test.ts
@@ -121,5 +121,44 @@ describe.concurrent("bundler", () => {
         stdout: "Home status: 200\nHome has content: true\nAbout status: 200\nAbout has content: true",
       },
     });
+
+    // The page carries the raw asset name. A browser percent-encodes it
+    // before the request, so the route is registered under that form.
+    itBundled(`compile/${backend}/HTMLServerEncodedAssetRoute`, {
+      compile: true,
+      backend: backend,
+      files: {
+        "/entry.ts": /* js */ `
+        import index from "./index.html";
+
+        using server = Bun.serve({
+          port: 0,
+          routes: {
+            "/": index,
+          },
+        });
+
+        const html = await (await fetch(server.url)).text();
+        for (const [, src] of html.matchAll(/<img src="([^"]+)"/g)) {
+          const url = new URL(src, server.url);
+          console.log(url.pathname.replace(/-[a-z0-9]+\.png$/, ".png"), (await fetch(url)).status);
+        }
+      `,
+        "/index.html": /* html */ `
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <img src="./my img.png">
+            <img src="./ünï.png">
+          </body>
+        </html>
+      `,
+        "/my img.png": "fake png",
+        "/ünï.png": "fake png",
+      },
+      run: {
+        stdout: "/my%20img.png 200\n/%C3%BCn%C3%AF.png 200",
+      },
+    });
   }
 });

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1606,3 +1606,33 @@ describe("production headers and import.meta.env", () => {
     expect(results).toEqual(cases.map(([, , expected]) => expected));
   });
 });
+
+// The page carries the raw asset name. A browser percent-encodes it before
+// the request, so the production build registers the route under that form.
+test.concurrent("production build serves an asset whose name has a space or non-ASCII", async () => {
+  using dir = tempDir("bun-serve-html-encoded-asset-route", {
+    "index.html": `<!DOCTYPE html><html><body><img src="./my img.png"><img src="./ünï.png"><script type="module" src="./app.ts"></script></body></html>`,
+    "my img.png": "fake png",
+    "ünï.png": "fake png",
+    "app.ts": `console.log("app");`,
+    "serve.ts": /*ts*/ `
+      import page from "./index.html";
+      using server = Bun.serve({ port: 0, development: false, routes: { "/": page } });
+      const html = await (await fetch(server.url)).text();
+      const result = [];
+      for (const [, src] of html.matchAll(/<img src="([^"]+)"/g)) {
+        const url = new URL(src, server.url);
+        result.push([src, url.pathname, (await fetch(url)).status]);
+      }
+      console.log(JSON.stringify(result));
+    `,
+  });
+  const { stdout, stderr, exitCode } = await runServeFixture(dir);
+  expect({ result: stdout === "" ? null : JSON.parse(stdout), exitCode }, stderr).toEqual({
+    result: [
+      [expect.stringMatching(/^\/my img-[a-z0-9]+\.png$/), expect.stringMatching(/^\/my%20img-[a-z0-9]+\.png$/), 200],
+      [expect.stringMatching(/^\/ünï-[a-z0-9]+\.png$/), expect.stringMatching(/^\/%C3%BCn%C3%AF-[a-z0-9]+\.png$/), 200],
+    ],
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### Problem
- A production `Bun.serve` HTML import (and a compiled executable) serves an asset whose name has a space or a non-ASCII character as a 404. The page says `src="/my img-24bdys0j.png"`. The browser requests `/my%20img-24bdys0j.png`. Only the raw bytes `/my img-24bdys0j.png` match. The dev server is not affected, it serves `/_bun/asset/<hash>.png`.
- The cause: `HTMLBundle.rs:613` and `server_body.rs:620` key the static route on the raw `dest_path`. The router compares request-target bytes as-is.

### Fix
- `percent_encode_route_path` (`src/runtime/server/mod.rs`) encodes a path the way a browser does before a request: the WHATWG URL path percent-encode set (C0 controls, space, `"`, `#`, `<`, `>`, `?`, `` ` ``, `{`, `}`, DEL and non-ASCII), upper-case hex. Both registration sites use it.
- Correct because the page keeps the raw name, which is valid HTML, and every browser encodes the same way. The route key now equals the request target. It does not change the router or the matcher. A name with no byte in the set is registered unchanged (`Cow::Borrowed`).
- Verified: `test/js/bun/http/bun-serve-html.test.ts` (production build, space and `ünï`) and `test/bundler/bundler_html_server.test.ts` (`HTMLServerEncodedAssetRoute`, compiled, both backends). Both fail on 1.4.3 with 404. Also ran `bun-serve-routes.test.ts`, `bun-serve-static.test.ts`, `bundler_html.test.ts`.

### Background
- A production HTML import bundles once, then registers one static route per output file (JS, CSS, copied assets, the page) on the server. The page is served under the route it was mounted on.
- A compiled executable (`bun build --compile`) embeds the same outputs and registers them from the HTML import manifest at server start. That is the second site.
- The router matches the request target against the route key byte for byte. It does not percent-decode. This PR does not change that. It makes the keys for bun's own outputs match what browsers send.

<details><summary>Notes</summary>

Repro on 1.4.3:

```sh
D=$(mktemp -d); cd $D
printf '<!doctype html><html><body><img src="./my img.png"><img src="./ünï.png"><script type="module" src="./app.ts"></script></body></html>' > index.html
printf 'PNG' > "my img.png"; cp "my img.png" "ünï.png"; echo 'export{}' > app.ts
cat > serve.mjs <<'JS'
import p from "./index.html";
const s = Bun.serve({ port: 0, development: false, routes: { "/": p }, fetch: () => new Response("no route", { status: 404 }) });
const h = await (await fetch(s.url)).text();
for (const m of h.matchAll(/src="(\/[^"]+\.png)"/g)) console.log(m[1], "->", encodeURI(m[1]), (await fetch(s.url.origin + encodeURI(m[1]))).status);
s.stop(true);
JS
bun serve.mjs
# /my img-24bdys0j.png -> /my%20img-24bdys0j.png 404
# /ünï-24bdys0j.png -> /%C3%BCn%C3%AF-24bdys0j.png 404
```

With this change both return 200. `bun build --compile serve.mjs` had the same two 404s and returns 200 with this change.

`bun_core::percent_encode_write` was not reused on purpose. Its escape set is the one for source map URLs: it does not escape a space and it escapes `%`, `~`, `[`, `]`, `|`, `^`, `\`. A browser leaves those as they are in a path.

`#` and `?` in an output name are escaped like the rest of the set, but a browser parses them as the fragment and the query, so such a name stays unreachable either way. That is a naming problem, not a route problem.

The PRs for the router side (#35249, #33096) normalize every request target. This change is independent of them: it only changes the keys bun registers for its own outputs.

Found by a fuzz pass over HTML import reference kinds. No user report.
</details>
