### PR TITLE
Bun.serve: throw when both port and unix are given

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -582,8 +582,7 @@ Server.prototype.listen = function () {
     }
   }
 
-  // As in node (and net.ts), a port takes precedence over `path`, and the
-  // pipe branch never reads `host`.
+  // Node precedence: a port wins over `path`, and a `path` listen ignores `host`.
   if ((typeof port === "number" || typeof port === "string") && socketPath) {
     socketPath = undefined;
   } else if (socketPath) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -582,9 +582,12 @@ Server.prototype.listen = function () {
     }
   }
 
-  // As in node (and net.ts), a port takes precedence over `path`.
+  // As in node (and net.ts), a port takes precedence over `path`, and the
+  // pipe branch never reads `host`.
   if ((typeof port === "number" || typeof port === "string") && socketPath) {
     socketPath = undefined;
+  } else if (socketPath) {
+    host = undefined;
   }
 
   const lastArg = arguments[argc - 1];

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -548,6 +548,10 @@ Server.prototype.listen = function () {
       port = arg0.port;
       host = arg0.host;
       socketPath = arg0.path;
+      // Node normalizes an explicit `port: undefined` or `port: null` to 0.
+      if ((port === undefined && "port" in arg0) || port === null) {
+        port = 0;
+      }
 
       const otherTLS = arg0.tls;
       if (otherTLS && $isObject(otherTLS)) {
@@ -576,6 +580,11 @@ Server.prototype.listen = function () {
     if (!Number.isNaN(portNumber)) {
       port = portNumber;
     }
+  }
+
+  // As in node (and net.ts), a port takes precedence over `path`.
+  if ((typeof port === "number" || typeof port === "string") && socketPath) {
+    socketPath = undefined;
   }
 
   const lastArg = arguments[argc - 1];

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -635,6 +635,7 @@ impl ServerConfig {
             ..ServerConfig::default()
         };
         let mut has_hostname = false;
+        let mut has_port = false;
 
         if env.get(b"NODE_ENV").unwrap_or(b"") == b"production" {
             args.development = DevelopmentOption::Production;
@@ -1083,6 +1084,7 @@ impl ServerConfig {
                 *tp = p;
             }
             port = p;
+            has_port = p != 0;
         }
 
         if let Some(base_uri) = arg.get_truthy(global, "baseURI")? {
@@ -1118,6 +1120,11 @@ impl ServerConfig {
                 if has_hostname {
                     return Err(global.throw_invalid_arguments(format_args!(
                         "Cannot specify both hostname and unix",
+                    )));
+                }
+                if has_port {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "Cannot specify both port and unix",
                     )));
                 }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2493,7 +2493,7 @@ it("unix socket connection throws an error on a bad domain without crashing", as
   }).toThrow();
 });
 
-it("Bun.serve throws when both port and unix are given", () => {
+it("Bun.serve throws when both port and unix are given", async () => {
   using dir = tempDir("port-and-unix", {});
   const unix = join(String(dir), "port-and-unix.sock");
   expect(() => {
@@ -2515,8 +2515,9 @@ it("Bun.serve throws when both port and unix are given", () => {
       return new Response("hey");
     },
   });
-  expect(String(server.url)).toBe(`unix://${unix}`);
   expect(server.port).toBeUndefined();
+  const res = await fetch("http://localhost/", { unix });
+  expect(await res.text()).toBe("hey");
 });
 
 it("#5859 text", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1,6 +1,6 @@
 import { file, gc, Serve, serve, Server } from "bun";
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
-import { readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import {
   bunEnv,
   bunExe,
@@ -2491,6 +2491,32 @@ it("unix socket connection throws an error on a bad domain without crashing", as
       },
     });
   }).toThrow();
+});
+
+it("Bun.serve throws when both port and unix are given", () => {
+  using dir = tempDir("port-and-unix", {});
+  const unix = join(String(dir), "port-and-unix.sock");
+  expect(() => {
+    using server = Bun.serve({
+      port: 1,
+      unix,
+      fetch() {
+        return new Response("hey");
+      },
+    });
+  }).toThrow("Cannot specify both port and unix");
+  expect(existsSync(unix)).toBe(false);
+
+  // port 0 asks for no specific port, so it does not conflict with unix.
+  using server = Bun.serve({
+    port: 0,
+    unix,
+    fetch() {
+      return new Response("hey");
+    },
+  });
+  expect(String(server.url)).toBe(`unix://${unix}`);
+  expect(server.port).toBeUndefined();
 });
 
 it("#5859 text", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1355,6 +1355,18 @@ describe("node:http", () => {
     expect(await response.text()).toBe("ok");
   });
 
+  test("listen({ path, host }) binds the path and ignores the host, as in node", async () => {
+    const socketPath = `${tmpdir()}/bun-server-${Math.random().toString(32)}.sock`;
+    await using server = createServer((req, res) => {
+      res.end("ok");
+    });
+    server.listen({ path: socketPath, host: "localhost" });
+    await once(server, "listening");
+    expect(server.address()).toBe(socketPath);
+    const response = await fetch("http://localhost/", { unix: socketPath });
+    expect(await response.text()).toBe("ok");
+  });
+
   test("should not decompress gzip, issue#4397", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1338,6 +1338,23 @@ describe("node:http", () => {
     await promise;
   });
 
+  // Node binds the TCP port and ignores `path` whenever the options carry a
+  // `port` key, including `port: undefined`, `port: null` and a string port.
+  test.each([0, "0", undefined, null])("listen({ port: %p, path }) binds the port and ignores the path", async port => {
+    const socketPath = `${tmpdir()}/bun-server-${Math.random().toString(32)}.sock`;
+    await using server = createServer((req, res) => {
+      res.end("ok");
+    });
+    server.listen({ port, path: socketPath });
+    await once(server, "listening");
+    const address = server.address() as AddressInfo;
+    expect(typeof address).toBe("object");
+    expect(address.port).toBeGreaterThan(0);
+    expect(nodefs.existsSync(socketPath)).toBe(false);
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+    expect(await response.text()).toBe("ok");
+  });
+
   test("should not decompress gzip, issue#4397", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### Problem
- `Bun.serve({ port: 8080, unix: "/tmp/app.sock", fetch })` binds only the unix socket. The port is dropped with no diagnostic: `server.port` is `undefined` and nothing listens on 8080.
- The cause is `src/runtime/server/ServerConfig.rs:1115`. The `unix` branch overwrites `args.address` after `port` was parsed into it. The sibling conflict, `unix` with `hostname`, already throws `Cannot specify both hostname and unix` a few lines above.

### Fix
- Throw `Cannot specify both port and unix` when `unix` is given with a non-zero `port`. Port 0 asks for no specific port, so it keeps its current behavior (the unix socket wins). In-tree tests rely on `port: 0` with `unix`.
- `node:http`'s `Server.listen` forwarded `port`, `host` and `unix: socketPath` together to `Bun.serve`. It now follows Node's `net.Server.listen`: when the options carry a `port` key (a number, a string, `undefined` or `null`), the port wins and the path is not forwarded. When the path wins, `host` is not forwarded (Node's pipe branch never reads it, and `listen({ path, host })` emitted `'error'` in bun before). `node:net` already applies the port rule in `src/js/node/net.ts`. Verified against node v26.3.0.
- Correct because the public types already declare `unix` exclusive with `hostname` and `port` (`packages/bun-types/serve.d.ts`, `XOR<HostnamePortServeOptions, UnixServeOptions>`). The runtime now enforces that contract.
- Verified: `test/js/bun/http/serve.test.ts` (new test) and `test/js/node/http/node-http.test.ts` (five new cases). All fail on bun 1.4.3 and pass with the fix, on linux x64 and Windows x64. Also ran `bun-serve-args.test.ts` and both full files.

### Background
- `ServerConfig::from_js` parses the `Bun.serve` options object into an `Address`, which is either `Tcp { hostname, port }` or `Unix(path)`. Each option is read in sequence, so a later option can silently replace an earlier one.
- `node:http` in bun is built on `Bun.serve`. `Server.prototype.listen` in `src/js/node/_http_server.ts` normalizes the Node argument shapes and calls `Bun.serve` in `kRealListen`.
- In Node, `Server.listen(options)` checks `options.port` before `options.path`. A `port` key of any accepted type takes the TCP branch and `path` is never looked at. The pipe branch reads only `path` and the pipe-specific options.

<details><summary>Notes</summary>

Found by an internal audit of places where bun picks a transport mode from conflicting input.

The first revision of the `Bun.serve` test asserted on `server.url`. Its getter throws `TypeError: Invalid URL` for a Windows drive path (`unix://C:\...`), which is the pre-existing #40182 (fix proposed in #35806). The test now asserts `server.port` is `undefined` and fetches over the unix socket instead.

Two pre-existing failures in `serve.test.ts` in my linux container (`#7187` root range port, `/bun:info` loopback clients) also fail on main there. They depend on the container running as root and on its network interfaces. They are unrelated to this change and pass in CI.

Self-reviewed: 4 concerns raised, 4 addressed (match the `net.ts` port precedence rule including string ports and Node's `undefined`/`null` normalization, keep the `port: 0` + `unix` boundary asserted next to the throw test, use `tempDir` in the new test, do not cite #14299 as precedent). Review follow-ups addressed: `listen({ path, host })` parity, Windows-portable test assertion.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->