### PR TITLE
bundler(html): decode a src/href URL before resolving the file it names

### DIFF
--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -67,11 +67,99 @@ impl<'a> HTMLScanner<'a> {
     }
 }
 
+/// The code point named by the `&name;` character reference, for the names
+/// that can appear in a URL attribute: `amp`, `lt`, `gt`, `quot`, `apos`
+/// and the numeric forms `#NNN` / `#xHH`.
+fn char_ref_code_point(name: &[u8]) -> Option<u32> {
+    let cp = match name {
+        b"amp" => '&' as u32,
+        b"lt" => '<' as u32,
+        b"gt" => '>' as u32,
+        b"quot" => '"' as u32,
+        b"apos" => '\'' as u32,
+        [b'#', b'x' | b'X', hex @ ..] if !hex.is_empty() => {
+            u32::from_str_radix(core::str::from_utf8(hex).ok()?, 16).ok()?
+        }
+        [b'#', dec @ ..] if !dec.is_empty() => core::str::from_utf8(dec).ok()?.parse().ok()?,
+        _ => return None,
+    };
+    (cp != 0 && cp <= 0x10FFFF).then_some(cp)
+}
+
+/// True for `scheme:...` (RFC 3986 scheme syntax) and for `//host/...`.
+/// Neither names a local file, so the resolver marks them external as-is.
+fn url_is_remote(url: &[u8]) -> bool {
+    if url.starts_with(b"//") {
+        return true;
+    }
+    let mut len = 0;
+    while len < url.len()
+        && (url[len].is_ascii_alphanumeric() || matches!(url[len], b'+' | b'-' | b'.'))
+    {
+        len += 1;
+    }
+    len > 0 && url[0].is_ascii_alphabetic() && url.get(len) == Some(&b':')
+}
+
+/// The character reference at the start of `text` as a code point and the
+/// number of bytes it spans, when there is one.
+fn char_ref(text: &[u8]) -> Option<(u32, usize)> {
+    if text.first() != Some(&b'&') {
+        return None;
+    }
+    let end = bun_core::strings::index_of_char_usize(text, b';')?;
+    Some((char_ref_code_point(&text[1..end])?, end + 1))
+}
+
+/// Splits a `src`/`href` attribute value into the URL path it names, with its
+/// HTML character references decoded (`&amp;` is how HTML spells `&`), and
+/// the `?query#fragment` text after it, kept as written.
+pub(crate) fn split_url(value: &[u8]) -> (Vec<u8>, &[u8]) {
+    let mut path = Vec::with_capacity(value.len());
+    let mut i = 0;
+    while i < value.len() {
+        let mut buf = [0u8; 4];
+        let (bytes, consumed): (&[u8], usize) = match char_ref(&value[i..]) {
+            Some((cp, consumed)) => {
+                let len = bun_core::strings::encode_wtf8_rune(&mut buf, cp);
+                (&buf[..len], consumed)
+            }
+            None => (&value[i..i + 1], 1),
+        };
+        if !path.is_empty() && matches!(bytes[0], b'?' | b'#') {
+            return (path, &value[i..]);
+        }
+        path.extend_from_slice(bytes);
+        i += consumed;
+    }
+    (path, b"")
+}
+
 impl<'a> HTMLScanner<'a> {
-    fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
+    fn create_import_record(&mut self, value: &[u8], kind: ImportKind) -> Result<(), Error> {
+        let is_remote = url_is_remote(value);
+        let decoded;
+        let input_path: &[u8] = if is_remote {
+            value
+        } else {
+            let (path, _suffix) = split_url(value);
+            // The file name as a browser or a static file server reads it from
+            // the URL. An invalid escape leaves the path as written.
+            let mut percent_decoded = Vec::with_capacity(path.len());
+            decoded = match bun_url::PercentEncoding::decode_fault_tolerant::<_, true>(
+                &mut percent_decoded,
+                &path,
+            ) {
+                Ok(_) => percent_decoded,
+                Err(_) => path,
+            };
+            &decoded
+        };
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
-        let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
+        let path_to_use: &[u8] = if is_remote {
+            input_path
+        } else if input_path.len() > 1 && input_path[0] == b'/' {
             resolve_path::join_abs_string::<platform::Auto>(
                 fs::FileSystem::instance().top_level_dir,
                 &[&input_path[1..]],

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -194,7 +194,12 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             {
                 element.remove();
             } else {
-                set_attribute(element, url_attribute, import_record.path.pretty);
+                set_attribute_with_suffix(
+                    element,
+                    url_attribute,
+                    import_record.path.pretty,
+                    suffix,
+                );
             }
             return;
         }

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -9,7 +9,7 @@ use bun_threading::thread_pool::Task as ThreadPoolLibTask;
 use lol_html::HandlerResult;
 use lol_html::html_content::{ContentType, Element, EndTag};
 
-use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler};
+use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler, split_url};
 use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext, debug};
 use crate::options::Loader;
 use crate::{Chunk, CompileResult};
@@ -101,6 +101,21 @@ fn set_attribute(element: &mut Element<'_, '_>, name: &[u8], value: &[u8]) {
     }
 }
 
+/// `set_attribute` with the source URL's `?query#fragment` appended, so that
+/// `sprite.svg#icon` still addresses the icon in the rewritten asset URL.
+fn set_attribute_with_suffix(
+    element: &mut Element<'_, '_>,
+    name: &[u8],
+    value: &[u8],
+    suffix: &[u8],
+) {
+    if suffix.is_empty() {
+        set_attribute(element, name, value);
+    } else {
+        set_attribute(element, name, &[value, suffix].concat());
+    }
+}
+
 impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_write_html(&mut self, bytes: &[u8]) {
         self.output.extend_from_slice(bytes);
@@ -116,9 +131,9 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_tag(
         &mut self,
         element: &mut Element<'_, '_>,
-        _path: &[u8],
+        path: &[u8],
         url_attribute: &[u8],
-        _kind: ImportKind,
+        kind: ImportKind,
     ) {
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(
@@ -145,6 +160,14 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         } else {
             Loader::File
         };
+        // The scanner resolved the URL without its `?query#fragment`. A copied
+        // asset keeps it. A script or stylesheet is merged into the page
+        // bundle, so there is nothing to keep it on.
+        let suffix: &[u8] = if kind == ImportKind::Url {
+            split_url(path).1
+        } else {
+            b""
+        };
 
         if import_record
             .flags
@@ -159,7 +182,12 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
 
         if self.linker.dev_server.is_some() {
             if !unique_key_for_additional_files.is_empty() {
-                set_attribute(element, url_attribute, unique_key_for_additional_files);
+                set_attribute_with_suffix(
+                    element,
+                    url_attribute,
+                    unique_key_for_additional_files,
+                    suffix,
+                );
             } else if import_record.path.is_disabled
                 || loader.is_javascript_like()
                 || loader.is_css()
@@ -190,14 +218,24 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
             let url_for_css =
                 parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
             if !url_for_css.is_empty() {
-                set_attribute(element, url_attribute, url_for_css);
+                // A `?query` would land inside the data: URL body. Keep the fragment only.
+                let fragment: &[u8] = match strings::index_of_char_usize(suffix, b'#') {
+                    Some(i) => &suffix[i..],
+                    None => b"",
+                };
+                set_attribute_with_suffix(element, url_attribute, url_for_css, fragment);
                 return;
             }
         }
 
         if !unique_key_for_additional_files.is_empty() {
             // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
-            set_attribute(element, url_attribute, unique_key_for_additional_files);
+            set_attribute_with_suffix(
+                element,
+                url_attribute,
+                unique_key_for_additional_files,
+                suffix,
+            );
             return;
         }
     }

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -96,6 +96,31 @@ devTest("image tag", {
     await dev.fetch(url).expect404(); // TODO
   },
 });
+devTest("image tag keeps ?query#fragment", {
+  files: {
+    "index.html": `
+      <!DOCTYPE html><html><head></head><body>
+      <img src="./image.png?v=1#frag" alt="test image">
+      </body></html>
+    `,
+    "image.png": "FIRST",
+  },
+  async test(dev) {
+    const imgSrc = async () => (await (await dev.fetch("/")).text()).match(/<img src="([^"]*)"/)?.[1];
+
+    const url = await imgSrc();
+    expect(url).toMatch(/^\/_bun\/asset\/[0-9a-f]{16}\.png\?v=1#frag$/);
+    await dev.fetch(url!).expect.toBe("FIRST");
+
+    // An HTML edit re-renders the page against the asset the dev server has already cached.
+    await dev.patch("index.html", {
+      find: 'alt="test image"',
+      replace: 'alt="modified image"',
+    });
+    await dev.fetch("/").expect.toInclude('alt="modified image"');
+    expect(await imgSrc()).toBe(url);
+  },
+});
 devTest("image import in JS", {
   files: {
     "index.html": `

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -190,6 +190,69 @@ describe("bundler", () => {
     },
   });
 
+  // Test protocol-relative (scheme-relative) external assets in every tag kind
+  itBundled("html/external-assets-protocol-relative", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="//cdn.example.com/style.css">
+    <script src="//cdn.example.com/script.js"></script>
+  </head>
+  <body>
+    <img src="//cdn.example.com/logo.png">
+  </body>
+</html>`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      expect(html).toContain('href="//cdn.example.com/style.css"');
+      expect(html).toContain('src="//cdn.example.com/script.js"');
+      expect(html).toContain('src="//cdn.example.com/logo.png"');
+    },
+  });
+
+  // #fragment / ?query on an asset URL must survive the rewrite (SVG sprite
+  // symbol selectors, media-fragment ranges, cache-bust queries), and two
+  // references to one file with different suffixes emit one asset.
+  itBundled("html/asset-url-fragment-query", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <img src="./sprite.svg#home">
+    <video src="./clip.png#t=10,20"></video>
+    <img src="./clip.png?v=3">
+    <img src="./sprite.svg?q=1#icon">
+    <img src="https://example.com/sprite.svg#ext">
+  </body>
+</html>`,
+      "/sprite.svg": `<svg xmlns="http://www.w3.org/2000/svg"><symbol id="home"/></svg>`,
+      "/clip.png": "fake image content",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const attrs = [...html.matchAll(/(?:src|href)="([^"]*)"/g)].map(m => m[1]);
+
+      expect(attrs.filter(a => /sprite-[a-z0-9]+\.svg#home$/.test(a))).toHaveLength(1);
+      expect(attrs.filter(a => /clip-[a-z0-9]+\.png#t=10,20$/.test(a))).toHaveLength(1);
+      expect(attrs.filter(a => /clip-[a-z0-9]+\.png\?v=3$/.test(a))).toHaveLength(1);
+      expect(attrs.filter(a => /sprite-[a-z0-9]+\.svg\?q=1#icon$/.test(a))).toHaveLength(1);
+      // External reference is left untouched.
+      expect(attrs).toContain("https://example.com/sprite.svg#ext");
+
+      // Both references to clip.png point at the same emitted asset.
+      const clipHashes = new Set(attrs.map(a => a.match(/clip-([a-z0-9]+)\.png/)?.[1]).filter(Boolean));
+      expect(clipHashes.size).toBe(1);
+    },
+  });
+
   // Test mixed local and external assets
   itBundled("html/mixed-assets", {
     outdir: "out/",

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -146,6 +146,50 @@ describe("bundler", () => {
     },
   });
 
+  // A src/href is a URL. The file it names has its character references and
+  // percent escapes decoded and no ?query#fragment. A copied asset keeps the
+  // ?query#fragment. A scheme or a //host URL is external and stays as-is.
+  itBundled("html/url-decoding", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./a&amp;b.css?v=2">
+    <script src="./my%20script.js?v=1#top"></script>
+    <script src="//cdn.example.com/lib.js"></script>
+    <link rel="icon" href="./ic%C3%B6n.png">
+  </head>
+  <body>
+    <img src="./sprite&#x26;2.svg?v=3#home">
+    <img src="./photo.jpg?w=100&amp;h=50">
+  </body>
+</html>`,
+      "/a&b.css": "body { color: red; }",
+      "/my script.js": "console.log('my script')",
+      "/icön.png": "fake icon",
+      "/sprite&2.svg": "<svg></svg>",
+      "/photo.jpg": "fake photo",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      expect(html).toMatch(/href="\.\/index-[a-z0-9]+\.css"/);
+      expect(html).toMatch(/src="\.\/index-[a-z0-9]+\.js"/);
+      expect(html).toContain('src="//cdn.example.com/lib.js"');
+      expect(html).toMatch(/href="\.\/icön-[a-z0-9]+\.png"/);
+      expect(html).toMatch(/src="\.\/sprite&2-[a-z0-9]+\.svg\?v=3#home"/);
+      // The query is kept as written: `&amp;` is how HTML spells `&` there too.
+      expect(html).toMatch(/src="\.\/photo-[a-z0-9]+\.jpg\?w=100&amp;h=50"/);
+      expect(html).not.toContain("%");
+      const js = api.readFile("out/" + html.match(/src="\.\/(index-[a-z0-9]+\.js)"/)![1]);
+      expect(js).toContain("my script");
+      const css = api.readFile("out/" + html.match(/href="\.\/(index-[a-z0-9]+\.css)"/)![1]);
+      expect(css).toContain("color: red");
+    },
+  });
+
   // Test mixed local and external assets
   itBundled("html/mixed-assets", {
     outdir: "out/",


### PR DESCRIPTION
### Problem
- `bun build index.html` (and the dev and production servers, which share the scanner) passes the raw `src`/`href` text to the resolver. `href="./a&amp;b.css"` fails with `Could not resolve: "./a&amp;b.css"`. `src="./my%20file.js"` fails the same way. `src="./app.js?v=1"` fails for a script. A copied asset resolves, but the rewritten URL loses its `?query#fragment`: `sprite.svg#home` becomes `sprite-<hash>.svg`.
- `src="//cdn.example.com/lib.js"` fails with `Could not resolve: "/cdn.example.com/lib.js"`. `HTMLScanner.rs:74` rewrote every value that starts with `/` into a project-rooted path, and `//host` took that branch.

### Fix
- `split_url` (`src/bundler/HTMLScanner.rs`) decodes the HTML character references of the value (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, `&#N;`, `&#xH;`) and splits off the `?query#fragment`, kept as written. `create_import_record` percent-decodes the path part with `bun_url::PercentEncoding` (fault tolerant, so `%PUBLIC_URL%` stays as is) and resolves that. A value with a scheme or a `//host` is passed through unchanged, and the resolver marks it external as it already did for `http://`.
- `on_tag` (`generateCompileResultForHtmlChunk.rs`) appends the suffix, as written, to the rewritten URL of a copied asset (`ImportKind::Url`). An inlined `data:` URL gets only the `#fragment`. This is the rule `src/css/printer.rs:340` applies to CSS `url()`.
- Correct because an attribute value is HTML text that names a URL, and a browser does the same two decodes before it asks a server for the file. The suffix is appended as written because lol_html escapes only `"` when it writes an attribute, so a decoded `&amp;` would be read again by the browser.
- Verified: `test/bundler/bundler_html.test.ts` `html/url-decoding` (fails on 1.4.3 with `Bundle Failed`). Also ran all of `bundler_html.test.ts`, `bundler_naming.test.ts`, `bake/dev/html.test.ts`, `bake/dev-and-prod.test.ts`, `bun-serve-html.test.ts`.

### Background
- The HTML loader runs lol_html twice over the page with the same selectors. The scan pass creates one `ImportRecord` per matched tag. The rewrite pass walks the same tags in the same order and replaces each `src`/`href` with the record's output URL. The two passes have to agree on the value, so both call `split_url`.
- lol_html returns attribute values as written. It does not decode character references (`Attribute::value` says so).
- The dev server rewrites a copied asset to `/_bun/asset/<hash>.<ext>`, the production build to `<name>-<hash>.<ext>`. Both paths get the suffix.

<details><summary>Notes</summary>

Repro on 1.4.3:

```sh
D=$(mktemp -d); cd $D
cat > index.html <<'EOF'
<link rel="stylesheet" href="./a&amp;b.css">
<script src="./my%20file.js"></script>
<script src="//cdn.example.com/lib.js"></script>
<img src="./sprite.svg#home">
EOF
echo 'body{color:red}' > 'a&b.css'; echo 'console.log(1)' > 'my file.js'; printf '<svg/>' > sprite.svg
bun build index.html --outdir out
# error: Could not resolve: "/cdn.example.com/lib.js"
# error: Could not resolve: "./my%20file.js"
# error: Could not resolve: "./a&amp;b.css"
```

With this change the build succeeds, the CDN tag is left as is, and the output has `src="./sprite-<hash>.svg#home"`. The dev server output is `src="/_bun/asset/<hash>.svg#home"` and the asset is served with 200.

Supersedes #36007 (the `//host` guard) and #36008 (the suffix). Both fixes are in this diff in the same place, because the split of the value into path and suffix is what both need. fcbd2fc963 adds their test cases (`html/external-assets-protocol-relative`, `html/asset-url-fragment-query`). It also appends the suffix on the dev-server branch that re-renders a page against an asset the dev server has already cached (`import_record.path.pretty` in `on_tag`), which #36008 had and this diff did not, with a dev test (`image tag keeps ?query#fragment` in `test/bake/dev/html.test.ts`).

The resolver retries a CSS-kind import without its `?#` suffix (`resolver.rs:1368`), which is why an `<img>` resolved before and a `<script>` did not. The scanner now strips the suffix for every kind, so the retry is no longer what makes HTML work.

`srcset` is not handled here. It needs one record per candidate, see #36012.

Found by a fuzz pass over HTML import reference kinds. No user report.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [1269.42ms]
(pass) bundler > html/implicit-relative-paths [486.97ms]
(pass) bundler > html/multiple-assets [306.24ms]
(pass) bundler > html/image-hashing [344.46ms]
(pass) bundler > html/external-assets [236.36ms]
1430 |             }
1431 | 
1432 |             return testRef(id, opts);
1433 |           }
1434 | 
1435 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/index.html:-1:-1: Could not resolve: "./a&amp;b.css?v=2"
/index.html:-1:-1: Could not resolve: "./my%20script.js?v=1#top"
/index.html:-1:-1: Could not resolve: "/cdn.example.com/lib.js"
/index.html:-1:-1: Could not resolve: "./ic%C3%B6n.png"
/index.html:-1:-1: Could not resolve: "./sprite&#x26;2.svg?v=3#home"
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1435:21)
(fail) bundler > html/url-decoding [303.20ms]
(pass) bundler > html/mixed-a
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [112.16ms]
(pass) bundler > html/implicit-relative-paths [16.82ms]
(pass) bundler > html/multiple-assets [25.51ms]
(pass) bundler > html/image-hashing [18.91ms]
(pass) bundler > html/external-assets [8.09ms]
1430 |             }
1431 | 
1432 |             return testRef(id, opts);
1433 |           }
1434 | 
1435 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/index.html:-1:-1: Could not resolve: "./a&amp;b.css?v=2"
/index.html:-1:-1: Could not resolve: "./my%20script.js?v=1#top"
/index.html:-1:-1: Could not resolve: "/cdn.example.com/lib.js"
/index.html:-1:-1: Could not resolve: "./ic%C3%B6n.png"
/index.html:-1:-1: Could not resolve: "./sprite&#x26;2.svg?v=3#home"
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1435:21)
(fail) bundler > html/url-decoding [4.42ms]
(pass) bundler > html/mixed-assets [17.67ms]
(pass) bundler > html/js-imports [26.05ms]
(pass) bundler > html/script-that-is-also-an-entry-point [22.46ms]
(pass) bundler > html/css-imports [123.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [853.32ms]
(pass) bundler > html/implicit-relative-paths [1063.91ms]
(pass) bundler > html/multiple-assets [632.57ms]
(pass) bundler > html/image-hashing [520.39ms]
(pass) bundler > html/external-assets [255.89ms]
(pass) bundler > html/url-decoding [552.62ms]
(pass) bundler > html/mixed-assets [352.57ms]
(pass) bundler > html/js-imports [537.87ms]
(pass) bundler > html/script-that-is-also-an-entry-point [494.37ms]
(pass) bundler > html/css-imports [506.35ms]
(pass) bundler > html/multiple-entries [354.06ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [449.45ms]
(pass) bundler > html/modulepreload-links [449.65ms]
(pass) bundler > html/shared-chunks [623.04ms]
(pass) bundler > html/js-importing-html [508.66ms]
// in/entry.js
console.log("Loaded HTML!");

// in/2nd.js
console.log("2nd");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [535.46ms]
(pass) bundler > html/j
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0a5a0f2498
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 12144ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir codegen
[2/2863] mkdir pch
[3/2863] mkdir obj
[4/2863] gen bindgenv2
[5/2863] fetch mimalloc
[mimalloc] up to date
[6/2863] fetch WebKit
[WebKit] up to date
[7/2863] gen .bind.ts → GeneratedBindings.cpp
[8/2863] fetch icu
[icu] up to date
[9/2863] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/2863] fetch tinycc
[tinycc] up to date
[11/2863] gen ErrorCode+*.h
[12/2863] mkdir stamps
[13/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[14/2863] gen lut ArrayConstructor.lut.h
[15/2863] gen lut AsyncFromSyncIteratorPrototype.lut.h
[16/2863] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/HTMLScanner.rs                         | 92 +++++++++++++++++++++-
 .../generateCompileResultForHtmlChunk.rs           | 50 ++++++++++--
 test/bundler/bundler_html.test.ts                  | 44 +++++++++++
 3 files changed, 178 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/HTMLScanner.rs                                    4      3     10
…ler/linker_context/generateCompileResultForHtmlChunk.rs      4      4     10
test/bundler/bundler_html.test.ts                             0      0     10
```

</details>

<!-- robobun:evidence:end -->