### PR TITLE
WebKit b4220c0de029: release a frontend's remote objects when it disconnects from the inspector (oven-sh/WebKit#575)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "b4220c0de02922c4fb752c6d83c3956a6392e341";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -603,3 +603,92 @@ test("error.stack doesnt lose frames", () => {
   // We allow it to differ by the existence of <anonymous> as a string. But that's it.
   expect(no.split("\n").slice(0, -2).join("\n").trim()).toBe(yes.split("\n").slice(0, -2).join("\n").trim());
 });
+
+test("remote objects a frontend created are released when it disconnects", async () => {
+  using dir = tempDir("inspect-release-on-disconnect", {
+    "entry.mjs": `
+      import { heapStats } from "bun:jsc";
+      globalThis.countUint8Arrays = () => {
+        Bun.gc(true);
+        return heapStats().objectTypeCounts.Uint8Array | 0;
+      };
+      setInterval(() => {}, 60_000);
+    `,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  const { promise: inspectorUrl, resolve: foundUrl, reject: noUrl } = Promise.withResolvers<string>();
+  (async () => {
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr) {
+      stderr += decoder.decode(chunk, { stream: true });
+      const line = stderr
+        .split("\n")
+        .slice(0, -1)
+        .find(line => line.trim().startsWith("ws://"));
+      if (line) foundUrl(line.trim());
+    }
+    noUrl(new Error(`No inspector URL in stderr:\n${stderr}`));
+  })();
+  const url = await inspectorUrl;
+
+  async function session(run: (evaluate: (expression: string, params?: object) => Promise<any>) => Promise<void>) {
+    const ws = new WebSocket(url);
+    const { promise: open, resolve: opened, reject: failed } = Promise.withResolvers<void>();
+    ws.on("open", opened);
+    ws.on("error", failed);
+    await open;
+    const waiters = new Map<number, (message: any) => void>();
+    ws.on("message", data => {
+      const message = JSON.parse(String(data));
+      if (typeof message.id === "number") waiters.get(message.id)?.(message);
+    });
+    let nextId = 1;
+    const evaluate = async (expression: string, params: object = {}) => {
+      const id = nextId++;
+      const { promise, resolve } = Promise.withResolvers<any>();
+      waiters.set(id, resolve);
+      ws.send(JSON.stringify({ id, method: "Runtime.evaluate", params: { expression, ...params } }));
+      const { result, error } = await promise;
+      if (error) throw new Error(`Runtime.evaluate failed: ${error.message}`);
+      return result;
+    };
+    try {
+      await run(evaluate);
+    } finally {
+      const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+      ws.on("close", () => onClose());
+      ws.close();
+      await closed;
+    }
+  }
+
+  const count = 50;
+  let before = 0;
+  let whileConnected = 0;
+  await session(async evaluate => {
+    before = (await evaluate("countUint8Arrays()", { returnByValue: true })).result.value;
+    // Each result is returned as a RemoteObject, so the inspector binds the array for the frontend.
+    for (let i = 0; i < count; i++) {
+      const { result } = await evaluate("new Uint8Array(64 * 1024)");
+      expect(result.objectId).toBeString();
+    }
+    whileConnected = (await evaluate("countUint8Arrays()", { returnByValue: true })).result.value;
+  });
+  expect(whileConnected).toBeGreaterThanOrEqual(before + count);
+
+  // The second frontend's own evaluate runs after the first one's disconnect is processed.
+  let afterDisconnect = 0;
+  await session(async evaluate => {
+    afterDisconnect = (await evaluate("countUint8Arrays()", { returnByValue: true })).result.value;
+  });
+  expect(afterDisconnect).toBeLessThan(before + count);
+});

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -646,6 +646,15 @@ test("remote objects a frontend created are released when it disconnects", async
     ws.on("open", opened);
     ws.on("error", failed);
     await open;
+    // Any pending evaluate rejects when the socket drops or the debuggee exits.
+    const { promise: lost, reject: lose } = Promise.withResolvers<never>();
+    lost.catch(() => {});
+    let closing = false;
+    ws.on("close", event => {
+      if (!closing) lose(new Error(`WebSocket closed (${event})\ninspectee stderr:\n${stderr}`));
+    });
+    ws.on("error", error => lose(error));
+    proc.exited.then(code => lose(new Error(`inspectee exited with ${code}\ninspectee stderr:\n${stderr}`)));
     const waiters = new Map<number, (message: any) => void>();
     ws.on("message", data => {
       const message = JSON.parse(String(data));
@@ -657,13 +666,14 @@ test("remote objects a frontend created are released when it disconnects", async
       const { promise, resolve } = Promise.withResolvers<any>();
       waiters.set(id, resolve);
       ws.send(JSON.stringify({ id, method: "Runtime.evaluate", params: { expression, ...params } }));
-      const { result, error } = await promise;
+      const { result, error } = await Promise.race([promise, lost]);
       if (error) throw new Error(`Runtime.evaluate failed: ${error.message}`);
       return result;
     };
     try {
       await run(evaluate);
     } finally {
+      closing = true;
       const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
       ws.on("close", () => onClose());
       ws.close();
@@ -671,7 +681,7 @@ test("remote objects a frontend created are released when it disconnects", async
     }
   }
 
-  const count = 50;
+  const count = 20;
   let before = 0;
   let whileConnected = 0;
   await session(async evaluate => {


### PR DESCRIPTION
### Problem
- With `bun --inspect`, every object a frontend materializes (a `Runtime.evaluate` result, a `getProperties` walk, a console preview) stays alive in the debuggee after the frontend disconnects. 500 `Runtime.evaluate` calls of `new Uint8Array(256 * 1024)` leave `U8=500 rss=156` after the client closes, and `Bun.gc(true)` cannot reclaim them. Objects evaluated without an `objectGroup` (the default) cannot be released by a later client either.
- The cause is in JavaScriptCore: `JSGlobalObjectInspectorController::disconnectFrontend` (JSGlobalObjectInspectorController.cpp:150) never discards the InjectedScript that holds the remote object table. Only `globalObjectDestroyed()` does, and Bun calls that at exit.

### Fix
- Bumps WebKit from `2e2aa2290fac` to [`b4220c0de029`](https://github.com/oven-sh/WebKit/commit/b4220c0de02922c4fb752c6d83c3956a6392e341), the oven-sh/WebKit#575 branch. Once that PR merges, this bumps to the merge commit on `main`.
- oven-sh/WebKit#575 calls `m_injectedScriptManager->discardInjectedScripts()` in `disconnectFrontend` when the last frontend disconnects. This mirrors the WebCore controllers (`PageInspectorController`, `WorkerInspectorController`), which call `removeClient()` there and discard the injected scripts when the client count reaches zero.
- Correct because the next frontend gets a fresh InjectedScript with a new id. A stale objectId from the old session resolves to no script and fails as a normal protocol error. The call runs under the JS lock, inside `JSGlobalObjectDebuggable::disconnect`.
- Verified: `test/cli/inspect/inspect.test.ts` (new test: a frontend evaluates 50 typed arrays, disconnects, a second frontend sees them collected). Fails on bun 1.4.2 with `Expected: < 50, Received: 50`. Also `test/cli/inspect/` and `test/js/node/inspector/`, 114 pass.

### Background
- Bun multiplexes every inspector WebSocket onto one `JSGlobalObjectInspectorController` (src/jsc/bindings/BunDebugger.cpp). A WebSocket close goes `debugger.ts` → `jsFunctionDisconnect` → `BunInspectorConnection::disconnect` → `JSGlobalObjectDebuggable::disconnect` → `disconnectFrontend`.
- An InjectedScript is the JS object built from `InjectedScriptSource.js`. It maps remote object ids to JS values in `_idToWrappedObject` and is held by a `JSC::Strong` in `InjectedScriptManager`. `Runtime.releaseObjectGroup` only frees objects that were bound with an `objectGroup`.
- The fix lives in the WebKit dependency, so a fail-before check that restores only `src/` and `packages/` still builds with the new WebKit and passes the test. The fail-before proof is the run against bun 1.4.2 above.

<details><summary>Notes</summary>

Repro from the report (target prints `U8=<Uint8Array count> rss=<MB>` each second after `Bun.gc(true)`; client sends 500 `Runtime.evaluate` over the inspector WebSocket and closes):

- bun 1.4.2: `U8=0 rss=31` → `U8=500 rss=158` → stays `U8=500 rss=158` after the socket closes.
- This branch (debug build): `U8=360 rss=454` while evaluating → `U8=0 rss=365` once the socket closes.

Why not a Bun-side fix: `m_injectedScriptManager` is private in `JSGlobalObjectInspectorController`, and no public path reaches it. Recreating the controller on disconnect is not an option either (see the CheckedPtr ordering note in `Bun__InspectorConnection__disconnectAllOnExit`).

Multiple frontends: the discard happens only when the last one disconnects, the same as WebCore. `willDestroyFrontendAndBackend` already runs on every agent on any disconnect, so no agent holds an InjectedScript across the call.

Ledger #24492 in the diagnostics tooling audit.
</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/inspect/inspect.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/inspect/inspect.test.ts
bun test v1.4.3 (f42e98025)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [767.54ms]
(pass) websocket > bun --inspect=0 [551.68ms]
(pass) websocket > bun --inspect=34566 [589.37ms]
(pass) websocket > bun --inspect=localhost [602.76ms]
(pass) websocket > bun --inspect=localhost/ [607.64ms]
(pass) websocket > bun --inspect=localhost:0 [572.49ms]
(pass) websocket > bun --inspect=localhost:0/ [679.44ms]
(pass) websocket > bun --inspect=localhost/foo/bar [755.47ms]
(pass) websocket > bun --inspect=127.0.0.1 [587.66ms]
(pass) websocket > bun --inspect=127.0.0.1/ [572.95ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [616.05ms]
(pass) websocket > bun --inspect=[::1] [576.75ms]
(pass) websocket > bun --inspect=[::1]:0 [620.65ms]
(pass) websocket > bun --inspect=[::1]:0/ [548.10ms]
(pass) websocket > bun --inspect=/ [532.57ms]
(pass) websocket > bun --inspect=/foo [643.02ms]
(pass) websocket > bun --inspect=/foo/baz/ [654.98ms]
(pass) websocket > bun --inspect=:0 [540.07ms]
(pass) websocket > bun --inspect=:0/ [638.36ms]
(pass) websocket > bun --inspect=ws://localhost/ [528.66ms]
(pass) websocket > bun --inspect=ws://localhost:0/ [548.74ms]
(pass) websocket > bun --inspect=ws://localhost:6499/foo/bar [577.75ms]
(todo) websocket > bun --inspect=ws+unix:///tmp/inspect.sock
(pass) http metadata endpoint > serves /json/version only for a Host of the bound hostname, localhost, or an IP literal [605.93ms]
(pass) http metadata endpoint > serves /json/version only to allowed web origins [529.91ms]
Hello
--------------------- Bun Inspector ---------------------
Listening on unix://.tmp/usx8qsi9q4m.sock
--------------------- Bun Inspector ---------------------
(pass) unix domain socket without websocket > bun --inspect=unix:// [670.80ms]
Hello
--------------------- Bun Inspector ---------------------
Listening on unix:.tmp/5vbxp6cvmdx.sock
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts     |  2 +-
 test/cli/inspect/inspect.test.ts | 99 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 100 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
scripts/build/deps/webkit.ts          1      1     10
test/cli/inspect/inspect.test.ts      2      2     10
```

</details>

**root cause** · written by the author bot

When an inspector frontend disconnected, the per-context injected scripts created during that session were kept alive along with every remote object handle they held, so values a frontend had inspected via `Runtime.evaluate` or `getProperties` stayed reachable and could never be collected, and repeated connect and disconnect cycles accumulated them indefinitely. The fix, carried in the pinned WebKit change, discards the injected scripts when a session ends so their remote object groups are released and the objects become collectable on the next GC. A test connects two sessions in turn, crea…

<!-- robobun:evidence:end -->