### PR TITLE
Bun.serve: honor perMessageDeflate compress and decompress set to false or "disable"

### DIFF
--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -263,7 +263,7 @@ To compress an individual message, pass a `boolean` as the second argument to `.
 ws.send("Hello world", true);
 ```
 
-For fine-grained control over compression characteristics, refer to the [Reference](#reference). Each direction can be configured on its own. With `compress: "disable"` the server still inflates compressed messages from clients but never compresses its own. With `decompress: "disable"` the extension is not negotiated at all, because `permessage-deflate` cannot be enabled for one direction only.
+For fine-grained control over compression characteristics, refer to the [Reference](#reference). Each direction can be configured on its own. With `compress: "disable"` the server still inflates compressed messages from clients but never compresses its own. With `decompress: "disable"` the extension is not negotiated at all. `permessage-deflate` cannot be enabled for one direction only, so `Bun.serve()` throws when `compress` is on and `decompress` is off.
 
 ```ts
 Bun.serve({

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -263,7 +263,7 @@ To compress an individual message, pass a `boolean` as the second argument to `.
 ws.send("Hello world", true);
 ```
 
-For fine-grained control over compression characteristics, refer to the [Reference](#reference). Each direction can be configured on its own. With `compress: "disable"` the server still inflates compressed messages from clients but never compresses its own. With `decompress: "disable"` the extension is not negotiated at all. `permessage-deflate` cannot be enabled for one direction only, so `Bun.serve()` throws when `compress` is on and `decompress` is off.
+For fine-grained control over compression characteristics, refer to the [Reference](#reference). Each direction can be configured on its own. With `compress: "disable"` and `decompress` on, the server still inflates compressed messages from clients but never compresses its own. With `decompress: "disable"` the extension is not negotiated at all. `permessage-deflate` cannot be enabled for one direction only, so `Bun.serve()` throws when `compress` is on and `decompress` is off.
 
 ```ts
 Bun.serve({

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -263,7 +263,18 @@ To compress an individual message, pass a `boolean` as the second argument to `.
 ws.send("Hello world", true);
 ```
 
-For fine-grained control over compression characteristics, refer to the [Reference](#reference).
+For fine-grained control over compression characteristics, refer to the [Reference](#reference). Each direction can be configured on its own. With `compress: "disable"` the server still inflates compressed messages from clients but never compresses its own. With `decompress: "disable"` the extension is not negotiated at all, because `permessage-deflate` cannot be enabled for one direction only.
+
+```ts
+Bun.serve({
+  websocket: {
+    perMessageDeflate: {
+      compress: "disable", // never compress outbound messages
+      decompress: "shared", // inflate compressed inbound messages
+    },
+  },
+});
+```
 
 ### Backpressure
 

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -521,11 +521,23 @@ declare module "bun" {
       | boolean
       | {
           /**
-           * Sets the compression level.
+           * The compressor for messages the server sends.
+           *
+           * `false` or `"disable"` keeps the extension negotiated (so inbound
+           * messages are still inflated) but the server never compresses an
+           * outbound message, even when `send()` asks for it.
+           *
+           * @default "shared" when `decompress` is set
            */
           compress?: WebSocketCompressor | boolean;
           /**
-           * Sets the decompression level.
+           * The decompressor for messages the server receives.
+           *
+           * `false` or `"disable"` turns the extension off for the connection:
+           * permessage-deflate (RFC 7692) cannot be negotiated for one
+           * direction only, so outbound messages are not compressed either.
+           *
+           * @default "shared" when `compress` is set
            */
           decompress?: WebSocketCompressor | boolean;
         };

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -533,9 +533,12 @@ declare module "bun" {
           /**
            * The decompressor for messages the server receives.
            *
-           * `false` or `"disable"` turns the extension off for the connection:
-           * permessage-deflate (RFC 7692) cannot be negotiated for one
-           * direction only, so outbound messages are not compressed either.
+           * `false` or `"disable"` turns the extension off. permessage-deflate
+           * (RFC 7692) cannot be negotiated for one direction only, so
+           * `Bun.serve()` throws when `compress` is on and `decompress` is off.
+           *
+           * A size is the inflate window. Windows stop at 32KB, so `"64KB"`
+           * and above use the 32KB window.
            *
            * @default "shared" when `compress` is set
            */

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -523,9 +523,10 @@ declare module "bun" {
           /**
            * The compressor for messages the server sends.
            *
-           * `false` or `"disable"` keeps the extension negotiated (so inbound
-           * messages are still inflated) but the server never compresses an
-           * outbound message, even when `send()` asks for it.
+           * With `false` or `"disable"` the server never compresses an
+           * outbound message, even when `send()` asks for it. If `decompress`
+           * is on, the extension is still negotiated and inbound messages are
+           * still inflated. If `decompress` is not set, the extension is off.
            *
            * @default "shared" when `decompress` is set
            */

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -174,8 +174,11 @@ public:
             if (compress) {
                 WebSocketData *webSocketData = (WebSocketData *) Super::getAsyncSocketData();
 
-                /* Check and correct the compress hint. It is never valid to compress 0 bytes */
-                if (message.length() && opCode < 3 && webSocketData->compressionStatus == WebSocketData::ENABLED) {
+                /* Check and correct the compress hint. It is never valid to compress 0 bytes.
+                 * A context with no compressor bits negotiated the extension only to inflate
+                 * inbound messages; it never sends a compressed one. */
+                if (message.length() && opCode < 3 && webSocketData->compressionStatus == WebSocketData::ENABLED
+                    && (webSocketContextData->compression & CompressOptions::_COMPRESSOR_MASK)) {
                     LoopData *loopData = Super::getLoopData();
                     /* Compress using either shared or dedicated deflationStream */
                     if (webSocketData->deflationStream) {

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -254,13 +254,16 @@ pub(crate) fn on_create(
                 )));
             }
 
+            // `None` is an absent direction, `Some(0)` is one the user turned
+            // off with `false` or `"disable"`.
+            let mut compress: Option<i32> = None;
             if let Some(compression) = per_message_deflate.get_truthy(global_object, "compress")? {
                 if compression.is_boolean() {
-                    server.compression |= if compression.to_boolean() {
+                    compress = Some(if compression.to_boolean() {
                         uws::SHARED_COMPRESSOR
                     } else {
                         0
-                    };
+                    });
                 } else if compression.is_string() {
                     let key = compression.to_js_string_view(global_object)?;
                     let Some(&v) = COMPRESS_TABLE.lookup(key.to_utf8().slice()) else {
@@ -268,7 +271,7 @@ pub(crate) fn on_create(
                             "WebSocketServerContext expects a valid compress option, either disable \"shared\" \"dedicated\" \"3KB\" \"4KB\" \"8KB\" \"16KB\" \"32KB\" \"64KB\" \"128KB\" or \"256KB\""
                         )));
                     };
-                    server.compression |= v;
+                    compress = Some(v);
                 } else {
                     return Err(global_object.throw_invalid_arguments(format_args!(
                         "websocket expects a valid compress option, either disable \"shared\" \"dedicated\" \"3KB\" \"4KB\" \"8KB\" \"16KB\" \"32KB\" \"64KB\" \"128KB\" or \"256KB\""
@@ -276,15 +279,16 @@ pub(crate) fn on_create(
                 }
             }
 
+            let mut decompress: Option<i32> = None;
             if let Some(compression) =
                 per_message_deflate.get_truthy(global_object, "decompress")?
             {
                 if compression.is_boolean() {
-                    server.compression |= if compression.to_boolean() {
+                    decompress = Some(if compression.to_boolean() {
                         uws::SHARED_DECOMPRESSOR
                     } else {
                         0
-                    };
+                    });
                 } else if compression.is_string() {
                     let key = compression.to_js_string_view(global_object)?;
                     let Some(&v) = DECOMPRESS_TABLE.lookup(key.to_utf8().slice()) else {
@@ -292,13 +296,26 @@ pub(crate) fn on_create(
                             "websocket expects a valid decompress option, either \"disable\" \"shared\" \"dedicated\" \"3KB\" \"4KB\" \"8KB\" \"16KB\" \"32KB\" \"64KB\" \"128KB\" or \"256KB\""
                         )));
                     };
-                    server.compression |= v;
+                    decompress = Some(v);
                 } else {
                     return Err(global_object.throw_invalid_arguments(format_args!(
                         "websocket expects a valid decompress option, either \"disable\" \"shared\" \"dedicated\" \"3KB\" \"4KB\" \"8KB\" \"16KB\" \"32KB\" \"64KB\" \"128KB\" or \"256KB\""
                     )));
                 }
             }
+
+            // uWS negotiates permessage-deflate whenever `compression` is
+            // nonzero, and RFC 7692 has no way to accept inbound compression
+            // without inflating it, so `decompress` off turns the extension off.
+            // `compress` off leaves the compressor bits zero: `WebSocket::send`
+            // then never sets RSV1.
+            server.compression = match (compress, decompress) {
+                (None, None) | (Some(0), None) | (_, Some(0)) => 0,
+                (compress, decompress) => {
+                    compress.unwrap_or(uws::SHARED_COMPRESSOR)
+                        | decompress.unwrap_or(uws::SHARED_DECOMPRESSOR)
+                }
+            };
         }
     }
 

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -204,14 +204,16 @@ bun_core::comptime_string_map! {
         b"disable" => 0,
         b"shared" => uws::SHARED_DECOMPRESSOR,
         b"dedicated" => uws::DEDICATED_DECOMPRESSOR,
-        b"3KB" => uws::DEDICATED_COMPRESSOR_3KB,
-        b"4KB" => uws::DEDICATED_COMPRESSOR_4KB,
-        b"8KB" => uws::DEDICATED_COMPRESSOR_8KB,
-        b"16KB" => uws::DEDICATED_COMPRESSOR_16KB,
-        b"32KB" => uws::DEDICATED_COMPRESSOR_32KB,
-        b"64KB" => uws::DEDICATED_COMPRESSOR_64KB,
-        b"128KB" => uws::DEDICATED_COMPRESSOR_128KB,
-        b"256KB" => uws::DEDICATED_COMPRESSOR_256KB,
+        // A size is the inflate window. Deflate windows stop at 32KB
+        // (15 bits), so the larger names get the largest window.
+        b"3KB" => uws::DEDICATED_DECOMPRESSOR_2KB,
+        b"4KB" => uws::DEDICATED_DECOMPRESSOR_4KB,
+        b"8KB" => uws::DEDICATED_DECOMPRESSOR_8KB,
+        b"16KB" => uws::DEDICATED_DECOMPRESSOR_16KB,
+        b"32KB" => uws::DEDICATED_DECOMPRESSOR_32KB,
+        b"64KB" => uws::DEDICATED_DECOMPRESSOR_32KB,
+        b"128KB" => uws::DEDICATED_DECOMPRESSOR_32KB,
+        b"256KB" => uws::DEDICATED_DECOMPRESSOR_32KB,
     };
 }
 
@@ -310,7 +312,12 @@ pub(crate) fn on_create(
             // `compress` off leaves the compressor bits zero: `WebSocket::send`
             // then never sets RSV1.
             server.compression = match (compress, decompress) {
-                (None, None) | (Some(0), None) | (_, Some(0)) => 0,
+                (None, None) | (Some(0), None) | (None | Some(0), Some(0)) => 0,
+                (Some(_), Some(0)) => {
+                    return Err(global_object.throw_invalid_arguments(format_args!(
+                        "websocket perMessageDeflate cannot enable compress and disable decompress: permessage-deflate negotiates both directions at once. Use decompress: \"shared\" or perMessageDeflate: false"
+                    )));
+                }
                 (compress, decompress) => {
                     compress.unwrap_or(uws::SHARED_COMPRESSOR)
                         | decompress.unwrap_or(uws::SHARED_DECOMPRESSOR)

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -204,8 +204,7 @@ bun_core::comptime_string_map! {
         b"disable" => 0,
         b"shared" => uws::SHARED_DECOMPRESSOR,
         b"dedicated" => uws::DEDICATED_DECOMPRESSOR,
-        // A size is the inflate window. Deflate windows stop at 32KB
-        // (15 bits), so the larger names get the largest window.
+        // The inflate window; deflate windows stop at 32KB.
         b"3KB" => uws::DEDICATED_DECOMPRESSOR_2KB,
         b"4KB" => uws::DEDICATED_DECOMPRESSOR_4KB,
         b"8KB" => uws::DEDICATED_DECOMPRESSOR_8KB,
@@ -256,8 +255,7 @@ pub(crate) fn on_create(
                 )));
             }
 
-            // `None` is an absent direction, `Some(0)` is one the user turned
-            // off with `false` or `"disable"`.
+            // `None` is absent, `Some(0)` is `false` or "disable".
             let mut compress: Option<i32> = None;
             if let Some(compression) = per_message_deflate.get_truthy(global_object, "compress")? {
                 if compression.is_boolean() {
@@ -306,11 +304,8 @@ pub(crate) fn on_create(
                 }
             }
 
-            // uWS negotiates permessage-deflate whenever `compression` is
-            // nonzero, and RFC 7692 has no way to accept inbound compression
-            // without inflating it, so `decompress` off turns the extension off.
-            // `compress` off leaves the compressor bits zero: `WebSocket::send`
-            // then never sets RSV1.
+            // RFC 7692 negotiates both directions at once, so decompress off
+            // means no extension. Zero compressor bits make send() skip RSV1.
             server.compression = match (compress, decompress) {
                 (None, None) | (Some(0), None) | (None | Some(0), Some(0)) => 0,
                 (Some(_), Some(0)) => {

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -304,8 +304,7 @@ pub(crate) fn on_create(
                 }
             }
 
-            // RFC 7692 negotiates both directions at once, so decompress off
-            // means no extension. Zero compressor bits make send() skip RSV1.
+            // Zero compressor bits make `WebSocket::send` skip RSV1.
             server.compression = match (compress, decompress) {
                 (None, None) | (Some(0), None) | (None | Some(0), Some(0)) => 0,
                 (Some(_), Some(0)) => {

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -70,9 +70,7 @@ impl ResponseKind {
     }
 }
 
-// Mirrors `CompressOptions` in packages/bun-uws/src/PerMessageDeflate.h: the
-// compressor is the low byte (windowBits << 4 | memLevel), the decompressor
-// is bits 8 to 11 (windowBits).
+// Mirrors `CompressOptions` in packages/bun-uws/src/PerMessageDeflate.h.
 pub const SHARED_COMPRESSOR: i32 = 1;
 pub const SHARED_DECOMPRESSOR: i32 = 1 << 8;
 pub const DEDICATED_DECOMPRESSOR_512B: i32 = 9 << 8;

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -70,9 +70,19 @@ impl ResponseKind {
     }
 }
 
+// Mirrors `CompressOptions` in packages/bun-uws/src/PerMessageDeflate.h: the
+// compressor is the low byte (windowBits << 4 | memLevel), the decompressor
+// is bits 8 to 11 (windowBits).
 pub const SHARED_COMPRESSOR: i32 = 1;
-pub const SHARED_DECOMPRESSOR: i32 = 256;
-pub const DEDICATED_DECOMPRESSOR: i32 = 3840;
+pub const SHARED_DECOMPRESSOR: i32 = 1 << 8;
+pub const DEDICATED_DECOMPRESSOR_512B: i32 = 9 << 8;
+pub const DEDICATED_DECOMPRESSOR_1KB: i32 = 10 << 8;
+pub const DEDICATED_DECOMPRESSOR_2KB: i32 = 11 << 8;
+pub const DEDICATED_DECOMPRESSOR_4KB: i32 = 12 << 8;
+pub const DEDICATED_DECOMPRESSOR_8KB: i32 = 13 << 8;
+pub const DEDICATED_DECOMPRESSOR_16KB: i32 = 14 << 8;
+pub const DEDICATED_DECOMPRESSOR_32KB: i32 = 15 << 8;
+pub const DEDICATED_DECOMPRESSOR: i32 = DEDICATED_DECOMPRESSOR_32KB;
 pub const DEDICATED_COMPRESSOR_3KB: i32 = 145;
 pub const DEDICATED_COMPRESSOR_4KB: i32 = 146;
 pub const DEDICATED_COMPRESSOR_8KB: i32 = 163;

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -262,7 +262,8 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
 // `perMessageDeflate: { compress, decompress }` turns each direction off with
 // `false` or "disable". RFC 7692 negotiates both directions at once, so the
 // server can only honor "compress off" by never setting RSV1 on what it sends,
-// and "decompress off" by not negotiating the extension at all.
+// and "decompress off" by not negotiating the extension at all (and so it
+// refuses "compress on, decompress off").
 describe.concurrent("perMessageDeflate per-direction options", () => {
   // 320 repeated bytes deflate to a few bytes, so a compressed reply is short
   // and has RSV1 set, and a plain reply is 320 bytes with RSV1 clear.
@@ -281,10 +282,18 @@ describe.concurrent("perMessageDeflate per-direction options", () => {
   for (const perMessageDeflate of [
     { compress: "disable", decompress: "shared" },
     { compress: false, decompress: true },
+    { compress: false, decompress: "dedicated" },
+    // A sized decompressor must land in the decompressor bits, or the
+    // compressor bits it used to set would compress the reply.
+    { compress: "disable", decompress: "8KB" },
   ] as const) {
     it(`${JSON.stringify(perMessageDeflate)} inflates inbound messages and never compresses outbound ones`, async () => {
       using raw = await connectRaw({ perMessageDeflate, onMessage: echoCompressed });
       expect(raw.negotiated).toContain("permessage-deflate");
+      if (perMessageDeflate.decompress === "8KB") {
+        // An 8KB inflate window is 13 bits, and the server tells the client so.
+        expect(raw.negotiated).toContain("client_max_window_bits=13");
+      }
       raw.socket.write(frame(0x1, pmdDeflate(inbound), { rsv1: true }));
       expect(await Promise.race([raw.firstMessage, raw.serverClose])).toBe(`message:${inbound.toString("hex")}`);
       // A compressed reply is a few bytes with RSV1 set, so check the head
@@ -296,11 +305,29 @@ describe.concurrent("perMessageDeflate per-direction options", () => {
     });
   }
 
+  // The protocol cannot compress outbound without inflating inbound, so the
+  // server refuses the combination instead of silently picking one side.
   for (const perMessageDeflate of [
     { compress: "shared", decompress: "disable" },
     { compress: true, decompress: false },
+    { compress: "dedicated", decompress: false },
+  ] as const) {
+    it(`${JSON.stringify(perMessageDeflate)} is rejected by Bun.serve()`, () => {
+      expect(() =>
+        serve({
+          port: 0,
+          fetch: () => new Response(),
+          websocket: { message() {}, perMessageDeflate },
+        }),
+      ).toThrow("websocket perMessageDeflate cannot enable compress and disable decompress");
+    });
+  }
+
+  for (const perMessageDeflate of [
     { compress: "disable", decompress: "disable" },
     { compress: false, decompress: false },
+    { decompress: false },
+    { compress: "disable" },
   ] as const) {
     it(`${JSON.stringify(perMessageDeflate)} does not negotiate the extension`, async () => {
       using raw = await connectRaw({ perMessageDeflate, onMessage: echoCompressed });

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -1,6 +1,7 @@
 // RFC 6455 5.2 + RFC 7692 6.1: RSV1 ("per-message compressed") is only valid on
 // the first frame of a data message. A control or continuation frame setting it
 // must fail the connection, and must not arm the connection's compressed flag.
+import type { ServerWebSocket, WebSocketHandler } from "bun";
 import { serve } from "bun";
 import { describe, expect, it } from "bun:test";
 import net from "node:net";
@@ -16,135 +17,145 @@ function pmdDeflate(payload: Buffer): Buffer {
   return deflated.subarray(0, -4);
 }
 
-describe.concurrent("permessage-deflate RSV1 frames", () => {
-  function frame(opcode: number, payload: Buffer, opts: { fin?: boolean; rsv1?: boolean } = {}): Buffer {
-    const { fin = true, rsv1 = false } = opts;
-    if (payload.length > 0xffff) throw new Error("these tests only build short and medium frames");
-    const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
-    const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
-    const flags = (fin ? 0x80 : 0x00) | (rsv1 ? 0x40 : 0x00) | opcode;
-    const head =
-      payload.length < 126
-        ? Buffer.from([flags, 0x80 | payload.length])
-        : Buffer.from([flags, 0x80 | 126, payload.length >> 8, payload.length & 0xff]);
-    return Buffer.concat([head, mask, masked]);
+function frame(opcode: number, payload: Buffer, opts: { fin?: boolean; rsv1?: boolean } = {}): Buffer {
+  const { fin = true, rsv1 = false } = opts;
+  if (payload.length > 0xffff) throw new Error("these tests only build short and medium frames");
+  const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+  const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+  const flags = (fin ? 0x80 : 0x00) | (rsv1 ? 0x40 : 0x00) | opcode;
+  const head =
+    payload.length < 126
+      ? Buffer.from([flags, 0x80 | payload.length])
+      : Buffer.from([flags, 0x80 | 126, payload.length >> 8, payload.length & 0xff]);
+  return Buffer.concat([head, mask, masked]);
+}
+
+// Raw TCP WebSocket client that offers permessage-deflate to a Bun.serve
+// websocket server, then exposes exactly what the server observed
+// (message/ping/close handlers) and every frame byte the server wrote back.
+async function connectRaw(options: {
+  perMessageDeflate: WebSocketHandler["perMessageDeflate"];
+  onMessage?: (ws: ServerWebSocket<unknown>, message: string | Buffer) => void;
+}) {
+  const received: string[] = [];
+  const pings: string[] = [];
+  const firstMessage = Promise.withResolvers<string>();
+  const serverClose = Promise.withResolvers<{ code: number; reason: string }>();
+  const server = serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("upgrade failed", { status: 400 });
+    },
+    websocket: {
+      perMessageDeflate: options.perMessageDeflate,
+      message(ws, message) {
+        const hex = Buffer.from(message as Buffer).toString("hex");
+        received.push(hex);
+        firstMessage.resolve(`message:${hex}`);
+        options.onMessage?.(ws, message);
+      },
+      ping(ws, data) {
+        pings.push(Buffer.from(data).toString("hex"));
+      },
+      close(ws, code, reason) {
+        serverClose.resolve({ code, reason });
+      },
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  socket.setNoDelay(true);
+  const upgraded = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<string>();
+  socket.on("close", () => {
+    closed.resolve("socket-closed-by-server");
+    // No-op once the 101 already resolved it; fails the handshake fast otherwise.
+    upgraded.reject(new Error("socket closed before the 101 response"));
+  });
+  socket.on("error", (error: Error) => {
+    closed.resolve("socket-closed-by-server");
+    upgraded.reject(error);
+  });
+
+  // Every byte the server sends after the 101 head is WebSocket frame data.
+  let frameBytes = Buffer.alloc(0);
+  const frameByteListeners: (() => void)[] = [];
+  const onFrameData = (chunk: Buffer) => {
+    frameBytes = Buffer.concat([frameBytes, chunk]);
+    for (const notify of frameByteListeners) notify();
+  };
+
+  let head = Buffer.alloc(0);
+  let negotiated = "";
+  const onHead = (chunk: Buffer) => {
+    head = Buffer.concat([head, chunk]);
+    const end = head.indexOf("\r\n\r\n");
+    if (end === -1) return;
+    socket.off("data", onHead);
+    socket.on("data", onFrameData);
+    const headText = head.subarray(0, end).toString();
+    if (!headText.startsWith("HTTP/1.1 101")) {
+      upgraded.reject(new Error(`upgrade failed: ${headText.split("\r\n")[0]}`));
+      return;
+    }
+    negotiated = headText.split("\r\n").find(line => /^sec-websocket-extensions:/i.test(line)) ?? "";
+    const rest = head.subarray(end + 4);
+    if (rest.length) onFrameData(rest);
+    upgraded.resolve();
+  };
+  socket.on("data", onHead);
+  socket.write(
+    "GET / HTTP/1.1\r\n" +
+      "Host: localhost\r\n" +
+      "Connection: Upgrade\r\n" +
+      "Upgrade: websocket\r\n" +
+      "Sec-WebSocket-Version: 13\r\n" +
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+      "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" +
+      "\r\n",
+  );
+  try {
+    await upgraded.promise;
+  } catch (error) {
+    // The disposable below (the only thing that stops the server) is never
+    // created when the handshake fails, so release everything here.
+    socket.destroy();
+    server.stop(true);
+    throw error;
   }
 
-  // Raw TCP WebSocket client that negotiates permessage-deflate against a
-  // Bun.serve websocket server, then exposes exactly what the server observed
-  // (message/ping/close handlers) and every frame byte the server wrote back.
-  async function connectDeflated() {
-    const received: string[] = [];
-    const pings: string[] = [];
-    const firstMessage = Promise.withResolvers<string>();
-    const serverClose = Promise.withResolvers<{ code: number; reason: string }>();
-    const server = serve({
-      port: 0,
-      fetch(req, server) {
-        if (server.upgrade(req)) return;
-        return new Response("upgrade failed", { status: 400 });
-      },
-      websocket: {
-        perMessageDeflate: true,
-        message(ws, message) {
-          const hex = Buffer.from(message as Buffer).toString("hex");
-          received.push(hex);
-          firstMessage.resolve(`message:${hex}`);
-        },
-        ping(ws, data) {
-          pings.push(Buffer.from(data).toString("hex"));
-        },
-        close(ws, code, reason) {
-          serverClose.resolve({ code, reason });
-        },
-      },
-    });
-
-    const socket = net.connect(server.port, "127.0.0.1");
-    socket.setNoDelay(true);
-    const upgraded = Promise.withResolvers<void>();
-    const closed = Promise.withResolvers<string>();
-    socket.on("close", () => {
-      closed.resolve("socket-closed-by-server");
-      // No-op once the 101 already resolved it; fails the handshake fast otherwise.
-      upgraded.reject(new Error("socket closed before the 101 response"));
-    });
-    socket.on("error", (error: Error) => {
-      closed.resolve("socket-closed-by-server");
-      upgraded.reject(error);
-    });
-
-    // Every byte the server sends after the 101 head is WebSocket frame data.
-    let frameBytes = Buffer.alloc(0);
-    const frameByteListeners: (() => void)[] = [];
-    const onFrameData = (chunk: Buffer) => {
-      frameBytes = Buffer.concat([frameBytes, chunk]);
-      for (const notify of frameByteListeners) notify();
-    };
-
-    let head = Buffer.alloc(0);
-    let negotiated = "";
-    const onHead = (chunk: Buffer) => {
-      head = Buffer.concat([head, chunk]);
-      const end = head.indexOf("\r\n\r\n");
-      if (end === -1) return;
-      socket.off("data", onHead);
-      socket.on("data", onFrameData);
-      const headText = head.subarray(0, end).toString();
-      if (!headText.startsWith("HTTP/1.1 101")) {
-        upgraded.reject(new Error(`upgrade failed: ${headText.split("\r\n")[0]}`));
-        return;
-      }
-      negotiated = headText.split("\r\n").find(line => /^sec-websocket-extensions:/i.test(line)) ?? "";
-      const rest = head.subarray(end + 4);
-      if (rest.length) onFrameData(rest);
-      upgraded.resolve();
-    };
-    socket.on("data", onHead);
-    socket.write(
-      "GET / HTTP/1.1\r\n" +
-        "Host: localhost\r\n" +
-        "Connection: Upgrade\r\n" +
-        "Upgrade: websocket\r\n" +
-        "Sec-WebSocket-Version: 13\r\n" +
-        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
-        "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" +
-        "\r\n",
-    );
-    try {
-      await upgraded.promise;
-      // Every test here needs a connection that really negotiated compression.
-      expect(negotiated.toLowerCase()).toContain("permessage-deflate");
-    } catch (error) {
-      // The disposable below (the only thing that stops the server) is never
-      // created when the handshake fails, so release everything here.
+  return {
+    socket,
+    received,
+    pings,
+    negotiated: negotiated.toLowerCase(),
+    firstMessage: firstMessage.promise,
+    serverClose: serverClose.promise,
+    closed: closed.promise,
+    frames: () => frameBytes,
+    // Resolves once the server has written `count` bytes of frame data.
+    waitForFrameBytes(count: number): Promise<string> {
+      if (frameBytes.length >= count) return Promise.resolve("server-sent-a-frame");
+      const { promise, resolve } = Promise.withResolvers<string>();
+      frameByteListeners.push(() => {
+        if (frameBytes.length >= count) resolve("server-sent-a-frame");
+      });
+      return promise;
+    },
+    [Symbol.dispose]() {
       socket.destroy();
       server.stop(true);
-      throw error;
-    }
+    },
+  };
+}
 
-    return {
-      socket,
-      received,
-      pings,
-      firstMessage: firstMessage.promise,
-      serverClose: serverClose.promise,
-      closed: closed.promise,
-      frames: () => frameBytes,
-      // Resolves once the server has written `count` bytes of frame data.
-      waitForFrameBytes(count: number): Promise<string> {
-        if (frameBytes.length >= count) return Promise.resolve("server-sent-a-frame");
-        const { promise, resolve } = Promise.withResolvers<string>();
-        frameByteListeners.push(() => {
-          if (frameBytes.length >= count) resolve("server-sent-a-frame");
-        });
-        return promise;
-      },
-      [Symbol.dispose]() {
-        socket.destroy();
-        server.stop(true);
-      },
-    };
+describe.concurrent("permessage-deflate RSV1 frames", () => {
+  // Every test here needs a connection that really negotiated compression.
+  async function connectDeflated() {
+    const raw = await connectRaw({ perMessageDeflate: true });
+    expect(raw.negotiated).toContain("permessage-deflate");
+    return raw;
   }
 
   // A conforming server neither answers an RSV1 ping nor lets it reach ping().
@@ -246,4 +257,75 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
     expect(raw.frames()).toEqual(Buffer.from([0x8a, 0x02, 0x68, 0x69]));
     expect(raw.pings).toEqual([Buffer.from("hi").toString("hex")]);
   });
+});
+
+// `perMessageDeflate: { compress, decompress }` turns each direction off with
+// `false` or "disable". RFC 7692 negotiates both directions at once, so the
+// server can only honor "compress off" by never setting RSV1 on what it sends,
+// and "decompress off" by not negotiating the extension at all.
+describe.concurrent("perMessageDeflate per-direction options", () => {
+  // 320 repeated bytes deflate to a few bytes, so a compressed reply is short
+  // and has RSV1 set, and a plain reply is 320 bytes with RSV1 clear.
+  const reply = Buffer.alloc(320, "x");
+  const plainReply = Buffer.concat([Buffer.from([0x82, 126, reply.length >> 8, reply.length & 0xff]), reply]);
+  const inbound = Buffer.from("hello from the client");
+  // The flags of the first frame the server wrote.
+  function replyHead(raw: Awaited<ReturnType<typeof connectRaw>>) {
+    const head = raw.frames()[0];
+    return { rsv1: (head & 0x40) !== 0 };
+  }
+  const echoCompressed = (ws: ServerWebSocket<unknown>) => {
+    ws.send(reply, true);
+  };
+
+  for (const perMessageDeflate of [
+    { compress: "disable", decompress: "shared" },
+    { compress: false, decompress: true },
+  ] as const) {
+    it(`${JSON.stringify(perMessageDeflate)} inflates inbound messages and never compresses outbound ones`, async () => {
+      using raw = await connectRaw({ perMessageDeflate, onMessage: echoCompressed });
+      expect(raw.negotiated).toContain("permessage-deflate");
+      raw.socket.write(frame(0x1, pmdDeflate(inbound), { rsv1: true }));
+      expect(await Promise.race([raw.firstMessage, raw.serverClose])).toBe(`message:${inbound.toString("hex")}`);
+      // A compressed reply is a few bytes with RSV1 set, so check the head
+      // as soon as it arrives rather than wait for 320 bytes that never come.
+      expect(await Promise.race([raw.waitForFrameBytes(2), raw.closed])).toBe("server-sent-a-frame");
+      expect(replyHead(raw).rsv1).toBe(false);
+      expect(await Promise.race([raw.waitForFrameBytes(plainReply.length), raw.closed])).toBe("server-sent-a-frame");
+      expect(raw.frames()).toEqual(plainReply);
+    });
+  }
+
+  for (const perMessageDeflate of [
+    { compress: "shared", decompress: "disable" },
+    { compress: true, decompress: false },
+    { compress: "disable", decompress: "disable" },
+    { compress: false, decompress: false },
+  ] as const) {
+    it(`${JSON.stringify(perMessageDeflate)} does not negotiate the extension`, async () => {
+      using raw = await connectRaw({ perMessageDeflate, onMessage: echoCompressed });
+      expect(raw.negotiated).toBe("");
+      raw.socket.write(frame(0x1, inbound));
+      expect(await Promise.race([raw.firstMessage, raw.serverClose])).toBe(`message:${inbound.toString("hex")}`);
+      expect(await Promise.race([raw.waitForFrameBytes(plainReply.length), raw.closed])).toBe("server-sent-a-frame");
+      expect(raw.frames()).toEqual(plainReply);
+    });
+  }
+
+  // Control: with both directions on, the same send() is compressed.
+  for (const perMessageDeflate of [
+    true,
+    { compress: "shared", decompress: "shared" },
+    { compress: "shared" },
+  ] as const) {
+    it(`${JSON.stringify(perMessageDeflate)} compresses outbound messages`, async () => {
+      using raw = await connectRaw({ perMessageDeflate, onMessage: echoCompressed });
+      expect(raw.negotiated).toContain("permessage-deflate");
+      raw.socket.write(frame(0x1, pmdDeflate(inbound), { rsv1: true }));
+      expect(await Promise.race([raw.firstMessage, raw.serverClose])).toBe(`message:${inbound.toString("hex")}`);
+      expect(await Promise.race([raw.waitForFrameBytes(2), raw.closed])).toBe("server-sent-a-frame");
+      expect(replyHead(raw).rsv1).toBe(true);
+      expect(raw.frames().length).toBeLessThan(plainReply.length);
+    });
+  }
 });

--- a/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
+++ b/test/js/bun/websocket/websocket-server-rsv-frames.test.ts
@@ -154,7 +154,13 @@ describe.concurrent("permessage-deflate RSV1 frames", () => {
   // Every test here needs a connection that really negotiated compression.
   async function connectDeflated() {
     const raw = await connectRaw({ perMessageDeflate: true });
-    expect(raw.negotiated).toContain("permessage-deflate");
+    try {
+      expect(raw.negotiated).toContain("permessage-deflate");
+    } catch (error) {
+      // The caller's `using` never binds when this throws, so release here.
+      raw[Symbol.dispose]();
+      throw error;
+    }
     return raw;
   }
 


### PR DESCRIPTION
### Problem
- `Bun.serve` websocket `perMessageDeflate: { compress, decompress }` ignores `false` and `"disable"` for one direction. `{ compress: "disable", decompress: "shared" }` still sends `ws.send(x, true)` compressed (RSV1 set, 320 bytes go out as 8). `{ compress: "shared", decompress: "disable" }` still negotiates the extension and inflates inbound frames. All four mixed configs produce the same handshake as `true`.
- The cause is `src/runtime/server/WebSocketServerContext.rs:257-301`. It ORs both directions into one uWS `CompressOptions` bitfield. Off contributes 0, and uWS negotiates both directions whenever the field is nonzero. A second bug in the same parser: `DECOMPRESS_TABLE` maps `"3KB"` to `"256KB"` to compressor constants, so `decompress: "8KB"` sets compressor bits and leaves the inflater shared.

### Fix
- Each direction is parsed on its own (`None` absent, `Some(0)` off). `compress` off leaves the compressor bits zero. `WebSocket::send` in `packages/bun-uws/src/WebSocket.h` now drops the compress hint when the context has no compressor bits, so `ws.send`, `ws.publish` and `server.publish` never set RSV1. Inbound frames are still inflated.
- `decompress` off turns the extension off. RFC 7692 has no way to accept the extension and refuse inbound compression. `compress` on with `decompress` off now throws at `Bun.serve()` with a message that names the fix, instead of compressing both ways as before.
- `src/uws/lib.rs` gains the `DEDICATED_DECOMPRESSOR_*` constants from `PerMessageDeflate.h`, and `DECOMPRESS_TABLE` maps each size to an inflate window. Sizes above 32KB use the 32KB window (the deflate maximum).
- Verified: `test/js/bun/websocket/websocket-server-rsv-frames.test.ts` (11 new tests, 7 fail on bun 1.4.3). Also `websocket-server.test.ts` (perMessageDeflate block), `bun-serve-args.test.ts`, `20053.test.ts`, `29684.test.ts` and the bun-types test.

### Background
- `CompressOptions` packs the compressor in the low byte (`windowBits << 4 | memLevel`) and the decompressor in bits 8 to 11 (`windowBits`). `SHARED_*` is 1 in that byte. `DISABLED` is 0 for the whole field.
- RSV1 is the frame bit that marks a message as compressed. `send(message, compress)` is a hint. uWS already drops it when the client did not offer the extension.
- `{ compress: "shared" }` alone and `{}` behave as before: shared both ways, and off. An absent direction defaults to shared when the other is on.

<details><summary>Notes</summary>

Self-reviewed: 2 concerns raised, 2 addressed. The first draft turned the extension off for `compress` on with `decompress` off. The review found one public project with `{ compress: "dedicated", decompress: "disable" }` that would lose compression silently, and found the `DECOMPRESS_TABLE` hole that let `decompress: "8KB"` defeat the compressor-bits check. This version throws for the first and fixes the table for the second.

Shapes considered for `compress` on with `decompress` off: negotiate and fail inbound RSV1 frames (breaks browsers, which compress whenever the extension is negotiated), negotiate and inflate anyway (keeps the option a no-op), turn the extension off (silent loss of compression), or throw. The throw is loud and the message says what to do.

Repro on bun 1.4.2 and main: a server with `perMessageDeflate: JSON.parse(process.argv[2])` and `message(ws) { ws.send("x".repeat(320), true) }`, a raw client that offers `permessage-deflate; client_max_window_bits` and sends one deflated RSV1 text frame. For every mixed config the reply frame head is `0xc1` and the frame is 8 bytes, and the 101 carries `permessage-deflate; client_no_context_takeover; server_no_context_takeover`.

`websocket-server.test.ts` as a whole has tests that time out in this container on main too (the `(benchmark)` test starves its neighbors on a debug build). They do not use compression.

#41629 changes `HttpResponse.h` and `WebSocketExtensions.h` (dedicated compressor selection and RFC 7692 negotiation). This PR does not touch those files. The `client_max_window_bits=13` assertion for `decompress: "8KB"` relies on the current `client_max_window_bits` handling, which that PR keeps.
</details>
