### PR TITLE
bunfig: match the jsx runtime name case-insensitively

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -952,14 +952,15 @@ impl<'a> Parser<'a> {
 
         if let Some(expr) = json.get(b"jsx") {
             if let Some(value) = expr.as_string(self.bump) {
-                if value == b"react" {
+                // Case-insensitive, like the same key in tsconfig.json.
+                if value.eq_ignore_ascii_case(b"react") {
                     jsx_runtime = api::JsxRuntime::Classic;
-                } else if value == b"solid" {
+                } else if value.eq_ignore_ascii_case(b"solid") {
                     jsx_runtime = api::JsxRuntime::Solid;
-                } else if value == b"react-jsx" {
+                } else if value.eq_ignore_ascii_case(b"react-jsx") {
                     jsx_runtime = api::JsxRuntime::Automatic;
                     jsx_dev = false;
-                } else if value == b"react-jsxDEV" {
+                } else if value.eq_ignore_ascii_case(b"react-jsxdev") {
                     jsx_runtime = api::JsxRuntime::Automatic;
                     jsx_dev = true;
                 } else {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1374,7 +1374,7 @@ describe.concurrent("jsx/bunfigRuntimeSpelling", () => {
     "node_modules/react/jsx-runtime.js": `export function jsx() { return "jsx"; }`,
     "index.tsx": `import React from "react";\nconsole.log(<a />);`,
   };
-  for (const [spelling, expected] of [
+  test.each([
     ["react", "createElement"],
     ["React", "createElement"],
     ["react-jsxdev", "jsxDEV"],
@@ -1382,20 +1382,18 @@ describe.concurrent("jsx/bunfigRuntimeSpelling", () => {
     ["REACT-JSXDEV", "jsxDEV"],
     ["react-jsx", "jsx"],
     ["React-JSX", "jsx"],
-  ]) {
-    test(`jsx = "${spelling}"`, async () => {
-      using dir = tempDir("bunfig-jsx-spelling", { ...stubs, "bunfig.toml": `jsx = "${spelling}"\n` });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "index.tsx"],
-        env: { ...bunEnv, NODE_ENV: "development" },
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe(`${expected}\n`);
-      expect(exitCode).toBe(0);
+  ])('jsx = "%s"', async (spelling, expected) => {
+    using dir = tempDir("bunfig-jsx-spelling", { ...stubs, "bunfig.toml": `jsx = "${spelling}"\n` });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.tsx"],
+      env: { ...bunEnv, NODE_ENV: "development" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
     });
-  }
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`${expected}\n`);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1363,3 +1363,36 @@ describe("bundler", () => {
     });
   });
 });
+
+// The bunfig `jsx` key takes the tsconfig `compilerOptions.jsx` values, and
+// tsconfig matches them case-insensitively.
+describe.concurrent("jsx/bunfigRuntimeSpelling", () => {
+  const stubs = {
+    "node_modules/react/package.json": `{ "name": "react" }`,
+    "node_modules/react/jsx-dev-runtime.js": `export function jsxDEV() { return "jsxDEV"; }`,
+    "node_modules/react/jsx-runtime.js": `export function jsx() { return "jsx"; }`,
+    "index.tsx": `console.log(<a />);`,
+  };
+  for (const [spelling, expected] of [
+    ["react-jsxdev", "jsxDEV"],
+    ["react-jsxDEV", "jsxDEV"],
+    ["REACT-JSXDEV", "jsxDEV"],
+    ["react-jsx", "jsx"],
+    ["React-JSX", "jsx"],
+  ]) {
+    test(`jsx = "${spelling}"`, async () => {
+      using dir = tempDir("bunfig-jsx-spelling", { ...stubs, "bunfig.toml": `jsx = "${spelling}"\n` });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.tsx"],
+        env: { ...bunEnv, NODE_ENV: "development" },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(`${expected}\n`);
+      expect(exitCode).toBe(0);
+    });
+  }
+});

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1368,12 +1368,15 @@ describe("bundler", () => {
 // tsconfig matches them case-insensitively.
 describe.concurrent("jsx/bunfigRuntimeSpelling", () => {
   const stubs = {
-    "node_modules/react/package.json": `{ "name": "react" }`,
+    "node_modules/react/package.json": `{ "name": "react", "main": "index.js" }`,
+    "node_modules/react/index.js": `export default { createElement() { return "createElement"; } };`,
     "node_modules/react/jsx-dev-runtime.js": `export function jsxDEV() { return "jsxDEV"; }`,
     "node_modules/react/jsx-runtime.js": `export function jsx() { return "jsx"; }`,
-    "index.tsx": `console.log(<a />);`,
+    "index.tsx": `import React from "react";\nconsole.log(<a />);`,
   };
   for (const [spelling, expected] of [
+    ["react", "createElement"],
+    ["React", "createElement"],
     ["react-jsxdev", "jsxDEV"],
     ["react-jsxDEV", "jsxDEV"],
     ["REACT-JSXDEV", "jsxDEV"],


### PR DESCRIPTION
### Problem
- `jsx = "react-jsxdev"` in `bunfig.toml` fails to load: `error: Invalid jsx runtime, only 'react', 'solid', 'react-jsx', and 'react-jsxDEV' are supported`. Every bun command in that directory then fails with `Invalid Bunfig`.
- `react-jsxdev` is the spelling tsconfig and the TypeScript docs use, and bun's tsconfig loader matches the value case-insensitively (`src/resolver/tsconfig_json.rs:481`). The bunfig loader (`src/bunfig/bunfig.rs:955`) compared the bytes exactly.

### Fix
- Compare the bunfig `jsx` value with `eq_ignore_ascii_case`, for all four names.
- The docs present the bunfig `jsx*` keys as the tsconfig `compilerOptions` keys, so both loaders now accept the same spellings.
- Verified: `test/bundler/bundler_jsx.test.ts` (`jsx/bunfigRuntimeSpelling`, 3 of 5 cases fail on stock bun). Also the rest of `bundler_jsx.test.ts` and `test/cli/bunfig-test-options.test.ts`.

### Background
- `bunfig.toml` `jsx` selects the JSX runtime for `bun run` and `bun build`: `react` (classic `React.createElement`), `react-jsx` (automatic, production `jsx`), `react-jsxDEV` (automatic, development `jsxDEV`), and `solid`.
- `tsconfig.json` `compilerOptions.jsx` has the same job. bun lowercases that value before the lookup, so `REACT-JSXDEV` works there.

<details><summary>Notes</summary>

Repro:

```sh
printf 'jsx = "react-jsxdev"\n' > bunfig.toml
bun app.tsx
# error: Invalid jsx runtime, only 'react', 'solid', 'react-jsx', and 'react-jsxDEV' are supported
```

Reproduced on 1.4.2 and on canary. Found by a JSX configuration comparison against tsc.
</details>
