### PR TITLE
Serve the Chrome DevTools workspace route when HMR is off

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -568,6 +568,9 @@ declare module "bun" {
            * With this enabled, you can persistently edit files in the browser. Bun adds the following route to the server:
            * `/.well-known/appspecific/com.chrome.devtools.json`
            *
+           * The route is added when the server is in development mode and has at least one HTML route.
+           * It does not depend on `hmr`.
+           *
            * The response is a JSON object with the following shape:
            * ```json
            * {

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -20,7 +20,6 @@ pub(crate) mod bake_body;
 #[path = "DevServer.rs"]
 mod dev_server_body;
 pub(crate) use dev_server_body::get_deinit_count_for_testing;
-pub(crate) use dev_server_body::is_allowed_dev_host;
 pub(crate) use dev_server_body::is_allowed_host_header;
 
 #[path = "FrameworkRouter.rs"]

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -44,7 +44,8 @@ pub struct ServerConfig {
     /// https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
     /// https://github.com/ChromeDevTools/vite-plugin-devtools-json/blob/76080b04422b36230d4b7a674b90d6df296cbff5/src/index.ts#L60-L77
     ///
-    /// If HMR is not enabled, then this field is ignored.
+    /// Only honoured in development mode on a server with an HTML route.
+    /// It does not depend on HMR.
     pub(crate) enable_chrome_devtools_automatic_workspace_folders: bool,
 
     /// Raw shadow of the wrapper's `onError`/`onRequest`/`onNodeHTTPRequest`

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -44,8 +44,7 @@ pub struct ServerConfig {
     /// https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
     /// https://github.com/ChromeDevTools/vite-plugin-devtools-json/blob/76080b04422b36230d4b7a674b90d6df296cbff5/src/index.ts#L60-L77
     ///
-    /// Only honoured in development mode on a server with an HTML route.
-    /// It does not depend on HMR.
+    /// Honoured in development mode when the server has an HTML route.
     pub(crate) enable_chrome_devtools_automatic_workspace_folders: bool,
 
     /// Raw shadow of the wrapper's `onError`/`onRequest`/`onNodeHTTPRequest`

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2255,10 +2255,17 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             self.dev_server.as_deref_mut().map(std::ptr::from_mut);
 
         // https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
-        // Only enable this when we're using the dev server.
+        // Only enable this when the server serves a frontend: either through
+        // the dev server (HMR on) or through an HTML bundle route (HMR off).
+        let serves_html = dev_server.is_some()
+            || self
+                .config
+                .static_routes
+                .iter()
+                .any(|entry| matches!(entry.route, AnyRoute::Html(_)));
         let mut should_add_chrome_devtools_json_route = DEBUG
             && self.config.allow_hot
-            && dev_server.is_some()
+            && serves_html
             && self
                 .config
                 .enable_chrome_devtools_automatic_workspace_folders;

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2255,8 +2255,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             self.dev_server.as_deref_mut().map(std::ptr::from_mut);
 
         // https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
-        // Only enable this when the server serves a frontend: either through
-        // the dev server (HMR on) or through an HTML bundle route (HMR off).
+        // Only for a server that serves HTML, with or without the dev server.
         let serves_html = dev_server.is_some()
             || self
                 .config

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3381,33 +3381,26 @@ where
             httplog!("{} - {}", BStr::new(&m), BStr::new(&u));
         }
 
-        let authorized = 'brk: {
-            let Some(dev_server) = self.dev_server.as_deref() else {
-                break 'brk false;
-            };
-
-            // The loopback source-IP check below is not enough on its own: a
-            // DNS-rebound origin connects from 127.0.0.1 but presents the
-            // attacker's hostname in `Host`. Apply the same Host allowlist as
-            // the `/_bun/*` routes before disclosing the project root path.
-            if !bake::is_allowed_dev_host(dev_server, req) {
-                break 'brk false;
-            }
-
-            if resp
+        // The loopback source-IP check is not enough on its own: a
+        // DNS-rebound origin connects from 127.0.0.1 but presents the
+        // attacker's hostname in `Host`. Apply the same Host allowlist as
+        // the `/_bun/*` routes before disclosing the project root path.
+        let authorized = bake::is_allowed_host_header(req, Some(&self.config.address))
+            && resp
                 .get_remote_socket_info()
-                .is_some_and(|address| address.is_loopback())
-            {
-                break 'brk true;
-            }
-
-            false
-        };
+                .is_some_and(|address| address.is_loopback());
 
         if !authorized {
             req.set_yield(true);
             return;
         }
+
+        // Without a DevServer (HMR off) the HTML bundle is still served from
+        // the project root, which is the cwd the DevServer would have used.
+        let root: &[u8] = match self.dev_server.as_deref() {
+            Some(dev_server) => &dev_server.root,
+            None => FileSystem::instance().top_level_dir,
+        };
 
         // They need a 16 byte uuid. It needs to be somewhat consistent. We don't want to store this field anywhere.
 
@@ -3423,7 +3416,6 @@ where
         // And then we use a hash of their project root directory:
         let second_hash_segment: [u8; 8] = 'brk: {
             let mut buffer = paths::path_buffer_pool::get();
-            let root = &self.dev_server.as_ref().unwrap().root;
             let len = root.len().min(buffer.len());
             break 'brk hash(strings::copy_lowercase(&root[..len], &mut buffer[..len]))
                 .to_ne_bytes();
@@ -3445,10 +3437,7 @@ where
         let _ = write!(
             &mut json_string,
             "{{ \"workspace\": {{ \"root\": {}, \"uuid\": \"{}\" }} }}",
-            bun_fmt::format_json_string_utf8(
-                &self.dev_server.as_ref().unwrap().root,
-                Default::default()
-            ),
+            bun_fmt::format_json_string_utf8(root, Default::default()),
             uuid,
         );
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3397,9 +3397,13 @@ where
 
         // Without a DevServer (HMR off) the HTML bundle is still served from
         // the project root, which is the cwd the DevServer would have used.
+        // `process.chdir()` leaves a trailing separator on `top_level_dir`;
+        // strip it the way `DevServer::init` does so both modes agree.
         let root: &[u8] = match self.dev_server.as_deref() {
             Some(dev_server) => &dev_server.root,
-            None => FileSystem::instance().top_level_dir,
+            None => paths::string_paths::without_trailing_slash_windows_path(
+                FileSystem::instance().top_level_dir,
+            ),
         };
 
         // They need a 16 byte uuid. It needs to be somewhat consistent. We don't want to store this field anywhere.

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3381,10 +3381,7 @@ where
             httplog!("{} - {}", BStr::new(&m), BStr::new(&u));
         }
 
-        // The loopback source-IP check is not enough on its own: a
-        // DNS-rebound origin connects from 127.0.0.1 but presents the
-        // attacker's hostname in `Host`. Apply the same Host allowlist as
-        // the `/_bun/*` routes before disclosing the project root path.
+        // Check `Host` too: a DNS-rebound origin connects from loopback with a foreign `Host`.
         let authorized = bake::is_allowed_host_header(req, Some(&self.config.address))
             && resp
                 .get_remote_socket_info()
@@ -3395,10 +3392,7 @@ where
             return;
         }
 
-        // Without a DevServer (HMR off) the HTML bundle is still served from
-        // the project root, which is the cwd the DevServer would have used.
-        // `process.chdir()` leaves a trailing separator on `top_level_dir`;
-        // strip it the way `DevServer::init` does so both modes agree.
+        // `process.chdir()` leaves a trailing separator on `top_level_dir`; strip it like `DevServer::init`.
         let root: &[u8] = match self.dev_server.as_deref() {
             Some(dev_server) => &dev_server.root,
             None => paths::string_paths::without_trailing_slash_windows_path(

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1606,3 +1606,53 @@ describe("production headers and import.meta.env", () => {
     expect(results).toEqual(cases.map(([, , expected]) => expected));
   });
 });
+
+describe("chrome devtools automatic workspace folders", () => {
+  const route = "/.well-known/appspecific/com.chrome.devtools.json";
+
+  // The route is served only while the server is in development mode and has
+  // an HTML route. It must not depend on HMR: `{ hmr: false }` is still
+  // development mode.
+  const cases: [development: string, served: boolean][] = [
+    ["true", true],
+    ["{ hmr: false }", true],
+    ["{ hmr: false, chromeDevToolsAutomaticWorkspaceFolders: true }", true],
+    ["{ hmr: true, chromeDevToolsAutomaticWorkspaceFolders: false }", false],
+    ["{ hmr: false, chromeDevToolsAutomaticWorkspaceFolders: false }", false],
+    ["false", false],
+  ];
+
+  test.concurrent.each(cases)("development: %s", async (development, served) => {
+    using dir = tempDir("bun-serve-html-devtools-json", {
+      "index.html": `<!DOCTYPE html><html><head><script type="module" src="./app.ts"></script></head><body>hi</body></html>`,
+      "app.ts": `console.log("app");`,
+      "serve.ts": /*ts*/ `
+        import page from "./index.html";
+        using server = Bun.serve({
+          port: 0,
+          development: ${development},
+          routes: { "/": page },
+          fetch: () => new Response("fell through", { status: 404 }),
+        });
+        const response = await fetch(new URL(${JSON.stringify(route)}, server.url));
+        const status = response.status;
+        const body = status === 200 ? await response.json() : await response.text();
+        console.log(JSON.stringify({ status, body }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "serve.ts"],
+      env: { ...bunEnv, NODE_ENV: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(stdout + "\n" + stderr);
+    expect(JSON.parse(stdout)).toEqual(
+      served
+        ? { status: 200, body: { workspace: { root: String(dir), uuid: expect.any(String) } } }
+        : { status: 404, body: "fell through" },
+    );
+  });
+});

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1655,4 +1655,40 @@ describe("chrome devtools automatic workspace folders", () => {
         : { status: 404, body: "fell through" },
     );
   });
+
+  // `process.chdir()` stores the cwd with a trailing separator. Both modes
+  // must report the same normalized root, so the uuid is the same too.
+  test.concurrent("root is the same with and without HMR after process.chdir()", async () => {
+    using dir = tempDir("bun-serve-html-devtools-json-chdir", {
+      "index.html": `<!DOCTYPE html><html><head><script type="module" src="./app.ts"></script></head><body>hi</body></html>`,
+      "app.ts": `console.log("app");`,
+      "serve.ts": /*ts*/ `
+        import page from "./index.html";
+        process.chdir(import.meta.dir);
+        const results = [];
+        for (const hmr of [true, false]) {
+          using server = Bun.serve({
+            port: 0,
+            development: { hmr },
+            routes: { "/": page },
+          });
+          const response = await fetch(new URL(${JSON.stringify(route)}, server.url));
+          results.push(await response.json());
+        }
+        console.log(JSON.stringify(results));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "serve.ts")],
+      env: { ...bunEnv, NODE_ENV: undefined },
+      cwd: join(String(dir), ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(stdout + "\n" + stderr);
+    const [withHmr, withoutHmr] = JSON.parse(stdout);
+    expect(withHmr).toEqual({ workspace: { root: String(dir), uuid: expect.any(String) } });
+    expect(withoutHmr).toEqual(withHmr);
+  });
 });


### PR DESCRIPTION
### Problem
- `Bun.serve({ development: { hmr: false, chromeDevToolsAutomaticWorkspaceFolders: true } })` accepts the option and ignores it. A GET to `/.well-known/appspecific/com.chrome.devtools.json` falls through to `fetch()`. With `hmr: true` the same config serves the JSON. The docs describe the flag with no condition on `hmr`, and `@default true`.
- The cause is the route condition in `src/runtime/server/mod.rs:2259`. It requires `dev_server.is_some()`, and `ServerConfig.rs:939` creates the DevServer only when HMR is on. The handler in `server_body.rs:3370` also reads `root` and the Host allowlist from the DevServer.

### Fix
- The route condition now accepts a server that has a DevServer or an `AnyRoute::Html` static route. Development mode and `chromeDevToolsAutomaticWorkspaceFolders` are still required.
- The handler checks `Host` with `is_allowed_host_header(req, Some(&self.config.address))`, which is what `is_allowed_dev_host` did through the DevServer. With no DevServer, `root` is `FileSystem::instance().top_level_dir` with the trailing separator stripped, the same value `DevServer::init` stores as `root` for HTML routes (`ServerConfig.rs:948`, `DevServer.rs:481`). The uuid and the JSON body are unchanged.
- A production server or a server with no HTML route does not get the route. That matches the current behaviour.
- Verified: `test/js/bun/http/bun-serve-html.test.ts` (new `chrome devtools automatic workspace folders` block: 6 cases plus a `process.chdir()` case that checks both modes report the same root and uuid, stock bun fails the `hmr: false` cases). Also the whole file and `test/bake/dev/html.test.ts`.

### Background
- `development: { hmr: false }` is still development mode (`DevelopmentOption::DevelopmentWithoutHmr`). HTML imports are bundled with dev settings and served through `HTMLBundle` static routes. No DevServer exists in that mode.
- The DevServer (`src/runtime/bake/DevServer.rs`) is the HMR engine. It owns `root` and the `/_bun/*` routes. The devtools route was added next to it and inherited its lifetime.
- Chrome reads `com.chrome.devtools.json` to map a served page to a folder on disk (automatic workspace folders). The handler answers only for a loopback peer with an allowed `Host`, and otherwise yields to the next route.

<details><summary>Notes</summary>

Repro (bun 1.4.3), with an `index.html` next to the script:

```
{"hmr":false,"chromeDevToolsAutomaticWorkspaceFolders":true} 404 fell through to fetch()
{"hmr":true,"chromeDevToolsAutomaticWorkspaceFolders":true}  200 { "workspace": { "root": ...
{"hmr":false}                                                404 fell through to fetch()
{"chromeDevToolsAutomaticWorkspaceFolders":false}            404 fell through to fetch()
true                                                         200 { "workspace": { "root": ...
```

After the fix the two `hmr: false` rows without `chromeDevToolsAutomaticWorkspaceFolders: false` return 200 with the same body as the `hmr: true` row.

`is_allowed_dev_host` had one remaining caller outside `DevServer.rs`, so its re-export in `bake/mod.rs` is removed. The function itself stays for the DevServer routes.

The `.d.ts` comment now states the condition: development mode and at least one HTML route, independent of `hmr`.

Self-reviewed: 2 concerns raised, 2 addressed (stale comment on the config field, trailing separator on the root after `process.chdir()`).

Suites run: `test/js/bun/http/bun-serve-html.test.ts` (36 pass, 2 skip), `test/bake/dev/html.test.ts` (11 pass).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_a1lJQv {
  "/": "/tmp/html-css-js_a1lJQv/index.html",
  "/dashboard": "/tmp/html-css-js_a1lJQv/dashboard.html",
}
[0.07ms] bundle index.html 1.09 KB
[0.06ms] bundle dashboard.html 1.27 KB
(pass) serve html [662.20ms]
waitForServer /tmp/bun-serve-html-txt_Jk6du5 {
  "/": "/tmp/bun-serve-html-txt_Jk6du5/index.html",
}
[0.08ms] bundle index.html 0.40 KB
HASH rq3x286y
(pass) serve plugins > basic plugin [644.03ms]
waitForServer /tmp/html-css-js-failing-plugin_H4fQkl {
  "/": "/tmp/html-css-js-failing-plugin_H4fQkl/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_H4fQkl/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_H4fQkl/styles.css:0
(pass) serve plugins > serve html with failing plugin [637.09ms]
waitForServer /tmp/html-css-js-empty-plugins_SDqrGO {
  "/": "/tmp/html-css-js-empty-plugins_SDqrGO/index.html",
}
[0.07ms] bun
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_Mq55Xw {
  "/": "/tmp/html-css-js_Mq55Xw/index.html",
  "/dashboard": "/tmp/html-css-js_Mq55Xw/dashboard.html",
}
[0.01ms] bundle index.html 1.09 KB
[0.03ms] bundle dashboard.html 1.27 KB
(pass) serve html [57.43ms]
waitForServer /tmp/bun-serve-html-txt_so8HFJ {
  "/": "/tmp/bun-serve-html-txt_so8HFJ/index.html",
}
[0.02ms] bundle index.html 0.40 KB
HASH rq3x286y
(pass) serve plugins > basic plugin [67.48ms]
waitForServer /tmp/html-css-js-failing-plugin_xNqSRY {
  "/": "/tmp/html-css-js-failing-plugin_xNqSRY/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_xNqSRY/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_xNqSRY/styles.css:0
(pass) serve plugins > serve html with failing plugin [26.35ms]
waitForServer /tmp/html-css-js-empty-plugins_dFlAz8 {
  "/": "/tmp/html-css-js-empty-plugins_dFlAz8/index.html",
}
[0.00ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [53.78ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_2Cqcmz {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_6H4g0b {
  "/": "/tmp/html-css-js_6H4g0b/index.html",
  "/dashboard": "/tmp/html-css-js_6H4g0b/dashboard.html",
}
[0.07ms] bundle index.html 1.09 KB
[0.06ms] bundle dashboard.html 1.27 KB
(pass) serve html [686.91ms]
waitForServer /tmp/bun-serve-html-txt_KcynR7 {
  "/": "/tmp/bun-serve-html-txt_KcynR7/index.html",
}
[0.12ms] bundle index.html 0.40 KB
HASH rq3x286y
(pass) serve plugins > basic plugin [648.86ms]
waitForServer /tmp/html-css-js-failing-plugin_rjqQzw {
  "/": "/tmp/html-css-js-failing-plugin_rjqQzw/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_rjqQzw/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_rjqQzw/styles.css:0
(pass) serve plugins > serve html with failing plugin [868.59ms]
waitForServer /tmp/html-css-js-empty-plugins_20IfEN {
  "/": "/tmp/html-css-js-empty-plugins_20IfEN/index.html",
}
[0.09ms] bun
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2507ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/9] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/serve.d.ts           |  3 ++
 src/runtime/bake/mod.rs                 |  1 -
 src/runtime/server/ServerConfig.rs      |  2 +-
 src/runtime/server/mod.rs               | 10 +++-
 src/runtime/server/server_body.rs       | 39 +++++----------
 test/js/bun/http/bun-serve-html.test.ts | 86 +++++++++++++++++++++++++++++++++
 6 files changed, 111 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
packages/bun-types/serve.d.ts                1      2     10
src/runtime/bake/mod.rs                      0      0     10
src/runtime/server/ServerConfig.rs           0      0     10
src/runtime/server/mod.rs                    2      1     10
src/runtime/server/server_body.rs            2      3     10
test/js/bun/http/bun-serve-html.test.ts      2      3     10
```

</details>

<!-- robobun:evidence:end -->