### PR TITLE
node:https: forward crl, sessionTimeout, ecdhCurve, sigalgs and honorCipherOrder to the TLS listener

### DIFF
--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -135,6 +135,110 @@ function secureProtocolToVersionRange(secureProtocol) {
   return null;
 }
 
+const VALID_TLS_VERSIONS = new Set(["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]);
+
+const SUPPORTED_ECDH_GROUPS = new Set([
+  "P-256",
+  "prime256v1",
+  "P-384",
+  "secp384r1",
+  "P-521",
+  "secp521r1",
+  "X25519",
+  "x25519",
+  "X25519MLKEM768",
+  "MLKEM1024",
+]);
+
+const StringPrototypeSplit = String.prototype.split;
+
+// Subset of Node's configSecureContext() validations:
+// https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/internal/tls/secure-context.js#L318
+function validateSecureContextOptions(options) {
+  const { validateString, validateBuffer } = require("internal/validators");
+  const {
+    ciphers,
+    passphrase,
+    ecdhCurve,
+    minVersion,
+    maxVersion,
+    sessionTimeout,
+    sigalgs,
+    ticketKeys,
+    clientCertEngine,
+    dhparam,
+    secureProtocol,
+  } = options;
+  validateSecureProtocol(secureProtocol);
+  if (ciphers !== undefined && ciphers !== null) validateString(ciphers, "options.ciphers");
+  if (passphrase !== undefined && passphrase !== null) validateString(passphrase, "options.passphrase");
+  if (sigalgs !== undefined && sigalgs !== null) {
+    validateString(sigalgs, "options.sigalgs");
+    if (sigalgs === "") throw $ERR_INVALID_ARG_VALUE("options.sigalgs", sigalgs);
+  }
+  if (ecdhCurve !== undefined) {
+    validateString(ecdhCurve, "options.ecdhCurve");
+    if (ecdhCurve !== "auto") {
+      for (const curve of StringPrototypeSplit.$call(ecdhCurve, ":")) {
+        if (!SUPPORTED_ECDH_GROUPS.has(curve)) {
+          // Not $ERR_*: Node's THROW_ERR_CRYPTO_OPERATION_FAILED has no bracketed
+          // toString; test-tls-ecdh-multiple.js pins /Error: Failed to set ECDH curve/.
+          const err = new Error("Failed to set ECDH curve") as Error & { code: string };
+          err.code = "ERR_CRYPTO_OPERATION_FAILED";
+          throw err;
+        }
+      }
+    }
+  }
+  // clientCertEngine must be a string (engine name); a provided engine then
+  // fails because BoringSSL (which Bun always uses) has no OpenSSL ENGINE
+  // support, matching Node's setClientCertEngine. Node:
+  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L296
+  if (clientCertEngine !== undefined && clientCertEngine !== null) {
+    if (typeof clientCertEngine !== "string") {
+      throw $ERR_INVALID_ARG_TYPE("options.clientCertEngine", ["string", "null", "undefined"], clientCertEngine);
+    }
+    throw $ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED("Custom engines not supported by this OpenSSL");
+  }
+  // BoringSSL (always used by Bun) has no automatic DH parameter selection.
+  // Matches Node's setDHParam('auto') throwing ERR_CRYPTO_UNSUPPORTED_OPERATION.
+  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L254
+  if (dhparam === "auto") {
+    throw $ERR_CRYPTO_UNSUPPORTED_OPERATION("Automatic DH parameter selection is not supported");
+  }
+  if (minVersion != null && !VALID_TLS_VERSIONS.has(minVersion))
+    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(minVersion), "minimum");
+  if (maxVersion != null && !VALID_TLS_VERSIONS.has(maxVersion))
+    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(maxVersion), "maximum");
+  if (ticketKeys !== undefined && ticketKeys !== null) {
+    validateBuffer(ticketKeys, "options.ticketKeys");
+    const ticketKeysByteLength = ticketKeys.byteLength;
+    if (ticketKeysByteLength !== 48) {
+      throw $ERR_INVALID_ARG_VALUE("options.ticketKeys", ticketKeysByteLength, "must be exactly 48 bytes");
+    }
+  }
+  // Negative session timeouts are rejected (min 0), matching Node — newer
+  // OpenSSL/BoringSSL do not handle negative values as users expect.
+  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L319
+  if (sessionTimeout !== undefined && sessionTimeout !== null) {
+    // Node validates this with validateInt32(..., 0), whose range message
+    // reads ">= 0 && <= 2147483647"; the shared validator here words it
+    // differently, so spell the check out to match.
+    if (typeof sessionTimeout !== "number") {
+      throw $ERR_INVALID_ARG_TYPE("options.sessionTimeout", "number", sessionTimeout);
+    }
+    if (!Number.isInteger(sessionTimeout)) {
+      throw $ERR_OUT_OF_RANGE("options.sessionTimeout", "an integer", sessionTimeout);
+    }
+    if (sessionTimeout < 0 || sessionTimeout > 2147483647) {
+      throw $ERR_OUT_OF_RANGE("options.sessionTimeout", ">= 0 && <= 2147483647", sessionTimeout);
+    }
+  }
+}
+
+// SSL_OP_CIPHER_SERVER_PREFERENCE: `honorCipherOrder` folds into secureOptions.
+const SSL_OP_CIPHER_SERVER_PREFERENCE = 0x00400000;
+
 let NativeSecureContext;
 
 /**
@@ -179,9 +283,11 @@ function processPfxOptions(options) {
 }
 
 export {
+  SSL_OP_CIPHER_SERVER_PREFERENCE,
   processPfxOptions,
   secureProtocolToVersionRange,
   throwOnInvalidTLSArray,
   tlsStringToProtocolVersion,
+  validateSecureContextOptions,
   validateSecureProtocol,
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -380,7 +380,7 @@ function Server(options, callback): void {
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
         sessionTimeout: options.sessionTimeout ?? undefined,
-        ecdhCurve: options.ecdhCurve,
+        ecdhCurve: options.ecdhCurve ?? require("node:tls").DEFAULT_ECDH_CURVE,
         sigalgs: options.sigalgs,
         allowPartialTrustChain: !!options.allowPartialTrustChain,
       });

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -323,6 +323,11 @@ function Server(options, callback): void {
       this[isTlsSymbol] = true;
     }
 
+    const crl = options.crl;
+    if (crl && this[isTlsSymbol]) {
+      tlsHelpers.throwOnInvalidTLSArray("options.crl", crl);
+    }
+
     let passphrase = options.passphrase;
     if (passphrase && typeof passphrase !== "string") {
       throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
@@ -339,11 +344,21 @@ function Server(options, callback): void {
     }
 
     if (this[isTlsSymbol]) {
-      const { validateSecureProtocol, secureProtocolToVersionRange, tlsStringToProtocolVersion } = tlsHelpers;
+      const {
+        validateSecureContextOptions,
+        secureProtocolToVersionRange,
+        tlsStringToProtocolVersion,
+        SSL_OP_CIPHER_SERVER_PREFERENCE,
+      } = tlsHelpers;
+      // The same checks tls.createServer runs (ecdhCurve, sigalgs,
+      // sessionTimeout, secureProtocol, ...), so a bad option throws here
+      // instead of reaching the native config.
+      validateSecureContextOptions(options);
+      // Node's tls.Server defaults honorCipherOrder to true.
+      if (options.honorCipherOrder !== false) secureOptions |= SSL_OP_CIPHER_SERVER_PREFERENCE;
       // Translate minVersion/maxVersion/secureProtocol into the integer
       // protocol range the native layer applies (secureProtocol wins, like
       // Node's SecureContext::Init); 0 keeps the native defaults.
-      validateSecureProtocol(options.secureProtocol);
       let minVersion, maxVersion;
       const range = secureProtocolToVersionRange(options.secureProtocol);
       if (range) {
@@ -358,6 +373,7 @@ function Server(options, callback): void {
         key,
         cert,
         ca,
+        crl,
         passphrase,
         secureOptions,
         minVersion,
@@ -365,6 +381,10 @@ function Server(options, callback): void {
         ciphers: typeof options.ciphers === "string" && options.ciphers ? options.ciphers : undefined,
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
+        sessionTimeout: options.sessionTimeout ?? undefined,
+        ecdhCurve: options.ecdhCurve,
+        sigalgs: options.sigalgs,
+        allowPartialTrustChain: !!options.allowPartialTrustChain,
       });
     } else {
       this[tlsSymbol] = null;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -350,9 +350,7 @@ function Server(options, callback): void {
         tlsStringToProtocolVersion,
         SSL_OP_CIPHER_SERVER_PREFERENCE,
       } = tlsHelpers;
-      // The same checks tls.createServer runs (ecdhCurve, sigalgs,
-      // sessionTimeout, secureProtocol, ...), so a bad option throws here
-      // instead of reaching the native config.
+      // The same checks tls.createServer runs.
       validateSecureContextOptions(options);
       // Node's tls.Server defaults honorCipherOrder to true.
       if (options.honorCipherOrder !== false) secureOptions |= SSL_OP_CIPHER_SERVER_PREFERENCE;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -11,6 +11,8 @@ const {
   secureProtocolToVersionRange,
   processPfxOptions,
   validateSecureProtocol,
+  validateSecureContextOptions,
+  SSL_OP_CIPHER_SERVER_PREFERENCE,
 } = require("internal/tls");
 const {
   validateString,
@@ -181,104 +183,6 @@ function validateCiphers(ciphers: string, name: string = "options") {
     }
     if (sawLegacyEntry && !sawUsableEntry) {
       throw $ERR_SSL_NO_CIPHER_MATCH();
-    }
-  }
-}
-
-const VALID_TLS_VERSIONS = new Set(["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]);
-
-const SUPPORTED_ECDH_GROUPS = new Set([
-  "P-256",
-  "prime256v1",
-  "P-384",
-  "secp384r1",
-  "P-521",
-  "secp521r1",
-  "X25519",
-  "x25519",
-  "X25519MLKEM768",
-  "MLKEM1024",
-]);
-
-// Subset of Node's configSecureContext() validations:
-// https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/internal/tls/secure-context.js#L318
-function validateSecureContextOptions(options) {
-  const {
-    ciphers,
-    passphrase,
-    ecdhCurve,
-    minVersion,
-    maxVersion,
-    sessionTimeout,
-    sigalgs,
-    ticketKeys,
-    clientCertEngine,
-    dhparam,
-    secureProtocol,
-  } = options;
-  validateSecureProtocol(secureProtocol);
-  if (ciphers !== undefined && ciphers !== null) validateString(ciphers, "options.ciphers");
-  if (passphrase !== undefined && passphrase !== null) validateString(passphrase, "options.passphrase");
-  if (sigalgs !== undefined && sigalgs !== null) {
-    validateString(sigalgs, "options.sigalgs");
-    if (sigalgs === "") throw $ERR_INVALID_ARG_VALUE("options.sigalgs", sigalgs);
-  }
-  if (ecdhCurve !== undefined) {
-    validateString(ecdhCurve, "options.ecdhCurve");
-    if (ecdhCurve !== "auto") {
-      for (const curve of StringPrototypeSplit.$call(ecdhCurve, ":")) {
-        if (!SUPPORTED_ECDH_GROUPS.has(curve)) {
-          // Not $ERR_*: Node's THROW_ERR_CRYPTO_OPERATION_FAILED has no bracketed
-          // toString; test-tls-ecdh-multiple.js pins /Error: Failed to set ECDH curve/.
-          const err = new Error("Failed to set ECDH curve") as Error & { code: string };
-          err.code = "ERR_CRYPTO_OPERATION_FAILED";
-          throw err;
-        }
-      }
-    }
-  }
-  // clientCertEngine must be a string (engine name); a provided engine then
-  // fails because BoringSSL (which Bun always uses) has no OpenSSL ENGINE
-  // support, matching Node's setClientCertEngine. Node:
-  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L296
-  if (clientCertEngine !== undefined && clientCertEngine !== null) {
-    if (typeof clientCertEngine !== "string") {
-      throw $ERR_INVALID_ARG_TYPE("options.clientCertEngine", ["string", "null", "undefined"], clientCertEngine);
-    }
-    throw $ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED("Custom engines not supported by this OpenSSL");
-  }
-  // BoringSSL (always used by Bun) has no automatic DH parameter selection.
-  // Matches Node's setDHParam('auto') throwing ERR_CRYPTO_UNSUPPORTED_OPERATION.
-  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L254
-  if (dhparam === "auto") {
-    throw $ERR_CRYPTO_UNSUPPORTED_OPERATION("Automatic DH parameter selection is not supported");
-  }
-  if (minVersion != null && !VALID_TLS_VERSIONS.has(minVersion))
-    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(minVersion), "minimum");
-  if (maxVersion != null && !VALID_TLS_VERSIONS.has(maxVersion))
-    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(maxVersion), "maximum");
-  if (ticketKeys !== undefined && ticketKeys !== null) {
-    validateBuffer(ticketKeys, "options.ticketKeys");
-    const ticketKeysByteLength = ticketKeys.byteLength;
-    if (ticketKeysByteLength !== 48) {
-      throw $ERR_INVALID_ARG_VALUE("options.ticketKeys", ticketKeysByteLength, "must be exactly 48 bytes");
-    }
-  }
-  // Negative session timeouts are rejected (min 0), matching Node — newer
-  // OpenSSL/BoringSSL do not handle negative values as users expect.
-  // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/internal/tls/secure-context.js#L319
-  if (sessionTimeout !== undefined && sessionTimeout !== null) {
-    // Node validates this with validateInt32(..., 0), whose range message
-    // reads ">= 0 && <= 2147483647"; the shared validator here words it
-    // differently, so spell the check out to match.
-    if (typeof sessionTimeout !== "number") {
-      throw $ERR_INVALID_ARG_TYPE("options.sessionTimeout", "number", sessionTimeout);
-    }
-    if (!Number.isInteger(sessionTimeout)) {
-      throw $ERR_OUT_OF_RANGE("options.sessionTimeout", "an integer", sessionTimeout);
-    }
-    if (sessionTimeout < 0 || sessionTimeout > 2147483647) {
-      throw $ERR_OUT_OF_RANGE("options.sessionTimeout", ">= 0 && <= 2147483647", sessionTimeout);
     }
   }
 }
@@ -535,8 +439,6 @@ function normalizePemKeyOption(key, ctxPassphrase) {
     return createPrivateKey({ key: k.pem, passphrase }).export({ type: "pkcs8", format: "pem" });
   });
 }
-
-const SSL_OP_CIPHER_SERVER_PREFERENCE = 0x00400000;
 
 function newNativeSecureContext(options, cached = false) {
   maybeWarnAboutExtraCACerts();

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -10,7 +10,6 @@ const {
   tlsStringToProtocolVersion,
   secureProtocolToVersionRange,
   processPfxOptions,
-  validateSecureProtocol,
   validateSecureContextOptions,
   SSL_OP_CIPHER_SERVER_PREFERENCE,
 } = require("internal/tls");

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1151,35 +1151,56 @@ describe("https.createServer forwards every TLS server option", () => {
     });
   });
 
+  const ecdhHandshake = async (port: number, ecdhCurve: string) => {
+    const outcome = Promise.withResolvers<string>();
+    const client = connect({ port, host: "127.0.0.1", rejectUnauthorized: false, ecdhCurve });
+    client.once("secureConnect", () => {
+      client.destroy();
+      outcome.resolve("ok");
+    });
+    client.once("error", err => {
+      client.destroy();
+      const code = (err as Error & { code?: string }).code ?? "error";
+      outcome.resolve(code.includes("HANDSHAKE_FAILURE") ? "handshake_failure" : code);
+    });
+    client.once("close", () => outcome.resolve("closed"));
+    return outcome.promise;
+  };
+
   it("restricts the key-share groups to ecdhCurve", async () => {
     await using server = https.createServer({ ...COMMON_CERT, ecdhCurve: "P-384" }, (_req, res) => res.end("ok"));
     server.on("tlsClientError", () => {});
     await once(server.listen(0, "127.0.0.1"), "listening");
     const { port } = server.address() as AddressInfo;
 
-    const handshake = async (ecdhCurve: string) => {
-      const outcome = Promise.withResolvers<string>();
-      const client = connect({ port, host: "127.0.0.1", rejectUnauthorized: false, ecdhCurve });
-      client.once("secureConnect", () => {
-        client.destroy();
-        outcome.resolve("ok");
-      });
-      client.once("error", err => {
-        client.destroy();
-        const code = (err as Error & { code?: string }).code ?? "error";
-        outcome.resolve(code.includes("HANDSHAKE_FAILURE") ? "handshake_failure" : code);
-      });
-      client.once("close", () => outcome.resolve("closed"));
-      return outcome.promise;
-    };
-
     expect({
-      x25519Only: await handshake("X25519"),
-      p384Only: await handshake("P-384"),
+      x25519Only: await ecdhHandshake(port, "X25519"),
+      p384Only: await ecdhHandshake(port, "P-384"),
     }).toEqual({
       x25519Only: "handshake_failure",
       p384Only: "ok",
     });
+  });
+
+  it("falls back to tls.DEFAULT_ECDH_CURVE when ecdhCurve is omitted", async () => {
+    const saved = tls.DEFAULT_ECDH_CURVE;
+    tls.DEFAULT_ECDH_CURVE = "P-384";
+    try {
+      await using server = https.createServer({ ...COMMON_CERT }, (_req, res) => res.end("ok"));
+      server.on("tlsClientError", () => {});
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { port } = server.address() as AddressInfo;
+
+      expect({
+        x25519Only: await ecdhHandshake(port, "X25519"),
+        p384Only: await ecdhHandshake(port, "P-384"),
+      }).toEqual({
+        x25519Only: "handshake_failure",
+        p384Only: "ok",
+      });
+    } finally {
+      tls.DEFAULT_ECDH_CURVE = saved;
+    }
   });
 
   it("honors the server cipher order unless honorCipherOrder is false", async () => {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1068,6 +1068,172 @@ it("createServer({pfx, requestCert}) verifies client certificates against the pf
   }
 });
 
+describe("https.createServer forwards every TLS server option", () => {
+  // ca2 signs agent3 and agent4; ca2-crl-agent3.pem revokes agent3 only.
+  const fixtures = join(import.meta.dir, "../test/fixtures/keys");
+  const read = (name: string) => readFileSync(join(fixtures, name), "utf8");
+  const mtls = {
+    key: read("agent1-key.pem"),
+    cert: read("agent1-cert.pem"),
+    ca: read("ca2-cert.pem"),
+    crl: read("ca2-crl-agent3.pem"),
+    requestCert: true,
+  };
+
+  type Verdict = { authorized: boolean | undefined; authorizationError: unknown };
+
+  async function httpsRequest(port: number, agent: string) {
+    const outcome = Promise.withResolvers<string>();
+    const req = https.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: `/${agent}`,
+        key: read(`${agent}-key.pem`),
+        cert: read(`${agent}-cert.pem`),
+        rejectUnauthorized: false,
+      },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on("data", chunk => chunks.push(chunk));
+        res.on("end", () => outcome.resolve(`served ${Buffer.concat(chunks)}`));
+      },
+    );
+    req.on("error", () => outcome.resolve("refused"));
+    req.end();
+    return outcome.promise;
+  }
+
+  it("refuses a client certificate that the crl revokes", async () => {
+    const verdicts: Record<string, Verdict> = {};
+    await using server = https.createServer({ ...mtls, rejectUnauthorized: true }, (req, res) => {
+      const socket = req.socket as TLSSocket;
+      const name = req.url!.slice(1);
+      verdicts[name] = { authorized: socket.authorized, authorizationError: socket.authorizationError };
+      res.end(name);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    expect({
+      revoked: await httpsRequest(port, "agent3"),
+      good: await httpsRequest(port, "agent4"),
+      verdicts,
+    }).toEqual({
+      revoked: "refused",
+      good: "served agent4",
+      verdicts: { agent4: { authorized: true, authorizationError: null } },
+    });
+  });
+
+  it("reports CERT_REVOKED on req.socket when rejectUnauthorized is false", async () => {
+    const verdicts: Record<string, Verdict> = {};
+    await using server = https.createServer({ ...mtls, rejectUnauthorized: false }, (req, res) => {
+      const socket = req.socket as TLSSocket;
+      const name = req.url!.slice(1);
+      verdicts[name] = { authorized: socket.authorized, authorizationError: socket.authorizationError };
+      res.end(name);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    expect({
+      revoked: await httpsRequest(port, "agent3"),
+      good: await httpsRequest(port, "agent4"),
+      verdicts,
+    }).toEqual({
+      revoked: "served agent3",
+      good: "served agent4",
+      verdicts: {
+        agent3: { authorized: false, authorizationError: "CERT_REVOKED" },
+        agent4: { authorized: true, authorizationError: null },
+      },
+    });
+  });
+
+  it("restricts the key-share groups to ecdhCurve", async () => {
+    await using server = https.createServer({ ...COMMON_CERT, ecdhCurve: "P-384" }, (_req, res) => res.end("ok"));
+    server.on("tlsClientError", () => {});
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const handshake = async (ecdhCurve: string) => {
+      const outcome = Promise.withResolvers<string>();
+      const client = connect({ port, host: "127.0.0.1", rejectUnauthorized: false, ecdhCurve });
+      client.once("secureConnect", () => {
+        client.destroy();
+        outcome.resolve("ok");
+      });
+      client.once("error", err => {
+        client.destroy();
+        const code = (err as Error & { code?: string }).code ?? "error";
+        outcome.resolve(code.includes("HANDSHAKE_FAILURE") ? "handshake_failure" : code);
+      });
+      client.once("close", () => outcome.resolve("closed"));
+      return outcome.promise;
+    };
+
+    expect({
+      x25519Only: await handshake("X25519"),
+      p384Only: await handshake("P-384"),
+    }).toEqual({
+      x25519Only: "handshake_failure",
+      p384Only: "ok",
+    });
+  });
+
+  it("honors the server cipher order unless honorCipherOrder is false", async () => {
+    const aes256 = "ECDHE-RSA-AES256-GCM-SHA384";
+    const aes128 = "ECDHE-RSA-AES128-GCM-SHA256";
+    const negotiated = async (honorCipherOrder: boolean | undefined) => {
+      await using server = https.createServer(
+        { ...COMMON_CERT, ciphers: `${aes256}:${aes128}`, honorCipherOrder },
+        (_req, res) => res.end("ok"),
+      );
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { port } = server.address() as AddressInfo;
+      const client = connect({
+        port,
+        host: "127.0.0.1",
+        rejectUnauthorized: false,
+        ciphers: `${aes128}:${aes256}`,
+        maxVersion: "TLSv1.2",
+      });
+      await once(client, "secureConnect");
+      const name = client.getCipher().name;
+      client.destroy();
+      return name;
+    };
+    expect({
+      default: await negotiated(undefined),
+      honored: await negotiated(true),
+      clientOrder: await negotiated(false),
+    }).toEqual({ default: aes256, honored: aes256, clientOrder: aes128 });
+  });
+
+  it("validates the secure context options like tls.createServer", () => {
+    const check = (options: object) => {
+      try {
+        https.createServer({ ...COMMON_CERT, ...options });
+      } catch (e: any) {
+        return e.code;
+      }
+      return "no error";
+    };
+    expect({
+      ecdhCurve: check({ ecdhCurve: "not-a-curve" }),
+      sessionTimeout: check({ sessionTimeout: -1 }),
+      sigalgs: check({ sigalgs: "" }),
+      crl: check({ crl: 42 }),
+    }).toEqual({
+      ecdhCurve: "ERR_CRYPTO_OPERATION_FAILED",
+      sessionTimeout: "ERR_OUT_OF_RANGE",
+      sigalgs: "ERR_INVALID_ARG_VALUE",
+      crl: "ERR_INVALID_ARG_TYPE",
+    });
+  });
+});
+
 it("SNICallback errors abort the handshake and surface as tlsClientError", async () => {
   // Node drops the connection before the handshake completes (no TLS alert is
   // sent) and emits 'tlsClientError' on the server with the callback's error.


### PR DESCRIPTION
### Problem
- `https.createServer({ crl, requestCert: true, rejectUnauthorized: true })` serves a client certificate that the CRL revokes, with `req.socket.authorized === true`. Node refuses it with `CERT_REVOKED`. Bun's `tls.createServer`, `Bun.serve` and `Bun.listen` refuse it too.
- The cause is `src/js/node/_http_server.ts:356`. The https Server builds its `Bun.serve` tls object from a fixed list of keys. `crl`, `sessionTimeout`, `ecdhCurve`, `sigalgs`, `honorCipherOrder` and `allowPartialTrustChain` never reach the native config, and no error says so.

### Fix
- Forward `crl`, `sessionTimeout`, `ecdhCurve` (with the `tls.DEFAULT_ECDH_CURVE` fallback that `tls.Server` uses), `sigalgs` and `allowPartialTrustChain` to the tls object. Fold `honorCipherOrder` into `secureOptions` as `SSL_OP_CIPHER_SERVER_PREFERENCE`, default true like `tls.Server` (`tls.ts:1276`) and Node.
- Run the same `validateSecureContextOptions` that `tls.createServer` runs, so a bad `ecdhCurve`, `sigalgs` or `sessionTimeout` throws from the constructor. The validator moves from `node/tls.ts` to `internal/tls.ts` so both modules share one copy.
- Correct because the native `SSLConfig` (`src/runtime/socket/SSLConfig.bindv2.ts`) already accepts every one of these keys. `Bun.serve` applies them through `as_usockets`. Only the https allowlist dropped them.
- Verified: `test/js/node/tls/node-tls-server.test.ts` (6 new tests, all fail on stock bun). Also `node-tls-context`, `node-tls-ecdh-curve`, `node-tls-connect`, `ssl-ctx-cache`, `node-http.test.ts` and the `test-https-*` node parallel tests. Self-reviewed: 3 concerns raised, 2 addressed (see Notes).

### Background
- `https.Server` in Bun is `http.Server` with a tls object. `listen()` passes that object to `Bun.serve({ tls })`. So every TLS option a user gives must be copied into that object by hand.
- `tls.createServer` goes through `newNativeSecureContext`, which hands the whole options object to native. That is why the same options work there.
- A CRL (certificate revocation list) is a CA-signed list of revoked serial numbers. BoringSSL only checks it when the CRL is loaded into the context's X509 store, which `crl` does.

<details><summary>Notes</summary>

Manual checks with `openssl s_client` against the debug build, https server:
- `sessionTimeout: 1`, TLS 1.2 session resumed after 2.5 s: `Reused` before, `New` after (node: `New`).
- `sessionTimeout` covers TLS 1.2 sessions only. The native site calls `SSL_CTX_set_timeout` (`packages/bun-usockets/src/crypto/openssl.c:1494`), which BoringSSL scopes to TLS 1.2 and below. A TLS 1.3 ticket keeps the 172800 s lifetime hint and is still `Reused` after 2.5 s (measured on `tls.createServer`, which shares that site; node: hint 1, `New`). #38145 fixes that natively for every TLS server. It is independent of this PR.
- `ciphers: "AES256:AES128"`, client prefers AES128: server picked AES128 before, AES256 after (honorCipherOrder default).
- `crl` with the revoked agent3 fixture: served before, `ECONNRESET` after.

Self-review concerns:
- https ignored `tls.DEFAULT_ECDH_CURVE` while `tls.Server` honors it. Addressed in 2e0899f, with a test.
- `honorCipherOrder` default true is a behaviour change for existing https servers that set `ciphers`. Kept: it matches Node and Bun's own `tls.Server`, and `honorCipherOrder: false` opts out. Called out in the Fix section above.
- This extends the hand-copied option list instead of making https reuse `tls.Server`'s translation. Not addressed here. #33054 (open, conflicting) moves the same validator into `internal/tls.ts` and forwards `ciphers`/`minVersion`/`maxVersion`, which have since landed on main. It does not forward `crl` or the other keys in this PR. A follow-up that makes both servers call one translation helper in `internal/tls.ts` would remove the remaining drift (`stripTls13CipherNames`, `setDefaultCACertificates`).

Not forwarded, because `Bun.serve`'s tls config has no equivalent: `ticketKeys`, `dhparam` (native takes a file path only), `SNICallback`, `ALPNProtocols`, the `keylog` event. Those stay as separate items.

`crl` without `key`/`cert` is ignored, as the https server is plaintext in that case today.

The `SNICallback runs even when the requested servername matches the bind hostname` test in the same file fails in this container with and without the change (`localhost` resolves to `::1` here, the client connects to `127.0.0.1`). It passes in CI.
</details>

