### PR TITLE
Report the native memory of CompressionStream, JSSink, MessagePort and Transpiler to the GC

### DIFF
--- a/src/bun_alloc/c_thunks.rs
+++ b/src/bun_alloc/c_thunks.rs
@@ -7,8 +7,7 @@
 //! | JSC `JSTypedArrayBytesDeallocator` | —                                      | `(bytes, ctx)`             |
 //!
 //! The plain (non-zone-tagged) variants are free functions below; the
-//! zone-tagged variants are minted per-label by [`c_thunks_for_zone!`]. The
-//! counted variants keep a running byte total in the `opaque` cookie.
+//! zone-tagged variants are minted per-label by [`c_thunks_for_zone!`].
 
 use core::ffi::{c_uint, c_void};
 use core::sync::atomic::{AtomicUsize, Ordering};
@@ -41,21 +40,17 @@ pub unsafe extern "C" fn mi_free_bytes(bytes: *mut c_void, _ctx: *mut c_void) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Counted thunks: the `opaque` cookie is a `*mut AtomicUsize` that tracks the
-// bytes currently held through these hooks, for GC extra-memory reporting.
-// The counter must outlive every allocation made through them.
+// Counted thunks: `opaque` is a `*mut AtomicUsize` holding the bytes in use
 // ──────────────────────────────────────────────────────────────────────────
 
-/// brotli-shape `(opaque, size)` → default allocator `malloc(size)`, adding the
-/// block's usable size to the counter at `opaque`. Null on failure.
+/// brotli-shape `(opaque, size)` → `malloc(size)`, counting the block's usable size.
 ///
 /// # Safety
-/// `opaque` points to a live `AtomicUsize`.
+/// `opaque` points to an `AtomicUsize` that outlives every block allocated here.
 pub unsafe extern "C" fn counted_malloc_size(opaque: *mut c_void, size: usize) -> *mut c_void {
     let ptr = raw::malloc(size);
     if !ptr.is_null() {
-        // SAFETY: the caller passes a live `AtomicUsize` as `opaque`, and `ptr`
-        // is a live default-allocator allocation.
+        // SAFETY: `opaque` is live (caller contract); `ptr` is a live allocation.
         unsafe {
             (*opaque.cast::<AtomicUsize>()).fetch_add(raw::usable_size(ptr), Ordering::Relaxed);
         }
@@ -76,18 +71,15 @@ pub unsafe extern "C" fn counted_malloc_items(
     unsafe { counted_malloc_size(opaque, items as usize * size as usize) }
 }
 
-/// `(opaque, ptr)` → default allocator `free(ptr)`, subtracting the block's
-/// usable size from the counter at `opaque`. Pairs with either counted alloc.
+/// `(opaque, ptr)` → `free(ptr)`, uncounting the block's usable size.
 ///
 /// # Safety
-/// `opaque` points to a live `AtomicUsize` and `ptr` is null or came from a
-/// counted alloc above.
+/// `opaque` points to a live `AtomicUsize`; `ptr` is null or from a counted alloc above.
 pub unsafe extern "C" fn counted_free(opaque: *mut c_void, ptr: *mut c_void) {
     if ptr.is_null() {
         return;
     }
-    // SAFETY: the caller's contract: a live counter and a live default-allocator
-    // allocation.
+    // SAFETY: caller contract.
     unsafe {
         (*opaque.cast::<AtomicUsize>()).fetch_sub(raw::usable_size(ptr), Ordering::Relaxed);
         raw::free(ptr);

--- a/src/bun_alloc/c_thunks.rs
+++ b/src/bun_alloc/c_thunks.rs
@@ -39,14 +39,7 @@ pub unsafe extern "C" fn mi_free_bytes(bytes: *mut c_void, _ctx: *mut c_void) {
     unsafe { raw::free(bytes) };
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Counted thunks: `opaque` is a `*mut AtomicUsize` holding the bytes in use
-// ──────────────────────────────────────────────────────────────────────────
-
-/// brotli-shape `(opaque, size)` → `malloc(size)`, counting the block's usable size.
-///
-/// # Safety
-/// `opaque` points to an `AtomicUsize` that outlives every block allocated here.
+/// brotli-shape alloc that adds the block's usable size to the `AtomicUsize` at `opaque`.
 pub unsafe extern "C" fn counted_malloc_size(opaque: *mut c_void, size: usize) -> *mut c_void {
     let ptr = raw::malloc(size);
     if !ptr.is_null() {
@@ -58,10 +51,7 @@ pub unsafe extern "C" fn counted_malloc_size(opaque: *mut c_void, size: usize) -
     ptr
 }
 
-/// zlib-shape `(opaque, items, size)` counterpart of [`counted_malloc_size`].
-///
-/// # Safety
-/// As [`counted_malloc_size`].
+/// zlib-shape counterpart of [`counted_malloc_size`].
 pub unsafe extern "C" fn counted_malloc_items(
     opaque: *mut c_void,
     items: c_uint,
@@ -71,10 +61,7 @@ pub unsafe extern "C" fn counted_malloc_items(
     unsafe { counted_malloc_size(opaque, items as usize * size as usize) }
 }
 
-/// `(opaque, ptr)` → `free(ptr)`, uncounting the block's usable size.
-///
-/// # Safety
-/// `opaque` points to a live `AtomicUsize`; `ptr` is null or from a counted alloc above.
+/// `free(ptr)` that subtracts the block's usable size from the `AtomicUsize` at `opaque`.
 pub unsafe extern "C" fn counted_free(opaque: *mut c_void, ptr: *mut c_void) {
     if ptr.is_null() {
         return;

--- a/src/bun_alloc/c_thunks.rs
+++ b/src/bun_alloc/c_thunks.rs
@@ -7,9 +7,11 @@
 //! | JSC `JSTypedArrayBytesDeallocator` | —                                      | `(bytes, ctx)`             |
 //!
 //! The plain (non-zone-tagged) variants are free functions below; the
-//! zone-tagged variants are minted per-label by [`c_thunks_for_zone!`].
+//! zone-tagged variants are minted per-label by [`c_thunks_for_zone!`]. The
+//! counted variants keep a running byte total in the `opaque` cookie.
 
 use core::ffi::{c_uint, c_void};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::default_alloc as raw;
 
@@ -36,6 +38,60 @@ pub use mi_free_opaque as mi_free_ctx;
 pub unsafe extern "C" fn mi_free_bytes(bytes: *mut c_void, _ctx: *mut c_void) {
     // SAFETY: bytes was allocated by the default allocator (or is null).
     unsafe { raw::free(bytes) };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Counted thunks: the `opaque` cookie is a `*mut AtomicUsize` that tracks the
+// bytes currently held through these hooks, for GC extra-memory reporting.
+// The counter must outlive every allocation made through them.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// brotli-shape `(opaque, size)` → default allocator `malloc(size)`, adding the
+/// block's usable size to the counter at `opaque`. Null on failure.
+///
+/// # Safety
+/// `opaque` points to a live `AtomicUsize`.
+pub unsafe extern "C" fn counted_malloc_size(opaque: *mut c_void, size: usize) -> *mut c_void {
+    let ptr = raw::malloc(size);
+    if !ptr.is_null() {
+        // SAFETY: the caller passes a live `AtomicUsize` as `opaque`, and `ptr`
+        // is a live default-allocator allocation.
+        unsafe {
+            (*opaque.cast::<AtomicUsize>()).fetch_add(raw::usable_size(ptr), Ordering::Relaxed);
+        }
+    }
+    ptr
+}
+
+/// zlib-shape `(opaque, items, size)` counterpart of [`counted_malloc_size`].
+///
+/// # Safety
+/// As [`counted_malloc_size`].
+pub unsafe extern "C" fn counted_malloc_items(
+    opaque: *mut c_void,
+    items: c_uint,
+    size: c_uint,
+) -> *mut c_void {
+    // SAFETY: same contract as `counted_malloc_size`.
+    unsafe { counted_malloc_size(opaque, items as usize * size as usize) }
+}
+
+/// `(opaque, ptr)` → default allocator `free(ptr)`, subtracting the block's
+/// usable size from the counter at `opaque`. Pairs with either counted alloc.
+///
+/// # Safety
+/// `opaque` points to a live `AtomicUsize` and `ptr` is null or came from a
+/// counted alloc above.
+pub unsafe extern "C" fn counted_free(opaque: *mut c_void, ptr: *mut c_void) {
+    if ptr.is_null() {
+        return;
+    }
+    // SAFETY: the caller's contract: a live counter and a live default-allocator
+    // allocation.
+    unsafe {
+        (*opaque.cast::<AtomicUsize>()).fetch_sub(raw::usable_size(ptr), Ordering::Relaxed);
+        raw::free(ptr);
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -99,8 +99,7 @@ function header() {
             static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
             static size_t estimatedSize(JSCell* cell, JSC::VM& vm);
             static size_t memoryCost(void* sinkPtr);
-            // ${name}__reportMemoryCost: the sink's buffered bytes, reported to the GC as extra
-            // memory so a dropped sink that still holds data counts toward the next collection.
+            // ${name}__reportMemoryCost: the buffered bytes, as GC extra memory.
             void reportMemoryCost(size_t cost);
 
             void ref();

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -99,12 +99,16 @@ function header() {
             static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
             static size_t estimatedSize(JSCell* cell, JSC::VM& vm);
             static size_t memoryCost(void* sinkPtr);
+            // ${name}__reportMemoryCost: the sink's buffered bytes, reported to the GC as extra
+            // memory so a dropped sink that still holds data counts toward the next collection.
+            void reportMemoryCost(size_t cost);
 
             void ref();
             void unref();
                                                                                                                                                                                     
             void* m_sinkPtr;
             int m_refCount { 1 };
+            size_t m_memoryCostForGC { 0 };
 
             uintptr_t m_onDestroy { 0 };
                                                                                                                                                                                     
@@ -196,6 +200,8 @@ public:
 
     void* wrapped() const { return m_sinkPtr; }
     SinkID sinkId() const { return m_sinkId; }
+    // See JS*Sink::reportMemoryCost.
+    void reportMemoryCost(size_t cost);
 
     void* m_sinkPtr;
     SinkID m_sinkId;
@@ -203,6 +209,7 @@ public:
     mutable WriteBarrier<JSC::JSObject> m_onClose;
     mutable JSC::Weak<JSObject> m_weakReadableStream;
     uintptr_t m_onDestroy { 0 };
+    size_t m_memoryCostForGC { 0 };
 
 protected:
     JSReadableSinkControllerBase(JSC::VM& vm, JSC::Structure* structure, void* sinkPtr, SinkID sinkId, uintptr_t onDestroy)
@@ -296,12 +303,37 @@ ${classes.map(name => `extern "C" size_t ${name}__memoryCost(void* sinkPtr);`).j
 ${classes.map(name => `extern "C" void ${name}__controllerDetached(void* sinkPtr, JSC::EncodedJSValue controllerValue);`).join("\n")}
 
 const ClassInfo JSReadableSinkControllerBase::s_info = { "ReadableSinkController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadableSinkControllerBase) };
+
+void JSReadableSinkControllerBase::reportMemoryCost(size_t cost)
+{
+    if (cost > m_memoryCostForGC)
+        vm().heap.reportExtraMemoryAllocated(this, cost - m_memoryCostForGC);
+    m_memoryCostForGC = cost;
+}
 `;
   var templ = head;
 
   for (let name of classes) {
     const { className, controller, prototypeName, controllerName, controllerPrototypeName, constructor } = names(name);
     templ += `
+
+  void ${className}::reportMemoryCost(size_t cost) {
+    if (cost > m_memoryCostForGC)
+      vm().heap.reportExtraMemoryAllocated(this, cost - m_memoryCostForGC);
+    m_memoryCostForGC = cost;
+  }
+
+  // JSSink::sync_memory_cost (Sink.rs): after a JS-driven write/start/flush/end on either cell.
+  extern "C" void ${name}__reportMemoryCost(JSC::EncodedJSValue value, size_t cost)
+  {
+    JSC::JSValue thisValue = JSC::JSValue::decode(value);
+    if (auto* sink = dynamicDowncast<${className}>(thisValue)) {
+      sink->reportMemoryCost(cost);
+      return;
+    }
+    if (auto* controller = dynamicDowncast<${controller}>(thisValue))
+      controller->reportMemoryCost(cost);
+  }
 
   void ${className}::ref() {
     if (!m_sinkPtr)
@@ -830,6 +862,7 @@ void ${controller}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     // Avoid duplicating in the heap snapshot
     visitor.appendHidden(thisObject->m_onPull);
     visitor.appendHidden(thisObject->m_onClose);
+    visitor.reportExtraMemoryVisited(thisObject->m_memoryCostForGC);
     
     void* ptr = thisObject->m_sinkPtr;
     if (ptr)
@@ -844,6 +877,7 @@ void ${className}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ${className}* thisObject = uncheckedDowncast<${className}>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
+    visitor.reportExtraMemoryVisited(thisObject->m_memoryCostForGC);
     void* ptr = thisObject->m_sinkPtr;
     if (ptr)
       visitor.addOpaqueRoot(ptr);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -93,7 +93,7 @@ function header() {
 
             void detach() {
                 m_sinkPtr = nullptr;
-
+                m_memoryCostForGC = 0;
             }
 
             static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -699,6 +699,7 @@ void JS${controllerName}::detach() {
 
     auto* sinkPtr = std::exchange(m_sinkPtr, nullptr);
     auto destroy = std::exchange(m_onDestroy, 0);
+    m_memoryCostForGC = 0;
 
     m_onPull.clear();
     m_onClose.clear();

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -416,9 +416,15 @@ void JSMessagePort::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
     thisObject->visitAdditionalChildrenInGCThread(visitor);
+    visitor.reportExtraMemoryVisited(thisObject->wrapped().memoryCost());
 }
 
 DEFINE_VISIT_CHILDREN(JSMessagePort);
+
+size_t JSMessagePort::estimatedSize(JSCell* cell, VM& vm)
+{
+    return Base::estimatedSize(cell, vm) + uncheckedDowncast<JSMessagePort>(cell)->wrapped().memoryCost();
+}
 
 template<typename Visitor>
 void JSMessagePort::visitOutputConstraints(JSCell* cell, Visitor& visitor)

--- a/src/jsc/bindings/webcore/JSMessagePort.h
+++ b/src/jsc/bindings/webcore/JSMessagePort.h
@@ -62,6 +62,7 @@ public:
 
     template<typename Visitor> static void visitOutputConstraints(JSCell*, Visitor&);
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
+    static size_t estimatedSize(JSCell*, JSC::VM&);
     MessagePort& wrapped() const
     {
         return static_cast<MessagePort&>(Base::wrapped());

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -142,7 +142,13 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
         }
     }
 
-    m_pipe->send(m_side, MessageWithMessagePorts { messageData.releaseReturnValue(), WTF::move(transferredPorts) });
+    MessageWithMessagePorts message { messageData.releaseReturnValue(), WTF::move(transferredPorts) };
+    size_t cost = message.memoryCost();
+    m_pipe->send(m_side, WTF::move(message));
+    // The serialized bytes now sit in the peer's inbox, native memory the GC cannot see. The
+    // peer's wrapper (if any, maybe on another thread) reports them as visited; this tells the
+    // GC about the growth now, so a loop that posts to a never-started port still triggers one.
+    vm.heap.reportExtraMemoryAllocated(nullptr, cost);
     return {};
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -145,9 +145,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     MessageWithMessagePorts message { messageData.releaseReturnValue(), WTF::move(transferredPorts) };
     size_t cost = message.memoryCost();
     m_pipe->send(m_side, WTF::move(message));
-    // The serialized bytes now sit in the peer's inbox, native memory the GC cannot see. The
-    // peer's wrapper (if any, maybe on another thread) reports them as visited; this tells the
-    // GC about the growth now, so a loop that posts to a never-started port still triggers one.
+    // No cell: the peer's wrapper may not exist or may be on another thread.
     vm.heap.reportExtraMemoryAllocated(nullptr, cost);
     return {};
 }

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -101,8 +101,7 @@ public:
 
     MessagePortPipe* pipe() const { return m_pipe.ptr(); }
     uint8_t side() const { return m_side; }
-    // Bytes of messages queued for this port and not yet delivered. Lockless (GC thread safe:
-    // m_pipe is a Ref held for the port's whole life); the wrapper reports it as extra memory.
+    // Bytes queued for this port, not yet delivered. Lockless (GC thread safe).
     size_t memoryCost() const { return m_pipe->queuedBytes(m_side); }
 
     // EventTarget.

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -101,6 +101,9 @@ public:
 
     MessagePortPipe* pipe() const { return m_pipe.ptr(); }
     uint8_t side() const { return m_side; }
+    // Bytes of messages queued for this port and not yet delivered. Lockless (GC thread safe:
+    // m_pipe is a Ref held for the port's whole life); the wrapper reports it as extra memory.
+    size_t memoryCost() const { return m_pipe->queuedBytes(m_side); }
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return MessagePortEventTargetInterfaceType; }

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -41,6 +41,7 @@ void MessagePortPipe::send(uint8_t fromSide, MessageWithMessagePorts&& message)
         if (s & Closed)
             return;
 
+        dst.queuedBytes.fetch_add(message.memoryCost(), std::memory_order_relaxed);
         dst.inbox.append(WTF::move(message));
 
         uint64_t ns = s + QueuedOne;
@@ -161,6 +162,7 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
                 limit -= n;
             }
             message = s.draining.takeFirst();
+            s.queuedBytes.fetch_sub(message->memoryCost(), std::memory_order_relaxed);
             s.state.store(st - QueuedOne, std::memory_order_release);
         }
 
@@ -203,7 +205,9 @@ std::optional<MessageWithMessagePorts> MessagePortPipe::takeOne(uint8_t side)
     if (queue.isEmpty())
         return std::nullopt;
     s.state.fetch_sub(QueuedOne, std::memory_order_acq_rel);
-    return queue.takeFirst();
+    auto message = queue.takeFirst();
+    s.queuedBytes.fetch_sub(message.memoryCost(), std::memory_order_relaxed);
+    return message;
 }
 
 void MessagePortPipe::attach(uint8_t side, ScriptExecutionContext& context, ThreadSafeWeakPtr<MessagePort> port)
@@ -303,6 +307,7 @@ void MessagePortPipe::close(uint8_t side, CloseKind kind)
             dropped = std::exchange(s.inbox, {});
             while (!s.draining.isEmpty())
                 dropped.prepend(s.draining.takeLast());
+            s.queuedBytes.store(0, std::memory_order_relaxed);
         }
 
         // Harvest transferred pipes before `dropped` destructs so their

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -80,7 +80,6 @@ public:
 
     // Lockless snapshot for the GC visitor / hasPendingActivity.
     uint64_t state(uint8_t side) const { return m_sides[side].state.load(std::memory_order_acquire); }
-    // Serialized bytes queued for `side` (SerializedScriptValue::memoryCost of each message).
     // Lockless: the receiving port's wrapper reports it to the GC as extra memory.
     size_t queuedBytes(uint8_t side) const { return m_sides[side].queuedBytes.load(std::memory_order_acquire); }
     bool isOtherSideOpen(uint8_t side) const { return !(state(1 - side) & Closed); }

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -80,6 +80,9 @@ public:
 
     // Lockless snapshot for the GC visitor / hasPendingActivity.
     uint64_t state(uint8_t side) const { return m_sides[side].state.load(std::memory_order_acquire); }
+    // Serialized bytes queued for `side` (SerializedScriptValue::memoryCost of each message).
+    // Lockless: the receiving port's wrapper reports it to the GC as extra memory.
+    size_t queuedBytes(uint8_t side) const { return m_sides[side].queuedBytes.load(std::memory_order_acquire); }
     bool isOtherSideOpen(uint8_t side) const { return !(state(1 - side) & Closed); }
     bool isOtherSideClosedByRequest(uint8_t side) const { return state(1 - side) & ClosedByRequest; }
 
@@ -108,6 +111,8 @@ private:
         ThreadSafeWeakPtr<MessagePort> port WTF_GUARDED_BY_LOCK(lock);
         // Packed flags + count. Written only while holding `lock`; read locklessly.
         std::atomic<uint64_t> state { 0 };
+        // Sum of memoryCost() over `inbox` + `draining`. Written only while holding `lock`.
+        std::atomic<size_t> queuedBytes { 0 };
     };
     Side m_sides[2];
 };

--- a/src/jsc/bindings/webcore/MessageWithMessagePorts.h
+++ b/src/jsc/bindings/webcore/MessageWithMessagePorts.h
@@ -34,6 +34,8 @@ namespace WebCore {
 struct MessageWithMessagePorts {
     RefPtr<SerializedScriptValue> message;
     Vector<TransferredMessagePort> transferredPorts;
+
+    size_t memoryCost() const { return message ? message->memoryCost() : 0; }
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
@@ -165,6 +165,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCompressionStreamConst
     }
     auto* stream = JSCompressionStream::create(vm, structure);
     stream->m_coder = coder;
+    reportCoderMemoryCost(vm, stream, coder);
     vm.heap.addFinalizer(stream, static_cast<JSC::Heap::CFinalizer>([](JSCell* cell) {
         CompressionStreamCoder__destroy(std::exchange(static_cast<JSCompressionStream*>(cell)->m_coder, nullptr));
     }));

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -131,6 +131,11 @@ static void* coderOf(JSTransformStream* stream)
     return nullptr;
 }
 
+void reportCoderMemoryCost(VM& vm, JSTransformStream* stream, const void* coder)
+{
+    stream->reportNativeMemoryCost(vm, CompressionStreamCoder__memoryCost(coder));
+}
+
 // One step, with its output already handed to the consumer.
 struct CodecStepResult {
     // The coder stopped at its output bound; the chunk needs another step.
@@ -148,11 +153,13 @@ static CodecStepResult runStepHere(JSGlobalObject* globalObject, JSTransformStre
     CodecStepResult step;
     if (void* sinkPtr = stream->m_nativeSinkPtr) {
         JSValue wrote = JSValue::decode(CompressionStreamCoder__transformInto(coder, globalObject, input, inputLen, finish, stream->m_nativeSinkId, sinkPtr, &step.more));
+        reportCoderMemoryCost(vm, stream, coder);
         RETURN_IF_EXCEPTION(scope, step);
         step.sinkBackpressure = nativeSinkWriteIsBackpressure(vm, wrote);
         return step;
     }
     JSValue out = JSValue::decode(CompressionStreamCoder__transform(coder, globalObject, input, inputLen, finish, &step.more));
+    reportCoderMemoryCost(vm, stream, coder);
     RETURN_IF_EXCEPTION(scope, step);
     auto* view = dynamicDowncast<JSArrayBufferView>(out);
     if (view && view->length()) {
@@ -418,6 +425,8 @@ extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* global
     }
 
     stream->m_asyncCodecInFlight = false;
+    if (void* coder = coderOf(stream))
+        reportCoderMemoryCost(vm, stream, coder);
     // A terminal abandoned the chunk while this step ran (the delivery above may have been it).
     if (!stream->m_codecPromise) {
         nativeTransformReleaseStateIfIdle(stream);

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -14,14 +14,13 @@ extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JS
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr, bool* more);
 // Off-thread step, completed by Bun__CompressionStream__deliverAsync.
 extern "C" void CompressionStreamCoder__transformAsync(void* coder, JSC::JSGlobalObject* global, JSC::EncodedJSValue streamCell, JSC::EncodedJSValue chunk, const uint8_t* input, size_t inputLen, bool finish);
-// Bytes the coder holds (codec state + a parked chunk). JS thread, no off-thread step in flight.
+// JS thread only, with no off-thread step in flight.
 extern "C" size_t CompressionStreamCoder__memoryCost(const void* coder);
 
 namespace Bun {
 namespace WebStreams {
 
-// Re-reads the coder's size and reports growth to the GC (JSTransformStream::reportNativeMemoryCost).
-// Called after construction and after every step: zstd and brotli allocate their buffers lazily.
+// After construction and after every step: zstd and brotli allocate their buffers lazily.
 void reportCoderMemoryCost(JSC::VM&, WebCore::JSTransformStream*, const void* coder);
 
 std::optional<CompressionFormat> parseCompressionFormat(JSC::JSGlobalObject*, JSC::JSValue formatValue);

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -14,9 +14,15 @@ extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JS
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr, bool* more);
 // Off-thread step, completed by Bun__CompressionStream__deliverAsync.
 extern "C" void CompressionStreamCoder__transformAsync(void* coder, JSC::JSGlobalObject* global, JSC::EncodedJSValue streamCell, JSC::EncodedJSValue chunk, const uint8_t* input, size_t inputLen, bool finish);
+// Bytes the coder holds (codec state + a parked chunk). JS thread, no off-thread step in flight.
+extern "C" size_t CompressionStreamCoder__memoryCost(const void* coder);
 
 namespace Bun {
 namespace WebStreams {
+
+// Re-reads the coder's size and reports growth to the GC (JSTransformStream::reportNativeMemoryCost).
+// Called after construction and after every step: zstd and brotli allocate their buffers lazily.
+void reportCoderMemoryCost(JSC::VM&, WebCore::JSTransformStream*, const void* coder);
 
 std::optional<CompressionFormat> parseCompressionFormat(JSC::JSGlobalObject*, JSC::JSValue formatValue);
 // The optional second constructor argument, read like a queuing strategy: its highWaterMark (bytes,

--- a/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
@@ -165,6 +165,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDecompressionStreamCon
     }
     auto* stream = JSDecompressionStream::create(vm, structure);
     stream->m_coder = coder;
+    reportCoderMemoryCost(vm, stream, coder);
     vm.heap.addFinalizer(stream, static_cast<JSC::Heap::CFinalizer>([](JSCell* cell) {
         CompressionStreamCoder__destroy(std::exchange(static_cast<JSDecompressionStream*>(cell)->m_coder, nullptr));
     }));

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -271,6 +271,19 @@ void JSTransformStream::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.appendHidden(thisObject->m_nativeSinkCell);
     visitor.appendHidden(thisObject->m_nativeSinkReadyPromise);
     visitor.appendHidden(thisObject->m_codecPromise);
+    visitor.reportExtraMemoryVisited(thisObject->m_nativeMemoryCost);
+}
+
+size_t JSTransformStream::estimatedSize(JSCell* cell, VM& vm)
+{
+    return Base::estimatedSize(cell, vm) + uncheckedDowncast<JSTransformStream>(cell)->m_nativeMemoryCost;
+}
+
+void JSTransformStream::reportNativeMemoryCost(VM& vm, size_t cost)
+{
+    if (cost > m_nativeMemoryCost)
+        vm.heap.reportExtraMemoryAllocated(this, cost - m_nativeMemoryCost);
+    m_nativeMemoryCost = cost;
 }
 
 void JSTransformStream::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -80,13 +80,10 @@ public:
     JSC::WriteBarrier<JSC::JSPromise> m_codecPromise;
     void* m_nativeSinkPtr { nullptr };
     uint8_t m_nativeSinkId { 0 };
-    // Native state bytes last reported to the GC for this cell (reportNativeMemoryCost). The
-    // codec state of a CompressionStream is hundreds of KB the GC cannot see otherwise, so
-    // a loop that drops unused streams never triggers a collection.
+    // Native state bytes last reported to the GC for this cell; visitChildren reports it back.
     size_t m_nativeMemoryCost { 0 };
 
-    // Reports growth of the native state as extra memory allocated and caches `cost` for
-    // visitChildren; after the state is freed, call it with 0.
+    // Reports growth as extra memory and caches `cost`; call with 0 once the state is freed.
     void reportNativeMemoryCost(JSC::VM&, size_t cost);
 
 protected:

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -30,6 +30,7 @@ public:
     // visitChildrenImpl MUST visit every WriteBarrier field below.
     DECLARE_VISIT_CHILDREN;
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
+    static size_t estimatedSize(JSCell*, JSC::VM&);
 
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
@@ -79,6 +80,14 @@ public:
     JSC::WriteBarrier<JSC::JSPromise> m_codecPromise;
     void* m_nativeSinkPtr { nullptr };
     uint8_t m_nativeSinkId { 0 };
+    // Native state bytes last reported to the GC for this cell (reportNativeMemoryCost). The
+    // codec state of a CompressionStream is hundreds of KB the GC cannot see otherwise, so
+    // a loop that drops unused streams never triggers a collection.
+    size_t m_nativeMemoryCost { 0 };
+
+    // Reports growth of the native state as extra memory allocated and caches `cost` for
+    // visitChildren; after the state is freed, call it with 0.
+    void reportNativeMemoryCost(JSC::VM&, size_t cost);
 
 protected:
     JSTransformStream(JSC::VM&, JSC::Structure*);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -353,11 +353,13 @@ extern "C" void TextDecoder__destroyForStream(void*);
 void nativeTransformReleaseState(JSTransformStream* stream)
 {
     stream->m_nativeStateReleasePending = false;
-    if (auto* s = dynamicDowncast<JSCompressionStream>(stream))
+    if (auto* s = dynamicDowncast<JSCompressionStream>(stream)) {
         CompressionStreamCoder__destroy(std::exchange(s->m_coder, nullptr));
-    else if (auto* s = dynamicDowncast<JSDecompressionStream>(stream))
+        s->m_nativeMemoryCost = 0;
+    } else if (auto* s = dynamicDowncast<JSDecompressionStream>(stream)) {
         CompressionStreamCoder__destroy(std::exchange(s->m_coder, nullptr));
-    else if (auto* s = dynamicDowncast<JSTextEncoderStream>(stream))
+        s->m_nativeMemoryCost = 0;
+    } else if (auto* s = dynamicDowncast<JSTextEncoderStream>(stream))
         TextEncoderStreamEncoder__destroyForStream(std::exchange(s->m_encoder, nullptr));
     else if (auto* s = dynamicDowncast<JSTextDecoderStream>(stream))
         TextDecoder__destroyForStream(std::exchange(s->m_decoder, nullptr));

--- a/src/runtime/api/JSBundler.classes.ts
+++ b/src/runtime/api/JSBundler.classes.ts
@@ -8,6 +8,7 @@ export default [
     refCounted: true,
     hasPendingActivity: false,
     configurable: false,
+    estimatedSize: true,
     klass: {},
     JSType: "0b11101110",
     proto: {

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -2,6 +2,7 @@
 
 use bun_alloc::ArenaVecExt as _;
 use bun_options_types::TargetExt as _;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use std::io::Write as _;
 
 use crate::Error;
@@ -49,8 +50,8 @@ pub struct JSTranspiler {
     // address is stable across the move into `Box<JSTranspiler>` —
     // `transpiler.arena` holds a `&'static Arena` pointing into it.
     pub arena: Box<Arena>,
-    /// Computed once at the end of construction: the GC thread reads it concurrently.
-    estimated_size: usize,
+    /// Re-synced when the retained output buffer grows: the GC thread reads it concurrently.
+    estimated_size: AtomicUsize,
     pub(crate) ref_count: bun_ptr::RefCount<JSTranspiler>,
 }
 
@@ -998,7 +999,7 @@ impl JSTranspiler {
             transpiler: JsCell::new(transpiler),
             scan_pass_result: JsCell::new(ScanPassResult::init()),
             buffer_writer: JsCell::new(None),
-            estimated_size: 0,
+            estimated_size: AtomicUsize::new(0),
             ref_count: bun_ptr::RefCount::init(),
         });
         // errdefer past this point → `this: Box<_>` drops and runs Drop for JSTranspiler.
@@ -1057,14 +1058,23 @@ impl JSTranspiler {
         transpiler.options.react_fast_refresh = false;
         transpiler.options.repl_mode = config.repl_mode;
 
-        let mut this = this;
-        this.estimated_size = this.compute_estimated_size();
+        this.estimated_size
+            .store(this.compute_estimated_size(), Ordering::Relaxed);
         Ok(bun_core::heap::into_raw(this))
     }
 
     /// `Transpiler__estimatedSize` (JSBundler.classes.ts `estimatedSize: true`).
     pub(crate) fn estimated_size(&self) -> usize {
-        self.estimated_size
+        self.estimated_size.load(Ordering::Relaxed)
+    }
+
+    /// After a call that can grow retained memory (transformSync keeps its output buffer).
+    fn sync_estimated_size(&self, global: &JSGlobalObject) {
+        let size = self.compute_estimated_size();
+        let previous = self.estimated_size.swap(size, Ordering::Relaxed);
+        if size > previous {
+            global.vm().deprecated_report_extra_memory(size - previous);
+        }
     }
 
     /// Mutator thread only: it reads the define hash maps.
@@ -1083,8 +1093,14 @@ impl JSTranspiler {
                 .values()
                 .map(|v| v.capacity() * size_of::<DotDefine>())
                 .sum::<usize>();
+        let output = self
+            .buffer_writer
+            .get()
+            .as_ref()
+            .map_or(0, |w| w.buffer.list.capacity());
         size_of::<Self>()
             + self.arena.allocated_bytes()
+            + output
             + config.tsconfig_buf.len()
             + config.macros_buf.len()
             + size_of::<bun_js_parser::defines::Define>()
@@ -1563,6 +1579,7 @@ impl JSTranspiler {
         buffer_writer = printer.ctx;
         let result = bun_string_jsc::create_utf8_for_js(global, buffer_writer.written());
         self.buffer_writer.set(Some(buffer_writer));
+        self.sync_estimated_size(global);
         result
     }
 }

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -49,10 +49,7 @@ pub struct JSTranspiler {
     // address is stable across the move into `Box<JSTranspiler>` —
     // `transpiler.arena` holds a `&'static Arena` pointing into it.
     pub arena: Box<Arena>,
-    /// Native bytes this instance retains, computed once at the end of
-    /// construction (everything sized here is fixed after that) and reported
-    /// to the GC through the `estimatedSize` class hook. A plain field because
-    /// the GC reads it from its own thread, concurrently with the mutator.
+    /// Computed once at the end of construction: the GC thread reads it concurrently.
     estimated_size: usize,
     pub(crate) ref_count: bun_ptr::RefCount<JSTranspiler>,
 }
@@ -1070,9 +1067,7 @@ impl JSTranspiler {
         self.estimated_size
     }
 
-    /// The inline struct, the config arena, the config buffers and the define
-    /// tables `configure_defines` filled. Mutator thread only: it reads the
-    /// hash maps.
+    /// Mutator thread only: it reads the define hash maps.
     fn compute_estimated_size(&self) -> usize {
         use bun_js_parser::defines::{DotDefine, IdentifierDefine};
         use core::mem::size_of;

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -49,6 +49,11 @@ pub struct JSTranspiler {
     // address is stable across the move into `Box<JSTranspiler>` —
     // `transpiler.arena` holds a `&'static Arena` pointing into it.
     pub arena: Box<Arena>,
+    /// Native bytes this instance retains, computed once at the end of
+    /// construction (everything sized here is fixed after that) and reported
+    /// to the GC through the `estimatedSize` class hook. A plain field because
+    /// the GC reads it from its own thread, concurrently with the mutator.
+    estimated_size: usize,
     pub(crate) ref_count: bun_ptr::RefCount<JSTranspiler>,
 }
 
@@ -996,6 +1001,7 @@ impl JSTranspiler {
             transpiler: JsCell::new(transpiler),
             scan_pass_result: JsCell::new(ScanPassResult::init()),
             buffer_writer: JsCell::new(None),
+            estimated_size: 0,
             ref_count: bun_ptr::RefCount::init(),
         });
         // errdefer past this point → `this: Box<_>` drops and runs Drop for JSTranspiler.
@@ -1054,7 +1060,41 @@ impl JSTranspiler {
         transpiler.options.react_fast_refresh = false;
         transpiler.options.repl_mode = config.repl_mode;
 
+        let mut this = this;
+        this.estimated_size = this.compute_estimated_size();
         Ok(bun_core::heap::into_raw(this))
+    }
+
+    /// `Transpiler__estimatedSize` (JSBundler.classes.ts `estimatedSize: true`).
+    pub(crate) fn estimated_size(&self) -> usize {
+        self.estimated_size
+    }
+
+    /// The inline struct, the config arena, the config buffers and the define
+    /// tables `configure_defines` filled. Mutator thread only: it reads the
+    /// hash maps.
+    fn compute_estimated_size(&self) -> usize {
+        use bun_js_parser::defines::{DotDefine, IdentifierDefine};
+        use core::mem::size_of;
+
+        let config = self.config.get();
+        let define = &self.transpiler.get().options.define;
+        let identifiers = define.identifiers.capacity()
+            * (size_of::<bun_collections::StringHashMapKey>() + size_of::<IdentifierDefine>() + 1);
+        let dots = define.dots.capacity()
+            * (size_of::<bun_collections::StringHashMapKey>() + size_of::<Vec<DotDefine>>() + 1)
+            + define
+                .dots
+                .values()
+                .map(|v| v.capacity() * size_of::<DotDefine>())
+                .sum::<usize>();
+        size_of::<Self>()
+            + self.arena.allocated_bytes()
+            + config.tsconfig_buf.len()
+            + config.macros_buf.len()
+            + size_of::<bun_js_parser::defines::Define>()
+            + identifiers
+            + dots
     }
 }
 

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -143,9 +143,8 @@ pub struct CompressionStreamCoder {
     high_water_mark: usize,
     /// Set while a chunk's transform spans steps; `None` between chunks.
     pending: Option<Pending>,
-    /// Bytes the zlib / brotli state holds right now, kept by the
-    /// `bun_alloc::c_thunks::counted_*` hooks (zstd reports its own size).
-    /// Boxed so the hooks' `opaque` pointer stays valid while the coder moves.
+    /// Bytes zlib / brotli hold now (zstd reports its own size). Boxed: the
+    /// allocator hooks keep its address.
     native_bytes: Box<AtomicUsize>,
 }
 
@@ -296,9 +295,7 @@ impl CompressionStreamCoder {
         }))
     }
 
-    /// Bytes this coder holds outside the JS heap: the codec state (window,
-    /// hash tables, workspace) plus a parked chunk's unconsumed input. Read on
-    /// the JS thread between steps only: zstd walks its context to answer.
+    /// JS thread, between steps only: zstd walks its context to answer.
     fn memory_cost(&self) -> usize {
         let codec = match &self.backend {
             Backend::Deflate(_)
@@ -821,8 +818,7 @@ pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCo
     }
 }
 
-/// See [`CompressionStreamCoder::memory_cost`]. JS thread only, with no
-/// off-thread step in flight.
+/// See [`CompressionStreamCoder::memory_cost`].
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__memoryCost(this: *const CompressionStreamCoder) -> usize {

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -143,8 +143,7 @@ pub struct CompressionStreamCoder {
     high_water_mark: usize,
     /// Set while a chunk's transform spans steps; `None` between chunks.
     pending: Option<Pending>,
-    /// Bytes zlib / brotli hold now (zstd reports its own size). Boxed: the
-    /// allocator hooks keep its address.
+    /// Bytes zlib / brotli hold now. Boxed: the allocator hooks keep its address.
     native_bytes: Box<AtomicUsize>,
 }
 
@@ -298,10 +297,12 @@ impl CompressionStreamCoder {
     /// JS thread, between steps only: zstd walks its context to answer.
     fn memory_cost(&self) -> usize {
         let codec = match &self.backend {
-            Backend::Deflate(_)
-            | Backend::Inflate { .. }
-            | Backend::BrotliEncode(_)
-            | Backend::BrotliDecode(_) => self.native_bytes.load(Ordering::Relaxed),
+            Backend::Deflate(_) | Backend::Inflate { .. } => {
+                core::mem::size_of::<zlib::z_stream>() + self.native_bytes.load(Ordering::Relaxed)
+            }
+            Backend::BrotliEncode(_) | Backend::BrotliDecode(_) => {
+                self.native_bytes.load(Ordering::Relaxed)
+            }
             // SAFETY: the context is live until `drop`, and no step runs
             // concurrently with this read.
             Backend::ZstdEncode(p) => unsafe { zstd::ZSTD_sizeof_CCtx(p.as_ptr()) },
@@ -309,7 +310,7 @@ impl CompressionStreamCoder {
             Backend::ZstdDecode(p) => unsafe { zstd::ZSTD_sizeof_DCtx(p.as_ptr()) },
         };
         let pending = self.pending.as_ref().map_or(0, |p| p.input.capacity());
-        core::mem::size_of::<Self>() + codec + pending
+        core::mem::size_of::<Self>() + core::mem::size_of::<AtomicUsize>() + codec + pending
     }
 
     const ZSTD_MAGIC: [u8; 4] = 0xFD2F_B528u32.to_le_bytes();

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -16,13 +16,15 @@
 //! again once the consumer has room; in between, the coder keeps the chunk's
 //! unconsumed input ([`Pending`]).
 
-use core::ffi::c_int;
+use core::ffi::{c_int, c_void};
 use core::ptr::{self, NonNull};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use bun_core::EncodedSlice;
 use bun_jsc::EncodedSliceJsc as _;
 use bun_jsc::{ErrorCode, JSGlobalObject, JSUint8Array, JSValue, PinnedArrayBuffer, Strong};
 
+use bun_alloc::c_thunks;
 use bun_brotli::c as brotli;
 use bun_zlib as zlib;
 use bun_zstd::c as zstd;
@@ -141,6 +143,10 @@ pub struct CompressionStreamCoder {
     high_water_mark: usize,
     /// Set while a chunk's transform spans steps; `None` between chunks.
     pending: Option<Pending>,
+    /// Bytes the zlib / brotli state holds right now, kept by the
+    /// `bun_alloc::c_thunks::counted_*` hooks (zstd reports its own size).
+    /// Boxed so the hooks' `opaque` pointer stays valid while the coder moves.
+    native_bytes: Box<AtomicUsize>,
 }
 
 // SAFETY: the z_stream / Brotli*Instance / ZSTD_*Ctx handles are single-owner
@@ -191,9 +197,16 @@ impl CompressionStreamCoder {
         decompress: bool,
         high_water_mark: usize,
     ) -> Result<Box<Self>, CodecError> {
+        let native_bytes = Box::new(AtomicUsize::new(0));
+        let opaque = ptr::from_ref::<AtomicUsize>(&native_bytes)
+            .cast_mut()
+            .cast::<c_void>();
         let backend = match (format, decompress) {
             (Format::Deflate | Format::DeflateRaw | Format::Gzip, false) => {
                 let mut s = Box::new(bun_core::ffi::zeroed::<zlib::z_stream>());
+                s.alloc_func = Some(c_thunks::counted_malloc_items);
+                s.free_func = Some(c_thunks::counted_free);
+                s.user_data = opaque;
                 // Spec: "default compression level". Z_DEFAULT_COMPRESSION = -1.
                 // SAFETY: `s` is a zeroed, #[repr(C)] z_stream; zlibVersion() is
                 // a static C string.
@@ -216,6 +229,9 @@ impl CompressionStreamCoder {
             }
             (Format::Deflate | Format::DeflateRaw | Format::Gzip, true) => {
                 let mut s = Box::new(bun_core::ffi::zeroed::<zlib::z_stream>());
+                s.alloc_func = Some(c_thunks::counted_malloc_items);
+                s.free_func = Some(c_thunks::counted_free);
+                s.user_data = opaque;
                 // SAFETY: as above.
                 let rc = unsafe {
                     zlib::inflateInit2_(
@@ -234,17 +250,25 @@ impl CompressionStreamCoder {
                 }
             }
             (Format::Brotli, false) => {
-                // SAFETY: FFI — the default-allocator instance (all nulls).
+                // SAFETY: FFI; the hooks and `opaque` outlive the instance.
                 let p = NonNull::new(unsafe {
-                    brotli::BrotliEncoderCreateInstance(None, None, ptr::null_mut())
+                    brotli::BrotliEncoderCreateInstance(
+                        Some(c_thunks::counted_malloc_size),
+                        Some(c_thunks::counted_free),
+                        opaque,
+                    )
                 })
                 .ok_or(CodecError::Message("failed to initialize brotli encoder"))?;
                 Backend::BrotliEncode(p)
             }
             (Format::Brotli, true) => {
-                // SAFETY: FFI — the default-allocator instance (all nulls).
+                // SAFETY: FFI; the hooks and `opaque` outlive the instance.
                 let p = NonNull::new(unsafe {
-                    brotli::BrotliDecoderCreateInstance(None, None, ptr::null_mut())
+                    brotli::BrotliDecoderCreateInstance(
+                        Some(c_thunks::counted_malloc_size),
+                        Some(c_thunks::counted_free),
+                        opaque,
+                    )
                 })
                 .ok_or(CodecError::Message("failed to initialize brotli decoder"))?;
                 Backend::BrotliDecode(p)
@@ -268,7 +292,27 @@ impl CompressionStreamCoder {
             zstd_head_len: 0,
             high_water_mark,
             pending: None,
+            native_bytes,
         }))
+    }
+
+    /// Bytes this coder holds outside the JS heap: the codec state (window,
+    /// hash tables, workspace) plus a parked chunk's unconsumed input. Read on
+    /// the JS thread between steps only: zstd walks its context to answer.
+    fn memory_cost(&self) -> usize {
+        let codec = match &self.backend {
+            Backend::Deflate(_)
+            | Backend::Inflate { .. }
+            | Backend::BrotliEncode(_)
+            | Backend::BrotliDecode(_) => self.native_bytes.load(Ordering::Relaxed),
+            // SAFETY: the context is live until `drop`, and no step runs
+            // concurrently with this read.
+            Backend::ZstdEncode(p) => unsafe { zstd::ZSTD_sizeof_CCtx(p.as_ptr()) },
+            // SAFETY: as above.
+            Backend::ZstdDecode(p) => unsafe { zstd::ZSTD_sizeof_DCtx(p.as_ptr()) },
+        };
+        let pending = self.pending.as_ref().map_or(0, |p| p.input.capacity());
+        core::mem::size_of::<Self>() + codec + pending
     }
 
     const ZSTD_MAGIC: [u8; 4] = 0xFD2F_B528u32.to_le_bytes();
@@ -775,6 +819,19 @@ pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCo
         // the cell's reference has not been released yet.
         unsafe { bun_ptr::ThreadSafeRefCount::<CompressionStreamCoder>::deref(this) };
     }
+}
+
+/// See [`CompressionStreamCoder::memory_cost`]. JS thread only, with no
+/// off-thread step in flight.
+#[unsafe(no_mangle)]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn CompressionStreamCoder__memoryCost(this: *const CompressionStreamCoder) -> usize {
+    if this.is_null() {
+        return 0;
+    }
+    // SAFETY: `this` was returned by `CompressionStreamCoder__create` and the
+    // cell's reference has not been released yet.
+    unsafe { &*this }.memory_cost()
 }
 
 /// One JS-thread [`step`](CompressionStreamCoder::step): returns its output as

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -187,9 +187,7 @@ pub trait JsSinkAbi {
         global: &crate::webcore::jsc::JSGlobalObject,
         ptr: *mut c_void,
     ) -> crate::webcore::jsc::JSValue;
-    /// `${abi_name}__reportMemoryCost`: caches `cost` on the sink or
-    /// controller cell `value` and reports any growth to the GC as extra
-    /// memory (a no-op for any other value).
+    /// `${abi_name}__reportMemoryCost`: GC extra memory for the sink or controller cell `value`.
     fn report_memory_cost_extern(value: crate::webcore::jsc::JSValue, cost: usize);
 }
 
@@ -422,10 +420,7 @@ impl<T: JsSinkType> JSSink<T> {
         }
     }
 
-    /// Tells the GC how many bytes the sink holds after a JS-driven call on
-    /// `this_value` (the sink or controller cell). The sink's buffer is native
-    /// memory the GC cannot see otherwise, so a loop that drops sinks holding
-    /// data never triggers a collection.
+    /// After a JS-driven call on `this_value` (the sink or controller cell).
     fn sync_memory_cost(this: &JSSink<T>, this_value: crate::webcore::jsc::JSValue) {
         T::report_memory_cost_extern(this_value, Self::js_memory_cost(&this.sink));
     }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -71,6 +71,8 @@ macro_rules! decl_js_sink_externs {
                     g: &::bun_jsc::JSGlobalObject,
                     p: *mut ::core::ffi::c_void,
                 ) -> ::bun_jsc::JSValue;
+                #[link_name = concat!($abi, "__reportMemoryCost")]
+                pub(crate) safe fn report_memory_cost(v: ::bun_jsc::JSValue, cost: usize);
             }
         }
     };
@@ -103,6 +105,9 @@ macro_rules! impl_js_sink_abi {
                     ptr: *mut ::core::ffi::c_void,
                 ) -> ::bun_jsc::JSValue {
                     __abi::create_controller(global, ptr)
+                }
+                fn report_memory_cost_extern(value: ::bun_jsc::JSValue, cost: usize) {
+                    __abi::report_memory_cost(value, cost)
                 }
             }
         };
@@ -182,6 +187,10 @@ pub trait JsSinkAbi {
         global: &crate::webcore::jsc::JSGlobalObject,
         ptr: *mut c_void,
     ) -> crate::webcore::jsc::JSValue;
+    /// `${abi_name}__reportMemoryCost`: caches `cost` on the sink or
+    /// controller cell `value` and reports any growth to the GC as extra
+    /// memory (a no-op for any other value).
+    fn report_memory_cost_extern(value: crate::webcore::jsc::JSValue, cost: usize);
 }
 
 /// `from_js_extern` encodes two distinct failure types using 0 and 1. Any other
@@ -413,6 +422,14 @@ impl<T: JsSinkType> JSSink<T> {
         }
     }
 
+    /// Tells the GC how many bytes the sink holds after a JS-driven call on
+    /// `this_value` (the sink or controller cell). The sink's buffer is native
+    /// memory the GC cannot see otherwise, so a loop that drops sinks holding
+    /// data never triggers a collection.
+    fn sync_memory_cost(this: &JSSink<T>, this_value: crate::webcore::jsc::JSValue) {
+        T::report_memory_cost_extern(this_value, Self::js_memory_cost(&this.sink));
+    }
+
     /// `${abi_name}__construct` host-fn body.
     pub(crate) fn js_construct(
         global: &crate::webcore::jsc::JSGlobalObject,
@@ -471,10 +488,9 @@ impl<T: JsSinkType> JSSink<T> {
             }
             // Borrowed view over GC-kept buffer for the duration of the call.
             let data = bun_ptr::RawSlice::new(slice);
-            return Ok(this
-                .sink
-                .write_bytes(&streams::Result::Temporary(data))
-                .to_js(global));
+            let wrote = this.sink.write_bytes(&streams::Result::Temporary(data));
+            Self::sync_memory_cost(this, frame.this());
+            return Ok(wrote.to_js(global));
         }
 
         if !arg.is_string() {
@@ -493,17 +509,15 @@ impl<T: JsSinkType> JSSink<T> {
             let utf16 = view.utf16();
             let bytes: &[u8] = bytemuck::cast_slice(utf16);
             let data = bun_ptr::RawSlice::new(bytes);
-            return Ok(this
-                .sink
-                .write_utf16(&streams::Result::Temporary(data))
-                .to_js(global));
+            let wrote = this.sink.write_utf16(&streams::Result::Temporary(data));
+            Self::sync_memory_cost(this, frame.this());
+            return Ok(wrote.to_js(global));
         }
 
         let data = bun_ptr::RawSlice::new(view.latin1());
-        Ok(this
-            .sink
-            .write_latin1(&streams::Result::Temporary(data))
-            .to_js(global))
+        let wrote = this.sink.write_latin1(&streams::Result::Temporary(data));
+        Self::sync_memory_cost(this, frame.this());
+        Ok(wrote.to_js(global))
     }
 
     /// `${abi_name}__flush` host-fn body.
@@ -525,13 +539,17 @@ impl<T: JsSinkType> JSSink<T> {
             let wait = frame.arguments_count() > 0
                 && frame.argument(0).is_boolean()
                 && frame.argument(0).as_boolean();
-            return match this.sink.flush_from_js(global, wait) {
+            let flushed = this.sink.flush_from_js(global, wait);
+            Self::sync_memory_cost(this, frame.this());
+            return match flushed {
                 sys::Result::Ok(value) => Ok(value),
                 sys::Result::Err(err) => Err(global.throw_value(err.to_js(global)?)),
             };
         }
 
-        match this.sink.flush() {
+        let flushed = this.sink.flush();
+        Self::sync_memory_cost(this, frame.this());
+        match flushed {
             sys::Result::Ok(()) => Ok(JSValue::UNDEFINED),
             sys::Result::Err(err) => Err(global.throw_value(err.to_js(global)?)),
         }
@@ -565,7 +583,9 @@ impl<T: JsSinkType> JSSink<T> {
             return Err(global.throw_value(err));
         }
 
-        match this.sink.start(config) {
+        let started = this.sink.start(config);
+        Self::sync_memory_cost(this, frame.this());
+        match started {
             sys::Result::Ok(()) => Ok(JSValue::UNDEFINED),
             sys::Result::Err(err) => Err(global.throw_value(err.to_js(global)?)),
         }
@@ -586,7 +606,9 @@ impl<T: JsSinkType> JSSink<T> {
             return Err(global.throw_value(err));
         }
 
-        let result = match this.sink.end_from_js(global) {
+        let ended = this.sink.end_from_js(global);
+        Self::sync_memory_cost(this, frame.this());
+        let result = match ended {
             sys::Result::Ok(value) => Ok(value),
             sys::Result::Err(err) => Err(global.throw_value(err.to_js(global)?)),
         };

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1151,6 +1151,9 @@ impl<const SSL: bool> crate::webcore::sink::JsSinkAbi for HTTPServerWritable<SSL
     fn create_controller_extern(global: &JSGlobalObject, ptr: *mut c_void) -> JSValue {
         http_sink_dispatch!(create_controller(global, ptr))
     }
+    fn report_memory_cost_extern(value: JSValue, cost: usize) {
+        http_sink_dispatch!(report_memory_cost(value, cost))
+    }
 }
 
 impl<const SSL: bool> HTTPServerWritable<SSL> {

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -138,6 +138,9 @@ pub mod c {
         pub fn ZSTD_freeCCtx(cctx: *mut ZSTD_CCtx) -> usize;
         pub safe fn ZSTD_createDCtx() -> *mut ZSTD_DCtx;
         pub fn ZSTD_freeDCtx(dctx: *mut ZSTD_DCtx) -> usize;
+        /// Bytes the context currently holds, including its workspace buffers.
+        pub fn ZSTD_sizeof_CCtx(cctx: *const ZSTD_CCtx) -> usize;
+        pub fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> usize;
         pub fn ZSTD_CCtx_setPledgedSrcSize(
             cctx: *mut ZSTD_CCtx,
             pledged_src_size: c_ulonglong,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, hideFromStackTrace, tempDir } from "harness";
+import { bunEnv, bunExe, expectNativeMemoryReportedToGC, hideFromStackTrace, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.Transpiler", () => {
@@ -6115,5 +6115,19 @@ describe("same-target destructuring with an unstable target", () => {
       stable: "a1b1",
     });
     expect(exitCode).toBe(0);
+  });
+});
+
+// Each instance keeps tens of KiB outside the JS heap: the inline transpiler
+// struct, the define tables and the options arena. The class reports that as
+// its estimated size, so a loop that drops transpilers still triggers
+// collections (30000 instances reached 1.4 GiB RSS before).
+describe("Bun.Transpiler GC accounting", () => {
+  it("reports its native size to the GC", async () => {
+    await expectNativeMemoryReportedToGC("", `new Bun.Transpiler({ loader: "ts" })`, {
+      drop: 600,
+      live: 100,
+      minBytesEach: 8 * 1024,
+    });
   });
 });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -409,10 +409,10 @@ export async function expectNativeMemoryReportedToGC(
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", probe], env: bunEnv, stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr.trim()).toBe("");
-  expect(exitCode).toBe(0);
   const { collected, extraBytes } = JSON.parse(stdout.trim().split("\n").at(-1)!);
   expect(collected).toBeGreaterThan(drop / 10);
   expect(extraBytes).toBeGreaterThanOrEqual(live * minBytesEach);
+  expect(exitCode).toBe(0);
 }
 
 let emptyBunMaxRSS: Promise<number> | undefined;

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -366,6 +366,55 @@ export async function expectRssDeltaBelow(
   expect(exitCode).toBe(0);
 }
 
+/**
+ * Checks that a wrapper object reports the native memory it owns to the GC.
+ *
+ * Runs a probe in a child bun. `setup` runs once; `create` is an expression
+ * that makes one object (it may reference what `setup` defined). The probe:
+ * 1. drops `drop` objects in a loop with no explicit GC (one microtask turn
+ *    each) and counts, through a FinalizationRegistry, how many the GC
+ *    collected on its own. Native memory the GC cannot see never triggers a
+ *    collection, so that count stays 0.
+ * 2. keeps `live` objects alive across a `Bun.gc(true)` and measures the
+ *    `heapStats().extraMemorySize` delta they account for. Each must report at
+ *    least `minBytesEach`.
+ */
+export async function expectNativeMemoryReportedToGC(
+  setup: string,
+  create: string,
+  { drop, live, minBytesEach }: { drop: number; live: number; minBytesEach: number },
+) {
+  const probe = `
+    const { heapStats } = require("bun:jsc");
+    ${setup}
+    let collected = 0;
+    const registry = new FinalizationRegistry(() => collected++);
+    for (let i = 0; i < ${drop}; i++) {
+      registry.register(${create}, i);
+      await 0;
+    }
+    // Cleanup callbacks run from the event loop, so give it a few turns. Far
+    // below the 1 s idle GC timer, so an unfixed build still sees no collection.
+    for (let i = 0; i < 50 && collected === 0; i++) await new Promise(resolve => setImmediate(resolve));
+
+    Bun.gc(true);
+    const before = heapStats().extraMemorySize;
+    const kept = [];
+    for (let i = 0; i < ${live}; i++) kept.push(${create});
+    Bun.gc(true);
+    const extraBytes = heapStats().extraMemorySize - before;
+    if (kept.length !== ${live}) throw new Error("unreachable");
+    console.log(JSON.stringify({ collected, extraBytes }));
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", probe], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.trim()).toBe("");
+  expect(exitCode).toBe(0);
+  const { collected, extraBytes } = JSON.parse(stdout.trim().split("\n").at(-1)!);
+  expect(collected).toBeGreaterThan(drop / 10);
+  expect(extraBytes).toBeGreaterThanOrEqual(live * minBytesEach);
+}
+
 let emptyBunMaxRSS: Promise<number> | undefined;
 export function emptyProcessMaxRSS() {
   return (emptyBunMaxRSS ??= (async () => {

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -1,6 +1,6 @@
 import { ArrayBufferSink } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, expectNativeMemoryReportedToGC, isASAN, withoutAggressiveGC } from "harness";
 import { join } from "node:path";
 
 describe("ArrayBufferSink", () => {
@@ -154,6 +154,17 @@ describe("ArrayBufferSink", () => {
     expect(() => s.flush()).toThrow(/already been closed/);
     expect(() => s.end()).toThrow(/already been closed/);
     expect(s.close()).toBeUndefined();
+  });
+
+  // The buffered bytes live in a native Vec the GC cannot see. Each write
+  // re-reports the sink's size, so dropped sinks holding data count toward the
+  // next collection (500 x 4 MiB sinks reached 2 GiB RSS before).
+  it("reports its buffered bytes to the GC", async () => {
+    await expectNativeMemoryReportedToGC(
+      "const payload = new Uint8Array(1 << 20).fill(7);",
+      "(() => { const s = new Bun.ArrayBufferSink(); s.start(); s.write(payload); return s; })()",
+      { drop: 300, live: 20, minBytesEach: 1 << 20 },
+    );
   });
 
   it("start() with an option getter that closes the sink throws instead of crashing", async () => {

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, expectNativeMemoryReportedToGC, isASAN } from "harness";
 import { once } from "node:events";
 import { addAbortSignal } from "node:stream";
 import zlib from "node:zlib";
@@ -1237,6 +1237,20 @@ describe("bounded output per input chunk", () => {
     },
   );
 });
+
+// A gzip deflate context is ~200 KiB of window and hash tables outside the JS
+// heap. The cell reports it as extra memory, so a loop that drops unused
+// streams still triggers collections (1.4 GiB RSS at 1e6 streams before).
+test.concurrent.each(["CompressionStream", "DecompressionStream"])(
+  "%s reports its codec state to the GC",
+  async ctor => {
+    await expectNativeMemoryReportedToGC("", `new ${ctor}("gzip")`, {
+      drop: 300,
+      live: 50,
+      minBytesEach: ctor === "CompressionStream" ? 128 * 1024 : 8 * 1024,
+    });
+  },
+);
 
 // The native coder (a gzip deflate context is ~280 KiB of zlib state) must be
 // released eagerly at the transform's terminal (ClearAlgorithms: post-flush,

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -1,3 +1,5 @@
+import { expectNativeMemoryReportedToGC } from "harness";
+
 test("simple usage", done => {
   const channel = new MessageChannel();
   const port1 = channel.port1;
@@ -252,6 +254,19 @@ test("many message channels", done => {
       expect().fail("branch should not be reached");
     }
   };
+});
+
+// A message queued on a port that never started is a SerializedScriptValue in
+// the pipe's inbox, outside the JS heap. The receiving port's wrapper reports
+// it as extra memory and postMessage reports the growth, so dropping channels
+// with queued messages still triggers collections (2000 x 1 MiB reached
+// 2 GiB RSS before).
+test("queued messages are reported to the GC", async () => {
+  await expectNativeMemoryReportedToGC(
+    "const payload = new Uint8Array(1 << 20);",
+    "(() => { const { port1, port2 } = new MessageChannel(); port1.postMessage(payload); return port2; })()",
+    { drop: 300, live: 20, minBytesEach: 1 << 20 },
+  );
 });
 
 test("gc", () => {


### PR DESCRIPTION
### Problem
- Four wrappers own memory outside the JS heap that the GC never hears about: `CompressionStream` / `DecompressionStream` (gzip deflate state, about 205 KB each), `Bun.ArrayBufferSink` (its buffered bytes), `MessagePort` (serialized messages queued in the pipe inbox) and `Bun.Transpiler` (about 47 KB each). A loop that drops them without yielding to the event loop never triggers a collection (the 1 s idle timer only helps a loop that yields). `heapUsed` stays at 1 MB while RSS grows until the process is killed: 1440 MB for `new CompressionStream("gzip")` x 1e6, 2 GB for 500 sinks holding 4 MB, 2 GB for 2000 channels with a 1 MB message, 1.4 GB for 30000 transpilers. An explicit `Bun.gc(true)` frees all of it, so this is accounting, not a leak.
- The cause: none of these cells call `reportExtraMemoryAllocated` or `reportExtraMemoryVisited`. The JSSink codegen (`src/codegen/generate-jssink.ts`) emits `memoryCost` for heap snapshots only, and `Transpiler` has no `estimatedSize` in its class definition.

### Fix
- `CompressionStreamCoder.rs`: zlib and brotli get counted allocator hooks (`bun_alloc::c_thunks::counted_*`) that keep a byte counter in the coder, zstd answers with `ZSTD_sizeof_*`. `JSTransformStream` caches that cost (`m_nativeMemoryCost`), reports growth after construction and after every codec step, reports it as visited in `visitChildren`, and adds it to `estimatedSize`. The eager release path zeroes it.
- JSSink codegen: `write`, `start`, `flush` and `end` re-sync the sink's memory cost to the cell they were called on through a new `${name}__reportMemoryCost` extern. The sink and controller cells cache it, report growth as allocated and report it as visited. This covers all seven sink classes.
- `MessagePortPipe`: each side keeps an atomic `queuedBytes` counter, maintained under the existing lock. `postMessage` reports the growth, and the receiving port's wrapper reports the queued bytes as visited and in `estimatedSize`.
- `Transpiler`: `estimatedSize: true`. The size (inline struct, arena, define tables, config buffers, the retained `transformSync` output buffer) is computed at the end of construction and re-synced after each `transformSync`, since that call keeps its output buffer.
- Self-reviewed: 6 concerns raised, 2 addressed (the counted hooks moved into `bun_alloc::c_thunks` so node:zlib can reuse them, and the change is one commit per subsystem so each part can be reverted alone). Rejected: a split into four PRs, because the ask was one change that enforces the invariant for every wrapper. Review follow-ups: a detached sink cell reports 0, the coder counts its boxed `z_stream` and counter, and a transferred port's queue is deliberately not folded into the outer message's cost (it can change in transit).
- Verified: one test per module (`compression.test.ts`, `arraybuffersink.test.ts`, `message-channel.test.ts`, `transpiler.test.js`) through a new harness helper. Each fails on bun 1.4.3 and passes with this change. Also ran the full files above plus `filesink`, `message-port-*`, `worker-postmessage-transfer`, `serve-direct-readable-stream`, `node/zlib` and the HTMLRewriter tests.

### Background
- JSC sizes its heap from the bytes it allocated since the last collection. Native memory is invisible to it unless a cell reports it twice: `reportExtraMemoryAllocated(cell, bytes)` when the memory is acquired (this feeds the collection trigger) and `reportExtraMemoryVisited(bytes)` from `visitChildren` of the live cell (this feeds the post-collection heap size, which sets the next threshold). `estimatedSize` only feeds heap snapshots.
- `visitChildren` runs on the GC thread, concurrently with the mutator. So every report here reads a plain cached field or an atomic: the transform cell's `m_nativeMemoryCost`, the sink cell's `m_memoryCostForGC`, the pipe side's `queuedBytes`, the transpiler's `estimated_size`. The mutator updates those fields on the JS thread.
- `CompressionStreamCoder` is the Rust codec behind a compression stream. zstd and brotli allocate their buffers lazily during the first chunks, which is why the cost is re-read after each step rather than fixed at construction.

<details><summary>Notes</summary>

Measured per-instance native size on bun 1.4.3 release (RSS delta over 200 kept instances): gzip encode 210 KB fresh, 297 KB after a 1 MB write. gzip decode 15 KB fresh, 169 KB after. brotli encode 10 KB fresh, 3 MB after a 1 MB write. zstd encode 5 KB fresh, 800 KB after the first write. The lazy growth is the reason for re-reporting after each step.

Probe results on the debug build with the fix, 300 dropped objects with one microtask turn each and no explicit GC: 237 CompressionStreams, 199 sinks (4 MB each), 277 MessagePorts (1 MB each) and 131 Transpilers were collected. On 1.4.3 release all four probes collect 0.

Live reporting on the debug build after `Bun.gc(true)`: 50 gzip CompressionStreams account for 16.7 MB of `extraMemorySize`, 10 sinks with 4 MB for 40 MB, 20 channels with a 1 MB message for 20 MB, 100 Transpilers for 2.2 MB (about 23 KB each: the remaining part of the measured 47 KB is allocator page granularity the estimate does not see).

Sinks: only JS-driven calls re-sync the cost (the host functions have the cell as `this`). Native writes into a sink (a transform stream piping into a native sink) do not, so a sink that both has a JS wrapper and is fed natively reports the cost as of its last JS call.

MessagePort: `postMessage` reports the growth with no cell (`reportExtraMemoryAllocated(nullptr, bytes)`, the same path `deprecatedReportExtraMemory` uses) because the receiving wrapper may not exist or may live on another thread. The receiving wrapper's `visitChildren` corrects the steady state on the next collection.

`Bun.gc(true)` in the same tick still frees none of a sync loop of CompressionStreams: the stream's start promise reaction keeps the cell reachable until the microtask queue drains. That is the spec's start algorithm and out of scope here.

The streams-leak.test.ts "Absolute memory usage" test times out in this container on the release binary as well, so it was not used as evidence.
</details>


