### PR TITLE
S3: writer() no longer keeps the process alive before end()

### DIFF
--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -537,9 +537,6 @@ pub(crate) fn writable_stream(
     // SAFETY: freshly heap-allocated and refcounted; only shared access from here on.
     let task = unsafe { &*task_ptr };
 
-    task.poll_ref
-        .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
-
     // Heap-allocate; `JSSink<NetworkSink>` is layout-
     // compatible (`{ sink: NetworkSink }`) so the cast in `to_sink()` is just a pointer reinterpret.
     let response_stream: *mut NetworkSink =
@@ -945,9 +942,6 @@ pub(crate) fn upload_stream(
     unsafe { (*task_ptr).root.set(core::ptr::NonNull::new(task_ptr)) };
     // SAFETY: freshly heap-allocated and refcounted; only shared access from here on.
     let task = unsafe { &*task_ptr };
-
-    task.poll_ref
-        .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
 
     let ctx_ptr: *mut S3UploadStreamWrapper =
         bun_core::heap::into_raw(Box::new(S3UploadStreamWrapper {

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -1025,8 +1025,7 @@ impl MultiPartUpload {
         self.options.get().part_size as usize
     }
 
-    /// EOF received: hold the event loop until the upload settles (`Drop` releases it).
-    /// Before EOF only in-flight requests hold it, so an un-ended writer can exit.
+    /// Holds the event loop from EOF until `Drop`.
     fn mark_ended(&self) {
         self.ended.set(true);
         self.poll_ref

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -1025,6 +1025,16 @@ impl MultiPartUpload {
         self.options.get().part_size as usize
     }
 
+    /// The caller has sent EOF and now awaits the result. Keep the event loop
+    /// alive until the upload finishes (released in `Drop`). Before EOF, only
+    /// in-flight requests hold the loop (each `S3HttpSimpleTask` has its own
+    /// `KeepAlive`), so a writer that is never ended does not pin the process.
+    fn mark_ended(&self) {
+        self.ended.set(true);
+        self.poll_ref
+            .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
+    }
+
     pub(crate) fn continue_stream(&self) {
         if self.state.get() == State::WaitStreamCheck {
             self.state.set(State::NotStarted);
@@ -1080,7 +1090,7 @@ impl MultiPartUpload {
 
         if self.state.get() == State::WaitStreamCheck && chunk.is_empty() && is_last {
             // we do this because stream will close if the file dont exists and we dont wanna to send an empty part in this case
-            self.ended.set(true);
+            self.mark_ended();
             if self.buffered.get().size() > 0 {
                 self.process_buffered(self.part_size_in_bytes());
             }
@@ -1091,7 +1101,7 @@ impl MultiPartUpload {
             });
         }
         if is_last {
-            self.ended.set(true);
+            self.mark_ended();
             if !chunk.is_empty() {
                 self.append_chunk(encoding, chunk)?;
             }

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -1025,10 +1025,8 @@ impl MultiPartUpload {
         self.options.get().part_size as usize
     }
 
-    /// The caller has sent EOF and now awaits the result. Keep the event loop
-    /// alive until the upload finishes (released in `Drop`). Before EOF, only
-    /// in-flight requests hold the loop (each `S3HttpSimpleTask` has its own
-    /// `KeepAlive`), so a writer that is never ended does not pin the process.
+    /// EOF received: hold the event loop until the upload settles (`Drop` releases it).
+    /// Before EOF only in-flight requests hold it, so an un-ended writer can exit.
     fn mark_ended(&self) {
         self.ended.set(true);
         self.poll_ref

--- a/test/js/bun/s3/s3-writer-keepalive.test.ts
+++ b/test/js/bun/s3/s3-writer-keepalive.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// An S3 writer holds the event loop only while a request is in flight or after
+// `end()` while the upload settles. A writer that is never ended must not keep
+// the process alive on its own.
+
+// `Bun.serve` that answers every S3 request the writer can send.
+const serverSource = `
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (req.method === "POST" && url.searchParams.has("uploads")) {
+        return new Response(
+          "<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>",
+          { headers: { "content-type": "application/xml" } },
+        );
+      }
+      if (req.method === "PUT") {
+        await req.arrayBuffer();
+        return new Response("", { headers: { ETag: '"etag"' } });
+      }
+      await req.text();
+      return new Response(
+        '<CompleteMultipartUploadResult><ETag>"etag-1"</ETag></CompleteMultipartUploadResult>',
+        { headers: { "content-type": "application/xml" } },
+      );
+    },
+  });
+  server.unref();
+  const client = new Bun.S3Client({
+    endpoint: "http://127.0.0.1:" + server.port,
+    bucket: "bucket",
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+    region: "us-east-1",
+  });
+`;
+
+// The S3 client does not consult NO_PROXY, so a proxy in the environment would
+// capture the loopback requests.
+const env = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+async function run(source: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", serverSource + source],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+const cases: [string, string][] = [
+  ["no write", `client.file("key").writer(); console.log("done");`],
+  ["one buffered write", `const w = client.file("key").writer(); w.write("a"); console.log("done");`],
+  [
+    "wrapper collected",
+    `(() => { const w = client.file("key").writer(); w.write("a"); })(); Bun.gc(true); console.log("done");`,
+  ],
+  [
+    "a part was flushed",
+    `const w = client.file("key").writer({ partSize: 5 * 1024 * 1024 });
+     w.write(new Uint8Array(6 * 1024 * 1024));
+     console.log("done");`,
+  ],
+];
+
+for (const [name, source] of cases) {
+  test.concurrent(`S3 writer() that is never ended does not keep the process alive (${name})`, async () => {
+    const { stdout, stderr, exitCode } = await run(source);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done\n");
+    expect(exitCode).toBe(0);
+  });
+}
+
+test.concurrent("S3 writer() end() keeps the process alive until the upload settles", async () => {
+  const { stdout, stderr, exitCode } = await run(`
+    const w = client.file("key").writer();
+    w.write("hello");
+    w.end().then(n => console.log("resolved", n), e => console.log("rejected", e.code));
+  `);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("resolved 5\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/s3/s3-writer-keepalive.test.ts
+++ b/test/js/bun/s3/s3-writer-keepalive.test.ts
@@ -74,14 +74,15 @@ const cases: [string, string][] = [
   ],
 ];
 
-for (const [name, source] of cases) {
-  test.concurrent(`S3 writer() that is never ended does not keep the process alive (${name})`, async () => {
+test.concurrent.each(cases)(
+  "S3 writer() that is never ended does not keep the process alive (%s)",
+  async (_name, source) => {
     const { stdout, stderr, exitCode } = await run(source);
     expect(stderr).toBe("");
     expect(stdout).toBe("done\n");
     expect(exitCode).toBe(0);
-  });
-}
+  },
+);
 
 test.concurrent("S3 writer() end() keeps the process alive until the upload settles", async () => {
   const { stdout, stderr, exitCode } = await run(`


### PR DESCRIPTION
### Problem
- `s3file.writer()` keeps the process alive forever unless `end()` runs. This holds with zero bytes written, with one buffered byte, after `unref()`, and after the JS wrapper is collected. `Bun.file(path).writer()` exits at once in the same cases.
- The cause is in `writable_stream` and `upload_stream` (`src/runtime/webcore/s3/client.rs:540` and `:949`). They call `poll_ref.ref_()` on the `MultiPartUpload` at construction. The only release is `Drop`, which runs when the upload completes or fails. A writer that is never ended never reaches either.

### Fix
- Remove the construction-time `ref_()`. `MultiPartUpload::mark_ended` (`src/runtime/webcore/s3/multipart.rs`) sets `ended` and takes the `KeepAlive` in one place. `write()` calls it when it receives EOF.
- Correct because every S3 request already holds its own `KeepAlive` (`S3HttpSimpleTask.poll_ref`, released after its callback). Before EOF, only in-flight requests need to hold the loop. After EOF, the caller awaits a result, so the upload holds the loop until `Drop`.
- `Bun.S3Client.write(key, stream)` follows the same rule. A stream that never delivers EOF and has no pending I/O no longer pins the process. That matches the writer and `Bun.file`.
- Verified: `test/js/bun/s3/s3-writer-keepalive.test.ts` (4 never-ended cases time out on stock bun, 1 `end()` guard). Also `s3-upload-stream-gc`, `s3-stream-error-gc`, `s3-stream-cancel-leak`, `s3-connection-close`, `s3.leak`, `s3-write-to-file-sync-close`, `s3-argument-validation`.

### Background
- `KeepAlive` (`src/io/keep_alive.rs`) is an Active/Inactive flag on the event loop's active count. While one is Active, the process does not exit. `ref_()` and `unref()` are idempotent.
- `MultiPartUpload` is the native state machine behind `writer()` and stream uploads. It buffers bytes, sends one PUT for a small upload, or starts a multipart upload and sends parts. `NetworkSink` is the JS-facing sink that forwards `write()` and `end()` to it.
- `S3HttpSimpleTask` is one HTTP request to S3. It takes a `KeepAlive` when it is queued and drops it after the completion callback ran on the JS thread.

<details><summary>Notes</summary>

Repro from the report, on 1.4.2 and on main before the fix (`timeout 6 bun t.mjs <mode>`):

```
nowrite still alive at 3 s   rc=124
write1 still alive at 3 s    rc=124
unref still alive at 3 s     rc=124
gc still alive at 3 s        rc=124
filesink -> exit after 9 ms  rc=0
end -> exit after 13 ms      rc=0
```

With the fix, every mode exits in under 30 ms.

`NetworkSink` does not implement `update_ref`, so `writer.unref()` and `writer.ref()` stay no-ops. After this change they have nothing to control before `end()`. Wiring them to the task's `KeepAlive` after `end()` is possible but out of scope.

A writer that flushed a part and was then dropped still leaves the multipart upload open on the server (no `AbortMultipartUpload`). That is a separate problem. This PR only stops it from pinning the process.

The new test strips `HTTP_PROXY` and `HTTPS_PROXY` from the child env, as `s3-upload-stream-gc.test.ts` does, because the S3 client does not consult `NO_PROXY`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3-writer-keepalive.test.ts"
bun test v1.4.3 (f42e98025)

test/js/bun/s3/s3-writer-keepalive.test.ts:
(pass) S3 writer() end() keeps the process alive until the upload settles [569.52ms]
(fail) S3 writer() that is never ended does not keep the process alive (no write) [5004.93ms]
  ^ this test timed out after 5000ms.
(fail) S3 writer() that is never ended does not keep the process alive (one buffered write) [5004.41ms]
  ^ this test timed out after 5000ms.
(fail) S3 writer() that is never ended does not keep the process alive (wrapper collected) [5000.14ms]
  ^ this test timed out after 5000ms.
(fail) S3 writer() that is never ended does not keep the process alive (a part was flushed) [5000.16ms]
  ^ this test timed out after 5000ms.

 1 pass
 4 fail
 3 expect() calls
Ran 5 tests across 1 file. [7.25s]
error: script "bd" exited with code 1
__F:4:S:0

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/s3/s3-writer-keepalive.test.ts:
(pass) S3 writer() end() keeps the process alive until the upload settles [12.43ms]
(fail) S3 writer() that is never ended does not keep the process alive (no write) [5000.74ms]
  ^ this test timed out after 5000ms.
(fail) S3 writer() that is never ended does not keep the process alive (one buffered write) [5000.07ms]
  ^ this test timed out after 5000ms.
(fail) S3 writer() that is never ended does not keep the process alive (wrapper collected) [5000.06ms]
  ^ this test timed out after 5000ms.
(fail) S3 writer() that is never ended does not keep the process alive (a part was flushed) [5000.07ms]
  ^ this test timed out after 5000ms.

 1 pass
 4 fail
 3 expect() calls
Ran 5 tests across 1 file. [5.10s]
__F:4:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3-writer-keepalive.test.ts"
bun test v1.4.3 (f42e98025)

test/js/bun/s3/s3-writer-keepalive.test.ts:
(pass) S3 writer() that is never ended does not keep the process alive (no write) [347.82ms]
(pass) S3 writer() that is never ended does not keep the process alive (wrapper collected) [317.85ms]
(pass) S3 writer() end() keeps the process alive until the upload settles [324.25ms]
(pass) S3 writer() that is never ended does not keep the process alive (one buffered write) [359.42ms]
(pass) S3 writer() that is never ended does not keep the process alive (a part was flushed) [365.69ms]

 5 pass
 0 fail
 15 expect() calls
Ran 5 tests across 1 file. [2.82s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 9124ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/2374] host-cxx deps/icu/host-obj/source/i18n/numparse_validators.cpp.o
[2/2374] host-cxx deps/icu/host-obj/source/i18n/numsys.cpp.o
[3/2374] host-cxx deps/icu/host-obj/source/i18n/numparse_symbols.cpp.o
[4/2374] host-cxx deps/icu/host-obj/source/i18n/quant.cpp.o
[5/2374] host-cxx deps/icu/host-obj/source/i18n/quantityformatter.cpp.o
[6/2374] host-cxx deps/icu/host-obj/source/i18n/numrange_impl.cpp.o
[7/2374] host-cxx deps/icu/host-obj/source/i18n/persncal.cpp.o
[8/2374] host-cxx deps/icu/host-obj/source/i18n/pluralranges.cpp.o
[9/2374] host-cxx deps/icu/host-obj/source/i18n/numrange_capi.cpp.o
[10/2374] host-cxx deps/icu/host-obj/source/i18n/numrange_fluent.cpp.o
[11/2374] host-cxx deps/icu/host-obj/source/i18n/olsontz.cpp.o
[12/2374] host-cxx deps/icu/host-obj/source/i18n/numparse_impl.cpp.o
[13/2374] host-cxx deps/icu/host-obj/source/i18n/plurfmt.cpp.o
[14/2374] host-cxx deps/icu/host-obj/source/i18n/numfmt.cpp.o
[15/2374] host-cxx deps/icu/host-obj/source/i18n/number_skeletons.cpp.o
[16/2374] host-c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/s3/client.rs           |  6 --
 src/runtime/webcore/s3/multipart.rs        | 11 +++-
 test/js/bun/s3/s3-writer-keepalive.test.ts | 96 ++++++++++++++++++++++++++++++
 3 files changed, 105 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/webcore/s3/client.rs                2      2     10
src/runtime/webcore/s3/multipart.rs             7      6     10
test/js/bun/s3/s3-writer-keepalive.test.ts      0      4     10
```

</details>

**root cause** · written by the author bot

The S3 multipart writer took its event loop KeepAlive at construction time instead of at first flush, so a writer that was created but never ended kept the process alive indefinitely. The fix removes the eager poll_ref calls from upload setup and instead has the final write call mark_ended, which holds the loop only from EOF until the upload settles and Drop releases it. Before EOF only in-flight requests hold the loop, so un-ended writers let the process exit while ended uploads still run to completion.

<!-- robobun:evidence:end -->