### PR TITLE
Bun.serve: require the Host header on Upgrade and CONNECT requests

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1264,14 +1264,16 @@ struct HttpResponseData;
             }
 
             /* Break if no host header (but we can have empty string which is different from nullptr).
-             * Upgrade and CONNECT requests are exempt: Node.js dispatches them through the
-             * 'upgrade'/'connect' events before its Host requirement is enforced.
+             * node:http only: Upgrade and CONNECT requests are exempt, because Node.js
+             * dispatches them through the 'upgrade'/'connect' events before its Host
+             * requirement is enforced. Bun.serve has no such events, and a Host-less
+             * request would reach fetch() with a relative req.url, so it is rejected.
              * Checked after the Content-Length / Transfer-Encoding smuggling checks: those are
              * detected while llhttp parses the headers, whereas the Host requirement is a
              * post-completion check, so on doubly-invalid input the framing error wins (Node
              * reports e.g. HPE_INVALID_TRANSFER_ENCODING for such requests). */
             if (!req->ancientHttp && requireHostHeader && !req->getHeader("host").data()
-                && !isConnectRequest && !req->getHeader("upgrade").data()) {
+                && !(IsNodeHttp && (isConnectRequest || req->getHeader("upgrade").data()))) {
                 return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_MISSING_HOST_HEADER);
             }
 

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1779,6 +1779,68 @@ describe("Host header field values in request.url", () => {
     expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe("/index");
   });
 
+  // The Host requirement is only relaxed for node:http, whose 'upgrade' and
+  // 'connect' events run before Node enforces it. Bun.serve has no such events:
+  // a Host-less request would reach fetch() with a relative req.url.
+  test.each([
+    ["Upgrade: websocket", "GET /index HTTP/1.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"],
+    ["Upgrade: foo", "GET /index HTTP/1.1\r\nUpgrade: foo\r\n\r\n"],
+    ["empty Upgrade", "GET /index HTTP/1.1\r\nUpgrade:\r\n\r\n"],
+    ["CONNECT", "CONNECT example.com:443 HTTP/1.1\r\n\r\n"],
+  ])("rejects an HTTP/1.1 request with no Host header even with %s", async (_name, payload) => {
+    let reached = false;
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch() {
+        reached = true;
+        return new Response("OK");
+      },
+      websocket: {
+        message() {},
+      },
+    });
+
+    // Read the status line only: a server that wrongly serves the request keeps
+    // the connection open, so waiting for close would hang.
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const client = net.connect(server.port, "127.0.0.1", () => client.write(payload));
+    client.on("error", reject);
+    client.on("data", chunk => resolve(chunk.toString()));
+    try {
+      const response = await promise;
+      expect(response).toStartWith("HTTP/1.1 400");
+      expect(reached).toBe(false);
+    } finally {
+      client.destroy();
+    }
+  });
+
+  test("a node:http server still emits 'upgrade' for a request with no Host header", async () => {
+    const server = createServer((req, res) => {
+      res.writeHead(500);
+      res.end();
+    });
+    const { promise, resolve, reject } = Promise.withResolvers<string | undefined>();
+    server.on("upgrade", (req, socket) => {
+      resolve(req.headers.host);
+      socket.end("HTTP/1.1 101 Switching Protocols\r\nUpgrade: foo\r\nConnection: Upgrade\r\n\r\n");
+    });
+    server.on("clientError", reject);
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const response = await sendRawRequest(
+        server.address() as { port: number },
+        "GET / HTTP/1.1\r\nUpgrade: foo\r\nConnection: Upgrade\r\n\r\n",
+      );
+      expect(response).toStartWith("HTTP/1.1 101");
+      expect(await promise).toBeUndefined();
+    } finally {
+      server.close();
+    }
+  });
+
   test.each([
     [0x21, 0x40],
     [0x41, 0x60],

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1806,7 +1806,11 @@ describe("Host header field values in request.url", () => {
     const { promise, resolve, reject } = Promise.withResolvers<string>();
     const client = net.connect(server.port, "127.0.0.1", () => client.write(payload));
     client.on("error", reject);
-    client.on("data", chunk => resolve(chunk.toString()));
+    let received = "";
+    client.on("data", chunk => {
+      received += chunk.toString();
+      if (received.includes("\r\n")) resolve(received);
+    });
     try {
       const response = await promise;
       expect(response).toStartWith("HTTP/1.1 400");


### PR DESCRIPTION
### Problem
- Since 1.4.0, any `Upgrade:` request header (even an empty value) or a `CONNECT` request exempts an HTTP/1.1 request from Bun.serve's missing-Host `400 Bad Request`. The Host-less request reaches `fetch()` and `routes` with a relative `req.url` (`"/x"`), so `new URL(req.url)` throws, and `server.upgrade()` completes a 101 for it. 1.3.14 answered 400 for all of these.
- The cause is the Host check in `packages/bun-uws/src/HttpParser.h:1273`. The exemption for upgrade and CONNECT was added for node:http (whose `'upgrade'` and `'connect'` events run before Node enforces Host), but it is not gated on the `IsNodeHttp` template parameter, so the Bun.serve parser inherits it.

### Fix
- Gate the exemption on `IsNodeHttp`. The Bun.serve parser (`IsNodeHttp = false`) rejects every Host-less HTTP/1.1 request with 400, as it did in 1.3.14. The node:http parser keeps the exemption.
- Correct because Bun.serve has no `'upgrade'` or `'connect'` event. Its only consumer of such a request is `fetch()`, which needs an absolute `req.url`. RFC 9112 section 3.2 requires a 400 for an HTTP/1.1 request with no Host.
- Verified: `test/js/bun/http/request-smuggling.test.ts` (4 new Bun.serve cases, stock bun serves all of them with 200, and 1 node:http case that still emits `'upgrade'` with `req.headers.host === undefined`). Also `bun-server.test.ts`, `test/js/bun/websocket/`, and the node `test-http-upgrade-*` and `test-http-connect*` parallel tests.

### Background
- uWS `HttpParser.h` is one template that serves two layouts. `IsNodeHttp = false` is the Bun.serve layout. `IsNodeHttp = true` is the node:http layout, which carries the extra state Node semantics need (CONNECT tunnel mode, request trailers, deferred framing errors).
- `requireHostHeader` is a per-context flag. Bun.serve sets it, and node:http sets it from `http.createServer({ requireHostHeader })`.

<details><summary>Notes</summary>

Repro on 1.4.3 before the fix, raw bytes over `net.connect`:

```
"GET /x HTTP/1.1 | "                    -> HTTP/1.1 400 Bad Request
"GET /x HTTP/1.1 | Upgrade: websocket"  -> HTTP/1.1 200 OK | url="/x" host=null new URL(req.url) THROWS
"GET /x HTTP/1.1 | Upgrade: "           -> HTTP/1.1 200 OK | url="/x" host=null new URL(req.url) THROWS
"CONNECT example.com:443 HTTP/1.1 | "   -> HTTP/1.1 200 OK | url="example.com:443" host=null
```

With the fix all four answer `400 Bad Request`. A CONNECT with a Host header is still dispatched as before.

The exemption arrived in c4a937c53d (#31587). The unix listener and the TLS listener share the same parser, so they are fixed by the same line.

Suites run with the debug build: `request-smuggling.test.ts` (94 pass), `bun-server.test.ts` (one IPv6 listen failure that is the container, no `::1`), `test/js/bun/websocket/` (the `ServerWebSocket > send*` timeouts also fail on main in this container), `node-http-connect.test.ts`, and the node parallel tests `test-http-connect.js`, `test-http-connect-req-res.js`, `test-http-upgrade-server.js`, `test-http-upgrade-server2.js`, `test-http-upgrade-server-callback.js`, `test-http-upgrade-client.js`, `test-http-upgrade-server-with-body.mjs`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/request-smuggling.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [351.75ms]
(pass) rejects Transfer-Encoding with chunked not last [109.20ms]
(pass) rejects duplicate chunked in Transfer-Encoding [54.32ms]
(pass) rejects Transfer-Encoding + Content-Length [51.81ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [66.67ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (Connection: keep-alive) [41.37ms]
(pass) accepts Transfer-Encoding: chunked on an HTTP/1.1 request [73.25ms]
(pass) node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity) [368.60ms]
(pass) rejects conflicting duplicate Content-Length headers [45.13ms]
(pass) accepts duplicate Content-Length headers with identical values [50.05ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [56.02ms]
(pass) accepts valid Transfer-Encoding: chunked [53.32ms]
(pass) rejects Transfer-Encodin
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [8.64ms]
(pass) rejects Transfer-Encoding with chunked not last [2.79ms]
(pass) rejects duplicate chunked in Transfer-Encoding [2.01ms]
(pass) rejects Transfer-Encoding + Content-Length [1.56ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [1.83ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (Connection: keep-alive) [1.45ms]
(pass) accepts Transfer-Encoding: chunked on an HTTP/1.1 request [2.04ms]
(pass) node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity) [8.05ms]
(pass) rejects conflicting duplicate Content-Length headers [1.68ms]
(pass) accepts duplicate Content-Length headers with identical values [1.64ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [1.40ms]
(pass) accepts valid Transfer-Encoding: chunked [1.66ms]
(pass) rejects Transfer-Encoding: gzip, chunked [1.42ms]
(pass) accepts Transfer-Encoding with whitespace around chunked [1.53ms]
(pass) rejects malformed Transfer-Encoding with chunked-false [1.42ms]
(pass) prev
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/request-smuggling.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [519.68ms]
(pass) rejects Transfer-Encoding with chunked not last [166.39ms]
(pass) rejects duplicate chunked in Transfer-Encoding [80.62ms]
(pass) rejects Transfer-Encoding + Content-Length [87.05ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (default close) [120.50ms]
(pass) rejects Transfer-Encoding on an HTTP/1.0 request (Connection: keep-alive) [57.92ms]
(pass) accepts Transfer-Encoding: chunked on an HTTP/1.1 request [109.18ms]
(pass) node:http dispatches Transfer-Encoding on an HTTP/1.0 request (llhttp parity) [539.51ms]
(pass) rejects conflicting duplicate Content-Length headers [70.94ms]
(pass) accepts duplicate Content-Length headers with identical values [91.86ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [82.01ms]
(pass) accepts valid Transfer-Encoding: chunked [111.02ms]
(pass) rejects Transfer-Enco
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2166ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/15] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 43s
[8/15] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[10/15] link bun-profile
rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSSLConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80120154)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSocketConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80120154)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSocketCo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpParser.h          |  8 ++--
 test/js/bun/http/request-smuggling.test.ts | 66 ++++++++++++++++++++++++++++++
 2 files changed, 71 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-uws/src/HttpParser.h               2      1      9
test/js/bun/http/request-smuggling.test.ts      3      3      8
```

</details>

**root cause** · written by the author bot

The HTTP parser in uWS skipped the HTTP/1.1 Host header requirement whenever a request carried an Upgrade header (or was a CONNECT request), a relaxation added for node:http compatibility so its 'upgrade' and 'connect' events could fire before Node enforces Host, but the condition was not gated on the node:http parser persona, so Bun.serve inherited it. As a result a Host-less request with any Upgrade value reached fetch() and routes with a relative req.url, causing new URL(req.url) to throw and letting server.upgrade() complete a 101 that 1.3.14 correctly rejected with 400. The fix scopes …

<!-- robobun:evidence:end -->