### PR TITLE
install: compare bytes on lockfile string pool hit

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2599,9 +2599,7 @@ impl<'a> StringBuilder<'a> {
     fn count_with_hash(&mut self, slice: &[u8], hash: u64) {
         self.assert_not_allocated();
 
-        // Reserve space unless the pool already holds this exact string. A hash
-        // hit alone is not enough: two distinct strings can share one hash, and
-        // `append` stores both, so both need reserved bytes.
+        // A hash hit with different bytes is a collision, and `append` stores it too.
         let already_pooled = match self.string_pool.get(hash) {
             Some(existing) => strings::eql(existing.slice(self.string_bytes.as_slice()), slice),
             None => false,
@@ -2653,10 +2651,6 @@ impl<'a> StringBuilder<'a> {
         let string_entry = self.string_pool.get_or_put(hash).expect("unreachable");
         if string_entry.found_existing {
             let existing = *string_entry.value_ptr;
-            // Two distinct strings can share one hash. Compare the bytes before
-            // the pooled string is reused, so a collision does not return
-            // another string's value. `count_with_hash` reserves space for the
-            // second string, so the fallback write stays inside the region.
             if strings::eql(existing.slice(self.string_bytes.as_slice()), slice) {
                 return T::from_pooled(existing, hash);
             }
@@ -2676,9 +2670,7 @@ impl<'a> StringBuilder<'a> {
         T::from_pooled(*string_entry.value_ptr, hash)
     }
 
-    /// Append `slice` into the reserved region without keeping it in the pool.
-    /// Used when a hash hit turns out to be a collision between two distinct
-    /// strings, so the second string still gets its own bytes.
+    /// Stores a string whose hash collides with a different pooled string.
     fn append_without_pool<T: StringBuilderType>(&mut self, slice: &[u8], hash: u64) -> T {
         debug_assert!(self.ptr.is_some());
         let start = self.off + self.len;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2599,7 +2599,14 @@ impl<'a> StringBuilder<'a> {
     fn count_with_hash(&mut self, slice: &[u8], hash: u64) {
         self.assert_not_allocated();
 
-        if !self.string_pool.contains(hash) {
+        // Reserve space unless the pool already holds this exact string. A hash
+        // hit alone is not enough: two distinct strings can share one hash, and
+        // `append` stores both, so both need reserved bytes.
+        let already_pooled = match self.string_pool.get(hash) {
+            Some(existing) => strings::eql(existing.slice(self.string_bytes.as_slice()), slice),
+            None => false,
+        };
+        if !already_pooled {
             self.cap += slice.len();
         }
     }
@@ -2644,21 +2651,43 @@ impl<'a> StringBuilder<'a> {
         debug_assert!(self.ptr.is_some()); // must call allocate first
 
         let string_entry = self.string_pool.get_or_put(hash).expect("unreachable");
-        if !string_entry.found_existing {
-            // See `append_without_pool` — safe indexing into the region
-            // `allocate()` already resized.
-            let start = self.off + self.len;
-            let end = start + slice.len();
-            self.string_bytes[start..end].copy_from_slice(slice);
-            let final_slice = &self.string_bytes[start..end];
-            self.len += slice.len();
-
-            *string_entry.value_ptr = SemverString::init(self.string_bytes.as_slice(), final_slice);
+        if string_entry.found_existing {
+            let existing = *string_entry.value_ptr;
+            // Two distinct strings can share one hash. Compare the bytes before
+            // the pooled string is reused, so a collision does not return
+            // another string's value. `count_with_hash` reserves space for the
+            // second string, so the fallback write stays inside the region.
+            if strings::eql(existing.slice(self.string_bytes.as_slice()), slice) {
+                return T::from_pooled(existing, hash);
+            }
+            return self.append_without_pool::<T>(slice, hash);
         }
+
+        // Safe indexing into the region `allocate()` already resized.
+        let start = self.off + self.len;
+        let end = start + slice.len();
+        self.string_bytes[start..end].copy_from_slice(slice);
+        let final_slice = &self.string_bytes[start..end];
+        self.len += slice.len();
+        *string_entry.value_ptr = SemverString::init(self.string_bytes.as_slice(), final_slice);
 
         debug_assert!(self.len <= self.cap);
 
         T::from_pooled(*string_entry.value_ptr, hash)
+    }
+
+    /// Append `slice` into the reserved region without keeping it in the pool.
+    /// Used when a hash hit turns out to be a collision between two distinct
+    /// strings, so the second string still gets its own bytes.
+    fn append_without_pool<T: StringBuilderType>(&mut self, slice: &[u8], hash: u64) -> T {
+        debug_assert!(self.ptr.is_some());
+        let start = self.off + self.len;
+        let end = start + slice.len();
+        self.string_bytes[start..end].copy_from_slice(slice);
+        let final_slice = &self.string_bytes[start..end];
+        self.len += slice.len();
+        debug_assert!(self.len <= self.cap);
+        T::from_init(self.string_bytes.as_slice(), final_slice, hash)
     }
 }
 

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -569,17 +569,8 @@ pub mod semver_string {
             if String::can_inline(str) {
                 return Ok(String::init_inline(str));
             }
-
             let hash = Builder::string_hash(str);
-            let entry = self.pool.get_or_put(hash)?;
-            if entry.found_existing {
-                return Ok(*entry.value_ptr);
-            }
-
-            // new entry
-            let new = String::init_append(self.bytes, str)?;
-            *entry.value_ptr = new;
-            Ok(new)
+            self.append_with_hash(str, hash)
         }
 
         pub fn append_with_hash(&mut self, str: &[u8], hash: u64) -> Result<String, AllocError> {
@@ -589,7 +580,15 @@ pub mod semver_string {
 
             let entry = self.pool.get_or_put(hash)?;
             if entry.found_existing {
-                return Ok(*entry.value_ptr);
+                let existing = *entry.value_ptr;
+                // Two distinct strings can share one hash. Compare the bytes
+                // before the pooled string is reused, so a collision does not
+                // return another string's value. `Builder::append_with_hash`
+                // does the same check.
+                if strings::eql(existing.slice(self.bytes), str) {
+                    return Ok(existing);
+                }
+                return String::init_append(self.bytes, str);
             }
 
             // new entry
@@ -600,25 +599,7 @@ pub mod semver_string {
 
         pub fn append_external(&mut self, str: &[u8]) -> Result<ExternalString, AllocError> {
             let hash = Builder::string_hash(str);
-
-            if String::can_inline(str) {
-                return Ok(ExternalString {
-                    value: String::init_inline(str),
-                    hash,
-                });
-            }
-
-            let entry = self.pool.get_or_put(hash)?;
-            if entry.found_existing {
-                return Ok(ExternalString {
-                    value: *entry.value_ptr,
-                    hash,
-                });
-            }
-
-            let new = String::init_append(self.bytes, str)?;
-            *entry.value_ptr = new;
-            Ok(ExternalString { value: new, hash })
+            self.append_external_with_hash(str, hash)
         }
 
         pub fn append_external_with_hash(
@@ -635,10 +616,15 @@ pub mod semver_string {
 
             let entry = self.pool.get_or_put(hash)?;
             if entry.found_existing {
-                return Ok(ExternalString {
-                    value: *entry.value_ptr,
-                    hash,
-                });
+                let existing = *entry.value_ptr;
+                if strings::eql(existing.slice(self.bytes), str) {
+                    return Ok(ExternalString {
+                        value: existing,
+                        hash,
+                    });
+                }
+                let new = String::init_append(self.bytes, str)?;
+                return Ok(ExternalString { value: new, hash });
             }
 
             let new = String::init_append(self.bytes, str)?;
@@ -843,6 +829,12 @@ pub mod semver_string {
         #[inline]
         pub fn contains(&self, hash: u64) -> bool {
             self.map.contains_key(&hash)
+        }
+        /// The pooled string for `hash`, if one is present. The caller compares
+        /// its bytes to guard against a hash collision.
+        #[inline]
+        pub fn get(&self, hash: u64) -> Option<String> {
+            self.map.get(&hash).copied()
         }
         /// Number of slots reservable without rehash.
         #[inline]

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -872,7 +872,15 @@ pub mod semver_string {
                 return;
             }
 
-            if !self.string_pool.contains(hash) {
+            // A hash hit with different bytes is a collision, and `append` stores it too.
+            let already_pooled = match self.string_pool.get(hash) {
+                Some(existing) => {
+                    let buf: &[u8] = self.ptr.as_deref().unwrap_or(&[]);
+                    strings::eql(existing.slice(buf), slice_)
+                }
+                None => false,
+            };
+            if !already_pooled {
                 self.cap += slice_.len();
             }
         }

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -578,10 +578,6 @@ pub mod semver_string {
             let entry = self.pool.get_or_put(hash)?;
             if entry.found_existing {
                 let existing = *entry.value_ptr;
-                // Two distinct strings can share one hash. Compare the bytes
-                // before the pooled string is reused, so a collision does not
-                // return another string's value. `Builder::append_with_hash`
-                // does the same check.
                 if strings::eql(existing.slice(self.bytes), str) {
                     return Ok(existing);
                 }
@@ -827,8 +823,6 @@ pub mod semver_string {
         pub fn contains(&self, hash: u64) -> bool {
             self.map.contains_key(&hash)
         }
-        /// The pooled string for `hash`, if one is present. The caller compares
-        /// its bytes to guard against a hash collision.
         #[inline]
         pub fn get(&self, hash: u64) -> Option<String> {
             self.map.get(&hash).copied()

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -178,10 +178,7 @@ pub mod external_string {
             lhs_buf: &[u8],
             rhs_buf: &[u8],
         ) -> Ordering {
-            if self.hash == rhs.hash && self.hash > 0 {
-                return Ordering::Equal;
-            }
-
+            // An equal hash is not an equal string. Order by the bytes.
             self.value.order(rhs.value, lhs_buf, rhs_buf)
         }
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -28,6 +28,7 @@ import {
   type TestContext,
 } from "./dummy.registry.js";
 import { constructStdCollision } from "./wyhash-std-collision.js";
+import { wyhash11 } from "./wyhash11.js";
 
 expect.extend({
   toBeWorkspaceLink,
@@ -11217,6 +11218,69 @@ it.skipIf(isWindows)("file: deps with colliding abs-path hashes resolve to disti
   const alpha = await file(join(victimDir, "node_modules", "alphadep", "package.json")).json();
   const beta = await file(join(victimDir, "node_modules", "betadep", "package.json")).json();
   expect({ alpha: alpha.name, beta: beta.name }).toEqual({ alpha: "pkg-alpha", beta: "pkg-beta" });
+});
+
+// The lockfile interns every out-of-line string in a pool keyed by
+// Wyhash11(0, bytes). The pool returned the pooled string on a hash hit with
+// no byte compare, so two dependency specifiers that collide under that hash
+// shared one string. The second dependency then inherited the first
+// specifier and its resolution: the lockfile recorded the wrong specifier
+// text, the wrong integrity, and collapsed two packages into one.
+// https://github.com/oven-sh/bun/issues/32741
+it.skipIf(isWindows)("colliding tarball specifiers intern to distinct strings", async () => {
+  // Two 68-byte relative tarball paths that differ in one byte and collide
+  // under Wyhash11(0). The interning pool keys on that hash.
+  const specA = "./t/m3daaaaaaaaaaaaaaaaaaaaaaaaa.7aQs_ePaaaaaaaaw9Aaaaaaaaaaaaaa.tgz";
+  const specB = "./t/m3daaaaaaaaaaaaaaaaaaaaaaaaa.7aQs_ePbaaaaaaaw9Aaaaaaaaaaaaaa.tgz";
+  const enc = (s: string) => new TextEncoder().encode(s);
+  // Confirm the collision holds before relying on it.
+  expect(specA).not.toBe(specB);
+  expect(wyhash11(0n, enc(specA))).toBe(wyhash11(0n, enc(specB)));
+
+  using dir = tempDir("pool-collision", {
+    "A/package/package.json": JSON.stringify({ name: "pa", version: "1.0.0", main: "index.js" }),
+    "A/package/index.js": `module.exports = "I am A";`,
+    "B/package/package.json": JSON.stringify({ name: "pb", version: "2.0.0", main: "index.js" }),
+    "B/package/index.js": `module.exports = "I am B";`,
+  });
+  const root = String(dir);
+  await mkdir(join(root, "t"), { recursive: true });
+  for (const [src, spec] of [
+    ["A", specA],
+    ["B", specB],
+  ] as const) {
+    await using tar = Bun.spawn({
+      cmd: ["tar", "-czf", join(root, spec), "-C", join(root, src), "package"],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(await tar.exited).toBe(0);
+  }
+  await write(join(root, "package.json"), JSON.stringify({ name: "app", dependencies: { pa: specA, pb: specB } }));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: root,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  // Two distinct resolutions install as two packages, not one.
+  expect(stdout).toContain("2 packages installed");
+  expect(exitCode).toBe(0);
+
+  // The lockfile keeps both specifiers. Before the fix the pool returned
+  // specA for specB, so specB never reached the lockfile.
+  const lock = await file(join(root, "bun.lock")).text();
+  expect(lock).toContain(specA);
+  expect(lock).toContain(specB);
+
+  // Each package keeps its own resolution, so the two integrity hashes differ.
+  const integrities = [...lock.matchAll(/"(sha512-[^"]+)"/g)].map(m => m[1]);
+  expect(new Set(integrities).size).toBe(2);
 });
 
 it("reports an invalid URL for a manifest tarball URL containing a newline", async () => {

--- a/test/cli/install/wyhash11.ts
+++ b/test/cli/install/wyhash11.ts
@@ -1,0 +1,85 @@
+// Pure-JS port of `Wyhash11` (the legacy 32-byte-round, 5-prime wyhash variant
+// in src/wyhash/lib.rs). `Wyhash11::hash(0, bytes)` keys the lockfile string
+// interning pool (`semver::string::Buf`), so two different strings whose bytes
+// collide under this function share one pool slot. Use this to confirm a
+// collision holds before a test relies on it. This is a different algorithm
+// from `Bun.hash.wyhash` (the final4 variant); do not substitute one for the
+// other.
+
+const MASK = (1n << 64n) - 1n;
+const M128 = (1n << 128n) - 1n;
+const P = [
+  0xa0761d6478bd642fn,
+  0xe7037ed1a0b428dbn,
+  0x8ebc6af09c88c6e3n,
+  0x589965cc75374cc3n,
+  0x1d8e4e27c47d124fn,
+];
+
+function rd(n: number, d: Uint8Array, o: number): bigint {
+  let r = 0n;
+  for (let i = 0; i < n; i++) r |= BigInt(d[o + i]) << BigInt(8 * i);
+  return r;
+}
+// read_8bytes_swapped: the two 32-bit halves are swapped relative to a plain LE u64.
+const rd8sw = (d: Uint8Array, o: number) => ((rd(4, d, o) << 32n) | rd(4, d, o + 4)) & MASK;
+
+function mum(a: bigint, b: bigint): bigint {
+  const r = ((a & MASK) * (b & MASK)) & M128;
+  return ((r >> 64n) ^ r) & MASK;
+}
+const mix0 = (a: bigint, b: bigint, s: bigint) => mum((a ^ s ^ P[0]) & MASK, (b ^ s ^ P[1]) & MASK);
+const mix1 = (a: bigint, b: bigint, s: bigint) => mum((a ^ s ^ P[2]) & MASK, (b ^ s ^ P[3]) & MASK);
+
+function byteWord(k: Uint8Array, o: number, len: number): bigint {
+  // Reproduces the `read4<<N | read2<<M | read1` tail assembly for 1..=7 bytes.
+  switch (len) {
+    case 1:
+      return rd(1, k, o);
+    case 2:
+      return rd(2, k, o);
+    case 3:
+      return (rd(2, k, o) << 8n) | rd(1, k, o + 2);
+    case 4:
+      return rd(4, k, o);
+    case 5:
+      return (rd(4, k, o) << 8n) | rd(1, k, o + 4);
+    case 6:
+      return (rd(4, k, o) << 16n) | rd(2, k, o + 4);
+    case 7:
+      return (rd(4, k, o) << 24n) | (rd(2, k, o + 4) << 8n) | rd(1, k, o + 6);
+    default:
+      throw new Error("byteWord: len must be 1..=7, got " + len);
+  }
+}
+
+function finalSeed(seed: bigint, k: Uint8Array, o: number, len: number): bigint {
+  if (len === 0) return seed;
+  if (len <= 7) return mix0(byteWord(k, o, len), P[4], seed);
+  if (len === 8) return mix0(rd8sw(k, o), P[4], seed);
+  if (len <= 15) return mix0(rd8sw(k, o), byteWord(k, o + 8, len - 8), seed);
+  if (len === 16) return mix0(rd8sw(k, o), rd8sw(k, o + 8), seed);
+  // 17..=31: head over the first 16 bytes, tail over the remainder.
+  const head = mix0(rd8sw(k, o), rd8sw(k, o + 8), seed);
+  const remLen = len - 16;
+  const tail = remLen <= 7 ? mix1(byteWord(k, o + 16, remLen), P[4], seed) : mix1(rd8sw(k, o + 16), remLen === 8 ? P[4] : byteWord(k, o + 24, remLen - 8), seed);
+  return (head ^ tail) & MASK;
+}
+
+export function wyhash11(seed: bigint | number, bytes: Uint8Array): bigint {
+  let s = BigInt(seed) & MASK;
+  const len = bytes.length;
+  const aligned = len - (len % 32);
+  let off = 0;
+  while (off < aligned) {
+    s =
+      (mix0(rd(8, bytes, off), rd(8, bytes, off + 8), s) ^
+        mix1(rd(8, bytes, off + 16), rd(8, bytes, off + 24), s)) &
+      MASK;
+    off += 32;
+  }
+  const finalLen = len - aligned;
+  const s2 = finalSeed(s, bytes, aligned, finalLen);
+  const msgLen = BigInt(aligned + finalLen);
+  return mum((s2 ^ msgLen) & MASK, P[4]);
+}


### PR DESCRIPTION
### Problem
- The lockfile interns every out-of-line string in a pool keyed by `Wyhash11(0, bytes)`. On a hash hit, `StringBuilder::append` (`src/install/lockfile.rs`) returned the pooled string with no byte compare.
- Two distinct strings can share one 64-bit hash. So one dependency could inherit another dependency's pooled string. A crafted pair of local tarball specifiers that differ in one byte and collide under `Wyhash11(0)` made the second dependency take the first specifier. Both resolved to one package, and the lockfile recorded the wrong specifier and the wrong integrity.

### Fix
- Compare the bytes on a pool hit. Return the pooled string only when the bytes match. On a collision, store the second string on its own with `append_without_pool`.
- `count` now reserves space for the second string, so the fallback write stays inside the builder region.
- Apply the same compare to `semver::string::Buf` (text lockfile, git, and yarn specifiers), which had the same gap.
- The sibling `semver::string::Builder` already does this compare. The fix makes all three interning paths agree. `ExternalString::order` also stopped short-circuiting to `Equal` on a hash match, so version tags order by bytes.
- Verified: `test/cli/install/bun-install.test.ts` (new block, stock bun installs one package, the fixed build installs two with distinct specifiers and integrity). Also `bun-lockb.test.ts`, `bun-install-tarball-integrity.test.ts`, and the existing folder-resolution collision test.

### Background
- The install string pool deduplicates repeated strings (names, versions, specifiers) in one growable buffer. Each pooled entry is a `{offset, length}` into that buffer.
- A hash is not an identity. Bun already byte-compares at several hash-keyed sites (`#32741`, PR `#32745`). This adds the same guard to the string pool.
- Out of scope, on purpose: `Version::eql` and `Tag::eql` compare `pre` tags by hash only. They take no string buffers, so a byte compare needs a signature change across 22 callers. The on-disk tarball cache folder is still named by `Wyhash11(0, url)` alone, so colliding URLs install the wrong bytes even with this fix. That is a separate cache-format change and is tracked separately.

<details><summary>Notes</summary>

The collision pair used in the test is two 68-byte relative tarball paths that differ in one byte and collide under `Wyhash11(0)`. `test/cli/install/wyhash11.ts` is a JS port of `Wyhash11` used to assert the collision holds before the test relies on it.

Stock bun: the lockfile records `pb` with `pa`'s specifier and `pa`'s sha512, one package installed. Fixed: two packages, each with its own specifier and integrity.

The cache-folder collision (`cached_tarball_folder_name_print`, `src/install/PackageManager/PackageManagerDirectories.rs`) is why the installed bytes are still wrong for colliding URLs. It needs a collision-resistant folder name, which changes the persisted cache format.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->