### PR TITLE
bunfig: reject install.scopes entries with an empty url or an unknown key

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1192,8 +1192,6 @@ impl<'a> Parser<'a> {
         .parse_registry_url_string_impl(url)?)
     }
 
-    /// An empty scope url would inherit the default registry with the scope's
-    /// credentials (`PackageManagerOptions::load`).
     fn check_scope_url(
         &mut self,
         scope: Option<&[u8]>,

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1192,12 +1192,67 @@ impl<'a> Parser<'a> {
         .parse_registry_url_string_impl(url)?)
     }
 
-    fn parse_registry_object(&mut self, obj: &E::Object) -> crate::Result<api::NpmRegistry> {
+    /// A scope whose `url` is empty inherits the default registry together with
+    /// the scope's credentials (`PackageManagerOptions::load`). Only a missing
+    /// `url` may do that, so an explicit empty string is an error.
+    fn check_scope_url(
+        &mut self,
+        scope: Option<&[u8]>,
+        url: &[u8],
+        loc: bun_ast::Loc,
+    ) -> crate::Result<()> {
+        if let Some(scope) = scope
+            && url.is_empty()
+        {
+            return self.add_error_format(
+                loc,
+                format_args!(
+                    "Expected a non-empty registry url for scope \"@{}\"",
+                    bstr::BStr::new(scope)
+                ),
+            );
+        }
+        Ok(())
+    }
+
+    /// `scope` is the scope name for `[install.scopes]` entries, `None` for
+    /// `[install] registry`.
+    fn parse_registry_object(
+        &mut self,
+        obj: &E::Object,
+        scope: Option<&[u8]>,
+    ) -> crate::Result<api::NpmRegistry> {
+        if scope.is_some() {
+            // A stray key in a scope table (`registry = ...` for `url = ...`)
+            // leaves `url` unset and routes the scope's credentials to the
+            // default registry.
+            for prop in obj.properties.slice() {
+                let Some(key_expr) = prop.key.as_ref() else {
+                    continue;
+                };
+                let Some(key) = key_expr.as_string(self.bump) else {
+                    continue;
+                };
+                if !matches!(key, b"url" | b"username" | b"password" | b"token") {
+                    self.add_error_format(
+                        key_expr.loc,
+                        format_args!(
+                            "Unknown registry key \"{}\". Expected one of \"url\", \"username\", \"password\", \"token\"",
+                            bstr::BStr::new(key)
+                        ),
+                    )?;
+                }
+            }
+        }
+
         // `user:pass@` / `:token@` in the URL are credentials, as in the string form.
         let mut registry = match obj.get(b"url") {
-            Some(url) => {
-                self.expect_string(&url)?;
-                let url = url.as_string(self.bump).expect("infallible: type checked");
+            Some(url_expr) => {
+                self.expect_string(&url_expr)?;
+                let url = url_expr
+                    .as_string(self.bump)
+                    .expect("infallible: type checked");
+                self.check_scope_url(scope, url, url_expr.loc)?;
                 self.parse_registry_url(url)?
             }
             None => api::NpmRegistry::default(),
@@ -1240,13 +1295,18 @@ impl<'a> Parser<'a> {
         Ok(registry)
     }
 
-    fn parse_registry(&mut self, expr: &Expr) -> crate::Result<api::NpmRegistry> {
+    fn parse_registry(
+        &mut self,
+        expr: &Expr,
+        scope: Option<&[u8]>,
+    ) -> crate::Result<api::NpmRegistry> {
         match &expr.data {
             ExprData::EString(s) => {
                 let url = s.string(self.bump)?;
+                self.check_scope_url(scope, url, expr.loc)?;
                 self.parse_registry_url(url)
             }
-            ExprData::EObject(o) => self.parse_registry_object(o),
+            ExprData::EObject(o) => self.parse_registry_object(o, scope),
             _ => {
                 self.add_error(
                     expr.loc,
@@ -1320,7 +1380,7 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(registry) = install_obj.get(b"registry") {
-            install.default_registry = Some(self.parse_registry(&registry)?);
+            install.default_registry = Some(self.parse_registry(&registry, None)?);
         }
 
         if let Some(scopes) = install_obj.get(b"scopes") {
@@ -1339,7 +1399,7 @@ impl<'a> Parser<'a> {
                     continue;
                 }
                 let name = if name_[0] == b'@' { &name_[1..] } else { name_ };
-                let registry = self.parse_registry(value)?;
+                let registry = self.parse_registry(value, Some(name))?;
                 registry_map.scopes.insert(name, registry);
             }
             install.scoped = Some(registry_map);

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1192,9 +1192,8 @@ impl<'a> Parser<'a> {
         .parse_registry_url_string_impl(url)?)
     }
 
-    /// A scope whose `url` is empty inherits the default registry together with
-    /// the scope's credentials (`PackageManagerOptions::load`). Only a missing
-    /// `url` may do that, so an explicit empty string is an error.
+    /// An empty scope url would inherit the default registry with the scope's
+    /// credentials (`PackageManagerOptions::load`).
     fn check_scope_url(
         &mut self,
         scope: Option<&[u8]>,
@@ -1215,17 +1214,12 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    /// `scope` is the scope name for `[install.scopes]` entries, `None` for
-    /// `[install] registry`.
     fn parse_registry_object(
         &mut self,
         obj: &E::Object,
         scope: Option<&[u8]>,
     ) -> crate::Result<api::NpmRegistry> {
         if scope.is_some() {
-            // A stray key in a scope table (`registry = ...` for `url = ...`)
-            // leaves `url` unset and routes the scope's credentials to the
-            // default registry.
             for prop in obj.properties.slice() {
                 let Some(key_expr) = prop.key.as_ref() else {
                     continue;

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9719,6 +9719,106 @@ describe("registry/token env var priority", () => {
   });
 });
 
+describe.concurrent("install.scopes rejects a scope that would fall back to the default registry", () => {
+  // A scope entry with an empty `url` (or a misspelt key, so `url` is
+  // missing and a stray key carries the registry) used to inherit the
+  // default registry and send the scope's token there.
+  async function installWithScopes(scopes: string) {
+    const received: { path: string; authorization: string | null }[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        received.push({ path: new URL(req.url).pathname, authorization: req.headers.get("authorization") });
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("scopes-empty-url", {
+      "bunfig.toml": `[install]\ncache = false\nregistry = "http://localhost:${server.port}/"\n\n[install.scopes]\n${scopes}\n`,
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { "@corp/internal": "1.0.0" } }),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr: normalizeBunSnapshot(stderr, dir), exitCode, received };
+  }
+
+  test("object form with an empty url", async () => {
+    const { stderr, exitCode, received } = await installWithScopes(
+      `"@corp" = { url = "", token = "TOK_CORP_PRIVATE" }`,
+    );
+    expect(stderr).toContain('error: Expected a non-empty registry url for scope "@corp"');
+    expect(stderr).toContain("Invalid Bunfig");
+    expect(exitCode).toBe(1);
+    expect(received).toEqual([]);
+  });
+
+  test("object form with an unknown key instead of url", async () => {
+    const { stderr, exitCode, received } = await installWithScopes(
+      `"@corp" = { registry = "https://npm.corp.example/", token = "TOK_CORP_PRIVATE" }`,
+    );
+    expect(stderr).toContain(
+      'error: Unknown registry key "registry". Expected one of "url", "username", "password", "token"',
+    );
+    expect(stderr).toContain("Invalid Bunfig");
+    expect(exitCode).toBe(1);
+    expect(received).toEqual([]);
+  });
+
+  test("string form with an empty url", async () => {
+    const { stderr, exitCode, received } = await installWithScopes(`"@corp" = ""`);
+    expect(stderr).toContain('error: Expected a non-empty registry url for scope "@corp"');
+    expect(stderr).toContain("Invalid Bunfig");
+    expect(exitCode).toBe(1);
+    expect(received).toEqual([]);
+  });
+
+  test("an unknown key in [install] registry is still ignored", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("not found", { status: 404 }),
+    });
+    using dir = tempDir("registry-unknown-key", {
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${server.port}/", foo = "bar" }\n`,
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } }),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("Invalid Bunfig");
+    expect(stderr).toContain(`error: GET http://localhost:${server.port}/no-deps - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("object form with a url and a token only talks to the scope registry", async () => {
+    const scoped: { path: string; authorization: string | null }[] = [];
+    await using scopeServer = Bun.serve({
+      port: 0,
+      fetch(req) {
+        scoped.push({ path: new URL(req.url).pathname, authorization: req.headers.get("authorization") });
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const { stderr, received } = await installWithScopes(
+      `"@corp" = { url = "http://localhost:${scopeServer.port}/", token = "TOK_CORP_PRIVATE" }`,
+    );
+    expect(stderr).not.toContain("Invalid Bunfig");
+    expect(scoped).toEqual([{ path: "/@corp%2finternal", authorization: "Bearer TOK_CORP_PRIVATE" }]);
+    expect(received).toEqual([]);
+  });
+});
+
 test("npm manifest cache entries with invalid package version records are treated as invalid", async () => {
   await write(
     packageJson,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9795,7 +9795,7 @@ describe.concurrent("install.scopes rejects a scope that would fall back to the 
       stderr: "pipe",
       env,
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("Invalid Bunfig");
     expect(stderr).toContain(`error: GET http://localhost:${server.port}/no-deps - 404`);
     expect(exitCode).toBe(1);


### PR DESCRIPTION
### Problem
- A bunfig `[install.scopes]` entry with an empty `url` is accepted. `"@corp" = { url = "", token = "TOK" }` and `"@corp" = ""` both route `@corp/*` to the default registry. With the object form, `bun install` sends `Authorization: Bearer TOK` to registry.npmjs.org, and `bun publish` of an `@corp/*` package uploads there.
- A misspelt key does the same: `"@corp" = { registry = "https://npm.corp/", token = "TOK" }` leaves `url` unset, and the stray key is ignored.
- The cause is `PackageManagerOptions::load` (`src/install/PackageManager/PackageManagerOptions.rs:460`). It copies the default registry URL into any scope whose URL is empty and keeps the scope's credentials. After parsing, `url = ""` and a missing `url` are the same empty slice, so only the bunfig parser can tell them apart.

### Fix
- `src/bunfig/bunfig.rs`: `parse_registry` and `parse_registry_object` take the scope name. For a scope entry, an empty URL (string or object form) is an `Invalid Bunfig` error: `Expected a non-empty registry url for scope "@corp"`.
- For a scope table, a key other than `url`, `username`, `password`, `token` is an error: `Unknown registry key "registry". Expected one of ...`. This check is gated to scope tables. `[install] registry = { ... }` is unchanged.
- A scope table with no `url` key still inherits the default registry. That form (`foo = { token = "bar" }`) is tested in `bun-install.test.ts` ("should handle @scoped authentication") and is the shape for private packages on npmjs.org.
- Verified: `test/cli/install/bun-install-registry.test.ts` (new block, 5 tests, 3 fail on the current release). Also the scoped and registry tests in `test/cli/install/bun-install.test.ts` and `test/regression/issue/026039.test.ts`.

### Background
- A scope entry in bunfig becomes an `api::NpmRegistry` (`url`, `username`, `password`, `token`). `PackageManagerOptions::load` turns each one into an `Npm::registry::Scope` that the installer picks by package scope.
- Self-reviewed: 10 concerns raised. The unknown-key check is now gated to scope tables, and the empty-URL check is one helper. There is no user report for this. The reproduction is in the notes.

<details><summary>Notes</summary>

Reproduction on bun 1.4.3 with a loopback `Bun.serve` stub as `[install] registry`:

```
"@corp" = { url = "", token = "TOK_CORP_PRIVATE" }
  -> stub GOT /@corp%2finternal-pkg Authorization: Bearer TOK_CORP_PRIVATE
"@corp" = { registry = "https://npm.corp.example/", token = "TOK_CORP_PRIVATE" }
  -> stub GOT /@corp%2finternal-pkg Authorization: Bearer TOK_CORP_PRIVATE
"@corp" = ""
  -> stub GOT /@corp%2finternal-pkg Authorization: null
"@corp" = { url = "$CORP_REGISTRY", token = "..." } with CORP_REGISTRY unset
  -> resolve fails, no request to the stub (not changed here)
```

The unknown-key error is the first strict key check in bunfig. The review flagged that as a policy choice. A warning would not stop the token from reaching the default registry, so this PR keeps it as an error for scope tables only. A maintainer can ask for a warning instead.

`bun-audit.test.ts` `audit fix` cases hit their 5s timeout when the whole file runs under the ASAN build in this container. They pass alone and do not touch scope parsing.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->