### PR TITLE
Read a character device synchronously when the kernel refuses to poll it

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -546,15 +546,11 @@ impl PosixBufferedReader {
     }
 
     /// The kernel refused to watch this fd: `epoll_ctl` returns `EPERM` and
-    /// kqueue `EINVAL` or `ENXIO` for a character device with no poll support
-    /// (`/dev/zero`, `/dev/null`, `/dev/urandom`).
+    /// kqueue `EINVAL` for a character device with no poll support
+    /// (`/dev/zero`, `/dev/null`, `/dev/urandom`). The shell's `IOWriter`
+    /// falls back on the same pair.
     fn is_unpollable(err: &sys::Error) -> bool {
-        match err.get_errno() {
-            sys::E::EPERM => true,
-            #[cfg(target_os = "macos")]
-            sys::E::EINVAL | sys::E::ENXIO => true,
-            _ => false,
-        }
+        matches!(err.get_errno(), sys::E::EPERM | sys::E::EINVAL)
     }
 
     /// A read on such an fd never waits, so drop the poll and read it

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -536,7 +536,7 @@ impl PosixBufferedReader {
         }
 
         match poll.register_with_fd(lp.cast(), FilePollKind::Readable, poll.fd()) {
-            sys::Result::Err(err) if Self::is_unpollable(&err) => {
+            sys::Result::Err(err) if crate::pipes::is_unpollable(&err) => {
                 self.demote_to_unpollable();
                 Ok(())
             }
@@ -545,16 +545,9 @@ impl PosixBufferedReader {
         }
     }
 
-    /// The kernel refused to watch this fd: `epoll_ctl` returns `EPERM` and
-    /// kqueue `EINVAL` for a character device with no poll support
-    /// (`/dev/zero`, `/dev/null`, `/dev/urandom`). The shell's `IOWriter`
-    /// falls back on the same pair.
-    fn is_unpollable(err: &sys::Error) -> bool {
-        matches!(err.get_errno(), sys::E::EPERM | sys::E::EINVAL)
-    }
-
-    /// A read on such an fd never waits, so drop the poll and read it
-    /// synchronously like a regular file.
+    /// Drops the poll the kernel refused and reads the fd synchronously, like
+    /// a regular file. No poll callback will come, so a caller that waits for
+    /// one must issue the read itself: see [`Self::is_pollable`].
     fn demote_to_unpollable(&mut self) {
         self.flags.remove(PosixFlags::POLLABLE);
         let fd = self.handle.get_fd();
@@ -595,6 +588,12 @@ impl PosixBufferedReader {
     /// Ends the reader after the next `len` bytes of the source as if they were followed by EOF (`ReadLimit`); `None` reads to EOF. Set before starting.
     pub fn set_limit(&mut self, len: Option<usize>) {
         self.limit = ReadLimit(len);
+    }
+
+    /// False after `start(fd, true)` when the kernel refused the poll. Reads
+    /// then run synchronously, and nothing drives them until the parent reads.
+    pub fn is_pollable(&self) -> bool {
+        self.flags.contains(PosixFlags::POLLABLE)
     }
 
     // Exists for consistently with Windows.

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -536,8 +536,34 @@ impl PosixBufferedReader {
         }
 
         match poll.register_with_fd(lp.cast(), FilePollKind::Readable, poll.fd()) {
+            sys::Result::Err(err) if Self::is_unpollable(&err) => {
+                self.demote_to_unpollable();
+                Ok(())
+            }
             sys::Result::Err(err) => Err(err),
             sys::Result::Ok(()) => Ok(()),
+        }
+    }
+
+    /// The kernel refused to watch this fd: `epoll_ctl` returns `EPERM` and
+    /// kqueue `EINVAL` or `ENXIO` for a character device with no poll support
+    /// (`/dev/zero`, `/dev/null`, `/dev/urandom`).
+    fn is_unpollable(err: &sys::Error) -> bool {
+        match err.get_errno() {
+            sys::E::EPERM => true,
+            #[cfg(target_os = "macos")]
+            sys::E::EINVAL | sys::E::ENXIO => true,
+            _ => false,
+        }
+    }
+
+    /// A read on such an fd never waits, so drop the poll and read it
+    /// synchronously like a regular file.
+    fn demote_to_unpollable(&mut self) {
+        self.flags.remove(PosixFlags::POLLABLE);
+        let fd = self.handle.get_fd();
+        if let PollOrFd::Poll(poll) = mem::replace(&mut self.handle, PollOrFd::Fd(fd)) {
+            poll.deinit_force_unregister();
         }
     }
 

--- a/src/io/pipes.rs
+++ b/src/io/pipes.rs
@@ -8,6 +8,16 @@ use bun_sys::FdExt;
 use crate::FilePollFlag;
 use crate::{FilePollRef, Owner};
 
+/// The kernel refused to watch the fd because it has no poll support: a
+/// regular file, or a character device such as `/dev/null`, `/dev/zero` or
+/// `/dev/urandom`. `epoll_ctl` reports it as `EPERM`, kqueue as `EINVAL`.
+/// A read or write on such an fd never waits, so the caller continues
+/// without a poll.
+#[cfg(not(windows))]
+pub fn is_unpollable(err: &bun_sys::Error) -> bool {
+    matches!(err.get_errno(), bun_sys::E::EPERM | bun_sys::E::EINVAL)
+}
+
 pub enum PollOrFd {
     Poll(FilePollRef),
     Fd(Fd),

--- a/src/io/pipes.rs
+++ b/src/io/pipes.rs
@@ -13,7 +13,6 @@ use crate::{FilePollRef, Owner};
 /// `/dev/urandom`. `epoll_ctl` reports it as `EPERM`, kqueue as `EINVAL`.
 /// A read or write on such an fd never waits, so the caller continues
 /// without a poll.
-#[cfg(not(windows))]
 pub fn is_unpollable(err: &bun_sys::Error) -> bool {
     matches!(err.get_errno(), bun_sys::E::EPERM | bun_sys::E::EINVAL)
 }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -566,7 +566,10 @@ impl FileResponseStream {
             self.insert_state(State::RESPONSE_DONE);
             self.detach_resp();
             let resp = self.resp.get();
-            resp.end_without_body(resp.should_close_connection());
+            // The reader hit EOF before any write. `end` frames the empty body
+            // (`content-length: 0`, or the last chunk) so a keep-alive client
+            // does not wait for more.
+            resp.end(b"", resp.should_close_connection());
             self.deliver(resp, StreamEnd::Complete);
             // This end runs uncorked (reader callbacks), so no cork or parser
             // gate will run the close check; do it here, after `on_complete`

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2005,6 +2005,9 @@ where
             offset: sendfile.offset as u64,
             length: if is_regular {
                 Some(sendfile.remain as u64)
+            } else if original_size != crate::webcore::blob::MAX_SIZE {
+                // A `.slice()` bounds a device or pipe body. Without one the reader runs to EOF.
+                Some(original_size as u64)
             } else {
                 None
             },

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -218,6 +218,13 @@ impl IOReader {
                 let fd = self.state().fd;
                 if let Err(e) = r.start(fd, true) {
                     self.on_reader_error(&e);
+                } else if !r.is_pollable() {
+                    // The kernel refused the poll (a regular file, /dev/null):
+                    // no callback will come, so read the fd now.
+                    // SAFETY: the reader cell is live for `self`'s lifetime and
+                    // `r` is not used past this point; `read` is the raw
+                    // re-entrancy-safe entry (its dispatch runs shell code).
+                    unsafe { bun_io::BufferedReader::read(self.reader.get()) };
                 }
             }
             return Yield::suspended();

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -356,31 +356,19 @@ impl IOWriter {
         if let Err(e) = s.writer.start(s.fd, s.flags.pollable) {
             #[cfg(not(windows))]
             {
-                // We get this if we pass in a file descriptor that is not
-                // pollable, for example a special character device like
-                // /dev/null. If so, restart with polling disabled.
+                // A regular file or a character device such as /dev/null:
+                // restart with polling disabled.
                 //
                 // It's also possible on Linux for EINVAL to be returned
                 // when registering multiple writable/readable polls for the
                 // same file descriptor. The shell code here makes sure to
                 // _not_ run into that case, but it is possible.
-                if e.get_errno() == E::EINVAL {
-                    crate::shell_log!("IOWriter(fd={}) got EINVAL", s.fd);
+                if bun_io::pipes::is_unpollable(&e) {
+                    crate::shell_log!("IOWriter(fd={}) got {}", s.fd, e.get_errno());
                     s.flags.pollable = false;
                     s.flags.nonblock = false;
                     s.flags.is_socket = false;
                     return self.__start();
-                }
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                {
-                    // On linux regular files are not pollable and return EPERM,
-                    // so restart if that's the case with polling disabled.
-                    if e.get_errno() == E::EPERM {
-                        s.flags.pollable = false;
-                        s.flags.nonblock = false;
-                        s.flags.is_socket = false;
-                        return self.__start();
-                    }
                 }
             }
             #[cfg(windows)]

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -411,6 +411,19 @@ impl FileReader {
                 }
                 return streams::Start::Err(e);
             }
+            #[cfg(unix)]
+            {
+                use bun_io::pipe_reader::PosixFlags;
+                // The kernel refused to poll the fd (a character device such as
+                // `/dev/zero`), so the reader is synchronous from here on and
+                // the ref would root an abandoned stream forever.
+                if need_io_ref && !self.reader().flags.contains(PosixFlags::POLLABLE) {
+                    self.waiting_for_on_reader_done.set(false);
+                    let parent = self.parent();
+                    // SAFETY: see `parent()`; JS finalizer still holds a ref so this cannot free it.
+                    let _ = unsafe { Source::decrement_count(parent) };
+                }
+            }
         } else {
             #[cfg(unix)]
             {

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1258,31 +1258,41 @@ describe.skipIf(isWindows)("Response(Bun.file(<character device>))", () => {
   });
 });
 
-// A FIFO whose writer closes without a byte ends the reader at EOF before the
-// first write. The response must still frame its empty body. Linux only: the
+// A writer that leaves without a byte ends the reader at EOF before the first
+// body write. The response must still frame its empty body. Linux only: the
 // server does not see a FIFO hangup on macOS yet.
-test.skipIf(!isLinux)("Response(Bun.file(FIFO)) with no data frames an empty body", async () => {
+test.skipIf(!isLinux)("Response(Bun.file(FIFO)) whose writer leaves without data frames an empty body", async () => {
   using dir = tempDir("serve-fifo-empty", {});
   const fifoPath = join(String(dir), "body.fifo");
   mkfifo(fifoPath);
 
-  await using server = Bun.serve({
-    port: 0,
-    hostname: "127.0.0.1",
-    fetch() {
-      return new Response(Bun.file(fifoPath));
-    },
-  });
-  // The writer's open(O_WRONLY) waits for the server's read end. The server
-  // opens it with O_NONBLOCK and sees no hangup until a writer has connected,
-  // so its read waits for this writer, which then closes without a byte.
-  await using writer = Bun.spawn({ cmd: ["sh", "-c", `: > "${fifoPath}"`], env: bunEnv });
-  const res = await fetch(`http://127.0.0.1:${server.port}/`);
-  expect({
-    status: res.status,
-    body: (await res.arrayBuffer()).byteLength,
-    writerExit: await writer.exited,
-  }).toEqual({ status: 200, body: 0, writerExit: 0 });
+  // Held read+write, so the server's open finds a writer and its first read
+  // waits on the poll instead of ending at once.
+  let writerFd: number | undefined = openSync(fifoPath, "r+");
+  const closeWriter = () => {
+    if (writerFd !== undefined) closeSync(writerFd);
+    writerFd = undefined;
+  };
+  try {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        // The server opens and polls the FIFO when this handler returns, in
+        // the same event-loop turn. The writer leaves on the next turn.
+        setImmediate(closeWriter);
+        return new Response(Bun.file(fifoPath));
+      },
+    });
+    const res = await fetch(`http://127.0.0.1:${server.port}/`);
+    expect({
+      status: res.status,
+      contentLength: res.headers.get("content-length"),
+      body: (await res.arrayBuffer()).byteLength,
+    }).toEqual({ status: 200, contentLength: "0", body: 0 });
+  } finally {
+    closeWriter();
+  }
 });
 
 // A file route serves the window of the Bun.file() slice it was built from,

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1270,16 +1270,19 @@ test.skipIf(!isLinux)("Response(Bun.file(FIFO)) with no data frames an empty bod
     port: 0,
     hostname: "127.0.0.1",
     fetch() {
-      // The writer opens the FIFO, which lets the server's open proceed, and closes it at once.
-      Bun.spawn({ cmd: ["sh", "-c", `: > "${fifoPath}"`], env: bunEnv });
       return new Response(Bun.file(fifoPath));
     },
   });
+  // The writer's open(O_WRONLY) waits for the server's read end. The server
+  // opens it with O_NONBLOCK and sees no hangup until a writer has connected,
+  // so its read waits for this writer, which then closes without a byte.
+  await using writer = Bun.spawn({ cmd: ["sh", "-c", `: > "${fifoPath}"`], env: bunEnv });
   const res = await fetch(`http://127.0.0.1:${server.port}/`);
   expect({
     status: res.status,
     body: (await res.arrayBuffer()).byteLength,
-  }).toEqual({ status: 200, body: 0 });
+    writerExit: await writer.exited,
+  }).toEqual({ status: 200, body: 0, writerExit: 0 });
 });
 
 // A file route serves the window of the Bun.file() slice it was built from,

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,6 +1,6 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, rmScope, rss, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, isWindows, rmScope, rss, tempDir, tempDirWithFiles } from "harness";
 import { mkfifo } from "mkfifo";
 import { closeSync, openSync, unlinkSync, writeSync } from "node:fs";
 import { join } from "node:path";
@@ -1223,6 +1223,63 @@ test.skipIf(isWindows)("Response(Bun.file(FIFO)) frames the body as chunked, not
   } finally {
     closeSync(writerFd);
   }
+});
+
+// The kernel refuses to poll these character devices (epoll_ctl EPERM). The
+// server must read them synchronously, not fail the response.
+describe.skipIf(isWindows)("Response(Bun.file(<character device>))", () => {
+  it("/dev/null ends as an empty body a keep-alive client can frame", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        return new Response(Bun.file("/dev/null"));
+      },
+    });
+    const res = await fetch(`http://127.0.0.1:${server.port}/`);
+    expect({
+      status: res.status,
+      contentLength: res.headers.get("content-length"),
+      body: (await res.arrayBuffer()).byteLength,
+    }).toEqual({ status: 200, contentLength: "0", body: 0 });
+  });
+
+  it("/dev/urandom slice delivers the slice", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        return new Response(Bun.file("/dev/urandom").slice(0, 200_000));
+      },
+    });
+    const res = await fetch(`http://127.0.0.1:${server.port}/`);
+    expect(res.status).toBe(200);
+    expect((await res.arrayBuffer()).byteLength).toBe(200_000);
+  });
+});
+
+// A FIFO whose writer closes without a byte ends the reader at EOF before the
+// first write. The response must still frame its empty body. Linux only: the
+// server does not see a FIFO hangup on macOS yet.
+test.skipIf(!isLinux)("Response(Bun.file(FIFO)) with no data frames an empty body", async () => {
+  using dir = tempDir("serve-fifo-empty", {});
+  const fifoPath = join(String(dir), "body.fifo");
+  mkfifo(fifoPath);
+
+  await using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      // The writer opens the FIFO, which lets the server's open proceed, and closes it at once.
+      Bun.spawn({ cmd: ["sh", "-c", `: > "${fifoPath}"`], env: bunEnv });
+      return new Response(Bun.file(fifoPath));
+    },
+  });
+  const res = await fetch(`http://127.0.0.1:${server.port}/`);
+  expect({
+    status: res.status,
+    body: (await res.arrayBuffer()).byteLength,
+  }).toEqual({ status: 200, body: 0 });
 });
 
 // A file route serves the window of the Bun.file() slice it was built from,

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2060,7 +2060,9 @@ describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
 describe.skipIf(isWindows)("Bun.file().stream() on a character device", () => {
   it.each(["/dev/zero", "/dev/urandom"])("%s streams the sliced range", async path => {
     let total = 0;
-    for await (const chunk of Bun.file(path).slice(0, 1 << 20).stream()) {
+    for await (const chunk of Bun.file(path)
+      .slice(0, 1 << 20)
+      .stream()) {
       total += chunk.length;
     }
     expect(total).toBe(1 << 20);

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2055,6 +2055,51 @@ describe.skipIf(isWindows)("Bun.file().stream() surfaces read() errors", () => {
   });
 });
 
+// epoll and kqueue refuse a character device with no poll support. The reader
+// must read such a device synchronously, not report the refusal as an error.
+describe.skipIf(isWindows)("Bun.file().stream() on a character device", () => {
+  it.each(["/dev/zero", "/dev/urandom"])("%s streams the sliced range", async path => {
+    let total = 0;
+    for await (const chunk of Bun.file(path).slice(0, 1 << 20).stream()) {
+      total += chunk.length;
+    }
+    expect(total).toBe(1 << 20);
+  });
+
+  it("/dev/null streams to a clean end", async () => {
+    const chunks = [];
+    for await (const chunk of Bun.file("/dev/null").stream()) chunks.push(chunk);
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("Response(Bun.file(device).slice()).body delivers the slice", async () => {
+    let total = 0;
+    for await (const chunk of new Response(Bun.file("/dev/zero").slice(0, 1024)).body) {
+      total += chunk.length;
+    }
+    expect(total).toBe(1024);
+  });
+
+  it("a stream left mid-read does not keep the process alive", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const reader = Bun.file("/dev/urandom").stream().getReader();
+        const { value } = await reader.read();
+        console.log("read", value.length > 0);
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("read true\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("fs.createReadStream(filename) should be able to break inside async loop", async () => {
   for (let i = 0; i < 10; i++) {
     const fileStream = createReadStream(join(import.meta.dir, "..", "fetch", "fixture.png"));


### PR DESCRIPTION
### Problem
- On main, `Bun.file("/dev/zero").slice(0, n).stream()` rejects with `EPERM: Operation not permitted (epoll_ctl)`. The same happens for `/dev/urandom`, `/dev/null`, and `new Response(Bun.file(dev).slice(0, n)).body`. Bun 1.4.2 and 1.4.3 stream these devices. The regression is unreleased (#41420).
- `Lazy::open_file_blob` (`src/runtime/webcore/FileReader.rs:222`) marks every path-opened non-regular file as pollable. The reader then calls `epoll_ctl(ADD)` on the device, and the kernel refuses with `EPERM` (a character device with no poll support). Before #41420 the refusal was dropped and reads ran synchronously. #41420 stores it as the stream's error.
- `Bun.serve` has the same refusal on the same devices, and closes the connection with no status line (#2461 in the fuzz ledger).

### Fix
- `PosixBufferedReader::try_register_poll` (`src/io/PipeReader.rs`) treats `EPERM` or `EINVAL` from the poll registration as "this fd cannot be polled". It drops the poll and clears `POLLABLE`, so the reader reads the fd synchronously like a regular file. The predicate lives in `bun_io::pipes::is_unpollable`. The shell's `IOWriter` fallback calls it too, and the shell `IOReader` reads a demoted fd at once.
- `FileReader::on_start` releases the across-read ref it took for a pollable source when the reader was demoted. Without that an abandoned device stream stays rooted, and its fd stays open.
- `FileResponseStream::finish` ends a zero-byte body with `resp.end(b"")`, so the response carries `content-length: 0`. `end_without_body` wrote no framing, and a keep-alive client waited forever. This also fixes `new Response(Bun.file(fifo))` when the writer closes without data. `do_sendfile` now passes a `.slice()` bound through for a non-regular file, so `Bun.file("/dev/urandom").slice(0, n)` served stops at `n` bytes instead of streaming to EOF. Both are intentional behaviour changes for device and pipe bodies.
- Verified: `test/js/web/streams/streams.test.js` ("on a character device", 5 tests) and `test/js/bun/http/bun-serve-file.test.ts` (3 tests). All fail on main. Also the full streams, serve-file, spawn, shell and fetch-file-upload suites.

### Background
- `PosixBufferedReader` is the shared reader behind `Bun.file().stream()`, `Bun.serve` file bodies, subprocess pipes and the shell. A pollable fd registers a `FilePoll` and reads when the event loop reports it readable. A non-pollable fd is read synchronously.
- Only the kernel knows whether an fd supports polling. `S_ISCHR` is not enough: a tty or `/dev/random` polls, `/dev/zero` does not. `epoll_ctl` reports the refusal as `EPERM`, kqueue as `EINVAL`. The shell's `IOWriter::__start` already used this pair.
- This supersedes the reader half of #34257, which predates #41420 and has conflicts. Its serve-side framing changes are carried here in the same shape.

<details><summary>Notes</summary>

Repro on main (`bun chardev-stream.mjs`):

```js
for await (const chunk of Bun.file("/dev/zero").slice(0, 1 << 20).stream()) {}
// EPERM: Operation not permitted (epoll_ctl)
```

Serve on main (`new Response(Bun.file("/dev/null"))`): the client sees a connection reset. With the reader fix alone it became a hang: the reader reached EOF before any write, and `finish` wrote headers with no `content-length` and no chunk. Hence the `resp.end(b"")` change. The same hang exists on 1.4.3 for a FIFO whose writer closes without a byte (the new FIFO test, Linux only: the server does not see a FIFO hangup on macOS yet, see #40099).

`/dev/urandom` served as `.slice(0, 200_000)` on the reader fix alone streamed forever: `length` was `None` for every non-regular file. The slice bound now reaches `set_limit`.

The shell `cat` builtin is disabled on POSIX, so the `IOReader` demotion read has no test on Linux or macOS. It keeps the contract explicit: after `start(fd, true)` a caller checks `is_pollable()` and issues the read when the kernel refused the poll.

The macOS `EINVAL` value comes from the review of #34257, where kqueue on `/dev/null` returned `EINVAL` on a macOS machine. I did not run this change on macOS.

Self-reviewed: 4 concerns raised, 4 addressed (cite and supersede #34257, one shared errno predicate, a visible outcome for the silent pollable-to-sync switch, name the slice change as intentional).

Pre-existing in this container, with or without the change: the three concurrent "pollable Bun.file response stops reading" tests in `bun-serve-file.test.ts` take 4.2 to 4.7 s each alone under the debug build and can cross the 5 s budget when the whole file runs. `bun-write.test.js` and `streams-leak.test.ts` time out here even on the release 1.4.3 binary.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js, test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->