### PR TITLE
redis: remember the database a SELECT chose across reconnect and duplicate()

### DIFF
--- a/src/runtime/valkey_jsc/ValkeyCommand.rs
+++ b/src/runtime/valkey_jsc/ValkeyCommand.rs
@@ -34,6 +34,14 @@ impl<'a> Args<'a> {
             Args::Raw(args) => args.len(),
         }
     }
+
+    fn get(&self, index: usize) -> Option<&[u8]> {
+        match self {
+            Args::Slices(args) => args.get(index).map(|arg| arg.slice()),
+            Args::Args(args) => args.get(index).map(|arg| arg.slice()),
+            Args::Raw(args) => args.get(index).copied(),
+        }
+    }
 }
 
 impl<'a> Command<'a> {
@@ -82,6 +90,18 @@ impl<'a> Command<'a> {
         let mut buf: Vec<u8> = Vec::with_capacity(self.byte_length());
         self.write(&mut buf)?;
         Ok(buf.into_boxed_slice())
+    }
+
+    /// The database index this command selects, when it is a `SELECT <n>`.
+    /// The index is remembered once the server replies `OK`, so a reconnect
+    /// and `duplicate()` land on the same database.
+    pub(crate) fn selected_db(&self) -> Option<u32> {
+        if !bun_core::strings::eql_case_insensitive_ascii(self.command, b"SELECT", true)
+            || self.args.len() != 1
+        {
+            return None;
+        }
+        core::str::from_utf8(self.args.get(0)?).ok()?.parse().ok()
     }
 }
 
@@ -182,13 +202,19 @@ fn is_subscription_command(name: &[u8]) -> bool {
 /// Promise for a Valkey command
 pub struct Promise {
     pub(crate) meta: Meta,
+    /// See [`Command::selected_db`].
+    pub(crate) selected_db: Option<u32>,
     pub(crate) promise: jsc::JSPromiseStrong,
 }
 
 impl Promise {
-    pub(crate) fn create(global_object: &JSGlobalObject, meta: Meta) -> Promise {
+    pub(crate) fn create(global_object: &JSGlobalObject, command: &Command<'_>) -> Promise {
         let promise = jsc::JSPromiseStrong::init(global_object);
-        Promise { meta, promise }
+        Promise {
+            meta: command.meta,
+            selected_db: command.selected_db(),
+            promise,
+        }
     }
 
     pub(crate) fn resolve(

--- a/src/runtime/valkey_jsc/ValkeyCommand.rs
+++ b/src/runtime/valkey_jsc/ValkeyCommand.rs
@@ -92,9 +92,7 @@ impl<'a> Command<'a> {
         Ok(buf.into_boxed_slice())
     }
 
-    /// The database index this command selects, when it is a `SELECT <n>`.
-    /// The index is remembered once the server replies `OK`, so a reconnect
-    /// and `duplicate()` land on the same database.
+    /// `Some(n)` for a `SELECT n` command.
     pub(crate) fn selected_db(&self) -> Option<u32> {
         if !bun_core::strings::eql_case_insensitive_ascii(self.command, b"SELECT", true)
             || self.args.len() != 1

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -719,6 +719,7 @@ impl JSValkeyClient {
                     valkey::TLS::None
                 },
                 database,
+                selected_database: database,
                 flags: valkey::ConnectionFlags {
                     enable_auto_reconnect: options.enable_auto_reconnect,
                     enable_offline_queue: options.enable_offline_queue,
@@ -822,6 +823,7 @@ impl JSValkeyClient {
                 }),
                 tls,
                 database: client.database,
+                selected_database: client.database,
                 flags: valkey::ConnectionFlags {
                     enable_offline_queue: if sub_ctx.is_subscriber {
                         sub_ctx.original_enable_offline_queue

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -1207,6 +1207,12 @@ impl ValkeyClient {
             }
         }
 
+        if let Some(db) = pair.promise.selected_db
+            && matches!(value, RESPValue::SimpleString(ok) if ok.as_ref() == b"OK")
+        {
+            self.database = db;
+        }
+
         // Resolve the promise with the potentially transformed value
         let promise_ptr = &mut pair.promise;
         let global_this = self.global_object();
@@ -1441,7 +1447,7 @@ impl ValkeyClient {
         let mut checked_command = *command;
         checked_command.meta = command.meta.check(command);
 
-        let mut promise = command::Promise::create(global_this, checked_command.meta);
+        let mut promise = command::Promise::create(global_this, &checked_command);
 
         let js_promise: *mut JSPromise = std::ptr::from_mut::<JSPromise>(promise.promise.get());
         if let Some(message) = self.send_rejection() {

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -258,7 +258,11 @@ pub struct ValkeyClient {
     // when constructing/duplicating clients.
     pub(crate) password: Box<[u8]>,
     pub(crate) username: Box<[u8]>,
+    /// The database from the URL. `duplicate()` copies it.
     pub(crate) database: u32,
+    /// The database this client's session is on: the URL database until a
+    /// `SELECT` is acknowledged. The reconnect handshake replays it.
+    pub(crate) selected_database: u32,
     pub(crate) address: Address,
     pub(crate) protocol: Protocol,
 
@@ -1088,7 +1092,7 @@ impl ValkeyClient {
                     }
 
                     // SELECT was successful.
-                    debug!("SELECT {} successful", self.database);
+                    debug!("SELECT {} successful", self.selected_database);
                     // Connection is now fully ready on the specified database.
                     // If any commands were queued while waiting for SELECT, try to send them.
                     self.send_next_command();
@@ -1210,7 +1214,7 @@ impl ValkeyClient {
         if let Some(db) = pair.promise.selected_db
             && matches!(value, RESPValue::SimpleString(ok) if ok.as_ref() == b"OK")
         {
-            self.database = db;
+            self.selected_database = db;
         }
 
         // Resolve the promise with the potentially transformed value
@@ -1276,9 +1280,9 @@ impl ValkeyClient {
         }
 
         // If using a specific database, send SELECT command
-        if self.database > 0 {
+        if self.selected_database > 0 {
             let mut int_buf = [0u8; 64];
-            let db_str = bun_core::fmt::int_as_bytes(&mut int_buf, self.database);
+            let db_str = bun_core::fmt::int_as_bytes(&mut int_buf, self.selected_database);
             let select_cmd = Command {
                 command: b"SELECT",
                 args: Args::Raw(&[db_str]),

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -258,10 +258,9 @@ pub struct ValkeyClient {
     // when constructing/duplicating clients.
     pub(crate) password: Box<[u8]>,
     pub(crate) username: Box<[u8]>,
-    /// The database from the URL. `duplicate()` copies it.
+    /// From the URL. `duplicate()` copies it.
     pub(crate) database: u32,
-    /// The database this client's session is on: the URL database until a
-    /// `SELECT` is acknowledged. The reconnect handshake replays it.
+    /// Follows an acknowledged `SELECT`. The reconnect handshake replays it.
     pub(crate) selected_database: u32,
     pub(crate) address: Address,
     pub(crate) protocol: Protocol,

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -504,7 +504,7 @@ describe("Valkey: Auto-Reconnect Selected Database", () => {
   const options = { autoReconnect: true, enableOfflineQueue: true, connectionTimeout: 5000, maxRetries: 10 };
   const currentDb = (client: RedisClient) => client.send("CLIENT", ["INFO"]);
 
-  test("select() is replayed after an auto-reconnect and inherited by duplicate()", async () => {
+  test("select() is replayed after an auto-reconnect, and duplicate() starts on the URL database", async () => {
     using peer = createDbPeer();
     const port = await peer.listen();
     const client = new RedisClient(`redis://127.0.0.1:${port}/2`, options);
@@ -523,11 +523,13 @@ describe("Valkey: Auto-Reconnect Selected Database", () => {
         ["SELECT", "5"],
       ]);
 
+      // Like ioredis and node-redis, a duplicate is built from the
+      // configuration, not from the session's SELECT.
       duplicate = await client.duplicate();
-      expect(await currentDb(duplicate)).toBe("db=5");
+      expect(await currentDb(duplicate)).toBe("db=2");
       expect(peer.commands[2].slice(0, 2)).toEqual([
         ["HELLO", "3"],
-        ["SELECT", "5"],
+        ["SELECT", "2"],
       ]);
     } finally {
       duplicate?.close();

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -450,6 +450,119 @@ describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
   });
 });
 
+describe("Valkey: Auto-Reconnect Selected Database", () => {
+  // A RESP peer that tracks the selected database per connection and
+  // records every command it receives, per connection.
+  function createDbPeer() {
+    const sockets: net.Socket[] = [];
+    const commands: string[][][] = [];
+    const hellos: PromiseWithResolvers<void>[] = [];
+    const helloOn = (connection: number) => {
+      while (hellos.length < connection) hellos.push(Promise.withResolvers<void>());
+      return hellos[connection - 1].promise;
+    };
+    const server = net.createServer(socket => {
+      const connection = commands.push([]);
+      sockets.push(socket);
+      const state = { buffer: Buffer.alloc(0), db: 0 };
+      socket.on("data", chunk => {
+        state.buffer = Buffer.concat([state.buffer, chunk]);
+        for (const args of readCommands(state)) {
+          commands[connection - 1].push(args);
+          const name = (args[0] ?? "").toUpperCase();
+          if (name === "HELLO") {
+            socket.write("+OK\r\n");
+            helloOn(connection);
+            hellos[connection - 1].resolve();
+          } else if (name === "SELECT") {
+            state.db = Number(args[1]);
+            socket.write("+OK\r\n");
+          } else if (name === "CLIENT") {
+            const info = `db=${state.db}`;
+            socket.write(`$${info.length}\r\n${info}\r\n`);
+          } else {
+            socket.write("+OK\r\n");
+          }
+        }
+      });
+      socket.on("error", () => {});
+    });
+    return {
+      listen: () =>
+        new Promise<number>(resolve =>
+          server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
+        ),
+      commands,
+      helloOn,
+      dropAll: () => sockets.splice(0).forEach(socket => socket.destroy()),
+      [Symbol.dispose]: () => {
+        server.close();
+        sockets.forEach(socket => socket.destroy());
+      },
+    };
+  }
+  const options = { autoReconnect: true, enableOfflineQueue: true, connectionTimeout: 5000, maxRetries: 10 };
+  const currentDb = (client: RedisClient) => client.send("CLIENT", ["INFO"]);
+
+  test("select() is replayed after an auto-reconnect and inherited by duplicate()", async () => {
+    using peer = createDbPeer();
+    const port = await peer.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}/2`, options);
+    let duplicate: RedisClient | undefined;
+    try {
+      await client.set("a", "1");
+      expect(await (client as any).select(5)).toBe("OK");
+      expect(await currentDb(client)).toBe("db=5");
+
+      peer.dropAll();
+      await peer.helloOn(2);
+      await client.set("c", "1");
+      expect(await currentDb(client)).toBe("db=5");
+      expect(peer.commands[1].slice(0, 2)).toEqual([
+        ["HELLO", "3"],
+        ["SELECT", "5"],
+      ]);
+
+      duplicate = await client.duplicate();
+      expect(await currentDb(duplicate)).toBe("db=5");
+      expect(peer.commands[2].slice(0, 2)).toEqual([
+        ["HELLO", "3"],
+        ["SELECT", "5"],
+      ]);
+    } finally {
+      duplicate?.close();
+      client.close();
+    }
+  });
+
+  test("a raw SELECT is tracked too, and select(0) stops the reconnect SELECT", async () => {
+    using peer = createDbPeer();
+    const port = await peer.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}/2`, options);
+    try {
+      expect(await client.send("SELECT", ["4"])).toBe("OK");
+      peer.dropAll();
+      await peer.helloOn(2);
+      expect(await currentDb(client)).toBe("db=4");
+      expect(peer.commands[1].slice(0, 2)).toEqual([
+        ["HELLO", "3"],
+        ["SELECT", "4"],
+      ]);
+
+      expect(await (client as any).select(0)).toBe("OK");
+      peer.dropAll();
+      await peer.helloOn(3);
+      expect(await currentDb(client)).toBe("db=0");
+      expect(peer.commands[2].slice(0, 2)).toEqual([
+        ["HELLO", "3"],
+        ["CLIENT", "INFO"],
+      ]);
+    } finally {
+      client.close();
+    }
+  });
+});
+
 describe("Valkey: Recovering After fail()", () => {
   // Answers the chunk carrying HELLO with `+OK` and the one carrying PING with
   // `+PONG` unless `replies` says otherwise for that connection (a hook that


### PR DESCRIPTION
### Problem
- After `await client.select(5)`, an auto-reconnect sends `SELECT 2` (the database from the URL) or no `SELECT` at all. Later commands silently run against the wrong database.
- Cause: `authenticate` in `src/runtime/valkey_jsc/valkey.rs:1273` sends `SELECT` from `self.database`, which only the URL parser wrote. `select()` and `send("SELECT", [n])` are plain passthrough commands that never updated it. ioredis and node-redis both re-select the last chosen database on reconnect.

### Fix
- `Command::selected_db` (`ValkeyCommand.rs`) recognizes a `SELECT <n>` command with one integer argument. `Promise::create` stores that index next to the command's `meta`.
- When the reply for that command arrives and is `+OK`, `handle_response` writes the index to a new field, `selected_database`. The reconnect handshake sends that field. `select(0)` sets it to 0, and the handshake then sends no `SELECT`, which is the Redis default.
- `database` keeps the URL value, and `duplicate()` still copies it. A duplicate starts on the configured database, as in ioredis and node-redis, which build a duplicate from the client options.
- A `SELECT` that the server rejects, or that was in flight when the connection dropped, leaves `selected_database` as it was. Only an acknowledged `SELECT` changes it.
- Verified: `test/js/valkey/reliability/connection-failures.test.ts` ("Valkey: Auto-Reconnect Selected Database", two tests, both fail on stock bun). Also the rest of that file.

### Background
- `RedisClient` keeps one `ValkeyClient` state struct per connection. `database: u32` in it is the index from the URL. The handshake selects `selected_database` after `HELLO`.
- Every command sent gets a `Promise` record (`meta` flags plus the JS promise) that waits in `in_flight` until its reply arrives. `handle_response` pops the record and resolves the promise. The new `selected_db` field rides on that record.
- Redis replies to `SELECT` with the simple string `OK`. Inside `MULTI` it replies `QUEUED`, so a `SELECT` queued in a transaction does not update the tracked index.

<details><summary>Notes</summary>

Found with an in-process RESP3 peer that logs every command byte for byte: `before drop: db=5`, `after reconnect: db=2`. With the fix both read `db=5` and the second connection sends `HELLO 3`, `SELECT 5`.

The raw `send("SELECT", ["4"])` path is covered as well because the check runs in `ValkeyClient::send`, which both entry points share. The command name is matched case-insensitively.

Self-reviewed: the review found that the first version also made `duplicate()` inherit the session `SELECT`, which neither ioredis nor node-redis does. Commit e06b802 splits the field so `duplicate()` keeps the URL database.
</details>
