### PR TITLE
Serialize Bun.cron crontab edits, fail closed on crontab -l errors, filter only bun entries

### DIFF
--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -794,6 +794,13 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
             )));
         }
     };
+    let now_ms = bun_core::time::milli_timestamp() as f64;
+    if parsed.next(global, now_ms, CronTz::Local)?.is_none() {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Cron expression '{}' has no future occurrences",
+            bstr::BStr::new(schedule_slice.slice())
+        )));
+    }
     let mut fmt_buf = [0u8; 512];
     let normalized_schedule = parsed.format_numeric(&mut fmt_buf);
 
@@ -830,9 +837,9 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
             return Err(global.throw(format_args!("Failed to get bun executable path")));
         }
     };
-    if bun_core::strings::index_of_any(bun_exe.as_bytes(), b"'%").is_some() {
+    if bun_core::strings::index_of_any(bun_exe.as_bytes(), b"'%\n\r").is_some() {
         return Err(global.throw_invalid_arguments(format_args!(
-                "Bun executable path '{}' contains characters (' or %) that cannot be safely embedded in a crontab entry",
+                "Bun executable path '{}' contains characters (', % or a line break) that cannot be safely embedded in a crontab entry",
                 bstr::BStr::new(bun_exe.as_bytes())
             )));
     }

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -149,6 +149,8 @@ trait CronJobBase: Sized + bun_ptr::AnyRefCounted {
         }
         drop(owner);
         ev.exit();
+        #[cfg(all(not(target_os = "macos"), not(windows)))]
+        crontab_queue::on_job_finished();
     }
 
     fn set_err(&self, args: core::fmt::Arguments<'_>) {
@@ -868,7 +870,7 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
     #[cfg(windows)]
     CronRegisterJob::start_windows(job);
     #[cfg(all(not(target_os = "macos"), not(windows)))]
-    CronRegisterJob::start_linux(job);
+    crontab_queue::enqueue(crontab_queue::Queued::Register(job));
 
     Ok(promise_value)
 }
@@ -1311,7 +1313,7 @@ pub(crate) fn cron_remove(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     #[cfg(windows)]
     CronRemoveJob::start_windows(job);
     #[cfg(all(not(target_os = "macos"), not(windows)))]
-    CronRemoveJob::start_linux(job);
+    crontab_queue::enqueue(crontab_queue::Queued::Remove(job));
     Ok(promise_value)
 }
 
@@ -1876,6 +1878,99 @@ pub(crate) fn cron_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
         return Ok(JSValue::NULL);
     }
     Ok(JSValue::from_date_number(global, next_ms))
+}
+
+// ============================================================================
+// Crontab job queue
+// ============================================================================
+
+/// `crontab(1)` takes no lock: the jobs of one thread run one at a time.
+#[cfg(all(not(target_os = "macos"), not(windows)))]
+mod crontab_queue {
+    use super::{CronRegisterJob, CronRemoveJob};
+    use bun_ptr::ThisPtr;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    pub(super) enum Queued {
+        Register(ThisPtr<CronRegisterJob>),
+        Remove(ThisPtr<CronRemoveJob>),
+    }
+
+    struct Queue {
+        running: bool,
+        draining: bool,
+        finished_while_draining: bool,
+        pending: VecDeque<Queued>,
+    }
+
+    thread_local! {
+        static QUEUE: RefCell<Queue> = const {
+            RefCell::new(Queue {
+                running: false,
+                draining: false,
+                finished_while_draining: false,
+                pending: VecDeque::new(),
+            })
+        };
+    }
+
+    /// Starts `job` now or queues it behind the running one. May free `job`.
+    pub(super) fn enqueue(job: Queued) {
+        let start_now = QUEUE.with(|q| {
+            let mut q = q.borrow_mut();
+            if q.running {
+                q.pending.push_back(job);
+                None
+            } else {
+                q.running = true;
+                Some(job)
+            }
+        });
+        if let Some(job) = start_now {
+            start(job);
+        }
+    }
+
+    /// Starts the queued jobs in turn, without recursing through `finish`.
+    pub(super) fn on_job_finished() {
+        let nested = QUEUE.with(|q| {
+            let mut q = q.borrow_mut();
+            if q.draining {
+                q.finished_while_draining = true;
+                return true;
+            }
+            q.draining = true;
+            false
+        });
+        if nested {
+            return;
+        }
+        loop {
+            let next = QUEUE.with(|q| {
+                let mut q = q.borrow_mut();
+                q.finished_while_draining = false;
+                let next = q.pending.pop_front();
+                q.running = next.is_some();
+                next
+            });
+            let Some(job) = next else {
+                break;
+            };
+            start(job);
+            if !QUEUE.with(|q| q.borrow().finished_while_draining) {
+                break;
+            }
+        }
+        QUEUE.with(|q| q.borrow_mut().draining = false);
+    }
+
+    fn start(job: Queued) {
+        match job {
+            Queued::Register(job) => CronRegisterJob::start_linux(job),
+            Queued::Remove(job) => CronRemoveJob::start_linux(job),
+        }
+    }
 }
 
 // ============================================================================

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -244,7 +244,6 @@ struct CronRegisterJob {
     state: Cell<RegisterState>,
     process: JsCell<Option<ProcessHandle>>,
     stdout_reader: JsCell<OutputReader>,
-    #[cfg(windows)]
     stderr_reader: JsCell<OutputReader>,
     remaining_fds: Cell<i8>,
     has_called_process_exit: Cell<bool>,
@@ -338,22 +337,14 @@ impl CronJobBase for CronRegisterJob {
         let state = self.state.get();
         match status {
             Status::Exited(exited) => {
-                if exited.code != 0
-                    && !(state == RegisterState::ReadingCrontab && exited.code == 1)
-                    && state != RegisterState::BootingOut
-                {
-                    // Materialize the trimmed stderr into an owned buffer so
-                    // no borrow of the reader outlives this statement
-                    // (Windows only; POSIX ignores stderr here).
-                    #[cfg(windows)]
-                    let stderr_owned: Vec<u8> = self.stderr_reader.with_mut(|r| {
-                        bun_core::strings::trim(r.final_buffer().as_slice(), &ASCII_WHITESPACE)
-                            .to_vec()
-                    });
-                    #[cfg(windows)]
-                    let stderr_output: &[u8] = stderr_owned.as_slice();
-                    #[cfg(not(windows))]
-                    let stderr_output: &[u8] = b"";
+                let stderr_owned: Vec<u8> = self.stderr_reader.with_mut(|r| {
+                    bun_core::strings::trim(r.final_buffer().as_slice(), &ASCII_WHITESPACE).to_vec()
+                });
+                let stderr_output: &[u8] = stderr_owned.as_slice();
+                let no_crontab = state == RegisterState::ReadingCrontab
+                    && exited.code == 1
+                    && is_no_crontab_listing(stderr_output);
+                if exited.code != 0 && !no_crontab && state != RegisterState::BootingOut {
                     // On Windows, detect the SID resolution error and provide
                     // a clear message instead of the raw schtasks output.
                     #[cfg(windows)]
@@ -858,7 +849,6 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
         state: Cell::new(RegisterState::ReadingCrontab),
         process: JsCell::new(None),
         stdout_reader: JsCell::new(OutputReader::init::<CronRegisterJob>()),
-        #[cfg(windows)]
         stderr_reader: JsCell::new(OutputReader::init::<CronRegisterJob>()),
         remaining_fds: Cell::new(0),
         has_called_process_exit: Cell::new(false),
@@ -980,7 +970,6 @@ impl Drop for CronRegisterJob {
     }
 }
 
-#[cfg(windows)]
 const ASCII_WHITESPACE: [u8; 6] = *b" \t\n\r\x0b\x0c";
 
 // ============================================================================
@@ -1001,7 +990,6 @@ struct CronRemoveJob {
     state: Cell<RemoveState>,
     process: JsCell<Option<ProcessHandle>>,
     stdout_reader: JsCell<OutputReader>,
-    #[cfg(windows)]
     stderr_reader: JsCell<OutputReader>,
     remaining_fds: Cell<i8>,
     has_called_process_exit: Cell<bool>,
@@ -1090,22 +1078,18 @@ impl CronJobBase for CronRemoveJob {
         let state = self.state.get();
         match status {
             Status::Exited(exited) => {
+                let stderr_owned: Vec<u8> = self.stderr_reader.with_mut(|r| {
+                    bun_core::strings::trim(r.final_buffer().as_slice(), &ASCII_WHITESPACE).to_vec()
+                });
+                let stderr_output: &[u8] = stderr_owned.as_slice();
                 let is_acceptable_nonzero = (state == RemoveState::ReadingCrontab
-                    && exited.code == 1)
+                    && exited.code == 1
+                    && is_no_crontab_listing(stderr_output))
                     || state == RemoveState::BootingOut
                     // On Windows, schtasks /delete exits non-zero when the task doesn't exist;
                     // removal of a non-existent job should resolve without error.
                     || (cfg!(windows) && state == RemoveState::InstallingCrontab);
                 if exited.code != 0 && !is_acceptable_nonzero {
-                    #[cfg(windows)]
-                    let stderr_owned: Vec<u8> = self.stderr_reader.with_mut(|r| {
-                        bun_core::strings::trim(r.final_buffer().as_slice(), &ASCII_WHITESPACE)
-                            .to_vec()
-                    });
-                    #[cfg(windows)]
-                    let stderr_output: &[u8] = stderr_owned.as_slice();
-                    #[cfg(not(windows))]
-                    let stderr_output: &[u8] = b"";
                     if !stderr_output.is_empty() {
                         self.set_err(format_args!("{}", bstr::BStr::new(stderr_output)));
                     } else {
@@ -1203,15 +1187,16 @@ impl CronRemoveJob {
     /// May free `this`; see [`CronJobBase`] note.
     #[cfg(not(target_os = "macos"))]
     fn remove_crontab_entry(this: ThisPtr<Self>) {
-        let Ok((crontab_path, tmp_path)) = this.prepare_filtered_crontab() else {
+        let Ok(Some((crontab_path, tmp_path))) = this.prepare_filtered_crontab() else {
             return Self::finish(this);
         };
         let argv = [crontab_path.as_cstr(), tmp_path.as_cstr()];
         Self::spawn_cmd(this, &argv, spawn::Stdio::Ignore, spawn::Stdio::Ignore);
     }
 
+    /// `Ok(None)`: no entry with this title, nothing to rewrite.
     #[cfg(not(target_os = "macos"))]
-    fn prepare_filtered_crontab(&self) -> Result<(ZString, ZString), ()> {
+    fn prepare_filtered_crontab(&self) -> Result<Option<(ZString, ZString)>, ()> {
         let mut result: Vec<u8> = Vec::new();
         let filtered = self.stdout_reader.with_mut(|r| {
             filter_crontab(
@@ -1221,9 +1206,13 @@ impl CronRemoveJob {
             )
         });
 
-        if filtered.is_err() {
-            self.set_err(format_args!("Out of memory"));
-            return Err(());
+        match filtered {
+            Ok(true) => {}
+            Ok(false) => return Ok(None),
+            Err(_) => {
+                self.set_err(format_args!("Out of memory"));
+                return Err(());
+            }
         }
 
         let tmp_path = match make_temp_path("bun-cron-rm-") {
@@ -1262,7 +1251,7 @@ impl CronRemoveJob {
             self.set_err(format_args!("crontab not found in PATH"));
             return Err(());
         };
-        Ok((crontab_path, tmp_path))
+        Ok(Some((crontab_path, tmp_path)))
     }
 
     /// May free `this`; see [`CronJobBase`] note.
@@ -1304,7 +1293,6 @@ pub(crate) fn cron_remove(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
         state: Cell::new(RemoveState::ReadingCrontab),
         process: JsCell::new(None),
         stdout_reader: JsCell::new(OutputReader::init::<CronRemoveJob>()),
-        #[cfg(windows)]
         stderr_reader: JsCell::new(OutputReader::init::<CronRemoveJob>()),
         remaining_fds: Cell::new(0),
         has_called_process_exit: Cell::new(false),
@@ -1899,7 +1887,6 @@ trait SpawnCmdTarget: CronJobBase + BufferedReaderParent + bun_spawn::ProcessExi
     fn process_slot(&self) -> &JsCell<Option<ProcessHandle>>;
     #[cfg(unix)]
     fn stdout_reader(&self) -> &JsCell<OutputReader>;
-    #[cfg(windows)]
     fn stderr_reader(&self) -> &JsCell<OutputReader>;
 }
 
@@ -1927,7 +1914,6 @@ impl SpawnCmdTarget for CronRegisterJob {
     fn stdout_reader(&self) -> &JsCell<OutputReader> {
         &self.stdout_reader
     }
-    #[cfg(windows)]
     fn stderr_reader(&self) -> &JsCell<OutputReader> {
         &self.stderr_reader
     }
@@ -1940,7 +1926,6 @@ impl SpawnCmdTarget for CronRemoveJob {
     fn stdout_reader(&self) -> &JsCell<OutputReader> {
         &self.stdout_reader
     }
-    #[cfg(windows)]
     fn stderr_reader(&self) -> &JsCell<OutputReader> {
         &self.stderr_reader
     }
@@ -1989,10 +1974,14 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
     stdin_opt: spawn::Stdio,
     stdout_opt: spawn::Stdio,
 ) -> Result<ProcessHandle, ()> {
+    #[cfg(windows)]
     let this_ptr: *mut core::ffi::c_void = this.as_ptr().cast();
     this.has_called_process_exit().set(false);
     this.exit_status().set(None);
     this.remaining_fds().set(0);
+    // A job spawns two commands. Each gets its own stderr reader.
+    #[cfg(unix)]
+    this.stderr_reader().set(OutputReader::init::<T>());
 
     #[cfg(not(windows))]
     let resolved_argv0: Option<*const core::ffi::c_char> = None;
@@ -2018,31 +2007,27 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
             }
         }
     }
-    #[cfg(unix)]
-    let env = spawn::SpawnEnv::Inherit;
-    #[cfg(windows)]
-    let envp_owned;
-    #[cfg(windows)]
-    let env_strings: Vec<&CStr>;
-    #[cfg(windows)]
-    let env = {
-        match vm_mut()
-            .transpiler
-            .env_mut()
-            .map
-            .create_null_delimited_env_map()
-        {
-            Ok(v) => {
-                envp_owned = v;
-                env_strings = envp_owned.iter().collect();
-                spawn::SpawnEnv::Strings(&env_strings)
-            }
-            Err(_) => {
-                this.set_err(format_args!("Failed to create environment block"));
-                return Err(());
-            }
+    let envp_owned = match vm_mut()
+        .transpiler
+        .env_mut()
+        .map
+        .create_null_delimited_env_map()
+    {
+        Ok(v) => v,
+        Err(_) => {
+            this.set_err(format_args!("Failed to create environment block"));
+            return Err(());
         }
     };
+    let env_strings: Vec<&CStr> = envp_owned.iter().collect();
+    // `is_no_crontab_listing` matches the English message.
+    #[cfg(unix)]
+    let env_strings: Vec<&CStr> = env_strings
+        .into_iter()
+        .filter(|e| !e.to_bytes().starts_with(b"LC_ALL="))
+        .chain(core::iter::once(c"LC_ALL=C"))
+        .collect();
+    let env = spawn::SpawnEnv::Strings(&env_strings);
 
     // Ownership note: BOTH
     // `Source::Pipe` and `WindowsStdioResult::Buffer` own a `Box<uv::Pipe>`,
@@ -2072,7 +2057,7 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
         #[cfg(windows)]
         stderr: spawn::Stdio::Buffer(stderr_pipe_ptr),
         #[cfg(not(windows))]
-        stderr: spawn::Stdio::Ignore,
+        stderr: spawn::Stdio::Buffer,
         cwd: cwd.into(),
         argv0: resolved_argv0,
         #[cfg(windows)]
@@ -2114,35 +2099,12 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
     #[cfg(unix)]
     {
         if let Some(stdout) = spawned.stdout {
-            if !spawned.memfds[1] {
-                this.stdout_reader().with_mut(|r| r.set_parent(this_ptr));
-                let _ = sys::set_nonblocking(stdout);
-                this.remaining_fds().set(this.remaining_fds().get() + 1);
-                let started = this.stdout_reader().with_mut(|r| {
-                    use bun_io::pipe_reader::PosixFlags;
-                    r.flags.insert(PosixFlags::NONBLOCKING | PosixFlags::SOCKET);
-                    r.flags.remove(
-                        PosixFlags::MEMFD
-                            | PosixFlags::RECEIVED_EOF
-                            | PosixFlags::CLOSED_WITHOUT_REPORTING,
-                    );
-                    r.start(stdout, true)
-                });
-                if started.is_err() {
-                    this.set_err(format_args!("Failed to start reading stdout"));
-                    return Err(());
-                }
-                this.stdout_reader().with_mut(|r| {
-                    if let Some(p) = r.handle.get_poll() {
-                        p.set_flag(bun_io::FilePollFlag::Socket);
-                    }
-                });
-            } else {
-                this.stdout_reader().with_mut(|r| {
-                    r.set_parent(this_ptr);
-                    r.start_memfd(stdout);
-                });
-            }
+            start_posix_reader(this, this.stdout_reader(), stdout, spawned.memfds[1])
+                .map_err(|_| this.set_err(format_args!("Failed to start reading stdout")))?;
+        }
+        if let Some(stderr) = spawned.stderr {
+            start_posix_reader(this, this.stderr_reader(), stderr, spawned.memfds[2])
+                .map_err(|_| this.set_err(format_args!("Failed to start reading stderr")))?;
         }
     }
     #[cfg(windows)]
@@ -2175,6 +2137,44 @@ fn spawn_cmd_prepare<T: SpawnCmdTarget>(
 
     let ev_handle = EventLoopHandle::init(vm_mut().event_loop().cast::<()>());
     Ok(spawned.to_process_handle(ev_handle))
+}
+
+/// Wires one captured stdio fd of the spawned command into `reader`.
+#[cfg(unix)]
+fn start_posix_reader<T: SpawnCmdTarget>(
+    this: ThisPtr<T>,
+    reader: &JsCell<OutputReader>,
+    fd: Fd,
+    is_memfd: bool,
+) -> Result<(), ()> {
+    let this_ptr: *mut core::ffi::c_void = this.as_ptr().cast();
+    if is_memfd {
+        reader.with_mut(|r| {
+            r.set_parent(this_ptr);
+            r.start_memfd(fd);
+        });
+        return Ok(());
+    }
+    reader.with_mut(|r| r.set_parent(this_ptr));
+    let _ = sys::set_nonblocking(fd);
+    this.remaining_fds().set(this.remaining_fds().get() + 1);
+    let started = reader.with_mut(|r| {
+        use bun_io::pipe_reader::PosixFlags;
+        r.flags.insert(PosixFlags::NONBLOCKING | PosixFlags::SOCKET);
+        r.flags.remove(
+            PosixFlags::MEMFD | PosixFlags::RECEIVED_EOF | PosixFlags::CLOSED_WITHOUT_REPORTING,
+        );
+        r.start(fd, true)
+    });
+    if started.is_err() {
+        return Err(());
+    }
+    reader.with_mut(|r| {
+        if let Some(p) = r.handle.get_poll() {
+            p.set_flag(bun_io::FilePollFlag::Socket);
+        }
+    });
+    Ok(())
 }
 
 /// Find crontab binary using bun.which (searches PATH).
@@ -2265,31 +2265,63 @@ pub(crate) fn validate_title(title: &[u8]) -> bool {
     true
 }
 
-/// Filter crontab content, removing any entry with matching title marker.
+/// `crontab -l` exits 1 for a spool error too. Only this text means empty.
+fn is_no_crontab_listing(stderr: &[u8]) -> bool {
+    strings::contains(stderr, b"no crontab")
+        || strings::contains(stderr, b"No such file or directory")
+}
+
+/// Removes the entry with this title marker. Returns whether one was removed.
 #[cfg(not(target_os = "macos"))]
 pub(crate) fn filter_crontab(
     content: &[u8],
     title: &[u8],
     result: &mut Vec<u8>,
-) -> Result<(), bun_alloc::AllocError> {
+) -> Result<bool, bun_alloc::AllocError> {
     let mut marker = Vec::new();
     let _ = write!(&mut marker, "# bun-cron: {}", bstr::BStr::new(title));
-    let mut skip_next = false;
-    for line in strings::split(content, b"\n") {
-        if skip_next {
-            skip_next = false;
-            continue;
+    let mut flag = Vec::new();
+    let _ = write!(&mut flag, "--cron-title={}", bstr::BStr::new(title));
+    let body = content.strip_suffix(b"\n").unwrap_or(content);
+    if body.is_empty() {
+        return Ok(false);
+    }
+    let mut removed = false;
+    let mut after_marker = false;
+    for line in strings::split(body, b"\n") {
+        if after_marker {
+            after_marker = false;
+            if is_bun_cron_command(line, &flag) {
+                removed = true;
+                continue;
+            }
         }
         if bun_core::trim(line, b" \t") == marker.as_slice() {
-            skip_next = true;
+            after_marker = true;
+            removed = true;
             continue;
         }
-        if !line.is_empty() {
-            result.extend_from_slice(line);
-            result.push(b'\n');
-        }
+        result
+            .try_reserve(line.len() + 1)
+            .map_err(|_| bun_alloc::AllocError)?;
+        result.extend_from_slice(line);
+        result.push(b'\n');
     }
-    Ok(())
+    Ok(removed)
+}
+
+/// True when `line` carries `flag` (`--cron-title=<title>`) as a whole word.
+#[cfg(not(target_os = "macos"))]
+fn is_bun_cron_command(line: &[u8], flag: &[u8]) -> bool {
+    let mut rest = line;
+    while let Some(i) = strings::index_of(rest, flag) {
+        let after = &rest[i + flag.len()..];
+        if after.first().is_none_or(|&c| c == b' ' || c == b'\t') {
+            return true;
+        }
+        rest = after;
+    }
+    false
 }
 
 /// XML-escape a string for safe embedding in plist XML.

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1,6 +1,15 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
-import { chmodSync, existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 const crontabPath = Bun.which("crontab");
@@ -145,6 +154,12 @@ describe("Bun.cron API", () => {
     expect(() => Bun.cron("./test.ts", "* * *", "test-bad")).toThrow(/cron expression/i);
     expect(() => Bun.cron("./test.ts", "* * * * * *", "test-bad")).toThrow(/cron expression/i);
     expect(() => Bun.cron("./test.ts", "abc * * * *", "test-bad")).toThrow(/cron expression/i);
+  });
+
+  test("throws for a schedule with no future occurrence, like the in-process form", () => {
+    // The check runs before any OS backend is called, so it applies on every platform.
+    expect(() => Bun.cron("./test.ts", "0 0 30 2 *", "feb30")).toThrow(/no future occurrences/);
+    expect(() => Bun.cron("0 0 30 2 *", () => {})).toThrow(/no future occurrences/);
   });
 
   test("throws with percent sign in path", async () => {
@@ -2003,5 +2018,35 @@ describe.skipIf(!isLinux)("crontab read-modify-write (stub crontab)", () => {
     expect(stdout).toBe("rejected:crontab not found in PATH\n");
     expect(exitCode).toBe(0);
     expect(readLog(String(dir))).toEqual(["-l"]);
+  });
+
+  test.concurrent("rejects a bun executable path that contains a line break", async () => {
+    using dir = stubDir();
+    const evilDir = join(String(dir), "evil\n* * * * * touch INJECTED #");
+    mkdirSync(evilDir);
+    const evilBun = join(evilDir, "bun");
+    try {
+      linkSync(bunExe(), evilBun);
+    } catch {
+      copyFileSync(bunExe(), evilBun);
+    }
+    await using proc = Bun.spawn({
+      cmd: [
+        evilBun,
+        "-e",
+        `try { await Bun.cron("./w.ts", "@hourly", "nl"); console.log("resolved"); }
+         catch (e) { console.log("rejected: " + e.message); }`,
+      ],
+      cwd: String(dir),
+      env: stubEnv(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/^rejected: Bun executable path '.*' contains characters/s);
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(String(dir), "crontab.txt"))).toBe(false);
+    expect(readLog(String(dir))).toEqual([]);
   });
 });

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const crontabPath = Bun.which("crontab");
 const hasCrontab = !!crontabPath && isLinux;
@@ -1773,5 +1774,168 @@ describe("Bun.cron.parse", () => {
     const fromNumber = Bun.cron.parse("30 * * * *", ms)!;
     const fromDate = Bun.cron.parse("30 * * * *", new Date(ms))!;
     expect(fromNumber.getTime()).toBe(fromDate.getTime());
+  });
+});
+
+// ==========================================================================
+// crontab read-modify-write, against a crontab(1) stand-in on PATH
+// ==========================================================================
+
+// The stand-in keeps the crontab in $BUN_TEST_CRONTAB_FILE and appends every
+// invocation to $BUN_TEST_CRONTAB_LOG, so a test can assert what bun ran
+// without touching the real user crontab. The spawned bun gets a PATH with
+// only the stub directory, so a missing stub can never fall through to a real
+// crontab(1). The stub sets its own PATH for cat/cp/rm.
+const CRONTAB_STUB = `#!/bin/sh
+PATH=/usr/bin:/bin
+printf '%s\\n' "$*" >> "$BUN_TEST_CRONTAB_LOG"
+case "$1" in
+  -l)
+    if [ -n "$BUN_TEST_CRONTAB_HOLD" ]; then
+      while [ ! -e "$BUN_TEST_CRONTAB_HOLD" ]; do sleep 0.01 2>/dev/null || sleep 1; done
+    fi
+    if [ -n "$BUN_TEST_CRONTAB_FAIL_LIST_ONCE" ] && [ ! -e "$BUN_TEST_CRONTAB_FAIL_LIST_ONCE" ]; then
+      touch "$BUN_TEST_CRONTAB_FAIL_LIST_ONCE"
+      echo "crontab: pam_start: transient failure" >&2
+      exit 1
+    fi
+    if [ -e "$BUN_TEST_CRONTAB_FILE" ]; then
+      cat "$BUN_TEST_CRONTAB_FILE"
+      exit 0
+    fi
+    if [ "$LC_ALL" = C ]; then
+      echo "no crontab for user" >&2
+    else
+      echo "crontab: Datei oder Verzeichnis nicht gefunden" >&2
+    fi
+    exit 1
+    ;;
+  -r) rm -f "$BUN_TEST_CRONTAB_FILE" ;;
+  -) cat > "$BUN_TEST_CRONTAB_FILE" ;;
+  *) cp "$1" "$BUN_TEST_CRONTAB_FILE" ;;
+esac
+`;
+
+const WORKER_TS = `export default { scheduled() {} };\n`;
+
+describe.skipIf(!isLinux)("crontab read-modify-write (stub crontab)", () => {
+  function stubDir(files: Record<string, string> = {}) {
+    const dir = tempDir("bun-cron-stub", {
+      "bin/crontab": CRONTAB_STUB,
+      "w.ts": WORKER_TS,
+      ...files,
+    });
+    chmodSync(join(String(dir), "bin", "crontab"), 0o755);
+    return dir;
+  }
+
+  function stubEnv(dir: string, extra: Record<string, string> = {}) {
+    return {
+      ...bunEnv,
+      PATH: join(dir, "bin"),
+      BUN_TEST_CRONTAB_FILE: join(dir, "crontab.txt"),
+      BUN_TEST_CRONTAB_LOG: join(dir, "crontab.log"),
+      ...extra,
+    };
+  }
+
+  async function runInDir(dir: string, code: string, extra: Record<string, string> = {}) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      cwd: dir,
+      env: stubEnv(dir, extra),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function readStub(dir: string): string {
+    const p = join(dir, "crontab.txt");
+    return existsSync(p) ? readFileSync(p, "utf8") : "";
+  }
+
+  function readLog(dir: string): string[] {
+    const p = join(dir, "crontab.log");
+    return existsSync(p) ? readFileSync(p, "utf8").trim().split("\n") : [];
+  }
+
+  test.concurrent("a crontab -l failure that is not 'no crontab' rejects and leaves the crontab alone", async () => {
+    const existing = "MAILTO=ops\n0 1 * * * /usr/local/bin/nightly\n";
+    using dir = stubDir({ "crontab.txt": existing });
+    const { stdout, stderr, exitCode } = await runInDir(
+      String(dir),
+      `try { await Bun.cron("./w.ts", "@hourly", "x"); console.log("resolved"); }
+       catch (e) { console.log("rejected: " + e.message); }`,
+      { BUN_TEST_CRONTAB_FAIL_LIST_ONCE: join(String(dir), "failed-once") },
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("rejected: crontab: pam_start: transient failure\n");
+    expect(exitCode).toBe(0);
+    expect(readStub(String(dir))).toBe(existing);
+    expect(readLog(String(dir))).toEqual(["-l"]);
+  });
+
+  test.concurrent("'no crontab for user' still counts as an empty crontab, in any locale", async () => {
+    using dir = stubDir();
+    // The stub prints a translated message unless LC_ALL=C. bun pins the locale of the crontab it spawns.
+    const { stderr, exitCode } = await runInDir(String(dir), `await Bun.cron("./w.ts", "@hourly", "first");`, {
+      LC_ALL: "de_DE.UTF-8",
+    });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(readStub(String(dir))).toContain("# bun-cron: first\n0 * * * * ");
+  });
+
+  test.concurrent("only the bun command under a marker is removed, blank lines are kept", async () => {
+    const existing = [
+      "# bun-cron: t1",
+      "0 2 * * * /bin/true USER-A",
+      "",
+      "0 3 * * * /bin/true USER-B",
+      "  # bun-cron: t1  ",
+      "0 4 * * * /bin/true USER-C",
+      "# bun-cron: t1",
+      "0 5 * * * '/x/bun' run --cron-title=t1 --cron-period='0 5 * * *' '/x/w.ts'",
+      "# bun-cron: t10",
+      "0 6 * * * '/x/bun' run --cron-title=t10 --cron-period='0 6 * * *' '/x/w.ts'",
+      "",
+    ].join("\n");
+    using dir = stubDir({ "crontab.txt": existing });
+    const { stderr, exitCode } = await runInDir(String(dir), `await Bun.cron("./w.ts", "@hourly", "t1");`);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const lines = readStub(String(dir)).split("\n");
+    expect(lines.slice(0, 7)).toEqual([
+      "0 2 * * * /bin/true USER-A",
+      "",
+      "0 3 * * * /bin/true USER-B",
+      "0 4 * * * /bin/true USER-C",
+      "# bun-cron: t10",
+      "0 6 * * * '/x/bun' run --cron-title=t10 --cron-period='0 6 * * *' '/x/w.ts'",
+      "# bun-cron: t1",
+    ]);
+    expect(lines[7]).toContain("--cron-title=t1 --cron-period='0 * * * *'");
+    expect(lines.slice(8)).toEqual([""]);
+  });
+
+  test.concurrent("removing a title that is not registered does not rewrite the crontab", async () => {
+    const existing = "# a\n\n0 1 * * * /bin/true\n\n# b\n";
+    using dir = stubDir({ "crontab.txt": existing });
+    const { stderr, exitCode } = await runInDir(String(dir), `await Bun.cron.remove("nope");`);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(readStub(String(dir))).toBe(existing);
+    expect(readLog(String(dir))).toEqual(["-l"]);
+  });
+
+  test.concurrent("removing from an empty crontab does not install one", async () => {
+    using dir = stubDir();
+    const { stderr, exitCode } = await runInDir(String(dir), `await Bun.cron.remove("nope");`);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(String(dir), "crontab.txt"))).toBe(false);
+    expect(readLog(String(dir))).toEqual(["-l"]);
   });
 });

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -1861,6 +1861,44 @@ describe.skipIf(!isLinux)("crontab read-modify-write (stub crontab)", () => {
     return existsSync(p) ? readFileSync(p, "utf8").trim().split("\n") : [];
   }
 
+  test.concurrent("concurrent registrations all land, in call order", async () => {
+    using dir = stubDir();
+    const { stdout, stderr, exitCode } = await runInDir(
+      String(dir),
+      `await Promise.all([0, 1, 2, 3, 4, 5].map(i => Bun.cron("./w.ts", "@hourly", "c" + i)));
+       console.log("all 6 resolved");`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("all 6 resolved\n");
+    expect(exitCode).toBe(0);
+    const markers = readStub(String(dir))
+      .split("\n")
+      .filter(l => l.startsWith("# bun-cron: "));
+    expect(markers).toEqual(["c0", "c1", "c2", "c3", "c4", "c5"].map(t => `# bun-cron: ${t}`));
+  });
+
+  test.concurrent("concurrent removes and a register do not lose each other's work", async () => {
+    using dir = stubDir({
+      "crontab.txt": ["r0", "r1", "r2", "r3"]
+        .map(t => `# bun-cron: ${t}\n0 * * * * '/x/bun' run --cron-title=${t} --cron-period='0 * * * *' '/x/w.ts'\n`)
+        .join(""),
+    });
+    const { stderr, exitCode } = await runInDir(
+      String(dir),
+      `await Promise.all([
+         Bun.cron.remove("r0"), Bun.cron.remove("r1"),
+         Bun.cron("./w.ts", "@daily", "added"),
+         Bun.cron.remove("r2"), Bun.cron.remove("r3"),
+       ]);`,
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const markers = readStub(String(dir))
+      .split("\n")
+      .filter(l => l.startsWith("# bun-cron: "));
+    expect(markers).toEqual(["# bun-cron: added"]);
+  });
+
   test.concurrent("a crontab -l failure that is not 'no crontab' rejects and leaves the crontab alone", async () => {
     const existing = "MAILTO=ops\n0 1 * * * /usr/local/bin/nightly\n";
     using dir = stubDir({ "crontab.txt": existing });
@@ -1936,6 +1974,34 @@ describe.skipIf(!isLinux)("crontab read-modify-write (stub crontab)", () => {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
     expect(existsSync(join(String(dir), "crontab.txt"))).toBe(false);
+    expect(readLog(String(dir))).toEqual(["-l"]);
+  });
+
+  test.concurrent("a long queue of jobs that fail before they spawn rejects each one", async () => {
+    using dir = stubDir();
+    // The first job's `crontab -l` is held in the stub until a release file appears. Once the stub
+    // has logged the call (so /bin/sh has the script open), the stub is deleted and 2000 jobs are
+    // queued behind the first. PATH holds only the stub dir, so after the release the first job's
+    // install step and every queued job fail inside start(), and the queue drains them in a loop.
+    // Nothing can reach a real crontab(1).
+    const log = join(String(dir), "crontab.log");
+    const release = join(String(dir), "release");
+    const { stdout, stderr, exitCode } = await runInDir(
+      String(dir),
+      `import { existsSync, rmSync, writeFileSync } from "node:fs";
+       const first = Bun.cron("./w.ts", "@hourly", "first");
+       while (!existsSync(${JSON.stringify(log)})) await Bun.sleep(1);
+       rmSync(${JSON.stringify(join(String(dir), "bin", "crontab"))});
+       const rest = Array.from({ length: 2000 }, (_, i) => (i % 2 ? Bun.cron("./w.ts", "@hourly", "q" + i) : Bun.cron.remove("q" + i)));
+       writeFileSync(${JSON.stringify(release)}, "");
+       const results = await Promise.allSettled([first, ...rest]);
+       const reasons = new Set(results.map(r => r.status + ":" + (r.reason?.message ?? "")));
+       console.log([...reasons].join(","));`,
+      { BUN_TEST_CRONTAB_HOLD: release },
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("rejected:crontab not found in PATH\n");
+    expect(exitCode).toBe(0);
     expect(readLog(String(dir))).toEqual(["-l"]);
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.cron()` and `Bun.cron.remove()` rewrite the user crontab with `crontab -l`, a filter, and `crontab <tmp>`. A `crontab -l` failure with exit 1 (a PAM or spool error) is treated as "no crontab", so the rewrite installs a crontab with only the bun entry and every existing job is gone (`src/runtime/api/cron.rs:341` before this change).
- `filter_crontab` (`cron.rs:2270` before) drops the line after any `# bun-cron: <title>` marker without a check that it is bun's line, and drops every blank line. `Bun.cron.remove("unknown")` still rewrites the crontab. Six concurrent `Bun.cron()` calls all resolve and one entry lands, because the read-modify-write has no serialisation.

### Fix
Three commits, one decision each. Each compiles on linux, `aarch64-apple-darwin`, and `x86_64-pc-windows-msvc`.
- 9a7757d, the data-loss fix: `crontab -l` exit 1 is an empty crontab only when stderr contains `no crontab` (cronie, vixie, FreeBSD) or `No such file or directory` (busybox). Any other failure rejects and leaves the crontab untouched. POSIX spawns capture stderr and run with `LC_ALL=C`, so the check sees the English text and a failed install reports the crontab error. The filter removes the line under a marker only when it carries `--cron-title=<title>` as a whole word, and keeps blank lines. `remove()` skips the install when nothing matched.
- 68f4680, serialisation: a per-thread queue (`crontab_queue`) runs crontab jobs one at a time, in call order. It drains in a loop, so a job that fails before it spawns adds no stack frame.
- 179baee, two checks in `cron_register` that run before any backend: a schedule with no future occurrence is rejected like the in-process form, and the executable path check adds `\n` and `\r`. These change launchd and schtasks acceptance too. Drop this commit if that is not wanted.
- Verified: `test/js/bun/cron/cron.test.ts`, block "crontab read-modify-write (stub crontab)" (9 tests against a `crontab(1)` stand-in on PATH) plus one ungated API test. 8 of them fail on stock bun. All 4 files in `test/js/bun/cron/` pass.

### Background
- `Bun.cron(path, schedule, title)` registers an OS-level job. On Linux that is a `# bun-cron: <title>` comment plus one command line in the user crontab. `Bun.cron.remove(title)` takes both lines out.
- `CronRegisterJob` and `CronRemoveJob` are state machines driven by process exit and pipe reader callbacks. `finish` settles the promise and releases the job's owning ref, so nothing touches the job after it.
- `crontab(1)` takes no lock. The only place to serialise is in bun.

<details><summary>Notes</summary>

Origin: an internal audit of host side effects outside the project directory. All findings were verified against bun 1.4.2 and canary with a tmpfs over `/var/spool/cron`.

Why a stub crontab in the test: the real `crontab` is not installed in most CI images and a test must not rewrite the invoking user's crontab. The stub is a `/bin/sh` script that keeps the crontab in a file under the temp dir and logs each invocation, so a test can assert that `remove("unknown")` ran `-l` and nothing else. `find_crontab` resolves through `PATH`, and the spawned bun gets a `PATH` that holds only the stub directory, so no test can reach a real `crontab(1)`. The stub prints a German strerror unless `LC_ALL=C`, which is how the locale pinning is tested.

The exe-newline test hard links the test binary into a directory with a newline in its name (copy as fallback when the link crosses filesystems, the same pattern as the bunx test in `test/cli/bun.test.ts`). `self_exe_path` reads `/proc/self/exe`, which reports the path used at exec.

The queue is per event loop thread. Two workers in one process, or two bun processes, can still race. `crontab(1)` offers nothing to lock on.

Self-review and bot review: the stderr reader is reset in `spawn_cmd_prepare` before every spawn, so the macOS bootout and bootstrap steps each report their own stderr. The child env is built from the VM env map on every platform, with `LC_ALL` replaced on unix. The queue drains iteratively. The queue test holds the first job's `crontab -l` inside the stub until a release file appears, deletes the stub once the stub has logged the call, queues 2000 more jobs, then releases. The drain loop is the path that rejects them.

Not changed, left for a maintainer decision: `@reboot` support, `*/61` normalisation, a notice on stdout when the crontab is rewritten, a list API, `crontab -r` when the last entry goes, the cron job's cwd and env.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/cron/cron.test.ts

<!-- robobun:evidence:end -->

