### PR TITLE
cli: reject --user-agent and bun publish --otp values containing CR, LF or NUL

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1459,6 +1459,11 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             }
 
             if let Some(otp) = args.option(b"--otp") {
+                // Sent verbatim in `npm-otp`, so CR/LF/NUL would inject header lines into the publish request.
+                if strings::contains_any(otp, b"\r\n\0") {
+                    Output::err_generic("the value of --otp contains a newline or NUL byte", ());
+                    Global::crash();
+                }
                 cli.publish_config.otp = otp;
             }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1163,6 +1163,14 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         }
 
         if let Some(user_agent) = args.option(b"--user-agent") {
+            // Sent verbatim in `User-Agent`, so CR/LF/NUL would inject header lines into every request.
+            if strings::contains_any(user_agent, b"\r\n\0") {
+                Output::err_generic(
+                    "the value of --user-agent contains a newline or NUL byte\n",
+                    (),
+                );
+                Global::exit(1);
+            }
             // argv slices returned by `clap::Args::option` borrow
             // process-lifetime `argv` storage.
             let _ = bun_http::OVERRIDDEN_DEFAULT_USER_AGENT.set(user_agent);

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -923,6 +923,52 @@ describe.concurrent("credentials in the registry url", () => {
   });
 });
 
+describe.concurrent("--otp containing CR or LF", () => {
+  // The value is written into `npm-otp: <otp>` as-is, so CR/LF would end the
+  // header line and inject header lines or a second request into the PUT.
+  async function publishWithOtp(otp: string) {
+    const requests: { method: string; pathname: string; otp: string | null; injected: string | null }[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        requests.push({
+          method: req.method,
+          pathname: new URL(req.url).pathname,
+          otp: req.headers.get("npm-otp"),
+          injected: req.headers.get("x-injected"),
+        });
+        return new Response("{}", { status: 200 });
+      },
+    });
+    const packageDir = tmpdirSync();
+    await write(join(packageDir, "package.json"), JSON.stringify({ name: "otp-crlf-pkg", version: "1.0.0" }));
+    const { out, err, exitCode } = await publish(
+      env,
+      packageDir,
+      "--registry",
+      `http://:publish-token@127.0.0.1:${server.port}/`,
+      `--otp=${otp}`,
+    );
+    return { requests, out, err, exitCode };
+  }
+
+  for (const [name, otp] of [
+    ["CRLF", "123456\r\nX-Injected: otp"],
+    ["bare CR", "123456\rX-Injected: otp"],
+    ["bare LF", "123456\nX-Injected: otp"],
+    ["smuggled request", "1\r\n\r\nPUT /-/user/evil HTTP/1.1\r\nHost: x\r\n\r\n"],
+  ] as const) {
+    test(name, async () => {
+      const { requests, err, exitCode } = await publishWithOtp(otp);
+      expect(err).toContain("--otp");
+      expect(err).toContain("newline or NUL");
+      expect(requests).toEqual([]);
+      expect(exitCode).toBe(1);
+    });
+  }
+});
+
 describe("lifecycle scripts", async () => {
   const script = `const fs = require("fs");
     fs.writeFileSync(process.argv[2] + ".txt", \`

--- a/test/cli/user-agent.test.ts
+++ b/test/cli/user-agent.test.ts
@@ -76,4 +76,56 @@ try {
     const exitCode = await proc.exited;
     expect(exitCode).toBe(0);
   });
+
+  // The value is copied into every request head as-is, so CR, LF or NUL
+  // would end the User-Agent line and inject header lines or a second request.
+  describe.concurrent("rejects a value containing CR, LF or NUL", () => {
+    async function run(userAgent: string, viaEnv: boolean) {
+      const seen: string[] = [];
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          seen.push(req.headers.get("user-agent") ?? "");
+          return new Response("ok");
+        },
+      });
+      const script = `await fetch("http://127.0.0.1:${server.port}/")`;
+      await using proc = Bun.spawn({
+        cmd: viaEnv ? [bunExe(), "-e", script] : [bunExe(), `--user-agent=${userAgent}`, "-e", script],
+        env: viaEnv ? { ...bunEnv, BUN_OPTIONS: `--user-agent="${userAgent}"` } : bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { seen, stdout, stderr, exitCode };
+    }
+
+    for (const [name, userAgent] of [
+      ["CRLF", "evil\r\nInjected: 1"],
+      ["bare CR", "evil\rInjected: 1"],
+      ["bare LF", "evil\nInjected: 1"],
+    ] as const) {
+      test(name, async () => {
+        const { seen, stdout, stderr, exitCode } = await run(userAgent, false);
+        expect(stdout).toBe("");
+        expect(stderr).toContain("--user-agent");
+        expect(stderr).toContain("newline or NUL");
+        expect(seen).toEqual([]);
+        expect(exitCode).toBe(1);
+      });
+    }
+
+    test("via BUN_OPTIONS", async () => {
+      const { seen, stdout, stderr, exitCode } = await run(
+        "evil\r\n\r\nGET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n",
+        true,
+      );
+      expect(stdout).toBe("");
+      expect(stderr).toContain("--user-agent");
+      expect(stderr).toContain("newline or NUL");
+      expect(seen).toEqual([]);
+      expect(exitCode).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `bun --user-agent=$'evil\r\nInjected: 1' -e 'await fetch(url)'` sends `User-Agent: evil\r\nInjected: 1\r\n` to the peer. Every `fetch()` in the process carries it. A value with `\r\n\r\nGET /smuggled HTTP/1.1...` puts a second request inside the head. `BUN_OPTIONS` reaches the same code.
- `bun publish --otp=$'123456\r\nX-Injected: otp'` does the same through the `npm-otp` header of the publish PUT. A node server parses a separate `PUT /-/user/evil` from the second repro.
- Cause: `src/runtime/cli/Arguments.rs:1165` stores the flag into `OVERRIDDEN_DEFAULT_USER_AGENT` and `src/install/PackageManager/CommandLineArguments.rs:1461` stores `--otp` into `publish_config.otp`. Neither checks the bytes. The request writer copies them as-is. `fetch(url, {headers: {"user-agent": "a\r\nb"}})` already throws `TypeError: Header 'User-Agent' has invalid value`, and npm rejects the same OTP with `ERR_INVALID_CHAR`.

### Fix
- Reject `\r`, `\n` and `\0` where each flag is parsed. Print `error: the value of --user-agent contains a newline or NUL byte` (or `--otp`) and exit 1. No request is sent.
- This is the same check and wording as the registry token validation in #37458 (`strings::contains_any(value, b"\r\n\0")`). The check runs before any network I/O, so the value never reaches the header writer.
- Verified: `test/cli/user-agent.test.ts` (4 new tests: CRLF, bare CR, bare LF, via `BUN_OPTIONS`) and `test/cli/install/bun-publish.test.ts` (4 new tests under `--otp containing CR or LF`). Each asserts the error, exit 1, and that the mock server saw no request. All 8 fail on the released build and pass with this change. The rest of the `otp` block in `bun-publish.test.ts` still passes.

### Background
- `--user-agent` is a runtime flag. Its value replaces the default `Bun/<version>` header on every outgoing HTTP request from the process. `BUN_OPTIONS` is spliced into argv before parsing, so it reaches the same code.
- `bun publish --otp` sends the one-time password to the registry in the `npm-otp` request header. The install client builds its request head itself, with no per-header validation.
- The interactive OTP prompt reads one line from stdin and strips the trailing `\r`, so it cannot produce a value with a newline. Only the flag path is affected.

<details><summary>Notes</summary>

- A NUL byte cannot be passed through argv or the environment, so the tests cover CR and LF only. The check still rejects NUL for consistency with the token check.
- `--registry` CR/LF is stripped by the URL parser. `--tag` CR/LF is JSON-escaped in the PUT body. Neither splits the head.
- Wire bytes verified on bun 1.4.2 and the current canary with a loopback raw socket capture.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-publish.test.ts

<!-- robobun:evidence:end -->