### PR TITLE
node:tls: throw from setSession() after the handshake starts instead of aborting

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6897,7 +6897,9 @@ declare module "bun" {
     getSession(): void;
 
     /**
-     * Sets the session of the socket.
+     * Sets the TLS session to resume. Call it before the handshake starts,
+     * for example inside the `open` handler. It throws once the handshake
+     * has started.
      *
      * @param session The session to set.
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6897,9 +6897,10 @@ declare module "bun" {
     getSession(): void;
 
     /**
-     * Sets the TLS session to resume. Call it before the handshake starts,
-     * for example inside the `open` handler. It throws once the handshake
-     * has started.
+     * Sets the TLS session to resume. Call it before the handshake starts.
+     * The `open` handler runs before the handshake only when a `handshake`
+     * handler is also registered. Without one, `open` runs after the
+     * handshake. It throws `Already started.` once the handshake has started.
      *
      * @param session The session to set.
      */

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -208,6 +208,10 @@ static int us_ssl_new_session_ref_idx = -1;
  * 'session' event (fetch) can still cache without paying the serialized
  * pending-session queue. */
 static int us_ssl_session_sink_idx = -1;
+/* (SSL) (void*)1 once the info callback saw SSL_CB_HANDSHAKE_START, i.e. the
+ * handshake state machine left its initial state. BoringSSL exposes no query
+ * for that, and SSL_set_session abort()s the process when called after it. */
+static int us_ssl_handshake_started_ex_idx = -1;
 #ifdef _WIN32
 static INIT_ONCE us_ex_idx_once = INIT_ONCE_STATIC_INIT;
 #else
@@ -463,6 +467,7 @@ static void us_ex_idx_init(void) {
   us_ssl_pending_keylog_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_pending_session_free);
   us_ssl_new_session_ref_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_new_session_ref_free);
   us_ssl_session_sink_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_session_sink_free);
+  us_ssl_handshake_started_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 }
 
 #ifdef _WIN32
@@ -562,6 +567,23 @@ int us_ssl_pop_pending_keylog(SSL *ssl, unsigned char *out, int out_cap) {
 SSL_SESSION *us_ssl_get_new_session(SSL *ssl) {
   if (us_ssl_new_session_ref_idx < 0) return NULL;
   return SSL_get_ex_data(ssl, us_ssl_new_session_ref_idx);
+}
+
+/* Installed on every SSL_CTX from us_ssl_ctx_build_raw. BoringSSL fires
+ * SSL_CB_HANDSHAKE_START from the state-0 step of both the client and the
+ * server state machine, which is exactly the point after which
+ * SSL_set_session abort()s. Only that transition is recorded. */
+static void us_ssl_info_cb(const SSL *ssl, int type, int value) {
+  (void)value;
+  if (type == SSL_CB_HANDSHAKE_START) {
+    SSL_set_ex_data((SSL *)ssl, us_ssl_handshake_started_ex_idx, (void *)1);
+  }
+}
+
+int us_ssl_handshake_started(SSL *ssl) {
+  if (SSL_is_init_finished(ssl)) return 1;
+  return us_ssl_handshake_started_ex_idx >= 0 &&
+         SSL_get_ex_data(ssl, us_ssl_handshake_started_ex_idx) != NULL;
 }
 
 int us_ssl_ctx_cache_ex_idx(void) {
@@ -1269,6 +1291,7 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
   /* Register the live-count free_func first thing so every exit (including
    * build_fail) balances. The packed reneg policy reuses the same slot. */
   SSL_CTX_set_ex_data(ssl_context, us_ssl_ctx_ex_idx(), NULL);
+  SSL_CTX_set_info_callback(ssl_context, us_ssl_info_cb);
 
   /* Default options we rely on — changing these breaks the BIO logic. */
   SSL_CTX_set_read_ahead(ssl_context, 1);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -570,6 +570,9 @@ int us_ssl_pop_pending_keylog(struct ssl_st *ssl, unsigned char *out, int out_ca
 /* The resumable session most recently delivered via the new-session callback,
  * or NULL if none. Borrowed; valid until the next NewSessionTicket or SSL_free. */
 struct ssl_session_st *us_ssl_get_new_session(struct ssl_st *ssl);
+/* 1 once the handshake on `ssl` has started (or completed). SSL_set_session
+ * is only legal while this is 0: BoringSSL abort()s otherwise. */
+int us_ssl_handshake_started(struct ssl_st *ssl);
 /* Per-SSL session sink: each resumable session reaching the new-session
  * callback is SSL_SESSION_up_ref'd and handed to on_new_session (which takes
  * ownership of that reference). on_free(owner) runs once on SSL_free. */

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -107,8 +107,7 @@ pub(super) mod ffi {
         pub(crate) safe fn SSL_get_session(ssl: &SSL) -> *mut SSL_SESSION;
         // Borrowed from the SSL's ex_data; no caller-side precondition.
         pub(crate) safe fn us_ssl_get_new_session(ssl: &SSL) -> *mut SSL_SESSION;
-        /// 1 once the handshake has started (usockets openssl.c records
-        /// SSL_CB_HANDSHAKE_START). SSL_set_session abort()s after that.
+        /// 1 once SSL_CB_HANDSHAKE_START fired (usockets openssl.c).
         pub(crate) safe fn us_ssl_handshake_started(ssl: &SSL) -> c_int;
         // Both handles are opaque-ZST refs (`UnsafeCell` body); BoringSSL bumps
         // `session`'s refcount internally — no caller-side precondition.
@@ -1180,8 +1179,7 @@ pub(super) fn set_session(
         // so we must release the one returned by d2i_SSL_SESSION on every path.
         // SAFETY: `s` is the +1 SSL_SESSION reference returned by d2i_SSL_SESSION; we own it.
         let _guard = scopeguard::guard(session, |s| unsafe { ffi::SSL_SESSION_free(s) });
-        // BoringSSL abort()s the process if SSL_set_session runs after the
-        // handshake state machine has left its initial state.
+        // SSL_set_session abort()s once the handshake has started.
         if ffi::us_ssl_handshake_started(boringssl::SSL::opaque_ref(ssl_ptr)) != 0 {
             return Err(global.throw(format_args!("Already started.")));
         }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -107,6 +107,9 @@ pub(super) mod ffi {
         pub(crate) safe fn SSL_get_session(ssl: &SSL) -> *mut SSL_SESSION;
         // Borrowed from the SSL's ex_data; no caller-side precondition.
         pub(crate) safe fn us_ssl_get_new_session(ssl: &SSL) -> *mut SSL_SESSION;
+        /// 1 once the handshake has started (usockets openssl.c records
+        /// SSL_CB_HANDSHAKE_START). SSL_set_session abort()s after that.
+        pub(crate) safe fn us_ssl_handshake_started(ssl: &SSL) -> c_int;
         // Both handles are opaque-ZST refs (`UnsafeCell` body); BoringSSL bumps
         // `session`'s refcount internally — no caller-side precondition.
         pub(crate) safe fn SSL_set_session(ssl: &SSL, session: &SSL_SESSION) -> c_int;
@@ -1177,6 +1180,11 @@ pub(super) fn set_session(
         // so we must release the one returned by d2i_SSL_SESSION on every path.
         // SAFETY: `s` is the +1 SSL_SESSION reference returned by d2i_SSL_SESSION; we own it.
         let _guard = scopeguard::guard(session, |s| unsafe { ffi::SSL_SESSION_free(s) });
+        // BoringSSL abort()s the process if SSL_set_session runs after the
+        // handshake state machine has left its initial state.
+        if ffi::us_ssl_handshake_started(boringssl::SSL::opaque_ref(ssl_ptr)) != 0 {
+            return Err(global.throw(format_args!("Already started.")));
+        }
         if ffi::SSL_set_session(
             boringssl::SSL::opaque_ref(ssl_ptr),
             ffi::SSL_SESSION::opaque_ref(session),

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4706,3 +4706,26 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
 
   await Promise.all([serverClosed.promise, clientClosed.promise]);
 });
+
+describe.concurrent("setSession() after the handshake started", () => {
+  // BoringSSL's SSL_set_session abort()s the process once the handshake state
+  // machine has left its initial state. The fixture feeds a valid session to
+  // setSession() through each Bun socket door and prints what happened.
+  const fixture = join(import.meta.dirname, "../../node/tls/node-tls-set-session-after-start.fixture.ts");
+
+  async function run(door: string) {
+    await using proc = Bun.spawn({ cmd: [bunExe(), fixture, door], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  it.each([["bun-connect-handshake"], ["bun-listen-handshake"]])("%s throws instead of aborting", async door => {
+    expect(await run(door)).toEqual({ threw: "Already started." });
+  });
+
+  it("is still accepted from open(), before the ClientHello", async () => {
+    expect(await run("bun-connect-open")).toEqual({ threw: null });
+  });
+});

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4721,8 +4721,10 @@ describe.concurrent("setSession() after the handshake started", () => {
     expect(exitCode).toBe(0);
   }
 
-  it.each([["bun-connect-handshake"], ["bun-listen-handshake"]])("%s throws instead of aborting", async door => {
-    await run(door, { threw: "Already started." });
+  describe.each([["bun-connect-handshake"], ["bun-listen-handshake"]])("%s", door => {
+    it("throws instead of aborting", async () => {
+      await run(door, { threw: "Already started." });
+    });
   });
 
   it("is still accepted from open(), before the ClientHello", async () => {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4713,19 +4713,19 @@ describe.concurrent("setSession() after the handshake started", () => {
   // setSession() through each Bun socket door and prints what happened.
   const fixture = join(import.meta.dirname, "../../node/tls/node-tls-set-session-after-start.fixture.ts");
 
-  async function run(door: string) {
+  async function run(door: string, expected: { threw: string | null }) {
     await using proc = Bun.spawn({ cmd: [bunExe(), fixture, door], env: bunEnv, stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(expected);
     expect(exitCode).toBe(0);
-    return JSON.parse(stdout);
   }
 
   it.each([["bun-connect-handshake"], ["bun-listen-handshake"]])("%s throws instead of aborting", async door => {
-    expect(await run(door)).toEqual({ threw: "Already started." });
+    await run(door, { threw: "Already started." });
   });
 
   it("is still accepted from open(), before the ClientHello", async () => {
-    expect(await run("bun-connect-open")).toEqual({ threw: null });
+    await run("bun-connect-open", { threw: null });
   });
 });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -619,6 +619,27 @@ it("setSession() should not leak the SSL_SESSION returned by d2i_SSL_SESSION", a
   expect(exitCode).toBe(0);
 }, 60_000);
 
+describe.concurrent("setSession() after the handshake started", () => {
+  // BoringSSL's SSL_set_session abort()s the process once the handshake state
+  // machine has left its initial state. Every door below used to take the
+  // whole process down with rc 134; now each one throws.
+  it.each([["node-client-secureConnect"], ["node-server-secureConnection"], ["node-duplex-secureConnect"]])(
+    "%s throws instead of aborting",
+    async door => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dirname, "node-tls-set-session-after-start.fixture.ts"), door],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ threw: "Already started." });
+      expect(exitCode).toBe(0);
+    },
+  );
+});
+
 it.each([["TLSv1.2"], ["TLSv1.3"]] as const)(
   "%s: data written after secureConnect is delivered both ways even when the server ends first",
   async version => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -623,19 +623,21 @@ describe.concurrent("setSession() after the handshake started", () => {
   // BoringSSL's SSL_set_session abort()s the process once the handshake state
   // machine has left its initial state. Every door below used to take the
   // whole process down with rc 134; now each one throws.
-  it.each([["node-client-secureConnect"], ["node-server-secureConnection"], ["node-duplex-secureConnect"]])(
-    "%s throws instead of aborting",
-    async door => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(import.meta.dirname, "node-tls-set-session-after-start.fixture.ts"), door],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
+  describe.each([["node-client-secureConnect"], ["node-server-secureConnection"], ["node-duplex-secureConnect"]])(
+    "%s",
+    door => {
+      it("throws instead of aborting", async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), join(import.meta.dirname, "node-tls-set-session-after-start.fixture.ts"), door],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual({ threw: "Already started." });
+        expect(exitCode).toBe(0);
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual({ threw: "Already started." });
-      expect(exitCode).toBe(0);
     },
   );
 });

--- a/test/js/node/tls/node-tls-set-session-after-start.fixture.ts
+++ b/test/js/node/tls/node-tls-set-session-after-start.fixture.ts
@@ -6,13 +6,22 @@
 // valid serialized session to setSession() on a socket whose handshake has
 // started, through a different JS entry point. The expected outcome is a JS
 // exception, printed as JSON on stdout, and a normal exit.
-import { tls as certs } from "harness";
 import { once } from "node:events";
+import fs from "node:fs";
 import net from "node:net";
+import path from "node:path";
 import { Duplex } from "node:stream";
 import tls from "node:tls";
 
 const door = process.argv[2];
+
+// Read the cert from disk instead of importing "harness": that import costs
+// about two seconds under a debug build, most of this fixture's runtime.
+const fixturesDir = path.join(import.meta.dirname, "fixtures");
+const certs = {
+  key: fs.readFileSync(path.join(fixturesDir, "agent1-key.pem")),
+  cert: fs.readFileSync(path.join(fixturesDir, "agent1-cert.pem")),
+};
 
 let session: Buffer;
 const server = tls.createServer({ key: certs.key, cert: certs.cert }, socket => {
@@ -24,7 +33,7 @@ const server = tls.createServer({ key: certs.key, cert: certs.cert }, socket => 
 });
 await once(server.listen(0, "127.0.0.1"), "listening");
 const port = (server.address() as net.AddressInfo).port;
-const clientOptions = { host: "127.0.0.1", port, ca: certs.cert, servername: "localhost" } as const;
+const clientOptions = { host: "127.0.0.1", port, rejectUnauthorized: false } as const;
 
 // A first connection produces the session blob every door feeds back in.
 const first = tls.connect(clientOptions);
@@ -80,7 +89,7 @@ switch (door) {
     await Bun.connect({
       hostname: "127.0.0.1",
       port,
-      tls: { ca: certs.cert, serverName: "localhost" },
+      tls: { rejectUnauthorized: false },
       socket: {
         handshake(socket) {
           report(() => socket.setSession(session));
@@ -97,7 +106,7 @@ switch (door) {
     await Bun.connect({
       hostname: "127.0.0.1",
       port,
-      tls: { ca: certs.cert, serverName: "localhost" },
+      tls: { rejectUnauthorized: false },
       socket: {
         open(socket) {
           report(() => socket.setSession(session));

--- a/test/js/node/tls/node-tls-set-session-after-start.fixture.ts
+++ b/test/js/node/tls/node-tls-set-session-after-start.fixture.ts
@@ -1,0 +1,132 @@
+// Fixture for the "setSession() after the handshake started" tests in
+// node-tls-connect.test.ts and test/js/bun/net/socket.test.ts.
+//
+// BoringSSL's SSL_set_session abort()s the whole process when the handshake
+// state machine has already left its initial state. Each "door" below hands a
+// valid serialized session to setSession() on a socket whose handshake has
+// started, through a different JS entry point. The expected outcome is a JS
+// exception, printed as JSON on stdout, and a normal exit.
+import { tls as certs } from "harness";
+import { once } from "node:events";
+import net from "node:net";
+import { Duplex } from "node:stream";
+import tls from "node:tls";
+
+const door = process.argv[2];
+
+let session: Buffer;
+const server = tls.createServer({ key: certs.key, cert: certs.cert }, socket => {
+  if (door === "node-server-secureConnection" && session) {
+    report(() => socket.setSession(session));
+  }
+  socket.on("data", () => {});
+  socket.on("error", () => {});
+});
+await once(server.listen(0, "127.0.0.1"), "listening");
+const port = (server.address() as net.AddressInfo).port;
+const clientOptions = { host: "127.0.0.1", port, ca: certs.cert, servername: "localhost" } as const;
+
+// A first connection produces the session blob every door feeds back in.
+const first = tls.connect(clientOptions);
+await once(first, "secureConnect");
+session = first.getSession()!;
+first.destroy();
+await once(first, "close");
+
+let reported = false;
+function report(call: () => void) {
+  if (reported) return;
+  reported = true;
+  let threw: string | null = null;
+  try {
+    call();
+  } catch (e) {
+    threw = (e as Error).message;
+  }
+  console.log(JSON.stringify({ threw }));
+  setImmediate(() => process.exit(0));
+}
+
+switch (door) {
+  case "node-client-secureConnect": {
+    const client = tls.connect(clientOptions);
+    await once(client, "secureConnect");
+    report(() => client.setSession(session));
+    break;
+  }
+  case "node-server-secureConnection": {
+    const client = tls.connect(clientOptions);
+    await once(client, "secureConnect");
+    break;
+  }
+  case "node-duplex-secureConnect": {
+    // TLS over a user Duplex is driven by a separate SSL wrapper, not uSockets.
+    const raw = net.connect(port, "127.0.0.1");
+    await once(raw, "connect");
+    const proxy = new Duplex({
+      read() {},
+      write(chunk, _enc, cb) {
+        raw.write(chunk, cb);
+      },
+    });
+    raw.on("data", chunk => proxy.push(chunk));
+    raw.on("end", () => proxy.push(null));
+    const client = tls.connect({ ...clientOptions, socket: proxy });
+    await once(client, "secureConnect");
+    report(() => client.setSession(session));
+    break;
+  }
+  case "bun-connect-handshake": {
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      tls: { ca: certs.cert, serverName: "localhost" },
+      socket: {
+        handshake(socket) {
+          report(() => socket.setSession(session));
+        },
+        data() {},
+        error() {},
+      },
+    });
+    break;
+  }
+  case "bun-connect-open": {
+    // With both `open` and `handshake` handlers, `open` fires before the
+    // ClientHello is queued. The call is legal there and must keep working.
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      tls: { ca: certs.cert, serverName: "localhost" },
+      socket: {
+        open(socket) {
+          report(() => socket.setSession(session));
+        },
+        handshake() {},
+        data() {},
+        error() {},
+      },
+    });
+    break;
+  }
+  case "bun-listen-handshake": {
+    const listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: { key: certs.key, cert: certs.cert },
+      socket: {
+        handshake(socket) {
+          report(() => socket.setSession(session));
+        },
+        data() {},
+        error() {},
+      },
+    });
+    const client = tls.connect({ ...clientOptions, port: listener.port });
+    client.on("error", () => {});
+    await once(client, "secureConnect");
+    break;
+  }
+  default:
+    throw new Error(`unknown door ${door}`);
+}


### PR DESCRIPTION
### Problem
- `tlsSocket.setSession(<valid session>)` on a socket whose handshake has already started aborts the whole process: `panic(main thread): abort() called`, rc 134, no JS exception. Node returns normally.
- The cause is the native `set_session` host function (`src/runtime/socket/tls_socket_functions.rs:1180`). It hands the parsed session straight to `SSL_set_session`. The vendored BoringSSL `SSL_set_session` calls `abort()` when `initial_handshake_complete`, `hs == nullptr`, or `hs->state != 0` (`vendor/boringssl/ssl/ssl_session.cc:1128`).
- All five JS doors funnel into that one host function: client `secureConnect`, server `secureConnection`, a duplex-wrapped `TLSSocket`, `Bun.connect` `handshake`, and `Bun.listen` `handshake`. Garbage input does not abort, because the parse fails first and the call is ignored.

### Fix
- Record the start of the handshake on each SSL. An `SSL_CTX` info callback sets a per-SSL flag on `SSL_CB_HANDSHAKE_START`, which BoringSSL fires from the state-0 step of both the client and the server state machine. That is the exact point after which `SSL_set_session` aborts.
- `set_session` now queries `us_ssl_handshake_started` after it parses the session. If the handshake has started, it throws `Already started.`, the same error `setServername` throws for the same situation. A valid session applied before the handshake still resumes.
- The check runs after the parse, so invalid or empty input stays silently ignored, as before and as in Node.
- Verified: `test/js/node/tls/node-tls-connect.test.ts` and `test/js/bun/net/socket.test.ts` (6 new cases across the 5 doors plus the legal pre-handshake window). Each aborting case fails on the unfixed build with rc 134. Also ran the full `node-tls-connect.test.ts` (52 pass) and the TLS resumption cases.

### Background
- `SSL_set_session` tells BoringSSL which TLS session to resume. BoringSSL documents that it may only be called before the handshake has started, and enforces that with an `abort()`. OpenSSL tolerates the late call, so Node does not crash.
- A TLS session is a serialized blob from `getSession()` or a `session` ticket event. The legal way to resume is the `session:` option of `tls.connect()`, which Bun applies before the handshake. Session-cache and reconnect helpers that instead call `setSession()` on a live socket hit the late path.
- Bun drives the handshake through BoringSSL in two places: uSockets (`packages/bun-usockets/src/crypto/openssl.c`) for normal sockets, and a Rust `SSLWrapper` for TLS over a user duplex or a named pipe. Both build their `SSL_CTX` through `us_ssl_ctx_build_raw`, so one info callback there covers every door.

<details><summary>Notes</summary>

Repro (self-signed loopback cert):

```js
const s = tls.connect({ host, port, ca, servername }, () => {
  const sess = s.getSession();
  s.setSession(sess); // rc 134 on bun 1.4.3, "Already started." after this fix
});
```

`Bun.connect` `open()` fires before the ClientHello only when a `handshake` handler is also supplied. In that window `setSession()` still works. Without a `handshake` handler, `open()` fires after the handshake has started, so the call throws there too. The fixture covers both.

The info callback is the only way to observe the state that triggers the abort. BoringSSL exposes no public query for `hs->state`, and `SSL_in_init` is already true before the handshake starts (the handshake object exists), so it cannot distinguish the legal window from the illegal one.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->