### PR TITLE
WebSocket: read constructor options through the prototype chain

### DIFF
--- a/src/jsc/bindings/ObjectBindings.cpp
+++ b/src/jsc/bindings/ObjectBindings.cpp
@@ -92,19 +92,4 @@ JSC::JSValue getIfPropertyExistsPrototypePollutionMitigation(JSC::VM& vm, JSC::J
     return value;
 }
 
-JSC::JSValue getOwnPropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::PropertyName& name)
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    PropertySlot slot(object, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
-    if (!object->methodTable()->getOwnPropertySlot(object, globalObject, name, slot)) {
-        RETURN_IF_EXCEPTION(scope, {});
-        return JSC::jsUndefined();
-    }
-    RETURN_IF_EXCEPTION(scope, {});
-    JSValue value = slot.getValue(globalObject, name);
-    RETURN_IF_EXCEPTION(scope, {});
-    return value;
-}
-
 }

--- a/src/jsc/bindings/ObjectBindings.h
+++ b/src/jsc/bindings/ObjectBindings.h
@@ -26,13 +26,6 @@ ALWAYS_INLINE JSC::JSValue getIfPropertyExistsPrototypePollutionMitigation(JSC::
     return getIfPropertyExistsPrototypePollutionMitigation(JSC::getVM(globalObject), globalObject, object, name);
 }
 
-/**
- * Gets an own property only (no prototype chain lookup).
- * Returns jsUndefined() if property doesn't exist as own property.
- * This is the strictest form of property access - use for security-critical options.
- */
-JSC::JSValue getOwnPropertyIfExists(JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::PropertyName& name);
-
 // Whether `getIteratorResult` runs `get(value)` on a result whose `done` is true. IteratorStepValue never does.
 enum class IteratorDoneValue : uint8_t {
     Read,

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -232,7 +232,7 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
 
     if (JSC::JSObject* options = optionsObjectValue.getObject()) {
         const auto& builtinnames = WebCore::builtinNames(vm);
-        auto headersValue = Bun::getOwnPropertyIfExists(globalObject, options, builtinnames.headersPublicName());
+        auto headersValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, options, builtinnames.headersPublicName());
         RETURN_IF_EXCEPTION(throwScope, {});
         if (headersValue) {
             if (!headersValue.isUndefinedOrNull()) {
@@ -241,31 +241,31 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
             }
         }
 
-        auto protocolsValue = Bun::getOwnPropertyIfExists(globalObject, options, PropertyName(Identifier::fromString(vm, "protocols"_s)));
+        auto protocolsValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, options, PropertyName(Identifier::fromString(vm, "protocols"_s)));
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (protocolsValue) {
-            if (!protocolsValue.isUndefinedOrNull()) {
+        if (!protocolsValue.isUndefinedOrNull()) {
+            if (protocolsValue.isString()) {
+                protocols = Vector<String> { convert<IDLDOMString>(*lexicalGlobalObject, protocolsValue) };
+            } else {
                 protocols = convert<IDLSequence<IDLDOMString>>(*lexicalGlobalObject, protocolsValue);
-                RETURN_IF_EXCEPTION(throwScope, {});
             }
-        } else {
-            auto protocolValue = Bun::getOwnPropertyIfExists(globalObject, options, PropertyName(Identifier::fromString(vm, "protocol"_s)));
             RETURN_IF_EXCEPTION(throwScope, {});
-            if (protocolValue) {
-                if (!protocolValue.isUndefinedOrNull()) {
-                    protocols = Vector<String> { convert<IDLDOMString>(*lexicalGlobalObject, protocolValue) };
-                    RETURN_IF_EXCEPTION(throwScope, {});
-                }
+        } else {
+            auto protocolValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, options, PropertyName(Identifier::fromString(vm, "protocol"_s)));
+            RETURN_IF_EXCEPTION(throwScope, {});
+            if (!protocolValue.isUndefinedOrNull()) {
+                protocols = Vector<String> { convert<IDLDOMString>(*lexicalGlobalObject, protocolValue) };
+                RETURN_IF_EXCEPTION(throwScope, {});
             }
         }
 
         // Parse TLS options using the native SSLConfig parser for full TLS option support
-        JSValue tlsOptionsValue = Bun::getOwnPropertyIfExists(globalObject, options, PropertyName(Identifier::fromString(vm, "tls"_s)));
+        JSValue tlsOptionsValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, options, PropertyName(Identifier::fromString(vm, "tls"_s)));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (tlsOptionsValue && !tlsOptionsValue.isUndefinedOrNull() && tlsOptionsValue.isObject()) {
             // Also extract rejectUnauthorized for backwards compatibility
             JSC::JSObject* tlsOptions = tlsOptionsValue.getObject();
-            auto rejectUnauthorizedValue = Bun::getOwnPropertyIfExists(globalObject, tlsOptions, PropertyName(Identifier::fromString(vm, "rejectUnauthorized"_s)));
+            auto rejectUnauthorizedValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, tlsOptions, PropertyName(Identifier::fromString(vm, "rejectUnauthorized"_s)));
             RETURN_IF_EXCEPTION(throwScope, {});
             if (rejectUnauthorizedValue && !rejectUnauthorizedValue.isUndefinedOrNull() && rejectUnauthorizedValue.isBoolean()) {
                 rejectUnauthorized = rejectUnauthorizedValue.asBoolean() ? 1 : 0;
@@ -280,14 +280,14 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
         // `const opts = { perMessageDeflate: true, ...options }; if (opts.perMessageDeflate)`
         // — any falsy value (`false`, `null`, `0`, `''`, explicit `undefined`)
         // suppresses the extension offer; omitted / truthy keeps the default.
-        JSValue perMessageDeflateValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "perMessageDeflate"_s));
+        JSValue perMessageDeflateValue = Bun::getIfPropertyExistsPrototypePollutionMitigationUnsafe(vm, globalObject, options, PropertyName(Identifier::fromString(vm, "perMessageDeflate"_s)));
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (perMessageDeflateValue && !perMessageDeflateValue.toBoolean(lexicalGlobalObject)) {
+        if (JSValue::encode(perMessageDeflateValue) != JSValue::ValueDeleted && !perMessageDeflateValue.toBoolean(lexicalGlobalObject)) {
             offerPerMessageDeflate = false;
         }
 
         // Parse proxy option - can be string or { url, headers }
-        auto proxyValue = Bun::getOwnPropertyIfExists(globalObject, options, PropertyName(Identifier::fromString(vm, "proxy"_s)));
+        auto proxyValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, options, PropertyName(Identifier::fromString(vm, "proxy"_s)));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (proxyValue) {
             if (!proxyValue.isUndefinedOrNull()) {
@@ -302,14 +302,14 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
                 } else if (proxyValue.isObject()) {
                     // proxy: { url: "http://proxy:8080", headers: {...} }
                     JSC::JSObject* proxyOptions = proxyValue.getObject();
-                    auto proxyUrlValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, PropertyName(Identifier::fromString(vm, "url"_s)));
+                    auto proxyUrlValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, proxyOptions, PropertyName(Identifier::fromString(vm, "url"_s)));
                     RETURN_IF_EXCEPTION(throwScope, {});
                     if (proxyUrlValue && !proxyUrlValue.isUndefinedOrNull()) {
                         proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyUrlValue);
                         RETURN_IF_EXCEPTION(throwScope, {});
                     }
 
-                    auto proxyHeadersValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, builtinnames.headersPublicName());
+                    auto proxyHeadersValue = Bun::getIfPropertyExistsPrototypePollutionMitigation(globalObject, proxyOptions, builtinnames.headersPublicName());
                     RETURN_IF_EXCEPTION(throwScope, {});
                     if (proxyHeadersValue && !proxyHeadersValue.isUndefinedOrNull()) {
                         // Check if it's already a Headers instance (like fetch does)

--- a/test/js/web/websocket/websocket-custom-headers.test.ts
+++ b/test/js/web/websocket/websocket-custom-headers.test.ts
@@ -379,3 +379,89 @@ describe("WebSocket custom headers", () => {
     ws.close();
   });
 });
+
+describe("WebSocket options are read through the prototype chain", () => {
+  // Upgrades every request and echoes the upgrade request headers as the first message.
+  function headerEchoServer() {
+    return Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req, { data: req.headers.toJSON() })) return;
+        return new Response("not a websocket", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          ws.send(JSON.stringify(ws.data));
+        },
+        message() {},
+      },
+    });
+  }
+
+  async function upgradeHeaders(url: string, options: any): Promise<Record<string, string>> {
+    const { promise, resolve, reject } = Promise.withResolvers<Record<string, string>>();
+    const ws = new WebSocket(url, options);
+    clients.push(ws);
+    ws.onmessage = event => resolve(JSON.parse(event.data));
+    ws.onerror = () => reject(new Error("websocket failed"));
+    ws.onclose = event => reject(new Error(`closed: ${event.code} ${event.reason}`));
+    const headers = await promise;
+    ws.onclose = null;
+    ws.close();
+    return headers;
+  }
+
+  it("honors headers and protocols inherited from a prototype", async () => {
+    using server = headerEchoServer();
+    const defaults = { headers: { "X-Auth": "secret", "Authorization": "Bearer T" }, protocols: ["chat"] };
+    const headers = await upgradeHeaders(server.url.href, Object.create(defaults));
+    expect(headers).toMatchObject({
+      "x-auth": "secret",
+      "authorization": "Bearer T",
+      "sec-websocket-protocol": "chat",
+    });
+  });
+
+  it("honors headers and protocols from prototype getters", async () => {
+    using server = headerEchoServer();
+    class Config {
+      get headers() {
+        return { "X-From-Getter": "1" };
+      }
+      get protocols() {
+        return ["getter-proto"];
+      }
+    }
+    const headers = await upgradeHeaders(server.url.href, new Config());
+    expect(headers).toMatchObject({
+      "x-from-getter": "1",
+      "sec-websocket-protocol": "getter-proto",
+    });
+  });
+
+  it("honors an inherited perMessageDeflate: false and offers the extension when omitted", async () => {
+    using server = headerEchoServer();
+    const disabled = await upgradeHeaders(server.url.href, Object.create({ perMessageDeflate: false }));
+    expect(disabled["sec-websocket-extensions"]).toBeUndefined();
+    const enabled = await upgradeHeaders(server.url.href, {});
+    expect(enabled["sec-websocket-extensions"]).toContain("permessage-deflate");
+  });
+
+  it("accepts a single protocol string via protocols or protocol", async () => {
+    using server = headerEchoServer();
+    expect((await upgradeHeaders(server.url.href, { protocols: "chat" }))["sec-websocket-protocol"]).toBe("chat");
+    expect((await upgradeHeaders(server.url.href, { protocol: "chat" }))["sec-websocket-protocol"]).toBe("chat");
+  });
+
+  it("ignores options placed on Object.prototype", async () => {
+    using server = headerEchoServer();
+    (Object.prototype as any).headers = { "X-Polluted": "1" };
+    let headers: Record<string, string>;
+    try {
+      headers = await upgradeHeaders(server.url.href, {});
+    } finally {
+      delete (Object.prototype as any).headers;
+    }
+    expect(headers["x-polluted"]).toBeUndefined();
+  });
+});

--- a/test/js/web/websocket/websocket-custom-headers.test.ts
+++ b/test/js/web/websocket/websocket-custom-headers.test.ts
@@ -456,12 +456,18 @@ describe("WebSocket options are read through the prototype chain", () => {
   it("ignores options placed on Object.prototype", async () => {
     using server = headerEchoServer();
     (Object.prototype as any).headers = { "X-Polluted": "1" };
+    (Object.prototype as any).protocols = ["polluted"];
+    (Object.prototype as any).perMessageDeflate = false;
     let headers: Record<string, string>;
     try {
       headers = await upgradeHeaders(server.url.href, {});
     } finally {
       delete (Object.prototype as any).headers;
+      delete (Object.prototype as any).protocols;
+      delete (Object.prototype as any).perMessageDeflate;
     }
     expect(headers["x-polluted"]).toBeUndefined();
+    expect(headers["sec-websocket-protocol"]).toBeUndefined();
+    expect(headers["sec-websocket-extensions"]).toContain("permessage-deflate");
   });
 });


### PR DESCRIPTION
### Problem
- Since #25614 (bun 1.3.6) the WebSocket constructor reads `headers`, `protocols`, `tls`, `proxy` and their nested keys as own properties only. `new WebSocket(url, Object.create(defaults))` or a config class with prototype getters connects with no custom headers, no `Sec-WebSocket-Protocol`, default TLS and no proxy. Nothing throws. `fetch()` in the same process honors the inherited `headers`.
- The own-only helper returns `undefined` for a missing key, so the `else` branch in `constructJSWebSocket3` (`src/jsc/bindings/webcore/JSWebSocket.cpp:251`) that reads the `protocol` option was never reached. `bun.d.ts` declares `protocol?: string` and `protocols?: string | string[]`, but `{ protocol: "chat" }` sends no protocol and `{ protocols: "chat" }` throws `Value is not a sequence`.

### Fix
- Read every option with `Bun::getIfPropertyExistsPrototypePollutionMitigation`. It walks the prototype chain and stops at `Object.prototype`. The review on #25614 asked for own-only reads so that `Object.prototype.rejectUnauthorized = false` cannot disable TLS verification. This reader still blocks that case (the new test sets `headers`, `protocols` and `perMessageDeflate` on `Object.prototype` and checks that none of them is used). The Rust `SSLConfig` parser already reads the other `tls.*` keys on the same object this way.
- `perMessageDeflate` used plain `getIfPropertyExists`, which did consult `Object.prototype`. It now uses the `Unsafe` variant of the mitigated reader, which returns `ValueDeleted` for a missing key. An omitted key keeps the default offer, an explicit `undefined` still opts out.
- Consult `protocol` when `protocols` is absent, and accept a single string for `protocols`.
- Remove `getOwnPropertyIfExists` from `ObjectBindings.{h,cpp}`. It has no callers after this change.
- Verified: `test/js/web/websocket/websocket-custom-headers.test.ts` (new describe block, 4 of 5 tests fail on bun 1.4.3). Also ran the rest of `test/js/web/websocket/` (proxy, permessage-deflate, subprotocol, unix, client suites).

### Background
- A WebIDL dictionary is read with ordinary `[[Get]]`, so browsers and undici honor prototype getters on an options bag. Bun's C++ option readers do the same but stop at `Object.prototype` (`src/jsc/bindings/ObjectBindings.cpp`). The Rust `JSValue::get` goes through the same function.
- Self-reviewed: 10 concerns raised, all addressed. The review asked to delete the dead helper, to state the #25614 rationale, and to cover `perMessageDeflate` in the pollution test.

<details><summary>Notes</summary>

Repro (bun 1.4.3, before the fix):

```
/own          Sec-WebSocket-Protocol: chat | Authorization: Bearer T | X-Auth: secret
/inherited    (none)
/class-getter (none)
/spread-copy  Sec-WebSocket-Protocol: chat | Authorization: Bearer T | X-Auth: secret
```

After the fix `/inherited` and `/class-getter` carry the headers and protocol.

Open PRs #36357 and #41648 touch the same block. They need a rebase after this lands: #36357 has the old calls as context lines, #41648 adds a `tls.checkServerIdentity` read that must use the mitigated reader.

Not every option bag in bun uses this reader. `Bun.build` reads some keys own-only (`JSBundler.rs`), so does `bun:ffi`. Those are out of scope here.

`websocket.test.js` has 4 tests that dial `ws.postman-echo.com`. They fail in this container with no network. They fail the same way on main.
</details>
