### PR TITLE
gc: zero the stack the collector used after a synchronous collection

### DIFF
--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -87,8 +87,12 @@ impl VM {
         JSC__VM__shrinkFootprint(self)
     }
 
+    /// A synchronous full collection, conducted on this thread. The stack
+    /// region the collector used is zeroed before this returns.
     pub fn run_gc(&self, sync: bool) -> usize {
-        JSC__VM__runGC(self, sync)
+        let heap_size = JSC__VM__runGC(self, sync);
+        zero_collector_stack();
+        heap_size
     }
 
     pub(crate) fn heap_size(&self) -> usize {
@@ -156,6 +160,31 @@ impl VM {
     pub(crate) fn block_bytes_allocated(&self) -> usize {
         JSC__VM__blockBytesAllocated(self)
     }
+}
+
+/// Zero the stack below this frame after a collection that ran on this thread.
+///
+/// The collector's frames held the address of every cell the marker visited.
+/// Those frames are gone when `JSC__VM__runGC` returns, but the memory keeps
+/// the addresses until something overwrites them. A later callee whose frame
+/// has a slot it never writes (alignment padding, a local of a branch it does
+/// not take) then exposes one of them to the next conservative stack scan, and
+/// a dead object survives an explicit `gc()`. JSC's own `sanitizeStackForVM`
+/// does not cover this: it zeroes only between the last sanitize point (inside
+/// the collector, above the marking frames) and the current stack pointer.
+///
+/// A synchronous full collection reaches about 20 KiB below its caller. 32 KiB
+/// covers that and stays inside JSC's 64 KiB `reservedZoneSize`, so this is
+/// safe from a `gc()` call near the JS stack limit.
+#[inline(never)]
+fn zero_collector_stack() {
+    const BYTES: usize = 32 * 1024;
+    let mut region = core::mem::MaybeUninit::<[u8; BYTES]>::uninit();
+    // SAFETY: `region` is a live local of this frame and all-zero bytes are a
+    // valid `[u8; BYTES]`.
+    unsafe { core::ptr::write_bytes(region.as_mut_ptr(), 0, 1) };
+    // Keep the stores: without a use, the compiler drops the dead writes.
+    core::hint::black_box(&region);
 }
 
 /// RAII JSLockHolder returned by [`VM::get_api_lock`]. Released on `Drop`.

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -87,12 +87,8 @@ impl VM {
         JSC__VM__shrinkFootprint(self)
     }
 
-    /// A synchronous full collection, conducted on this thread. The stack
-    /// region the collector used is zeroed before this returns.
     pub fn run_gc(&self, sync: bool) -> usize {
-        let heap_size = JSC__VM__runGC(self, sync);
-        zero_collector_stack();
-        heap_size
+        JSC__VM__runGC(self, sync)
     }
 
     pub(crate) fn heap_size(&self) -> usize {
@@ -160,31 +156,6 @@ impl VM {
     pub(crate) fn block_bytes_allocated(&self) -> usize {
         JSC__VM__blockBytesAllocated(self)
     }
-}
-
-/// Zero the stack below this frame after a collection that ran on this thread.
-///
-/// The collector's frames held the address of every cell the marker visited.
-/// Those frames are gone when `JSC__VM__runGC` returns, but the memory keeps
-/// the addresses until something overwrites them. A later callee whose frame
-/// has a slot it never writes (alignment padding, a local of a branch it does
-/// not take) then exposes one of them to the next conservative stack scan, and
-/// a dead object survives an explicit `gc()`. JSC's own `sanitizeStackForVM`
-/// does not cover this: it zeroes only between the last sanitize point (inside
-/// the collector, above the marking frames) and the current stack pointer.
-///
-/// A synchronous full collection reaches about 20 KiB below its caller. 32 KiB
-/// covers that and stays inside JSC's 64 KiB `reservedZoneSize`, so this is
-/// safe from a `gc()` call near the JS stack limit.
-#[inline(never)]
-fn zero_collector_stack() {
-    const BYTES: usize = 32 * 1024;
-    let mut region = core::mem::MaybeUninit::<[u8; BYTES]>::uninit();
-    // SAFETY: `region` is a live local of this frame and all-zero bytes are a
-    // valid `[u8; BYTES]`.
-    unsafe { core::ptr::write_bytes(region.as_mut_ptr(), 0, 1) };
-    // Keep the stores: without a use, the compiler drops the dead writes.
-    core::hint::black_box(&region);
 }
 
 /// RAII JSLockHolder returned by [`VM::get_api_lock`]. Released on `Drop`.

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -1,4 +1,5 @@
 #include "root.h"
+#include "ZeroCollectorStack.h"
 
 #include "BunDebugger.h"
 #include "ZigGlobalObject.h"
@@ -755,8 +756,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionReportNodeInspectorServerStarted, (JSGlobalOb
     // sweep here before waking the main thread (which may immediately
     // process.exit()). close() is synchronous and rare enough that a full
     // collection is acceptable.
-    if (url.isEmpty() && error.isEmpty())
+    if (url.isEmpty() && error.isEmpty()) {
         vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
+        Bun::zeroCollectorStack();
+    }
 
     auto& state = nodeInspectorState();
     {

--- a/src/jsc/bindings/JSCTestingHelpers.cpp
+++ b/src/jsc/bindings/JSCTestingHelpers.cpp
@@ -1,4 +1,5 @@
 #include "root.h"
+#include "ZeroCollectorStack.h"
 
 #include "JavaScriptCore/ObjectConstructor.h"
 #include <JavaScriptCore/JSGlobalObject.h>
@@ -92,6 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsLiveCellAtRawAddress, (JSGlobalObject * glo
 JSC_DEFINE_HOST_FUNCTION(jsFunctionCollectSyncWithoutSweep, (JSGlobalObject * globalObject, CallFrame*))
 {
     JSC::getVM(globalObject).heap.collectSync(JSC::CollectionScope::Full);
+    Bun::zeroCollectorStack();
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/ZeroCollectorStack.cpp
+++ b/src/jsc/bindings/ZeroCollectorStack.cpp
@@ -1,0 +1,11 @@
+#include "root.h"
+#include "ZeroCollectorStack.h"
+
+NEVER_INLINE void Bun::zeroCollectorStack()
+{
+    constexpr size_t bytes = 32 * 1024;
+    char region[bytes];
+    memset(region, 0, bytes);
+    // The address escapes into the asm, so the stores above are not dead.
+    __asm__ __volatile__("" : : "r"(region) : "memory");
+}

--- a/src/jsc/bindings/ZeroCollectorStack.h
+++ b/src/jsc/bindings/ZeroCollectorStack.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace Bun {
+
+// Zero the stack below the caller's frame after a synchronous collection that
+// ran on this thread. Call it right after the collectNow / collectSync call,
+// from the same function.
+//
+// The collector's frames held the address of every cell the marker visited.
+// Those frames are gone when the collection returns, but the memory keeps the
+// addresses until something overwrites them. A later callee whose frame has a
+// slot it never writes (alignment padding, a local of a branch it does not
+// take) then exposes one of them to the next conservative stack scan, and a
+// dead object survives an explicit gc(). JSC's own sanitizeStackForVM does not
+// cover this: it zeroes only between the last sanitize point, which the
+// collector sets above its marking frames, and the current stack pointer.
+//
+// A synchronous full collection reaches about 20 KiB below its caller. 32 KiB
+// covers that and stays inside JSC's 64 KiB reservedZoneSize, so this is safe
+// from a gc() call near the JS stack limit.
+void zeroCollectorStack();
+
+} // namespace Bun

--- a/src/jsc/bindings/ZeroCollectorStack.h
+++ b/src/jsc/bindings/ZeroCollectorStack.h
@@ -2,22 +2,10 @@
 
 namespace Bun {
 
-// Zero the stack below the caller's frame after a synchronous collection that
-// ran on this thread. Call it right after the collectNow / collectSync call,
-// from the same function.
-//
-// The collector's frames held the address of every cell the marker visited.
-// Those frames are gone when the collection returns, but the memory keeps the
-// addresses until something overwrites them. A later callee whose frame has a
-// slot it never writes (alignment padding, a local of a branch it does not
-// take) then exposes one of them to the next conservative stack scan, and a
-// dead object survives an explicit gc(). JSC's own sanitizeStackForVM does not
-// cover this: it zeroes only between the last sanitize point, which the
-// collector sets above its marking frames, and the current stack pointer.
-//
-// A synchronous full collection reaches about 20 KiB below its caller. 32 KiB
-// covers that and stays inside JSC's 64 KiB reservedZoneSize, so this is safe
-// from a gc() call near the JS stack limit.
+// Zero 32 KiB of stack below the caller. Call it right after a synchronous
+// collection, from the same function: the marker's dead frames below hold cell
+// addresses that a later frame's unwritten slot would show to the conservative
+// scan. A full collection reaches about 20 KiB; JSC reserves 64 KiB for us.
 void zeroCollectorStack();
 
 } // namespace Bun

--- a/src/jsc/bindings/ZeroCollectorStack.h
+++ b/src/jsc/bindings/ZeroCollectorStack.h
@@ -2,10 +2,8 @@
 
 namespace Bun {
 
-// Zero 32 KiB of stack below the caller. Call it right after a synchronous
-// collection, from the same function: the marker's dead frames below hold cell
-// addresses that a later frame's unwritten slot would show to the conservative
-// scan. A full collection reaches about 20 KiB; JSC reserves 64 KiB for us.
+// Zero 32 KiB of stack below the caller, right after a synchronous collection,
+// so the marker's dead frames cannot feed the next conservative stack scan.
 void zeroCollectorStack();
 
 } // namespace Bun

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1,4 +1,5 @@
 #include "root.h"
+#include "ZeroCollectorStack.h"
 
 #include "ZigGlobalObject.h"
 #include "BuiltinModuleKeys.h"
@@ -3379,6 +3380,7 @@ void GlobalObject::reload()
     // So we run the GC every other time.
     if ((this->reloadCount++ + 1) % 2 == 0) {
         this->vm().heap.collectSync();
+        Bun::zeroCollectorStack();
     }
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2321,15 +2321,6 @@ inline bool deepEqualsWrapperImpl(JSC::EncodedJSValue a, JSC::EncodedJSValue b, 
 }
 }
 
-NEVER_INLINE void Bun::zeroCollectorStack()
-{
-    constexpr size_t bytes = 32 * 1024;
-    char region[bytes];
-    memset(region, 0, bytes);
-    // The address escapes into the asm, so the stores above are not dead.
-    __asm__ __volatile__("" : : "r"(region) : "memory");
-}
-
 extern "C" {
 
 bool WebCore__FetchHeaders__isEmpty(WebCore::FetchHeaders* arg0)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -8,6 +8,7 @@
  *      can be disabled if necessary. Consult cppbind.ts for details.
  */
 #include "root.h"
+#include "ZeroCollectorStack.h"
 
 #include "JavaScriptCore/ErrorType.h"
 #include "JavaScriptCore/TopExceptionScope.h"
@@ -2318,6 +2319,15 @@ inline bool deepEqualsWrapperImpl(JSC::EncodedJSValue a, JSC::EncodedJSValue b, 
     bool result = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(global, JSC::JSValue::decode(a), JSC::JSValue::decode(b), args, stack, scope, true);
     RELEASE_AND_RETURN(scope, result);
 }
+}
+
+NEVER_INLINE void Bun::zeroCollectorStack()
+{
+    constexpr size_t bytes = 32 * 1024;
+    char region[bytes];
+    memset(region, 0, bytes);
+    // The address escapes into the asm, so the stores above are not dead.
+    __asm__ __volatile__("" : : "r"(region) : "memory");
 }
 
 extern "C" {
@@ -4998,6 +5008,7 @@ size_t JSC__VM__runGC(JSC::VM* vm, bool sync)
     }
 #endif
 
+    Bun::zeroCollectorStack();
     return vm->heap.sizeAfterLastFullCollection();
 }
 

--- a/src/jsc/bindings/v8/V8Isolate.cpp
+++ b/src/jsc/bindings/v8/V8Isolate.cpp
@@ -3,6 +3,7 @@
 #include "V8String.h"
 #include "shim/GlobalInternals.h"
 #include "ZigGlobalObject.h"
+#include "ZeroCollectorStack.h"
 #include "real_v8.h"
 #include "v8_compatibility_assertions.h"
 #include <JavaScriptCore/Error.h>
@@ -61,6 +62,7 @@ void Isolate::LowMemoryNotification()
 {
     JSC::JSLockHolder lock(vm());
     vm().heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
+    Bun::zeroCollectorStack();
 }
 
 void Isolate::AutomaticallyRestoreInitialHeapLimit(double)

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -1,4 +1,5 @@
 #include "root.h"
+#include "ZeroCollectorStack.h"
 #include "_NativeModule.h"
 
 #include "ExceptionOr.h"
@@ -169,6 +170,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGCAndSweep,
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     vm.heap.collectNow(Sync, CollectionScope::Full);
+    Bun::zeroCollectorStack();
     return JSValue::encode(jsNumber(vm.heap.sizeAfterLastFullCollection()));
 }
 
@@ -179,6 +181,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFullGC,
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     vm.heap.collectSync(CollectionScope::Full);
+    Bun::zeroCollectorStack();
     return JSValue::encode(jsNumber(vm.heap.sizeAfterLastFullCollection()));
 }
 
@@ -189,6 +192,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEdenGC,
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     vm.heap.collectSync(CollectionScope::Eden);
+    Bun::zeroCollectorStack();
     return JSValue::encode(jsNumber(vm.heap.sizeAfterLastEdenCollection()));
 }
 
@@ -232,6 +236,7 @@ JSC_DEFINE_HOST_FUNCTION(functionMemoryUsageStatistics,
 
     if (vm.heap.size() == 0) {
         vm.heap.collectNow(Sync, CollectionScope::Full);
+        Bun::zeroCollectorStack();
     }
 
     const auto createdSortedTypeCounts =

--- a/test/js/bun/gc/collector-stack-scrub.test.ts
+++ b/test/js/bun/gc/collector-stack-scrub.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// A synchronous collection runs on the calling thread. JSC's marker visits
+// every live cell on that thread's stack, so when the collector's frames are
+// gone the memory below the caller still holds the address of every visited
+// cell. A later callee whose frame has a slot it never writes exposes one of
+// those addresses to the next conservative stack scan, and a dead object
+// survives an explicit gc(). VM::run_gc zeroes the region the collector used
+// before it returns. This checks that region is zero after Bun.gc(true).
+//
+// Sizes: the scrub covers 32 KiB below run_gc's frame, which starts about
+// 1.5 KiB below the caller in a debug build. The return path from Bun.gc and
+// the call into the scanner reach about 5 KiB below the caller in a debug
+// ASAN build, so the check starts 8 KiB down. Without the scrub the window is
+// full of the collector's frames (a full collection reaches about 20 KiB) and
+// of the startup frames that ran before. The scan is the first statement
+// after Bun.gc: in a debug build, ordinary JS such as a first access to the
+// lazy `console` global or an Array push goes more than 20 KiB deep.
+const scanner = `
+#include <stdint.h>
+
+// Deepest non-zero word in [sp - 28 KiB, sp - 8 KiB), as a byte distance
+// below sp, or 0 when the window is all zero. No calls inside the loop, so
+// nothing below the stack pointer changes while it scans.
+int64_t deepest_nonzero_below(void) {
+  volatile uint64_t anchor = 0;
+  uint64_t sp = (uint64_t)&anchor;
+  volatile uint64_t *p = (volatile uint64_t *)(sp - 28 * 1024);
+  volatile uint64_t *end = (volatile uint64_t *)(sp - 8 * 1024);
+  for (; p < end; p++) {
+    if (*p != 0) return (int64_t)(sp - (uint64_t)p);
+  }
+  return (int64_t)(anchor & 0);
+}
+`;
+
+const entry = `
+import { cc } from "bun:ffi";
+const { symbols: { deepest_nonzero_below } } = cc({
+  source: "./scanner.c",
+  symbols: { deepest_nonzero_below: { args: [], returns: "int64_t" } },
+});
+// Something for the marker to visit on this thread.
+const keep = [];
+for (let i = 0; i < 4096; i++) keep.push({ i, s: "x" + i });
+globalThis.keep = keep;
+const log = console.log;
+Bun.gc(true);
+const deepest = deepest_nonzero_below();
+log(String(deepest));
+`;
+
+// cc() is not available on Windows.
+test.skipIf(isWindows)("Bun.gc(true) zeroes the stack the collector used", async () => {
+  using dir = tempDir("collector-stack-scrub", { "scanner.c": scanner, "entry.mjs": entry });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("0\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `test-process-finalization.mjs` fails on main at random: `should exit file gc-not-close.mjs with code=0`, `AssertionError: true !== false`. An object survived `gc()`: four CI sightings since #41330, none in the 500 builds before it.
- Cause: the synchronous collection after the entry point loads (`src/runtime/cli/run_command.rs:1475`) marks on the main thread and leaves the object's address in dead stack below `Run::start`. The `setImmediate` callback's `Interpreter::executeCall` frame covers that spot with a slot it never writes (`rbp-0x110`), so the conservative scan in `gc()` keeps the object. #41330 changed frame layouts so the two line up.

### Fix
- `Bun::zeroCollectorStack()` (`src/jsc/bindings/ZeroCollectorStack.cpp`) zeroes 32 KiB of stack below its caller. Each synchronous collection site calls it afterwards: `JSC__VM__runGC` (post-entry, `Bun.gc(true)`, `gc()`), `--hot` reload, the `bun:jsc` collectors, `Isolate::LowMemoryNotification`, the JSC testing helper, the inspector close path.
- Correct because that region is dead once the collection returns. A full collection reaches about 20 KiB deep, and JSC keeps 64 KiB of native stack below JS frames (`reservedZoneSize`).
- Self-reviewed: 3 concerns raised (uncovered C++ sites, a duplicate Rust copy, code in `bindings.cpp`), 3 addressed.
- Verified: `test/js/bun/gc/collector-stack-scrub.test.ts` (new, fails on main). Also `test-process-finalization.mjs`, `ffi/cc.test.ts`, `test/js/bun/gc/`, `test/v8`.

### Background
- JSC scans the machine stack conservatively: any word that looks like a cell address keeps the cell alive.
- JSC's `sanitizeStackForVM` zeroes dead stack only down to its last recorded point, which sits above the marking frames.
- Compilers leave frame slots that the executed path never writes. They show old memory to the scan.

<details><summary>Notes</summary>

Reproduction: with 8 loops of the fixture in parallel, the canary profile build (d316760e8) fails 27 to 31 of 2000 runs and the build before #41330 fails 0 of 2000. Alone it does not fail.

How the cause was found, on that canary build:

- `require("bun:jsc").generateHeapSnapshotForDebugging()` taken in the immediate after `gc()`: the `{ foo: 'bar' }` node has no incoming edge and no `roots` entry.
- A stopped process scanned over `/proc/pid/mem`: the cell address sits at exactly one live slot, `rbp-0x110` in `JSC::Interpreter::executeCall` (the frame that runs the immediate callback, called from `Bun__JSTimeout__call`). `objdump` of `executeCall` shows no instruction touches `-0x110(%rbp)`.
- An in-process scanner (`bun:ffi`) on 1600 runs under load: 22 of 22 survivors had the address at that slot before `gc()`, 0 of 1578 non-survivors did. At module end no copy of the address existed anywhere on the live stack.
- A poller thread watching that slot, with a SIGUSR2 handler walking the frame pointers of the main thread: every first write came from `SlotVisitor::drain` / `drainFromShared` / `MarkingConstraintSolver` under `Heap::collectInMutatorThread` ← `JSC__VM__runGC` ← `Run::start`, that is, the post-entry collection.
- `BUN_JSC_logGC=1` on the fixture: exactly two collections, the post-entry one and `gc()`.
- A painted-stack measurement of `Bun.gc(true)` and `Bun.gc(false)`: the collector's frames reach 19.4 to 20.0 KiB below the caller.

Safety of the 32 KiB frame: main thread stacks are 8 MB or more, Bun Worker threads get 4 MB (18 MB reserve on Windows), the inspector thread 16 MB, bundler macro threads the pool default. A host function called from JS at maximum recursion still has `softReservedZoneSize` (128 KiB, tripled under ASAN) of native stack. clang emits `__chkstk` probes for the frame on Windows. Bun's `__asan_default_options` pins `detect_stack_use_after_return=0`, so the array stays on the real stack under ASAN. The empty `__asm__ __volatile__` with the array as an `"r"` input and a `memory` clobber is the idiom WTF's `secureZeroSpan` uses. `NEVER_INLINE` keeps the frame below the caller under ThinLTO.

Not covered, on purpose: `destroyVM` collects right before the VM is torn down, so nothing scans afterwards. `Bun.shrink()` collects inside JSC's `whenIdle` callback, and a concurrent collection whose conn the mutator takes also marks on the mutator stack from `stopIfNecessary`. Both are inside JavaScriptCore. A JSC-side variant of this change (zero below `Heap::collectInMutatorThread` when it finishes) would cover them too, at the cost of a WebKit commit. This PR keeps the change in Bun.

Review: the first push scrubbed only in Rust `VM::run_gc`. The review pointed out the C++ sites that call `collectNow`/`collectSync` directly, so the scrub moved to C++ and is called from each of them, and the Rust copy was dropped.

Why the test checks zeros and not object survival: the survival depends on the frame layout of the binary. The debug build does not reproduce the fixture failure in 480 runs under load without the fix. The scrub is the mechanism, and the test checks it directly: after `Bun.gc(true)`, the window 8 to 28 KiB below the caller is zero. It scans from a `cc()`-compiled C function, so Windows is skipped. On CI it passes on debian x64, x64-asan, alpine x64 and aarch64, and darwin aarch64. Without the fix it reports 28672 (debug) and 27800 (release) bytes of residue.

Culprit: #41330 (frame layouts). The post-entry collection itself dates from the Zig runtime.
</details>
