### PR TITLE
FormData: parse the multipart boundary parameter per WHATWG MIME rules

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5354,8 +5354,9 @@ pub mod form_data {
         }
     }
 
-    /// `FormData.getBoundary` — borrow the `boundary=` value out of a
-    /// `Content-Type` header. Returns `None` on malformed quoting.
+    /// `FormData.getBoundary` — the `boundary=` value out of a
+    /// `Content-Type` header. Returns `None` when there is no boundary or
+    /// the boundary is empty.
     ///
     /// Parameters are `;`-delimited per RFC 7231 and the parameter *name* must
     /// be exactly `boundary`, so a different parameter (`xboundary=FAKE`) or a
@@ -5363,7 +5364,15 @@ pub mod form_data {
     /// by an unanchored substring search. A `;` inside a quoted parameter
     /// value (RFC 7230 quoted-string, `\` escapes the next byte) does not
     /// delimit parameters.
-    pub fn get_boundary(content_type: &[u8]) -> Option<&[u8]> {
+    ///
+    /// The value follows WHATWG "parse a MIME type": an unquoted value runs
+    /// to the next `;` with trailing HTTP whitespace removed (`boundary=abc ;
+    /// charset=utf-8` is `abc`, not `abc `). A quoted value is unescaped
+    /// (`"ab\c"` is `abc`), runs to the end of the header when the closing
+    /// quote is missing, and anything between the closing quote and the next
+    /// `;` is discarded.
+    pub fn get_boundary(content_type: &[u8]) -> Option<std::borrow::Cow<'_, [u8]>> {
+        use std::borrow::Cow;
         let mut rest = content_type;
         loop {
             let semi = index_of_unquoted_semicolon(rest)?;
@@ -5379,18 +5388,35 @@ pub mod form_data {
                 continue;
             }
             let begin = &param[eq + 1..];
-            if begin.is_empty() {
-                return None;
+            if begin.first() == Some(&b'"') {
+                let mut value = Vec::new();
+                let mut i = 1;
+                while i < begin.len() {
+                    match begin[i] {
+                        b'"' => break,
+                        b'\\' => {
+                            i += 1;
+                            if i >= begin.len() {
+                                value.push(b'\\');
+                                break;
+                            }
+                            value.push(begin[i]);
+                        }
+                        c => value.push(c),
+                    }
+                    i += 1;
+                }
+                if value.is_empty() {
+                    return None;
+                }
+                return Some(Cow::Owned(value));
             }
             let end = crate::strings::index_of_char_usize(begin, b';').unwrap_or(begin.len());
-            if begin[0] == b'"' {
-                if end > 1 && begin[end - 1] == b'"' {
-                    return Some(&begin[1..end - 1]);
-                }
-                // Opening quote with no matching closing quote — malformed.
+            let value = crate::strings_impl::trim_right(&begin[..end], b" \t\r\n");
+            if value.is_empty() {
                 return None;
             }
-            return Some(&begin[..end]);
+            return Some(Cow::Borrowed(value));
         }
     }
 

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5354,23 +5354,9 @@ pub mod form_data {
         }
     }
 
-    /// `FormData.getBoundary` — the `boundary=` value out of a
-    /// `Content-Type` header. Returns `None` when there is no boundary or
-    /// the boundary is empty.
-    ///
-    /// Parameters are `;`-delimited per RFC 7231 and the parameter *name* must
-    /// be exactly `boundary`, so a different parameter (`xboundary=FAKE`) or a
-    /// `boundary=` substring inside another parameter's value is not picked up
-    /// by an unanchored substring search. A `;` inside a quoted parameter
-    /// value (RFC 7230 quoted-string, `\` escapes the next byte) does not
-    /// delimit parameters.
-    ///
-    /// The value follows WHATWG "parse a MIME type": an unquoted value runs
-    /// to the next `;` with trailing HTTP whitespace removed (`boundary=abc ;
-    /// charset=utf-8` is `abc`, not `abc `). A quoted value is unescaped
-    /// (`"ab\c"` is `abc`), runs to the end of the header when the closing
-    /// quote is missing, and anything between the closing quote and the next
-    /// `;` is discarded. The first `boundary` parameter with a value wins.
+    /// `FormData.getBoundary` — the `boundary` parameter of a `Content-Type`
+    /// header, read per WHATWG "parse a MIME type". `None` when there is no
+    /// boundary or it is empty.
     pub fn get_boundary(content_type: &[u8]) -> Option<std::borrow::Cow<'_, [u8]>> {
         use std::borrow::Cow;
         let mut rest = content_type;
@@ -5413,9 +5399,8 @@ pub mod form_data {
             }
             let end = crate::strings::index_of_char_usize(begin, b';').unwrap_or(begin.len());
             let value = crate::strings_impl::trim_right(&begin[..end], b" \t\r\n");
-            // An empty unquoted value does not set the parameter, so a later
-            // `boundary=` still counts. An empty quoted value (`""`) does set
-            // it, and an empty boundary is rejected.
+            // An empty unquoted value does not set the parameter (a later
+            // `boundary=` still counts), unlike an empty quoted value.
             if value.is_empty() {
                 continue;
             }

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5370,7 +5370,7 @@ pub mod form_data {
     /// charset=utf-8` is `abc`, not `abc `). A quoted value is unescaped
     /// (`"ab\c"` is `abc`), runs to the end of the header when the closing
     /// quote is missing, and anything between the closing quote and the next
-    /// `;` is discarded.
+    /// `;` is discarded. The first `boundary` parameter with a value wins.
     pub fn get_boundary(content_type: &[u8]) -> Option<std::borrow::Cow<'_, [u8]>> {
         use std::borrow::Cow;
         let mut rest = content_type;
@@ -5413,8 +5413,11 @@ pub mod form_data {
             }
             let end = crate::strings::index_of_char_usize(begin, b';').unwrap_or(begin.len());
             let value = crate::strings_impl::trim_right(&begin[..end], b" \t\r\n");
+            // An empty unquoted value does not set the parameter, so a later
+            // `boundary=` still counts. An empty quoted value (`""`) does set
+            // it, and an empty boundary is rejected.
             if value.is_empty() {
-                return None;
+                continue;
             }
             return Some(Cow::Borrowed(value));
         }

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5399,8 +5399,7 @@ pub mod form_data {
             }
             let end = crate::strings::index_of_char_usize(begin, b';').unwrap_or(begin.len());
             let value = crate::strings_impl::trim_right(&begin[..end], b" \t\r\n");
-            // An empty unquoted value does not set the parameter (a later
-            // `boundary=` still counts), unlike an empty quoted value.
+            // An empty unquoted value leaves the parameter unset.
             if value.is_empty() {
                 continue;
             }

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5359,69 +5359,54 @@ pub mod form_data {
     /// boundary or it is empty.
     pub fn get_boundary(content_type: &[u8]) -> Option<std::borrow::Cow<'_, [u8]>> {
         use std::borrow::Cow;
-        let mut rest = content_type;
+        const HTTP_WHITESPACE: &[u8] = b" \t\r\n";
+        // `rest` always starts right after a `;`.
+        let mut rest =
+            &content_type[crate::strings::index_of_char_usize(content_type, b';')? + 1..];
         loop {
-            let semi = index_of_unquoted_semicolon(rest)?;
-            rest = &rest[semi + 1..];
-            let param = crate::strings_impl::trim_left(rest, b" \t");
+            rest = crate::strings_impl::trim_left(rest, HTTP_WHITESPACE);
+            let name_end = crate::strings::index_of_any(rest, b";=")?;
             // RFC 2045 §5.1: parameter attribute names are case-insensitive;
-            // the `=` value is matched byte-exact (the boundary delimiter in
-            // the body must match it verbatim).
-            let Some(eq) = crate::strings::index_of_char_usize(param, b'=') else {
-                continue;
-            };
-            if !param[..eq].eq_ignore_ascii_case(b"boundary") {
+            // the value is matched byte-exact against the body's delimiters.
+            let is_boundary = rest[..name_end].eq_ignore_ascii_case(b"boundary");
+            if rest[name_end] == b';' {
+                rest = &rest[name_end + 1..];
                 continue;
             }
-            let begin = &param[eq + 1..];
-            if begin.first() == Some(&b'"') {
+            rest = &rest[name_end + 1..];
+            if rest.first() == Some(&b'"') {
                 let mut value = Vec::new();
                 let mut i = 1;
-                while i < begin.len() {
-                    match begin[i] {
+                while i < rest.len() {
+                    match rest[i] {
                         b'"' => break,
                         b'\\' => {
                             i += 1;
-                            if i >= begin.len() {
+                            if i >= rest.len() {
                                 value.push(b'\\');
                                 break;
                             }
-                            value.push(begin[i]);
+                            value.push(rest[i]);
                         }
                         c => value.push(c),
                     }
                     i += 1;
                 }
-                if value.is_empty() {
-                    return None;
+                if is_boundary {
+                    return (!value.is_empty()).then_some(Cow::Owned(value));
                 }
-                return Some(Cow::Owned(value));
+                rest = &rest[i.min(rest.len())..];
+            } else {
+                let end = crate::strings::index_of_char_usize(rest, b';').unwrap_or(rest.len());
+                let value = crate::strings_impl::trim_right(&rest[..end], HTTP_WHITESPACE);
+                // An empty unquoted value leaves the parameter unset.
+                if is_boundary && !value.is_empty() {
+                    return Some(Cow::Borrowed(value));
+                }
+                rest = &rest[end..];
             }
-            let end = crate::strings::index_of_char_usize(begin, b';').unwrap_or(begin.len());
-            let value = crate::strings_impl::trim_right(&begin[..end], b" \t\r\n");
-            // An empty unquoted value leaves the parameter unset.
-            if value.is_empty() {
-                continue;
-            }
-            return Some(Cow::Borrowed(value));
+            rest = &rest[crate::strings::index_of_char_usize(rest, b';')? + 1..];
         }
-    }
-
-    /// Index of the next `;` in `s` that is not inside an RFC 7230
-    /// quoted-string (`\` escapes the following byte inside quotes).
-    fn index_of_unquoted_semicolon(s: &[u8]) -> Option<usize> {
-        let mut in_quotes = false;
-        let mut i = 0;
-        while i < s.len() {
-            match s[i] {
-                b'"' => in_quotes = !in_quotes,
-                b'\\' if in_quotes => i += 1,
-                b';' if !in_quotes => return Some(i),
-                _ => {}
-            }
-            i += 1;
-        }
-        None
     }
 
     /// `FormData.AsyncFormData` — heap-allocated, owns its `Encoding`.

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -5392,7 +5392,7 @@ pub mod form_data {
                     }
                     i += 1;
                 }
-                if is_boundary {
+                if is_boundary && value.iter().all(is_quoted_string_token_byte) {
                     return (!value.is_empty()).then_some(Cow::Owned(value));
                 }
                 rest = &rest[i.min(rest.len())..];
@@ -5400,13 +5400,19 @@ pub mod form_data {
                 let end = crate::strings::index_of_char_usize(rest, b';').unwrap_or(rest.len());
                 let value = crate::strings_impl::trim_right(&rest[..end], HTTP_WHITESPACE);
                 // An empty unquoted value leaves the parameter unset.
-                if is_boundary && !value.is_empty() {
+                if is_boundary && !value.is_empty() && value.iter().all(is_quoted_string_token_byte)
+                {
                     return Some(Cow::Borrowed(value));
                 }
                 rest = &rest[end..];
             }
             rest = &rest[crate::strings::index_of_char_usize(rest, b';')? + 1..];
         }
+    }
+
+    /// WHATWG "HTTP quoted-string token code point": HTAB, 0x20..=0x7E, 0x80..=0xFF.
+    fn is_quoted_string_token_byte(b: &u8) -> bool {
+        matches!(b, b'\t' | 0x20..=0x7E | 0x80..=0xFF)
     }
 
     /// `FormData.AsyncFormData` — heap-allocated, owns its `Encoding`.

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -319,6 +319,9 @@ describe("FormData", () => {
       'multipart/form-data; x="a;b"; boundary=abc',
       'multipart/form-data; charset=x"y; boundary=abc',
       "multipart/form-data; x; boundary=abc",
+      // A value with a control character is not recorded. The next one wins.
+      "multipart/form-data; boundary=abc\x0b; boundary=abc",
+      'multipart/form-data; boundary="ab\x01c"; boundary=abc',
     ];
     const noBoundary = "incorrect MIME type/boundary";
     const rejects = [

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -300,6 +300,66 @@ describe("FormData", () => {
     }
   });
 
+  // WHATWG "parse a MIME type": an unquoted parameter value ends at the next
+  // ";" with trailing HTTP whitespace removed; a quoted value is unescaped and
+  // runs to the end of the header when the closing quote is missing.
+  describe("Content-Type boundary parameter value", () => {
+    const body = '--abc\r\nContent-Disposition: form-data; name="k"\r\n\r\nv\r\n--abc--\r\n';
+    const parses = [
+      "multipart/form-data; boundary=abc ; charset=utf-8",
+      "multipart/form-data; boundary=abc\t; charset=utf-8",
+      "multipart/form-data; boundary=abc \t ",
+      'multipart/form-data; boundary="ab\\c"',
+      'multipart/form-data; boundary="abc',
+      'multipart/form-data; boundary="abc" junk; charset=utf-8',
+    ];
+    const rejects = [
+      // The delimiter in the body is "--abc", not "--abc ".
+      { ct: "multipart/form-data; boundary=abc ; charset=utf-8", body: body.replaceAll("--abc", "--abc ") },
+      // An empty boundary is not a boundary.
+      {
+        ct: 'multipart/form-data; boundary=""',
+        body: "--\r\n" + body.slice("--abc\r\n".length, -"--abc--\r\n".length) + "----\r\n",
+      },
+      { ct: "multipart/form-data; boundary= ; charset=utf-8", body },
+    ];
+
+    for (const C of [Response, Request] as const) {
+      const make = (b: string, ct: string) =>
+        C === Response
+          ? new Response(b, { headers: { "Content-Type": ct } })
+          : new Request("http://x/", { method: "POST", body: b, headers: { "Content-Type": ct } });
+
+      it.each(parses)(`${C.name}: %j parses`, async ct => {
+        expect([...(await make(body, ct).formData())]).toEqual([["k", "v"]]);
+      });
+
+      it.each(rejects)(`${C.name}: $ct rejects`, async ({ ct, body }) => {
+        await expect(make(body, ct).formData()).rejects.toThrow();
+      });
+    }
+
+    it("Bun.serve request.formData() trims whitespace before ';'", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          try {
+            return Response.json([...(await req.formData())]);
+          } catch (e) {
+            return new Response(String(e), { status: 400 });
+          }
+        },
+      });
+      const res = await fetch(server.url, {
+        method: "POST",
+        headers: { "Content-Type": "multipart/form-data; boundary=abc ; charset=utf-8" },
+        body,
+      });
+      expect(await res.json()).toEqual([["k", "v"]]);
+      expect(res.status).toBe(200);
+    });
+  });
+
   // RFC 2183 §2: the disposition type is a case-insensitive token.
   // RFC 9112 §5.6.3: OWS = *( SP / HTAB ), so HTAB is valid after the colon.
   describe("Content-Disposition: form-data token + OWS", () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -312,6 +312,8 @@ describe("FormData", () => {
       'multipart/form-data; boundary="ab\\c"',
       'multipart/form-data; boundary="abc',
       'multipart/form-data; boundary="abc" junk; charset=utf-8',
+      // An empty unquoted value does not set the parameter. The next one wins.
+      "multipart/form-data; boundary= ; boundary=abc",
     ];
     const rejects = [
       // The delimiter in the body is "--abc", not "--abc ".

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -314,6 +314,11 @@ describe("FormData", () => {
       'multipart/form-data; boundary="abc" junk; charset=utf-8',
       // An empty unquoted value does not set the parameter. The next one wins.
       "multipart/form-data; boundary= ; boundary=abc",
+      // A ";" inside a quoted value does not end the parameter. A stray '"'
+      // inside an unquoted value is just a byte.
+      'multipart/form-data; x="a;b"; boundary=abc',
+      'multipart/form-data; charset=x"y; boundary=abc',
+      "multipart/form-data; x; boundary=abc",
     ];
     const rejects = [
       // The delimiter in the body is "--abc", not "--abc ".

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -320,15 +320,21 @@ describe("FormData", () => {
       'multipart/form-data; charset=x"y; boundary=abc',
       "multipart/form-data; x; boundary=abc",
     ];
+    const noBoundary = "incorrect MIME type/boundary";
     const rejects = [
       // The delimiter in the body is "--abc", not "--abc ".
-      { ct: "multipart/form-data; boundary=abc ; charset=utf-8", body: body.replaceAll("--abc", "--abc ") },
+      {
+        ct: "multipart/form-data; boundary=abc ; charset=utf-8",
+        body: body.replaceAll("--abc", "--abc "),
+        error: "missing final boundary",
+      },
       // An empty boundary is not a boundary.
       {
         ct: 'multipart/form-data; boundary=""',
         body: "--\r\n" + body.slice("--abc\r\n".length, -"--abc--\r\n".length) + "----\r\n",
+        error: noBoundary,
       },
-      { ct: "multipart/form-data; boundary= ; charset=utf-8", body },
+      { ct: "multipart/form-data; boundary= ; charset=utf-8", body, error: noBoundary },
     ];
 
     for (const C of [Response, Request] as const) {
@@ -341,8 +347,8 @@ describe("FormData", () => {
         expect([...(await make(body, ct).formData())]).toEqual([["k", "v"]]);
       });
 
-      it.each(rejects)(`${C.name}: $ct rejects`, async ({ ct, body }) => {
-        await expect(make(body, ct).formData()).rejects.toThrow();
+      it.each(rejects)(`${C.name}: $ct rejects`, async ({ ct, body, error }) => {
+        await expect(make(body, ct).formData()).rejects.toThrow(error);
       });
     }
 


### PR DESCRIPTION
### Problem
- `Body.formData()` rejects a valid multipart body when the `Content-Type` has whitespace before the next `;`. `multipart/form-data; boundary=abc ; charset=utf-8` yields the boundary `abc `, so a body delimited by `--abc` fails with `FormData parse error missing final boundary`. Node and undici parse it. The same happens for `Request`, `Response`, and `Bun.serve` `req.formData()`.
- The cause is `get_boundary` in `src/bun_core/util.rs:5366`. It slices the value up to the next `;` with no trim. It also keeps escapes in a quoted value (`"ab\c"` stays `ab\c`), drops an unterminated quoted value (`"abc`), and accepts `boundary=""` as an empty delimiter.

### Fix
- The value now follows WHATWG "parse a MIME type". An unquoted value loses trailing HTTP whitespace. A quoted value is unescaped, runs to the end of the header when the closing quote is missing, and drops anything before the next `;`.
- The loop walks one parameter at a time. It enters quoted-string mode only when the byte after `=` is `"`, so a stray `"` in an unquoted value does not swallow the next `;`. An empty unquoted value, or a value with a byte outside the HTTP quoted-string token set (HTAB, 0x20 to 0x7E, 0x80 to 0xFF), leaves the parameter unset, so a later `boundary=` counts.
- An empty quoted boundary returns `None` and the caller rejects. RFC 2046 requires 1 to 70 characters. `get_boundary` returns `Cow<[u8]>` because unescaping needs an owned buffer. The only caller boxes the result.
- Verified: `test/js/web/html/FormData.test.ts` (new block, 25 of 31 cases fail on stock bun). Also `body.test.ts`, `FormData-multipart-serialization.test.ts`, `form-data-boundary-crash.test.ts`, `form-data-set-append.test.js`.

### Background
- RFC 9110 8.3.1 allows optional whitespace around the `;` between media type parameters. A boundary may not end in a space (RFC 2046 5.1.1).
- WHATWG "parse a MIME type" is what undici and browsers use to read `Content-Type`. It trims an unquoted value and unescapes a quoted value with "collect an HTTP quoted string".
- The multipart parser compares the boundary byte for byte against the `--boundary` delimiters in the body. A trailing space in the boundary means no delimiter matches.

<details><summary>Notes</summary>

Output of the report's script on stock bun 1.4.2 and with this change. Node v26 gives the second column.

| Content-Type | stock bun | this PR |
| --- | --- | --- |
| `boundary=abc ; charset=utf-8` | rejected | `[["k","v"]]` |
| `boundary=abc\t; charset=utf-8` | rejected | `[["k","v"]]` |
| `boundary="ab\c"` | rejected | `[["k","v"]]` |
| `boundary="abc` | rejected | `[["k","v"]]` |
| `boundary="abc" junk; x=y` | rejected | `[["k","v"]]` |
| `boundary= ; boundary=abc` | rejected | `[["k","v"]]` |
| `charset=x"y; boundary=abc` | rejected | `[["k","v"]]` |
| `boundary=abc\x0b; boundary=abc` | rejected | `[["k","v"]]` |
| body delimited by `--abc `, `boundary=abc ;` | `[["k","v"]]` | rejected |
| `boundary=""`, body delimited by `--` | `[["k","v"]]` | rejected |

Parameter names are still matched without trimming (`boundary =abc` is not a boundary). That matches WHATWG, where a name with a trailing space is not a token and the parameter is skipped. The first `boundary` parameter with a value wins.

Earlier revisions returned `None` for an empty unquoted value and scanned for an unquoted `;` across the whole header, which treated any `"` as a quote. Both were changed after review.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 25 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.74ms]
(pass) FormData > should be able to append a Blob [9.24ms]
(pass) FormData > should be able to set a Blob [7.05ms]
(pass) FormData > should be able to set a string [3.40ms]
(pass) FormData > should get filename from file [4.75ms]
(pass) FormData > should use the correct filenames [5.54ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [18.65ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [37.97ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.90ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [6.30ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.90ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.79ms]
(pass) FormData > should parse multipart/form-data (sim
... (truncated)

release without fix: 25 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.10ms]
(pass) FormData > should be able to append a Blob [0.19ms]
(pass) FormData > should be able to set a Blob [0.10ms]
(pass) FormData > should be able to set a string [0.07ms]
(pass) FormData > should get filename from file [0.07ms]
(pass) FormData > should use the correct filenames [0.14ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.41ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [1.68ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.07ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.06ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.04ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.32ms]
(pass) FormData > should be able to append a Blob [7.88ms]
(pass) FormData > should be able to set a Blob [6.25ms]
(pass) FormData > should be able to set a string [2.77ms]
(pass) FormData > should get filename from file [3.90ms]
(pass) FormData > should use the correct filenames [5.02ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [14.69ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [30.90ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.56ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.19ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.49ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.03ms]
(pass) FormData > should parse multipart/form-data (sim
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2887ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/1569] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/util.rs              | 96 ++++++++++++++++++++-------------------
 test/js/web/html/FormData.test.ts | 76 +++++++++++++++++++++++++++++++
 2 files changed, 126 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/bun_core/util.rs                   8     10     19
test/js/web/html/FormData.test.ts      6      7     18
```

</details>

**root cause** · written by the author bot

`get_boundary` extracted the multipart boundary as a raw slice of the Content-Type value running to the next `;`, so optional whitespace before that `;` and the literal contents of quoted values were kept verbatim, producing boundaries like `abc ` that rejected correctly delimited bodies. The fix rewrites the helper to follow the WHATWG "parse a MIME type" algorithm: it walks `;`-separated parameters, matches the name case-insensitively, trims HTTP whitespace from unquoted values, decodes quoted-pair escapes in quoted values, treats an unterminated quote as running to the end, and returns `…

<!-- robobun:evidence:end -->