### PR TITLE
js_printer: keep the parentheses a new callee or template tag needs

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3689,6 +3689,8 @@ pub(crate) mod __gated_printer {
                         if flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
+                            // The parentheses already isolate the chain from `new`.
+                            flags.remove(ExprFlag::ForbidCall);
                         }
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
                     }
@@ -3753,6 +3755,8 @@ pub(crate) mod __gated_printer {
                         if flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
+                            // The parentheses already isolate the chain from `new`.
+                            flags.remove(ExprFlag::ForbidCall);
                         }
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
                     }
@@ -4209,7 +4213,9 @@ pub(crate) mod __gated_printer {
                         } else if let ExprData::ECommonjsExportIdentifier(id) = tag.data {
                             self.print_commonjs_export_identifier(id, tag.loc, true);
                         } else {
-                            self.print_expr(*tag, Level::Postfix, ExprFlag::none());
+                            // Inside the target of `new`, a call in the tag must keep its
+                            // parentheses: `new foo()\`x\`()` calls `new foo()` first.
+                            self.print_expr(*tag, Level::Postfix, flags & ExprFlag::ForbidCall);
                         }
                     } else {
                         self.add_source_mapping(expr.loc);

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3449,8 +3449,6 @@ pub(crate) mod __gated_printer {
                     self.add_source_mapping(expr.loc);
                     self.print(b"new");
                     self.print_space();
-                    // The callee is not part of the `new` expression's chain, so an
-                    // optional chain there must keep its grouping parentheses.
                     self.print_expr(
                         e.target,
                         Level::New,
@@ -3689,7 +3687,6 @@ pub(crate) mod __gated_printer {
                         if flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
-                            // The parentheses already isolate the chain from `new`.
                             flags.remove(ExprFlag::ForbidCall);
                         }
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
@@ -3755,7 +3752,6 @@ pub(crate) mod __gated_printer {
                         if flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
-                            // The parentheses already isolate the chain from `new`.
                             flags.remove(ExprFlag::ForbidCall);
                         }
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
@@ -4213,8 +4209,6 @@ pub(crate) mod __gated_printer {
                         } else if let ExprData::ECommonjsExportIdentifier(id) = tag.data {
                             self.print_commonjs_export_identifier(id, tag.loc, true);
                         } else {
-                            // Inside the target of `new`, a call in the tag must keep its
-                            // parentheses: `new foo()\`x\`()` calls `new foo()` first.
                             self.print_expr(*tag, Level::Postfix, flags & ExprFlag::ForbidCall);
                         }
                     } else {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3449,7 +3449,13 @@ pub(crate) mod __gated_printer {
                     self.add_source_mapping(expr.loc);
                     self.print(b"new");
                     self.print_space();
-                    self.print_expr(e.target, Level::New, ExprFlag::forbid_call());
+                    // The callee is not part of the `new` expression's chain, so an
+                    // optional chain there must keep its grouping parentheses.
+                    self.print_expr(
+                        e.target,
+                        Level::New,
+                        ExprFlag::forbid_call() | ExprFlag::HasNonOptionalChainParent,
+                    );
                     let args = e.args.slice();
                     if !args.is_empty() || level.gte(Level::Postfix) {
                         self.print(b"(");
@@ -4190,7 +4196,7 @@ pub(crate) mod __gated_printer {
                         self.add_source_mapping(expr.loc);
                         // Optional chains are forbidden in template tags
                         // `Expr::is_optional_chain` is gated upstream; inline its body.
-                        let is_optional_chain = match &expr.data {
+                        let is_optional_chain = match &tag.data {
                             ExprData::EDot(d) => d.optional_chain.is_some(),
                             ExprData::EIndex(i) => i.optional_chain.is_some(),
                             ExprData::ECall(c) => c.optional_chain.is_some(),

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -4054,6 +4054,26 @@ describe("bundler", () => {
     format: "cjs",
     run: { file: "/check.js", stdout: `{"x":1} true` },
   });
+  itBundled("edgecase/ParenthesizedOptionalChainTagAndNewCallee", {
+    files: {
+      "/entry.ts": /* ts */ `
+        var a = null, o = { t: s => s[0], K: class { constructor() { this.v = 1 } }, f() { return o } }, r = [];
+        r.push((o?.t)\`A\`);
+        r.push((o?.["t"])\`D\`);
+        r.push((o?.f().t)\`B\`);
+        r.push((o.f?.().t)\`C\`);
+        r.push((o?.t as any)\`E\`);
+        r.push(new (o?.K)().v);
+        r.push(new (o?.f().K)().v);
+        r.push(new (o?.K)!().v);
+        try { (a?.t)\`x\` } catch (e) { r.push(e.name) }
+        try { new (a?.K)() } catch (e) { r.push(e.name) }
+        console.log(JSON.stringify(r));
+      `,
+    },
+    minifySyntax: true,
+    run: { stdout: `["A","D","B","C","E",1,1,1,"TypeError","TypeError"]` },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -4057,7 +4057,7 @@ describe("bundler", () => {
   itBundled("edgecase/ParenthesizedOptionalChainTagAndNewCallee", {
     files: {
       "/entry.ts": /* ts */ `
-        var a = null, o = { t: s => s[0], K: class { constructor() { this.v = 1 } }, f() { return o } }, r = [];
+        var a = null, o = { t: s => s[0], K: class { constructor() { this.v = 1 } }, f() { return o }, g() { return s => o.K } }, r = [];
         r.push((o?.t)\`A\`);
         r.push((o?.["t"])\`D\`);
         r.push((o?.f().t)\`B\`);
@@ -4066,13 +4066,14 @@ describe("bundler", () => {
         r.push(new (o?.K)().v);
         r.push(new (o?.f().K)().v);
         r.push(new (o?.K)!().v);
+        r.push(new (o.g()\`K\`)().v);
         try { (a?.t)\`x\` } catch (e) { r.push(e.name) }
         try { new (a?.K)() } catch (e) { r.push(e.name) }
         console.log(JSON.stringify(r));
       `,
     },
     minifySyntax: true,
-    run: { stdout: `["A","D","B","C","E",1,1,1,"TypeError","TypeError"]` },
+    run: { stdout: `["A","D","B","C","E",1,1,1,1,"TypeError","TypeError"]` },
   });
 });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3699,17 +3699,50 @@ console.log(resolve.length)
     ts.expectPrinted_("new (a?.b as any)(2)", "new (a?.b)(2)");
     ts.expectPrinted_("new (a?.b!)()", "new (a?.b)");
     expectPrinted_("new a.b()", "new a.b");
+    expectPrinted_("new (a.b.c)()", "new a.b.c");
     expectPrinted_("new (a())()", "new (a())");
+    expectPrinted_("new (a().b)()", "new (a()).b");
+    expectPrinted_("new (a()[b])()", "new (a())[b]");
+    expectPrinted_("new (a().b())()", "new (a().b())");
     expectPrinted_("new (a?.b.c).d()", "new (a?.b.c).d");
     expectPrinted_("new (a?.b().c).d()", "new (a?.b().c).d");
+    expectPrinted_("new ((a?.b)[c])()", "new (a?.b)[c]");
+    expectPrinted_("new ((a?.()).b)()", "new (a?.()).b");
   });
 
-  it("tagged template with a call in the tag as new callee", () => {
+  it("tagged template as new callee", () => {
     expectPrinted_("new (a()`x`)()", "new (a())`x`");
     expectPrinted_("new (a()`x`.b)()", "new (a())`x`.b");
     expectPrinted_("new (a.b`x`)()", "new a.b`x`");
+    expectPrinted_("new (a`x`)()", "new a`x`");
     expectPrinted_("new a`x`()", "new a`x`");
+    expectPrinted_("new ((a?.b)`x`)()", "new (a?.b)`x`");
+    expectPrinted_("new ((a?.b())`x`)()", "new (a?.b())`x`");
+    expectPrinted_("new ((a?.b)`x`.c)()", "new (a?.b)`x`.c");
+    expectPrinted_("new (import(x)`y`)()", "new (import(x))`y`");
+    expectPrinted_('new (require("m")`y`)()', 'new (require("m"))`y`');
     expectPrinted_("a()`x`", "a()`x`");
+  });
+
+  // https://github.com/oven-sh/bun/issues/31812
+  it("runs a new expression whose callee needs parentheses", async () => {
+    const run = async code => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    };
+    const ok = { stdout: "A {}\n", stderr: "", exitCode: 0 };
+    expect(
+      await Promise.all([
+        run("const foo = () => (args) => class A {}; console.log(new (foo()`bar`)());"),
+        run("const baz = () => ({ qux: class A {} }); console.log(new (baz()?.qux)());"),
+      ]),
+    ).toEqual([ok, ok]);
   });
 
   it("useDefineForConst TypeScript class initialization", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3693,13 +3693,23 @@ console.log(resolve.length)
     expectPrinted_("new (a?.b())()", "new (a?.b())");
     expectPrinted_("new (a?.b()).c()", "new (a?.b()).c");
     expectPrinted_("new (a.b?.().c)()", "new (a.b?.().c)");
-    expectPrinted_("new ((a.h())?.c)", "new ((a.h())?.c)");
+    expectPrinted_("new ((a.h())?.c)", "new (a.h()?.c)");
     expectPrinted_("new ((a.arr[1])?.b)()", "new (a.arr[1]?.b)");
     ts.expectPrinted_("new (a?.b)!()", "new (a?.b)");
     ts.expectPrinted_("new (a?.b as any)(2)", "new (a?.b)(2)");
     ts.expectPrinted_("new (a?.b!)()", "new (a?.b)");
     expectPrinted_("new a.b()", "new a.b");
     expectPrinted_("new (a())()", "new (a())");
+    expectPrinted_("new (a?.b.c).d()", "new (a?.b.c).d");
+    expectPrinted_("new (a?.b().c).d()", "new (a?.b().c).d");
+  });
+
+  it("tagged template with a call in the tag as new callee", () => {
+    expectPrinted_("new (a()`x`)()", "new (a())`x`");
+    expectPrinted_("new (a()`x`.b)()", "new (a())`x`.b");
+    expectPrinted_("new (a.b`x`)()", "new a.b`x`");
+    expectPrinted_("new a`x`()", "new a`x`");
+    expectPrinted_("a()`x`", "a()`x`");
   });
 
   it("useDefineForConst TypeScript class initialization", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3666,6 +3666,42 @@ console.log(resolve.length)
     expectPrinted_("delete foo?.bar?.baz", "delete foo?.bar?.baz");
   });
 
+  it("parenthesized optional chain as template tag", () => {
+    expectPrinted_("(a?.b)`x`", "(a?.b)`x`");
+    expectPrinted_("(a?.[0])`x`", "(a?.[0])`x`");
+    expectPrinted_("(a?.b.c)`x`", "(a?.b.c)`x`");
+    expectPrinted_("(a?.b())`x`", "(a?.b())`x`");
+    expectPrinted_("(a?.b()).c`x`", "(a?.b()).c`x`");
+    expectPrinted_("(a.b?.().c)`x`", "(a.b?.().c)`x`");
+    expectPrinted_("(a.b?.())`x`", "(a.b?.())`x`");
+    expectPrinted_("((a?.b))`x`", "(a?.b)`x`");
+    expectPrinted_("((0 >= a.b)?.())`x`", "((0 >= a.b)?.())`x`");
+    ts.expectPrinted_("(a?.b)!`x`", "(a?.b)`x`");
+    ts.expectPrinted_("(a?.b as any)`x`", "(a?.b)`x`");
+    ts.expectPrinted_("(<any>a?.b)`x`", "(a?.b)`x`");
+    ts.expectPrinted_("(a?.b satisfies any)`x`", "(a?.b)`x`");
+    expectPrinted_("a.b`x`", "a.b`x`");
+    expectPrinted_("a()`x`", "a()`x`");
+  });
+
+  it("parenthesized optional chain as new callee", () => {
+    expectPrinted_("new (a?.b)()", "new (a?.b)");
+    expectPrinted_("new (a?.b)().c", "new (a?.b)().c");
+    expectPrinted_("new (a?.b)(1)", "new (a?.b)(1)");
+    expectPrinted_("new (a?.[0])()", "new (a?.[0])");
+    expectPrinted_("new (a?.b.c)()", "new (a?.b.c)");
+    expectPrinted_("new (a?.b())()", "new (a?.b())");
+    expectPrinted_("new (a?.b()).c()", "new (a?.b()).c");
+    expectPrinted_("new (a.b?.().c)()", "new (a.b?.().c)");
+    expectPrinted_("new ((a.h())?.c)", "new ((a.h())?.c)");
+    expectPrinted_("new ((a.arr[1])?.b)()", "new (a.arr[1]?.b)");
+    ts.expectPrinted_("new (a?.b)!()", "new (a?.b)");
+    ts.expectPrinted_("new (a?.b as any)(2)", "new (a?.b)(2)");
+    ts.expectPrinted_("new (a?.b!)()", "new (a?.b)");
+    expectPrinted_("new a.b()", "new a.b");
+    expectPrinted_("new (a())()", "new (a())");
+  });
+
   it("useDefineForConst TypeScript class initialization", () => {
     var { expectPrinted_ } = ts;
     expectPrinted_(


### PR DESCRIPTION
Fixes #31812

### Problem
- The printer drops required parentheses around a `new` callee and a template tag. `new (a?.b)()` prints as `new a?.b` and ``(o?.t)`A` `` as ``o?.t`A` ``, both SyntaxErrors (`Cannot call constructor in an optional chain`, `Cannot use tagged templates in an optional chain`). ``new (foo()`bar`)()`` prints as ``new foo()`bar` ``, which runs `new foo()` first: `TypeError: function is not a constructor`.
- Causes in `src/js_printer/lib.rs`: the template arm checked `expr.data` instead of `tag.data` for an optional chain, and printed the tag with no flags, so `ForbidCall` from `new` was lost. The `new` arm printed its target without `HasNonOptionalChainParent`, so a chain never wrapped itself.

### Fix
- The template arm reads `tag.data` and forwards `ForbidCall` to the tag. The `new` arm adds `HasNonOptionalChainParent`, so the `EDot`, `EIndex` and `ECall` arms wrap the chain as they already do for `(a?.b).c`. esbuild uses the same flag here.
- An `EDot` or `EIndex` that wraps for this reason drops `ForbidCall`, because the parentheses isolate the chain: `new (a.b?.().c)`, not `new ((a.b?.()).c)`.
- Verified: `test/bundler/transpiler/transpiler.test.js` (49 spellings, plus the two #31812 programs under `bun -e`) and `test/bundler/bundler_edgecase.test.ts` (runs the artifact). All fail on 1.4.3. Other suites: see Notes.
- Self-reviewed: 1 concern raised, 0 addressed. `new (a?.b ? c : d)()` prints as `new ((a?.b) ? c : d)`: redundant but valid, like the existing `new ((a()) ? c : d)`. See Notes.

### Background
- The printer decides parentheses bottom-up. A parent passes `ExprFlag`s to a child, and the child wraps itself when its shape would re-parse differently in that position.
- `HasNonOptionalChainParent` means the parent is outside this optional chain. A chain link that sees it wraps itself, because `a?.b.c` and `(a?.b).c` are different programs.
- `ForbidCall` is set for the target of `new`. An `ECall` that sees it wraps itself, because `new a()()` and `new (a())()` differ. A tagged template is a `MemberExpression`, so ``new a`x`()`` already means ``new (a`x`)()``. Only a call inside the tag needs the parentheses.

<details><summary>Notes</summary>

Fuller account of the problem, as first written for this PR:

- The printer drops the grouping parentheses around an optional chain when it is a template tag or the target of `new`. `(o?.t)\`A\`` prints as `o?.t\`A\`` and `new (o?.K)()` prints as `new o?.K`. Both are early SyntaxErrors, so `bun run` refuses a valid file and every `bun build` mode exits 0 with an artifact that does not load. TypeScript wrappers (`(o?.t as any)\`A\``, `new (o?.K)!()`) hit the same path once they are erased.
- A call inside the tag of a template that is the target of `new` loses its parentheses too: `new (foo()\`bar\`)()` prints as `new foo()\`bar\`()`, which runs `new foo()` first (the first case in #31812).
- Causes in `src/js_printer/lib.rs`: the template arm tested `expr.data` (the template itself) instead of `tag.data`, so the optional-chain check never fired. The `new` arm printed its target without `HasNonOptionalChainParent`, so the `EDot`/`EIndex`/`ECall` arms never wrapped. The template arm printed its tag with no flags, so `ForbidCall` from `new` was lost.

Repro on 1.4.3:

```
cat > n2.mjs <<'EOF'
var a = null, o = { t: s => s[0], K: class { constructor() { this.v = 1 } }, f() { return o } }, r = [];
r.push((o?.t)`A`);
r.push((o?.["t"])`D`);
r.push(new (o?.K)().v);
r.push(new (o?.f().K)().v);
try { (a?.t)`x` } catch (e) { r.push(e.name) }
try { new (a?.K)() } catch (e) { r.push(e.name) }
console.log(JSON.stringify(r));
EOF
node n2.mjs        # ["A","D",1,1,"TypeError","TypeError"]
bun n2.mjs         # SyntaxError: Cannot use tagged templates in an optional chain.
bun build n2.mjs --no-bundle | grep -n 'o?.t`A`\|new o?.K'
```

Printed output, before and after:

| source | before | after |
| --- | --- | --- |
| `(a?.b)\`x\`` | `a?.b\`x\`` | `(a?.b)\`x\`` |
| `(a.b?.())\`x\`` | `a.b?.()\`x\`` | `(a.b?.())\`x\`` |
| `new (a?.b)()` | `new a?.b` | `new (a?.b)` |
| `new (a?.b())()` | `new a?.b()` | `new (a?.b())` |
| `new (a?.b()).c()` | `new (a?.b()).c` | `new (a?.b()).c` |
| `new (a.b?.().c)()` | `new a.b?.().c` | `new (a.b?.().c)` |
| `new (foo()\`bar\`)()` | `new foo()\`bar\`` | `new (foo())\`bar\`` |
| `new (a.b.c)()` | `new a.b.c` | `new a.b.c` |

`(a?.b).c`, `(a?.b)[0]`, `(a?.b)()`, `delete (a?.b).c`, `for ((a?.b).c of x)` and `extends (a?.b).C` already kept their parentheses and are unchanged.

Related PRs: #31813 (a chain walk at the `new` arm) is closed in favor of this PR. Its test spellings are folded in here (8aa12d9d97): each of its 25 printer inputs produces the same program under this branch (checked by comparing acorn ASTs of input and output), though the printed form differs where the call wraps itself instead of the whole callee (`new (a().b)()` prints as `new (a()).b`, ``new (a()`x`)()`` as ``new (a())`x` ``). #40793 (parser early errors) and #40829 (`this` for rewritten call targets) carry part of this fix inside a larger change. This PR is the flag-based shape with no extra walk.

Review note: the `EIf` arm forwards all parent flags to its test, so `new (a?.b ? c : d)()` prints as `new ((a?.b) ? c : d)`, the same way `new (a() ? c : d)()` already prints as `new ((a()) ? c : d)` on main. Both are valid and equivalent. esbuild masks the flags to `forbidIn` there. That mask is left for a separate change because the same forwarding also passes `ExprResultIsUnused` to the test, which is a different bug with its own repro (a statement-level `require("./esm.mjs") ? x : y` in a bundle prints with an empty test).

Not in this PR: JavaScriptCore does not throw for `(a?.b)()` when `a` is nullish. That is engine behavior, reproducible through `eval`, and the printer keeps that source unchanged.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 33 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [725.56ms]
(pass) bundler > edgecase/EmptyCommonJSModule [593.53ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [534.55ms]
(pass) bundler > edgecase/ImportStarFunction [511.10ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [561.21ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [186.02ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [521.71ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [419.01ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [278.83ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [342.24ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [169.64ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [501.20ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/Impo
... (truncated)

release without fix: 4 failed, 33 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [44.96ms]
(pass) bundler > edgecase/EmptyCommonJSModule [13.38ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [13.03ms]
(pass) bundler > edgecase/ImportStarFunction [12.94ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [13.92ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [4.79ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [11.88ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [6.77ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [6.49ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [6.71ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [4.58ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [45.49ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [19.51ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [7.18ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [4.21ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDefaul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 33 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [857.94ms]
(pass) bundler > edgecase/EmptyCommonJSModule [693.86ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [707.01ms]
(pass) bundler > edgecase/ImportStarFunction [510.53ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [602.38ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [370.85ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [664.41ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [370.80ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [290.49ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [328.77ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [268.30ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [733.34ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/Impo
... (truncated)

release with fix: 33 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8f67bb5076
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 2089ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir obj
[2/2863] mkdir codegen
[3/2863] mkdir pch
[4/2863] mkdir stamps
[5/2863] gen ErrorCode+*.h
[6/2863] fetch mimalloc
[mimalloc] up to date
[7/2863] fetch icu
[icu] up to date
[8/2863] fetch WebKit
[WebKit] up to date
[9/2863] fetch tinycc
[tinycc] up to date
[10/2863] gen bindgenv2
[11/2863] fetch zlib
[zlib] up to date
[12/2863] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[13/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[14/2863] gen lut ArrayConstructor.lut.h
[15/2863] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [195.00ms]
[16/2863] gen lut AsyncFromSyncIteratorPrototype.lut.h
[17/2863] gen CombinedDomains.json
[18/2863] gen lut AsyncGeneratorPrototype.lut.h
[19/2863] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                      | 12 ++++++--
 test/bundler/bundler_edgecase.test.ts      | 21 ++++++++++++++
 test/bundler/transpiler/transpiler.test.js | 46 ++++++++++++++++++++++++++++++
 3 files changed, 76 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_printer/lib.rs                           8      3     20
test/bundler/bundler_edgecase.test.ts           1      2     10
test/bundler/transpiler/transpiler.test.js      2      3     15
```

</details>

**root cause** · written by the author bot

When a `new` callee or a template tag contained an optional chain, the printer did not propagate the flag that marks a non-optional parent, so the chain never wrapped itself in parentheses and the output parsed differently or failed to parse (for example `new (a.b?.c)()` degrading to `new a.b?.c()`), and the template-tag check inspected the template node itself instead of its tag, so it could never fire. The fix passes `HasNonOptionalChainParent` from the `ENew` arm to its target and examines `tag.data` in the template arm while forwarding `ForbidCall` to it, so optional chains in those pos…

<!-- robobun:evidence:end -->
