### PR TITLE
bun:ffi: implement Symbol.dispose on dlopen/cc/linkSymbols libraries and CFunction

### DIFF
--- a/docs/runtime/ffi.mdx
+++ b/docs/runtime/ffi.mdx
@@ -41,6 +41,29 @@ const {
 console.log(`SQLite 3 version: ${sqlite3_libversion()}`);
 ```
 
+### Closing a library
+
+Call `close()` to unload the library and free the memory allocated for its symbols. Once closed, the symbols must not be called again.
+
+The returned object also implements the explicit resource management protocol, so it can be used with a `using` declaration. Disposing the returned object closes the library.
+
+```ts
+import { dlopen, FFIType, suffix } from "bun:ffi";
+
+{
+  using lib = dlopen(`libsqlite3.${suffix}`, {
+    sqlite3_libversion: {
+      args: [],
+      returns: FFIType.cstring,
+    },
+  });
+
+  console.log(`SQLite 3 version: ${lib.symbols.sqlite3_libversion()}`);
+} // lib.close() is invoked automatically here
+```
+
+The objects returned by `cc()` and `linkSymbols()`, `CFunction`, and `JSCallback` implement the same protocol.
+
 ---
 
 ## Performance
@@ -335,7 +358,7 @@ setTimeout(() => {
 }, 5000);
 ```
 
-When you're done with a `JSCallback`, call `close()` to free the memory.
+When you're done with a `JSCallback`, call `close()` to free the memory. `JSCallback` also implements the explicit resource management protocol, so it can be used with a `using` declaration.
 
 ### Experimental thread-safe callbacks
 

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -539,6 +539,25 @@ declare module "bun:ffi" {
      * Calling a function from a library that has been closed is undefined behavior.
      */
     close(): void;
+
+    /**
+     * Closes the library at the end of a `using` block (explicit resource management).
+     *
+     * Equivalent to calling {@link Library.close}.
+     *
+     * @example
+     * ```ts
+     * import { dlopen, FFIType, suffix } from "bun:ffi";
+     *
+     * {
+     *   using lib = dlopen(`libsqlite3.${suffix}`, {
+     *     sqlite3_libversion: { args: [], returns: FFIType.cstring },
+     *   });
+     *   console.log(lib.symbols.sqlite3_libversion());
+     * } // lib.close() is called automatically here
+     * ```
+     */
+    [Symbol.dispose](): void;
   }
 
   type ToFFIType<T extends FFITypeOrString> = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never;
@@ -725,6 +744,13 @@ declare module "bun:ffi" {
      * Free the memory allocated by the wrapping function
      */
     close(): void;
+
+    /**
+     * Frees the wrapping function at the end of a `using` block (explicit resource management).
+     *
+     * Equivalent to calling `close()`.
+     */
+    [Symbol.dispose](): void;
   };
 
   /**
@@ -1087,6 +1113,23 @@ declare module "bun:ffi" {
      * If called multiple times, does nothing after the first call.
      */
     close(): void;
+
+    /**
+     * Frees the callback at the end of a `using` block (explicit resource management).
+     *
+     * Equivalent to calling {@link JSCallback.close}.
+     *
+     * @example
+     * ```ts
+     * import { JSCallback } from "bun:ffi";
+     *
+     * {
+     *   using callback = new JSCallback(() => 42, { returns: "int32_t", args: [] });
+     *   nativeFunction(callback.ptr);
+     * } // callback.close() is called automatically here
+     * ```
+     */
+    [Symbol.dispose](): void;
   }
 
   /**

--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -741,14 +741,15 @@ declare module "bun:ffi" {
    */
   function CFunction(fn: FFIFunction & { ptr: Pointer | number | bigint }): CallableFunction & {
     /**
-     * Free the memory allocated by the wrapping function
+     * Provided for symmetry with {@link Library.close}. The wrapping function is
+     * managed by the garbage collector, so this is currently a no-op.
      */
     close(): void;
 
     /**
-     * Frees the wrapping function at the end of a `using` block (explicit resource management).
+     * Lets a `CFunction` be declared with `using` (explicit resource management).
      *
-     * Equivalent to calling `close()`.
+     * Equivalent to calling `close()`, which is currently a no-op.
      */
     [Symbol.dispose](): void;
   };

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -275,6 +275,7 @@ function CFunction(options) {
   const fn = nativeCFunction(options, identifier);
   if (Error.isError(fn)) throw fn;
   fn.close = closeJSCFFICFunction;
+  fn[Symbol.dispose] = closeJSCFFICFunction;
   return fn;
 }
 

--- a/src/runtime/ffi/ffi.classes.ts
+++ b/src/runtime/ffi/ffi.classes.ts
@@ -12,6 +12,10 @@ export default [
         fn: "close",
         length: 0,
       },
+      "@@dispose": {
+        fn: "close",
+        length: 0,
+      },
 
       symbols: {
         cache: "symbolsValue",

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -199,6 +199,25 @@ describe.skip("given a strlen(cstring) function", () => {
 
 // =============================================================================
 
+// TinyCC's setjmp/longjmp error handling conflicts with ASan.
+it.skipIf(isWindows || isASAN)("cc() library closes at the end of a `using` block", () => {
+  using dir = tempDir("bun-ffi-cc-dispose", {
+    "add.c": `int add(int a, int b) { return a + b; }`,
+  });
+  let library: Disposable;
+  {
+    using lib = cc({
+      source: path.join(String(dir), "add.c"),
+      symbols: { add: { args: ["int", "int"], returns: "int" } },
+    });
+    library = lib;
+    expect(typeof lib[Symbol.dispose]).toBe("function");
+    expect(lib.symbols.add(40, 2)).toBe(42);
+  }
+  // Disposing twice is a no-op, like close().
+  expect(library[Symbol.dispose]()).toBeUndefined();
+});
+
 function makeValidCase<Fns extends Record<string, FFIFunction>>(
   name: string,
   source: string,

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1874,3 +1874,80 @@ describe.skipIf(!ABI_FIXTURE_PATH)("ABI conformance", () => {
     }
   });
 });
+
+describe("Symbol.dispose", () => {
+  it("JSCallback closes at the end of a `using` block", () => {
+    let callback;
+    {
+      using cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
+      callback = cb;
+      expect(typeof cb[Symbol.dispose]).toBe("function");
+      expect(cb.ptr > 0).toBe(true);
+    }
+    expect(callback.ptr).toBeNull();
+    // Disposing twice is a no-op, like close().
+    expect(callback[Symbol.dispose]()).toBeUndefined();
+  });
+
+  it("CFunction disposes at the end of a `using` block", () => {
+    const callback = new JSCallback(() => 42, { returns: "int32_t", args: [] });
+    try {
+      {
+        using fn = new CFunction({ ptr: callback.ptr, returns: "int32_t", args: [] });
+        expect(typeof fn[Symbol.dispose]).toBe("function");
+        expect(fn()).toBe(42);
+      }
+    } finally {
+      callback.close();
+    }
+  });
+
+  it.skipIf(!FFI_FIXTURE_PATH)("dlopen() library closes at the end of a `using` block", () => {
+    let library;
+    {
+      using lib = dlopen(FFI_FIXTURE_PATH, {
+        returns_true: { args: [], returns: "bool" },
+        add_int32_t: { args: ["i32", "i32"], returns: "i32" },
+      });
+      library = lib;
+      expect(typeof lib[Symbol.dispose]).toBe("function");
+      expect(lib.symbols.returns_true()).toBe(true);
+      expect(lib.symbols.add_int32_t(40, 2)).toBe(42);
+    }
+    // Disposing twice is a no-op, like close().
+    expect(library[Symbol.dispose]()).toBeUndefined();
+    expect(library.close()).toBeUndefined();
+  });
+
+  it.skipIf(!FFI_FIXTURE_PATH)("dlopen() library is still closed when the `using` block throws", () => {
+    let library;
+    expect(() => {
+      using lib = dlopen(FFI_FIXTURE_PATH, {
+        returns_true: { args: [], returns: "bool" },
+      });
+      library = lib;
+      throw new Error("boom");
+    }).toThrow("boom");
+    expect(library[Symbol.dispose]()).toBeUndefined();
+  });
+
+  it.skipIf(!FFI_FIXTURE_PATH)("linkSymbols() library closes at the end of a `using` block", () => {
+    const {
+      symbols: { add_int32_t },
+      close,
+    } = dlopen(FFI_FIXTURE_PATH, {
+      add_int32_t: { args: ["i32", "i32"], returns: "i32" },
+    });
+    try {
+      {
+        using linked = linkSymbols({
+          sum: { ptr: add_int32_t.ptr, args: ["i32", "i32"], returns: "i32" },
+        });
+        expect(typeof linked[Symbol.dispose]).toBe("function");
+        expect(linked.symbols.sum(40, 2)).toBe(42);
+      }
+    } finally {
+      close();
+    }
+  });
+});

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1876,6 +1876,25 @@ describe.skipIf(!ABI_FIXTURE_PATH)("ABI conformance", () => {
 });
 
 describe("Symbol.dispose", () => {
+  // The native library prototype defines `@@dispose` as non-writable but configurable,
+  // so it is wrapped with defineProperty to observe the calls made by `using`.
+  function countDisposeCalls(proto) {
+    const original = proto[Symbol.dispose];
+    const counter = {
+      count: 0,
+      [Symbol.dispose]() {
+        Object.defineProperty(proto, Symbol.dispose, { value: original });
+      },
+    };
+    Object.defineProperty(proto, Symbol.dispose, {
+      value() {
+        counter.count++;
+        return original.call(this);
+      },
+    });
+    return counter;
+  }
+
   it("JSCallback closes at the end of a `using` block", () => {
     let callback;
     {
@@ -1889,7 +1908,8 @@ describe("Symbol.dispose", () => {
     expect(callback[Symbol.dispose]()).toBeUndefined();
   });
 
-  it("CFunction disposes at the end of a `using` block", () => {
+  // CFunction.close() is a no-op (the function is GC-managed), so only the protocol is checked.
+  it("CFunction can be declared with `using`", () => {
     const callback = new JSCallback(() => 42, { returns: "int32_t", args: [] });
     try {
       {
@@ -1903,6 +1923,8 @@ describe("Symbol.dispose", () => {
   });
 
   it.skipIf(!FFI_FIXTURE_PATH)("dlopen() library closes at the end of a `using` block", () => {
+    using probe = dlopen(FFI_FIXTURE_PATH, { returns_true: { args: [], returns: "bool" } });
+    using disposeCalls = countDisposeCalls(Object.getPrototypeOf(probe));
     let library;
     {
       using lib = dlopen(FFI_FIXTURE_PATH, {
@@ -1913,41 +1935,38 @@ describe("Symbol.dispose", () => {
       expect(typeof lib[Symbol.dispose]).toBe("function");
       expect(lib.symbols.returns_true()).toBe(true);
       expect(lib.symbols.add_int32_t(40, 2)).toBe(42);
+      expect(disposeCalls.count).toBe(0);
     }
+    expect(disposeCalls.count).toBe(1);
     // Disposing twice is a no-op, like close().
     expect(library[Symbol.dispose]()).toBeUndefined();
     expect(library.close()).toBeUndefined();
   });
 
   it.skipIf(!FFI_FIXTURE_PATH)("dlopen() library is still closed when the `using` block throws", () => {
-    let library;
+    using probe = dlopen(FFI_FIXTURE_PATH, { returns_true: { args: [], returns: "bool" } });
+    using disposeCalls = countDisposeCalls(Object.getPrototypeOf(probe));
     expect(() => {
       using lib = dlopen(FFI_FIXTURE_PATH, {
         returns_true: { args: [], returns: "bool" },
       });
-      library = lib;
       throw new Error("boom");
     }).toThrow("boom");
-    expect(library[Symbol.dispose]()).toBeUndefined();
+    expect(disposeCalls.count).toBe(1);
   });
 
   it.skipIf(!FFI_FIXTURE_PATH)("linkSymbols() library closes at the end of a `using` block", () => {
-    const {
-      symbols: { add_int32_t },
-      close,
-    } = dlopen(FFI_FIXTURE_PATH, {
+    using outer = dlopen(FFI_FIXTURE_PATH, {
       add_int32_t: { args: ["i32", "i32"], returns: "i32" },
     });
-    try {
-      {
-        using linked = linkSymbols({
-          sum: { ptr: add_int32_t.ptr, args: ["i32", "i32"], returns: "i32" },
-        });
-        expect(typeof linked[Symbol.dispose]).toBe("function");
-        expect(linked.symbols.sum(40, 2)).toBe(42);
-      }
-    } finally {
-      close();
+    using disposeCalls = countDisposeCalls(Object.getPrototypeOf(outer));
+    {
+      using linked = linkSymbols({
+        sum: { ptr: outer.symbols.add_int32_t.ptr, args: ["i32", "i32"], returns: "i32" },
+      });
+      expect(typeof linked[Symbol.dispose]).toBe("function");
+      expect(linked.symbols.sum(40, 2)).toBe(42);
     }
+    expect(disposeCalls.count).toBe(1);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Every handle returned by `bun:ffi` can now be closed by a `using` declaration.

Before this change only `JSCallback` implemented `[Symbol.dispose]` (added in #10818). The library object returned by `dlopen()`, `cc()` and `linkSymbols()` only had `close()`, so `using lib = dlopen(...)` threw `TypeError: @@dispose must not be undefined or null`. `CFunction` had the same gap.

The change:

- `src/runtime/ffi/ffi.classes.ts`: add a `@@dispose` entry that aliases the existing `close` function on the native FFI library class. This is the same pattern `server.classes.ts`, `sockets.classes.ts` and `cron.classes.ts` already use. This is the load-bearing hunk; `dlopen()`, `cc()` and `linkSymbols()` all return this class, so one entry covers all three.
- `src/js/bun/ffi.ts`: assign `fn[Symbol.dispose]` on the function returned by `CFunction()`, pointing at the same function `close` already uses. Note that `CFunction.close()` has been a no-op since #35246 made the wrapper an engine-native, GC-managed function, so this entry only provides protocol conformance so that `using fn = new CFunction(...)` does not throw. The `.d.ts` comments for both `close` and `[Symbol.dispose]` now say so instead of claiming they free memory.
- `packages/bun-types/ffi.d.ts`: declare `[Symbol.dispose](): void` on `Library`, `CFunction` and `JSCallback`. `JSCallback` already had it at runtime but the declaration was missing, so `using cb = new JSCallback(...)` failed to type-check.
- `docs/runtime/ffi.mdx`: add a "Closing a library" section with a `using` example, worded like the [Node.js `dlopen()` docs](https://nodejs.org/api/ffi.html#ffidlopenpath-definitions), and mention the protocol next to the existing `JSCallback.close()` paragraph. The example runs as written.

Disposing twice is a no-op, matching `close()`.

No behavior of `close()` changes, and no existing test was modified.

### How did you verify your code works?

New tests, all of which fail on the unfixed build (`USE_SYSTEM_BUN=1`, Bun 1.4.2) with `TypeError: @@dispose must not be undefined or null`:

- `test/js/bun/ffi/ffi.test.js`, `describe("Symbol.dispose")`:
  - `JSCallback` is closed at the end of a `using` block (`ptr` becomes `null`).
  - `CFunction` can be declared with `using` and is still callable inside the block (protocol only, since `close()` is a no-op).
  - `dlopen()` library: the prototype's `@@dispose` is wrapped to count calls, and the test asserts exactly one call at the end of the `using` block; disposing again and calling `close()` afterwards are no-ops.
  - `dlopen()` library: exactly one dispose call when the `using` block throws.
  - `linkSymbols()` library: exactly one dispose call at the end of the `using` block.
- `test/js/bun/ffi/cc.test.ts`: `cc()` library is disposable, skipped on Windows and ASAN like the other `cc()` tests in that file.

```
bun bd test test/js/bun/ffi/ffi.test.js -t "Symbol.dispose"
 5 pass, 0 fail

USE_SYSTEM_BUN=1 bun test test/js/bun/ffi/ffi.test.js -t "Symbol.dispose"
 1 pass, 4 fail   (the JSCallback test passes because #10818 already shipped it)

USE_SYSTEM_BUN=1 bun test test/js/bun/ffi/cc.test.ts -t "using"
 0 pass, 1 fail

USE_SYSTEM_BUN=1 bun test test/integration/bun-types/bun-types.test.ts
 21 pass, 0 fail
```

Note: my local debug build is an ASAN build, so the new `cc()` test was skipped locally by the same `skipIf(isASAN)` condition as the rest of `cc.test.ts`. It needs the non-ASAN CI jobs to confirm.

