### PR TITLE
webcrypto: generate RSA, P-384 and P-521 key pairs on the work pool

### DIFF
--- a/bench/snippets/webcrypto-generateKey.mjs
+++ b/bench/snippets/webcrypto-generateKey.mjs
@@ -1,0 +1,25 @@
+import { bench, group, run } from "../runner.mjs";
+
+const algorithms = [
+  ["ECDSA P-256", { name: "ECDSA", namedCurve: "P-256" }, ["sign", "verify"]],
+  ["ECDSA P-384", { name: "ECDSA", namedCurve: "P-384" }, ["sign", "verify"]],
+  ["ECDSA P-521", { name: "ECDSA", namedCurve: "P-521" }, ["sign", "verify"]],
+  [
+    "RSA-PSS 2048",
+    { name: "RSA-PSS", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+    ["sign", "verify"],
+  ],
+];
+
+for (const [name, params, usages] of algorithms) {
+  group(name, () => {
+    bench(`${name} sequential`, async () => {
+      await crypto.subtle.generateKey(params, true, usages);
+    });
+    bench(`${name} Promise.all(16)`, async () => {
+      await Promise.all(Array.from({ length: 16 }, () => crypto.subtle.generateKey(params, true, usages)));
+    });
+  });
+}
+
+await run();

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
@@ -143,8 +143,7 @@ void CryptoAlgorithm::dispatchOperationInWorkQueue(WorkQueue& workQueue, ScriptE
 
 void CryptoAlgorithm::dispatchKeyPairGeneration(ScriptExecutionContext& context, Function<EvpPKeyPair()>&& generate, Function<CryptoKeyPair(EvpPKeyPair&&)>&& wrap, KeyPairCallback&& callback, KeyPairFailureCallback&& failureCallback)
 {
-    auto workQueue = Bun::PhonyWorkQueue::create("key pair generation"_s);
-    workQueue->dispatch(context.globalObject(),
+    Bun::PhonyWorkQueue::dispatchToPool(context.globalObject(),
         [generate = WTF::move(generate), wrap = WTF::move(wrap), callback = WTF::move(callback), failureCallback = WTF::move(failureCallback), contextIdentifier = context.identifier(), loopKind = context.currentLoopKind()]() mutable {
             auto keys = generate();
             ScriptExecutionContext::postTaskTo(contextIdentifier, loopKind, [keys = WTF::move(keys), wrap = WTF::move(wrap), callback = WTF::move(callback), failureCallback = WTF::move(failureCallback)](auto&) mutable {

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
@@ -141,6 +141,22 @@ void CryptoAlgorithm::dispatchOperationInWorkQueue(WorkQueue& workQueue, ScriptE
     dispatchAlgorithmOperation(workQueue, context, WTF::move(callback), WTF::move(exceptionCallback), WTF::move(operation));
 }
 
+void CryptoAlgorithm::dispatchKeyPairGeneration(ScriptExecutionContext& context, Function<EvpPKeyPair()>&& generate, Function<CryptoKeyPair(EvpPKeyPair&&)>&& wrap, KeyPairCallback&& callback, KeyPairFailureCallback&& failureCallback)
+{
+    auto workQueue = Bun::PhonyWorkQueue::create("key pair generation"_s);
+    workQueue->dispatch(context.globalObject(),
+        [generate = WTF::move(generate), wrap = WTF::move(wrap), callback = WTF::move(callback), failureCallback = WTF::move(failureCallback), contextIdentifier = context.identifier(), loopKind = context.currentLoopKind()]() mutable {
+            auto keys = generate();
+            ScriptExecutionContext::postTaskTo(contextIdentifier, loopKind, [keys = WTF::move(keys), wrap = WTF::move(wrap), callback = WTF::move(callback), failureCallback = WTF::move(failureCallback)](auto&) mutable {
+                if (!keys) {
+                    failureCallback(OperationError);
+                    return;
+                }
+                callback(wrap(WTF::move(keys)));
+            });
+        });
+}
+
 }
 
 #endif

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
@@ -37,6 +37,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 #include "SubtleCrypto.h"
+#include "OpenSSLCryptoUniquePtr.h"
 
 #if ENABLE(WEB_CRYPTO)
 
@@ -83,6 +84,12 @@ public:
 
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Function<ExceptionOr<Vector<uint8_t>>()>&&);
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, BoolCallback&&, ExceptionCallback&&, Function<ExceptionOr<bool>()>&&);
+
+    using KeyPairCallback = Function<void(CryptoKeyPair&&)>;
+    using KeyPairFailureCallback = Function<void(ExceptionCode)>;
+    // Runs `generate` on the work pool, then `wrap` (which builds the CryptoKey wrappers) and one
+    // of the callbacks on the context's thread. Null keys from `generate` become OperationError.
+    static void dispatchKeyPairGeneration(ScriptExecutionContext&, Function<EvpPKeyPair()>&& generate, Function<CryptoKeyPair(EvpPKeyPair&&)>&& wrap, KeyPairCallback&&, KeyPairFailureCallback&&);
 
     // Truncates `secret` to the first `length` bits, zeroing the unused trailing bits of the
     // final byte, per https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits. A null

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
@@ -45,7 +45,7 @@ CryptoAlgorithmIdentifier CryptoAlgorithmECDH::identifier() const
     return s_identifier;
 }
 
-void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&)
+void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context)
 {
     const auto& ecParameters = downcast<CryptoAlgorithmEcKeyParams>(parameters);
 
@@ -54,16 +54,15 @@ void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameter
         return;
     }
 
-    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, ecParameters.namedCurve, extractable, usages);
-    if (result.hasException()) {
-        exceptionCallback(result.releaseException().code(), ""_s);
-        return;
-    }
-
-    auto pair = result.releaseReturnValue();
-    pair.publicKey->setUsagesBitmap(0);
-    pair.privateKey->setUsagesBitmap(pair.privateKey->usagesBitmap() & (CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits));
-    callback(WTF::move(pair));
+    auto keyPairCallback = [callback = WTF::move(callback)](CryptoKeyPair&& pair) mutable {
+        pair.publicKey->setUsagesBitmap(0);
+        pair.privateKey->setUsagesBitmap(pair.privateKey->usagesBitmap() & (CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits));
+        callback(WTF::move(pair));
+    };
+    auto failureCallback = [exceptionCallback = WTF::move(exceptionCallback)](ExceptionCode code) mutable {
+        exceptionCallback(code, ""_s);
+    };
+    CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, ecParameters.namedCurve, extractable, usages, WTF::move(keyPairCallback), WTF::move(failureCallback), context);
 }
 
 void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, std::optional<size_t> length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDSA.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDSA.cpp
@@ -81,7 +81,7 @@ void CryptoAlgorithmECDSA::verify(const CryptoAlgorithmParameters& parameters, R
         });
 }
 
-void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&)
+void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context)
 {
     const auto& ecParameters = downcast<CryptoAlgorithmEcKeyParams>(parameters);
 
@@ -90,16 +90,15 @@ void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& paramete
         return;
     }
 
-    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDSA, ecParameters.namedCurve, extractable, usages);
-    if (result.hasException()) {
-        exceptionCallback(result.releaseException().code(), ""_s);
-        return;
-    }
-
-    auto pair = result.releaseReturnValue();
-    pair.publicKey->setUsagesBitmap(pair.publicKey->usagesBitmap() & CryptoKeyUsageVerify);
-    pair.privateKey->setUsagesBitmap(pair.privateKey->usagesBitmap() & CryptoKeyUsageSign);
-    callback(WTF::move(pair));
+    auto keyPairCallback = [callback = WTF::move(callback)](CryptoKeyPair&& pair) mutable {
+        pair.publicKey->setUsagesBitmap(pair.publicKey->usagesBitmap() & CryptoKeyUsageVerify);
+        pair.privateKey->setUsagesBitmap(pair.privateKey->usagesBitmap() & CryptoKeyUsageSign);
+        callback(WTF::move(pair));
+    };
+    auto failureCallback = [exceptionCallback = WTF::move(exceptionCallback)](ExceptionCode code) mutable {
+        exceptionCallback(code, ""_s);
+    };
+    CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDSA, ecParameters.namedCurve, extractable, usages, WTF::move(keyPairCallback), WTF::move(failureCallback), context);
 }
 
 void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)

--- a/src/jsc/bindings/webcrypto/CryptoKeyEC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyEC.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_CRYPTO)
 
 #include "CryptoAlgorithmRegistry.h"
+#include "CryptoAlgorithm.h"
 #include "JsonWebKey.h"
 #include <wtf/text/Base64.h>
 
@@ -59,17 +60,34 @@ CryptoKeyEC::CryptoKeyEC(CryptoAlgorithmIdentifier identifier, NamedCurve curve,
     ASSERT(platformSupportedCurve(curve));
 }
 
-ExceptionOr<CryptoKeyPair> CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier identifier, const String& curve, bool extractable, CryptoKeyUsageBitmap usages)
+void CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier identifier, const String& curve, bool extractable, CryptoKeyUsageBitmap usages, KeyPairCallback&& callback, FailureCallback&& failureCallback, ScriptExecutionContext& context)
 {
     auto namedCurve = toNamedCurve(curve);
-    if (!namedCurve || !platformSupportedCurve(*namedCurve))
-        return Exception { NotSupportedError };
+    if (!namedCurve || !platformSupportedCurve(*namedCurve)) {
+        failureCallback(NotSupportedError);
+        return;
+    }
 
-    auto result = platformGeneratePair(identifier, *namedCurve, extractable, usages);
-    if (!result)
-        return Exception { OperationError };
+    auto wrap = [identifier, namedCurve = *namedCurve, extractable, usages](EvpPKeyPair&& keys) {
+        auto publicKey = CryptoKeyEC::create(identifier, namedCurve, CryptoKeyType::Public, WTF::move(keys.publicKey), true, usages);
+        auto privateKey = CryptoKeyEC::create(identifier, namedCurve, CryptoKeyType::Private, WTF::move(keys.privateKey), extractable, usages);
+        return CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) };
+    };
 
-    return WTF::move(*result);
+    // A P-256 pair costs about 15 us, as much as the round trip through the work pool, so it is
+    // generated inline. P-384 (0.5 ms) and P-521 (1.2 ms) would stall the event loop.
+    if (*namedCurve == NamedCurve::P256) {
+        auto keys = platformGeneratePair(*namedCurve);
+        if (!keys) {
+            failureCallback(OperationError);
+            return;
+        }
+        callback(wrap(WTF::move(keys)));
+        return;
+    }
+
+    CryptoAlgorithm::dispatchKeyPairGeneration(
+        context, [namedCurve = *namedCurve] { return platformGeneratePair(namedCurve); }, WTF::move(wrap), WTF::move(callback), WTF::move(failureCallback));
 }
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier identifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)

--- a/src/jsc/bindings/webcrypto/CryptoKeyEC.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyEC.h
@@ -28,6 +28,7 @@
 #include "CryptoKey.h"
 #include "CryptoKeyPair.h"
 #include "ExceptionOr.h"
+#include <wtf/Function.h>
 
 #if ENABLE(WEB_CRYPTO)
 
@@ -40,6 +41,7 @@ typedef WebCore::EvpPKeyPtr PlatformECKeyContainer;
 namespace WebCore {
 
 struct JsonWebKey;
+class ScriptExecutionContext;
 
 class CryptoKeyEC final : public CryptoKey {
 public:
@@ -55,7 +57,12 @@ public:
     }
     virtual ~CryptoKeyEC() = default;
 
-    WEBCORE_EXPORT static ExceptionOr<CryptoKeyPair> generatePair(CryptoAlgorithmIdentifier, const String& curve, bool extractable, CryptoKeyUsageBitmap);
+    using KeyPairCallback = Function<void(CryptoKeyPair&&)>;
+    using FailureCallback = Function<void(ExceptionCode)>;
+    // Runs one of the callbacks on the context's thread. P-384 and P-521 pairs are generated on the
+    // work pool; a P-256 pair inline. An unsupported curve fails synchronously with NotSupportedError,
+    // a failed generation with OperationError.
+    WEBCORE_EXPORT static void generatePair(CryptoAlgorithmIdentifier, const String& curve, bool extractable, CryptoKeyUsageBitmap, KeyPairCallback&&, FailureCallback&&, ScriptExecutionContext&);
     WEBCORE_EXPORT static RefPtr<CryptoKeyEC> importRaw(CryptoAlgorithmIdentifier, const String& curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyEC> importJwk(CryptoAlgorithmIdentifier, const String& curve, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap);
     // On failure, `keyTypeMismatch` (when given) reports whether the data held a
@@ -84,7 +91,8 @@ private:
     KeyAlgorithm algorithm() const final;
 
     static bool platformSupportedCurve(NamedCurve);
-    static std::optional<CryptoKeyPair> platformGeneratePair(CryptoAlgorithmIdentifier, NamedCurve, bool extractable, CryptoKeyUsageBitmap);
+    // Safe to call off the context's thread.
+    static EvpPKeyPair platformGeneratePair(NamedCurve);
     static RefPtr<CryptoKeyEC> platformImportRaw(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyEC> platformImportJWKPublic(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyEC> platformImportJWKPrivate(CryptoAlgorithmIdentifier, NamedCurve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap);

--- a/src/jsc/bindings/webcrypto/CryptoKeyECOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyECOpenSSL.cpp
@@ -101,38 +101,36 @@ bool CryptoKeyEC::platformSupportedCurve(NamedCurve curve)
     return curve == NamedCurve::P256 || curve == NamedCurve::P384 || curve == NamedCurve::P521;
 }
 
-std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages)
+EvpPKeyPair CryptoKeyEC::platformGeneratePair(NamedCurve curve)
 {
     // To generate a key pair, we generate a private key and extract the public key from the private key.
     auto privateECKey = createECKey(curve);
     if (!privateECKey)
-        return std::nullopt;
+        return {};
 
     if (EC_KEY_generate_key(privateECKey.get()) <= 0)
-        return std::nullopt;
+        return {};
 
     auto point = ECPointPtr(EC_POINT_dup(EC_KEY_get0_public_key(privateECKey.get()), EC_KEY_get0_group(privateECKey.get())));
     if (!point)
-        return std::nullopt;
+        return {};
 
     auto publicECKey = createECKey(curve);
     if (!publicECKey)
-        return std::nullopt;
+        return {};
 
     if (EC_KEY_set_public_key(publicECKey.get(), point.get()) <= 0)
-        return std::nullopt;
+        return {};
 
     auto privatePKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_EC_KEY(privatePKey.get(), privateECKey.get()) <= 0)
-        return std::nullopt;
+    if (!privatePKey || EVP_PKEY_set1_EC_KEY(privatePKey.get(), privateECKey.get()) <= 0)
+        return {};
 
     auto publicPKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_EC_KEY(publicPKey.get(), publicECKey.get()) <= 0)
-        return std::nullopt;
+    if (!publicPKey || EVP_PKEY_set1_EC_KEY(publicPKey.get(), publicECKey.get()) <= 0)
+        return {};
 
-    auto publicKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Public, WTF::move(publicPKey), true, usages);
-    auto privateKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Private, WTF::move(privatePKey), extractable, usages);
-    return CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) };
+    return { WTF::move(publicPKey), WTF::move(privatePKey) };
 }
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)

--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_CRYPTO)
 
+#include "CryptoAlgorithm.h"
 #include "CryptoAlgorithmRegistry.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSAComponents.h"
@@ -189,7 +190,30 @@ static std::optional<uint32_t> exponentVectorToUInt32(const Vector<uint8_t>& exp
     return result;
 }
 
-void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgorithmIdentifier hash, bool hasHash, unsigned modulusLength, const Vector<uint8_t>& publicExponent, bool extractable, CryptoKeyUsageBitmap usages, KeyPairCallback&& callback, VoidCallback&& failureCallback, ScriptExecutionContext*)
+// Safe to call off the context's thread.
+static EvpPKeyPair generatePlatformKeyPair(unsigned modulusLength, const Vector<uint8_t>& publicExponent)
+{
+    auto exponent = convertToBigNumber(publicExponent);
+    auto privateRSA = RSAPtr(RSA_new());
+    if (!exponent || !privateRSA || RSA_generate_key_ex(privateRSA.get(), modulusLength, exponent.get(), nullptr) <= 0)
+        return {};
+
+    auto publicRSA = RSAPtr(RSAPublicKey_dup(privateRSA.get()));
+    if (!publicRSA)
+        return {};
+
+    auto privatePKey = EvpPKeyPtr(EVP_PKEY_new());
+    if (!privatePKey || EVP_PKEY_set1_RSA(privatePKey.get(), privateRSA.get()) <= 0)
+        return {};
+
+    auto publicPKey = EvpPKeyPtr(EVP_PKEY_new());
+    if (!publicPKey || EVP_PKEY_set1_RSA(publicPKey.get(), publicRSA.get()) <= 0)
+        return {};
+
+    return { WTF::move(publicPKey), WTF::move(privatePKey) };
+}
+
+void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgorithmIdentifier hash, bool hasHash, unsigned modulusLength, const Vector<uint8_t>& publicExponent, bool extractable, CryptoKeyUsageBitmap usages, KeyPairCallback&& callback, VoidCallback&& failureCallback, ScriptExecutionContext* context)
 {
     // OpenSSL doesn't report an error if the exponent is smaller than three or even.
     auto e = exponentVectorToUInt32(publicExponent);
@@ -198,34 +222,16 @@ void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgor
         return;
     }
 
-    auto exponent = convertToBigNumber(publicExponent);
-    auto privateRSA = RSAPtr(RSA_new());
-    if (!exponent || RSA_generate_key_ex(privateRSA.get(), modulusLength, exponent.get(), nullptr) <= 0) {
-        failureCallback();
-        return;
-    }
-
-    auto publicRSA = RSAPtr(RSAPublicKey_dup(privateRSA.get()));
-    if (!publicRSA) {
-        failureCallback();
-        return;
-    }
-
-    auto privatePKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_RSA(privatePKey.get(), privateRSA.get()) <= 0) {
-        failureCallback();
-        return;
-    }
-
-    auto publicPKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_RSA(publicPKey.get(), publicRSA.get()) <= 0) {
-        failureCallback();
-        return;
-    }
-
-    auto publicKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Public, WTF::move(publicPKey), true, usages);
-    auto privateKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Private, WTF::move(privatePKey), extractable, usages);
-    callback(CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) });
+    CryptoAlgorithm::dispatchKeyPairGeneration(
+        *context,
+        [modulusLength, publicExponent = publicExponent] { return generatePlatformKeyPair(modulusLength, publicExponent); },
+        [algorithm, hash, hasHash, extractable, usages](EvpPKeyPair&& keys) {
+            auto publicKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Public, WTF::move(keys.publicKey), true, usages);
+            auto privateKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Private, WTF::move(keys.privateKey), extractable, usages);
+            return CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) };
+        },
+        WTF::move(callback),
+        [failureCallback = WTF::move(failureCallback)](ExceptionCode) mutable { failureCallback(); });
 }
 
 RefPtr<CryptoKeyRSA> CryptoKeyRSA::importSpki(CryptoAlgorithmIdentifier identifier, std::optional<CryptoAlgorithmIdentifier> hash, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, bool* keyTypeMismatch)

--- a/src/jsc/bindings/webcrypto/OpenSSLCryptoUniquePtr.h
+++ b/src/jsc/bindings/webcrypto/OpenSSLCryptoUniquePtr.h
@@ -73,4 +73,13 @@ DEFINE_OPENSSL_CRYPTO_PTR_FULL(ASN1SequencePtr, ASN1_SEQUENCE_ANY, sk_ASN1_TYPE_
 #undef DEFINE_OPENSSL_CRYPTO_PTR
 #undef DEFINE_OPENSSL_CRYPTO_PTR_FULL
 
+// A generated key pair before its CryptoKey wrappers exist. It has no thread affinity, so a work
+// pool thread can generate it and hand it to the context's thread. Both keys are null on failure.
+struct EvpPKeyPair {
+    EvpPKeyPtr publicKey;
+    EvpPKeyPtr privateKey;
+
+    explicit operator bool() const { return publicKey && privateKey; }
+};
+
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/PhonyWorkQueue.cpp
+++ b/src/jsc/bindings/webcrypto/PhonyWorkQueue.cpp
@@ -13,7 +13,7 @@ Ref<PhonyWorkQueue> PhonyWorkQueue::create(WTF::ASCIILiteral name)
 
 extern "C" void ConcurrentCppTask__createAndRun(JSC::JSGlobalObject*, EventLoopTaskNoContext* task);
 
-void PhonyWorkQueue::dispatch(JSC::JSGlobalObject* globalObject, WTF::Function<void()>&& function)
+void PhonyWorkQueue::dispatchToPool(JSC::JSGlobalObject* globalObject, WTF::Function<void()>&& function)
 {
     ConcurrentCppTask__createAndRun(globalObject, new EventLoopTaskNoContext(WTF::move(function)));
 }

--- a/src/jsc/bindings/webcrypto/PhonyWorkQueue.h
+++ b/src/jsc/bindings/webcrypto/PhonyWorkQueue.h
@@ -13,7 +13,10 @@ class PhonyWorkQueue : public WTF::RefCounted<PhonyWorkQueue> {
 public:
     static Ref<PhonyWorkQueue> create(WTF::ASCIILiteral name);
 
-    void dispatch(JSC::JSGlobalObject* globalObject, Function<void()>&&);
+    // The queue carries no state: a caller without one at hand dispatches through this directly.
+    static void dispatchToPool(JSC::JSGlobalObject* globalObject, Function<void()>&&);
+
+    void dispatch(JSC::JSGlobalObject* globalObject, Function<void()>&& function) { dispatchToPool(globalObject, WTF::move(function)); }
 };
 
 }; // namespace Bun

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -1023,9 +1023,11 @@ void SubtleCrypto::generateKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&&
             rejectWithException(promise.releaseNonNull(), ec, msg);
     };
 
-    // The 26 January 2017 version of the specification suggests we should perform the following task asynchronously
-    // regardless what kind of keys it produces: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-generateKey
-    // That's simply not efficient for AES, HMAC and EC keys. Therefore, we perform it as an async task only for RSA keys.
+    // The specification performs this task asynchronously regardless of what kind of key it
+    // produces: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-generateKey
+    // Keys that take longer than a round trip through the work pool (RSA, and EC P-384 and
+    // P-521) are generated there (CryptoAlgorithm::dispatchKeyPairGeneration). AES, HMAC, OKP,
+    // ML-DSA, ML-KEM and EC P-256 keys take well under a millisecond and are generated inline.
     RELEASE_AND_RETURN(scope, algorithm->generateKey(*params, extractable, keyUsagesBitmap, WTF::move(callback), WTF::move(exceptionCallback), *scriptExecutionContext()));
 }
 

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1453,3 +1453,121 @@ describe("exception scope discipline", () => {
     });
   });
 });
+
+// RSA, P-384 and P-521 key pairs used to be generated on the JS thread, and the
+// promise resolved before generateKey returned. They now run on the work pool
+// and the promise settles from a task posted back to the JS thread. P-256 pairs
+// cost about as much as the round trip and stay inline.
+describe("generateKey runs slow key pairs on the work pool", () => {
+  const rejection = (p: Promise<unknown>) =>
+    p.then(
+      () => "resolved",
+      e => `${e.name}: ${e.message}`,
+    );
+  const ecdsa = (namedCurve: string) => ({ name: "ECDSA", namedCurve }) as const;
+  const ecdh = { name: "ECDH", namedCurve: "P-521" } as const;
+  const rsa = (name: string, modulusLength = 2048) =>
+    ({ name, hash: "SHA-256", modulusLength, publicExponent: new Uint8Array([1, 0, 1]) }) as const;
+
+  it("the promise is still pending when generateKey returns, except for P-256", async () => {
+    const pending = {
+      p256: crypto.subtle.generateKey(ecdsa("P-256"), true, ["sign", "verify"]),
+      p384: crypto.subtle.generateKey(ecdsa("P-384"), true, ["sign", "verify"]),
+      p521: crypto.subtle.generateKey(ecdsa("P-521"), true, ["sign", "verify"]),
+      ecdh: crypto.subtle.generateKey(ecdh, true, ["deriveBits"]),
+      rsaPss: crypto.subtle.generateKey(rsa("RSA-PSS"), true, ["sign", "verify"]),
+      rsaOaep: crypto.subtle.generateKey(rsa("RSA-OAEP"), true, ["encrypt", "decrypt"]),
+      rsaSsa: crypto.subtle.generateKey(rsa("RSASSA-PKCS1-v1_5"), true, ["sign", "verify"]),
+    };
+    expect(Object.fromEntries(Object.entries(pending).map(([k, p]) => [k, Bun.peek.status(p)]))).toEqual({
+      p256: "fulfilled",
+      p384: "pending",
+      p521: "pending",
+      ecdh: "pending",
+      rsaPss: "pending",
+      rsaOaep: "pending",
+      rsaSsa: "pending",
+    });
+
+    const data = new Uint8Array([1, 2, 3]);
+    const ec = await pending.p521;
+    const ecSignature = await crypto.subtle.sign({ name: "ECDSA", hash: "SHA-512" }, ec.privateKey, data);
+    const rsaKeys = await pending.rsaSsa;
+    const rsaSignature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", rsaKeys.privateKey, data);
+    const { privateKey, publicKey } = await pending.ecdh;
+    const other = await crypto.subtle.generateKey(ecdh, true, ["deriveBits"]);
+    const a = await crypto.subtle.deriveBits({ name: "ECDH", public: other.publicKey }, privateKey, 256);
+    const b = await crypto.subtle.deriveBits({ name: "ECDH", public: publicKey }, other.privateKey, 256);
+    expect({
+      ecVerified: await crypto.subtle.verify({ name: "ECDSA", hash: "SHA-512" }, ec.publicKey, ecSignature, data),
+      rsaVerified: await crypto.subtle.verify("RSASSA-PKCS1-v1_5", rsaKeys.publicKey, rsaSignature, data),
+      ecdhAgreed: Buffer.from(a).equals(Buffer.from(b)),
+    }).toEqual({ ecVerified: true, rsaVerified: true, ecdhAgreed: true });
+  });
+
+  it("a batch of concurrent P-521 generations all resolve with distinct usable keys", async () => {
+    const pairs = await Promise.all(
+      Array.from({ length: 16 }, () => crypto.subtle.generateKey(ecdsa("P-521"), true, ["sign", "verify"])),
+    );
+    const raws = await Promise.all(pairs.map(pair => crypto.subtle.exportKey("raw", pair.publicKey)));
+    expect(raws.map(raw => raw.byteLength)).toEqual(Array(16).fill(133));
+    expect(new Set(raws.map(raw => Buffer.from(raw).toString("hex"))).size).toBe(16);
+  });
+
+  it("rejections keep their names", async () => {
+    expect({
+      unsupportedCurve: await rejection(crypto.subtle.generateKey(ecdsa("P-999"), true, ["sign", "verify"])),
+      // Rejected synchronously, before the generation is dispatched.
+      evenExponent: await rejection(
+        crypto.subtle.generateKey({ ...rsa("RSA-OAEP"), publicExponent: new Uint8Array([4]) }, true, ["encrypt"]),
+      ),
+      // RSA_generate_key_ex fails on the pool thread.
+      tinyModulus: await rejection(crypto.subtle.generateKey(rsa("RSA-OAEP", 8), true, ["encrypt"])),
+      // Checked after the pair comes back from the pool.
+      emptyUsages: await rejection(crypto.subtle.generateKey(ecdsa("P-384"), true, [])),
+    }).toEqual({
+      unsupportedCurve: "NotSupportedError: The algorithm is not supported",
+      evenExponent: "OperationError: The operation failed for an operation-specific reason",
+      tinyModulus: "OperationError: The operation failed for an operation-specific reason",
+      emptyUsages: "SyntaxError: Usages cannot be empty when creating a key.",
+    });
+  });
+
+  it("a floating generateKey keeps the process alive until it resolves", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-384" }, true, ["deriveBits"]).then(k => console.log(k.privateKey.algorithm.namedCurve));
+         crypto.subtle.generateKey({ name: "RSA-PSS", hash: "SHA-256", modulusLength: 1024, publicExponent: new Uint8Array([1, 0, 1]) }, true, ["sign"]).then(k => console.log(k.privateKey.algorithm.modulusLength));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ lines: stdout.split("\n").sort(), stderr, exitCode }).toEqual({
+      lines: ["", "1024", "P-384"],
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("generates inside a Worker", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const w = new Worker(URL.createObjectURL(new Blob([
+          'crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-384" }, true, ["sign", "verify"]).then(k => postMessage(k.publicKey.type));'
+        ], { type: "application/javascript" })));
+        w.onmessage = e => { console.log(e.data); w.terminate(); };`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "public\n", stderr: "", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
### Problem
- `crypto.subtle.generateKey` for RSA, ECDSA and ECDH ran the BoringSSL key generation on the JS thread and resolved the promise before `generateKey` returned. An RSA-2048 pair stalls the event loop for 50 to 150 ms (4096: 500 ms or more), a P-521 pair for 1.2 ms, a P-384 pair for 0.5 ms. 200 P-521 pairs froze the loop for 240 ms. Node runs every key generation on its threadpool.
- The cause is `CryptoKeyRSA::generatePair` (`src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp`) and `CryptoKeyEC::generatePair` (`CryptoKeyEC.cpp`) calling `RSA_generate_key_ex` and `EC_KEY_generate_key` inline. Every other `subtle.*` operation already runs on the work pool.

### Fix
- `CryptoAlgorithm::dispatchKeyPairGeneration` (`CryptoAlgorithm.cpp`) runs a platform key generator on the work pool and posts the `EVP_PKEY`s back to the context's thread through `ScriptExecutionContext::postTaskTo`. There it builds the `CryptoKey` wrappers and runs the callbacks. Null keys become `OperationError`.
- `CryptoKeyRSA::generatePair` and `CryptoKeyEC::generatePair` are its two consumers. Each keeps its synchronous validation (exponent, curve) and its usage masking. `EvpPKeyPair` (`OpenSSLCryptoUniquePtr.h`) is the thread-free value that crosses the pool.
- A P-256 pair costs about 15 us, as much as the round trip, so it stays inline. The policy comment in `SubtleCrypto::generateKey` now states what Bun does.
- Verified: `test/js/web/crypto/web-crypto.test.ts` (new block; the first test fails on stock bun). Also the WPT generateKey suite (10226 tests), the node webcrypto RSA and EC tests, `cryptokey-workers`, `methods-not-async`, and all of `test/js/web/crypto/`.

### Background
- `SubtleCrypto::generateKey` hands the algorithm a `callback` and an `exceptionCallback` that settle the promise. Both hold a `WeakPtr` to the `SubtleCrypto`, so a callback that runs after the context is gone is a no-op.
- `Bun::PhonyWorkQueue` is the work pool entry the other `subtle.*` operations use (`dispatchAlgorithmOperation`). `postTaskTo(identifier, loopKind, task)` is the way back to the JS thread; a task posted to a dead context is dropped.
- `CryptoKey` objects are JS-thread objects. Only the raw `EVP_PKEY`s cross threads.
- This supersedes #37121, which did the RSA half with its own copy of the dispatch.

<details><summary>Notes</summary>

Measured with the repro from the report, release build, 200 `generateKey` calls in a `Promise.all`, 1 ms heartbeat:

- stock 1.4.2, P-521: `callsReturnedAfterMs 239, maxTimerGapMs 240, timerTicks 0`
- this branch, P-521: the calls return in the time 200 P-256 calls take, and the loop ticks while the pool works.

P-256 stays inline because a pair costs 13 to 19 us and a pool round trip 2 to 14 us. Offloading it would double the latency of a sequential `await generateKey(P-256)` for no event-loop gain.

`bench/snippets/webcrypto-generateKey.mjs` covers P-256, P-384, P-521 and RSA-2048, sequential and `Promise.all(16)`.

A `worker.terminate()` that lands while a pool task is in flight hits a pre-existing race in `ConcurrentCppTask` (noted in #37121). This change does not widen it beyond what `deriveBits` already has.

</details>
