### PR TITLE
node:http: http.Server ignores TLS options, https.Server always speaks TLS

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -27,7 +27,6 @@ const abortedSymbol = Symbol("aborted");
 const headerStateSymbol = Symbol("headerState");
 const eofInProgress = Symbol("eofInProgress");
 const fakeSocketSymbol = Symbol("fakeSocket");
-const isTlsSymbol = Symbol("is_tls");
 const kHandle = Symbol("handle");
 const kRealListen = Symbol("kRealListen");
 const noBodySymbol = Symbol("noBody");
@@ -503,7 +502,6 @@ export {
   getMaxHTTPHeaderSize,
   hasServerResponseFinished,
   headerStateSymbol,
-  isTlsSymbol,
   kAbortController,
   kCloseCallback,
   kHandle,

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -191,8 +191,7 @@ function normalizeServerTls(tls) {
   return tls;
 }
 
-// The `tls` config for Bun.serve behind an https.Server. Always returns a config, so the
-// listener speaks TLS without key/cert like Node's tls.Server.
+// Bun.serve `tls` config for https.Server. Never null: without key/cert the listener still speaks TLS.
 function httpsServerTlsOptions(options) {
   // Node's https.Server accepts PKCS#12 bundles (pfx [+ passphrase]); fold
   // them into plain key/cert/ca so the native TLS config sees PEM material.

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -178,7 +178,97 @@ function processPfxOptions(options) {
   return out;
 }
 
+// Node.js only requests a client certificate when `requestCert: true`.
+// The uSockets SSL context treats `ca` alone as "verify peer", so without
+// these two flags an `https.Server({ ca })` would reject every client that
+// doesn't present a cert. Mirror tls.Server (net.ts): default `requestCert`
+// to false and, when not requesting, force `rejectUnauthorized` to false so
+// the CA is loaded into the trust store without requiring a client cert.
+function normalizeServerTls(tls) {
+  const requestCert = !!tls.requestCert;
+  tls.requestCert = requestCert;
+  tls.rejectUnauthorized = requestCert ? tls.rejectUnauthorized !== false : false;
+  return tls;
+}
+
+// The `tls` config for Bun.serve behind an https.Server. Always returns a config, so the
+// listener speaks TLS without key/cert like Node's tls.Server.
+function httpsServerTlsOptions(options) {
+  // Node's https.Server accepts PKCS#12 bundles (pfx [+ passphrase]); fold
+  // them into plain key/cert/ca so the native TLS config sees PEM material.
+  let tlsOptions = options;
+  if (options.pfx) {
+    tlsOptions = processPfxOptions(options);
+  }
+
+  let cert = tlsOptions.cert;
+  if (cert) {
+    throwOnInvalidTLSArray("options.cert", cert);
+  }
+
+  let key = tlsOptions.key;
+  if (key) {
+    throwOnInvalidTLSArray("options.key", key);
+  }
+
+  let ca = tlsOptions.ca;
+  // PKCS#12-embedded CAs extend the trust set; the server path hands raw
+  // {key, cert, ca} to the native config and has no addCACert hook, so fold
+  // them into `ca` (mirrors tls.Server.setSecureContext).
+  const pfxExtraCAs = tlsOptions._pfxExtraCACerts;
+  if (pfxExtraCAs?.length) {
+    ca = ca == null ? pfxExtraCAs : $isArray(ca) ? [...ca, ...pfxExtraCAs] : [ca, ...pfxExtraCAs];
+  }
+  if (ca) {
+    throwOnInvalidTLSArray("options.ca", ca);
+  }
+
+  let passphrase = options.passphrase;
+  if (passphrase && typeof passphrase !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
+  }
+
+  let serverName = options.servername;
+  if (serverName && typeof serverName !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.servername", "string", serverName);
+  }
+
+  let secureOptions = options.secureOptions || 0;
+  if (secureOptions && typeof secureOptions !== "number") {
+    throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
+  }
+
+  // Translate minVersion/maxVersion/secureProtocol into the integer
+  // protocol range the native layer applies (secureProtocol wins, like
+  // Node's SecureContext::Init); 0 keeps the native defaults.
+  validateSecureProtocol(options.secureProtocol);
+  let minVersion, maxVersion;
+  const range = secureProtocolToVersionRange(options.secureProtocol);
+  if (range) {
+    minVersion = range[0];
+    maxVersion = range[1];
+  } else {
+    minVersion = tlsStringToProtocolVersion(options.minVersion);
+    maxVersion = tlsStringToProtocolVersion(options.maxVersion);
+  }
+  return normalizeServerTls({
+    serverName,
+    key,
+    cert,
+    ca,
+    passphrase,
+    secureOptions,
+    minVersion,
+    maxVersion,
+    ciphers: typeof options.ciphers === "string" && options.ciphers ? options.ciphers : undefined,
+    requestCert: options.requestCert,
+    rejectUnauthorized: options.rejectUnauthorized,
+  });
+}
+
 export {
+  httpsServerTlsOptions,
+  normalizeServerTls,
   processPfxOptions,
   secureProtocolToVersionRange,
   throwOnInvalidTLSArray,

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -233,19 +233,6 @@ function emitListenErrorNextTick(self, err) {
   self.emit("error", err);
 }
 
-// Node.js only requests a client certificate when `requestCert: true`.
-// The uSockets SSL context treats `ca` alone as "verify peer", so without
-// these two flags an `https.Server({ ca })` would reject every client that
-// doesn't present a cert. Mirror tls.Server (net.ts): default `requestCert`
-// to false and, when not requesting, force `rejectUnauthorized` to false so
-// the CA is loaded into the trust store without requiring a client cert.
-function normalizeServerTls(tls) {
-  const requestCert = !!tls.requestCert;
-  tls.requestCert = requestCert;
-  tls.rejectUnauthorized = requestCert ? tls.rejectUnauthorized !== false : false;
-  return tls;
-}
-
 // Node registers connectionListener on every http.Server so `server.emit("connection", socket)`
 // works for foreign Duplex sockets. The native listener handles its own sockets end to end;
 // this picks up the rest. https://github.com/nodejs/node/blob/main/lib/_http_server.js
@@ -259,95 +246,9 @@ function connectionListener(this: Server, socket) {
   });
 }
 
-// Always returns a config, so https.Server speaks TLS without key/cert like Node's tls.Server.
-function serverTlsOptions(options) {
-  const tlsHelpers = require("internal/tls");
-
-  // Node's https.Server accepts PKCS#12 bundles (pfx [+ passphrase]); fold
-  // them into plain key/cert/ca so the native TLS config sees PEM material.
-  let tlsOptions = options;
-  if (options.pfx) {
-    tlsOptions = tlsHelpers.processPfxOptions(options);
-  }
-
-  let cert = tlsOptions.cert;
-  if (cert) {
-    tlsHelpers.throwOnInvalidTLSArray("options.cert", cert);
-  }
-
-  let key = tlsOptions.key;
-  if (key) {
-    tlsHelpers.throwOnInvalidTLSArray("options.key", key);
-  }
-
-  let ca = tlsOptions.ca;
-  // PKCS#12-embedded CAs extend the trust set; the server path hands raw
-  // {key, cert, ca} to the native config and has no addCACert hook, so fold
-  // them into `ca` (mirrors tls.Server.setSecureContext).
-  const pfxExtraCAs = tlsOptions._pfxExtraCACerts;
-  if (pfxExtraCAs?.length) {
-    ca = ca == null ? pfxExtraCAs : $isArray(ca) ? [...ca, ...pfxExtraCAs] : [ca, ...pfxExtraCAs];
-  }
-  if (ca) {
-    tlsHelpers.throwOnInvalidTLSArray("options.ca", ca);
-  }
-
-  let passphrase = options.passphrase;
-  if (passphrase && typeof passphrase !== "string") {
-    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
-  }
-
-  let serverName = options.servername;
-  if (serverName && typeof serverName !== "string") {
-    throw $ERR_INVALID_ARG_TYPE("options.servername", "string", serverName);
-  }
-
-  let secureOptions = options.secureOptions || 0;
-  if (secureOptions && typeof secureOptions !== "number") {
-    throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
-  }
-
-  const { validateSecureProtocol, secureProtocolToVersionRange, tlsStringToProtocolVersion } = tlsHelpers;
-  // Translate minVersion/maxVersion/secureProtocol into the integer
-  // protocol range the native layer applies (secureProtocol wins, like
-  // Node's SecureContext::Init); 0 keeps the native defaults.
-  validateSecureProtocol(options.secureProtocol);
-  let minVersion, maxVersion;
-  const range = secureProtocolToVersionRange(options.secureProtocol);
-  if (range) {
-    minVersion = range[0];
-    maxVersion = range[1];
-  } else {
-    minVersion = tlsStringToProtocolVersion(options.minVersion);
-    maxVersion = tlsStringToProtocolVersion(options.maxVersion);
-  }
-  return normalizeServerTls({
-    serverName,
-    key,
-    cert,
-    ca,
-    passphrase,
-    secureOptions,
-    minVersion,
-    maxVersion,
-    ciphers: typeof options.ciphers === "string" && options.ciphers ? options.ciphers : undefined,
-    requestCert: options.requestCert,
-    rejectUnauthorized: options.rejectUnauthorized,
-  });
-}
-
-// Like Node, http.Server ignores key/cert/ca/pfx. Only HttpsServer reads them.
+// Like Node, http.Server ignores key/cert/ca/pfx. https.Server (https.ts) sets its own TLS config.
 function Server(options, callback): void {
   if (!(this instanceof Server)) return new Server(options, callback);
-  return initServer.$call(this, options, callback, false);
-}
-
-function HttpsServer(options, callback): void {
-  if (!(this instanceof HttpsServer)) return new HttpsServer(options, callback);
-  return initServer.$call(this, options, callback, true);
-}
-
-function initServer(options, callback, isTls: boolean) {
   EventEmitter.$call(this);
   this.on("listening", setupConnectionsTracking);
   this.on("connection", connectionListener);
@@ -375,9 +276,6 @@ function initServer(options, callback, isTls: boolean) {
     validateObject(options, "options");
     options = { ...options };
   }
-  if (isTls) {
-    this[tlsSymbol] = serverTlsOptions(options);
-  }
 
   this[optionsSymbol] = options;
   storeHTTPOptions.$call(this, options);
@@ -386,7 +284,6 @@ function initServer(options, callback, isTls: boolean) {
   return this;
 }
 $toClass(Server, "Server", EventEmitter);
-$toClass(HttpsServer, "Server", Server);
 
 Server.prototype[kIncomingMessage] = undefined;
 
@@ -560,7 +457,7 @@ Server.prototype.listen = function () {
 
       const otherTLS = arg0.tls;
       if (otherTLS && $isObject(otherTLS)) {
-        tls = normalizeServerTls({ ...otherTLS });
+        tls = require("internal/tls").normalizeServerTls({ ...otherTLS });
       }
     } else if (typeof arg0 === "string" && !(Number(arg0) >= 0)) {
       // (path[...][, cb])
@@ -3822,7 +3719,6 @@ function storeHTTPOptions(options) {
 
 export default {
   Server,
-  HttpsServer,
   ServerResponse,
   kConnectionsCheckingInterval,
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -259,9 +259,7 @@ function connectionListener(this: Server, socket) {
   });
 }
 
-// Builds the `tls` object handed to Bun.serve from Node-style https.Server
-// options. Returns a TLS config even when no key/cert is given, so the
-// listener speaks TLS (and fails handshakes) the way Node's tls.Server does.
+// Always returns a config, so https.Server speaks TLS without key/cert like Node's tls.Server.
 function serverTlsOptions(options) {
   const tlsHelpers = require("internal/tls");
 
@@ -338,8 +336,7 @@ function serverTlsOptions(options) {
   });
 }
 
-// Node's http.Server ignores TLS material (key, cert, ca, pfx) in its
-// options and always serves plaintext. Only https.Server reads them.
+// Like Node, http.Server ignores key/cert/ca/pfx. Only HttpsServer reads them.
 function Server(options, callback): void {
   if (!(this instanceof Server)) return new Server(options, callback);
   return initServer.$call(this, options, callback, false);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -38,7 +38,6 @@ const {
   emitCloseNT,
   NodeHTTPResponseAbortEvent,
   STATUS_CODES,
-  isTlsSymbol,
   hasServerResponseFinished,
   NodeHTTPBodyReadState,
   eofInProgress,
@@ -260,8 +259,98 @@ function connectionListener(this: Server, socket) {
   });
 }
 
+// Builds the `tls` object handed to Bun.serve from Node-style https.Server
+// options. Returns a TLS config even when no key/cert is given, so the
+// listener speaks TLS (and fails handshakes) the way Node's tls.Server does.
+function serverTlsOptions(options) {
+  const tlsHelpers = require("internal/tls");
+
+  // Node's https.Server accepts PKCS#12 bundles (pfx [+ passphrase]); fold
+  // them into plain key/cert/ca so the native TLS config sees PEM material.
+  let tlsOptions = options;
+  if (options.pfx) {
+    tlsOptions = tlsHelpers.processPfxOptions(options);
+  }
+
+  let cert = tlsOptions.cert;
+  if (cert) {
+    tlsHelpers.throwOnInvalidTLSArray("options.cert", cert);
+  }
+
+  let key = tlsOptions.key;
+  if (key) {
+    tlsHelpers.throwOnInvalidTLSArray("options.key", key);
+  }
+
+  let ca = tlsOptions.ca;
+  // PKCS#12-embedded CAs extend the trust set; the server path hands raw
+  // {key, cert, ca} to the native config and has no addCACert hook, so fold
+  // them into `ca` (mirrors tls.Server.setSecureContext).
+  const pfxExtraCAs = tlsOptions._pfxExtraCACerts;
+  if (pfxExtraCAs?.length) {
+    ca = ca == null ? pfxExtraCAs : $isArray(ca) ? [...ca, ...pfxExtraCAs] : [ca, ...pfxExtraCAs];
+  }
+  if (ca) {
+    tlsHelpers.throwOnInvalidTLSArray("options.ca", ca);
+  }
+
+  let passphrase = options.passphrase;
+  if (passphrase && typeof passphrase !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
+  }
+
+  let serverName = options.servername;
+  if (serverName && typeof serverName !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.servername", "string", serverName);
+  }
+
+  let secureOptions = options.secureOptions || 0;
+  if (secureOptions && typeof secureOptions !== "number") {
+    throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
+  }
+
+  const { validateSecureProtocol, secureProtocolToVersionRange, tlsStringToProtocolVersion } = tlsHelpers;
+  // Translate minVersion/maxVersion/secureProtocol into the integer
+  // protocol range the native layer applies (secureProtocol wins, like
+  // Node's SecureContext::Init); 0 keeps the native defaults.
+  validateSecureProtocol(options.secureProtocol);
+  let minVersion, maxVersion;
+  const range = secureProtocolToVersionRange(options.secureProtocol);
+  if (range) {
+    minVersion = range[0];
+    maxVersion = range[1];
+  } else {
+    minVersion = tlsStringToProtocolVersion(options.minVersion);
+    maxVersion = tlsStringToProtocolVersion(options.maxVersion);
+  }
+  return normalizeServerTls({
+    serverName,
+    key,
+    cert,
+    ca,
+    passphrase,
+    secureOptions,
+    minVersion,
+    maxVersion,
+    ciphers: typeof options.ciphers === "string" && options.ciphers ? options.ciphers : undefined,
+    requestCert: options.requestCert,
+    rejectUnauthorized: options.rejectUnauthorized,
+  });
+}
+
+// Node's http.Server ignores TLS material (key, cert, ca, pfx) in its
+// options and always serves plaintext. Only https.Server reads them.
 function Server(options, callback): void {
   if (!(this instanceof Server)) return new Server(options, callback);
+  return initServer.$call(this, options, callback, false);
+}
+
+function HttpsServer(options, callback): void {
+  if (!(this instanceof HttpsServer)) return new HttpsServer(options, callback);
+  return initServer.$call(this, options, callback, true);
+}
+
+function initServer(options, callback, isTls: boolean) {
   EventEmitter.$call(this);
   this.on("listening", setupConnectionsTracking);
   this.on("connection", connectionListener);
@@ -288,87 +377,9 @@ function Server(options, callback): void {
   } else {
     validateObject(options, "options");
     options = { ...options };
-    const tlsHelpers = options.pfx || options.cert || options.key || options.ca ? require("internal/tls") : undefined;
-
-    // Node's https.Server accepts PKCS#12 bundles (pfx [+ passphrase]); fold
-    // them into plain key/cert/ca so the native TLS config sees PEM material.
-    let tlsOptions = options;
-    if (options.pfx) {
-      tlsOptions = tlsHelpers.processPfxOptions(options);
-      this[isTlsSymbol] = true;
-    }
-
-    let cert = tlsOptions.cert;
-    if (cert) {
-      tlsHelpers.throwOnInvalidTLSArray("options.cert", cert);
-      this[isTlsSymbol] = true;
-    }
-
-    let key = tlsOptions.key;
-    if (key) {
-      tlsHelpers.throwOnInvalidTLSArray("options.key", key);
-      this[isTlsSymbol] = true;
-    }
-
-    let ca = tlsOptions.ca;
-    // PKCS#12-embedded CAs extend the trust set; the server path hands raw
-    // {key, cert, ca} to the native config and has no addCACert hook, so fold
-    // them into `ca` (mirrors tls.Server.setSecureContext).
-    const pfxExtraCAs = tlsOptions._pfxExtraCACerts;
-    if (pfxExtraCAs?.length) {
-      ca = ca == null ? pfxExtraCAs : $isArray(ca) ? [...ca, ...pfxExtraCAs] : [ca, ...pfxExtraCAs];
-    }
-    if (ca) {
-      tlsHelpers.throwOnInvalidTLSArray("options.ca", ca);
-      this[isTlsSymbol] = true;
-    }
-
-    let passphrase = options.passphrase;
-    if (passphrase && typeof passphrase !== "string") {
-      throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
-    }
-
-    let serverName = options.servername;
-    if (serverName && typeof serverName !== "string") {
-      throw $ERR_INVALID_ARG_TYPE("options.servername", "string", serverName);
-    }
-
-    let secureOptions = options.secureOptions || 0;
-    if (secureOptions && typeof secureOptions !== "number") {
-      throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
-    }
-
-    if (this[isTlsSymbol]) {
-      const { validateSecureProtocol, secureProtocolToVersionRange, tlsStringToProtocolVersion } = tlsHelpers;
-      // Translate minVersion/maxVersion/secureProtocol into the integer
-      // protocol range the native layer applies (secureProtocol wins, like
-      // Node's SecureContext::Init); 0 keeps the native defaults.
-      validateSecureProtocol(options.secureProtocol);
-      let minVersion, maxVersion;
-      const range = secureProtocolToVersionRange(options.secureProtocol);
-      if (range) {
-        minVersion = range[0];
-        maxVersion = range[1];
-      } else {
-        minVersion = tlsStringToProtocolVersion(options.minVersion);
-        maxVersion = tlsStringToProtocolVersion(options.maxVersion);
-      }
-      this[tlsSymbol] = normalizeServerTls({
-        serverName,
-        key,
-        cert,
-        ca,
-        passphrase,
-        secureOptions,
-        minVersion,
-        maxVersion,
-        ciphers: typeof options.ciphers === "string" && options.ciphers ? options.ciphers : undefined,
-        requestCert: options.requestCert,
-        rejectUnauthorized: options.rejectUnauthorized,
-      });
-    } else {
-      this[tlsSymbol] = null;
-    }
+  }
+  if (isTls) {
+    this[tlsSymbol] = serverTlsOptions(options);
   }
 
   this[optionsSymbol] = options;
@@ -378,6 +389,7 @@ function Server(options, callback): void {
   return this;
 }
 $toClass(Server, "Server", EventEmitter);
+$toClass(HttpsServer, "Server", Server);
 
 Server.prototype[kIncomingMessage] = undefined;
 
@@ -3813,6 +3825,7 @@ function storeHTTPOptions(options) {
 
 export default {
   Server,
+  HttpsServer,
   ServerResponse,
   kConnectionsCheckingInterval,
 };

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -2,6 +2,7 @@
 // The client portions (Agent, request, get) are a port of Node.js's lib/https.js
 // https://github.com/nodejs/node/blob/v26.3.0/lib/https.js
 const http = require("node:http");
+const { HttpsServer } = require("node:_http_server");
 const { isIP } = require("internal/net/isIP");
 const { urlToHttpOptions } = require("internal/url");
 const { kEmptyObject, once } = require("internal/shared");
@@ -514,7 +515,7 @@ function createServer(options, requestListener) {
     // ALPN requests are always answered with http/1.1.
     options.ALPNProtocols = ["http/1.1"];
   }
-  const server = http.createServer(options, requestListener);
+  const server = new HttpsServer(options, requestListener);
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {
     require("node:tls").convertALPNProtocols(optionsALPNProtocols, server);
@@ -531,7 +532,7 @@ var https = {
     timeout: 5000,
     proxyEnv: shouldUseEnvProxy() ? process.env : undefined,
   }),
-  Server: http.Server,
+  Server: HttpsServer,
   createServer,
   get,
   request,

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -2,12 +2,12 @@
 // The client portions (Agent, request, get) are a port of Node.js's lib/https.js
 // https://github.com/nodejs/node/blob/v26.3.0/lib/https.js
 const http = require("node:http");
-const { HttpsServer } = require("node:_http_server");
+const { httpsServerTlsOptions } = require("internal/tls");
 const { isIP } = require("internal/net/isIP");
 const { urlToHttpOptions } = require("internal/url");
 const { kEmptyObject, once } = require("internal/shared");
 const { validateObject } = require("internal/validators");
-const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel } = require("internal/http");
+const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel, tlsSymbol, optionsSymbol } = require("internal/http");
 const { validateHeaderValue } = require("node:_http_common");
 
 const ArrayPrototypeShift = Array.prototype.shift;
@@ -495,6 +495,16 @@ Agent.prototype._evictSession = function _evictSession(key) {
 
 const { shouldUseEnvProxy } = require("node:_http_agent");
 
+// Node's https.Server is a tls.Server: it always speaks TLS, and it reads the TLS
+// options that http.Server ignores.
+function Server(options, requestListener): void {
+  if (!(this instanceof Server)) return new Server(options, requestListener);
+  http.Server.$call(this, options, requestListener);
+  this[tlsSymbol] = httpsServerTlsOptions(this[optionsSymbol]);
+  return this;
+}
+$toClass(Server, "Server", http.Server);
+
 // Like Node's https.Server constructor: default ALPNProtocols to ['http/1.1']
 // when neither ALPNProtocols nor ALPNCallback was given, and store the
 // normalized protocol list / callback on the server instance the way
@@ -515,7 +525,7 @@ function createServer(options, requestListener) {
     // ALPN requests are always answered with http/1.1.
     options.ALPNProtocols = ["http/1.1"];
   }
-  const server = new HttpsServer(options, requestListener);
+  const server = new Server(options, requestListener);
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {
     require("node:tls").convertALPNProtocols(optionsALPNProtocols, server);
@@ -532,7 +542,7 @@ var https = {
     timeout: 5000,
     proxyEnv: shouldUseEnvProxy() ? process.env : undefined,
   }),
-  Server: HttpsServer,
+  Server,
   createServer,
   get,
   request,

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -495,8 +495,7 @@ Agent.prototype._evictSession = function _evictSession(key) {
 
 const { shouldUseEnvProxy } = require("node:_http_agent");
 
-// Node's https.Server is a tls.Server: it always speaks TLS, and it reads the TLS
-// options that http.Server ignores.
+// Always a TLS listener, like Node's tls.Server. http.Server ignores these TLS options.
 function Server(options, requestListener): void {
   if (!(this instanceof Server)) return new Server(options, requestListener);
   http.Server.$call(this, options, requestListener);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1433,6 +1433,69 @@ describe("node https server", async () => {
   });
 });
 
+// Node's http.Server ignores TLS material in its options and always serves
+// plaintext. Node's https.Server is a tls.Server: it speaks TLS even when no
+// key/cert is given (handshakes then fail).
+describe.concurrent("http.Server vs https.Server TLS mode", () => {
+  const handler = (req, res) => res.end(`proto=${req.socket.encrypted ? "TLS" : "plain"}`);
+
+  function plaintextGet(port: number): Promise<string> {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const chunks: Buffer[] = [];
+    const socket = connect({ port, host: "127.0.0.1" }, () => {
+      socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    });
+    socket.on("data", chunk => chunks.push(chunk));
+    socket.on("error", () => {});
+    socket.on("close", () => resolve(Buffer.concat(chunks).toString()));
+    return promise;
+  }
+
+  it.each([
+    ["key and cert", { key: tlsCert.key, cert: tlsCert.cert }],
+    ["ca only", { ca: tlsCert.cert }],
+  ])("http.createServer with %s serves plaintext", async (_, options) => {
+    const server = createServer(options, handler);
+    try {
+      const url = await listen(server);
+      expect(server instanceof https.Server).toBe(false);
+      const res = await fetch(url);
+      expect(await res.text()).toBe("proto=plain");
+      expect(await plaintextGet(Number(url.port))).toStartWith("HTTP/1.1 200");
+    } finally {
+      server.close();
+    }
+  });
+
+  it.each([
+    ["no options", undefined],
+    ["empty options", {}],
+  ])("https.createServer with %s refuses plaintext", async (_, options) => {
+    const server = options === undefined ? createHttpsServer(handler) : createHttpsServer(options, handler);
+    try {
+      const url = await listen(server);
+      expect(server instanceof https.Server).toBe(true);
+      expect(await plaintextGet(Number(url.port))).not.toStartWith("HTTP/1.1");
+      await expect(fetch(`https://127.0.0.1:${url.port}/`, { tls: { rejectUnauthorized: false } })).rejects.toThrow();
+    } finally {
+      server.close();
+    }
+  });
+
+  it("https.createServer with key and cert serves TLS only", async () => {
+    const server = createHttpsServer({ key: tlsCert.key, cert: tlsCert.cert }, handler);
+    try {
+      const url = await listen(server, "https");
+      expect(server instanceof https.Server).toBe(true);
+      const res = await fetch(url, { tls: { rejectUnauthorized: false } });
+      expect(await res.text()).toBe("proto=TLS");
+      expect(await plaintextGet(Number(url.port))).not.toStartWith("HTTP/1.1");
+    } finally {
+      server.close();
+    }
+  });
+});
+
 describe("server.address should be valid IP", () => {
   it("should return null before listening", done => {
     const server = createServer((req, res) => {});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1475,6 +1475,7 @@ describe.concurrent("http.Server vs https.Server TLS mode", () => {
     try {
       const url = await listen(server);
       expect(server instanceof https.Server).toBe(true);
+      expect(server instanceof http.Server).toBe(true);
       expect(await plaintextGet(Number(url.port))).not.toStartWith("HTTP/1.1");
       await expect(fetch(`https://127.0.0.1:${url.port}/`, { tls: { rejectUnauthorized: false } })).rejects.toThrow();
     } finally {


### PR DESCRIPTION
### Problem
- `http.createServer({ key, cert })` on plain `node:http` becomes a TLS listener. Plaintext clients get `ECONNRESET`. Node's `http.Server` ignores `key`, `cert`, `ca` and `pfx` and serves plaintext. `{ ca }` alone gives a port that refuses both plaintext and TLS.
- `https.createServer()` and `https.createServer({})` serve plaintext HTTP. Node gives a TLS listener whose handshakes fail.
- The cause is the `http.Server` constructor in `src/js/node/_http_server.ts:291-324` on main. It set the TLS config whenever one of those keys was present, and `https.Server` was the same function (`https.ts`: `Server: http.Server`), so neither class could opt out of that rule.

### Fix
- `http.Server` no longer reads any TLS option. `https.ts` defines its own `Server`: it calls `http.Server`, then always sets the TLS config from `httpsServerTlsOptions(options)`, even with no key or cert.
- The option parsing that lived inline in the `http.Server` constructor moved as is to `internal/tls.ts` (`httpsServerTlsOptions`, plus `normalizeServerTls`). `isTlsSymbol` had no other reader and is removed. The Bun-only `server.listen({ tls })` path on `http.Server` is unchanged.
- `https.Server.prototype` chains to `http.Server.prototype`, so `httpsServer instanceof http.Server` stays `true` (Node says `false`, because its `https.Server` extends `tls.Server`). `http.createServer() instanceof https.Server` is now `false`, as in Node.
- Verified: `test/js/node/http/node-http.test.ts` (describe `http.Server vs https.Server TLS mode`, 5 cases, 4 fail on bun 1.4.3). Also the `node-tls-*` suites, `node-https-checkServerIdentity`, `node-http-agent-tls-options` and the Node `test-https-*.js` parallel tests.

### Background
- `http.Server` in bun is a JS class over `Bun.serve`. `listen()` passes `this[tlsSymbol]` as the `tls` option. A `null` there means a plaintext listener.
- `SSLConfig::from_js` (`src/runtime/socket/SSLConfig.rs`) returns a config when any recognised member is set. `normalizeServerTls` always sets `requestCert` and `rejectUnauthorized`, so a config with no key or cert still makes the listener speak TLS. A client then gets a handshake failure, which is what Node's `tls.Server` does without a certificate.

<details><summary>Notes</summary>

Related open PRs that also make `https.Server` a distinct class: #32435 (adds `addContext` and the other `tls.Server` methods, 17 files), #33539 (https fails closed without key or cert), #41391 (class identity only), #41641 (more TLS options). All of them keep the rule that `http.Server` speaks TLS when `key` or `cert` is present. #32435 has a test that asserts it. This PR changes that rule to match Node, so whichever lands second needs a small rebase in the constructor. If #32435 lands first, this PR reduces to dropping the key/cert arm of its constructor gate plus the test flip. Related issues: #31125, #12157.

The first revision of this PR defined an `HttpsServer` inside `_http_server.ts` and exported it from `node:_http_server`. Review pointed out that this adds a non-Node export to a public `node:` module, so the class now lives in `https.ts` and the shared helpers in `internal/tls`.

Probe results, plaintext GET and TLS GET against each server:

| server | bun 1.4.3 | this PR | Node v26.3.0 |
| --- | --- | --- | --- |
| `http {key,cert}` | plain ECONNRESET, TLS ok | plain ok, TLS fails | plain ok, TLS fails |
| `http {ca}` | both fail | plain ok, TLS fails | plain ok, TLS fails |
| `https {key,cert}` / `new https.Server(...)` / `https.Server(...)` | plain ECONNRESET, TLS ok | same | same |
| `https {}` / none | plain ok, TLS fails | plain ECONNRESET, TLS fails | plain fails, TLS handshake failure |

`Object.keys(require("_http_server"))` is `Server, ServerResponse, kConnectionsCheckingInterval`, unchanged from main.

Pre-existing failures seen while running the suites, unrelated to this diff: `test-https-timeout.js` hangs on a debug build of main as well (a 10 ms request timeout never fires). `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname" fails with `ECONNREFUSED` on the released bun too in this container (localhost resolution).
</details>
