### PR TITLE
console: read a BigInt depth option by value in console.dir

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -521,8 +521,7 @@ fn message_with_type_and_level_(
                     // Clamp negatives to 0, then truncate (not saturate) to u16.
                     print_options.max_depth = depth_prop.to_int32().max(0) as u32 as u16;
                 } else if depth_prop.is_big_int() {
-                    // `to_int32` only handles numbers; on a BigInt cell it reads the
-                    // cell bits as the depth.
+                    // Negative clamps to 0, above u16::MAX saturates.
                     print_options.max_depth =
                         if depth_prop.is_big_int_in_int64_range(0, i64::from(u16::MAX)) {
                             depth_prop.coerce_to_int64(global)? as u16

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -517,9 +517,23 @@ fn message_with_type_and_level_(
         let opts = vals_slice[1];
         if opts.is_object() {
             if let Some(depth_prop) = opts.get(global, b"depth")? {
-                if depth_prop.is_int32() || depth_prop.is_number() || depth_prop.is_big_int() {
+                if depth_prop.is_number() {
                     // Clamp negatives to 0, then truncate (not saturate) to u16.
                     print_options.max_depth = depth_prop.to_int32().max(0) as u32 as u16;
+                } else if depth_prop.is_big_int() {
+                    // `to_int32` only handles numbers; on a BigInt cell it reads the
+                    // cell bits as the depth.
+                    print_options.max_depth =
+                        if depth_prop.is_big_int_in_int64_range(0, i64::from(u16::MAX)) {
+                            depth_prop.coerce_to_int64(global)? as u16
+                        } else if depth_prop
+                            .as_big_int_compare(global, JSValue::js_number_from_int32(0))
+                            == jsc::ComparisonResult::LessThan
+                        {
+                            0
+                        } else {
+                            u16::MAX
+                        };
                 } else if depth_prop.is_null() {
                     print_options.max_depth = u16::MAX;
                 }

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -50,6 +50,34 @@ it("long arrays get cutoff", () => {
   );
 });
 
+// A BigInt depth used to be read through the int32 path, which reinterprets the cell
+// pointer as the depth.
+it("console.dir depth accepts a BigInt", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let o = {}, c = o; for (let i = 0; i < 40; i++) { c.n = {}; c = c.n; }
+       for (const depth of [7n, 7, -1n, -1, 2n ** 70n, Infinity, -(2n ** 70n), 0]) {
+         console.dir(o, { depth, colors: false });
+         console.log("--");
+       }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [big7, num7, bigNeg, numNeg, bigHuge, numInf, bigHugeNeg, num0] = stdout.split("--\n");
+  expect(big7.split("\n").filter(line => line.includes("n:")).length).toBe(8);
+  expect(big7).toBe(num7);
+  expect(bigNeg).toBe(numNeg);
+  expect(bigHuge).toBe(numInf);
+  expect(bigHugeNeg).toBe(num0);
+  expect(exitCode).toBe(0);
+});
+
 it("console.group", async () => {
   const filepath = join(import.meta.dir, "console-group.fixture.js").replaceAll("\\", "/");
   const proc = Bun.spawnSync({


### PR DESCRIPTION
### Problem
- `console.dir(obj, { depth: 7n })` prints a different depth on every run: one level in some runs, all levels in others. The assert build aborts with `ASSERTION FAILED: isInt32()` in `JSValue::asInt32`.
- `src/jsc/ConsoleObject.rs:520` accepts the option when it `is_big_int()` and then calls `to_int32()`. `to_int32` handles numbers itself and falls through to `JSC__JSValue__toInt32`, which calls `asInt32()` on the BigInt cell. Release reads the cell bits as the depth.

### Fix
- A BigInt depth now goes through `coerce_to_int64` (the `toBigInt64` path) when it is in `[0, u16::MAX]`. A negative BigInt clamps to 0, like a negative number. A BigInt above `u16::MAX` saturates to the maximum depth, like `Infinity`.
- Correct because the value is read by value, never by cell bits. `console.dir(o, { depth: 7n })` now prints the same as `{ depth: 7 }`, which is what Node prints.
- Verified: `test/js/web/console/console-log.test.ts` (new test, fails on the release build). Also the rest of that file.

### Background
- `JSValue::to_int32` (`src/jsc/JSValue.rs:760`) is a fast path for numbers. Its fallback is JSC's `toInt32`, which asserts `isInt32()`. It is only safe after an `is_number()` check.
- `is_big_int_in_int64_range` compares a heap BigInt against a range without truncation. `as_big_int_compare` gives the sign of a BigInt that is out of the int64 range.
