### PR TITLE
install: fail to resolve an empty workspace: spec, and never make the root its own workspace member

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1987,17 +1987,15 @@ impl Package<u64> {
                             'brk: {
                                 let top_level_dir = FileSystem::instance().top_level_dir();
                                 let mut buf2 = bun_paths::path_buffer_pool::get();
-                                let rel = resolve_path::relative_platform::<
-                                    path::platform::Auto,
-                                    false,
-                                >(
-                                    top_level_dir,
-                                    resolve_path::join_abs_string_buf::<path::platform::Auto>(
+                                let rel =
+                                    resolve_path::relative_platform::<path::platform::Auto, false>(
                                         top_level_dir,
-                                        &mut buf2.0,
-                                        &[source.path.name().dir, workspace],
-                                    ),
-                                );
+                                        resolve_path::join_abs_string_buf::<path::platform::Auto>(
+                                            top_level_dir,
+                                            &mut buf2.0,
+                                            &[source.path.name().dir, workspace],
+                                        ),
+                                    );
                                 // if rel is empty, the path is the root package
                                 if rel.is_empty() {
                                     break 'brk b".";

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1977,10 +1977,7 @@ impl Package<u64> {
                     // borrow has a named place to point at.
                     let workspace_str = *dependency_version.workspace();
                     let workspace = workspace_str.slice(buf);
-                    // No workspace is named after this dependency. A spec with no path
-                    // (`workspace:`) or one that lands on the project root (`workspace:.`)
-                    // resolves like `workspace:*`, so it fails instead of linking the
-                    // declaring package under the dependency name.
+                    // An empty spec, or one that lands on the declaring package itself, is `*`.
                     let path = string_builder.append::<String>(
                         if workspace == b"*"
                             || strings::trim(workspace, &strings::WHITESPACE_CHARS).is_empty()
@@ -1988,15 +1985,28 @@ impl Package<u64> {
                             b"*"
                         } else {
                             'brk: {
+                                let top_level_dir = FileSystem::instance().top_level_dir();
+                                let mut self_buf = bun_paths::path_buffer_pool::get();
+                                let self_dir =
+                                    resolve_path::join_abs_string_buf::<path::platform::Auto>(
+                                        top_level_dir,
+                                        &mut self_buf.0,
+                                        &[source.path.name().dir],
+                                    );
                                 let mut buf2 = bun_paths::path_buffer_pool::get();
+                                let joined =
+                                    resolve_path::join_abs_string_buf::<path::platform::Auto>(
+                                        top_level_dir,
+                                        &mut buf2.0,
+                                        &[source.path.name().dir, workspace],
+                                    );
+                                if strings::eql(joined, self_dir) {
+                                    break 'brk b"*";
+                                }
                                 let rel =
                                     resolve_path::relative_platform::<path::platform::Auto, false>(
-                                        FileSystem::instance().top_level_dir(),
-                                        resolve_path::join_abs_string_buf::<path::platform::Auto>(
-                                            FileSystem::instance().top_level_dir(),
-                                            &mut buf2.0,
-                                            &[source.path.name().dir, workspace],
-                                        ),
+                                        top_level_dir,
+                                        joined,
                                     );
                                 if rel.is_empty() {
                                     break 'brk b"*";
@@ -2005,7 +2015,7 @@ impl Package<u64> {
                                 {
                                     // With ALWAYS_COPY=false, `rel` may borrow
                                     // RELATIVE_TO_BUF (resolve_path.rs early returns at L450/457/500/
-                                    // 522) or be `b""`. Re-deriving a slice of the common-path buf
+                                    // 522). Re-deriving a slice of the common-path buf
                                     // would yield stale bytes in those cases. Copy `rel` into the
                                     // common-path scratch when it isn't already there, then convert
                                     // and return that — returning `rel`'s bytes
@@ -2022,8 +2032,7 @@ impl Package<u64> {
                                     // otherwise `rel` borrows a disjoint allocation.
                                     let common = unsafe { &mut *common_raw };
                                     if !rel_is_common {
-                                        // `rel` is into a disjoint thread-local (RELATIVE_TO_BUF)
-                                        // or `b""` (len==0 → no read).
+                                        // `rel` is into a disjoint thread-local (RELATIVE_TO_BUF).
                                         common[..len].copy_from_slice(rel);
                                     }
                                     let s: &mut [u8] = &mut common[..len];

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2003,11 +2003,10 @@ impl Package<u64> {
                                 if strings::eql(joined, self_dir) {
                                     break 'brk b"*";
                                 }
-                                let rel =
-                                    resolve_path::relative_platform::<path::platform::Auto, false>(
-                                        top_level_dir,
-                                        joined,
-                                    );
+                                let rel = resolve_path::relative_platform::<
+                                    path::platform::Auto,
+                                    false,
+                                >(top_level_dir, joined);
                                 if rel.is_empty() {
                                     break 'brk b"*";
                                 }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1977,8 +1977,14 @@ impl Package<u64> {
                     // borrow has a named place to point at.
                     let workspace_str = *dependency_version.workspace();
                     let workspace = workspace_str.slice(buf);
+                    // No workspace is named after this dependency. A spec with no path
+                    // (`workspace:`) or one that lands on the project root (`workspace:.`)
+                    // resolves like `workspace:*`, so it fails instead of linking the
+                    // declaring package under the dependency name.
                     let path =
-                        string_builder.append::<String>(if workspace == b"*" {
+                        string_builder.append::<String>(if workspace == b"*"
+                            || strings::trim(workspace, &strings::WHITESPACE_CHARS).is_empty()
+                        {
                             b"*"
                         } else {
                             'brk: {
@@ -1992,6 +1998,9 @@ impl Package<u64> {
                                             &[source.path.name().dir, workspace],
                                         ),
                                     );
+                                if rel.is_empty() {
+                                    break 'brk b"*";
+                                }
                                 #[cfg(windows)]
                                 {
                                     // With ALWAYS_COPY=false, `rel` may borrow

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1977,7 +1977,7 @@ impl Package<u64> {
                     // borrow has a named place to point at.
                     let workspace_str = *dependency_version.workspace();
                     let workspace = workspace_str.slice(buf);
-                    // An empty spec, or one that lands on the declaring package itself, is `*`.
+                    // An empty spec names no workspace and no path, so it resolves like `*`.
                     let path = string_builder.append::<String>(
                         if workspace == b"*"
                             || strings::trim(workspace, &strings::WHITESPACE_CHARS).is_empty()
@@ -1986,29 +1986,21 @@ impl Package<u64> {
                         } else {
                             'brk: {
                                 let top_level_dir = FileSystem::instance().top_level_dir();
-                                let mut self_buf = bun_paths::path_buffer_pool::get();
-                                let self_dir =
-                                    resolve_path::join_abs_string_buf::<path::platform::Auto>(
-                                        top_level_dir,
-                                        &mut self_buf.0,
-                                        &[source.path.name().dir],
-                                    );
                                 let mut buf2 = bun_paths::path_buffer_pool::get();
-                                let joined =
+                                let rel = resolve_path::relative_platform::<
+                                    path::platform::Auto,
+                                    false,
+                                >(
+                                    top_level_dir,
                                     resolve_path::join_abs_string_buf::<path::platform::Auto>(
                                         top_level_dir,
                                         &mut buf2.0,
                                         &[source.path.name().dir, workspace],
-                                    );
-                                if strings::eql(joined, self_dir) {
-                                    break 'brk b"*";
-                                }
-                                let rel = resolve_path::relative_platform::<
-                                    path::platform::Auto,
-                                    false,
-                                >(top_level_dir, joined);
+                                    ),
+                                );
+                                // if rel is empty, the path is the root package
                                 if rel.is_empty() {
-                                    break 'brk b"*";
+                                    break 'brk b".";
                                 }
                                 #[cfg(windows)]
                                 {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1981,8 +1981,8 @@ impl Package<u64> {
                     // (`workspace:`) or one that lands on the project root (`workspace:.`)
                     // resolves like `workspace:*`, so it fails instead of linking the
                     // declaring package under the dependency name.
-                    let path =
-                        string_builder.append::<String>(if workspace == b"*"
+                    let path = string_builder.append::<String>(
+                        if workspace == b"*"
                             || strings::trim(workspace, &strings::WHITESPACE_CHARS).is_empty()
                         {
                             b"*"
@@ -2033,7 +2033,8 @@ impl Package<u64> {
                                 #[cfg(not(windows))]
                                 break 'brk rel;
                             }
-                        });
+                        },
+                    );
                     debug_assert!(path.len() > 0);
                     debug_assert!(!bun_paths::is_absolute(path.slice(buf)));
                     dependency_version.value.workspace = path;

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { install_test_helpers } from "bun:internal-for-testing";
 import { beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { dirname, join } from "path";
 
@@ -311,4 +311,39 @@ describe.concurrent("workspaces entries longer than the path buffer", () => {
       expect(exitCode).toBe(1);
     },
   );
+});
+
+// A `workspace:` spec with no path used to resolve to the project root and link it under the
+// dependency's name.
+describe.concurrent("workspace: spec that names no workspace", () => {
+  test.each(["workspace:", "workspace:."])("%s fails to resolve", async spec => {
+    using dir = tempDir("bad-workspace-empty-spec", {
+      "package.json": JSON.stringify({ name: "p", version: "1.0.0", dependencies: { a: spec } }),
+      "index.js": `module.exports = "root";`,
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir));
+
+    expect(stderr).toContain(`error: a@${spec} failed to resolve`);
+    expect(existsSync(join(String(dir), "node_modules", "a"))).toBe(false);
+    expect(exitCode).toBe(1);
+  });
+
+  test("workspace: links the workspace with the dependency's name", async () => {
+    using dir = tempDir("bad-workspace-empty-spec-found", {
+      "package.json": JSON.stringify({
+        name: "p",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+        dependencies: { a: "workspace:" },
+      }),
+      "packages/a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir));
+
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(String(dir), "node_modules", "a", "package.json"), "utf8")).toContain('"name":"a"');
+  });
 });

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -313,20 +313,53 @@ describe.concurrent("workspaces entries longer than the path buffer", () => {
   );
 });
 
-// A `workspace:` spec with no path used to resolve to the project root and link it under the
-// dependency's name.
+// A `workspace:` spec with no path used to resolve to the declaring package and link it under
+// the dependency's name.
 describe.concurrent("workspace: spec that names no workspace", () => {
-  test.each(["workspace:", "workspace:."])("%s fails to resolve", async spec => {
+  test("empty spec in the root fails to resolve", async () => {
     using dir = tempDir("bad-workspace-empty-spec", {
-      "package.json": JSON.stringify({ name: "p", version: "1.0.0", dependencies: { a: spec } }),
+      "package.json": JSON.stringify({ name: "p", version: "1.0.0", dependencies: { a: "workspace:" } }),
       "index.js": `module.exports = "root";`,
     });
 
     const { stderr, exitCode } = await runInstall(String(dir));
 
-    expect(stderr).toContain(`error: a@${spec} failed to resolve`);
+    expect(stderr).toContain("error: a@workspace: failed to resolve");
     expect(existsSync(join(String(dir), "node_modules", "a"))).toBe(false);
     expect(exitCode).toBe(1);
+  });
+
+  test("empty spec in a workspace member fails to resolve", async () => {
+    using dir = tempDir("bad-workspace-member-empty-spec", {
+      "package.json": JSON.stringify({ name: "p", version: "1.0.0", workspaces: ["packages/*"] }),
+      "packages/foo/package.json": JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: { bar: "workspace:" },
+      }),
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir));
+
+    expect(stderr).toContain("error: bar@workspace: failed to resolve");
+    expect(existsSync(join(String(dir), "node_modules", "bar"))).toBe(false);
+    expect(exitCode).toBe(1);
+  });
+
+  // `workspace:.` is a path. In the root it names the root package, like it names the member
+  // in a member (see "workspace self dependencies create symlinks" in isolated-install.test.ts).
+  test("workspace:. in the root links the root package under the dependency's name", async () => {
+    using dir = tempDir("bad-workspace-root-self-spec", {
+      "package.json": JSON.stringify({ name: "p", version: "1.0.0", dependencies: { a: "workspace:." } }),
+      "index.js": `module.exports = "root";`,
+    });
+
+    for (let i = 0; i < 2; i++) {
+      const { stderr, exitCode } = await runInstall(String(dir));
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(readFileSync(join(String(dir), "node_modules", "a", "package.json"), "utf8")).name).toBe("p");
+    }
   });
 
   test("workspace: links the workspace with the dependency's name", async () => {
@@ -345,22 +378,5 @@ describe.concurrent("workspace: spec that names no workspace", () => {
     expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
     expect(readFileSync(join(String(dir), "node_modules", "a", "package.json"), "utf8")).toContain('"name":"a"');
-  });
-
-  test("workspace:. in a workspace member does not link the member under another name", async () => {
-    using dir = tempDir("bad-workspace-member-self-spec", {
-      "package.json": JSON.stringify({ name: "p", version: "1.0.0", workspaces: ["packages/*"] }),
-      "packages/foo/package.json": JSON.stringify({
-        name: "foo",
-        version: "1.0.0",
-        dependencies: { bar: "workspace:." },
-      }),
-    });
-
-    const { stderr, exitCode } = await runInstall(String(dir));
-
-    expect(stderr).toContain("error: bar@workspace:. failed to resolve");
-    expect(existsSync(join(String(dir), "node_modules", "bar"))).toBe(false);
-    expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -350,7 +350,11 @@ describe.concurrent("workspace: spec that names no workspace", () => {
   test("workspace:. in a workspace member does not link the member under another name", async () => {
     using dir = tempDir("bad-workspace-member-self-spec", {
       "package.json": JSON.stringify({ name: "p", version: "1.0.0", workspaces: ["packages/*"] }),
-      "packages/foo/package.json": JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { bar: "workspace:." } }),
+      "packages/foo/package.json": JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: { bar: "workspace:." },
+      }),
     });
 
     const { stderr, exitCode } = await runInstall(String(dir));

--- a/test/cli/install/bad-workspace.test.ts
+++ b/test/cli/install/bad-workspace.test.ts
@@ -346,4 +346,17 @@ describe.concurrent("workspace: spec that names no workspace", () => {
     expect(exitCode).toBe(0);
     expect(readFileSync(join(String(dir), "node_modules", "a", "package.json"), "utf8")).toContain('"name":"a"');
   });
+
+  test("workspace:. in a workspace member does not link the member under another name", async () => {
+    using dir = tempDir("bad-workspace-member-self-spec", {
+      "package.json": JSON.stringify({ name: "p", version: "1.0.0", workspaces: ["packages/*"] }),
+      "packages/foo/package.json": JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { bar: "workspace:." } }),
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir));
+
+    expect(stderr).toContain("error: bar@workspace:. failed to resolve");
+    expect(existsSync(join(String(dir), "node_modules", "bar"))).toBe(false);
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun install` with `"a": "workspace:"` and no workspace named `a` links the root project as `node_modules/a` (`"a": ["p@root:", {}]` in `bun.lock`). The assert build panics with `assertion failed: path.len() > 0` at `src/install/lockfile/Package.rs:2028`.
- A `workspaces` entry that leaves the root and names it again reaches the same assertion: the root becomes its own member, and release links the root to itself. A glob (`["../*"]`) does this on every platform. A plain path (`["../root"]`) does it on Windows, where the root check in `WorkspaceMap.rs` compares `C:\repo` with `C:/repo` as bytes.

### Fix
- An empty `workspace:` spec is stored as `*`, like `workspace:*`. The install fails with `error: Workspace dependency "a" not found`, then `error: a@workspace: failed to resolve`, in the root and in a member.
- `workspace:.` stays a path, because #23609 relies on it in members. In the root it now stores `.`, not an empty path.
- Plain paths and globs skip the root through one helper, `is_root_package_json`. It tests whether `relative_workspace_path` is empty. That is the value the assertion guards, and it ignores separators.
- Verified: `test/cli/install/bad-workspace.test.ts` (six new tests) on Linux debug ASAN and on a Windows x64 debug build. Also `bun-workspaces.test.ts` and `isolated-install.test.ts` on Linux.

### Background
- `Package::parse` turns each `dependencies` entry and each `workspaces` member into a `Dependency`. For a `workspace:` spec it looks up `workspace_paths` by name first. Only when that fails does it treat the spec as a path.
- `FolderResolution::get_or_put` later joins the stored path onto the root. An empty path is the root itself. A path of `*` does not exist, so resolution fails.
- `WorkspaceMap.rs` expands the `workspaces` array. Plain paths and globs take separate branches.

<details><summary>Notes</summary>

History of this PR, for a reviewer who saw an earlier head:

- An early revision also rejected `workspace:.` when it pointed at the declaring package. CI showed that `isolated-install.test.ts` ("workspace self dependencies create symlinks", #23609) depends on that self link in members, so only a spec with no path at all is rejected.
- Up to c7cc2c70 this PR closed the glob case by accident. The root's empty member path hit the new empty-spec check, became `*`, and the install failed with `<root>@ failed to resolve`. That changed release behavior outside the scope of this PR, with a misleading message.
- bef3df90 skipped the root in the glob branch with the byte compare the plain-path branch used. That fixed Linux and macOS only. On both Windows lanes of build 117701 the new test still failed with `root@ failed to resolve`. 868395c5 replaces the byte compare at both sites.
- The plain-path byte compare is older than this PR and has not worked on Windows. The release build of main (canary 367d939d9) on Windows writes `"root": ["root@root:", {}]` into `bun.lock` for `"workspaces": ["../root", "../proj-a"]`. The same input is clean on Linux. With the empty-spec change, leaving it would have turned that self link into a failed install on Windows.
- This PR does not decide whether a `workspaces` pattern may leave the root. #41764 covers that, and the two PRs now conflict in the glob branch of `WorkspaceMap.rs` and in the test file. Every glob that names the root this way leaves the root. If #41764 refuses such patterns, the glob-branch skip and the glob case of the test are redundant and can be dropped when the conflict is resolved.

Checks at 868395c5:

- Windows x64 debug build: `bad-workspace.test.ts` 16 pass, 4 skip (existing platform gates), 0 fail.
- Linux debug ASAN build: `bad-workspace.test.ts` 20 pass, 0 fail.
- Of the six new tests, three fail on the Linux release build of main: both empty-spec tests and the glob case. The plain-path case fails only on Windows, which the `bun.lock` check above shows for main.

Checks at bef3df90 on Linux debug ASAN (the code they cover did not change in 868395c5 on POSIX):

- `["../*"]` and `["../evilrepo", "../projA"]` produce byte-identical `bun.lock` files.
- A root `package.json` with no `name` and `"workspaces": ["../*"]` installs with exit 0. The root is skipped before it is parsed as a member, so no "Missing name" error is raised for it.
- `isolated-install.test.ts` passed 85 of 85 in two runs of the file alone. In one combined run with the other two files, "ranged peer dependency resolution is stable across installs from bun.lock" failed once. It passed alone, and it uses no workspaces, globs, or `workspace:` specs.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bad-workspace.test.ts

<!-- robobun:evidence:end -->
