### PR TITLE
publish: reject a registry URL whose scheme is not http or https

### DIFF
--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -849,9 +849,12 @@ impl PublishCommand {
         let registry_url = registry.url.url();
 
         if !registry_url.has_http_like_protocol() {
-            return Err(PublishError::InvalidRegistryUrl(
-                registry_url.href_without_auth(),
-            ));
+            return Err(PublishError::InvalidRegistryUrl(if registry_url.protocol.is_empty() {
+                // `href_without_auth()` would print a scheme-less URL as `http://...`.
+                Box::from(registry.url.href())
+            } else {
+                registry_url.href_without_auth()
+            }));
         }
 
         if registry.token.is_empty()

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -2109,8 +2109,12 @@ impl PublishError {
     }
 }
 
-/// `url.href` without anything up to a `@` before the path, and with one trailing slash.
+/// `url.href` with every `user:password@` before the path cut out, and with one trailing slash.
 fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
+    fn after_last_at(s: &[u8]) -> &[u8] {
+        strings::last_index_of_char(s, b'@').map_or(s, |at| &s[at + 1..])
+    }
+
     let href = url.href;
     let authority_start = if !url.protocol.is_empty() {
         url.protocol.len() + b"://".len()
@@ -2122,12 +2126,10 @@ fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     let path_start = authority_start
         + strings::index_of_any(&href[authority_start..], b"/?#")
             .unwrap_or(href.len() - authority_start);
-    // `URL::parse` does not validate the scheme, so a `@` can also sit before `://`.
-    let (scheme, host_and_path) = match strings::last_index_of_char(&href[..path_start], b'@') {
-        Some(at) if at < authority_start => (&href[..0], &href[at + 1..]),
-        Some(at) => (&href[..authority_start], &href[at + 1..]),
-        None => (&href[..authority_start], &href[authority_start..]),
-    };
+    // `URL::parse` does not validate the scheme, so it can hold a `user:password@` too.
+    let scheme = after_last_at(&href[..authority_start]);
+    let host = after_last_at(&href[authority_start..path_start]);
+    let host_and_path = &href[path_start - host.len()..];
     let trimmed = strings::without_trailing_slash(host_and_path);
 
     let mut out = Vec::with_capacity(scheme.len() + trimmed.len() + 1);

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -2109,7 +2109,7 @@ impl PublishError {
     }
 }
 
-/// `url.href` with nothing before its last `@`, no `?query` or `#fragment`, and one trailing slash.
+/// `url.href` without userinfo, `?query` or `#fragment`, and with one trailing slash.
 fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     fn after_last_at(s: &[u8]) -> &[u8] {
         strings::last_index_of_char(s, b'@').map_or(s, |at| &s[at + 1..])
@@ -2123,14 +2123,13 @@ fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     } else {
         0
     };
-    let rest = after_last_at(href);
-    // When the last `@` sits inside the unvalidated scheme, `rest` starts at the real `scheme://`.
-    let at_was_in_authority = href.len() - rest.len() > authority_start;
-    let scheme: &[u8] = if at_was_in_authority {
-        after_last_at(&href[..authority_start])
-    } else {
-        b""
-    };
+    let authority_end = authority_start
+        + strings::index_of_char_usize(&href[authority_start..], b'/')
+            .unwrap_or(href.len() - authority_start);
+    // `URL::parse` does not validate the scheme, so that slice can hold a `user:password@` too.
+    let scheme = after_last_at(&href[..authority_start]);
+    let host = after_last_at(&href[authority_start..authority_end]);
+    let rest = &href[authority_end - host.len()..];
     let rest = &rest[..strings::index_of_any(rest, b"?#").unwrap_or(rest.len())];
     let trimmed = strings::without_trailing_slash(rest);
 

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -2109,7 +2109,8 @@ impl PublishError {
     }
 }
 
-/// `url.href` with every `user:password@` before the path cut out, and with one trailing slash.
+/// `url.href` for an error message: nothing before the last `@` (so no userinfo, whatever the
+/// password holds), no `?query` or `#fragment`, one trailing slash. A clean `scheme://` is kept.
 fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     fn after_last_at(s: &[u8]) -> &[u8] {
         strings::last_index_of_char(s, b'@').map_or(s, |at| &s[at + 1..])
@@ -2123,19 +2124,21 @@ fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     } else {
         0
     };
-    let path_start = authority_start
-        + strings::index_of_any(&href[authority_start..], b"/?#")
-            .unwrap_or(href.len() - authority_start);
-    // `URL::parse` does not validate the scheme, so it can hold a `user:password@` too.
-    let scheme = after_last_at(&href[..authority_start]);
-    let host = after_last_at(&href[authority_start..path_start]);
-    let host_and_path = &href[path_start - host.len()..];
-    let trimmed = strings::without_trailing_slash(host_and_path);
+    let rest = after_last_at(href);
+    // `URL::parse` does not validate the scheme, so the last `@` can sit inside it;
+    // `rest` then already starts at the real `scheme://`.
+    let scheme = if rest.len() < href.len() - authority_start {
+        after_last_at(&href[..authority_start])
+    } else {
+        b""
+    };
+    let rest = &rest[..strings::index_of_any(rest, b"?#").unwrap_or(rest.len())];
+    let trimmed = strings::without_trailing_slash(rest);
 
     let mut out = Vec::with_capacity(scheme.len() + trimmed.len() + 1);
     out.extend_from_slice(scheme);
     out.extend_from_slice(trimmed);
-    if trimmed.len() < host_and_path.len() {
+    if trimmed.len() < rest.len() {
         out.push(b'/');
     }
     out.into_boxed_slice()

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -849,14 +849,9 @@ impl PublishCommand {
         let registry_url = registry.url.url();
 
         if !registry_url.has_http_like_protocol() {
-            return Err(PublishError::InvalidRegistryUrl(
-                if registry_url.protocol.is_empty() {
-                    // `href_without_auth()` would print a scheme-less URL as `http://...`.
-                    Box::from(registry.url.href())
-                } else {
-                    registry_url.href_without_auth()
-                },
-            ));
+            return Err(PublishError::InvalidRegistryUrl(redacted_registry_href(
+                &registry_url,
+            )));
         }
 
         if registry.token.is_empty()
@@ -2090,8 +2085,6 @@ pub(crate) enum PublishError {
     OutOfMemory,
     #[error("NeedAuth")]
     NeedAuth,
-    /// The registry URL has a scheme other than http or https. The HTTP
-    /// client would send it as plaintext HTTP, with the token.
     #[error("InvalidRegistryUrl")]
     InvalidRegistryUrl(Box<[u8]>),
 }
@@ -2107,13 +2100,40 @@ impl PublishError {
             }
             PublishError::InvalidRegistryUrl(href) => {
                 Output::err_generic(
-                    "Registry URL must be http:// or https://\nReceived: \"{}/\"",
-                    (bstr::BStr::new(strings::without_trailing_slash(&href)),),
+                    "Registry URL must be http:// or https://\nReceived: {}",
+                    (bun_core::fmt::quote(&href),),
                 );
                 Global::crash();
             }
         }
     }
+}
+
+/// `url.href` as it is shown in an error: any `user:password@` is cut out of the
+/// authority (also for a URL with no scheme, where `URL::parse` leaves the userinfo
+/// inside the host or path), and repeated trailing slashes collapse to one.
+fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
+    let href = url.href;
+    let authority_start = if !url.protocol.is_empty() {
+        url.protocol.len() + b"://".len()
+    } else if href.starts_with(b"//") {
+        2
+    } else {
+        0
+    };
+    let rest = &href[authority_start..];
+    let authority = &rest[..strings::index_of_any(rest, b"/?#").unwrap_or(rest.len())];
+    let after_userinfo =
+        strings::last_index_of_char(authority, b'@').map_or(rest, |at| &rest[at + 1..]);
+    let trimmed = strings::without_trailing_slash(after_userinfo);
+
+    let mut out = Vec::with_capacity(authority_start + trimmed.len() + 1);
+    out.extend_from_slice(&href[..authority_start]);
+    out.extend_from_slice(trimmed);
+    if trimmed.len() < after_userinfo.len() {
+        out.push(b'/');
+    }
+    out.into_boxed_slice()
 }
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -849,12 +849,14 @@ impl PublishCommand {
         let registry_url = registry.url.url();
 
         if !registry_url.has_http_like_protocol() {
-            return Err(PublishError::InvalidRegistryUrl(if registry_url.protocol.is_empty() {
-                // `href_without_auth()` would print a scheme-less URL as `http://...`.
-                Box::from(registry.url.href())
-            } else {
-                registry_url.href_without_auth()
-            }));
+            return Err(PublishError::InvalidRegistryUrl(
+                if registry_url.protocol.is_empty() {
+                    // `href_without_auth()` would print a scheme-less URL as `http://...`.
+                    Box::from(registry.url.href())
+                } else {
+                    registry_url.href_without_auth()
+                },
+            ));
         }
 
         if registry.token.is_empty()

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -2109,8 +2109,7 @@ impl PublishError {
     }
 }
 
-/// `url.href` for an error message: nothing before the last `@` (so no userinfo, whatever the
-/// password holds), no `?query` or `#fragment`, one trailing slash. A clean `scheme://` is kept.
+/// `url.href` with nothing before its last `@`, no `?query` or `#fragment`, and one trailing slash.
 fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     fn after_last_at(s: &[u8]) -> &[u8] {
         strings::last_index_of_char(s, b'@').map_or(s, |at| &s[at + 1..])
@@ -2125,9 +2124,9 @@ fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
         0
     };
     let rest = after_last_at(href);
-    // `URL::parse` does not validate the scheme, so the last `@` can sit inside it;
-    // `rest` then already starts at the real `scheme://`.
-    let scheme = if rest.len() < href.len() - authority_start {
+    // When the last `@` sits inside the unvalidated scheme, `rest` starts at the real `scheme://`.
+    let at_was_in_authority = href.len() - rest.len() > authority_start;
+    let scheme: &[u8] = if at_was_in_authority {
         after_last_at(&href[..authority_start])
     } else {
         b""

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -2109,7 +2109,7 @@ impl PublishError {
     }
 }
 
-/// `url.href` without `user:password@` (scheme or not) and with one trailing slash.
+/// `url.href` without anything up to a `@` before the path, and with one trailing slash.
 fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     let href = url.href;
     let authority_start = if !url.protocol.is_empty() {
@@ -2119,16 +2119,21 @@ fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     } else {
         0
     };
-    let rest = &href[authority_start..];
-    let authority = &rest[..strings::index_of_any(rest, b"/?#").unwrap_or(rest.len())];
-    let after_userinfo =
-        strings::last_index_of_char(authority, b'@').map_or(rest, |at| &rest[at + 1..]);
-    let trimmed = strings::without_trailing_slash(after_userinfo);
+    let path_start = authority_start
+        + strings::index_of_any(&href[authority_start..], b"/?#")
+            .unwrap_or(href.len() - authority_start);
+    // `URL::parse` does not validate the scheme, so a `@` can also sit before `://`.
+    let (scheme, host_and_path) = match strings::last_index_of_char(&href[..path_start], b'@') {
+        Some(at) if at < authority_start => (&href[..0], &href[at + 1..]),
+        Some(at) => (&href[..authority_start], &href[at + 1..]),
+        None => (&href[..authority_start], &href[authority_start..]),
+    };
+    let trimmed = strings::without_trailing_slash(host_and_path);
 
-    let mut out = Vec::with_capacity(authority_start + trimmed.len() + 1);
-    out.extend_from_slice(&href[..authority_start]);
+    let mut out = Vec::with_capacity(scheme.len() + trimmed.len() + 1);
+    out.extend_from_slice(scheme);
     out.extend_from_slice(trimmed);
-    if trimmed.len() < after_userinfo.len() {
+    if trimmed.len() < host_and_path.len() {
         out.push(b'/');
     }
     out.into_boxed_slice()

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -2109,9 +2109,7 @@ impl PublishError {
     }
 }
 
-/// `url.href` as it is shown in an error: any `user:password@` is cut out of the
-/// authority (also for a URL with no scheme, where `URL::parse` leaves the userinfo
-/// inside the host or path), and repeated trailing slashes collapse to one.
+/// `url.href` without `user:password@` (scheme or not) and with one trailing slash.
 fn redacted_registry_href(url: &URL<'_>) -> Box<[u8]> {
     let href = url.href;
     let authority_start = if !url.protocol.is_empty() {

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -848,6 +848,12 @@ impl PublishCommand {
         let registry = ctx.manager.scope_for_package_name(&ctx.package_name);
         let registry_url = registry.url.url();
 
+        if !registry_url.has_http_like_protocol() {
+            return Err(PublishError::InvalidRegistryUrl(
+                registry_url.href_without_auth(),
+            ));
+        }
+
         if registry.token.is_empty()
             && registry.auth.is_empty()
             && (registry_url.password.is_empty() || registry_url.username.is_empty())
@@ -2079,6 +2085,10 @@ pub(crate) enum PublishError {
     OutOfMemory,
     #[error("NeedAuth")]
     NeedAuth,
+    /// The registry URL has a scheme other than http or https. The HTTP
+    /// client would send it as plaintext HTTP, with the token.
+    #[error("InvalidRegistryUrl")]
+    InvalidRegistryUrl(Box<[u8]>),
 }
 bun_core::oom_from_alloc!(PublishError);
 
@@ -2088,6 +2098,13 @@ impl PublishError {
             PublishError::OutOfMemory => bun_core::out_of_memory(),
             PublishError::NeedAuth => {
                 Output::err_generic("missing authentication (run <cyan>`bunx npm login`<r>)", ());
+                Global::crash();
+            }
+            PublishError::InvalidRegistryUrl(href) => {
+                Output::err_generic(
+                    "Registry URL must be http:// or https://\nReceived: \"{}/\"",
+                    (bstr::BStr::new(strings::without_trailing_slash(&href)),),
+                );
                 Global::crash();
             }
         }

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -922,65 +922,114 @@ describe.concurrent("credentials in the registry url", () => {
     expect(exitCode).toBe(1);
   });
 
-  // A scheme that is not http or https must not fall back to plaintext HTTP.
-  // The mock is a plain HTTP listener, so a downgraded request shows up in `mock.requests`.
-  test.each(["htps", "htp", "ftp"])("%s:// registry url scheme is rejected before sending a request", async scheme => {
-    using mock = registryMock();
-    const packageDir = await packageDirFor("bad-scheme-pkg");
-    await write(
-      join(packageDir, "bunfig.toml"),
-      `[install]\nregistry = { url = "${scheme}://localhost:${mock.port}/", token = "secret-token" }\n`,
-    );
+  // A registry url whose scheme is not http or https must be rejected, not sent as plaintext HTTP.
+  // The mock is a plain HTTP listener, so a downgraded request would show up in `mock.requests`.
+  type BadRegistrySetup = (port: number) => {
+    files: Record<string, string>;
+    args?: string[];
+    name?: string;
+    received: string;
+  };
+  describe.each<[string, BadRegistrySetup]>([
+    [
+      "bunfig registry with a typo in https",
+      port => ({
+        files: {
+          "bunfig.toml": `[install]\nregistry = { url = "htps://localhost:${port}/", token = "secret-token" }\n`,
+        },
+        received: `htps://localhost:${port}/`,
+      }),
+    ],
+    [
+      "bunfig registry with an ftp scheme",
+      port => ({
+        files: {
+          "bunfig.toml": `[install]\nregistry = { url = "ftp://localhost:${port}/", token = "secret-token" }\n`,
+        },
+        received: `ftp://localhost:${port}/`,
+      }),
+    ],
+    [
+      "bunfig scoped registry",
+      port => ({
+        name: "@corp/bad-scheme-pkg",
+        files: {
+          "bunfig.toml": `[install.scopes]\n"@corp" = { url = "htp://localhost:${port}/", token = "secret-token" }\n`,
+        },
+        received: `htp://localhost:${port}/`,
+      }),
+    ],
+    [
+      "bunfig registry with the token in the url, --dry-run",
+      port => ({
+        files: { "bunfig.toml": `[install]\nregistry = "htps://:secret-token@localhost:${port}/"\n` },
+        args: ["--dry-run"],
+        received: `htps://localhost:${port}/`,
+      }),
+    ],
+    [
+      "bunfig registry without a scheme",
+      port => ({
+        files: { "bunfig.toml": `[install]\nregistry = { url = "localhost:${port}/npm/", token = "secret-token" }\n` },
+        received: `localhost:${port}/npm/`,
+      }),
+    ],
+    [
+      "bunfig registry without a scheme, with userinfo",
+      port => ({
+        files: {
+          "bunfig.toml": `[install]\nregistry = { url = "pubuser:secret-token@localhost:${port}/npm/", token = "secret-token" }\n`,
+        },
+        received: `localhost:${port}/npm/`,
+      }),
+    ],
+    [
+      ".npmrc registry",
+      port => ({
+        files: { ".npmrc": `registry=htps://localhost:${port}/\n//localhost:${port}/:_authToken=secret-token\n` },
+        received: `htps://localhost:${port}/`,
+      }),
+    ],
+    [
+      ".npmrc scoped registry",
+      port => ({
+        name: "@corp/bad-scheme-pkg",
+        files: { ".npmrc": `@corp:registry=htps://localhost:${port}/\n//localhost:${port}/:_authToken=secret-token\n` },
+        received: `htps://localhost:${port}/`,
+      }),
+    ],
+  ])("%s that is not http:// or https://", (_, setup) => {
+    test("is rejected before sending a request, without echoing credentials", async () => {
+      using mock = registryMock();
+      const { files, args = [], name = "bad-scheme-pkg", received } = setup(mock.port);
+      const packageDir = await packageDirFor(name);
+      for (const [file, contents] of Object.entries(files)) {
+        await write(join(packageDir, file), contents);
+      }
 
-    const { err, exitCode } = await publish(env, packageDir);
-    expect(err).toBe(
-      `error: Registry URL must be http:// or https://\nReceived: "${scheme}://localhost:${mock.port}/"\n`,
-    );
-    expect(mock.requests).toEqual([]);
-    expect(exitCode).toBe(1);
+      const { out, err, exitCode } = await publish(env, packageDir, ...args);
+      expect(err).toBe(`error: Registry URL must be http:// or https://\nReceived: "${received}"\n`);
+      expect(out).not.toContain("secret-token");
+      expect(mock.requests).toEqual([]);
+      expect(exitCode).toBe(1);
+    });
   });
 
-  test("registry url without a scheme is rejected and echoed as written", async () => {
+  test("an upper-case HTTP:// registry url is accepted", async () => {
     using mock = registryMock();
-    const packageDir = await packageDirFor("no-scheme-pkg");
+    const packageDir = await packageDirFor("upper-case-scheme-pkg");
     await write(
       join(packageDir, "bunfig.toml"),
-      `[install]\nregistry = { url = "localhost:${mock.port}/npm/", token = "secret-token" }\n`,
+      `[install]\nregistry = { url = "HTTP://localhost:${mock.port}/", token = "secret-token" }\n`,
     );
 
-    const { err, exitCode } = await publish(env, packageDir);
-    expect(err).toBe(`error: Registry URL must be http:// or https://\nReceived: "localhost:${mock.port}/npm/"\n`);
-    expect(mock.requests).toEqual([]);
-    expect(exitCode).toBe(1);
-  });
-
-  test("scoped registry with a bad scheme is rejected before sending a request", async () => {
-    using mock = registryMock();
-    const packageDir = await packageDirFor("@corp/bad-scheme-pkg");
-    await write(
-      join(packageDir, "bunfig.toml"),
-      `[install.scopes]\n"@corp" = { url = "htps://localhost:${mock.port}/", token = "secret-token" }\n`,
-    );
-
-    const { err, exitCode } = await publish(env, packageDir);
-    expect(err).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
-    expect(mock.requests).toEqual([]);
-    expect(exitCode).toBe(1);
-  });
-
-  test("bad scheme is rejected with --dry-run", async () => {
-    using mock = registryMock();
-    const packageDir = await packageDirFor("bad-scheme-dry-run-pkg");
-    await write(
-      join(packageDir, "bunfig.toml"),
-      `[install]\nregistry = "htps://:secret-token@localhost:${mock.port}/"\n`,
-    );
-
-    const { out, err, exitCode } = await publish(env, packageDir, "--dry-run");
-    expect(err).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
-    expect(out).not.toContain("secret-token");
-    expect(mock.requests).toEqual([]);
-    expect(exitCode).toBe(1);
+    const { out, err, exitCode } = await publish(env, packageDir);
+    expect(err).not.toContain("error:");
+    expect(out).toContain(" + upper-case-scheme-pkg@1.0.0");
+    expect(mock.requests).toEqual([
+      { method: "PUT", pathname: "/upper-case-scheme-pkg", authorization: "Bearer secret-token" },
+    ]);
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -940,6 +940,20 @@ describe.concurrent("credentials in the registry url", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("registry url without a scheme is rejected and echoed as written", async () => {
+    using mock = registryMock();
+    const packageDir = await packageDirFor("no-scheme-pkg");
+    await write(
+      join(packageDir, "bunfig.toml"),
+      `[install]\nregistry = { url = "localhost:${mock.port}/npm/", token = "secret-token" }\n`,
+    );
+
+    const { err, exitCode } = await publish(env, packageDir);
+    expect(err).toBe(`error: Registry URL must be http:// or https://\nReceived: "localhost:${mock.port}/npm/"\n`);
+    expect(mock.requests).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+
   test("scoped registry with a bad scheme is rejected before sending a request", async () => {
     using mock = registryMock();
     const packageDir = await packageDirFor("@corp/bad-scheme-pkg");

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -993,6 +993,15 @@ describe.concurrent("credentials in the registry url", () => {
       }),
     ],
     [
+      "bunfig registry with userinfo before and after the scheme",
+      port => ({
+        files: {
+          "bunfig.toml": `[install]\nregistry = { url = "pubuser:secret-token@htps://pubuser:secret-token@localhost:${port}/", token = "secret-token" }\n`,
+        },
+        received: `htps://localhost:${port}/`,
+      }),
+    ],
+    [
       ".npmrc registry",
       port => ({
         files: { ".npmrc": `registry=htps://localhost:${port}/\n//localhost:${port}/:_authToken=secret-token\n` },

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -984,6 +984,15 @@ describe.concurrent("credentials in the registry url", () => {
       }),
     ],
     [
+      "bunfig registry with userinfo before the scheme",
+      port => ({
+        files: {
+          "bunfig.toml": `[install]\nregistry = { url = "pubuser:secret-token@htps://localhost:${port}/", token = "secret-token" }\n`,
+        },
+        received: `htps://localhost:${port}/`,
+      }),
+    ],
+    [
       ".npmrc registry",
       port => ({
         files: { ".npmrc": `registry=htps://localhost:${port}/\n//localhost:${port}/:_authToken=secret-token\n` },

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -977,6 +977,15 @@ describe.concurrent("credentials in the registry url", () => {
       }),
     ],
     [
+      "bunfig registry with an @ in the path",
+      port => ({
+        files: {
+          "bunfig.toml": `[install]\nregistry = { url = "htps://localhost:${port}/org/_packaging/feed@Local/npm/registry/", token = "secret-token" }\n`,
+        },
+        received: `htps://localhost:${port}/org/_packaging/feed@Local/npm/registry/`,
+      }),
+    ],
+    [
       "bunfig registry without a scheme",
       port => ({
         files: { "bunfig.toml": `[install]\nregistry = { url = "localhost:${port}/npm/", token = "secret-token" }\n` },

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -968,6 +968,15 @@ describe.concurrent("credentials in the registry url", () => {
       }),
     ],
     [
+      "bunfig registry with a # in the url password and a query",
+      port => ({
+        files: {
+          "bunfig.toml": `[install]\nregistry = { url = "htps://pubuser:secret#token@localhost:${port}/?t=secret-token", token = "secret-token" }\n`,
+        },
+        received: `htps://localhost:${port}/`,
+      }),
+    ],
+    [
       "bunfig registry without a scheme",
       port => ({
         files: { "bunfig.toml": `[install]\nregistry = { url = "localhost:${port}/npm/", token = "secret-token" }\n` },

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -921,6 +921,53 @@ describe.concurrent("credentials in the registry url", () => {
     expect(mock.requests).toEqual([]);
     expect(exitCode).toBe(1);
   });
+
+  // A scheme that is not http or https must not fall back to plaintext HTTP.
+  // The mock is a plain HTTP listener, so a downgraded request shows up in `mock.requests`.
+  test.each(["htps", "htp", "ftp"])("%s:// registry url scheme is rejected before sending a request", async scheme => {
+    using mock = registryMock();
+    const packageDir = await packageDirFor("bad-scheme-pkg");
+    await write(
+      join(packageDir, "bunfig.toml"),
+      `[install]\nregistry = { url = "${scheme}://localhost:${mock.port}/", token = "secret-token" }\n`,
+    );
+
+    const { err, exitCode } = await publish(env, packageDir);
+    expect(err).toBe(
+      `error: Registry URL must be http:// or https://\nReceived: "${scheme}://localhost:${mock.port}/"\n`,
+    );
+    expect(mock.requests).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("scoped registry with a bad scheme is rejected before sending a request", async () => {
+    using mock = registryMock();
+    const packageDir = await packageDirFor("@corp/bad-scheme-pkg");
+    await write(
+      join(packageDir, "bunfig.toml"),
+      `[install.scopes]\n"@corp" = { url = "htps://localhost:${mock.port}/", token = "secret-token" }\n`,
+    );
+
+    const { err, exitCode } = await publish(env, packageDir);
+    expect(err).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+    expect(mock.requests).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("bad scheme is rejected with --dry-run", async () => {
+    using mock = registryMock();
+    const packageDir = await packageDirFor("bad-scheme-dry-run-pkg");
+    await write(
+      join(packageDir, "bunfig.toml"),
+      `[install]\nregistry = "htps://:secret-token@localhost:${mock.port}/"\n`,
+    );
+
+    const { out, err, exitCode } = await publish(env, packageDir, "--dry-run");
+    expect(err).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+    expect(out).not.toContain("secret-token");
+    expect(mock.requests).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
 });
 
 describe("lifecycle scripts", async () => {


### PR DESCRIPTION
### Problem
- `bun publish` with a registry URL whose scheme is not `http` or `https` (the typo `htps://`, `ftp://`, or no scheme at all) sends the PUT as plaintext HTTP to the host and port, with the `Authorization: Bearer <token>` header and the tarball.
- `publish` in `src/runtime/cli/publish_command.rs:848` hands the scope URL to the HTTP client with no scheme check, and the client dials plain HTTP for every scheme but `https`. `bun install` with the same config fails with `Registry URL must be http:// or https://` (`src/install/NetworkTask.rs:523`).

### Fix
- `publish` checks `has_http_like_protocol()` on the scope URL before the auth check and before any request. A bad scheme prints the same message as `bun install` and exits 1. This covers bunfig `[install] registry`, bunfig `[install.scopes]`, and `.npmrc` `registry=` / `@scope:registry=`. `--dry-run` is rejected too. `HTTP://` and `HTTPS://` still work.
- The echoed URL goes through `redacted_registry_href()`: userinfo is stripped from the authority (up to the first `/`) and from whatever `URL::parse` took as the scheme, then `?query` and `#fragment` are dropped. An `@` later in the path (Azure Artifacts `feed@view`) stays. A scheme-less URL is shown as written, not as `http://...`.
- Verified: `test/cli/install/bun-publish.test.ts`, 12 new rejection cases that fail on stock bun (the plain HTTP mock receives the PUT with the token) plus one `HTTP://` acceptance case. The full file passes (59 tests).

### Background
- A registry scope (`Npm::Registry::Scope`) holds the registry URL and its credentials. `scope_for_package_name` picks the scope for the package being published.
- `URL::parse` (`src/url/lib.rs`) is a borrowing, non-validating parser. Without `://` it leaves `protocol` empty and does not split userinfo, and it accepts any bytes before `://` as the scheme. That is why the redaction helper works on the raw href.

<details><summary>Notes</summary>

Repro on canary f42e98025: a plain `Bun.serve` listener on loopback and a bunfig with `"@corp" = { url = "htps://localhost:PORT/", token = "TOK" }`. `bun publish` exits 0 and the listener logs `PUT /@corp%2Fx` with `authorization: Bearer TOK`.

Manual checks with the debug build: `.npmrc` `@corp:registry=htps://...` is rejected with the new message. `@corp:registry=HTTPS://...` passes the check and reaches the connect step.

A registry from `npm_config_registry` / `NPM_CONFIG_REGISTRY` / `BUN_CONFIG_REGISTRY` with a bad scheme is ignored by `PackageManagerOptions` (it only accepts `http://` and `https://` there), so it never reaches `publish`. The `--registry` flag has its own check in `CommandLineArguments`. Both paths are unchanged.

Redaction trade-off: an unencoded `/` inside a password is where URL grammar starts the path, so it is not special-cased. `?` and `#` inside a password are redacted because the authority is cut at `/` only.

Review history: the first version echoed `href_without_auth()`, which prints a scheme-less URL as `http://...`. Later versions echoed the raw href or stripped too little or too much around `@`. All are replaced by the rule above, with a test row for each case.

`bun pm view` and `bun audit` build their registry requests the same way and do not check the scheme either. This PR only changes `bun publish`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->