### PR TITLE
Bun.file().stream(): read regular files on the work pool instead of the JS thread

### DIFF
--- a/src/io/MaxBuf.rs
+++ b/src/io/MaxBuf.rs
@@ -168,14 +168,19 @@ impl MaxBuf {
     /// a 256 KB scratch read off a socketpair overshoots `maxBuffer` by hundreds
     /// of KB. Never empties a non-empty `buf` (that would read as EOF).
     pub(crate) fn clamp_read_buf(this: Option<NonNull<MaxBuf>>, buf: &mut [u8]) -> &mut [u8] {
+        let len = Self::clamp_read_len(this, buf.len());
+        &mut buf[..len]
+    }
+
+    /// The length form of [`Self::clamp_read_buf`], for a read that is sized before its buffer exists.
+    pub(crate) fn clamp_read_len(this: Option<NonNull<MaxBuf>>, len: usize) -> usize {
         let Some(this) = this else {
-            return buf;
+            return len;
         };
         let remaining = u64::try_from(Self::live(&this).remaining_bytes.get()).unwrap_or(0);
         let limit =
             usize::try_from(remaining.saturating_add(OVERREAD_ALLOWANCE)).unwrap_or(usize::MAX);
-        let len = buf.len().min(limit);
-        &mut buf[..len]
+        len.min(limit)
     }
 }
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -632,10 +632,9 @@ impl PosixBufferedReader {
             if fd == Fd::INVALID {
                 return None;
             }
-            let len = MaxBuf::clamp_read_len((*this).maxbuf, (*this).limit.clamp_len(max_len));
-            if len == 0 {
-                return None;
-            }
+            // Never an empty read: that would read as EOF, and a `None` here would park the pull.
+            let len =
+                MaxBuf::clamp_read_len((*this).maxbuf, (*this).limit.clamp_len(max_len.max(1)));
             (*this).flags.insert(PosixFlags::ASYNC_READ_IN_FLIGHT);
             let offset = (*this)
                 .flags

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -644,14 +644,18 @@ impl PosixBufferedReader {
         }
     }
 
-    /// Delivers the read reserved by [`Self::begin_async_read`] the way a synchronous read is
-    /// delivered (chunk, EOF, or error). A `close()` that landed meanwhile is finished here and the
-    /// bytes are dropped. Returns whether the parent wants the next read.
+    /// Accounts for the read reserved by [`Self::begin_async_read`]: budgets, the offset, EOF
+    /// and errors, and a `close()` that landed while the read was out (finished here, the bytes
+    /// dropped). `Some((len, state))` bytes are the parent's to deliver, followed by a call to
+    /// [`Self::finish_async_read`]. `None`: the reader ended and reported it.
     ///
     /// # Safety
     /// `this` is the live reader; the dispatches may free the parent, so the caller holds its own
     /// reference across this call.
-    pub unsafe fn complete_async_read(this: *mut Self, result: sys::Result<Vec<u8>>) -> bool {
+    pub unsafe fn account_async_read(
+        this: *mut Self,
+        result: sys::Result<usize>,
+    ) -> Option<(usize, ReadState)> {
         // SAFETY: caller contract; borrows end at each `;`.
         let vtable = unsafe {
             (*this).flags.remove(PosixFlags::ASYNC_READ_IN_FLIGHT);
@@ -665,21 +669,21 @@ impl PosixBufferedReader {
                 (*this).flags.remove(PosixFlags::DEFER_DONE_CALLBACK);
                 Self::close_handle(this);
             }
-            return false;
+            return None;
         }
         // SAFETY: caller contract; borrow ends at `;`.
         if unsafe { (*this).is_done() } {
-            return false;
+            return None;
         }
-        let bytes = match result {
-            sys::Result::Ok(bytes) => bytes,
+        let n = match result {
+            sys::Result::Ok(n) => n,
             sys::Result::Err(err) => {
                 // SAFETY: caller contract; `on_error` is the tail.
                 unsafe { Self::on_error(this, err) };
-                return false;
+                return None;
             }
         };
-        if bytes.is_empty() {
+        if n == 0 {
             // SAFETY: caller contract; `done` is the tail.
             unsafe {
                 (*this).close_without_reporting();
@@ -687,9 +691,8 @@ impl PosixBufferedReader {
                     Self::done(this);
                 }
             }
-            return false;
+            return None;
         }
-        let n = bytes.len();
         // SAFETY: caller contract; borrows end at the block.
         let stop = unsafe {
             (*this)._offset += n;
@@ -704,14 +707,17 @@ impl PosixBufferedReader {
         };
         // SAFETY: caller contract; borrow ends at `;`.
         unsafe { Self::close_if_final(this, stop.as_ref()) };
-        let keep_going = if vtable.is_streaming_enabled() {
-            vtable.on_read_chunk(Chunk::Owned(bytes), Self::read_state(stop.as_ref(), false))
-        } else {
-            // SAFETY: caller contract; borrow ends at `;`.
-            unsafe { (*this)._buffer.extend_from_slice(&bytes) };
-            true
-        };
-        if stop.is_some() {
+        Some((n, Self::read_state(stop.as_ref(), false)))
+    }
+
+    /// After the parent delivered the bytes from [`Self::account_async_read`]: ends the reader on
+    /// EOF. Returns whether the parent wants the next read (`keep_going` from its delivery, and
+    /// the reader neither paused nor done).
+    ///
+    /// # Safety
+    /// As [`Self::account_async_read`].
+    pub unsafe fn finish_async_read(this: *mut Self, state: ReadState, keep_going: bool) -> bool {
+        if state == ReadState::Eof {
             // SAFETY: caller contract; `done` is the tail.
             unsafe {
                 if !(*this).flags.contains(PosixFlags::IS_DONE) {
@@ -720,9 +726,40 @@ impl PosixBufferedReader {
             }
             return false;
         }
-        // SAFETY: caller contract (the dispatch never frees `*this`); borrow ends at `;`.
+        // SAFETY: caller contract; borrow ends at `;`.
         keep_going
             && unsafe { !(*this).is_done() && !(*this).flags.contains(PosixFlags::IS_PAUSED) }
+    }
+
+    /// The owned-buffer form: accounts for the read, delivers `bytes` to the parent the way a
+    /// synchronous read's are delivered, and finishes it.
+    ///
+    /// # Safety
+    /// As [`Self::account_async_read`].
+    pub unsafe fn complete_async_read(this: *mut Self, result: sys::Result<Vec<u8>>) -> bool {
+        let (bytes, counted) = match result {
+            sys::Result::Ok(bytes) => {
+                let n = bytes.len();
+                (bytes, sys::Result::Ok(n))
+            }
+            sys::Result::Err(err) => (Vec::new(), sys::Result::Err(err)),
+        };
+        // SAFETY: caller contract.
+        let Some((_, state)) = (unsafe { Self::account_async_read(this, counted) }) else {
+            return false;
+        };
+        // SAFETY: caller contract; the (Copy) vtable is read before the dispatch.
+        let vtable = unsafe { (*this).vtable };
+        let _parent = vtable.ref_parent();
+        let keep_going = if vtable.is_streaming_enabled() {
+            vtable.on_read_chunk(Chunk::Owned(bytes), state)
+        } else {
+            // SAFETY: caller contract; borrow ends at `;`.
+            unsafe { (*this)._buffer.extend_from_slice(&bytes) };
+            true
+        };
+        // SAFETY: caller contract.
+        unsafe { Self::finish_async_read(this, state, keep_going) }
     }
 
     pub fn watch(&mut self) {

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -432,7 +432,7 @@ impl PosixBufferedReader {
     /// the struct embedding `*this` — a free must never run under a live
     /// receiver protector.
     unsafe fn close_handle(this: *mut Self) {
-        // The pool thread still reads the fd: closing it now would hand the descriptor number to the next `open`. `complete_async_read` finishes the close.
+        // A read is out on the pool thread: `complete_async_read` finishes the close.
         // SAFETY: caller contract; borrow ends at `;`.
         if unsafe { (*this).flags.contains(PosixFlags::ASYNC_READ_IN_FLIGHT) } {
             // SAFETY: caller contract; borrow ends at `;`.
@@ -606,8 +606,8 @@ impl PosixBufferedReader {
     }
 
     /// Reserves one read of up to `max_len` bytes for the parent to perform off the event loop.
-    /// `None` when the reader is paused, done, or already has a read out, or when the byte
-    /// budget is used up: that is this reader's EOF, reported through `on_reader_done` here.
+    /// `None` when paused, done, a read is already out, or the budget is used up (this reader's
+    /// EOF, reported through `on_reader_done` here).
     ///
     /// # Safety
     /// `this` is the live reader; the `on_reader_done` dispatch may free the parent.
@@ -645,15 +645,13 @@ impl PosixBufferedReader {
         }
     }
 
-    /// Delivers the read reserved by [`Self::begin_async_read`]: the bytes go to the parent the way
-    /// a synchronous read's do, an empty read or a used-up budget ends the reader, and an error is
-    /// reported through `on_reader_error`. A `close()` that landed while the read was out is
-    /// finished here and the bytes are dropped. Returns whether the parent wants the next read
-    /// (it asked to keep going, and the reader is neither paused nor done).
+    /// Delivers the read reserved by [`Self::begin_async_read`] the way a synchronous read is
+    /// delivered (chunk, EOF, or error). A `close()` that landed meanwhile is finished here and the
+    /// bytes are dropped. Returns whether the parent wants the next read.
     ///
     /// # Safety
-    /// `this` is the live reader; the dispatches may free the parent, so the caller must hold
-    /// its own reference across this call.
+    /// `this` is the live reader; the dispatches may free the parent, so the caller holds its own
+    /// reference across this call.
     pub unsafe fn complete_async_read(this: *mut Self, result: sys::Result<Vec<u8>>) -> bool {
         // SAFETY: caller contract; borrows end at each `;`.
         let vtable = unsafe {

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -210,7 +210,20 @@ bitflags::bitflags! {
         const USE_PREAD                = 1 << 8;
         const IS_PAUSED                = 1 << 9;
         const KEEP_ALIVE               = 1 << 10; // default true
+        /// The parent is performing one read off the event loop (`begin_async_read`); the fd must stay open until `complete_async_read`.
+        const ASYNC_READ_IN_FLIGHT     = 1 << 11;
+        /// `close()` landed while a read was in flight; `complete_async_read` finishes it.
+        const DEFER_DONE_CALLBACK      = 1 << 12;
     }
+}
+
+/// One read the parent performs off the event loop: a regular file blocks the calling thread for the duration of the read, so the parent runs it on the work pool and hands the bytes back through [`PosixBufferedReader::complete_async_read`].
+#[derive(Clone, Copy, Debug)]
+pub struct AsyncRead {
+    pub fd: Fd,
+    /// `Some` reads at this offset with `pread`; `None` reads at the fd's own position.
+    pub offset: Option<usize>,
+    pub len: usize,
 }
 
 impl PosixFlags {
@@ -419,6 +432,13 @@ impl PosixBufferedReader {
     /// the struct embedding `*this` — a free must never run under a live
     /// receiver protector.
     unsafe fn close_handle(this: *mut Self) {
+        // The pool thread still reads the fd: closing it now would hand the descriptor number to the next `open`. `complete_async_read` finishes the close.
+        // SAFETY: caller contract; borrow ends at `;`.
+        if unsafe { (*this).flags.contains(PosixFlags::ASYNC_READ_IN_FLIGHT) } {
+            // SAFETY: caller contract; borrow ends at `;`.
+            unsafe { (*this).flags.insert(PosixFlags::DEFER_DONE_CALLBACK) };
+            return;
+        }
         // SAFETY: caller contract; borrows end at each `;`.
         let deferred_report =
             unsafe { (*this).flags.contains(PosixFlags::CLOSED_WITHOUT_REPORTING) };
@@ -575,13 +595,137 @@ impl PosixBufferedReader {
         self.limit = ReadLimit(len);
     }
 
-    // Exists for consistently with Windows.
+    /// A poll armed for the next wakeup, or a read out on the work pool.
     pub fn has_pending_read(&self) -> bool {
         // `is_watching()` (registered && !needs-rearm) rather than
         // `is_registered()`: a one-shot poll that has fired but not been
         // re-armed will not deliver another callback, so callers that skip
         // `read()` on "pending" must not be told one is in flight.
         matches!(&self.handle, PollOrFd::Poll(poll) if poll.is_watching())
+            || self.flags.contains(PosixFlags::ASYNC_READ_IN_FLIGHT)
+    }
+
+    /// Reserves one read of up to `max_len` bytes for the parent to perform off the event loop.
+    /// `None` when the reader is paused, done, or already has a read out, or when the byte
+    /// budget is used up: that is this reader's EOF, reported through `on_reader_done` here.
+    ///
+    /// # Safety
+    /// `this` is the live reader; the `on_reader_done` dispatch may free the parent.
+    pub unsafe fn begin_async_read(this: *mut Self, max_len: usize) -> Option<AsyncRead> {
+        // SAFETY: caller contract; borrows end at each `;`.
+        unsafe {
+            if (*this).is_done()
+                || (*this)
+                    .flags
+                    .intersects(PosixFlags::IS_PAUSED | PosixFlags::ASYNC_READ_IN_FLIGHT)
+            {
+                return None;
+            }
+            if (*this).limit.reached() {
+                (*this).close_without_reporting();
+                if !(*this).flags.contains(PosixFlags::IS_DONE) {
+                    Self::done(this);
+                }
+                return None;
+            }
+            let fd = (*this).get_fd();
+            if fd == Fd::INVALID {
+                return None;
+            }
+            let len = MaxBuf::clamp_read_len((*this).maxbuf, (*this).limit.clamp_len(max_len));
+            if len == 0 {
+                return None;
+            }
+            (*this).flags.insert(PosixFlags::ASYNC_READ_IN_FLIGHT);
+            let offset = (*this)
+                .flags
+                .contains(PosixFlags::USE_PREAD)
+                .then_some((*this)._offset);
+            Some(AsyncRead { fd, offset, len })
+        }
+    }
+
+    /// Delivers the read reserved by [`Self::begin_async_read`]: the bytes go to the parent the way
+    /// a synchronous read's do, an empty read or a used-up budget ends the reader, and an error is
+    /// reported through `on_reader_error`. A `close()` that landed while the read was out is
+    /// finished here and the bytes are dropped. Returns whether the parent wants the next read
+    /// (it asked to keep going, and the reader is neither paused nor done).
+    ///
+    /// # Safety
+    /// `this` is the live reader; the dispatches may free the parent, so the caller must hold
+    /// its own reference across this call.
+    pub unsafe fn complete_async_read(this: *mut Self, result: sys::Result<Vec<u8>>) -> bool {
+        // SAFETY: caller contract; borrows end at each `;`.
+        let vtable = unsafe {
+            (*this).flags.remove(PosixFlags::ASYNC_READ_IN_FLIGHT);
+            (*this).vtable
+        };
+        let _parent = vtable.ref_parent();
+        // SAFETY: caller contract; borrow ends at `;`.
+        if unsafe { (*this).flags.contains(PosixFlags::DEFER_DONE_CALLBACK) } {
+            // SAFETY: caller contract; `close_handle` is the (maybe-freeing) tail.
+            unsafe {
+                (*this).flags.remove(PosixFlags::DEFER_DONE_CALLBACK);
+                Self::close_handle(this);
+            }
+            return false;
+        }
+        // SAFETY: caller contract; borrow ends at `;`.
+        if unsafe { (*this).is_done() } {
+            return false;
+        }
+        let bytes = match result {
+            sys::Result::Ok(bytes) => bytes,
+            sys::Result::Err(err) => {
+                // SAFETY: caller contract; `on_error` is the tail.
+                unsafe { Self::on_error(this, err) };
+                return false;
+            }
+        };
+        if bytes.is_empty() {
+            // SAFETY: caller contract; `done` is the tail.
+            unsafe {
+                (*this).close_without_reporting();
+                if !(*this).flags.contains(PosixFlags::IS_DONE) {
+                    Self::done(this);
+                }
+            }
+            return false;
+        }
+        let n = bytes.len();
+        // SAFETY: caller contract; borrows end at the block.
+        let stop = unsafe {
+            (*this)._offset += n;
+            let limit_reached = (*this).limit.charge(n);
+            if (*this).charge_max_buffer(n) {
+                Some(Stop::OverBudget)
+            } else if limit_reached {
+                Some(Stop::Eof)
+            } else {
+                None
+            }
+        };
+        // SAFETY: caller contract; borrow ends at `;`.
+        unsafe { Self::close_if_final(this, stop.as_ref()) };
+        let keep_going = if vtable.is_streaming_enabled() {
+            vtable.on_read_chunk(Chunk::Owned(bytes), Self::read_state(stop.as_ref(), false))
+        } else {
+            // SAFETY: caller contract; borrow ends at `;`.
+            unsafe { (*this)._buffer.extend_from_slice(&bytes) };
+            true
+        };
+        if stop.is_some() {
+            // SAFETY: caller contract; `done` is the tail.
+            unsafe {
+                if !(*this).flags.contains(PosixFlags::IS_DONE) {
+                    Self::done(this);
+                }
+            }
+            return false;
+        }
+        // SAFETY: caller contract (the dispatch never frees `*this`); borrow ends at `;`.
+        keep_going
+            && unsafe { !(*this).is_done() && !(*this).flags.contains(PosixFlags::IS_PAUSED) }
     }
 
     pub fn watch(&mut self) {

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -663,7 +663,7 @@ pub use source::Source;
 // Stub for never-constructed-on-POSIX `Source` so cross-platform sigs
 // (`Option<Source>`) typecheck.
 
-pub use pipe_reader::{BufferedReader, BufferedReaderParent, PosixFlags};
+pub use pipe_reader::{AsyncRead, BufferedReader, BufferedReaderParent, PosixFlags};
 
 pub use open_for_writing_mod::{open_for_writing, open_for_writing_impl};
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -604,11 +604,15 @@ impl FileReader {
             return false;
         }
         self.read_size.set(buffer.len());
-        // SAFETY: `buffer` is the JS slab the pull pins (`pending_value`) until the read settles;
-        // a slice's data pointer is non-null even when empty.
-        let slab =
-            unsafe { bun_jsc::JsPtr::new(core::ptr::NonNull::new_unchecked(buffer.as_mut_ptr())) };
-        self.schedule_offloaded_read(ReadTarget::Slab(slab));
+        // An empty slab cannot hold the one byte a read asks for at least; read into an owned buffer.
+        let target = match core::ptr::NonNull::new(buffer.as_mut_ptr()) {
+            // SAFETY: `buffer` is the JS slab the pull pins (`pending_value`) until the read settles.
+            Some(slab) if !buffer.is_empty() => {
+                ReadTarget::Slab(unsafe { bun_jsc::JsPtr::new(slab) })
+            }
+            _ => ReadTarget::Owned(Vec::new()),
+        };
+        self.schedule_offloaded_read(target);
         true
     }
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -596,20 +596,24 @@ impl FileReader {
         }
     }
 
-    /// A JS pull on an offloaded file: sizes the next read to the pull buffer and hands it to the
-    /// work pool. `false` when the pull is served inline.
+    /// A JS pull on an offloaded file: hands a read straight into the pull buffer to the work
+    /// pool. `false` when the pull is served inline.
     #[cfg(unix)]
-    fn offload_pull(&self, len: usize) -> bool {
+    fn offload_pull(&self, buffer: &mut [u8]) -> bool {
         if !self.offloaded.get() || self.reader().has_pending_read() || !self.flowing.get() {
             return false;
         }
-        self.read_size.set(len);
-        self.schedule_offloaded_read();
+        self.read_size.set(buffer.len());
+        // SAFETY: `buffer` is the JS slab the pull pins (`pending_value`) until the read settles;
+        // a slice's data pointer is non-null even when empty.
+        let slab =
+            unsafe { bun_jsc::JsPtr::new(core::ptr::NonNull::new_unchecked(buffer.as_mut_ptr())) };
+        self.schedule_offloaded_read(ReadTarget::Slab(slab));
         true
     }
 
     #[cfg(not(unix))]
-    fn offload_pull(&self, _len: usize) -> bool {
+    fn offload_pull(&self, _buffer: &mut [u8]) -> bool {
         false
     }
 
@@ -617,7 +621,7 @@ impl FileReader {
     fn read(&self) {
         #[cfg(unix)]
         if self.offloaded.get() {
-            self.schedule_offloaded_read();
+            self.schedule_offloaded_read(ReadTarget::Owned(Vec::new()));
             return;
         }
         // SAFETY: the reader cell is live for `self`'s lifetime; `read` is
@@ -628,7 +632,7 @@ impl FileReader {
     /// Hands one read to the work pool. Nothing is scheduled with a read already out or nothing
     /// left to read (then the reader ends through `on_reader_done`).
     #[cfg(unix)]
-    fn schedule_offloaded_read(&self) {
+    fn schedule_offloaded_read(&self, target: ReadTarget) {
         // SAFETY: the reader cell is live for `self`'s lifetime; the JS wrapper's ref keeps the
         // source alive across the `on_reader_done` dispatch.
         let Some(request) =
@@ -643,11 +647,35 @@ impl FileReader {
             &global.js_thread(),
             OffloadedRead {
                 request,
-                bytes: Vec::new(),
-                error: None,
+                target,
+                read: sys::Result::Ok(0),
             },
             OffloadedReadPin(pin),
         );
+    }
+
+    /// Settles the parked pull with the `len` bytes an offloaded read put straight into its buffer.
+    #[cfg(unix)]
+    fn resolve_pending_read_in_place(&self, len: usize, state: ReadState) {
+        if self.pending.get().state != streams::PendingState::Pending {
+            return;
+        }
+        let into = streams::IntoArray {
+            value: self.pending_value.get().get().unwrap_or_default(),
+            len: len as u64,
+        };
+        let result = if state == ReadState::Eof || self.reader().is_done() {
+            streams::Result::IntoArrayAndDone(into)
+        } else {
+            streams::Result::IntoArray(into)
+        };
+        self.pending.with_mut(|p| p.result = result);
+        self.pending_value
+            .with_mut(|p| p.clear_without_deallocation());
+        self.pending_view.set(&mut []);
+        // SAFETY: see `parent()`; `run()` runs user JS that can cancel the stream.
+        let _pin = unsafe { SourcePin::new(self.parent()) };
+        self.pending.with_mut(|p| p.run());
     }
 
     pub(crate) fn on_cancel(&self) {
@@ -872,7 +900,7 @@ impl FileReader {
             return self.end_of_reader();
         }
 
-        if self.offload_pull(buffer.len()) {
+        if self.offload_pull(buffer) {
             bun_core::scoped_log!(FileReader, "onPull({}) = offloaded", buffer.len());
             // Nothing left to read: the reader ended inside `schedule_offloaded_read`.
             if self.reader().is_done() {
@@ -1128,13 +1156,22 @@ impl Drop for SourcePin {
     }
 }
 
+/// Where an offloaded read puts its bytes.
+#[cfg(unix)]
+enum ReadTarget {
+    /// The JS pull buffer, pinned by the parked pull: no copy on delivery.
+    Slab(bun_jsc::JsPtr<u8>),
+    /// A buffer of the read's own, for a native sink or a read with no pull waiting.
+    Owned(Vec<u8>),
+}
+
 /// One read of a regular file on the work pool. The bytes enter the reader on the JS thread
-/// through `complete_async_read`, the way a libuv read completes on Windows.
+/// through `account_async_read`, the way a libuv read completes on Windows.
 #[cfg(unix)]
 struct OffloadedRead {
     request: bun_io::AsyncRead,
-    bytes: Vec<u8>,
-    error: Option<sys::Error>,
+    target: ReadTarget,
+    read: sys::Result<usize>,
 }
 
 /// Keeps the source alive while its read is out. Dropped on the JS thread after the completion,
@@ -1147,36 +1184,53 @@ struct OffloadedReadPin(SourcePin);
 unsafe impl bun_jsc::job::JsAffine for OffloadedReadPin {}
 
 #[cfg(unix)]
+impl OffloadedRead {
+    fn read_into(request: bun_io::AsyncRead, buf: &mut [u8]) -> sys::Result<usize> {
+        let buf = &mut buf[..request.len];
+        match request.offset {
+            Some(offset) => sys::pread(request.fd, buf, i64::try_from(offset).expect("int cast")),
+            None => sys::read(request.fd, buf),
+        }
+    }
+}
+
+#[cfg(unix)]
 impl bun_jsc::JobContext for OffloadedRead {
     type OffThread = Self;
     type Js = OffloadedReadPin;
 
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
         let request = this.request;
-        if this.bytes.try_reserve_exact(request.len).is_err() {
-            this.error = Some(sys::Error::from_code(sys::E::ENOMEM, sys::Tag::read));
-            return Some(done);
-        }
-        // SAFETY: the syscall writes only initialized bytes into the prefix it reports, and
-        // only that prefix is committed.
-        let result = unsafe {
-            bun_core::vec::fill_spare(&mut this.bytes, 0, |spare| {
-                let buf = &mut spare[..request.len];
-                let result = match request.offset {
-                    Some(offset) => {
-                        sys::pread(request.fd, buf, i64::try_from(offset).expect("int cast"))
-                    }
-                    None => sys::read(request.fd, buf),
+        this.read = match &mut this.target {
+            ReadTarget::Slab(slab) => {
+                // SAFETY: `slab` is the parked pull's buffer of `request.len` bytes, kept alive by
+                // the pull's `pending_value`; the ticket keeps the VM alive; nothing reads the
+                // buffer until the pull settles.
+                let buf = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        core::ptr::from_mut(slab.under_ticket(done.ticket())),
+                        request.len,
+                    )
                 };
-                match result {
-                    sys::Result::Ok(n) => (n, sys::Result::Ok(())),
-                    sys::Result::Err(err) => (0, sys::Result::Err(err)),
+                Self::read_into(request, buf)
+            }
+            ReadTarget::Owned(bytes) => {
+                if bytes.try_reserve_exact(request.len).is_err() {
+                    sys::Result::Err(sys::Error::from_code(sys::E::ENOMEM, sys::Tag::read))
+                } else {
+                    // SAFETY: the syscall writes only initialized bytes into the prefix it
+                    // reports, and only that prefix is committed.
+                    unsafe {
+                        bun_core::vec::fill_spare(bytes, 0, |spare| {
+                            match Self::read_into(request, spare) {
+                                sys::Result::Ok(n) => (n, sys::Result::Ok(n)),
+                                sys::Result::Err(err) => (0, sys::Result::Err(err)),
+                            }
+                        })
+                    }
                 }
-            })
+            }
         };
-        if let sys::Result::Err(err) = result {
-            this.error = Some(err);
-        }
         Some(done)
     }
 
@@ -1185,18 +1239,31 @@ impl bun_jsc::JobContext for OffloadedRead {
         js: OffloadedReadPin,
         _cx: &bun_jsc::JsThread<'_>,
     ) -> bun_jsc::JsResult<()> {
-        let result = match this.error {
-            Some(err) => sys::Result::Err(err),
-            None => sys::Result::Ok(this.bytes),
-        };
         // SAFETY: `js` pins the source for the whole call.
         let file_reader: &FileReader = unsafe { &(*js.0.0).context };
-        // SAFETY: the reader cell is live while the source is; the pin holds the source.
-        let wants_more = unsafe { IOReader::complete_async_read(file_reader.reader.get(), result) };
-        // A native sink is drained by the reader itself. A JS consumer sizes each read with its
-        // pull; a read issued ahead of it would make `nativeAdjustChunkSize` shrink the slab.
-        if wants_more && file_reader.sink.get().is_some() {
-            file_reader.schedule_offloaded_read();
+        let reader = file_reader.reader.get();
+        match this.target {
+            ReadTarget::Slab(_) => {
+                // SAFETY: the reader cell is live while the source is; the pin holds the source.
+                if let Some((len, state)) =
+                    unsafe { IOReader::account_async_read(reader, this.read) }
+                {
+                    file_reader.resolve_pending_read_in_place(len, state);
+                    // SAFETY: as above.
+                    let _ = unsafe { IOReader::finish_async_read(reader, state, false) };
+                }
+            }
+            ReadTarget::Owned(bytes) => {
+                // SAFETY: the reader cell is live while the source is; the pin holds the source.
+                let wants_more =
+                    unsafe { IOReader::complete_async_read(reader, this.read.map(|_| bytes)) };
+                // A native sink is drained by the reader itself. A JS consumer sizes each read
+                // with its pull; a read issued ahead of it would make `nativeAdjustChunkSize`
+                // shrink the slab.
+                if wants_more && file_reader.sink.get().is_some() {
+                    file_reader.schedule_offloaded_read(ReadTarget::Owned(Vec::new()));
+                }
+            }
         }
         drop(js);
         Ok(())

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -66,7 +66,19 @@ pub struct FileReader {
     /// path; `pull_into_sink` is the drain-ack resume.
     pub(crate) sink: JsCell<SinkHandle>,
     pub(crate) sink_paused: Cell<bool>,
+    /// POSIX: the fd is a regular file. A read of it blocks the calling thread for as long as the
+    /// disk takes, so each read runs on the work pool and completes through the same callbacks a
+    /// libuv read completes through on Windows.
+    #[cfg(unix)]
+    pub(crate) offloaded: Cell<bool>,
+    /// How many bytes the next offloaded read asks for: the size of the last JS pull buffer.
+    #[cfg(unix)]
+    pub(crate) read_size: Cell<usize>,
 }
+
+/// The read size for an offloaded read that no JS pull sized (a native sink drains the reader).
+#[cfg(unix)]
+const OFFLOADED_READ_SIZE: usize = 256 * 1024;
 
 impl Default for FileReader {
     fn default() -> Self {
@@ -90,6 +102,10 @@ impl Default for FileReader {
             flowing: Cell::new(true),
             sink: JsCell::new(SinkHandle::None),
             sink_paused: Cell::new(false),
+            #[cfg(unix)]
+            offloaded: Cell::new(false),
+            #[cfg(unix)]
+            read_size: Cell::new(OFFLOADED_READ_SIZE),
         }
     }
 }
@@ -336,6 +352,7 @@ impl FileReader {
                             #[cfg(unix)]
                             {
                                 file_type = opened.file_type;
+                                self.offloaded.set(file_type == FileType::File && !pollable);
                             }
                             #[cfg(unix)]
                             {
@@ -380,12 +397,12 @@ impl FileReader {
         if was_lazy {
             // The across-read ref roots the JS wrapper (`increment_count`
             // upgrades `this_jsvalue` to Strong) so an event-loop callback
-            // firing with no JS on the stack never lands on a freed box. For a
-            // POSIX non-pollable regular file every read is synchronous
-            // (`read_file` → `sys::pread`), so there is no such callback —
-            // holding the Strong there would root an abandoned reader forever
-            // and leak its fd. Windows file reads are async via libuv even for
-            // regular files, so the ref is always taken there.
+            // firing with no JS on the stack never lands on a freed box. A
+            // POSIX regular file takes no such ref here: holding the Strong for
+            // the reader's whole life would root an abandoned reader forever
+            // and leak its fd. Its offloaded reads pin the source per read
+            // instead (`OffloadedRead`). Windows file reads are async via libuv
+            // even for regular files, so the ref is always taken there.
             #[cfg(unix)]
             let need_io_ref = pollable;
             #[cfg(windows)]
@@ -580,10 +597,63 @@ impl FileReader {
         }
         if !self.reader().has_pending_read() {
             self.reader().unpause();
-            // SAFETY: the reader cell is live for `self`'s lifetime; `read` is
-            // the raw re-entrancy-safe entry (its dispatch runs user JS).
-            unsafe { IOReader::read(self.reader.get()) };
+            self.read();
         }
+    }
+
+    /// A JS pull on an offloaded file that is flowing and has no read out: sizes the next read to
+    /// the pull buffer and hands it to the work pool. `false` when the pull is served inline.
+    #[cfg(unix)]
+    fn offload_pull(&self, len: usize) -> bool {
+        if !self.offloaded.get() || self.reader().has_pending_read() || !self.flowing.get() {
+            return false;
+        }
+        self.read_size.set(len);
+        self.schedule_offloaded_read();
+        true
+    }
+
+    #[cfg(not(unix))]
+    fn offload_pull(&self, _len: usize) -> bool {
+        false
+    }
+
+    /// Starts the next read: on the work pool for an offloaded file, inline otherwise.
+    fn read(&self) {
+        #[cfg(unix)]
+        if self.offloaded.get() {
+            self.schedule_offloaded_read();
+            return;
+        }
+        // SAFETY: the reader cell is live for `self`'s lifetime; `read` is
+        // the raw re-entrancy-safe entry (its dispatch runs user JS).
+        unsafe { IOReader::read(self.reader.get()) };
+    }
+
+    /// Hands one read of the file to the work pool. Nothing is scheduled when the reader has
+    /// nothing left to read (then it is done, reported through `on_reader_done`) or a read is
+    /// already out.
+    #[cfg(unix)]
+    fn schedule_offloaded_read(&self) {
+        // SAFETY: the reader cell is live for `self`'s lifetime; the `on_reader_done` dispatch
+        // settles a parked pull, which cannot free the source while the JS wrapper holds its ref.
+        let Some(request) =
+            (unsafe { IOReader::begin_async_read(self.reader.get(), self.read_size.get()) })
+        else {
+            return;
+        };
+        let global = self.parent_global();
+        // SAFETY: see `parent()`.
+        let pin = unsafe { SourcePin::new(self.parent()) };
+        bun_jsc::Job::<OffloadedRead>::schedule(
+            &global.js_thread(),
+            OffloadedRead {
+                request,
+                bytes: Vec::new(),
+                error: None,
+            },
+            OffloadedReadPin(pin),
+        );
     }
 
     pub(crate) fn on_cancel(&self) {
@@ -808,7 +878,17 @@ impl FileReader {
             return self.end_of_reader();
         }
 
-        if !self.reader().has_pending_read() && self.flowing.get() {
+        if self.offload_pull(buffer.len()) {
+            bun_core::scoped_log!(FileReader, "onPull({}) = offloaded", buffer.len());
+            // Nothing left to read: the reader ended inside `schedule_offloaded_read`.
+            if self.reader().is_done() {
+                let drained = self.drain();
+                if !drained.is_empty() {
+                    return streams::Result::OwnedAndDone(drained);
+                }
+                return self.end_of_reader();
+            }
+        } else if !self.reader().has_pending_read() && self.flowing.get() {
             // SAFETY: the reader cell is live for `self`'s lifetime; `read_into` is the raw re-entrancy-safe entry (EOF/error dispatch runs user JS).
             let (amount_read, state) = unsafe { IOReader::read_into(self.reader.get(), buffer) };
             bun_core::scoped_log!(FileReader, "onPull({}) = {}", buffer.len(), amount_read);
@@ -1017,10 +1097,7 @@ impl FileReader {
         if flag {
             self.reader().unpause();
             if !self.reader().is_done() && !self.reader().has_pending_read() {
-                // Kick off a new read if needed
-                // SAFETY: the reader cell is live for `self`'s lifetime; `read` is
-                // the raw re-entrancy-safe entry (its dispatch runs user JS).
-                unsafe { IOReader::read(self.reader.get()) };
+                self.read();
             }
         } else {
             self.reader().pause();
@@ -1054,6 +1131,86 @@ impl Drop for SourcePin {
     fn drop(&mut self) {
         // SAFETY: balances the ref taken in `new`.
         let _ = unsafe { Source::decrement_count(self.0) };
+    }
+}
+
+/// One read of a regular file on the work pool (`read`/`pread` block the thread that calls them
+/// for the disk's duration). The bytes come back to the JS thread and enter the reader through
+/// `complete_async_read`, the path a libuv read completes through on Windows.
+#[cfg(unix)]
+struct OffloadedRead {
+    request: bun_io::AsyncRead,
+    bytes: Vec<u8>,
+    error: Option<sys::Error>,
+}
+
+/// Keeps the source alive while its read is out. Dropped on the JS thread in every outcome: after
+/// the completion ran, or unrun at VM teardown (the pool is done with the fd by then, so the
+/// reader's own drop can close it).
+#[cfg(unix)]
+struct OffloadedReadPin(SourcePin);
+
+// SAFETY: a ref on a JS-thread-owned box, taken and released on that thread.
+#[cfg(unix)]
+unsafe impl bun_jsc::job::JsAffine for OffloadedReadPin {}
+
+#[cfg(unix)]
+impl bun_jsc::JobContext for OffloadedRead {
+    type OffThread = Self;
+    type Js = OffloadedReadPin;
+
+    fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
+        let request = this.request;
+        if this.bytes.try_reserve_exact(request.len).is_err() {
+            this.error = Some(sys::Error::from_code(sys::E::ENOMEM, sys::Tag::read));
+            return Some(done);
+        }
+        // SAFETY: the syscall writes only initialized bytes into the prefix it reports, and
+        // only that prefix is committed.
+        let result = unsafe {
+            bun_core::vec::fill_spare(&mut this.bytes, 0, |spare| {
+                let buf = &mut spare[..request.len];
+                let result = match request.offset {
+                    Some(offset) => {
+                        sys::pread(request.fd, buf, i64::try_from(offset).expect("int cast"))
+                    }
+                    None => sys::read(request.fd, buf),
+                };
+                match result {
+                    sys::Result::Ok(n) => (n, sys::Result::Ok(())),
+                    sys::Result::Err(err) => (0, sys::Result::Err(err)),
+                }
+            })
+        };
+        if let sys::Result::Err(err) = result {
+            this.error = Some(err);
+        }
+        Some(done)
+    }
+
+    fn then(
+        this: Self,
+        js: OffloadedReadPin,
+        _cx: &bun_jsc::JsThread<'_>,
+    ) -> bun_jsc::JsResult<()> {
+        let result = match this.error {
+            Some(err) => sys::Result::Err(err),
+            None => sys::Result::Ok(this.bytes),
+        };
+        // SAFETY: `js` pins the source for the whole call; `context` is reached as a field
+        // place, the way the vtable shims reach it.
+        let file_reader: &FileReader = unsafe { &(*js.0.0).context };
+        // SAFETY: the reader cell is live while the source is; the pin holds the source across
+        // the (user JS running) dispatches inside.
+        let wants_more = unsafe { IOReader::complete_async_read(file_reader.reader.get(), result) };
+        // A native sink is drained by the reader itself. A JS consumer sizes each read with its
+        // pull: a read issued ahead of the pull would be sized to the previous slab and make the
+        // stream shrink its slab back on every drain (`nativeAdjustChunkSize`).
+        if wants_more && file_reader.sink.get().is_some() {
+            file_reader.schedule_offloaded_read();
+        }
+        drop(js);
+        Ok(())
     }
 }
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -66,17 +66,15 @@ pub struct FileReader {
     /// path; `pull_into_sink` is the drain-ack resume.
     pub(crate) sink: JsCell<SinkHandle>,
     pub(crate) sink_paused: Cell<bool>,
-    /// POSIX: the fd is a regular file. A read of it blocks the calling thread for as long as the
-    /// disk takes, so each read runs on the work pool and completes through the same callbacks a
-    /// libuv read completes through on Windows.
+    /// POSIX regular file: every read blocks, so each one runs on the work pool (`OffloadedRead`).
     #[cfg(unix)]
     pub(crate) offloaded: Cell<bool>,
-    /// How many bytes the next offloaded read asks for: the size of the last JS pull buffer.
+    /// Bytes the next offloaded read asks for: the size of the last JS pull buffer.
     #[cfg(unix)]
     pub(crate) read_size: Cell<usize>,
 }
 
-/// The read size for an offloaded read that no JS pull sized (a native sink drains the reader).
+/// Read size before any JS pull sized one (a native sink drains the reader).
 #[cfg(unix)]
 const OFFLOADED_READ_SIZE: usize = 256 * 1024;
 
@@ -398,11 +396,8 @@ impl FileReader {
             // The across-read ref roots the JS wrapper (`increment_count`
             // upgrades `this_jsvalue` to Strong) so an event-loop callback
             // firing with no JS on the stack never lands on a freed box. A
-            // POSIX regular file takes no such ref here: holding the Strong for
-            // the reader's whole life would root an abandoned reader forever
-            // and leak its fd. Its offloaded reads pin the source per read
-            // instead (`OffloadedRead`). Windows file reads are async via libuv
-            // even for regular files, so the ref is always taken there.
+            // POSIX regular file is pinned per read instead (`OffloadedRead`):
+            // a ref for the reader's whole life would leak an abandoned reader's fd.
             #[cfg(unix)]
             let need_io_ref = pollable;
             #[cfg(windows)]
@@ -601,8 +596,8 @@ impl FileReader {
         }
     }
 
-    /// A JS pull on an offloaded file that is flowing and has no read out: sizes the next read to
-    /// the pull buffer and hands it to the work pool. `false` when the pull is served inline.
+    /// A JS pull on an offloaded file: sizes the next read to the pull buffer and hands it to the
+    /// work pool. `false` when the pull is served inline.
     #[cfg(unix)]
     fn offload_pull(&self, len: usize) -> bool {
         if !self.offloaded.get() || self.reader().has_pending_read() || !self.flowing.get() {
@@ -630,13 +625,12 @@ impl FileReader {
         unsafe { IOReader::read(self.reader.get()) };
     }
 
-    /// Hands one read of the file to the work pool. Nothing is scheduled when the reader has
-    /// nothing left to read (then it is done, reported through `on_reader_done`) or a read is
-    /// already out.
+    /// Hands one read to the work pool. Nothing is scheduled with a read already out or nothing
+    /// left to read (then the reader ends through `on_reader_done`).
     #[cfg(unix)]
     fn schedule_offloaded_read(&self) {
-        // SAFETY: the reader cell is live for `self`'s lifetime; the `on_reader_done` dispatch
-        // settles a parked pull, which cannot free the source while the JS wrapper holds its ref.
+        // SAFETY: the reader cell is live for `self`'s lifetime; the JS wrapper's ref keeps the
+        // source alive across the `on_reader_done` dispatch.
         let Some(request) =
             (unsafe { IOReader::begin_async_read(self.reader.get(), self.read_size.get()) })
         else {
@@ -1134,9 +1128,8 @@ impl Drop for SourcePin {
     }
 }
 
-/// One read of a regular file on the work pool (`read`/`pread` block the thread that calls them
-/// for the disk's duration). The bytes come back to the JS thread and enter the reader through
-/// `complete_async_read`, the path a libuv read completes through on Windows.
+/// One read of a regular file on the work pool. The bytes enter the reader on the JS thread
+/// through `complete_async_read`, the way a libuv read completes on Windows.
 #[cfg(unix)]
 struct OffloadedRead {
     request: bun_io::AsyncRead,
@@ -1144,9 +1137,8 @@ struct OffloadedRead {
     error: Option<sys::Error>,
 }
 
-/// Keeps the source alive while its read is out. Dropped on the JS thread in every outcome: after
-/// the completion ran, or unrun at VM teardown (the pool is done with the fd by then, so the
-/// reader's own drop can close it).
+/// Keeps the source alive while its read is out. Dropped on the JS thread after the completion,
+/// or unrun at VM teardown (the pool is done with the fd by then).
 #[cfg(unix)]
 struct OffloadedReadPin(SourcePin);
 
@@ -1197,15 +1189,12 @@ impl bun_jsc::JobContext for OffloadedRead {
             Some(err) => sys::Result::Err(err),
             None => sys::Result::Ok(this.bytes),
         };
-        // SAFETY: `js` pins the source for the whole call; `context` is reached as a field
-        // place, the way the vtable shims reach it.
+        // SAFETY: `js` pins the source for the whole call.
         let file_reader: &FileReader = unsafe { &(*js.0.0).context };
-        // SAFETY: the reader cell is live while the source is; the pin holds the source across
-        // the (user JS running) dispatches inside.
+        // SAFETY: the reader cell is live while the source is; the pin holds the source.
         let wants_more = unsafe { IOReader::complete_async_read(file_reader.reader.get(), result) };
         // A native sink is drained by the reader itself. A JS consumer sizes each read with its
-        // pull: a read issued ahead of the pull would be sized to the previous slab and make the
-        // stream shrink its slab back on every drain (`nativeAdjustChunkSize`).
+        // pull; a read issued ahead of it would make `nativeAdjustChunkSize` shrink the slab.
         if wants_more && file_reader.sink.get().is_some() {
             file_reader.schedule_offloaded_read();
         }

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -825,3 +825,81 @@ test.each([
   const blob = new Blob(["abc"], { type });
   expect(blob.slice(0, 1).type).toBe(expected);
 });
+
+// Bun.file(path).stream() on a regular file used to read every chunk with a
+// synchronous pread on the JS thread, and the stream re-pulled from
+// microtasks, so the event loop did not turn once until the whole file was
+// read. The reads now run on the work pool, one per pull, and each completion
+// comes back through the event loop.
+describe("Bun.file().stream() reads a regular file off the JS thread", () => {
+  const size = 16 * 1024 * 1024;
+  const fill = Buffer.alloc(size, 97);
+
+  test("the event loop turns while a large file streams", async () => {
+    using dir = tempDir("file-stream-offloaded", { "big.bin": fill });
+    const order: string[] = [];
+    const timer = new Promise<void>(resolve => {
+      setTimeout(() => {
+        order.push("timer");
+        resolve();
+      }, 0);
+    });
+    let total = 0;
+    for await (const chunk of Bun.file(`${dir}/big.bin`).stream()) {
+      total += chunk.byteLength;
+    }
+    order.push("stream");
+    await timer;
+    expect({ total, order }).toEqual({ total: size, order: ["timer", "stream"] });
+  });
+
+  test("cancelling with a read in flight ends the read and lets the process exit", async () => {
+    using dir = tempDir("file-stream-offloaded-cancel", { "big.bin": fill });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const reader = Bun.file(${JSON.stringify(`${dir}/big.bin`)}).stream().getReader();
+         const first = await reader.read();
+         const pending = reader.read();
+         await reader.cancel("stop");
+         const second = await pending;
+         Bun.gc(true);
+         console.log(JSON.stringify({ first: first.value.byteLength > 0, second }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: '{"first":true,"second":{"done":true}}\n',
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("a native sink drains the offloaded reads to the end", async () => {
+    using dir = tempDir("file-stream-offloaded-sink", { "big.bin": fill });
+    const written = await Bun.write(`${dir}/copy.bin`, Bun.file(`${dir}/big.bin`).stream());
+    const copy = await Bun.file(`${dir}/copy.bin`).bytes();
+    expect({ written, size: copy.byteLength, same: Buffer.from(copy).equals(fill) }).toEqual({
+      written: size,
+      size,
+      same: true,
+    });
+  });
+
+  test("a slice streams exactly its window through pread", async () => {
+    using dir = tempDir("file-stream-offloaded-slice", {
+      "data.bin": Buffer.from(Array.from({ length: 3000 }, (_, i) => i & 255)),
+    });
+    const start = 1000,
+      end = 2500;
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of Bun.file(`${dir}/data.bin`).slice(start, end).stream()) chunks.push(chunk);
+    const got = Buffer.concat(chunks);
+    expect(got.length).toBe(end - start);
+    expect(got.every((byte, i) => byte === ((start + i) & 255))).toBe(true);
+  });
+});

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2235,9 +2235,9 @@ describe("streamed input pacing", () => {
     const held = seen();
     expect(held).toBeLessThan(count);
     // Locked but not reading: give the loop real work to turn on and check the input did not advance meanwhile.
-    // (Windows reads are completions: the one already in flight when the sink pushed back still lands, nothing after it.)
+    // (File reads are completions: the one already in flight when the sink pushed back still lands, nothing after it.)
     expect((await Bun.file(otherFile).bytes()).length).toBe(otherPiece.length * count);
-    expect(seen() - held).toBeLessThanOrEqual(isWindows ? (256 * 1024) / piece.length : 0);
+    expect(seen() - held).toBeLessThanOrEqual((256 * 1024) / piece.length);
     const second = await reader.read();
     expect(seen()).toBeGreaterThan(held);
     expect(seen()).toBeLessThan(count);
@@ -2275,11 +2275,10 @@ describe("streamed input pacing", () => {
     expect(exitCode).toBe(0);
   });
 
-  // The whole document arrives in the first read: it finishes with that read
-  // however large its output — inside `transform()` where regular-file reads
-  // are synchronous (POSIX), on the read's completion otherwise — so the body
-  // is already materialized for consumers that need that (Content-Length,
-  // static routes) without anything reading it.
+  // The whole document arrives in the first read: it finishes on that read's
+  // completion however large its output, so the body is already materialized
+  // for consumers that need that (Content-Length, static routes) without
+  // anything reading it.
   it("a document that arrives in one chunk finishes with that chunk", async () => {
     const small = path.join(dir, "small.html");
     await Bun.write(small, Buffer.alloc(12 * 4000, "<p>hello</p>").toString());
@@ -2288,7 +2287,6 @@ describe("streamed input pacing", () => {
       .on("p", { element: e => void e.setAttribute("x", "1") })
       .onDocument({ end: () => void (ended = true) })
       .transform(new Response(Bun.file(small)));
-    if (!isWindows) expect(ended).toBe(true);
     while (!ended) await setImmediatePromise();
     await using server = Bun.serve({ port: 0, fetch: () => res });
     const served = await fetch(server.url);

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2235,7 +2235,8 @@ describe("streamed input pacing", () => {
     const held = seen();
     expect(held).toBeLessThan(count);
     // Locked but not reading: give the loop real work to turn on and check the input did not advance meanwhile.
-    // (File reads are completions: the one already in flight when the sink pushed back still lands, nothing after it.)
+    // (File reads are completions: the one already in flight when the sink pushed back still lands, nothing after it.
+    // A sink-driven read is 256 KiB: OFFLOADED_READ_SIZE in FileReader.rs, 64 KiB on Windows.)
     expect((await Bun.file(otherFile).bytes()).length).toBe(otherPiece.length * count);
     expect(seen() - held).toBeLessThanOrEqual((256 * 1024) / piece.length);
     const second = await reader.read();


### PR DESCRIPTION
### Problem
- `Bun.file(path).stream()` on a regular file reads every chunk with a synchronous `pread`/`read` on the JS thread. The stream re-pulls from microtasks, so the event loop does not turn until the whole file is read. 256 MB from the page cache: 80 ms with 0 timer ticks. On slow storage the stall is the full `size / bandwidth`: a 4 MB file at 1 MB/s froze the loop for 4.2 s (measured by the reporter), where `fs.createReadStream` and `Bun.file().arrayBuffer()` on the same file keep the gap under 5 ms.
- The cause is `FileReader::on_pull` (`src/runtime/webcore/FileReader.rs`) calling `BufferedReader::read_into`, one inline `sys::pread` per pull (`src/io/PipeReader.rs`).

### Fix
- A FileReader whose fd is a regular file (`file_type == File && !pollable`) hands each read to the work pool as a `bun_jsc::Job` and the pull returns `Pending`. A JS pull passes its own slab to the read (the parked pull pins it), so delivery stays zero-copy: the same `IntoArray` result the synchronous path produced, same chunk sizes (256 KB, then 512 KB). A native sink (`Bun.write`, fetch body, HTMLRewriter) has no pull buffer and gets an owned-buffer read, re-issued until backpressure, like the Windows libuv path.
- `PosixBufferedReader` gains `begin_async_read` / `account_async_read` / `finish_async_read` (plus the owned-buffer `complete_async_read`), an in-flight flag that `has_pending_read` reports, and a deferred close: a `cancel()` that lands while a read is out does not close the fd under the pool thread.
- The job pins the source per read (`SourcePin`), so an abandoned stream with no read out stays collectable (`streams-leak.test.ts`) and an in-flight read cannot outlive its reader.
- Verified: `test/js/web/fetch/blob.test.ts` (new block; the first test fails on stock bun). Also `streams.test.js`, `streams-leak.test.ts`, `filesink.test.ts`, `process-stdin.test.ts`, `bun-stdin-slice.test.ts`, `node-stream.test.js`, `bun-serve-file.test.ts`, `html-rewriter.test.js`, and `cargo check` for the Windows and macOS targets.

### Background
- `FileReader` is the native source behind `Bun.file().stream()`, `Bun.stdin.stream()`, and file bodies piped into native sinks. It embeds a `BufferedReader` and receives bytes through the `BufferedReaderParent` callbacks.
- On POSIX the reader polls pipes, sockets and ttys. A regular file is never pollable, so its reads were synchronous, and the stream driver (`BunStreamSource.cpp`) re-pulls while pulls return synchronously.
- On Windows every file read already completes asynchronously through libuv; FileReader's `pending` slot and `resolve_pending_read` exist for that. This change routes POSIX files through the same completion.
- `bun_jsc::Job` is the pool-then-JS-thread primitive: `run` on the pool (with a `Ticket` proving the VM is alive, which is what lets the read target the JS slab), `then` on the JS thread, a loop keep-alive while the job is out.

<details><summary>Notes</summary>

Release build, 256 MB file on tmpfs, 1 ms heartbeat during the stream: stock 1.4.2 `maxTimerGapMs 80, timerTicks 0`; this branch `maxTimerGapMs 3, timerTicks ~150`.

The first revision of this PR read into a fresh `Vec` per chunk and copied into the stream, which cost 45 to 80 % throughput on cached files and pinned chunk sizes at 256 KB. The current revision reads into the JS slab directly, so per chunk the only added cost over the old synchronous path is the pool hop (two task posts), and `nativeAdjustChunkSize` doubles the slab again as before.

The completion does not read ahead on the JS pull path: a read issued before the pull would not know the pull's slab and would be sized to the previous one.

Two html-rewriter pacing tests assumed POSIX file reads complete inside `transform()`; they now hold the Windows (completion-driven) expectation on every platform.

Not in this PR: `FileResponseStream` (Bun.serve file bodies that do not use sendfile) still reads synchronously; the reporter tracks that separately.

Repro:

```js
const p = "/tmp/big.bin"; // 256 MB
let maxGap = 0, ticks = 0, last = performance.now();
const iv = setInterval(() => { const n = performance.now(); maxGap = Math.max(maxGap, n - last); last = n; ticks++; }, 1);
await new Promise(r => setTimeout(r, 20));
let n = 0; for await (const c of Bun.file(p).stream()) n += c.length;
clearInterval(iv);
console.log({ n, maxGap, ticks });
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js, test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->