### PR TITLE
Mark stream reader and writer getter rejections as native getter type errors

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -10,6 +10,7 @@
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMGlobalObjectInlines.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSDOMWrapperCache.h"
 #include "JSReadRequest.h"
 #include "JSReadableByteStreamController.h"
@@ -388,7 +389,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamBYOBReaderPrototypeGetter_closed, (JSGl
 {
     const auto* reader = dynamicDowncast<JSReadableStreamBYOBReader>(JSValue::decode(thisValue));
     if (!reader) [[unlikely]]
-        return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'closed' getter can only be used on a ReadableStreamBYOBReader"_s)));
+        return createRejectedPromiseWithTypeError(*lexicalGlobalObject, "The 'closed' getter can only be used on a ReadableStreamBYOBReader"_s, RejectedPromiseWithTypeErrorCause::NativeGetter);
     return JSValue::encode(reader->m_closedPromise.get());
 }
 

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -9,6 +9,7 @@
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMGlobalObjectInlines.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSDOMWrapperCache.h"
 #include "JSDirectStreamController.h"
 #include "JSReadRequest.h"
@@ -693,7 +694,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsReadableStreamDefaultReaderPrototypeGetter_closed, (J
 {
     const auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(JSValue::decode(thisValue));
     if (!reader) [[unlikely]]
-        return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'closed' getter can only be used on a ReadableStreamDefaultReader"_s)));
+        return createRejectedPromiseWithTypeError(*lexicalGlobalObject, "The 'closed' getter can only be used on a ReadableStreamDefaultReader"_s, RejectedPromiseWithTypeErrorCause::NativeGetter);
     return JSValue::encode(reader->m_closedPromise.get());
 }
 

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -9,6 +9,7 @@
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMGlobalObjectInlines.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSDOMWrapperCache.h"
 #include "JSStreamPipeToOperation.h"
 #include "JSWritableStream.h"
@@ -401,7 +402,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_closed, (J
 {
     const auto* writer = dynamicDowncast<JSWritableStreamDefaultWriter>(JSValue::decode(thisValue));
     if (!writer) [[unlikely]]
-        return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'closed' getter can only be used on a WritableStreamDefaultWriter"_s)));
+        return createRejectedPromiseWithTypeError(*lexicalGlobalObject, "The 'closed' getter can only be used on a WritableStreamDefaultWriter"_s, RejectedPromiseWithTypeErrorCause::NativeGetter);
     return JSValue::encode(writer->m_closedPromise.get());
 }
 
@@ -424,7 +425,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsWritableStreamDefaultWriterPrototypeGetter_ready, (JS
 {
     auto* writer = dynamicDowncast<JSWritableStreamDefaultWriter>(JSValue::decode(thisValue));
     if (!writer) [[unlikely]]
-        return JSValue::encode(promiseRejectedWith(lexicalGlobalObject, createTypeError(lexicalGlobalObject, "The 'ready' getter can only be used on a WritableStreamDefaultWriter"_s)));
+        return createRejectedPromiseWithTypeError(*lexicalGlobalObject, "The 'ready' getter can only be used on a WritableStreamDefaultWriter"_s, RejectedPromiseWithTypeErrorCause::NativeGetter);
     return JSValue::encode(writer->readyPromise(lexicalGlobalObject));
 }
 

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -603,3 +603,96 @@ test("error.stack doesnt lose frames", () => {
   // We allow it to differ by the existence of <anonymous> as a string. But that's it.
   expect(no.split("\n").slice(0, -2).join("\n").trim()).toBe(yes.split("\n").slice(0, -2).join("\n").trim());
 });
+
+// Expanding a stream reader or writer in a debugger sends Runtime.getProperties
+// with generatePreview. The preview invokes the native `closed` and `ready`
+// getters on the prototype, which reject with a TypeError. That rejection must
+// not surface as an unhandled rejection that exits the debuggee.
+test("Runtime.getProperties preview of stream readers and writers does not exit the debuggee", async () => {
+  using dir = tempDir("inspect-stream-preview", {
+    "inspectee.js": `
+      globalThis.defaultReader = new ReadableStream({}).getReader();
+      globalThis.byobReader = new ReadableStream({ type: "bytes" }).getReader({ mode: "byob" });
+      globalThis.writer = new WritableStream({}).getWriter();
+      setInterval(() => {}, 1000);
+    `,
+  });
+  await using inspectee = spawn({
+    cwd: String(dir),
+    cmd: [bunExe(), "--inspect=127.0.0.1:0/", "inspectee.js"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  let url: URL | undefined;
+  let stderr = "";
+  const decoder = new TextDecoder();
+  const reader = inspectee.stderr.getReader();
+  while (!url) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    stderr += decoder.decode(value);
+    for (const line of stderr.split("\n")) {
+      try {
+        const candidate = new URL(line.trim());
+        if (candidate.protocol === "ws:") url = candidate;
+      } catch {}
+    }
+  }
+  if (!url) {
+    throw new Error("Unable to find listening URL: " + stderr);
+  }
+
+  const webSocket = new WebSocket(url);
+  const opened = Promise.withResolvers<void>();
+  webSocket.addEventListener("open", () => opened.resolve());
+  webSocket.addEventListener("error", cause => opened.reject(new Error("WebSocket error", { cause })));
+  await opened.promise;
+
+  const pending = new Map<number, PromiseWithResolvers<any>>();
+  webSocket.addEventListener("message", ({ data }) => {
+    const message = JSON.parse(data.toString());
+    if (typeof message.id === "number") pending.get(message.id)?.resolve(message);
+  });
+  webSocket.addEventListener("close", ({ code }) => {
+    for (const { reject } of pending.values()) reject(new Error(`WebSocket closed with code ${code}`));
+  });
+  let nextId = 1;
+  const send = (method: string, params?: object) => {
+    const id = nextId++;
+    const resolvers = Promise.withResolvers<any>();
+    pending.set(id, resolvers);
+    const { promise } = resolvers;
+    webSocket.send(JSON.stringify({ id, method, params }));
+    return promise;
+  };
+
+  for (const expression of ["defaultReader", "byobReader", "writer"]) {
+    const evaluated = await send("Runtime.evaluate", { expression });
+    const { objectId } = evaluated.result.result;
+    const properties = await send("Runtime.getProperties", { objectId, ownProperties: true, generatePreview: true });
+    expect(properties.error).toBeUndefined();
+    expect(properties.result.properties.map((p: any) => p.name)).toContain("__proto__");
+  }
+
+  // The debuggee is still alive after the previews.
+  const alive = await send("Runtime.evaluate", { expression: "1 + 1" });
+  expect(alive.result.result.value).toBe(2);
+
+  // Read the rest of stderr, then exit the debuggee on our own terms.
+  const rest = (async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      stderr += decoder.decode(value);
+    }
+  })();
+  send("Runtime.evaluate", { expression: "process.exit(42)" }).catch(() => {});
+  const exitCode = await inspectee.exited;
+  await rest;
+  webSocket.close();
+
+  expect(stderr).not.toContain("TypeError");
+  expect(exitCode).toBe(42);
+});


### PR DESCRIPTION
### Problem
- A debugger client that expands a `ReadableStreamDefaultReader`, `ReadableStreamBYOBReader` or `WritableStreamDefaultWriter` (`Runtime.getProperties` with `generatePreview: true`) kills the debuggee. The target prints `TypeError: The 'closed' getter can only be used on a ReadableStreamDefaultReader` and exits with code 1. The client sees close code 1006.
- The preview generator reads the native `closed` and `ready` getters on the prototype object. Those getters return a rejected promise for a non-instance receiver (`JSReadableStreamDefaultReader.cpp:696`, `JSReadableStreamBYOBReader.cpp:391`, `JSWritableStreamDefaultWriter.cpp:404` and `:427`). The injected script only attaches a handler to a rejection whose error carries the native getter flag. The plain `createTypeError` has no flag, so the rejection is unhandled and bun exits.

### Fix
- The four getters now build the rejected promise with `createRejectedPromiseWithTypeError(..., RejectedPromiseWithTypeErrorCause::NativeGetter)`. That is the helper the generated WebIDL bindings use for the same case. It calls `setNativeGetterTypeError()` on the error.
- The error type and message do not change. Only the flag is added, so the injected script silences the rejection and nothing else observes a difference.
- Verified: `test/cli/inspect/inspect.test.ts` (new test, fails on 1.4.3 with close code 1006, passes with the fix). Also the rest of `inspect.test.ts` and `test/js/web/streams/streams.test.js`.

### Background
- WebIDL promise-returning attributes reject instead of throwing on a brand check failure. So `Object.getOwnPropertyDescriptor(ReadableStreamDefaultReader.prototype, "closed").get.call({})` returns a rejected promise.
- The inspector's injected script (`InjectedScriptSource.js`, `createFakeValueDescriptor`) evaluates native getters as values when it builds a preview. It then asks `InjectedScriptHost.isPromiseRejectedWithNativeGetterTypeError` and adds a no-op rejection handler when the answer is yes. That check reads `ErrorInstance::isNativeGetterTypeError()`.
- Bun treats an unhandled promise rejection as fatal, like Node. In a browser the same rejection only logs to the console, which is why this path did not matter in WebKit.

<details><summary>Notes</summary>

Repro from the report: run `bun --inspect=127.0.0.1:9445/tok target.mjs` with `globalThis.reader = new ReadableStream({}).getReader()` and a keepalive interval, then from a client send `Runtime.evaluate {expression: "reader"}` followed by `Runtime.getProperties {objectId, ownProperties: true, generatePreview: true}`. Reproduced on 1.4.3 canary. Same result with `generatePreview` on `Runtime.getDisplayableProperties` and on `Runtime.evaluate("Object.getPrototypeOf(reader)")`. `generatePreview: false` is safe.

The other stream wrappers and the rest of the object zoo in the report use either synchronous throws (`throwVMTypeError`, `ERR::INVALID_THIS`) or the generated `rejectPromiseWithGetterTypeError` path, which already sets the flag. These four getters were the only hand-written promise attributes that rejected with a plain `createTypeError`.

The test spawns `bun --inspect=127.0.0.1:0/` on a fixture that holds all three objects, expands each with `generatePreview`, confirms the debuggee still answers `Runtime.evaluate`, then exits it through `process.exit(42)` and checks the exit code and that stderr has no `TypeError`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.3 (f42e98025)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [1227.46ms]
(pass) websocket > bun --inspect=0 [958.19ms]
(pass) websocket > bun --inspect=39708 [930.19ms]
(pass) websocket > bun --inspect=localhost [939.51ms]
(pass) websocket > bun --inspect=localhost/ [1023.60ms]
(pass) websocket > bun --inspect=localhost:0 [907.75ms]
(pass) websocket > bun --inspect=localhost:0/ [1025.30ms]
(pass) websocket > bun --inspect=localhost/foo/bar [966.41ms]
(pass) websocket > bun --inspect=127.0.0.1 [925.93ms]
(pass) websocket > bun --inspect=127.0.0.1/ [899.59ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [917.81ms]
(pass) websocket > bun --inspect=[::1] [977.93ms]
(pass) websocket > bun --inspect=[::1]:0 [913.45ms]
(pass) websocket > bun --inspect=[::1]:0/ [916.01ms]
(pass) websocket > bun --inspect=/ [1143.44ms]
(pass) websocket > bun --inspect=/foo [1039.50ms]
(pass) websocket > bun --inspect=/foo/baz/ [946.55ms]
(pass) websocket > bun --inspect=:0 [923.48ms]
(pass) web
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [29.61ms]
(pass) websocket > bun --inspect=0 [19.58ms]
(pass) websocket > bun --inspect=24843 [20.31ms]
(pass) websocket > bun --inspect=localhost [18.77ms]
(pass) websocket > bun --inspect=localhost/ [19.13ms]
(pass) websocket > bun --inspect=localhost:0 [25.01ms]
(pass) websocket > bun --inspect=localhost:0/ [19.15ms]
(pass) websocket > bun --inspect=localhost/foo/bar [19.10ms]
(pass) websocket > bun --inspect=127.0.0.1 [23.17ms]
(pass) websocket > bun --inspect=127.0.0.1/ [18.68ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [19.23ms]
(pass) websocket > bun --inspect=[::1] [21.02ms]
(pass) websocket > bun --inspect=[::1]:0 [19.63ms]
(pass) websocket > bun --inspect=[::1]:0/ [19.26ms]
(pass) websocket > bun --inspect=/ [23.73ms]
(pass) websocket > bun --inspect=/foo [21.85ms]
(pass) websocket > bun --inspect=/foo/baz/ [20.03ms]
(pass) websocket > bun --inspect=:0 [24.69ms]
(pass) websocket > bun --inspect=:0/ [23.71ms]
(pass) websocket > bun --inspect=ws://localhost/ [23.42ms]
(pass) websocket > bun --inspect=ws://localhost:0/ [23.64ms]
(pass) websocket > bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.3 (f42e98025)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [1105.40ms]
(pass) websocket > bun --inspect=0 [789.93ms]
(pass) websocket > bun --inspect=40330 [825.32ms]
(pass) websocket > bun --inspect=localhost [1001.08ms]
(pass) websocket > bun --inspect=localhost/ [870.51ms]
(pass) websocket > bun --inspect=localhost:0 [771.71ms]
(pass) websocket > bun --inspect=localhost:0/ [759.43ms]
(pass) websocket > bun --inspect=localhost/foo/bar [924.37ms]
(pass) websocket > bun --inspect=127.0.0.1 [967.73ms]
(pass) websocket > bun --inspect=127.0.0.1/ [878.71ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [709.39ms]
(pass) websocket > bun --inspect=[::1] [764.58ms]
(pass) websocket > bun --inspect=[::1]:0 [786.35ms]
(pass) websocket > bun --inspect=[::1]:0/ [834.72ms]
(pass) websocket > bun --inspect=/ [928.74ms]
(pass) websocket > bun --inspect=/foo [779.17ms]
(pass) websocket > bun --inspect=/foo/baz/ [755.97ms]
(pass) websocket > bun --inspect=:0 [860.68ms]
(pass) websoc
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4eacdac78f
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 1681ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir obj
[2/2863] mkdir codegen
[3/2863] mkdir pch
[4/2863] mkdir stamps
[5/2863] gen ErrorCode+*.h
[6/2863] fetch mimalloc
[mimalloc] up to date
[7/2863] fetch tinycc
[tinycc] up to date
[8/2863] gen bindgenv2
[9/2863] fetch icu
[icu] up to date
[10/2863] fetch WebKit
[WebKit] up to date
[11/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[12/2863] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [129.00ms]
[13/2863] fetch zlib
[zlib] up to date
[14/2863] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[15/2863] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[16/2863] host-cc deps/tinycc/host-obj/conftest.c.o
[17/2863] host-cxx deps/icu/host-obj/source/common/appendable.cpp.o
[18/2863] gen lut ArrayConstructor.lut.h
[19/2863] gen Com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/JSReadableStreamBYOBReader.cpp |  3 +-
 .../streams/JSReadableStreamDefaultReader.cpp      |  3 +-
 .../streams/JSWritableStreamDefaultWriter.cpp      |  5 +-
 test/cli/inspect/inspect.test.ts                   | 93 ++++++++++++++++++++++
 4 files changed, 100 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…bindings/webcore/streams/JSReadableStreamBYOBReader.cpp      0      0     10
…dings/webcore/streams/JSReadableStreamDefaultReader.cpp      1      0     11
…dings/webcore/streams/JSWritableStreamDefaultWriter.cpp      0      0     10
test/cli/inspect/inspect.test.ts                              2      0     10
```

</details>

<!-- robobun:evidence:end -->