### PR TITLE
mock.module: support mocking process.getBuiltinModule() and native require()

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -928,8 +928,16 @@ JSC::JSValue runVirtualModule(Zig::GlobalObject* globalObject, BunString* specif
     }
     auto& virtualModules = *globalObject->onLoadPlugins.virtualModules;
     WTF::String specifierString = specifier->toWTFString(BunString::ZeroCopy);
+    auto virtualModuleFn = virtualModules.get(specifierString);
+    if (!virtualModuleFn) {
+        if (specifierString.startsWith("node:"_s)) {
+            virtualModuleFn = virtualModules.get(specifierString.substring(5));
+        } else {
+            virtualModuleFn = virtualModules.get(makeString("node:"_s, specifierString));
+        }
+    }
 
-    if (auto virtualModuleFn = virtualModules.get(specifierString)) {
+    if (virtualModuleFn) {
         auto& vm = JSC::getVM(globalObject);
         JSC::JSObject* function = virtualModuleFn.get();
         auto throwScope = DECLARE_THROW_SCOPE(vm);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -36,6 +36,7 @@
 #include "JavaScriptCore/Synchronousness.h"
 #include "JavaScriptCore/JSCast.h"
 #include <JavaScriptCore/JSMapInlines.h>
+#include <JavaScriptCore/JSPromise.h>
 #include "root.h"
 #include "JavaScriptCore/SourceCode.h"
 #include "headers-handwritten.h"
@@ -1376,6 +1377,45 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
     JSValue specifierValue = callframe->argument(0);
     WTF::String specifier = specifierValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
+
+    if (isBunTest && globalObject->onLoadPlugins.hasVirtualModules()) {
+        bool wasModuleMock = false;
+        BunString specifierStr = Bun::toString(specifier);
+        JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, &specifierStr, wasModuleMock);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (virtualModuleResult) {
+            if (auto* promise = dynamicDowncast<JSPromise>(virtualModuleResult)) {
+                switch (promise->status()) {
+                case JSPromise::Status::Rejected: {
+                    promise->markAsHandled();
+                    JSC::throwException(globalObject, throwScope, promise->result());
+                    return {};
+                }
+                case JSPromise::Status::Pending: {
+                    throwTypeError(globalObject, throwScope, makeString("require() async module \""_s, specifier, "\" is unsupported. use \"await import()\" instead."_s));
+                    return {};
+                }
+                case JSPromise::Status::Fulfilled: {
+                    virtualModuleResult = promise->result();
+                    break;
+                }
+                }
+            }
+            if (auto* obj = virtualModuleResult.getObject()) {
+                auto esModuleValue = obj->getIfPropertyExists(globalObject, vm.propertyNames->__esModule);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                if (esModuleValue && esModuleValue.toBoolean(globalObject)) {
+                    auto defaultValue = obj->getIfPropertyExists(globalObject, vm.propertyNames->defaultKeyword);
+                    RETURN_IF_EXCEPTION(throwScope, {});
+                    if (defaultValue && !defaultValue.isUndefined()) {
+                        return JSC::JSValue::encode(defaultValue);
+                    }
+                }
+            }
+            return JSC::JSValue::encode(virtualModuleResult);
+        }
+    }
+
     ErrorableResolvedSource res;
     BunString specifierStr = Bun::toString(specifier);
     auto result = fetchBuiltinModuleWithoutResolution(globalObject, &specifierStr, &res);

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -578,6 +578,44 @@ JSValue resolveAndFetchBuiltinModule(
     if (Bun__resolveAndFetchBuiltinModule(specifier, &res)) {
         ASSERT(res.success);
 
+        if (isBunTest && globalObject->onLoadPlugins.hasVirtualModules()) {
+            bool wasModuleMock = false;
+            BunString mutableSpecifier = *specifier;
+            JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, &mutableSpecifier, wasModuleMock);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (virtualModuleResult) {
+                if (auto* promise = dynamicDowncast<JSPromise>(virtualModuleResult)) {
+                    switch (promise->status()) {
+                    case JSPromise::Status::Rejected: {
+                        promise->markAsHandled();
+                        JSC::throwException(globalObject, scope, promise->result());
+                        RELEASE_AND_RETURN(scope, JSValue {});
+                    }
+                    case JSPromise::Status::Pending: {
+                        JSC::throwTypeError(globalObject, scope, "process.getBuiltinModule() async module mock is unsupported"_s);
+                        RELEASE_AND_RETURN(scope, JSValue {});
+                    }
+                    case JSPromise::Status::Fulfilled: {
+                        virtualModuleResult = promise->result();
+                        break;
+                    }
+                    }
+                }
+                if (auto* obj = virtualModuleResult.getObject()) {
+                    auto esModuleValue = obj->getIfPropertyExists(globalObject, vm.propertyNames->__esModule);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    if (esModuleValue && esModuleValue.toBoolean(globalObject)) {
+                        auto defaultValue = obj->getIfPropertyExists(globalObject, vm.propertyNames->defaultKeyword);
+                        RETURN_IF_EXCEPTION(scope, {});
+                        if (defaultValue && !defaultValue.isUndefined()) {
+                            RELEASE_AND_RETURN(scope, defaultValue);
+                        }
+                    }
+                }
+                RELEASE_AND_RETURN(scope, virtualModuleResult);
+            }
+        }
+
         auto tag = res.result.value.tag;
         switch (tag) {
         // require("bun")

--- a/test/js/bun/test/mock/mock-module-builtin.test.ts
+++ b/test/js/bun/test/mock/mock-module-builtin.test.ts
@@ -1,0 +1,83 @@
+import { expect, mock, test } from "bun:test";
+import process from "node:process";
+
+test("mock.module with process.getBuiltinModule(node:os)", () => {
+  mock.module("node:os", () => {
+    return {
+      homedir: () => "/mock/node-os-homedir",
+      platform: () => "mockOS",
+    };
+  });
+
+  const os = process.getBuiltinModule("node:os");
+  expect(os).toBeDefined();
+  expect(os.homedir()).toBe("/mock/node-os-homedir");
+  expect(os.platform()).toBe("mockOS");
+
+  // Bare specifier should also resolve to the mock
+  const bareOs = process.getBuiltinModule("os");
+  expect(bareOs).toBeDefined();
+  expect(bareOs.homedir()).toBe("/mock/node-os-homedir");
+
+  // require() should also see the mock
+  const reqOs = require("node:os");
+  expect(reqOs.homedir()).toBe("/mock/node-os-homedir");
+  const reqBareOs = require("os");
+  expect(reqBareOs.homedir()).toBe("/mock/node-os-homedir");
+});
+
+test("mock.module with bare specifier process.getBuiltinModule(path)", () => {
+  mock.module("path", () => {
+    return {
+      join: (...args: string[]) => args.join("---"),
+    };
+  });
+
+  const path = process.getBuiltinModule("path");
+  expect(path).toBeDefined();
+  expect(path.join("a", "b")).toBe("a---b");
+
+  const prefixedPath = process.getBuiltinModule("node:path");
+  expect(prefixedPath).toBeDefined();
+  expect(prefixedPath.join("a", "b")).toBe("a---b");
+
+  expect(require("path").join("a", "b")).toBe("a---b");
+  expect(require("node:path").join("a", "b")).toBe("a---b");
+});
+
+test("process.getBuiltinModule for non-builtin returns undefined", () => {
+  expect(process.getBuiltinModule("some-random-non-builtin-module")).toBeUndefined();
+  expect(process.getBuiltinModule("")).toBeUndefined();
+});
+
+test("process.getBuiltinModule throws on async module mock but import() works", async () => {
+  mock.module("node:v8", async () => {
+    await Bun.sleep(1);
+    return { cachedDataVersionTag: () => 12345 };
+  });
+
+  expect(() => {
+    process.getBuiltinModule("node:v8");
+  }).toThrow(/async/);
+
+  expect(() => {
+    require("node:v8");
+  }).toThrow(/async/);
+
+  const imported = await import("node:v8");
+  expect(imported.cachedDataVersionTag()).toBe(12345);
+});
+
+test("process.getBuiltinModule returns same instance on subsequent calls", () => {
+  mock.module("node:zlib", () => {
+    return {
+      constants: { Z_NO_FLUSH: 999 },
+    };
+  });
+
+  const first = process.getBuiltinModule("node:zlib");
+  const second = process.getBuiltinModule("node:zlib");
+  const third = process.getBuiltinModule("zlib");
+  expect(first).toBe(second);
+  expect(first).toBe(third);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #26591

When mocking a builtin module using `mock.module("node:os", ...)` or `mock.module("os", ...)`, `globalThis.process.getBuiltinModule()` and native `require()` previously bypassed virtual module mocks and fetched internal un-mocked native modules directly.

This PR:
1. Updates `runVirtualModule` in `BunPlugin.cpp` to look up both bare (e.g. `os`) and `node:`-prefixed (e.g. `node:os`) specifiers in `virtualModules`.
2. Checks for test-scoped virtual module mocks in `resolveAndFetchBuiltinModule` (`ModuleLoader.cpp`) before resolving to native builtins.
3. Checks for test-scoped virtual module mocks in `jsFunctionRequireNativeModule` (`JSCommonJSModule.cpp`).
4. Ensures async mocks throw clean `TypeError`s when accessed synchronously, but properly resolve when accessed via `await import()`.
5. Adds comprehensive regression test coverage for `process.getBuiltinModule()` and `require()`.

### How did you verify your code works?

- Added `test/js/bun/test/mock/mock-module-builtin.test.ts` testing:
  - `process.getBuiltinModule("node:os")` and `process.getBuiltinModule("os")`
  - `process.getBuiltinModule("path")` and `process.getBuiltinModule("node:path")`
  - `require("node:os")` and `require("os")`
  - `process.getBuiltinModule("non-builtin")` returning `undefined`
  - Async mocks throwing on synchronous access and resolving on `await import()`
  - Instance referential equality on repeated calls
- Ran all existing mock tests: `test/js/bun/test/mock/mock-module.test.ts` (12/12 passed).
- Ran all process tests: `test/js/node/process/process.test.js` (171 passed, 0 failed).
- Formatted with `prettier` and `clang-format`.