### PR TITLE
Close the connection when a Bun.file response ends short of its Content-Length

### DIFF
--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -47,8 +47,7 @@ pub(crate) struct FileResponseStream {
     mode: Cell<Mode>,
     reader: JsCell<BufferedReader>,
     sendfile: JsCell<Sendfile>,
-    /// Bytes still owed on a fixed-length body (the caller wrote this many
-    /// into Content-Length). `None` streams to EOF.
+    /// Bytes still owed against the Content-Length the caller wrote; `None` streams to EOF.
     remaining: Cell<Option<u64>>,
 
     state: Cell<State>,
@@ -134,9 +133,7 @@ pub(crate) enum StreamOwner {
 enum StreamEnd {
     Complete,
     Abort,
-    /// The file ended before the length the caller committed to (it shrank
-    /// after the `fstat`). The socket is force-closed first; the owner only
-    /// has to release the request.
+    /// EOF before the committed length (the file shrank after the `fstat`).
     Truncated,
     Error(sys::Error),
 }
@@ -546,8 +543,6 @@ impl FileResponseStream {
         self.finish();
     }
 
-    /// Subtracts `sent` from the bytes still owed; returns the new balance
-    /// (`None` when the body has no fixed length).
     fn charge_remaining(&self, sent: u64) -> Option<u64> {
         let remaining = self.remaining.get().map(|n| n.saturating_sub(sent));
         self.remaining.set(remaining);
@@ -558,11 +553,8 @@ impl FileResponseStream {
         self.close_with(StreamEnd::Error(err));
     }
 
-    /// The headers already promised a Content-Length that the file no longer
-    /// backs. A clean end would retire the request as a complete keep-alive
-    /// response, and the client would wait for the missing bytes until the
-    /// idle timeout. Closing the connection is the one signal left that the
-    /// body is short.
+    /// The committed Content-Length can no longer be honoured, so a close is
+    /// the only signal left that tells the client the body is short.
     fn end_truncated(&self) {
         bun_output::scoped_log!(
             FileResponseStream,
@@ -607,9 +599,8 @@ impl FileResponseStream {
         self.insert_state(State::FINISHED);
 
         if !self.state.get().contains(State::RESPONSE_DONE) {
-            // The reader reports an EOF with no final chunk through
-            // `on_reader_done`, so this is where a short file lands. The nested
-            // `finish()` returns at the `FINISHED` guard above.
+            // An EOF with no final chunk arrives through `on_reader_done` and
+            // lands here; the nested `finish()` returns at the guard above.
             if self.remaining.get().is_some_and(|n| n > 0) {
                 self.end_truncated();
             } else {

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -47,6 +47,9 @@ pub(crate) struct FileResponseStream {
     mode: Cell<Mode>,
     reader: JsCell<BufferedReader>,
     sendfile: JsCell<Sendfile>,
+    /// Bytes still owed on a fixed-length body (the caller wrote this many
+    /// into Content-Length). `None` streams to EOF.
+    remaining: Cell<Option<u64>>,
 
     state: Cell<State>,
 }
@@ -61,7 +64,6 @@ pub enum Mode {
 struct Sendfile {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     socket_fd: Fd,
-    remain: u64,
     offset: u64,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     has_set_on_writable: bool,
@@ -77,7 +79,6 @@ impl Default for Sendfile {
         Self {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             socket_fd: Fd::INVALID,
-            remain: 0,
             offset: 0,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             has_set_on_writable: false,
@@ -133,6 +134,10 @@ pub(crate) enum StreamOwner {
 enum StreamEnd {
     Complete,
     Abort,
+    /// The file ended before the length the caller committed to (it shrank
+    /// after the `fstat`). The socket is force-closed first; the owner only
+    /// has to release the request.
+    Truncated,
     Error(sys::Error),
 }
 
@@ -147,7 +152,7 @@ impl StreamOwner {
                 on_abort,
                 on_error,
             } => match end {
-                StreamEnd::Complete => on_complete(ctx, resp),
+                StreamEnd::Complete | StreamEnd::Truncated => on_complete(ctx, resp),
                 StreamEnd::Abort => on_abort.unwrap_or(on_complete)(ctx, resp),
                 StreamEnd::Error(err) => on_error(ctx, resp, err),
             },
@@ -180,6 +185,7 @@ impl FileResponseStream {
                 }),
                 reader: JsCell::new(BufferedReader::init::<FileResponseStream>()),
                 sendfile: JsCell::new(Sendfile::default()),
+                remaining: Cell::new(opts.length),
                 state: Cell::new(State::default()),
             }));
         // SAFETY: `this` is the live allocation above; the guard's ref defers
@@ -214,7 +220,6 @@ impl FileResponseStream {
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 socket_fd: opts.resp.get_native_handle(),
                 offset: opts.offset,
-                remain: opts.length.expect("can_sendfile gates None"),
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 has_set_on_writable: false,
             });
@@ -314,8 +319,13 @@ impl FileResponseStream {
 
         let resp = self.resp.get();
         resp.timeout(self.idle_timeout.get());
+        let remaining = self.charge_remaining(chunk.len() as u64);
 
         if state == ReadState::Eof {
+            if remaining.is_some_and(|n| n > 0) {
+                self.end_truncated();
+                return false;
+            }
             self.insert_state(State::RESPONSE_DONE);
             self.detach_resp();
             resp.end(chunk, resp.should_close_connection());
@@ -406,8 +416,8 @@ impl FileResponseStream {
     fn on_sendfile(&self) -> bool {
         bun_output::scoped_log!(
             FileResponseStream,
-            "onSendfile remain={} offset={}",
-            self.sendfile.get().remain,
+            "onSendfile remain={:?} offset={}",
+            self.remaining.get(),
             self.sendfile.get().offset
         );
         if self.state.get().contains(State::RESPONSE_DONE) {
@@ -417,8 +427,9 @@ impl FileResponseStream {
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         loop {
-            let (errno, sent, remain) = self.sendfile.with_mut(|sf| {
-                let adjusted = sf.remain.min(i32::MAX as u64);
+            let remain = self.remaining.get().expect("can_sendfile gates None");
+            let (errno, sent) = self.sendfile.with_mut(|sf| {
+                let adjusted = remain.min(i32::MAX as u64);
                 let mut off: i64 = i64::try_from(sf.offset).expect("int cast");
                 // SAFETY: both fds are valid open file descriptors owned by `self`;
                 // `off` is a stack local.
@@ -435,14 +446,21 @@ impl FileResponseStream {
                     u64::try_from((off - i64::try_from(sf.offset).expect("int cast")).max(0))
                         .unwrap();
                 sf.offset = u64::try_from(off).expect("int cast");
-                sf.remain = sf.remain.saturating_sub(sent);
-                (errno, sent, sf.remain)
+                (errno, sent)
             });
+            let remain = self
+                .charge_remaining(sent)
+                .expect("can_sendfile gates None");
 
             match errno {
                 sys::E::SUCCESS => {
-                    if remain == 0 || sent == 0 {
+                    if remain == 0 {
                         self.end_sendfile();
+                        return false;
+                    }
+                    if sent == 0 {
+                        // EOF before the committed length: the file shrank.
+                        self.end_truncated();
                         return false;
                     }
                     return self.arm_sendfile_writable();
@@ -528,13 +546,39 @@ impl FileResponseStream {
         self.finish();
     }
 
+    /// Subtracts `sent` from the bytes still owed; returns the new balance
+    /// (`None` when the body has no fixed length).
+    fn charge_remaining(&self, sent: u64) -> Option<u64> {
+        let remaining = self.remaining.get().map(|n| n.saturating_sub(sent));
+        self.remaining.set(remaining);
+        remaining
+    }
+
     fn fail_with(&self, err: sys::Error) {
+        self.close_with(StreamEnd::Error(err));
+    }
+
+    /// The headers already promised a Content-Length that the file no longer
+    /// backs. A clean end would retire the request as a complete keep-alive
+    /// response, and the client would wait for the missing bytes until the
+    /// idle timeout. Closing the connection is the one signal left that the
+    /// body is short.
+    fn end_truncated(&self) {
+        bun_output::scoped_log!(
+            FileResponseStream,
+            "endTruncated remaining={:?}",
+            self.remaining.get()
+        );
+        self.close_with(StreamEnd::Truncated);
+    }
+
+    fn close_with(&self, end: StreamEnd) {
         if !self.state.get().contains(State::RESPONSE_DONE) {
             self.insert_state(State::RESPONSE_DONE | State::ERRORED);
             self.detach_resp();
             let resp = self.resp.get();
             resp.force_close();
-            self.deliver(resp, StreamEnd::Error(err));
+            self.deliver(resp, end);
         }
         self.finish();
     }
@@ -563,15 +607,14 @@ impl FileResponseStream {
         self.insert_state(State::FINISHED);
 
         if !self.state.get().contains(State::RESPONSE_DONE) {
-            self.insert_state(State::RESPONSE_DONE);
-            self.detach_resp();
-            let resp = self.resp.get();
-            resp.end_without_body(resp.should_close_connection());
-            self.deliver(resp, StreamEnd::Complete);
-            // This end runs uncorked (reader callbacks), so no cork or parser
-            // gate will run the close check; do it here, after `on_complete`
-            // like `end_sendfile`, so the callbacks see a live socket.
-            resp.close_if_done_and_marked();
+            // The reader reports an EOF with no final chunk through
+            // `on_reader_done`, so this is where a short file lands. The nested
+            // `finish()` returns at the `FINISHED` guard above.
+            if self.remaining.get().is_some_and(|n| n > 0) {
+                self.end_truncated();
+            } else {
+                self.end_complete_without_body();
+            }
         }
 
         // Release the owner ref from `heap::into_raw` in `start()`. Every entry
@@ -579,6 +622,18 @@ impl FileResponseStream {
         // that guard's drop, not here.
         // SAFETY: `self` is live and owns the ref; nothing touches `self` after.
         unsafe { Self::deref(self.as_ptr()) };
+    }
+
+    fn end_complete_without_body(&self) {
+        self.insert_state(State::RESPONSE_DONE);
+        self.detach_resp();
+        let resp = self.resp.get();
+        resp.end_without_body(resp.should_close_connection());
+        self.deliver(resp, StreamEnd::Complete);
+        // This end runs uncorked (reader callbacks), so no cork or parser
+        // gate will run the close check; do it here, after `on_complete`
+        // like `end_sendfile`, so the callbacks see a live socket.
+        resp.close_if_done_and_marked();
     }
 
     fn event_loop(&self) -> EventLoopHandle {

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,9 +1,11 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, rmScope, rss, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, rmScope, rss, tempDir, tempDirWithFiles, tls } from "harness";
 import { mkfifo } from "mkfifo";
-import { closeSync, openSync, unlinkSync, writeSync } from "node:fs";
+import { closeSync, openSync, truncateSync, unlinkSync, writeFileSync, writeSync } from "node:fs";
+import { connect as netConnect } from "node:net";
 import { join } from "node:path";
+import { connect as tlsConnect } from "node:tls";
 
 const LARGE_SIZE = 1024 * 1024 * 8;
 const files = {
@@ -1301,6 +1303,72 @@ test("file routes frame a slice that reaches or starts past EOF by the bytes the
     "slice(5, 5)": { blob: exactly(""), stream: exactly("") },
     "slice(100)": { blob: exactly(""), stream: exactly("") },
     "whole file": { blob: exactly("0123456789ABCDEF"), stream: exactly("0123456789ABCDEF") },
+  });
+});
+
+// The server writes Content-Length from the fstat it takes when the response
+// starts. When the file shrinks before the body is fully sent, the read hits
+// EOF short of that length. The response used to end there as if the body
+// were whole, and the connection stayed open: the client waited for the
+// missing bytes until the idle timeout (forever with idleTimeout: 0). A body
+// that ends short of the committed length must close the connection. Plain
+// TCP on Linux takes the sendfile path; TLS (and every other platform) takes
+// the buffered reader path.
+describe.concurrent.each([
+  ["plain", false],
+  ["tls", true],
+])("Response(Bun.file) whose file shrinks mid-body over %s", (_label, useTls) => {
+  test("closes the connection instead of leaving the client waiting for the missing bytes", async () => {
+    using dir = tempDir("serve-file-shrinks", {});
+    const filePath = join(String(dir), "big.bin");
+    // Far more than the loopback socket buffers hold, so the file is still
+    // streaming when it shrinks.
+    const SIZE = 32 * 1024 * 1024;
+    writeFileSync(filePath, Buffer.alloc(SIZE, 67));
+
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 0,
+      ...(useTls ? { tls } : {}),
+      fetch: () => new Response(Bun.file(filePath)),
+    });
+
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    let head = "";
+    let contentLength = -1;
+    let bodyBytes = 0;
+    let shrunk = false;
+
+    const socket = useTls
+      ? tlsConnect({ host: "127.0.0.1", port: server.port, rejectUnauthorized: false })
+      : netConnect({ host: "127.0.0.1", port: server.port });
+    socket.on("error", () => {});
+    socket.on("close", () => onClose());
+    socket.on("data", (chunk: Buffer) => {
+      if (contentLength < 0) {
+        head += chunk.toString("latin1");
+        const headEnd = head.indexOf("\r\n\r\n");
+        if (headEnd < 0) return;
+        contentLength = Number(/^content-length:\s*(\d+)/im.exec(head.slice(0, headEnd))![1]);
+        chunk = Buffer.from(head.slice(headEnd + 4), "latin1");
+      }
+      bodyBytes += chunk.length;
+      if (bodyBytes > 0 && !shrunk) {
+        // The head is on the wire with the full size and the body has
+        // started: shrink the file under the server.
+        shrunk = true;
+        truncateSync(filePath, 4096);
+      }
+    });
+    socket.once(useTls ? "secureConnect" : "connect", () => {
+      socket.write("GET /big HTTP/1.1\r\nHost: x\r\n\r\n");
+    });
+
+    // The server must hang up on its own. The client sends nothing more, so
+    // a server that treats the short body as complete never closes.
+    await closed;
+    expect({ contentLength, bodyShort: bodyBytes < contentLength }).toEqual({ contentLength: SIZE, bodyShort: true });
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.serve` writes `Content-Length` for a `new Response(Bun.file(p))` body from the `fstat` it takes when the response starts. When `p` shrinks after the headers are on the wire, the body ends short of that length and the server retires the request as a complete keep-alive response. The client waits for the missing bytes until the idle timeout, forever with `idleTimeout: 0`. No `error()` call, no `request.signal` abort, nothing on stderr.
- The cause is `FileResponseStream::on_sendfile` (`src/runtime/server/FileResponseStream.rs:444`), which treats `sendfile(2)` returning 0 (EOF) like `remain == 0`. The buffered reader path (TLS, macOS, Windows, files under 1 MiB) has the same hole at its EOF chunk and in `finish()`, where the reader's done callback lands when EOF comes with no final chunk.

### Fix
- `FileResponseStream` keeps one `remaining: Option<u64>` balance for a fixed-length body, seeded from `StartOptions.length`, and charges every chunk or `sendfile` result against it. `Sendfile.remain` is folded into it.
- An EOF while the balance is above zero goes through `end_truncated`: the socket is force-closed (the same path as a mid-stream read error, an RST), and the owner gets its cleanup callback. The owners (`RequestContext`, `FileRoute`, `DirectoryRoute`) only release the request on either callback, so the contract does not change.
- Correct because HTTP/1.1 cannot retract a committed `Content-Length`. A close is the one signal left that tells the client the body is short, and it keeps the keep-alive connection from being reused with a desynced frame (RFC 9112 6.2). #32842 applied the same rule to a `ReadableStream` body that errors mid-send.
- Verified: `test/js/bun/http/bun-serve-file.test.ts` (two new cases, plain and TLS, both time out on stock 1.4.3 because the client never sees a close). Also `bun-serve-static`, `serve-directory-routes`, `serve-file-slice-read-error`.

### Background
- `FileResponseStream` streams an open fd to a uWS response. It has two backends: `sendfile(2)` for plain TCP on Linux with a body of 1 MiB or more, and a `BufferedReader` everywhere else.
- The reader reports EOF in two ways: as an `on_read_chunk` call with `ReadState::Eof`, or, when the last read returns 0 bytes, through `on_reader_done` alone. The second lands in `finish()`, which used to end the response as complete.
- `force_close` closes with `SO_LINGER {1, 0}`, so the peer sees an RST and any unflushed send buffer is dropped. That is the existing behaviour for a read error mid-body.

<details><summary>Notes</summary>

- Found by a maintainer's error-channel audit, not a user report. Repro: a 40 MiB file, `fs.truncateSync(p, 1 << 20)` 2 ms into the handler, a raw client that reads with a 12 s timeout. Stock bun: `content-length 41943040 body bytes 2691072`, no FIN or RST, `pendingRequests 0`. With this change the client gets a connection reset right after the delivered prefix.
- This supersedes #34185, the same fix from July. That branch is in conflict with main, only tests the Linux sendfile path, and does not cover the `finish()` EOF site.
- #41474 reads `Sendfile.remain` in its fallback arm. After this lands that read becomes `self.remaining.get()`.
- The fetch client's `Bun.file` upload path (`src/http/SendFile.rs:58`) has the same `val == 0` shape on the sending side and is not touched here.
- The test shrinks the file from the client's first `data` event, so the head with the full size is already on the wire and the server still has most of the 32 MiB to send. The client sends nothing more, so only the server can end the wait.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->