### PR TITLE
WebKit b4abe5323244: credit --cpu-prof samples taken in a C leaf to the JIT frame and call site that made the call (oven-sh/WebKit#579)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "bba45a44959775374e4dd3d8294db0b5f8eadbd2";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "31841b2700cbe64165b60e928dfc159241c2a129";
+export const WEBKIT_VERSION = "6f60e0c81bb98ad0ba580a60069972a4bac6ee9b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "6f60e0c81bb98ad0ba580a60069972a4bac6ee9b";
+export const WEBKIT_VERSION = "b4abe53232448ba1868afccb23e8e0e045368cd0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "bba45a44959775374e4dd3d8294db0b5f8eadbd2";
+export const WEBKIT_VERSION = "31841b2700cbe64165b60e928dfc159241c2a129";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -55,6 +55,13 @@ void startCPUProfiler(JSC::VM& vm)
     auto stopwatch = WTF::Stopwatch::create();
     stopwatch->start();
 
+    // Without a PC-to-code-origin map, a sample in DFG or FTL code is attributed
+    // to the call site index the frame last stored, not to the sampled PC. With
+    // a function inlined into its caller, that is the caller. JSC builds the
+    // map for code compiled after this flag is set, the same as it does for
+    // --useSamplingProfiler.
+    vm.setShouldBuildPCToCodeOriginMapping();
+
     JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
     samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
     samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -55,13 +55,6 @@ void startCPUProfiler(JSC::VM& vm)
     auto stopwatch = WTF::Stopwatch::create();
     stopwatch->start();
 
-    // Without a PC-to-code-origin map, a sample in DFG or FTL code is attributed
-    // to the call site index the frame last stored, not to the sampled PC. With
-    // a function inlined into its caller, that is the caller. JSC builds the
-    // map for code compiled after this flag is set, the same as it does for
-    // --useSamplingProfiler.
-    vm.setShouldBuildPCToCodeOriginMapping();
-
     JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
     samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
     samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -444,4 +444,54 @@ describe.concurrent("--cpu-prof", () => {
     const mdContent = readFileSync(join(String(dir), mdFiles[0]), "utf-8");
     expect(mdContent).toContain("# CPU Profile");
   });
+
+  // Math.sin from DFG code is a direct call into libm. JIT code does not store
+  // vm.topCallFrame before such a call, so a sample taken while the PC is in
+  // libm used to be dropped (a stale topCallFrame fails the walk) or credited
+  // to whichever frame last stored topCallFrame (here: the async caller).
+  test("samples inside a C leaf called from optimized code are credited to the JS function", async () => {
+    const windowMs = 250;
+    using dir = tempDir("cpu-prof-c-leaf", {
+      "test.mjs": `
+        function hot(n) {
+          let s = 0;
+          for (let i = 0; i < n; i++) s += Math.sin(i);
+          return s;
+        }
+        async function main() {
+          const end = performance.now() + ${windowMs};
+          let s = 0;
+          while (performance.now() < end) {
+            s += hot(1e5);
+            await new Promise(resolve => setImmediate(resolve));
+          }
+          return s;
+        }
+        await main();
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--cpu-prof", "--cpu-prof-name=leaf.cpuprofile", "test.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(await proc.exited).toBe(0);
+
+    const profile = JSON.parse(readFileSync(join(String(dir), "leaf.cpuprofile"), "utf-8"));
+    const selfSamples = (functionName: string) =>
+      profile.nodes
+        .filter((node: any) => node.callFrame.functionName === functionName)
+        .reduce((sum: number, node: any) => sum + node.hitCount, 0);
+    const hot = selfSamples("hot");
+    const main = selfSamples("main");
+
+    expect(hot).toBeGreaterThan(main);
+    // The sampler ticks every 1ms. Without the fix fewer than a fifth of the
+    // samples survive. Windows ticks at the 15.6ms timer quantum, so only the
+    // attribution check applies there.
+    if (!isWindows) expect(hot).toBeGreaterThan(windowMs / 3);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun --cpu-prof` loses or mis-credits samples taken while the PC is in a C function that DFG or FTL code called directly (libm `sin` through `sinDouble`). A 1.5 s loop over `Math.sqrt(i) * Math.sin(i)` at a 1 ms interval gets 754 samples instead of about 1300, with 2.5 to 20 ms gaps, and the hot function gets 115 self samples instead of about 490. With an async caller the samples land on the caller (main 298, hot 30). `BUN_JSC_useDFGJIT=0` shows the expected numbers.
- Two causes. JIT code does not store `vm.topCallFrame` before a pure operation call, so `SamplingProfiler::takeSample` walks from a stale frame: a dead one drops the sample, an older one gets the credit. And Bun never sets `VM::setShouldBuildPCToCodeOriginMapping()`, so no sample in JIT code (baseline, DFG, or FTL) is mapped to its PC. The frame's last stored call site index is used instead, which credits an inlined callee to its caller.

### Fix
- Bumps WebKit to [`b4abe5323244`](https://github.com/oven-sh/WebKit/commit/b4abe53232448ba1868afccb23e8e0e045368cd0), the oven-sh/WebKit#579 branch. Once that PR merges, this bumps to the merge commit on `main`. The sampler walks the frame pointer chain from the machine frame to the first live JS frame, and maps the return address into that frame through its `PCToCodeOriginMap`.
- `VM::ensureSamplingProfiler` (under `USE(BUN_JSC_ADDITIONS)`) sets `setShouldBuildPCToCodeOriginMapping()` the first time a sampler is created. Bun starts the sampler from three places (`--cpu-prof`, the `v8::CpuProfiler` shim, `bun:jsc`), and this covers all of them. JSC builds the map for code compiled after that, the same as for `--useSamplingProfiler`. Code compiled before a later `Profiler.start` has no map and keeps the old attribution.
- Verified on a release build (`--lto=off`): the loop above gets 1363 samples, hotA 492, 4 gaps over 2.5 ms. The async variant credits hot with 451 of 455. `test/cli/run/cpu-prof.test.ts` (new test, 13 pass), `test/js/node/inspector/inspector-profiler.test.ts`, `test/regression/issue/29240.test.ts`, and `test/cli/env/bun-options.test.ts` pass on release and on an ASAN debug build.

### Background
- The JSC sampling profiler suspends the JS thread every interval, reads its registers, and walks call frames. When the PC is not in JIT or LLInt code it has to pick a frame to start from. Before this change that was always `vm.topCallFrame`.
- `vm.topCallFrame` is stored by call frame tracers in operations that can throw and by the native call thunk. `AssemblyHelpers::prepareCallOperation` stores it only when `ASSERT_ENABLED`, so debug builds do not show the sample loss. The new test passes on both builds and fails on bun 1.4.3 (hot 26 to 38 self samples in 250 ms, the fix gives about 230).
- A `PCToCodeOriginMap` maps a PC in JIT code (baseline, DFG, FTL) to a `CodeOrigin`, with the inline stack for DFG and FTL. It costs memory per compiled code block, so JSC builds it only when asked.

<details><summary>Notes</summary>

Numbers (release build with `--lto=off`, 2 runs each; stock is bun 1.4.3):

| workload | stock | this branch |
| --- | --- | --- |
| w.mjs samples / hotA self | 754 / 115 | 1363 / 492 |
| w.mjs gaps over 2.5 ms | 184 | 4 |
| sin-async hot / main self | 30 / 298 | 451 / 1 |
| sin sync hot self (500 ms) | 45 | 459 |

The async face needed the return-address lookup: with `hot` inlined into the FTL code for `main`, the FTL's `callWithoutSideEffects` stores no call site index (`B3::Effects::none()` would let B3 move the call away from a store anyway), so the frame's index points at a call site in `main`.

The whole fix lives in the WebKit dependency, so a gate that restores `src/` to main and keeps the WebKit pin cannot show a fail-before. The debug build also has `ASSERT_ENABLED`, where JIT code stores `topCallFrame`. The fail-before proof is the run against bun 1.4.3.

Self-reviewed: 3 concerns raised, 3 addressed (the map flag moved from `startCPUProfiler` to `VM::ensureSamplingProfiler` so the `v8::CpuProfiler` shim and `bun:jsc` get the same attribution, the map wording, and a fresh CI run).

Ledger #24491 in the diagnostics tooling audit.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/cpu-prof.test.ts

<!-- robobun:evidence:end -->