### PR TITLE
cli: reject --user-agent and publish --otp values containing CR, LF or NUL

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1459,6 +1459,14 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             }
 
             if let Some(otp) = args.option(b"--otp") {
+                // Written verbatim into the `npm-otp` header.
+                if strings::contains_any(otp, b"\r\n\0") {
+                    Output::err_generic(
+                        "invalid `otp` value: must not contain a newline or NUL byte",
+                        (),
+                    );
+                    Global::exit(1);
+                }
                 cli.publish_config.otp = otp;
             }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1163,6 +1163,14 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         }
 
         if let Some(user_agent) = args.option(b"--user-agent") {
+            // Written verbatim into the `User-Agent` header of every request.
+            if strings::contains_any(user_agent, b"\r\n\0") {
+                Output::err_generic(
+                    "Invalid value for --user-agent: must not contain a newline or NUL byte\n",
+                    (),
+                );
+                Global::exit(1);
+            }
             // argv slices returned by `clap::Args::option` borrow
             // process-lifetime `argv` storage.
             let _ = bun_http::OVERRIDDEN_DEFAULT_USER_AGENT.set(user_agent);

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -482,6 +482,34 @@ describe("otp", async () => {
       expect(exitCode).toBe(0);
     });
   }
+
+  // `--otp` is written into `npm-otp: <value>` as-is, so a value holding "\r\n"
+  // used to end that header line and send whatever followed it as additional
+  // header lines. It must be rejected before any request is made.
+  test.each([
+    ["CRLF", "abc\r\nX-Injected: 1"],
+    ["a bare LF", "abc\ndef"],
+    ["a bare CR", "abc\rdef"],
+  ])("--otp containing %s is rejected", async (_, otp) => {
+    const seen: { injected: string | null }[] = [];
+    using mockRegistry = Bun.serve({
+      port: 0,
+      fetch(req) {
+        seen.push({ injected: req.headers.get("x-injected") });
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("publish-otp-crlf", {
+      "package.json": JSON.stringify({ name: "otp-pkg-crlf", version: "1.0.0" }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${mockRegistry.port}", token = "tok" }\n`,
+    });
+
+    const { err, exitCode } = await publish(env, String(dir), "--otp", otp);
+    expect(seen).toEqual([]);
+    expect(err).toContain("invalid `otp` value: must not contain a newline or NUL byte");
+    expect(exitCode).toBe(1);
+  });
 });
 
 test("can publish a package then install it", async () => {

--- a/test/cli/user-agent.test.ts
+++ b/test/cli/user-agent.test.ts
@@ -76,4 +76,55 @@ try {
     const exitCode = await proc.exited;
     expect(exitCode).toBe(0);
   });
+
+  // The value is written into `User-Agent: <value>` as-is, so a value holding
+  // "\r\n" used to end that header line and send whatever followed it as
+  // additional header lines. It must be rejected before any request is made.
+  describe.concurrent("value containing CR, LF or NUL is rejected", () => {
+    const error = "Invalid value for --user-agent: must not contain a newline or NUL byte";
+
+    async function fetchWith(flags: string[], env: Record<string, string> = {}) {
+      const seen: { injected: string | null }[] = [];
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          seen.push({ injected: req.headers.get("x-injected") });
+          return new Response("ok");
+        },
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...flags, "-e", `await fetch("${server.url}")`],
+        env: { ...bunEnv, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { seen, stdout, stderr, exitCode };
+    }
+
+    test("--user-agent with CRLF", async () => {
+      const { seen, stderr, exitCode } = await fetchWith(["--user-agent", "abc\r\nX-Injected: 1"]);
+      expect(seen).toEqual([]);
+      expect(stderr).toContain(error);
+      expect(exitCode).toBe(1);
+    });
+
+    test("--user-agent from BUN_OPTIONS", async () => {
+      const { seen, stderr, exitCode } = await fetchWith([], { BUN_OPTIONS: "--user-agent='abc\r\nX-Injected: 1'" });
+      expect(seen).toEqual([]);
+      expect(stderr).toContain(error);
+      expect(exitCode).toBe(1);
+    });
+
+    test.each([
+      ["a bare LF", "abc\ndef"],
+      ["a bare CR", "abc\rdef"],
+    ])("--user-agent with %s", async (_, userAgent) => {
+      const { seen, stderr, exitCode } = await fetchWith(["--user-agent", userAgent]);
+      expect(seen).toEqual([]);
+      expect(stderr).toContain(error);
+      expect(exitCode).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- The runtime `--user-agent <value>` flag (argv or `BUN_OPTIONS`) is stored as-is in `bun_http::OVERRIDDEN_DEFAULT_USER_AGENT` (`src/runtime/cli/Arguments.rs:1165`) and written verbatim into the `User-Agent` header of every request the HTTP client sends. A value holding `\r\n` ends the header line. What follows reaches the server as additional header lines, or as a second request on the same connection.
- `bun publish --otp <value>` (`src/install/PackageManager/CommandLineArguments.rs:1461`) has the same shape. The value goes verbatim into the `npm-otp` header in `construct_publish_headers`.
- Reproduced on 1.4.3 with a loopback `Bun.serve`: `bun --user-agent $'abc\r\nX-Injected: 1' -e 'await fetch(url)'` and `bun publish --otp $'abc\r\nX-Injected: 1'` both arrive with a separate `x-injected: 1` header.

### Fix
- Each value is checked where it is parsed, before it is stored. A value containing CR, LF or NUL prints an error and exits 1. No request is made.
- `--user-agent`: `error: Invalid value for --user-agent: must not contain a newline or NUL byte` (the same form as the `--max-http-header-size` error next to it).
- `--otp`: ``error: invalid `otp` value: must not contain a newline or NUL byte`` (the same form as the `--access` error next to it).
- Verified: `test/cli/user-agent.test.ts` (4 new tests: CRLF, `BUN_OPTIONS`, bare LF, bare CR) and `test/cli/install/bun-publish.test.ts` (3 new tests). All 7 fail on 1.4.3 and pass with this change. Also ran the rest of both files and `test/bundler/compile-argv.test.ts`.

### Background
- This follows #37458, which applies the same check to registry auth tokens in `Options::load`. That PR covers the `Authorization` header. These two flags are the remaining CLI entrances into the same header writer.
- The install HTTP client (`src/http/lib.rs`) and `http::HeaderBuilder` build the request bytes themselves. Unlike `fetch()` headers from JS, nothing validates the values on the way out. Validation at the parse site is the approach chosen for #37458, and this PR keeps to it.
- `--registry` URLs and URL userinfo were checked in the same audit and are not affected: the URL parser strips CR/LF, and userinfo is base64 encoded before it reaches a header.

<details><summary>Notes</summary>

- The interactive OTP prompt (`InitCommand::prompt`) trims its input, so only the flag form needs the check.
- `--tag` goes into the JSON body, not a header, and is not affected.
- NUL cannot be passed through argv, so the tests cover CR and LF only. The check still rejects NUL for consistency with #37458.
- `BUN_OPTIONS` is split into argv before parsing, so the same check covers it. The test for that path asserts the error and that the server saw no request.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->