### PR TITLE
bun test --parallel: print a test's error output before its result line

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -447,33 +447,32 @@ impl<'a> Coordinator<'a> {
         self.print_pending_lines(w);
     }
 
-    /// Prints pending results in frame order: a stream line once its copy is
-    /// in `captured`, a dot right away behind the complete lines before it.
+    /// Prints pending results in frame order. A stream line prints with the
+    /// captured output before it once its copy is in `captured`. A dot has
+    /// no copy in the stream, so it takes nothing from `captured`: what the
+    /// test wrote prints with the next stream line or at file end.
     fn print_pending_lines(&mut self, w: &mut Worker) {
         while let Some(p) = w.pending_lines.front() {
-            let (file_idx, end) = if p.in_stream {
+            if p.in_stream {
                 let Some(pos) = strings::index_of(&w.captured, &p.line) else {
                     break;
                 };
-                (p.file_idx, pos + p.line.len())
-            } else {
-                (
-                    p.file_idx,
-                    strings::last_index_of_char(&w.captured, b'\n').map_or(0, |nl| nl + 1),
-                )
-            };
-            let p = w.pending_lines.pop_front().expect("front was Some");
-            self.print_captured(w, end, Some(file_idx));
-            if !p.in_stream && !p.line.is_empty() {
-                let is_dot = self.dots;
-                if !is_dot {
-                    self.break_dots();
-                    self.ensure_header(file_idx);
-                }
-                let _ = Output::error_writer().write_all(&p.line);
-                self.last_printed_dot = is_dot;
-                Output::flush();
+                let (file_idx, end) = (p.file_idx, pos + p.line.len());
+                w.pending_lines.pop_front();
+                self.print_captured(w, end, Some(file_idx));
+                continue;
             }
+            let p = w.pending_lines.pop_front().expect("front was Some");
+            if p.line.is_empty() {
+                continue;
+            }
+            if !self.dots {
+                self.break_dots();
+                self.ensure_header(p.file_idx);
+            }
+            let _ = Output::error_writer().write_all(&p.line);
+            self.last_printed_dot = self.dots;
+            Output::flush();
         }
     }
 

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -56,6 +56,7 @@ pub struct Coordinator<'a> {
     pub(crate) parallel_limit: u32,
     pub(crate) scale_up_after_ms: i64,
     pub(crate) bail: u32,
+    pub(crate) dots: bool,
     pub(crate) files_done: u32,
     pub(crate) spawned_count: u32,
     pub(crate) live_workers: u32,
@@ -146,6 +147,7 @@ impl<'a> Coordinator<'a> {
                 return;
             }
             self.vm.event_loop_ref().tick();
+            self.print_arrived_lines();
             self.run_pending_reaps();
             self.maybe_scale_up();
             self.run_pending_reaps();
@@ -407,25 +409,21 @@ impl<'a> Coordinator<'a> {
         }
     }
 
-    /// Prints `captured[..end]` under the in-flight file's header. A lone
-    /// dot (`dot_len` bytes, no newline) joins the dots line instead.
-    fn print_captured(&mut self, w: &mut Worker, end: usize, dot_len: usize) {
+    /// Prints `captured[..end]` under the header of file `idx`.
+    fn print_captured(&mut self, w: &mut Worker, end: usize, idx: Option<u32>) {
         if end == 0 {
             return;
         }
-        if end > dot_len {
-            // The worker already ended the dots line.
-            if w.captured[0] == b'\n' {
-                self.last_printed_dot = false;
-            }
-            self.break_dots();
-            if let Some(idx) = w.inflight {
-                self.ensure_header(idx);
-            }
+        // The worker already ended the dots line.
+        if w.captured[0] == b'\n' {
+            self.last_printed_dot = false;
+        }
+        self.break_dots();
+        if let Some(idx) = idx {
+            self.ensure_header(idx);
         }
         let _ = Output::error_writer().write_all(&w.captured[..end]);
         w.captured.drain(..end);
-        self.last_printed_dot = dot_len > 0;
         Output::flush();
     }
 
@@ -437,41 +435,52 @@ impl<'a> Coordinator<'a> {
         {
             let wp: *mut Worker = w;
             // SAFETY: `wp` is the live worker slot; `w` is not used until
-            // `read` returns. `draining` keeps `on_read_chunk` from calling
-            // back into the coordinator.
+            // `read` returns.
             unsafe {
-                (*wp).draining = true;
                 for pipe in [&raw mut (*wp).out, &raw mut (*wp).err] {
                     if !(*pipe).done && (*pipe).reader.get_fd() != bun_sys::Fd::INVALID {
                         bun_io::BufferedReader::read(&raw mut (*pipe).reader);
                     }
                 }
-                (*wp).draining = false;
             }
         }
-        self.on_worker_output(w);
+        self.print_pending_lines(w);
     }
 
     /// Prints captured output through each pending result line found in it.
-    pub(crate) fn on_worker_output(&mut self, w: &mut Worker) {
-        while let Some(line) = w.pending_lines.front() {
+    fn print_pending_lines(&mut self, w: &mut Worker) {
+        while let Some((idx, line)) = w.pending_lines.front() {
             let Some(pos) = strings::index_of(&w.captured, line) else {
                 break;
             };
-            let end = pos + line.len();
-            let dot_len = if strings::ends_with_char(line, b'\n') {
-                0
-            } else {
-                line.len()
-            };
+            let (idx, end) = (*idx, pos + line.len());
             w.pending_lines.pop_front();
-            self.print_captured(w, end, dot_len);
+            self.print_captured(w, end, Some(idx));
+        }
+    }
+
+    /// Windows reads complete through libuv only, so a result line can land
+    /// after its frame. Called once per loop tick.
+    fn print_arrived_lines(&mut self) {
+        for i in 0..self.spawned_count as usize {
+            // SAFETY: `i < spawned_count <= workers.len()`; fresh derivation per slot.
+            let w = unsafe { &mut *self.workers.as_mut_ptr().add(i) };
+            if !w.pending_lines.is_empty() && !w.captured.is_empty() {
+                self.print_pending_lines(w);
+            }
+        }
+    }
+
+    /// Prints the complete lines captured so far under the in-flight file.
+    fn flush_complete_lines(&mut self, w: &mut Worker) {
+        if let Some(nl) = strings::last_index_of_char(&w.captured, b'\n') {
+            self.print_captured(w, nl + 1, w.inflight);
         }
     }
 
     /// File end. On POSIX the drain has read everything, so a line still
-    /// pending never reached the pipe. On Windows reads complete through
-    /// libuv only, so it prints with the chunk that carries it.
+    /// pending never reached the pipe. On Windows it prints with the chunk
+    /// that carries it.
     fn flush_file_end(&mut self, w: &mut Worker) {
         if cfg!(unix) {
             self.flush_captured(w);
@@ -486,7 +495,7 @@ impl<'a> Coordinator<'a> {
     /// Prints everything, result lines that never reached the pipe included.
     fn flush_captured(&mut self, w: &mut Worker) {
         self.flush_captured_lines(w);
-        for line in w.pending_lines.drain(..) {
+        for (_, line) in w.pending_lines.drain(..) {
             w.captured.extend_from_slice(&line);
         }
         self.flush_rest(w);
@@ -500,7 +509,7 @@ impl<'a> Coordinator<'a> {
             w.captured.push(b'\n');
         }
         let end = w.captured.len();
-        self.print_captured(w, end, 0);
+        self.print_captured(w, end, w.inflight);
     }
 
     pub(crate) fn on_frame(&mut self, w: &mut Worker, kind: frame::Kind, rd: &mut frame::Reader) {
@@ -522,11 +531,28 @@ impl<'a> Coordinator<'a> {
                 if let Some(file) = self.test_records.get_mut(idx as usize) {
                     file.tests.push(Box::from(rd.p));
                 }
-                // Empty for a pass under --only-failures.
-                if !formatted.is_empty() {
-                    w.pending_lines.push_back(Box::from(formatted));
+                if strings::ends_with_char(formatted, b'\n') {
+                    // The worker wrote this line to its stderr before the frame.
+                    w.pending_lines.push_back((idx, Box::from(formatted)));
+                    self.flush_captured_lines(w);
+                    return;
                 }
+                // Empty (a pass under --only-failures), a dot, or the short
+                // AI-agent status: not in the stream, so print what the
+                // test wrote and then the status.
                 self.flush_captured_lines(w);
+                self.flush_complete_lines(w);
+                if formatted.is_empty() {
+                    return;
+                }
+                let is_dot = self.dots;
+                if !is_dot {
+                    self.break_dots();
+                    self.ensure_header(idx);
+                }
+                let _ = Output::error_writer().write_all(formatted);
+                self.last_printed_dot = is_dot;
+                Output::flush();
             }
             frame::Kind::FileDone => {
                 let mut nums = [0u32; 9];

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -407,16 +407,14 @@ impl<'a> Coordinator<'a> {
         }
     }
 
-    /// Prints `captured[..end]` under the in-flight file's header.
-    /// `dot_len` is the length of a trailing dot (no newline) that joins the
-    /// dots line instead of opening a header of its own.
+    /// Prints `captured[..end]` under the in-flight file's header. A lone
+    /// dot (`dot_len` bytes, no newline) joins the dots line instead.
     fn print_captured(&mut self, w: &mut Worker, end: usize, dot_len: usize) {
         if end == 0 {
             return;
         }
         if end > dot_len {
-            // A worker that printed dots itself ends its dots line before
-            // other output, as the serial reporter does.
+            // The worker already ended the dots line.
             if w.captured[0] == b'\n' {
                 self.last_printed_dot = false;
             }
@@ -431,23 +429,16 @@ impl<'a> Coordinator<'a> {
         Output::flush();
     }
 
-    /// Reads what the worker's pipes hold right now, then prints captured
-    /// output through each result line that has arrived, in frame order.
-    /// Bytes past the last printed line stay captured: they belong to a test
-    /// whose result line is not here yet.
+    /// Drains the worker's pipes (POSIX only: the worker wrote the result
+    /// line before it sent the frame, so the drain sees it), then prints
+    /// through each result line that has arrived.
     fn flush_captured_lines(&mut self, w: &mut Worker) {
-        // The worker writes a test's output and its result line before it
-        // sends the frame, so on POSIX a synchronous drain sees all of it.
-        // Windows reads complete through libuv only; `on_worker_output`
-        // prints the lines when the chunk that carries them arrives.
         #[cfg(unix)]
         {
             let wp: *mut Worker = w;
-            // SAFETY: `wp` is the live worker slot. `read` dispatches
-            // `on_read_chunk`, which appends to `captured` through the pipe's
-            // worker backref; `w` is not touched until it returns (the same
-            // backref caveat as the `Worker::coord` field doc). `draining`
-            // keeps that dispatch from calling back into the coordinator.
+            // SAFETY: `wp` is the live worker slot; `w` is not used until
+            // `read` returns. `draining` keeps `on_read_chunk` from calling
+            // back into the coordinator.
             unsafe {
                 (*wp).draining = true;
                 for pipe in [&raw mut (*wp).out, &raw mut (*wp).err] {
@@ -461,8 +452,7 @@ impl<'a> Coordinator<'a> {
         self.on_worker_output(w);
     }
 
-    /// A chunk of worker stdout/stderr arrived: print through any result
-    /// line it completed.
+    /// Prints captured output through each pending result line found in it.
     pub(crate) fn on_worker_output(&mut self, w: &mut Worker) {
         while let Some(line) = w.pending_lines.front() {
             let Some(pos) = strings::index_of(&w.captured, line) else {
@@ -479,12 +469,9 @@ impl<'a> Coordinator<'a> {
         }
     }
 
-    /// File end: prints through the last result line and what follows it
-    /// (hook output). On POSIX the drain in `flush_captured_lines` has read
-    /// everything the worker wrote for this file, so a line still pending
-    /// never reached the pipe and prints from the frame. On Windows reads
-    /// complete through libuv only, so such a line stays pending and prints
-    /// with the chunk that carries it.
+    /// File end. On POSIX the drain has read everything, so a line still
+    /// pending never reached the pipe. On Windows reads complete through
+    /// libuv only, so it prints with the chunk that carries it.
     fn flush_file_end(&mut self, w: &mut Worker) {
         if cfg!(unix) {
             self.flush_captured(w);
@@ -496,8 +483,7 @@ impl<'a> Coordinator<'a> {
         }
     }
 
-    /// Prints everything the worker wrote. Result lines that never showed up
-    /// in the stream are printed from the frames so no result is lost.
+    /// Prints everything, result lines that never reached the pipe included.
     fn flush_captured(&mut self, w: &mut Worker) {
         self.flush_captured_lines(w);
         for line in w.pending_lines.drain(..) {
@@ -536,9 +522,7 @@ impl<'a> Coordinator<'a> {
                 if let Some(file) = self.test_records.get_mut(idx as usize) {
                     file.tests.push(Box::from(rd.p));
                 }
-                // The worker wrote `formatted` to its stderr before it sent
-                // this frame. Empty under --only-failures for a pass: that
-                // test's output waits for the next line or the file end.
+                // Empty for a pass under --only-failures.
                 if !formatted.is_empty() {
                     w.pending_lines.push_back(Box::from(formatted));
                 }

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -16,7 +16,7 @@ use bun_jsc::virtual_machine::VirtualMachine;
 use bun_ptr::Interned;
 
 use super::frame::{self, Frame};
-use super::worker::{Worker, WorkerPipe};
+use super::worker::{PendingLine, Worker, WorkerPipe};
 use crate::test_command::CommandLineReporter;
 
 // `Status` lives in `crate::api::bun::process`
@@ -447,15 +447,30 @@ impl<'a> Coordinator<'a> {
         self.print_pending_lines(w);
     }
 
-    /// Prints captured output through each pending result line found in it.
+    /// Prints pending results in frame order: a stream line once its copy is
+    /// in `captured`, a dot right away behind the complete lines before it.
     fn print_pending_lines(&mut self, w: &mut Worker) {
-        while let Some((idx, line)) = w.pending_lines.front() {
-            let Some(pos) = strings::index_of(&w.captured, line) else {
-                break;
+        while let Some(p) = w.pending_lines.front() {
+            let (file_idx, end) = if p.in_stream {
+                let Some(pos) = strings::index_of(&w.captured, &p.line) else {
+                    break;
+                };
+                (p.file_idx, pos + p.line.len())
+            } else {
+                (p.file_idx, strings::last_index_of_char(&w.captured, b'\n').map_or(0, |nl| nl + 1))
             };
-            let (idx, end) = (*idx, pos + line.len());
-            w.pending_lines.pop_front();
-            self.print_captured(w, end, Some(idx));
+            let p = w.pending_lines.pop_front().expect("front was Some");
+            self.print_captured(w, end, Some(file_idx));
+            if !p.in_stream && !p.line.is_empty() {
+                let is_dot = self.dots;
+                if !is_dot {
+                    self.break_dots();
+                    self.ensure_header(file_idx);
+                }
+                let _ = Output::error_writer().write_all(&p.line);
+                self.last_printed_dot = is_dot;
+                Output::flush();
+            }
         }
     }
 
@@ -465,16 +480,9 @@ impl<'a> Coordinator<'a> {
         for i in 0..self.spawned_count as usize {
             // SAFETY: `i < spawned_count <= workers.len()`; fresh derivation per slot.
             let w = unsafe { &mut *self.workers.as_mut_ptr().add(i) };
-            if !w.pending_lines.is_empty() && !w.captured.is_empty() {
+            if !w.pending_lines.is_empty() {
                 self.print_pending_lines(w);
             }
-        }
-    }
-
-    /// Prints the complete lines captured so far under the in-flight file.
-    fn flush_complete_lines(&mut self, w: &mut Worker) {
-        if let Some(nl) = strings::last_index_of_char(&w.captured, b'\n') {
-            self.print_captured(w, nl + 1, w.inflight);
         }
     }
 
@@ -495,8 +503,8 @@ impl<'a> Coordinator<'a> {
     /// Prints everything, result lines that never reached the pipe included.
     fn flush_captured(&mut self, w: &mut Worker) {
         self.flush_captured_lines(w);
-        for (_, line) in w.pending_lines.drain(..) {
-            w.captured.extend_from_slice(&line);
+        for p in w.pending_lines.drain(..) {
+            w.captured.extend_from_slice(&p.line);
         }
         self.flush_rest(w);
     }
@@ -531,28 +539,12 @@ impl<'a> Coordinator<'a> {
                 if let Some(file) = self.test_records.get_mut(idx as usize) {
                     file.tests.push(Box::from(rd.p));
                 }
-                if strings::ends_with_char(formatted, b'\n') {
-                    // The worker wrote this line to its stderr before the frame.
-                    w.pending_lines.push_back((idx, Box::from(formatted)));
-                    self.flush_captured_lines(w);
-                    return;
-                }
-                // Empty (a pass under --only-failures), a dot, or the short
-                // AI-agent status: not in the stream, so print what the
-                // test wrote and then the status.
+                w.pending_lines.push_back(PendingLine {
+                    file_idx: idx,
+                    line: Box::from(formatted),
+                    in_stream: strings::ends_with_char(formatted, b'\n'),
+                });
                 self.flush_captured_lines(w);
-                self.flush_complete_lines(w);
-                if formatted.is_empty() {
-                    return;
-                }
-                let is_dot = self.dots;
-                if !is_dot {
-                    self.break_dots();
-                    self.ensure_header(idx);
-                }
-                let _ = Output::error_writer().write_all(formatted);
-                self.last_printed_dot = is_dot;
-                Output::flush();
             }
             frame::Kind::FileDone => {
                 let mut nums = [0u32; 9];

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -457,7 +457,10 @@ impl<'a> Coordinator<'a> {
                 };
                 (p.file_idx, pos + p.line.len())
             } else {
-                (p.file_idx, strings::last_index_of_char(&w.captured, b'\n').map_or(0, |nl| nl + 1))
+                (
+                    p.file_idx,
+                    strings::last_index_of_char(&w.captured, b'\n').map_or(0, |nl| nl + 1),
+                )
             };
             let p = w.pending_lines.pop_front().expect("front was Some");
             self.print_captured(w, end, Some(file_idx));

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -414,10 +414,6 @@ impl<'a> Coordinator<'a> {
         if end == 0 {
             return;
         }
-        // The worker already ended the dots line.
-        if w.captured[0] == b'\n' {
-            self.last_printed_dot = false;
-        }
         self.break_dots();
         if let Some(idx) = idx {
             self.ensure_header(idx);

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -56,7 +56,6 @@ pub struct Coordinator<'a> {
     pub(crate) parallel_limit: u32,
     pub(crate) scale_up_after_ms: i64,
     pub(crate) bail: u32,
-    pub(crate) dots: bool,
     pub(crate) files_done: u32,
     pub(crate) spawned_count: u32,
     pub(crate) live_workers: u32,
@@ -408,19 +407,114 @@ impl<'a> Coordinator<'a> {
         }
     }
 
+    /// Prints `captured[..end]` under the in-flight file's header.
+    /// `dot_len` is the length of a trailing dot (no newline) that joins the
+    /// dots line instead of opening a header of its own.
+    fn print_captured(&mut self, w: &mut Worker, end: usize, dot_len: usize) {
+        if end == 0 {
+            return;
+        }
+        if end > dot_len {
+            // A worker that printed dots itself ends its dots line before
+            // other output, as the serial reporter does.
+            if w.captured[0] == b'\n' {
+                self.last_printed_dot = false;
+            }
+            self.break_dots();
+            if let Some(idx) = w.inflight {
+                self.ensure_header(idx);
+            }
+        }
+        let _ = Output::error_writer().write_all(&w.captured[..end]);
+        w.captured.drain(..end);
+        self.last_printed_dot = dot_len > 0;
+        Output::flush();
+    }
+
+    /// Reads what the worker's pipes hold right now, then prints captured
+    /// output through each result line that has arrived, in frame order.
+    /// Bytes past the last printed line stay captured: they belong to a test
+    /// whose result line is not here yet.
+    fn flush_captured_lines(&mut self, w: &mut Worker) {
+        // The worker writes a test's output and its result line before it
+        // sends the frame, so on POSIX a synchronous drain sees all of it.
+        // Windows reads complete through libuv only; `on_worker_output`
+        // prints the lines when the chunk that carries them arrives.
+        #[cfg(unix)]
+        {
+            let wp: *mut Worker = w;
+            // SAFETY: `wp` is the live worker slot. `read` dispatches
+            // `on_read_chunk`, which appends to `captured` through the pipe's
+            // worker backref; `w` is not touched until it returns (the same
+            // backref caveat as the `Worker::coord` field doc). `draining`
+            // keeps that dispatch from calling back into the coordinator.
+            unsafe {
+                (*wp).draining = true;
+                for pipe in [&raw mut (*wp).out, &raw mut (*wp).err] {
+                    if !(*pipe).done && (*pipe).reader.get_fd() != bun_sys::Fd::INVALID {
+                        bun_io::BufferedReader::read(&raw mut (*pipe).reader);
+                    }
+                }
+                (*wp).draining = false;
+            }
+        }
+        self.on_worker_output(w);
+    }
+
+    /// A chunk of worker stdout/stderr arrived: print through any result
+    /// line it completed.
+    pub(crate) fn on_worker_output(&mut self, w: &mut Worker) {
+        while let Some(line) = w.pending_lines.front() {
+            let Some(pos) = strings::index_of(&w.captured, line) else {
+                break;
+            };
+            let end = pos + line.len();
+            let dot_len = if strings::ends_with_char(line, b'\n') {
+                0
+            } else {
+                line.len()
+            };
+            w.pending_lines.pop_front();
+            self.print_captured(w, end, dot_len);
+        }
+    }
+
+    /// File end: prints through the last result line and what follows it
+    /// (hook output). On POSIX the drain in `flush_captured_lines` has read
+    /// everything the worker wrote for this file, so a line still pending
+    /// never reached the pipe and prints from the frame. On Windows reads
+    /// complete through libuv only, so such a line stays pending and prints
+    /// with the chunk that carries it.
+    fn flush_file_end(&mut self, w: &mut Worker) {
+        if cfg!(unix) {
+            self.flush_captured(w);
+            return;
+        }
+        self.flush_captured_lines(w);
+        if w.pending_lines.is_empty() {
+            self.flush_rest(w);
+        }
+    }
+
+    /// Prints everything the worker wrote. Result lines that never showed up
+    /// in the stream are printed from the frames so no result is lost.
     fn flush_captured(&mut self, w: &mut Worker) {
+        self.flush_captured_lines(w);
+        for line in w.pending_lines.drain(..) {
+            w.captured.extend_from_slice(&line);
+        }
+        self.flush_rest(w);
+    }
+
+    fn flush_rest(&mut self, w: &mut Worker) {
         if w.captured.is_empty() {
             return;
         }
-        self.break_dots();
-        if let Some(idx) = w.inflight {
-            self.ensure_header(idx);
-        }
-        let _ = Output::error_writer().write_all(&w.captured);
         if !strings::ends_with_char(&w.captured, b'\n') {
-            let _ = Output::error_writer().write_all(b"\n");
+            w.captured.push(b'\n');
         }
-        w.captured.clear();
+        let end = w.captured.len();
+        self.print_captured(w, end, 0);
     }
 
     pub(crate) fn on_frame(&mut self, w: &mut Worker, kind: frame::Kind, rd: &mut frame::Reader) {
@@ -442,20 +536,13 @@ impl<'a> Coordinator<'a> {
                 if let Some(file) = self.test_records.get_mut(idx as usize) {
                     file.tests.push(Box::from(rd.p));
                 }
-                self.flush_captured(w);
-                if formatted.is_empty() {
-                    return; // e.g. pass under --only-failures
+                // The worker wrote `formatted` to its stderr before it sent
+                // this frame. Empty under --only-failures for a pass: that
+                // test's output waits for the next line or the file end.
+                if !formatted.is_empty() {
+                    w.pending_lines.push_back(Box::from(formatted));
                 }
-                // dots-mode failures print a full line (writeTestStatusLine);
-                // dots themselves are unterminated.
-                let is_dot = self.dots && !strings::ends_with_char(formatted, b'\n');
-                if !is_dot {
-                    self.break_dots();
-                    self.ensure_header(idx);
-                }
-                let _ = Output::error_writer().write_all(formatted);
-                self.last_printed_dot = is_dot;
-                Output::flush();
+                self.flush_captured_lines(w);
             }
             frame::Kind::FileDone => {
                 let mut nums = [0u32; 9];
@@ -477,7 +564,7 @@ impl<'a> Coordinator<'a> {
                     file.elapsed_ns = rd.u64();
                 }
 
-                self.flush_captured(w);
+                self.flush_file_end(w);
                 if self.last_header_idx == Some(idx) {
                     self.end_group();
                 }
@@ -728,6 +815,7 @@ impl<'a> Coordinator<'a> {
             w.out = WorkerPipe::new(core::ptr::null());
             w.err = WorkerPipe::new(core::ptr::null());
             let _ = core::mem::take(&mut w.captured);
+            w.pending_lines.clear();
         }
     }
 

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -420,7 +420,11 @@ impl WorkerPipe {
     ///
     /// # Safety
     /// `this` is the live pipe, embedded in its worker.
-    pub(crate) unsafe fn on_read_chunk(this: *mut Self, chunk: &[u8], _: bun_io::ReadState) -> bool {
+    pub(crate) unsafe fn on_read_chunk(
+        this: *mut Self,
+        chunk: &[u8],
+        _: bun_io::ReadState,
+    ) -> bool {
         // SAFETY: worker backref valid while WorkerPipe is embedded in Worker.
         // Mutating through cast_mut requires write provenance on the stored
         // pointer; all backref creation sites (the runner.rs coord_ptr, the

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -64,11 +64,10 @@ pub struct Worker {
     pub(crate) dispatched_at: i64,
     /// Worker stdout+stderr not yet printed.
     pub(crate) captured: Vec<u8>,
-    /// Result lines from `test_done` frames not yet found in `captured`. The
-    /// worker writes each line to stderr before it sends the frame.
-    pub(crate) pending_lines: VecDeque<Box<[u8]>>,
-    /// The coordinator is draining the pipes itself.
-    pub(crate) draining: bool,
+    /// `(file index, result line)` from `test_done` frames not yet found in
+    /// `captured`. The worker writes each line to stderr before it sends
+    /// the frame.
+    pub(crate) pending_lines: VecDeque<(u32, Box<[u8]>)>,
     pub(crate) alive: bool,
     /// Set when the process-exit notification arrives. Reaping waits for both
     /// this and `ipc.done` so trailing IPC frames are decoded first.
@@ -411,27 +410,17 @@ impl WorkerPipe {
         }
     }
 
-    /// Raw receiver: the coordinator call forms a `&mut Worker` that
-    /// contains this pipe.
-    ///
-    /// # Safety
-    /// `this` is the live pipe, embedded in its worker.
-    pub(crate) unsafe fn on_read_chunk(
-        this: *mut Self,
-        chunk: &[u8],
-        _: bun_io::ReadState,
-    ) -> bool {
-        // SAFETY: the worker backref is valid while the pipe is embedded in
-        // its worker and carries write provenance (see `Worker::coord`).
-        // While the coordinator drains the pipe itself, `draining` is set
-        // and it is not called back.
-        unsafe {
-            let w = (*this).worker.cast_mut();
-            (*w).captured.extend_from_slice(chunk);
-            if !(*w).draining && !(*w).pending_lines.is_empty() {
-                (*(*w).coord.cast_mut()).on_worker_output(&mut *w);
-            }
-        }
+    pub(crate) fn on_read_chunk(&mut self, chunk: &[u8], _: bun_io::ReadState) -> bool {
+        // SAFETY: worker backref valid while WorkerPipe is embedded in Worker.
+        // Mutating `captured` through cast_mut requires write provenance on
+        // the stored pointer; all backref creation sites (the runner.rs
+        // coord_ptr, the Worker.rs start() errdefer guard, and the
+        // Coordinator.rs spawn_worker/respawn sites via
+        // `std::ptr::from_mut(..).cast_const()`) now establish it. The
+        // residual `&mut Coordinator`-during-drive aliasing caveat described
+        // in the `Worker::coord` field doc applies to this backref too. No
+        // other reference to `captured` is live during the read callback.
+        unsafe { (*self.worker.cast_mut()).captured.extend_from_slice(chunk) };
         true
     }
     pub(crate) fn on_reader_done(&mut self) {
@@ -448,7 +437,7 @@ impl WorkerPipe {
 bun_io::impl_buffered_reader_parent! {
     TestParallelWorkerPipe for WorkerPipe;
     has_on_read_chunk = true;
-    on_read_chunk   = |this, chunk, state| WorkerPipe::on_read_chunk(this, &chunk, state);
+    on_read_chunk   = |this, chunk, state| (*this).on_read_chunk(&chunk, state);
     on_reader_done  = |this| (*this).on_reader_done();
     on_reader_error = |this, err| (*this).on_reader_error(err);
     // `vm.uv_loop()` is `*mut bun_io::Loop` on every target.

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -62,16 +62,12 @@ pub struct Worker {
     /// Millisecond timestamp at the most recent dispatch; drives lazy
     /// scale-up.
     pub(crate) dispatched_at: i64,
-    /// Worker stdout+stderr not yet printed. Printed under the right file
-    /// header so concurrent files don't interleave.
+    /// Worker stdout+stderr not yet printed.
     pub(crate) captured: Vec<u8>,
-    /// Result lines from `test_done` frames whose copy in `captured` has not
-    /// been printed yet, in frame order. The worker writes each line to its
-    /// stderr right before it sends the frame, so the line marks where the
-    /// test's output ends in the byte stream.
+    /// Result lines from `test_done` frames not yet found in `captured`. The
+    /// worker writes each line to stderr before it sends the frame.
     pub(crate) pending_lines: VecDeque<Box<[u8]>>,
-    /// Set while the coordinator drains the pipes itself, so the read
-    /// callback does not re-enter it.
+    /// The coordinator is draining the pipes itself.
     pub(crate) draining: bool,
     pub(crate) alive: bool,
     /// Set when the process-exit notification arrives. Reaping waits for both
@@ -415,8 +411,8 @@ impl WorkerPipe {
         }
     }
 
-    /// Raw receiver: the coordinator call below forms a `&mut Worker`, which
-    /// contains this pipe, so no `&mut WorkerPipe` may be live across it.
+    /// Raw receiver: the coordinator call forms a `&mut Worker` that
+    /// contains this pipe.
     ///
     /// # Safety
     /// `this` is the live pipe, embedded in its worker.
@@ -425,17 +421,10 @@ impl WorkerPipe {
         chunk: &[u8],
         _: bun_io::ReadState,
     ) -> bool {
-        // SAFETY: worker backref valid while WorkerPipe is embedded in Worker.
-        // Mutating through cast_mut requires write provenance on the stored
-        // pointer; all backref creation sites (the runner.rs coord_ptr, the
-        // Worker.rs start() errdefer guard, and the Coordinator.rs
-        // spawn_worker/respawn sites via `std::ptr::from_mut(..).cast_const()`)
-        // establish it. The residual `&mut Coordinator`-during-drive aliasing
-        // caveat described in the `Worker::coord` field doc applies to this
-        // backref too. No other reference to the worker is live during the
-        // read callback, except while the coordinator drains the pipe itself
-        // from `flush_captured_lines`: `draining` is set then and the call
-        // into the coordinator is skipped.
+        // SAFETY: the worker backref is valid while the pipe is embedded in
+        // its worker and carries write provenance (see `Worker::coord`).
+        // While the coordinator drains the pipe itself, `draining` is set
+        // and it is not called back.
         unsafe {
             let w = (*this).worker.cast_mut();
             (*w).captured.extend_from_slice(chunk);

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -27,10 +27,8 @@ use super::frame;
 pub struct PendingLine {
     pub(crate) file_idx: u32,
     pub(crate) line: Box<[u8]>,
-    /// The worker wrote `line` to its stderr before it sent the frame, so it
-    /// prints when its copy is found in `captured`. A dot or the agent
-    /// status is not in the stream and prints right behind the entry
-    /// before it.
+    /// The worker wrote `line` to its stderr before it sent the frame. A
+    /// dot or the agent status is not in the stream.
     pub(crate) in_stream: bool,
 }
 

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -23,6 +23,17 @@ use super::coordinator::Coordinator;
 use super::file_range::FileRange;
 use super::frame;
 
+/// One `test_done` result the coordinator has not printed yet.
+pub struct PendingLine {
+    pub(crate) file_idx: u32,
+    pub(crate) line: Box<[u8]>,
+    /// The worker wrote `line` to its stderr before it sent the frame, so it
+    /// prints when its copy is found in `captured`. A dot or the agent
+    /// status is not in the stream and prints right behind the entry
+    /// before it.
+    pub(crate) in_stream: bool,
+}
+
 pub struct Worker {
     // BACKREF to the owning Coordinator. Stored as `*const` for LIFETIMES.tsv
     // parity, but mutation sites (`live_workers`, `on_worker_exit`, `frame`)
@@ -64,10 +75,8 @@ pub struct Worker {
     pub(crate) dispatched_at: i64,
     /// Worker stdout+stderr not yet printed.
     pub(crate) captured: Vec<u8>,
-    /// `(file index, result line)` from `test_done` frames not yet found in
-    /// `captured`. The worker writes each line to stderr before it sends
-    /// the frame.
-    pub(crate) pending_lines: VecDeque<(u32, Box<[u8]>)>,
+    /// Results from `test_done` frames not printed yet, in frame order.
+    pub(crate) pending_lines: VecDeque<PendingLine>,
     pub(crate) alive: bool,
     /// Set when the process-exit notification arrives. Reaping waits for both
     /// this and `ipc.done` so trailing IPC frames are decoded first.

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -4,6 +4,7 @@
 //! spawn/dispatch/shutdown mechanics.
 
 use core::ffi::c_void;
+use std::collections::VecDeque;
 
 #[cfg(unix)]
 use crate::api::bun::process::PosixStdio as Stdio;
@@ -61,9 +62,17 @@ pub struct Worker {
     /// Millisecond timestamp at the most recent dispatch; drives lazy
     /// scale-up.
     pub(crate) dispatched_at: i64,
-    /// Worker stdout+stderr since the last `test_done`. Flushed atomically
-    /// under the right file header so concurrent files don't interleave.
+    /// Worker stdout+stderr not yet printed. Printed under the right file
+    /// header so concurrent files don't interleave.
     pub(crate) captured: Vec<u8>,
+    /// Result lines from `test_done` frames whose copy in `captured` has not
+    /// been printed yet, in frame order. The worker writes each line to its
+    /// stderr right before it sends the frame, so the line marks where the
+    /// test's output ends in the byte stream.
+    pub(crate) pending_lines: VecDeque<Box<[u8]>>,
+    /// Set while the coordinator drains the pipes itself, so the read
+    /// callback does not re-enter it.
+    pub(crate) draining: bool,
     pub(crate) alive: bool,
     /// Set when the process-exit notification arrives. Reaping waits for both
     /// this and `ipc.done` so trailing IPC frames are decoded first.
@@ -406,17 +415,30 @@ impl WorkerPipe {
         }
     }
 
-    pub(crate) fn on_read_chunk(&mut self, chunk: &[u8], _: bun_io::ReadState) -> bool {
+    /// Raw receiver: the coordinator call below forms a `&mut Worker`, which
+    /// contains this pipe, so no `&mut WorkerPipe` may be live across it.
+    ///
+    /// # Safety
+    /// `this` is the live pipe, embedded in its worker.
+    pub(crate) unsafe fn on_read_chunk(this: *mut Self, chunk: &[u8], _: bun_io::ReadState) -> bool {
         // SAFETY: worker backref valid while WorkerPipe is embedded in Worker.
-        // Mutating `captured` through cast_mut requires write provenance on
-        // the stored pointer; all backref creation sites (the runner.rs
-        // coord_ptr, the Worker.rs start() errdefer guard, and the
-        // Coordinator.rs spawn_worker/respawn sites via
-        // `std::ptr::from_mut(..).cast_const()`) now establish it. The
-        // residual `&mut Coordinator`-during-drive aliasing caveat described
-        // in the `Worker::coord` field doc applies to this backref too. No
-        // other reference to `captured` is live during the read callback.
-        unsafe { (*self.worker.cast_mut()).captured.extend_from_slice(chunk) };
+        // Mutating through cast_mut requires write provenance on the stored
+        // pointer; all backref creation sites (the runner.rs coord_ptr, the
+        // Worker.rs start() errdefer guard, and the Coordinator.rs
+        // spawn_worker/respawn sites via `std::ptr::from_mut(..).cast_const()`)
+        // establish it. The residual `&mut Coordinator`-during-drive aliasing
+        // caveat described in the `Worker::coord` field doc applies to this
+        // backref too. No other reference to the worker is live during the
+        // read callback, except while the coordinator drains the pipe itself
+        // from `flush_captured_lines`: `draining` is set then and the call
+        // into the coordinator is skipped.
+        unsafe {
+            let w = (*this).worker.cast_mut();
+            (*w).captured.extend_from_slice(chunk);
+            if !(*w).draining && !(*w).pending_lines.is_empty() {
+                (*(*w).coord.cast_mut()).on_worker_output(&mut *w);
+            }
+        }
         true
     }
     pub(crate) fn on_reader_done(&mut self) {
@@ -433,7 +455,7 @@ impl WorkerPipe {
 bun_io::impl_buffered_reader_parent! {
     TestParallelWorkerPipe for WorkerPipe;
     has_on_read_chunk = true;
-    on_read_chunk   = |this, chunk, state| (*this).on_read_chunk(&chunk, state);
+    on_read_chunk   = |this, chunk, state| WorkerPipe::on_read_chunk(this, &chunk, state);
     on_reader_done  = |this| (*this).on_reader_done();
     on_reader_error = |this, err| (*this).on_reader_error(err);
     // `vm.uv_loop()` is `*mut bun_io::Loop` on every target.

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -130,7 +130,6 @@ pub(crate) fn run_as_coordinator(
             dispatched_at: 0,
             captured: Vec::new(),
             pending_lines: std::collections::VecDeque::new(),
-            draining: false,
             alive: false,
             exit_status: None,
             reap_pending: false,
@@ -174,6 +173,7 @@ pub(crate) fn run_as_coordinator(
             DEFAULT_SCALE_UP_AFTER_MS
         },
         bail: ctx.test_options.bail,
+        dots: ctx.test_options.reporters.dots,
         test_records: if ctx.test_options.reporters.junit {
             (0..n).map(|_| Default::default()).collect()
         } else {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -129,6 +129,8 @@ pub(crate) fn run_as_coordinator(
             inflight: None,
             dispatched_at: 0,
             captured: Vec::new(),
+            pending_lines: std::collections::VecDeque::new(),
+            draining: false,
             alive: false,
             exit_status: None,
             reap_pending: false,
@@ -172,7 +174,6 @@ pub(crate) fn run_as_coordinator(
             DEFAULT_SCALE_UP_AFTER_MS
         },
         bail: ctx.test_options.bail,
-        dots: ctx.test_options.reporters.dots,
         test_records: if ctx.test_options.reporters.junit {
             (0..n).map(|_| Default::default()).collect()
         } else {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1357,9 +1357,12 @@ impl CommandLineReporter {
             Self::test_case_report(result, buntest, sequence, test_entry, elapsed_ns, failure)
         });
         if let Some(idx) = this.worker_ipc_file_idx {
-            // Into stderr first: the coordinator prints captured stderr up
-            // to this line when the frame arrives.
-            let _ = Output::error_writer().write_all(formatted_line);
+            // A full line goes into stderr first, in sequence with the error
+            // output. The coordinator prints captured stderr up to it when
+            // the frame arrives. Dots stay out of the stream.
+            if strings::ends_with_char(formatted_line, b'\n') {
+                let _ = Output::error_writer().write_all(formatted_line);
+            }
             ParallelRunner::worker_emit_test_done(idx, formatted_line, report.as_ref());
         } else {
             let _ = Output::error_writer().write_all(formatted_line);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1357,6 +1357,10 @@ impl CommandLineReporter {
             Self::test_case_report(result, buntest, sequence, test_entry, elapsed_ns, failure)
         });
         if let Some(idx) = this.worker_ipc_file_idx {
+            // The line goes into the worker's own stderr so it is sequenced
+            // with the error output that precedes it. The coordinator prints
+            // captured stderr up to this line when the frame arrives.
+            let _ = Output::error_writer().write_all(formatted_line);
             ParallelRunner::worker_emit_test_done(idx, formatted_line, report.as_ref());
         } else {
             let _ = Output::error_writer().write_all(formatted_line);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1305,7 +1305,12 @@ impl CommandLineReporter {
                         let _ = bun_core::write_pretty!(writer, colors, "<r><red>.<r>");
                     }
                 }
-                reporter_ref.unwrap().last_printed_dot.set(true);
+                let reporter = reporter_ref.unwrap();
+                // Under --parallel the coordinator prints the dot and ends
+                // the dots line itself.
+                if reporter.worker_ipc_file_idx.is_none() {
+                    reporter.last_printed_dot.set(true);
+                }
             } else if basic != bun_test::BasicResult::Fail
                 && reporter_ref.is_some_and(|r| r.reporters.only_failures)
             {
@@ -1361,6 +1366,7 @@ impl CommandLineReporter {
             // output. The coordinator prints captured stderr up to it when
             // the frame arrives. Dots stay out of the stream.
             if strings::ends_with_char(formatted_line, b'\n') {
+                Output::flush();
                 let _ = Output::error_writer().write_all(formatted_line);
             }
             ParallelRunner::worker_emit_test_done(idx, formatted_line, report.as_ref());

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1357,9 +1357,8 @@ impl CommandLineReporter {
             Self::test_case_report(result, buntest, sequence, test_entry, elapsed_ns, failure)
         });
         if let Some(idx) = this.worker_ipc_file_idx {
-            // The line goes into the worker's own stderr so it is sequenced
-            // with the error output that precedes it. The coordinator prints
-            // captured stderr up to this line when the frame arrives.
+            // Into stderr first: the coordinator prints captured stderr up
+            // to this line when the frame arrives.
             let _ = Output::error_writer().write_all(formatted_line);
             ParallelRunner::worker_emit_test_done(idx, formatted_line, report.as_ref());
         } else {

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -784,6 +784,60 @@ test("--parallel never interleaves console output across files", async () => {
   expect(exitCode).toBe(0);
 });
 
+test("--parallel keeps each failure's error output and GitHub annotation with its (fail) line", async () => {
+  // Many failures with a long message per file. The error output rides the
+  // worker's stderr pipe and the result line rides the IPC channel, so the
+  // coordinator must print the stderr bytes that precede each result line
+  // before that line, and nothing past it.
+  const body = (tag: string) =>
+    `import {test} from "bun:test";
+     const big = Buffer.alloc(3000, "X").toString();
+     for (let i = 0; i < 60; i++) test("${tag}" + i, async () => {
+       if (i % 7 == 0) await Bun.sleep(1);
+       throw new Error("E-${tag}" + i + "\\n" + big + "\\nend");
+     });`;
+  using dir = tempDir("parallel-error-order", {
+    "a.test.js": body("a"),
+    "b.test.js": body("b"),
+    "c.test.js": body("c"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=3"],
+    env: { ...bunEnv, GITHUB_ACTIONS: "true", BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // Every annotation is one intact line that names its test.
+  const annotations = stderr.split("\n").filter(line => line.startsWith("::error "));
+  expect(annotations.length).toBe(180);
+  for (const line of annotations) {
+    expect(line).toMatch(/^::error file=[abc]\.test\.js,line=\d+,col=\d+,title=error: E-[abc]\d+::end%0A/);
+  }
+  // The code frame for a test is followed by that test's own (fail) line.
+  let pendingError: string | null = null;
+  let checked = 0;
+  for (const line of stderr.split("\n")) {
+    const err = line.match(/^error: (E-[abc]\d+)$/);
+    if (err) {
+      expect(pendingError).toBeNull();
+      pendingError = err[1];
+      continue;
+    }
+    const fail = line.match(/^\(fail\) ([abc]\d+)/);
+    if (fail) {
+      expect(pendingError).toBe("E-" + fail[1]);
+      pendingError = null;
+      checked++;
+    }
+  }
+  expect(checked).toBe(180);
+  expect(stderr).toContain("180 fail");
+  expect(exitCode).toBe(1);
+});
+
 test("--parallel lazily scales workers based on file duration", async () => {
   // Each test file appends its PID so we can count distinct worker processes.
   const body = (sleepMs: number) =>

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -808,7 +808,7 @@ test("--parallel keeps each failure's error output and GitHub annotation with it
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Every annotation is one intact line that names its test.
   const annotations = stderr.split("\n").filter(line => line.startsWith("::error "));


### PR DESCRIPTION
### Problem
- Under `bun test --parallel`, a failure's error output does not stay with its `(fail)` line. With 4 files of 150 failing tests and `--parallel=3`, 4 to 11 of the 600 GitHub Actions `::error file=...` annotations are cut mid-line by a `(fail)` line and a `::endgroup::`/`::group::` pair, and without `GITHUB_ACTIONS` the code frame of test N+1 lands above `(fail) tN` 17 to 50 times. Serial and `--parallel=1` are clean.
- The worker writes the error output to its stderr pipe and sends the result line in a `test_done` IPC frame on fd 3. The coordinator prints everything it has captured from the pipe when the frame lands (`Coordinator.rs:445`, `flush_captured`), at whatever byte the last pipe read stopped. The two channels have no ordering between them, and the annotation is written as several small unbuffered `write(2)` calls (`VirtualMachine.rs:6746`), so a cut inside it is common.

### Fix
- The worker now writes each full result line to its own stderr right before it sends the frame (`test_command.rs`, `handle_test_completed`). The line is in sequence with the error output that precedes it, as in a serial run. A dot (`--dots`) or an empty status (`--only-failures`) stays out of the stream.
- The coordinator queues the frame's copy of the line with its file index (`Worker.pending_lines`) and prints captured output through that line, never past it (`print_pending_lines`). Bytes after it belong to a test whose line has not arrived. A dot has no copy in the stream, so it prints on its own in frame order and takes nothing from the captured bytes. Those print with the next line or at file end.
- On POSIX the coordinator drains the worker's pipes synchronously when a frame lands (`bun_io::BufferedReader::read`). The worker wrote the line before it sent the frame, so the drain sees all of it and the output is exact. On Windows reads complete through libuv only, so a line that lands after its frame prints from the drive loop, under the header of the file the frame named. A line that never reached the pipe (file end on POSIX, or a worker that died) prints from the frame, so no result is lost.
- Scope: this orders stderr against the result line. Worker stdout is still a second pipe, merged by arrival order as before, so `console.log` output of a test can still land next to a neighbour. One pipe for both streams is a follow-up.
- Verified: `test/cli/test/parallel.test.ts` (new case, fails on 1.4.3-canary 4/4 runs, passes 4/4 with the fix). Also the rest of `parallel.test.ts`, `parallel-startup-failure`, `isolation`, `junit-reporter`, `coverage`, `bun-test`, `test-shard`, and `cargo check` for `x86_64-pc-windows-msvc`. Self-reviewed: the review asked for the file-end fallback on POSIX and the scope note above, both done. Later review rounds found issues with dots and late lines on Windows (header attribution, a `&mut Worker` formed in the read callback, the bare dot as a search key, a dot consuming a later test's line). All are fixed: only a full line, matched on its own text, consumes captured bytes.

### Background
- `bun test --parallel` spawns worker processes. Each worker runs files and reports to the coordinator over fd 3 with length-prefixed frames (`Frame.rs`): `test_done` carries the rendered result line and, for JUnit, the structured record. The worker's stdout and stderr are separate pipes, appended to `Worker.captured` as chunks arrive.
- The coordinator prints `captured` under a `path:` header (a `::group::` in GitHub Actions) so output from different files does not interleave. Until now it printed the whole buffer on each `test_done` and then the line from the frame.
- `bun_io::BufferedReader::read` is the synchronous entry of the pipe reader: on POSIX it reads until `EAGAIN` and dispatches the chunks to the owner; on Windows it only makes sure a libuv read is in flight.

<details><summary>Notes</summary>

Repro (from the report):

```
for f in a b c d; do cat > $f.test.ts <<'TS'
import {test} from "bun:test";
const big = "X".repeat(3000);
for (let i=0;i<150;i++) test("t"+i, async () => { if (i%7==0) await Bun.sleep(1); throw new Error("E"+i+"\n"+big+"\nend") });
TS
done
GITHUB_ACTIONS=true bun test --parallel=3 2>&1 | grep -c '^::error file=.*title=error: E[0-9]*::end%0A.*)$'
```

1.4.3-canary: 593, 596, 594 of 600. With the fix: 600 in 8 of 8 runs. Misplaced code frames without `GITHUB_ACTIONS`: 51, 48, 56 before, 0 in 8 of 8 runs after.

Old `--parallel --dots` output showed the same defect: `(fail) a4` printed before its `error:` block. Now the error block and the `(fail)` line stay together. Under `--dots` and `--only-failures` the console output of a passing test prints with the next full result line or at file end, not at its dot, because a dot cannot mark a position in the stream. The worker no longer ends a dots line it did not print, so the coordinator's line breaks are the only ones.

`--only-failures`: a pass sends an empty line in the frame, so that test's console output waits for the next result line or the file end instead of printing at once. It still prints under its own file header.

`test/cli/test/parallel.test.ts` "each worker has a unique JEST_WORKER_ID", "lazily scales workers" and "forwards --experimental-http2-fetch" fail intermittently in this container on a build of main as well (worker start-up time against a fixed sleep, and a run that takes 4.7 to 5.8 s against the 5 s default timeout on both builds). They are not touched by this change.

The `Coordinator.dots` field is removed: the coordinator no longer decides what a dot is, the line's missing newline does.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts

<!-- robobun:evidence:end -->

