### PR TITLE
Inspector: stop getRuntimeTypesForVariablesAtOffsets aborting on a non-numeric sourceID

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "dd63830c4cbe792239a83f8665750266a5f35bae";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/test/cli/inspect/bun-inspector-protocol.test.ts
+++ b/test/cli/inspect/bun-inspector-protocol.test.ts
@@ -262,3 +262,78 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
     ]),
   );
 });
+
+// Found by fuzzing bun's inspector. A non-numeric sourceID made
+// Runtime.getRuntimeTypesForVariablesAtOffsets abort the inspectee, because
+// JavaScriptCore parsed the id with parseInteger<uintptr_t>(sourceID).value()
+// and .value() on a failed parse throws bad_optional_access, which aborts with
+// exceptions off. The fix (oven-sh/WebKit#576) uses value_or(0), so an unknown
+// source reports isValid: false instead of crashing.
+test("Runtime.getRuntimeTypesForVariablesAtOffsets does not abort on a non-numeric sourceID", async () => {
+  using dir = tempDir("inspector-type-profiler", {
+    "entry.mjs": `setInterval(() => {}, 60_000);`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  const { promise: inspectorUrl, resolve: foundUrl, reject: noUrl } = Promise.withResolvers<URL>();
+  (async () => {
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr) {
+      stderr += decoder.decode(chunk, { stream: true });
+      const line = stderr
+        .split("\n")
+        .slice(0, -1)
+        .find(line => line.trim().startsWith("ws://"));
+      if (line) {
+        foundUrl(new URL(line.trim()));
+        return;
+      }
+    }
+    noUrl(new Error(`No inspector URL in stderr:\n${stderr}`));
+  })().catch(error => noUrl(error instanceof Error ? error : new Error(String(error))));
+
+  const ws = new WebSocket(await inspectorUrl);
+
+  // If the inspectee aborts, the socket closes before the response arrives. Turn
+  // that into a fast, descriptive failure instead of a timeout.
+  const { promise: failed, reject: fail } = Promise.withResolvers<never>();
+  failed.catch(() => {});
+  ws.addEventListener("close", event => fail(new Error(`inspectee socket closed (${event.code})`)));
+  proc.exited.then(code => fail(new Error(`inspectee exited (${code ?? proc.signalCode})`)));
+
+  const responseWaiters = new Map<number, (response: any) => void>();
+  ws.addEventListener("message", ({ data }) => {
+    const message = JSON.parse(String(data));
+    if (typeof message.id === "number") responseWaiters.get(message.id)?.(message);
+  });
+
+  let nextId = 1;
+  function request(method: string, params: Record<string, unknown> = {}): Promise<any> {
+    const id = nextId++;
+    ws.send(JSON.stringify({ id, method, params }));
+    return Promise.race([new Promise<any>(resolve => responseWaiters.set(id, resolve)), failed]);
+  }
+
+  try {
+    await Promise.race([new Promise<void>(resolve => ws.addEventListener("open", () => resolve())), failed]);
+
+    await request("Runtime.enableTypeProfiler");
+    const response = await request("Runtime.getRuntimeTypesForVariablesAtOffsets", {
+      locations: [{ typeInformationDescriptor: 1, sourceID: "a", divot: 10 }],
+    });
+
+    expect(response.error).toBeUndefined();
+    expect(response.result).toEqual({ types: [{ isValid: false }] });
+    expect(proc.signalCode).toBeNull();
+  } finally {
+    ws.close();
+  }
+});


### PR DESCRIPTION
### Problem

- A debugger client can abort any inspected bun process (`bun --inspect`) with two messages: `Runtime.enableTypeProfiler`, then `Runtime.getRuntimeTypesForVariablesAtOffsets` with a location whose `sourceID` is not a number (for example `"a"`, `""`, or `"-1"`). The inspectee dies with `abort()` and the socket closes with code 1006.
- The cause is in JavaScriptCore. `InspectorRuntimeAgent::getRuntimeTypesForVariablesAtOffsets` parses the id with `parseInteger<uintptr_t>(sourceID).value()`. A failed parse returns an empty `std::optional`, so `.value()` throws `bad_optional_access`, which aborts because the engine builds with exceptions off.

### Fix

- Bump WebKit to pick up oven-sh/WebKit#576, which changes that call to `value_or(0)`, the same pattern the sibling `getBasicBlocks` already uses. A `sourceID` of 0 matches no source, so `findLocation` returns null and the type description reports `isValid: false`.
- Add a test that drives the inspector, sends the two messages with a non-numeric `sourceID`, and asserts the inspectee survives and returns `{ types: [{ isValid: false }] }`.
- Verified: the test fails against the current build (socket closes 1006) and passes once WebKit is built from the bumped commit. The fix lives in JavaScriptCore, so the bun source tree is a version bump plus the test.

### Background

- `bun --inspect` embeds JavaScriptCore's inspector. Any attached client can call the Runtime domain, so this reached the abort with no special setup.
- bun compiles WebKit from source at `WEBKIT_VERSION`, so the bump picks up the fix directly. Re-point the version to the merge commit once oven-sh/WebKit#576 lands.

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/inspect/bun-inspector-protocol.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/inspect/bun-inspector-protocol.test.ts
bun test v1.4.3 (f42e98025)

test/cli/inspect/bun-inspector-protocol.test.ts:
(pass) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends [1346.45ms]
(pass) Runtime.getRuntimeTypesForVariablesAtOffsets does not abort on a non-numeric sourceID [631.94ms]

 2 pass
 0 fail
 7 expect() calls
Ran 2 tests across 1 file. [4.79s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                    |  2 +-
 test/cli/inspect/bun-inspector-protocol.test.ts | 75 +++++++++++++++++++++++++
 2 files changed, 76 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
scripts/build/deps/webkit.ts                         1      1      4
test/cli/inspect/bun-inspector-protocol.test.ts      1      2      4
```

</details>

**root cause** · written by the author bot

The inspector agent's `getRuntimeTypesForVariablesAtOffsets` handler called `std::optional::value()` on the result of parsing the `sourceID` string, so any non-numeric value produced a failed parse and threw `bad_optional_access`, which aborts the process when exceptions are disabled. The fix replaces `.value()` with `.value_or(0)`, matching the sibling `getBasicBlocks` handler, so a malformed `sourceID` now falls back to a safe default and returns a normal invalid-types result instead of crashing the debuggee.

<!-- robobun:evidence:end -->