### PR TITLE
import.meta.resolve: support URL parent and validate parentURL (#41318)

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -129,29 +129,36 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSync(JSC::JSGlobalObje
             }
         }
 
-        if (!fromValue.isUndefinedOrNull() && fromValue.isObject()) {
-
-            auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).pathsPublicName());
-            RETURN_IF_EXCEPTION(scope, {});
-            if (pathsObject) {
-                if (pathsObject.isCell() && pathsObject.asCell()->type() == JSC::JSType::ArrayType) {
-                    auto pathsArray = uncheckedDowncast<JSC::JSArray>(pathsObject);
-                    if (pathsArray->length() > 0) {
-                        fromValue = pathsArray->getIndex(globalObject, 0);
-                        RETURN_IF_EXCEPTION(scope, {});
+        if (!fromValue.isUndefinedOrNull()) {
+            if (WebCore::DOMURL* url = WebCoreCast<WebCore::JSDOMURL, WebCore::DOMURL>(JSValue::encode(fromValue))) {
+                from = JSC::JSValue::encode(jsString(vm, url->href().string()));
+            } else if (fromValue.isObject()) {
+                auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).pathsPublicName());
+                RETURN_IF_EXCEPTION(scope, {});
+                if (pathsObject) {
+                    if (pathsObject.isCell() && pathsObject.asCell()->type() == JSC::JSType::ArrayType) {
+                        auto pathsArray = uncheckedDowncast<JSC::JSArray>(pathsObject);
+                        if (pathsArray->length() > 0) {
+                            fromValue = pathsArray->getIndex(globalObject, 0);
+                            RETURN_IF_EXCEPTION(scope, {});
+                            if (WebCore::DOMURL* pathUrl = WebCoreCast<WebCore::JSDOMURL, WebCore::DOMURL>(JSValue::encode(fromValue))) {
+                                from = JSC::JSValue::encode(jsString(vm, pathUrl->href().string()));
+                            }
+                        }
                     }
                 }
+            } else if (fromValue.isBoolean()) {
+                isESM = fromValue.toBoolean(globalObject);
+                fromValue = JSC::jsUndefined();
             }
-
-        } else if (fromValue.isBoolean()) {
-            isESM = fromValue.toBoolean(globalObject);
-            fromValue = JSC::jsUndefined();
         }
 
-        if (fromValue.isString()) {
-            from = JSC::JSValue::encode(fromValue);
-        } else if (thisValue.isString()) {
-            from = JSC::JSValue::encode(thisValue);
+        if (JSValue::decode(from).isUndefined()) {
+            if (fromValue.isString()) {
+                from = JSC::JSValue::encode(fromValue);
+            } else if (thisValue.isString()) {
+                from = JSC::JSValue::encode(thisValue);
+            }
         }
 
     } else if (thisValue.isString()) {
@@ -351,22 +358,39 @@ JSC_DEFINE_HOST_FUNCTION(functionImportMeta__resolve,
     if (callFrame->argumentCount() >= 2) {
         JSValue fromValue = callFrame->uncheckedArgument(1);
 
-        if (!fromValue.isUndefinedOrNull() && fromValue.isObject()) {
-            auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).pathsPublicName());
-            RETURN_IF_EXCEPTION(scope, {});
-            if (pathsObject) {
-                if (pathsObject.isCell() && pathsObject.asCell()->type() == JSC::JSType::ArrayType) {
+        if (!fromValue.isUndefined()) {
+            if (fromValue.isString()) {
+                from = fromValue;
+            } else if (WebCore::DOMURL* url = WebCoreCast<WebCore::JSDOMURL, WebCore::DOMURL>(JSValue::encode(fromValue))) {
+                from = jsString(vm, url->href().string());
+            } else if (fromValue.isObject()) {
+                auto pathsObject = fromValue.getObject()->getIfPropertyExists(globalObject, builtinNames(vm).pathsPublicName());
+                RETURN_IF_EXCEPTION(scope, {});
+                if (pathsObject && pathsObject.isCell() && pathsObject.asCell()->type() == JSC::JSType::ArrayType) {
                     auto* pathsArray = uncheckedDowncast<JSC::JSArray>(pathsObject);
                     if (pathsArray->length() > 0) {
-                        fromValue = pathsArray->getIndex(globalObject, 0);
+                        JSValue firstPath = pathsArray->getIndex(globalObject, 0);
                         RETURN_IF_EXCEPTION(scope, {});
+                        if (firstPath.isString()) {
+                            from = firstPath;
+                        } else if (WebCore::DOMURL* pathUrl = WebCoreCast<WebCore::JSDOMURL, WebCore::DOMURL>(JSValue::encode(firstPath))) {
+                            from = jsString(vm, pathUrl->href().string());
+                        } else {
+                            Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "parentURL"_s, "string or an instance of URL"_s, fromValue);
+                            return {};
+                        }
+                    } else {
+                        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "parentURL"_s, "string or an instance of URL"_s, fromValue);
+                        return {};
                     }
+                } else {
+                    Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "parentURL"_s, "string or an instance of URL"_s, fromValue);
+                    return {};
                 }
+            } else {
+                Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "parentURL"_s, "string or an instance of URL"_s, fromValue);
+                return {};
             }
-        }
-
-        if (fromValue.isString()) {
-            from = fromValue;
         }
     }
 

--- a/test/js/bun/resolve/import-meta-resolve-url.test.ts
+++ b/test/js/bun/resolve/import-meta-resolve-url.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+describe("import.meta.resolve with URL instance parent (#41318)", () => {
+  test("resolves relative specifier with URL parent identical to string parent", () => {
+    const parentUrl = new URL("./sub/dir/mod.mjs", import.meta.url);
+    const resolvedFromUrl = import.meta.resolve("./sibling.mjs", parentUrl);
+    const resolvedFromString = import.meta.resolve("./sibling.mjs", parentUrl.href);
+
+    expect(resolvedFromUrl).toBe(resolvedFromString);
+    expect(resolvedFromUrl).toBe(new URL("./sub/dir/sibling.mjs", import.meta.url).href);
+  });
+
+  test("resolves parent directory specifier (..) with URL parent", () => {
+    const parentUrl = new URL("./sub/dir/mod.mjs", import.meta.url);
+    const resolvedFromUrl = import.meta.resolve("../parent-sibling.mjs", parentUrl);
+    const resolvedFromString = import.meta.resolve("../parent-sibling.mjs", parentUrl.href);
+
+    expect(resolvedFromUrl).toBe(resolvedFromString);
+    expect(resolvedFromUrl).toBe(new URL("./sub/parent-sibling.mjs", import.meta.url).href);
+  });
+
+  test("undefined parent falls back to caller base URL", () => {
+    const resolvedDefault = import.meta.resolve("./sibling.mjs");
+    const resolvedUndefined = import.meta.resolve("./sibling.mjs", undefined);
+
+    expect(resolvedUndefined).toBe(resolvedDefault);
+    expect(resolvedUndefined).toBe(new URL("./sibling.mjs", import.meta.url).href);
+  });
+
+  test("import.meta.resolveSync accepts URL instance as parent", () => {
+    const parentUrl = new URL("./src/index.ts", import.meta.url);
+    try {
+      import.meta.resolveSync("./does-not-exist.ts", parentUrl);
+    } catch (err: any) {
+      expect(err.message).toContain("file:///");
+      expect(err.message).toContain("src/index.ts");
+    }
+  });
+
+  describe("parentURL argument validation", () => {
+    test("rejects invalid parent types with TypeError [ERR_INVALID_ARG_TYPE]", () => {
+      const invalidParents = [
+        ["number", 42],
+        ["null", null],
+        ["boolean", true],
+        ["boolean false", false],
+        ["empty object", {}],
+        ["symbol", Symbol("parent")],
+        ["bigint", 100n],
+      ];
+
+      for (const [label, invalidValue] of invalidParents) {
+        expect(() => {
+          // @ts-ignore
+          import.meta.resolve("./sibling.mjs", invalidValue);
+        }).toThrow(
+          expect.objectContaining({
+            name: "TypeError",
+            code: "ERR_INVALID_ARG_TYPE",
+          }),
+        );
+      }
+    });
+
+    test("supports object with paths array", () => {
+      const testFile = path.join(import.meta.dir, "sub", "mod.mjs");
+      const resolved = import.meta.resolve("./sibling.mjs", { paths: [testFile] });
+      expect(resolved).toBe(new URL("./sub/sibling.mjs", import.meta.url).href);
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #41318.

In Bun, calling `import.meta.resolve(specifier, parent)` with a `URL` instance as `parent` (such as `new URL("./sub/mod.mjs", import.meta.url)` or `pathToFileURL(...)`) silently ignored the `URL` argument and fell back to resolving relative to the calling module's own path. Furthermore, passing invalid types (such as numbers, booleans, null, or generic objects) was also silently ignored instead of throwing `TypeError [ERR_INVALID_ARG_TYPE]`.

This breaks real-world packages like `@mikro-orm/cli` (`import.meta.resolve(id, pathToFileURL(from))`) and `@apollo/client`, causing them to resolve modules relative to the wrong directory under Bun.

This PR:
- Unwraps `WebCore::DOMURL` instances passed as the second argument (`parent`) in `import.meta.resolve` and `import.meta.resolveSync`, extracting `url->href().string()`.
- Validates the `parent` argument: throws `TypeError [ERR_INVALID_ARG_TYPE]: The "parentURL" argument must be of type string or an instance of URL. Received ...` when `parent` is not `undefined`, not a string, and not a `URL` instance (matching Node.js and WHATWG HTML error code and behavior).
- Preserves backwards compatibility for Bun's `{ paths: [...] }` object argument.

### How did you verify your code works?

1. **Reproduction Sandbox**:
Verified with `/tmp/bun-issue-41318-sandbox/repro.mjs` that `import.meta.resolve("./sibling.mjs", parentUrl)` resolves identically to `parentUrl.href`, and invalid types (`42`, `null`, `true`, `{}`) throw `TypeError [ERR_INVALID_ARG_TYPE]` matching Node.js 22+.
2. **Dedicated Test Suite**:
Added `test/js/bun/resolve/import-meta-resolve-url.test.ts` (6 passed, 0 failed):
- Resolving relative specifiers with `URL` parent identical to string parent.
- Resolving parent directory specifier (`..`) with `URL` parent.
- `undefined` parent falling back to caller base URL.
- `import.meta.resolveSync` accepting `URL` parent.
- `parentURL` argument validation rejecting numbers, null, booleans, symbols, bigints, and plain objects with `ERR_INVALID_ARG_TYPE`.
- Object with `paths` array.
3. **Full Regression Suite**:
Ran all tests in `test/js/bun/resolve/` (398 passed, 0 failed).