### PR TITLE
install: read a registry URL the way new URL() reads it

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -412,6 +412,18 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
 // (no struct lifetime params). Park a clone for the
 // lifetime of the install command via the named hand-off helper.
 #[inline]
+/// Whether `Scope::set_url(registry_url)` keeps `scope` on its host, with no downgrade from
+/// https. The URL is read as `set_url` reads it (WTF::URL, the string itself when it rejects it).
+fn keeps_origin(scope: &Npm::registry::Scope, registry_url: &[u8]) -> bool {
+    let normalized = bun_url::URL::from_string(&bun_core::String::borrow_utf8(registry_url))
+        .unwrap_or_else(|_| bun_url::OwnedURL::from_href(Box::from(registry_url)));
+    let new_url = normalized.url();
+    let prev_url = scope.url.url();
+    bun_core::without_trailing_slash(new_url.host)
+        == bun_core::without_trailing_slash(prev_url.host)
+        && (new_url.is_https() || !prev_url.is_https())
+}
+
 fn leak_static(s: &[u8]) -> &'static [u8] {
     bun_core::heap::release(s.to_vec().into_boxed_slice())
 }
@@ -630,15 +642,10 @@ impl Options {
                     {
                         let mut api_registry = Api::NpmRegistry::from_url(registry_);
                         // Credentials in the URL win, as they do for `registry=` in .npmrc.
-                        if !api_registry.has_credentials() {
-                            let prev_url = self.scope.url.url();
-                            let new_url = bun_url::URL::parse(&api_registry.url);
-                            if bun_core::without_trailing_slash(new_url.host)
-                                == bun_core::without_trailing_slash(prev_url.host)
-                                && (new_url.is_https() || !prev_url.is_https())
-                            {
-                                api_registry.token = core::mem::take(&mut self.scope.token);
-                            }
+                        if !api_registry.has_credentials()
+                            && keeps_origin(&self.scope, &api_registry.url)
+                        {
+                            api_registry.token = core::mem::take(&mut self.scope.token);
                         }
                         self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
                         break;
@@ -653,14 +660,7 @@ impl Options {
                 if api_registry.has_credentials() {
                     self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
                 } else {
-                    let new_url = bun_url::URL::parse(&api_registry.url);
-                    let same_origin = {
-                        let prev_url = self.scope.url.url();
-                        bun_core::without_trailing_slash(new_url.host)
-                            == bun_core::without_trailing_slash(prev_url.host)
-                            && (new_url.is_https() || !prev_url.is_https())
-                    };
-                    if !same_origin {
+                    if !keeps_origin(&self.scope, &api_registry.url) {
                         self.scope.token = Box::default();
                         self.scope.auth = Box::default();
                         self.scope.user = Box::default();

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -408,12 +408,7 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
     Err(crate::Error::MissingGlobalBinDirectoryTrySettingBUNINSTALL)
 }
 
-// `BunInstall` owns `Box<[u8]>`; Options stores `&'static [u8]`
-// (no struct lifetime params). Park a clone for the
-// lifetime of the install command via the named hand-off helper.
-#[inline]
-/// Whether `Scope::set_url(registry_url)` keeps `scope` on its host, with no downgrade from
-/// https. The URL is read as `set_url` reads it (WTF::URL, the string itself when it rejects it).
+/// Whether `Scope::set_url(registry_url)` keeps `scope` on its host with no downgrade from https.
 fn keeps_origin(scope: &Npm::registry::Scope, registry_url: &[u8]) -> bool {
     let normalized = bun_url::URL::from_string(&bun_core::String::borrow_utf8(registry_url))
         .unwrap_or_else(|_| bun_url::OwnedURL::from_href(Box::from(registry_url)));
@@ -424,6 +419,10 @@ fn keeps_origin(scope: &Npm::registry::Scope, registry_url: &[u8]) -> bool {
         && (new_url.is_https() || !prev_url.is_https())
 }
 
+// `BunInstall` owns `Box<[u8]>`; Options stores `&'static [u8]`
+// (no struct lifetime params). Park a clone for the
+// lifetime of the install command via the named hand-off helper.
+#[inline]
 fn leak_static(s: &[u8]) -> &'static [u8] {
     bun_core::heap::release(s.to_vec().into_boxed_slice())
 }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -155,7 +155,13 @@ pub mod api {
     }
 
     impl NpmRegistry {
+        /// `[scheme://][user[:password]@|:token@]host[:port][/path]`. With a scheme, the
+        /// registry is what `new URL(str)` reads. Without one, or when WTF::URL rejects the
+        /// string, the lenient parser reads it as before.
         pub fn from_url(str: &[u8]) -> NpmRegistry {
+            if let Some(registry) = Self::from_whatwg(str) {
+                return registry;
+            }
             let url = bun_url::URL::parse(str);
             let mut registry = NpmRegistry::default();
 
@@ -172,6 +178,41 @@ pub mod api {
             }
 
             registry
+        }
+
+        /// `None` when WTF::URL rejects `str` or finds no host in it (`localhost:4873` is the
+        /// scheme `localhost` to it).
+        fn from_whatwg(str: &[u8]) -> Option<NpmRegistry> {
+            let url = bun_url::whatwg::Parsed::from_utf8(str)?;
+            if url.hostname().is_empty() {
+                return None;
+            }
+            let username = url.username();
+            let password = url.password();
+            let mut href = url.href().to_owned_slice();
+            if !username.is_empty() || !password.is_empty() {
+                // The serialized href is `scheme://user:pass@host...`; the credentials have
+                // every `@` of their own encoded, so the first one ends them.
+                let authority = bun_core::strings::index_of(&href, b"://").map_or(0, |i| i + 3);
+                if let Some(at) = bun_core::strings::index_of_char_usize(&href[authority..], b'@') {
+                    href.drain(authority..=authority + at);
+                }
+            }
+            let mut registry = NpmRegistry {
+                url: href.into_boxed_slice(),
+                ..Default::default()
+            };
+            // WTF::URL serializes the credentials percent-encoded; `p@ss` comes back as `p%40ss`.
+            let decode = |s: &bun_core::String| -> Box<[u8]> {
+                bun_url::PercentEncoding::decode_lenient_alloc(&s.to_utf8())
+            };
+            if username.is_empty() {
+                registry.token = decode(&password);
+            } else {
+                registry.username = decode(&username);
+                registry.password = decode(&password);
+            }
+            Some(registry)
         }
 
         pub fn has_credentials(&self) -> bool {

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -155,9 +155,7 @@ pub mod api {
     }
 
     impl NpmRegistry {
-        /// `[scheme://][user[:password]@|:token@]host[:port][/path]`. With a scheme, the
-        /// registry is what `new URL(str)` reads. Without one, or when WTF::URL rejects the
-        /// string, the lenient parser reads it as before.
+        /// `[scheme://][user[:pass]@|:token@]host[:port][/path]`; with a scheme, what `new URL()` reads.
         pub fn from_url(str: &[u8]) -> NpmRegistry {
             if let Some(registry) = Self::from_whatwg(str) {
                 return registry;
@@ -180,8 +178,7 @@ pub mod api {
             registry
         }
 
-        /// `None` when WTF::URL rejects `str` or finds no host in it (`localhost:4873` is the
-        /// scheme `localhost` to it).
+        /// `None` when WTF::URL rejects `str` or finds no host in it (`localhost:4873`).
         fn from_whatwg(str: &[u8]) -> Option<NpmRegistry> {
             let url = bun_url::whatwg::Parsed::from_utf8(str)?;
             if url.hostname().is_empty() {
@@ -190,15 +187,13 @@ pub mod api {
             let username = url.username();
             let password = url.password();
             if username.is_empty() && password.is_empty() {
-                // Kept as written: `.npmrc` `//host/` credential keys are matched against
-                // these bytes, and `Scope::set_url` normalizes the href later.
+                // As written, since `.npmrc` `//host/` credential keys match these bytes.
                 return Some(NpmRegistry {
                     url: Box::from(str),
                     ..Default::default()
                 });
             }
-            // The serialized href is `scheme://user:pass@host...`; the credentials have every
-            // `@` of their own encoded, so the first one ends them.
+            // WTF::URL encodes every `@` inside the credentials, so the first `@` ends them.
             let mut href = url.href().to_owned_slice();
             let authority = bun_core::strings::index_of(&href, b"://").map_or(0, |i| i + 3);
             if let Some(at) = bun_core::strings::index_of_char_usize(&href[authority..], b'@') {

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -186,18 +186,20 @@ pub mod api {
             }
             let username = url.username();
             let password = url.password();
-            if username.is_empty() && password.is_empty() {
+            if password.is_empty() {
                 // As written, since `.npmrc` `//host/` credential keys match these bytes.
                 return Some(NpmRegistry {
                     url: Box::from(str),
                     ..Default::default()
                 });
             }
-            // WTF::URL encodes every `@` inside the credentials, so the first `@` ends them.
-            let mut href = url.href().to_owned_slice();
-            let authority = bun_core::strings::index_of(&href, b"://").map_or(0, |i| i + 3);
-            if let Some(at) = bun_core::strings::index_of_char_usize(&href[authority..], b'@') {
-                href.drain(authority..=authority + at);
+            // The same `scheme://host/path/` that `URL::href_without_auth` produces.
+            let mut href = url.protocol().to_owned_slice();
+            href.extend_from_slice(b"://");
+            href.extend_from_slice(&url.hostname().to_utf8());
+            href.extend_from_slice(&url.pathname().to_utf8());
+            if !href.ends_with(b"/") {
+                href.push(b'/');
             }
             let mut registry = NpmRegistry {
                 url: href.into_boxed_slice(),

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -189,14 +189,20 @@ pub mod api {
             }
             let username = url.username();
             let password = url.password();
+            if username.is_empty() && password.is_empty() {
+                // Kept as written: `.npmrc` `//host/` credential keys are matched against
+                // these bytes, and `Scope::set_url` normalizes the href later.
+                return Some(NpmRegistry {
+                    url: Box::from(str),
+                    ..Default::default()
+                });
+            }
+            // The serialized href is `scheme://user:pass@host...`; the credentials have every
+            // `@` of their own encoded, so the first one ends them.
             let mut href = url.href().to_owned_slice();
-            if !username.is_empty() || !password.is_empty() {
-                // The serialized href is `scheme://user:pass@host...`; the credentials have
-                // every `@` of their own encoded, so the first one ends them.
-                let authority = bun_core::strings::index_of(&href, b"://").map_or(0, |i| i + 3);
-                if let Some(at) = bun_core::strings::index_of_char_usize(&href[authority..], b'@') {
-                    href.drain(authority..=authority + at);
-                }
+            let authority = bun_core::strings::index_of(&href, b"://").map_or(0, |i| i + 3);
+            if let Some(at) = bun_core::strings::index_of_char_usize(&href[authority..], b'@') {
+                href.drain(authority..=authority + at);
             }
             let mut registry = NpmRegistry {
                 url: href.into_boxed_slice(),

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -1431,6 +1431,29 @@ impl PercentEncoding {
         Self::decode(&mut w, input)
     }
 
+    /// Decodes each `%XX` and keeps every other byte as written, a `%` without two hex digits
+    /// after it included (the WHATWG percent-decode).
+    pub fn decode_lenient_alloc(input: &[u8]) -> Box<[u8]> {
+        let mut out: Vec<u8> = Vec::with_capacity(input.len());
+        let mut rest = input;
+        while let Some(percent) = strings::index_of_char_usize(rest, b'%') {
+            out.extend_from_slice(&rest[..percent]);
+            rest = &rest[percent..];
+            match rest {
+                [b'%', hi, lo, ..] if let Some(byte) = bun_fmt::hex_pair_value(*hi, *lo) => {
+                    out.push(byte);
+                    rest = &rest[3..];
+                }
+                _ => {
+                    out.push(b'%');
+                    rest = &rest[1..];
+                }
+            }
+        }
+        out.extend_from_slice(rest);
+        out.into_boxed_slice()
+    }
+
     pub fn decode_fault_tolerant<W: bun_core::io::Write, const FAULT_TOLERANT: bool>(
         writer: &mut W,
         input: &[u8],

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -1431,8 +1431,7 @@ impl PercentEncoding {
         Self::decode(&mut w, input)
     }
 
-    /// Decodes each `%XX` and keeps every other byte as written, a `%` without two hex digits
-    /// after it included (the WHATWG percent-decode).
+    /// Decodes each `%XX` and keeps every other byte, a lone `%` included (WHATWG percent-decode).
     pub fn decode_lenient_alloc(input: &[u8]) -> Box<[u8]> {
         let mut out: Vec<u8> = Vec::with_capacity(input.len());
         let mut rest = input;

--- a/test/cli/install/registry-url-authority.test.ts
+++ b/test/cli/install/registry-url-authority.test.ts
@@ -35,8 +35,8 @@ async function install(files: Record<string, string>, args: string[], env: Recor
     cmd: [bunExe(), "install", ...args],
     cwd: String(dir),
     env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"), ...env },
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
   });
   return await proc.exited;
 }

--- a/test/cli/install/registry-url-authority.test.ts
+++ b/test/cli/install/registry-url-authority.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// A registry URL names the host `new URL()` names, however it reaches bun: the
+// authority ends at `#`, `\` or `?` and the credentials end at the last `@`.
+// Every registry below answers 404, so an install fails with exit 1; only where
+// the manifest request lands and what it carries is checked.
+
+function recorder() {
+  const requests: { path: string; authorization: string | null }[] = [];
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      requests.push({ path: new URL(req.url).pathname, authorization: req.headers.get("authorization") });
+      return new Response("not here", { status: 404 });
+    },
+  });
+  return {
+    port: server.port,
+    requests,
+    [Symbol.dispose]() {
+      server.stop(true);
+    },
+  };
+}
+
+async function install(files: Record<string, string>, args: string[], env: Record<string, string>) {
+  using dir = tempDir("registry-url-authority", {
+    "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } }),
+    ...files,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", ...args],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"), ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return await proc.exited;
+}
+
+const sources = {
+  BUN_CONFIG_REGISTRY: (url: string) => ({ files: {}, args: [], env: { BUN_CONFIG_REGISTRY: url } }),
+  "bunfig registry": (url: string) => ({
+    files: { "bunfig.toml": Bun.TOML.stringify({ install: { registry: url } }) },
+    args: [],
+    env: {},
+  }),
+  ".npmrc registry": (url: string) => ({ files: { ".npmrc": `registry=${url}\n` }, args: [], env: {} }),
+  "--registry": (url: string) => ({ files: {}, args: ["--registry", url], env: {} }),
+};
+
+describe.concurrent("registry URL authority", () => {
+  // Every source goes through the same parser: the separators are covered once,
+  // the sources with the one that regressed in 1.4. What follows the separator
+  // is a fragment (`#`), a path prefix (`\` is `/`) or a query. A query makes
+  // the registry URL unusable and nothing is requested at all.
+  const prefixed = /^\/@127\.0\.0\.1\S*\/no-deps$/;
+  test.each([
+    ["BUN_CONFIG_REGISTRY", "#@", "/no-deps"],
+    ["BUN_CONFIG_REGISTRY", "\\@", prefixed],
+    ["BUN_CONFIG_REGISTRY", "?@", null],
+    ["bunfig registry", "\\@", prefixed],
+    [".npmrc registry", "\\@", prefixed],
+    ["--registry", "\\@", prefixed],
+  ] as const)(
+    "%s: %j before a second host goes to the first host without credentials",
+    async (source, separator, path) => {
+      using a = recorder();
+      using b = recorder();
+      const { files, args, env } = sources[source](`http://127.0.0.1:${a.port}${separator}127.0.0.1:${b.port}/`);
+      const exitCode = await install(files, args, env);
+      expect({ a: a.requests, b: b.requests, exitCode }).toEqual({
+        a:
+          path === null
+            ? []
+            : [{ path: typeof path === "string" ? path : expect.stringMatching(path), authorization: null }],
+        b: [],
+        exitCode: 1,
+      });
+    },
+  );
+
+  test("credentials with an encoded @ are sent decoded", async () => {
+    using a = recorder();
+    const exitCode = await install({}, [], { BUN_CONFIG_REGISTRY: `http://carol:s3%40cret@127.0.0.1:${a.port}/` });
+    expect({ a: a.requests, exitCode }).toEqual({
+      a: [{ path: "/no-deps", authorization: `Basic ${Buffer.from("carol:s3@cret").toString("base64")}` }],
+      exitCode: 1,
+    });
+  });
+
+  test("a token before the host is still a Bearer token", async () => {
+    using a = recorder();
+    const exitCode = await install({}, [], { BUN_CONFIG_REGISTRY: `http://:tok-en@127.0.0.1:${a.port}/` });
+    expect({ a: a.requests, exitCode }).toEqual({
+      a: [{ path: "/no-deps", authorization: "Bearer tok-en" }],
+      exitCode: 1,
+    });
+  });
+});

--- a/test/cli/install/registry-url-authority.test.ts
+++ b/test/cli/install/registry-url-authority.test.ts
@@ -92,11 +92,43 @@ describe.concurrent("registry URL authority", () => {
     });
   });
 
+  test("credentials and a path prefix without a trailing slash keep the prefix", async () => {
+    using a = recorder();
+    const exitCode = await install({}, [], {
+      BUN_CONFIG_REGISTRY: `http://carol:s3cret@127.0.0.1:${a.port}/api/npm/repo`,
+    });
+    expect({ a: a.requests, exitCode }).toEqual({
+      a: [{ path: "/api/npm/repo/no-deps", authorization: `Basic ${Buffer.from("carol:s3cret").toString("base64")}` }],
+      exitCode: 1,
+    });
+  });
+
   test("a token before the host is still a Bearer token", async () => {
     using a = recorder();
     const exitCode = await install({}, [], { BUN_CONFIG_REGISTRY: `http://:tok-en@127.0.0.1:${a.port}/` });
     expect({ a: a.requests, exitCode }).toEqual({
       a: [{ path: "/no-deps", authorization: "Bearer tok-en" }],
+      exitCode: 1,
+    });
+  });
+
+  // An env registry on the same host as the .npmrc registry keeps its token.
+  // The host that decides this is the one the request goes to.
+  test.each([
+    ["BUN_CONFIG_REGISTRY", []],
+    ["--registry", ["--registry"]],
+  ] as const)("%s: the .npmrc token of a second host after #@ is not sent to the first host", async (_, args) => {
+    using a = recorder();
+    using b = recorder();
+    const url = `http://127.0.0.1:${a.port}#@127.0.0.1:${b.port}/`;
+    const exitCode = await install(
+      { ".npmrc": `registry=http://127.0.0.1:${b.port}/\n//127.0.0.1:${b.port}/:_authToken=secret-for-b\n` },
+      args.length ? [...args, url] : [],
+      args.length ? {} : { BUN_CONFIG_REGISTRY: url },
+    );
+    expect({ a: a.requests, b: b.requests, exitCode }).toEqual({
+      a: [{ path: "/no-deps", authorization: null }],
+      b: [],
       exitCode: 1,
     });
   });


### PR DESCRIPTION
### Problem
- `BUN_CONFIG_REGISTRY=http://127.0.0.1:A#@127.0.0.1:B/ bun install` sends `GET /no-deps` to B with `Authorization: Basic base64("127.0.0.1:A#")`. `new URL(registry).host` is `127.0.0.1:A`. `http://A\@B/` behaves the same, from `.npmrc`, bunfig and `--registry` too. For the env vars `\@` is a 1.4 regression.
- Cause: `NpmRegistry::from_url` (`src/options_types/schema.rs:158`), where every registry URL string is split, uses `bun_url::URL::parse`, whose credential and host scanning stop only at `/` and `?`. It takes `127.0.0.1:A#` for `user:password` and B for the host.

### Fix
- `from_url` parses the string with WTF::URL first. When it has a host but no password, the registry is the string as written, as today (`.npmrc` `//host/` keys match these bytes, and `Scope::set_url` normalizes later). With a password, the registry is `scheme://host/path/` from the WTF::URL components, the form `href_without_auth` produced, and the credentials are its username and password. A string WTF::URL rejects or finds no host in (`localhost:4873`) goes to `URL::parse` as before.
- WTF::URL serializes credentials percent-encoded (`p@ss` becomes `p%40ss`), so they are decoded with the new `PercentEncoding::decode_lenient_alloc`. `http://carol:s3%40cret@host/` now sends `carol:s3@cret`, as curl does.
- The two same-origin checks in `PackageManagerOptions.rs` that carry a `.npmrc` token over to an env or `--registry` URL now read that URL as `set_url` does (`keeps_origin`). With the lenient parser they named the host after `#@` while the request went to the one before it, so B's token reached A.
- Verified: `test/cli/install/registry-url-authority.test.ts`, 8 of 11 cases fail on 1.4.3 or on the first revision of this change. Also the install suites that use a registry URL (notes). The only failures need the public registry or GitHub.

### Background
- Every registry source reaches `from_url`. `Scope::from_api` (`src/install/npm.rs`) then builds the `Authorization` header, and `Scope::set_url` normalizes the href through WTF::URL. The host came from the first step.
- Bun has two URL parsers. WTF::URL (WebKit) is the WHATWG parser behind `new URL()`. `bun_url::URL::parse` slices an href that is already normalized. #39933 made the S3 endpoint take this path.
- #39603, #39063, #38834 and #40423 are open in the same function. None changes where the host comes from (notes).

<details><summary>Notes</summary>

Repro on release 1.4.3 with two `Bun.serve` recorders on 127.0.0.1 (run without `HTTP_PROXY`):

```
BUN_CONFIG_REGISTRY=http://127.0.0.1:A#@127.0.0.1:B/
  A: []
  B: [GET /no-deps  Authorization: Basic MTI3LjAuMC4xOjQ0MzMxIw==]   (base64 "127.0.0.1:A#")
BUN_CONFIG_REGISTRY=http://127.0.0.1:A\@127.0.0.1:B/
  A: []
  B: [GET /no-deps  Authorization: Basic ...XA==]                   (base64 "127.0.0.1:A\")
BUN_CONFIG_REGISTRY=http://127.0.0.1:A?@127.0.0.1:B/
  no request: "manifest URL http://127.0.0.1:A/no-deps is not on registry http://127.0.0.1:A/?@.../"
```

With the change the `#@` form requests `GET /no-deps` on A with no `Authorization`. The `\@` form requests `/@127.0.0.1/no-deps` on A: `\` is `/` to WTF::URL, so `@127.0.0.1:B/` is a path prefix, and `Scope::from_api` strips the `:B` as it strips any `:key` path suffix. The `?@` form still sends nothing, now for the same reason as before (a registry URL with a query matches no manifest URL). The test pins the first two and the absence of a request for the third.

The same function reads `bunfig.toml`, `.npmrc` and `--registry`; the test covers those with the `\@` form.

Why a WTF::URL result without a host falls through: WTF::URL reads `localhost:4873` as the scheme `localhost` with an opaque path, and `//host/` (#39000) as invalid. Both go to `URL::parse` as today.

Why `https://` is not prepended for scheme-less strings, unlike `parse_s3_endpoint`: a registry string without a scheme has never been valid here (the env vars are ignored without `http(s)://`, and `Scope::set_url` falls back to the raw bytes), so there is nothing to keep working.

Open PRs in the same function: #39603 decodes the credentials with a `decode_lenient_alloc` of the same name and shape, so whichever lands second drops its copy. #39063 sends a username without a password as Basic; #38834 expands `$ENV` registry values; #40423 reworks `.npmrc` credential lookup.

Suites run with the debug build: `config-precedence.test.ts`, `redacted-config-logs.test.ts`, `npmrc.test.ts`, `bun-publish.test.ts`, `bun-install-registry.test.ts`, `bun-install.test.ts`, `bun-add.test.ts`.

The `bun-install.test.ts` run had 42 failures, all Git, GitHub or public-registry tests (`DNSResolveFailed`), identical in kind to the failures of the same run on main in this container.

</details>


