### PR TITLE
Flush queued inspector messages before the process exits

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -11,8 +11,7 @@ class SocketFramer {
   sizeBuffer: Buffer = Buffer.alloc(4);
   sizeBufferIndex: number = 0;
   bufferedData: Buffer = Buffer.alloc(0);
-  // True while the socket holds bytes from `send` that it has not written yet.
-  // The socket's `drain` handler clears it.
+  // Set by a partial `$write`, cleared by the socket's `drain` handler.
   hasUnsentData = false;
 
   constructor(private onMessage: (message: string | string[]) => void) {
@@ -30,7 +29,6 @@ class SocketFramer {
     this.hasUnsentData = false;
   }
 
-  // The socket's `drain` handler fires once every buffered byte is written.
   didDrain(): void {
     this.hasUnsentData = false;
     reportExitFlushIfDrained();
@@ -144,14 +142,11 @@ export default function (
   return flushBeforeExit;
 }
 
-// Client transports that can still hold bytes the inspected thread expects to
-// be delivered. Checked when the inspected thread flushes before it exits.
+// Transports that may still hold bytes not yet written to their client.
 const activeTransports = new Set<Transport>();
 let exitFlushDone: (() => void) | undefined;
 
-// Called from the debugger thread's C++ side right before the inspected thread
-// exits, after every queued protocol message has been handed to the
-// transports. `done` unblocks the inspected thread.
+// Called on the debugger thread right before the inspected thread exits.
 function flushBeforeExit(done: () => void): void {
   exitFlushDone = done;
   reportExitFlushIfDrained();

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -11,6 +11,9 @@ class SocketFramer {
   sizeBuffer: Buffer = Buffer.alloc(4);
   sizeBufferIndex: number = 0;
   bufferedData: Buffer = Buffer.alloc(0);
+  // True while the socket holds bytes from `send` that it has not written yet.
+  // The socket's `drain` handler clears it.
+  hasUnsentData = false;
 
   constructor(private onMessage: (message: string | string[]) => void) {
     if (!socketFramerMessageLengthBuffer) {
@@ -24,6 +27,17 @@ class SocketFramer {
     this.bufferedData = Buffer.alloc(0);
     this.sizeBufferIndex = 0;
     this.sizeBuffer = Buffer.alloc(4);
+    this.hasUnsentData = false;
+  }
+
+  // The socket's `drain` handler fires once every buffered byte is written.
+  didDrain(): void {
+    this.hasUnsentData = false;
+    reportExitFlushIfDrained();
+  }
+
+  isFlushed(): boolean {
+    return !this.hasUnsentData;
   }
 
   send(socket: Socket<{ framer: SocketFramer; backend: Backend }>, data: string): void {
@@ -32,8 +46,11 @@ class SocketFramer {
     }
 
     socketFramerMessageLengthBuffer.writeUInt32BE(Buffer.byteLength(data), 0);
-    socket.$write(socketFramerMessageLengthBuffer);
-    socket.$write(data);
+    const wroteLength = socket.$write(socketFramerMessageLengthBuffer);
+    const wroteData = socket.$write(data);
+    if (!wroteLength || !wroteData) {
+      this.hasUnsentData = true;
+    }
   }
 
   onData(socket: Socket<{ framer: SocketFramer; backend: Writer }>, data: Buffer): void {
@@ -103,6 +120,58 @@ function cdpAdapterConstructor() {
 }
 
 export default function (
+  executionContextId: number,
+  url: string,
+  createBackend: CreateBackendFn,
+  send: (message: string | string[]) => void,
+  close: () => void,
+  isAutomatic: boolean,
+  urlIsServer: boolean,
+  isNodeInspector: boolean,
+  reportNodeInspectorServerStarted: (url: string, controlCallback?: (message: string) => void, error?: string) => void,
+): typeof flushBeforeExit {
+  start(
+    executionContextId,
+    url,
+    createBackend,
+    send,
+    close,
+    isAutomatic,
+    urlIsServer,
+    isNodeInspector,
+    reportNodeInspectorServerStarted,
+  );
+  return flushBeforeExit;
+}
+
+// Client transports that can still hold bytes the inspected thread expects to
+// be delivered. Checked when the inspected thread flushes before it exits.
+const activeTransports = new Set<Transport>();
+let exitFlushDone: (() => void) | undefined;
+
+// Called from the debugger thread's C++ side right before the inspected thread
+// exits, after every queued protocol message has been handed to the
+// transports. `done` unblocks the inspected thread.
+function flushBeforeExit(done: () => void): void {
+  exitFlushDone = done;
+  reportExitFlushIfDrained();
+}
+
+function reportExitFlushIfDrained(): void {
+  if (!exitFlushDone) {
+    return;
+  }
+  for (const transport of activeTransports) {
+    if (!transport.isFlushed()) {
+      return;
+    }
+  }
+  const done = exitFlushDone;
+  exitFlushDone = undefined;
+  done();
+}
+
+function start(
   executionContextId: number,
   url: string,
   createBackend: CreateBackendFn,
@@ -413,6 +482,7 @@ class Debugger {
             framer,
             backend,
           };
+          activeTransports.add(framer);
           socket.ref();
         },
         data: (socket, bytes) => {
@@ -422,13 +492,17 @@ class Debugger {
           }
           socket.data.framer.onData(socket, bytes);
         },
-        drain: _socket => {},
+        drain: socket => {
+          socket.data?.framer.didDrain();
+        },
         close: socket => {
           const socketData = socket.data;
           if (socketData) {
             const { backend, framer } = socketData;
+            activeTransports.delete(framer);
             backend.close();
             framer.reset();
+            reportExitFlushIfDrained();
           }
         },
       },
@@ -546,6 +620,7 @@ class Debugger {
     const { refEventLoop } = data;
 
     const client = bufferedWriter(writer);
+    activeTransports.add(client);
 
     if (this.#nodeInspector) {
       // node:inspector clients speak CDP; the adapter sits between the
@@ -599,15 +674,23 @@ class Debugger {
 
   #close(connection: ConnectionOwner): void {
     const { data } = connection;
-    const { backend } = data;
+    const { backend, client } = data;
+    if (client) {
+      activeTransports.delete(client);
+    }
     backend?.close();
+    reportExitFlushIfDrained();
   }
 
   #error(connection: ConnectionOwner, error: Error): void {
     const { data } = connection;
-    const { backend } = data;
+    const { backend, client } = data;
+    if (client) {
+      activeTransports.delete(client);
+    }
     console.error(error);
     backend?.close();
+    reportExitFlushIfDrained();
   }
 }
 
@@ -680,6 +763,7 @@ async function connectToUnixServer(
           backend,
         };
 
+        activeTransports.add(framer);
         socket.ref();
       },
       data: (socket, bytes) => {
@@ -693,14 +777,18 @@ async function connectToUnixServer(
 
       // Ensure we always drain the socket.
       // This is necessary due to socket.$write usage.
-      drain: _socket => {},
+      drain: socket => {
+        socket.data?.framer.didDrain();
+      },
 
       close: socket => {
         const socketData = socket.data;
         if (socketData) {
           const { backend, framer } = socketData;
+          activeTransports.delete(framer);
           backend.close();
           framer.reset();
+          reportExitFlushIfDrained();
         }
       },
     },
@@ -738,6 +826,7 @@ function nodeVersionInfo(): unknown {
 function webSocketWriter(ws: ServerWebSocket<unknown>): Writer {
   return {
     write: message => !!ws.sendText(message),
+    isFlushed: () => ws.getBufferedAmount() === 0,
     close: () => ws.close(),
   };
 }
@@ -766,7 +855,9 @@ function bufferedWriter(writer: Writer): Writer {
       } finally {
         draining = false;
       }
+      reportExitFlushIfDrained();
     },
+    isFlushed: () => pendingMessages.length === 0 && writer.isFlushed(),
     close: () => {
       writer.close();
       pendingMessages.length = 0;
@@ -913,7 +1004,12 @@ type Connection = {
   adapter?: any;
 };
 
-type Writer = {
+type Transport = {
+  // True when no byte handed to this transport is still waiting to be written.
+  isFlushed: () => boolean;
+};
+
+type Writer = Transport & {
   write: (message: string) => boolean;
   drain?: () => void;
   close: () => void;

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -161,6 +161,7 @@ impl Default for Debugger {
 unsafe extern "C" {
     safe fn Bun__createJSDebugger(global: &JSGlobalObject) -> u32;
     safe fn Bun__ensureDebugger(ctx_id: u32, wait: bool);
+    safe fn Bun__Debugger__flushBeforeExit(global: &JSGlobalObject);
     safe fn Bun__startJSDebuggerThread(
         global: &JSGlobalObject,
         ctx_id: u32,
@@ -186,6 +187,14 @@ struct DebuggerThreadInit {
 }
 
 impl Debugger {
+    /// Block until the debugger thread has written every queued protocol
+    /// message to its connected frontends, or until a short deadline. Called
+    /// right before the process exits so events emitted by the last test
+    /// (`TestReporter.end`, `LifecycleReporter.error`) reach the client.
+    pub fn flush_before_exit(global: &JSGlobalObject) {
+        Bun__Debugger__flushBeforeExit(global);
+    }
+
     /// `Debugger.waitForDebuggerIfNecessary(vm)` — block on the futex until
     /// `start()` (debugger thread) signals, then run the wait-loop until a
     /// frontend connects (`Debugger__didConnect`) or the deadline elapses.

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -188,9 +188,7 @@ struct DebuggerThreadInit {
 
 impl Debugger {
     /// Block until the debugger thread has written every queued protocol
-    /// message to its connected frontends, or until a short deadline. Called
-    /// right before the process exits so events emitted by the last test
-    /// (`TestReporter.end`, `LifecycleReporter.error`) reach the client.
+    /// message to the connected frontends, or until a short deadline.
     pub fn flush_before_exit(global: &JSGlobalObject) {
         Bun__Debugger__flushBeforeExit(global);
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1882,6 +1882,10 @@ impl VirtualMachine {
         // doing it causes like 50+ tests to break
         // self.event_loop().tick();
 
+        if self.debugger.is_some() {
+            crate::debugger::Debugger::flush_before_exit(self.global());
+        }
+
         if self.should_destruct_main_thread_on_exit() {
             // SAFETY: main-thread VM on the main thread; exit handlers have run.
             unsafe { Self::teardown(core::ptr::from_mut(self), Teardown::MainThreadExit) };

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -956,18 +956,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_closeNodeInspector, (JSGlobalObject*, CallFr
     return JSValue::encode(jsUndefined());
 }
 
-// Handshake between the inspected thread, which is about to exit, and the
-// debugger thread, which still holds outgoing protocol messages: in the
-// connection's queue, in internal/debugger.ts's per-client buffer, and in the
-// socket's write buffer. The inspected thread posts a task behind every
-// queued message and blocks until internal/debugger.ts reports that every
-// client transport has written its pending bytes.
+// Exit-time handshake: the inspected thread blocks here until
+// internal/debugger.ts reports that every client transport is drained.
 struct ExitFlushState {
     WTF::Lock lock;
     WTF::Condition condition;
     bool done { false };
-    // Owned by the debugger thread's VM; process-lifetime once set (the
-    // debugger thread is never joined).
+    // Owned by the debugger thread's VM, which is never torn down.
     JSC::Strong<JSC::Unknown> flushCallback {};
 };
 
@@ -1024,9 +1019,8 @@ extern "C" void Bun__Debugger__flushBeforeExit(Zig::GlobalObject* globalObject)
         state.done = false;
     }
 
-    // The debugger thread runs its concurrent tasks in order, so this task
-    // runs after every receiveMessagesOnDebuggerThread task posted before it
-    // has handed its messages to internal/debugger.ts.
+    // Concurrent tasks run in order: this one runs after every queued
+    // receiveMessagesOnDebuggerThread task has handed its messages to JS.
     debuggerScriptExecutionContext->postTaskConcurrently([](ScriptExecutionContext& context) {
         auto& state = exitFlushState();
         JSC::JSValue flushCallback;
@@ -1052,8 +1046,7 @@ extern "C" void Bun__Debugger__flushBeforeExit(Zig::GlobalObject* globalObject)
         }
     });
 
-    // A client that stops reading never drains. Bound the wait so such a
-    // client delays exit instead of preventing it.
+    // A client that stops reading never drains: bound the wait.
     auto deadline = MonotonicTime::now() + Seconds(2);
     Locker<Lock> locker(state.lock);
     while (!state.done) {

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -10,6 +10,7 @@
 #include <JavaScriptCore/HeapIterationScope.h>
 #include <JavaScriptCore/IsoCellSetInlines.h>
 #include <wtf/Condition.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/NeverDestroyed.h>
 #include "ScriptExecutionContext.h"
 #include "debug-helpers.h"
@@ -955,6 +956,112 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_closeNodeInspector, (JSGlobalObject*, CallFr
     return JSValue::encode(jsUndefined());
 }
 
+// Handshake between the inspected thread, which is about to exit, and the
+// debugger thread, which still holds outgoing protocol messages: in the
+// connection's queue, in internal/debugger.ts's per-client buffer, and in the
+// socket's write buffer. The inspected thread posts a task behind every
+// queued message and blocks until internal/debugger.ts reports that every
+// client transport has written its pending bytes.
+struct ExitFlushState {
+    WTF::Lock lock;
+    WTF::Condition condition;
+    bool done { false };
+    // Owned by the debugger thread's VM; process-lifetime once set (the
+    // debugger thread is never joined).
+    JSC::Strong<JSC::Unknown> flushCallback {};
+};
+
+static ExitFlushState& exitFlushState()
+{
+    static NeverDestroyed<ExitFlushState> instance;
+    return instance.get();
+}
+
+static void reportExitFlushDone()
+{
+    auto& state = exitFlushState();
+    Locker<Lock> locker(state.lock);
+    state.done = true;
+    state.condition.notifyAll();
+}
+
+JSC_DECLARE_HOST_FUNCTION(jsFunctionReportExitFlushDone);
+JSC_DEFINE_HOST_FUNCTION(jsFunctionReportExitFlushDone, (JSGlobalObject*, CallFrame*))
+{
+    reportExitFlushDone();
+    return JSValue::encode(jsUndefined());
+}
+
+extern "C" void Bun__Debugger__flushBeforeExit(Zig::GlobalObject* globalObject)
+{
+    if (!debuggerScriptExecutionContext)
+        return;
+
+    {
+        Locker<Lock> locker(inspectorConnectionsLock);
+        if (!inspectorConnections)
+            return;
+        auto* context = globalObject->scriptExecutionContext();
+        if (!context)
+            return;
+        auto it = inspectorConnections->find(context->identifier());
+        if (it == inspectorConnections->end())
+            return;
+        bool hasConnectedFrontend = false;
+        for (auto& connection : it->value) {
+            if (connection->status == ConnectionStatus::Connected) {
+                hasConnectedFrontend = true;
+                break;
+            }
+        }
+        if (!hasConnectedFrontend)
+            return;
+    }
+
+    auto& state = exitFlushState();
+    {
+        Locker<Lock> locker(state.lock);
+        state.done = false;
+    }
+
+    // The debugger thread runs its concurrent tasks in order, so this task
+    // runs after every receiveMessagesOnDebuggerThread task posted before it
+    // has handed its messages to internal/debugger.ts.
+    debuggerScriptExecutionContext->postTaskConcurrently([](ScriptExecutionContext& context) {
+        auto& state = exitFlushState();
+        JSC::JSValue flushCallback;
+        {
+            Locker<Lock> locker(state.lock);
+            flushCallback = state.flushCallback.get();
+        }
+        if (!flushCallback || !flushCallback.isCallable()) {
+            reportExitFlushDone();
+            return;
+        }
+
+        auto* globalObject = context.jsGlobalObject();
+        auto& vm = globalObject->vm();
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        MarkedArgumentBuffer arguments;
+        arguments.append(JSFunction::create(vm, globalObject, 0, String("reportExitFlushDone"_s), jsFunctionReportExitFlushDone, ImplementationVisibility::Public));
+        JSC::call(globalObject, flushCallback.getObject(), arguments, "Bun__Debugger__flushBeforeExit - flushCallback"_s);
+        if (auto* exception = scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            reportExitFlushDone();
+        }
+    });
+
+    // A client that stops reading never drains. Bound the wait so such a
+    // client delays exit instead of preventing it.
+    auto deadline = MonotonicTime::now() + Seconds(2);
+    Locker<Lock> locker(state.lock);
+    while (!state.done) {
+        if (!state.condition.waitUntil(state.lock, deadline))
+            break;
+    }
+}
+
 extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObject, ScriptExecutionContextIdentifier scriptId, const BunString* portOrPathString, int isAutomatic, bool isUrlServer, bool isNodeInspector)
 {
     if (!debuggerScriptExecutionContext)
@@ -983,8 +1090,14 @@ extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObje
     arguments.append(jsBoolean(isNodeInspector));
     arguments.append(JSFunction::create(vm, debuggerGlobalObject, 3, String("reportNodeInspectorServerStarted"_s), jsFunctionReportNodeInspectorServerStarted, ImplementationVisibility::Public));
 
-    JSC::call(debuggerGlobalObject, debuggerDefaultFn, arguments, "Bun__initJSDebuggerThread - debuggerDefaultFn"_s);
+    JSValue flushCallback = JSC::call(debuggerGlobalObject, debuggerDefaultFn, arguments, "Bun__initJSDebuggerThread - debuggerDefaultFn"_s);
     scope.assertNoException();
+
+    if (flushCallback.isCallable()) {
+        auto& state = exitFlushState();
+        Locker<Lock> locker(state.lock);
+        state.flushCallback = { vm, flushCallback };
+    }
 }
 
 enum class AsyncCallTypeUint8 : uint8_t {

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -455,4 +455,84 @@ afterAll(async () => {
     }
     expect(exitCode).toBe(0);
   });
+
+  test("delivers every event emitted before the test run exits", async () => {
+    // The debugger thread writes inspector events to the socket. The test
+    // runner exits right after the last test, so the events for the last tests
+    // (and the LifecycleReporter.error for the last failure) must be flushed
+    // before the process exits. No gate file holds the process open here.
+    const testCount = 100;
+    using dir = tempDir("test-reporter-exit-flush", {
+      "many.test.ts": `
+import { test, expect } from "bun:test";
+for (let i = 0; i < ${testCount}; i++) {
+  test("test " + i, () => {
+    expect(i).toBe(i);
+  });
+}
+test("last one fails", () => {
+  expect(1).toBe(2);
+});
+`,
+    });
+
+    const socketPath = join(String(dir), `inspector-${Math.random().toString(36).substring(2)}.sock`);
+
+    const session = new TestReporterSession();
+    const framer = new SocketFramer((message: string) => {
+      session.onMessage(message);
+    });
+    const errors: any[] = [];
+    session.addEventListener("LifecycleReporter.error", (params: any) => {
+      errors.push(params);
+    });
+
+    const socketClosed = Promise.withResolvers<void>();
+    const socketPromise = connect(`unix://${socketPath}`, () => socketClosed.resolve()).then(s => {
+      socket = s;
+      session.socket = s;
+      session.framer = framer;
+      s.data = {
+        onData: framer.onData.bind(framer),
+      };
+      return s;
+    });
+
+    proc = spawn({
+      cmd: [bunExe(), `--inspect-wait=unix:${socketPath}`, "test", "many.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    await socketPromise;
+
+    session.enableInspector();
+    session.enableTestReporter();
+    session.send("LifecycleReporter.enable");
+    session.initialize();
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // The process closed its end of the socket on exit. Once our end closes,
+    // every byte it wrote has been read.
+    await socketClosed.promise;
+
+    expect(stderr).toContain(`Ran ${testCount + 1} tests across 1 file.`);
+    const endedTests = session.getEndedTests();
+    expect({
+      found: session.getFoundTests().size,
+      started: session.getStartedTests().size,
+      ended: endedTests.size,
+      failed: [...endedTests.values()].filter(t => t.status === "fail").length,
+      errors: errors.map(e => e.message),
+    }).toEqual({
+      found: testCount + 1,
+      started: testCount + 1,
+      ended: testCount + 1,
+      failed: 1,
+      errors: [expect.stringContaining("expect(received).toBe(expected)")],
+    });
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -513,7 +513,8 @@ test("last one fails", () => {
     session.send("LifecycleReporter.enable");
     session.initialize();
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    void stdout;
     // The process closed its end of the socket on exit. Once our end closes,
     // every byte it wrote has been read.
     await socketClosed.promise;


### PR DESCRIPTION
### Problem
- `bun test` with an inspector client attached drops the events emitted just before it exits. With 200 tests, a client that enabled `TestReporter` gets 200 `found` events but only about 35 `start` and `end` events. The last `LifecycleReporter.error` (the last failing test, a load error) is lost too. A test explorer sees the run end with tests still "running".
- The debugger thread writes protocol messages to the frontends. `global_exit` (`src/jsc/VirtualMachine.rs`) called `Global::exit` at once. Messages still sat in three places: the connection's queue (`BunDebugger.cpp`, `debuggerThreadMessages`), the per-client buffer in `internal/debugger.ts`, and the socket's write buffer.

### Fix
- `global_exit` calls `Bun__Debugger__flushBeforeExit` when a frontend is connected. It posts a task to the debugger thread and blocks on a condition until the task reports done. The debugger thread runs its tasks in order, so the task runs after every queued message task has handed its messages to `internal/debugger.ts`.
- The task calls the flush function that `internal/debugger.ts` now returns from its entry point. That function reports done when every client transport has no unsent bytes: the WebSocket's `getBufferedAmount()` is 0 and the per-client queue is empty, or the unix/tcp socket's `drain` fired after a partial `$write`. A transport that closes is removed from the set.
- The wait has a 2 second deadline. A client that stops reading delays exit, it does not block it. With no client connected nothing changes: `bun --inspect -e 1` still exits at once.
- Verified: `test/cli/inspect/test-reporter.test.ts` (new test: 101 tests over the unix socket transport, the unfixed build delivers about 70 `end` events and no `error`). Also all of `test/cli/inspect/`, `test/js/node/inspector/`, and the `node:inspector` parallel tests.

### Background
- Bun's inspector runs on a second thread with its own JSC VM and event loop. `internal/debugger.ts` runs there. It owns the WebSocket server (`--inspect`) or the client socket (`--inspect=unix:...`, used by editors).
- An agent on the inspected thread (`InspectorTestReporterAgent.cpp`) sends an event through `BunInspectorConnection::sendMessageToFrontend`. That appends the message to a vector and posts one task to the debugger thread through `postTaskConcurrently`. The debugger thread hands the batch to `internal/debugger.ts`, which writes it to the socket.
- `Global::exit` is `quick_exit` on Linux. Only bytes that already reached the kernel survive it.
- The `node:inspector` open/close handshake in `BunDebugger.cpp` (`NodeInspectorState`) uses the same lock-and-condition shape. The flush state follows it.

<details><summary>Notes</summary>

Probe from the report (bun 1.4.3 canary, release): `bun test --inspect-wait=127.0.0.1:PORT/TOKEN` with N generated tests and a WebSocket client that enables `TestReporter` and `LifecycleReporter`, then sends `Inspector.initialized`. Results before the fix: N=10 gives found 6, start 0, end 0. N=50 gives end 38. N=200 gives end 33. After the fix, with the debug build: N=10, 50, 200 and 2000 all deliver N `start` and N `end` events. The 2000 case takes 5.6 s total, so the flush adds no visible delay.

The first attempt at the probe sometimes showed the debuggee hanging. That was the probe: its client connected 800 ms after spawn, before the debug build's server listened, so `--inspect-wait` waited forever for a connection. It is not related to the flush.

The existing tests in `test-reporter.test.ts` work around this bug with an `afterAll` gate file that keeps the process alive until the client has seen every `end`. The new test has no gate.

Order guarantee: `sendMessageToDebuggerThread` only posts a task when `debuggerThreadMessageScheduledCount` goes from 0 to 1. Messages appended while a task is pending ride along in the vector that `receiveMessagesOnDebuggerThread` swaps out. The flush task is posted after the last message, so it is behind the task that delivers that message. The concurrent task queue (`bun_threading::UnboundedQueue`) is FIFO.

The flush does not run for a connection in `Pending` or `Disconnected` state, for a VM with no debugger, or when the debugger thread never started.
</details>
