### PR TITLE
js_parser: require an operand after yield* and reject parenthesized arrow parameters

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -588,7 +588,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         r,
                         b"Unexpected parentheses in binding pattern",
                     );
-                    return Err(crate::Error::SyntaxError);
                 }
 
                 // Now that we've decided we're an arrow function, report binding pattern

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -113,16 +113,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         let mut value: Option<ExprNodeIndex> = None;
-        match p.lexer.token {
-            T::TCloseBrace
-            | T::TCloseParen
-            | T::TCloseBracket
-            | T::TColon
-            | T::TComma
-            | T::TSemicolon => {}
-            _ => {
-                if is_star || !p.lexer.has_newline_before {
-                    value = Some(p.parse_expr(Level::Yield)?);
+        if is_star {
+            // "yield*" always takes an operand
+            value = Some(p.parse_expr(Level::Yield)?);
+        } else {
+            match p.lexer.token {
+                T::TCloseBrace
+                | T::TCloseParen
+                | T::TCloseBracket
+                | T::TColon
+                | T::TComma
+                | T::TSemicolon => {}
+                _ => {
+                    if !p.lexer.has_newline_before {
+                        value = Some(p.parse_expr(Level::Yield)?);
+                    }
                 }
             }
         }
@@ -577,6 +582,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if is_arrow_fn || opts.force_arrow_fn {
                 p.maybe_comma_spread_error(comma_after_spread);
                 p.log_arrow_arg_errors(&mut arrow_arg_errors);
+                if let Some(r) = errors.invalid_paren {
+                    p.log().add_range_error(
+                        Some(p.source),
+                        r,
+                        b"Unexpected parentheses in binding pattern",
+                    );
+                    return Err(crate::Error::SyntaxError);
+                }
 
                 // Now that we've decided we're an arrow function, report binding pattern
                 // conversion errors

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -44,8 +44,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::Super {}, loc))
     }
 
-    fn pfx_t_open_paren(p: &mut Self, level: Level, flags: EFlags) -> PResult<Expr> {
+    fn pfx_t_open_paren(
+        p: &mut Self,
+        level: Level,
+        errors: Option<&mut DeferredErrors>,
+        flags: EFlags,
+    ) -> PResult<Expr> {
         let loc = p.lexer.loc();
+        if let Some(errors) = errors {
+            errors.invalid_paren = Some(p.lexer.range());
+        }
         p.lexer.next()?;
 
         // Arrow functions aren't allowed in the middle of expressions
@@ -1010,7 +1018,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TOpenBrace => Self::pfx_t_open_brace(p, errors),
             T::TLessThan => Self::pfx_t_less_than(p, level, errors, flags),
             T::TImport => Self::pfx_t_import(p, level),
-            T::TOpenParen => Self::pfx_t_open_paren(p, level, flags),
+            T::TOpenParen => Self::pfx_t_open_paren(p, level, errors, flags),
             T::TPrivateIdentifier => Self::pfx_t_private_identifier(p, level),
             T::TIdentifier => Self::pfx_t_identifier(p, level, flags),
             T::TFalse => Self::pfx_t_false(p),

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -789,8 +789,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            // "[(a)] = b" is a valid assignment target, but "([(a)] = b) => c"
-            // is not.
+            // Only an arrow parameter list rejects "[(a)] = b"
             if let Some(errors) = errors {
                 errors.invalid_paren = self_errors.invalid_paren.or(errors.invalid_paren);
             }
@@ -879,8 +878,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.allow_in = old_allow_in;
 
         if p.will_need_binding_pattern() {
-            // Is this a binding pattern? "{a: (b)} = c" is a valid assignment
-            // target, but "({a: (b)} = c) => d" is not.
+            // Only an arrow parameter list rejects "{a: (b)} = c"
             if let Some(errors) = errors {
                 errors.invalid_paren = self_errors.invalid_paren.or(errors.invalid_paren);
             }

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -789,7 +789,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            // noop
+            // "[(a)] = b" is a valid assignment target, but "([(a)] = b) => c"
+            // is not.
+            if let Some(errors) = errors {
+                errors.invalid_paren = self_errors.invalid_paren.or(errors.invalid_paren);
+            }
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);
@@ -875,7 +879,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.allow_in = old_allow_in;
 
         if p.will_need_binding_pattern() {
-            // Is this a binding pattern?
+            // Is this a binding pattern? "{a: (b)} = c" is a valid assignment
+            // target, but "({a: (b)} = c) => d" is not.
+            if let Some(errors) = errors {
+                errors.invalid_paren = self_errors.invalid_paren.or(errors.invalid_paren);
+            }
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1312,6 +1312,10 @@ pub struct DeferredErrors {
     /// These are errors for expressions
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
+
+    /// A parenthesized item such as `((a)) => a`. It is an error only if the
+    /// expression turns out to be the parameter list of an arrow function.
+    pub(crate) invalid_paren: Option<bun_ast::Range>,
 }
 
 impl DeferredErrors {
@@ -1322,6 +1326,7 @@ impl DeferredErrors {
         to.invalid_expr_after_question = self
             .invalid_expr_after_question
             .or(to.invalid_expr_after_question);
+        to.invalid_paren = self.invalid_paren.or(to.invalid_paren);
     }
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1313,8 +1313,7 @@ pub struct DeferredErrors {
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
 
-    /// A parenthesized item such as `((a)) => a`. It is an error only if the
-    /// expression turns out to be the parameter list of an arrow function.
+    /// A parenthesized item, an error only in an arrow parameter list: `((a)) => a`
     pub(crate) invalid_paren: Option<bun_ast::Range>,
 }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2989,6 +2989,46 @@ console.log(<div {...obj} key="after" />);`),
       // );
     });
 
+    it("yield* requires an operand", () => {
+      expectPrinted_("function* g() { yield* a }", "function* g() {\n  yield* a;\n}");
+      expectPrinted_("function* g() { yield }", "function* g() {\n  yield;\n}");
+      expectPrinted_("function* g() { var a = yield; }", "function* g() {\n  var a = yield;\n}");
+      expectPrinted_("function* g() { f(yield, yield) }", "function* g() {\n  f(yield, yield);\n}");
+
+      expectParseError("function* g() { yield* ; }", "Unexpected ;");
+      expectParseError("function* g() { yield* }", "Unexpected }");
+      expectParseError("function* g() { (yield*) }", "Unexpected )");
+      expectParseError("function* g() { f(yield*) }", "Unexpected )");
+      expectParseError("function* g() { f(yield*, a) }", "Unexpected ,");
+      expectParseError("function* g() { var a = yield * ; }", "Unexpected ;");
+      expectParseError("function* g() { yield * * 1 }", "Unexpected *");
+      expectParseError("function* g() { return yield*\n; }", "Unexpected ;");
+    });
+
+    it("parenthesized arrow parameters", () => {
+      expectPrinted_("var f = (a) => a", "var f = (a) => a");
+      expectPrinted_("var f = (a = (b)) => a", "var f = (a = b) => a");
+      expectPrinted_("var f = (a = (b, c)) => a", "var f = (a = (b, c)) => a");
+      expectPrinted_("var f = ([a] = (b)) => a", "var f = ([a] = b) => a");
+      expectPrinted_("var f = ({ a = (b) }) => a", "var f = ({ a = b }) => a");
+      expectPrinted_("var f = ((a), b)", "var f = (a, b)");
+      expectPrinted_("var f = [(a)] = [1]", "var f = [a] = [1]");
+      expectPrinted_("var f = async((a))", "var f = async(a)");
+
+      const message = "Unexpected parentheses in binding pattern";
+      expectParseError("var f = ((a)) => a", message);
+      expectParseError("var f = ((a), b) => b", message);
+      expectParseError("var f = (a, (b)) => b", message);
+      expectParseError("var f = ((a) = 1) => a", message);
+      expectParseError("var f = (...(a)) => a", message);
+      expectParseError("var f = ([(a)]) => a", message);
+      expectParseError("var f = ([...(a)]) => a", message);
+      expectParseError("var f = ({ a: (b) }) => b", message);
+      expectParseError("var f = ({ ...(a) }) => a", message);
+      expectParseError("var f = async ((a)) => a", message);
+      expectParseError("var f = (((a))) => a", message);
+    });
+
     it("import assert", () => {
       expectPrinted_(`import json from "./foo.json" assert { type: "json" };`, `import json from "./foo.json"`);
       expectPrinted_(`import json from "./foo.json";`, `import json from "./foo.json"`);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3027,6 +3027,18 @@ console.log(<div {...obj} key="after" />);`),
       expectParseError("var f = ({ ...(a) }) => a", message);
       expectParseError("var f = async ((a)) => a", message);
       expectParseError("var f = (((a))) => a", message);
+      expectParseError("var f = ([(a)] = b) => a", message);
+      expectParseError("var f = ([[(a)]] = b) => a", message);
+      expectParseError("var f = ({ a: (b) } = c) => b", message);
+      expectParseError("var f = ([{ a: (b) }] = c) => b", message);
+      // The parser keeps going after the error, so later errors are still reported.
+      try {
+        parsed("var f = ((a)) => a; var g = ((b)) => b;", false, false);
+        throw new Error("Expected parse error");
+      } catch (er) {
+        expect(er).toBeInstanceOf(AggregateError);
+        expect(er.errors.map(e => e.message)).toEqual([message, message]);
+      }
     });
 
     it("import assert", () => {


### PR DESCRIPTION
### Problem
- `function* g() { var a = yield * ; }` is a SyntaxError in every engine (node: `Unexpected token ';'`, esbuild: `Unexpected ";"`). Bun's parser accepts it and parses it as a bare `yield`. `bun run` runs the rewritten program. `bun build` prints `var a = yield;` and exits 0.
- `var f = ((a)) => a` and `((a), b) => b` are early errors (node: `Invalid destructuring assignment target`, esbuild: `Invalid binding pattern`). Bun parses them as `(a) => a` and `(a, b) => b`.
- The cause: `parse_yield_expr` (`src/js_parser/parse/mod.rs:102`) treats `;` `)` `}` `,` `:` `]` as "no operand" even after `*`. `parse_prefix` drops the parentheses around an item before `parse_paren_expr` converts the items to bindings, so the conversion sees a plain identifier.

### Fix
- `parse_yield_expr` always parses an operand after `*`. The "no operand" token list applies only to bare `yield`.
- `DeferredErrors` gains `invalid_paren`. `parse_prefix` records the range of a parenthesized item when a deferred error set is active (only `parse_paren_expr`, array literals, and object literals pass one). `parse_paren_expr` reports `Unexpected parentheses in binding pattern` once the list turns out to be an arrow parameter list, then keeps parsing. An array or object literal followed by `=` carries the record to its parent, so `([(a)] = b) => c` is rejected too. A parenthesized sequence, a call to `async`, an assignment pattern such as `[(a)] = [1]`, and a default value such as `(a = (b)) => a` are unchanged. This is esbuild's `invalidParens`.
- Verified: `test/bundler/transpiler/transpiler.test.js` (two new blocks, both fail on 1.4.3). Also ran `test/bundler/esbuild/{default,ts,lower}`, `test/bundler/bundler_edgecase.test.ts`, and `test/js/bun/transpiler/`.

### Background
- The parser is a port of esbuild. `parse_paren_expr` parses `(...)` as a list of expressions first. When `=>` follows, `convert_expr_to_binding` turns each expression into a binding pattern.
- `DeferredErrors` holds errors that are only errors in one of the two readings of an expression (a literal or a destructuring pattern). The parser logs them once it knows which reading applies.
- `Level::Yield` is the precedence used for the operand of `yield`. `yield* x` is `yield*` applied to an `AssignmentExpression`, so the operand cannot be empty.

<details><summary>Notes</summary>

Reported by the parser fuzz ledger (entries 24712 and 24713).

The new error for a parenthesized parameter points at the inner `(`. That is the same location the existing `is_parenthesized` check reports for `(([]) = []) => {}`, so that test keeps its message and offset.

`(a: number): (number) => a` is rejected before and after this change. tsc rejects it too (`'=>' expected`), because `(number) => a` reads as a function type.

Additional spellings checked by hand with the debug build: `yield*;`, `(yield*)`, `f(...yield*)`, `x = yield* ;`, `return yield*⏎;`, `yield * * 1`, `([(a)]) => a`, `({ a: (b) }) => b`, `(...(a)) => a`, `(((a))) => a`, `async ((a)) => a`, `([(a)] = b) => c`, `({ a: (b) } = c) => d`.

esbuild 0.21.5 accepts `([(a)] = b) => c`. Node rejects it, so this PR rejects it as well.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.26ms]
(pass) Bun.Transpiler > normalizes \r\n [7.64ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [5.74ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [10.62ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.62ms]
(pass) Bun.Transpiler > property access inlining > works [4.28ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.59ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [58.55ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [31.49ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [331.03ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 2 failed, 22 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.12ms]
(pass) Bun.Transpiler > normalizes \r\n [0.18ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.83ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.23ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [8.32ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.64ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.08ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [11.36ms]
(pass) Bun.Transpiler > normalizes \r\n [13.83ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [10.03ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [19.49ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [5.95ms]
(pass) Bun.Transpiler > property access inlining > works [6.60ms]
(pass) Bun.Transpiler > property access inlining > works nested [6.66ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [106.96ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [41.01ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [537.14ms]
(pass) Bun.Transpiler > property access inlining > bails out on opti
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3422ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/mod.rs                 | 32 ++++++++++++------
 src/js_parser/parse/parse_prefix.rs        | 22 ++++++++++---
 src/js_parser/parser.rs                    |  4 +++
 test/bundler/transpiler/transpiler.test.js | 52 ++++++++++++++++++++++++++++++
 4 files changed, 96 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/mod.rs                      3      5     13
src/js_parser/parse/parse_prefix.rs             2      5     13
src/js_parser/parser.rs                         1      2     13
test/bundler/transpiler/transpiler.test.js      2      3     13
```

</details>

<!-- robobun:evidence:end -->