### PR TITLE
Worker: throw ERR_WORKER_INIT_FAILED when the OS refuses the thread

### DIFF
--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -262,6 +262,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_ZSTD_INVALID_PARAM", RangeError],
   ["ERR_USE_AFTER_CLOSE", Error],
   ["ERR_WEBASSEMBLY_RESPONSE", TypeError],
+  ["ERR_WORKER_INIT_FAILED", Error],
   ["ERR_WORKER_NOT_RUNNING", Error],
   ["ERR_WORKER_UNSUPPORTED_OPERATION", TypeError],
   ["ERR_WORKER_PATH", TypeError],

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -50,6 +50,7 @@ extern "C" {
 
 // Allocates the thread object holding one ref for the caller, takes the keep-alive on the parent
 // event loop, and spawns the thread. Null (with errorMessage set) if nothing was started.
+// spawnFailed is set when the OS refused the thread (ERR_WORKER_INIT_FAILED in Node).
 void* WebWorker__create(
     WorkerMessagingProxy*,
     void* parentVM,
@@ -68,7 +69,8 @@ void* WebWorker__create(
     StringImpl** execArgvPtr,
     size_t execArgvLen,
     BunString* preloadModulesPtr,
-    size_t preloadModulesLen);
+    size_t preloadModulesLen,
+    bool* spawnFailed);
 // Raise a TerminationException in the worker VM at its next safepoint and wake its loop. Any thread.
 void WebWorker__requestTermination(void*);
 // Toggle the keep-alive this worker holds on the parent event loop. Parent thread.
@@ -145,6 +147,7 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
     BunString errorMessage = BunStringEmpty;
     BunString name = Bun::toString(m_options.name);
     BunString url = Bun::toString(scriptURL);
+    bool spawnFailed = false;
     m_workerThread = WebWorker__create(
         this,
         WebCore::clientData(m_scriptExecutionContext->vm())->bunVM,
@@ -163,12 +166,19 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
         execArgv.data(),
         execArgv.size(),
         preloadModules.begin(),
-        preloadModules.size());
+        preloadModules.size(),
+        &spawnFailed);
     m_options.preloadModules.clear();
 
     if (!m_workerThread) {
         m_state.store(State::Closed);
         deref();
+        if (spawnFailed) {
+            auto* globalObject = defaultGlobalObject(m_scriptExecutionContext->jsGlobalObject());
+            auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+            scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_INIT_FAILED, errorMessage.transferToWTFString()));
+            return Exception { ExistingExceptionError };
+        }
         return Exception { TypeError, errorMessage.transferToWTFString() };
     }
     return {};

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -495,7 +495,7 @@ impl WebWorker {
                     .raw_os_error()
                     .map(bun_errno::from_errno)
                     .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-                *error_message = BunString::clone_utf8(errno.to_string().as_bytes());
+                *error_message = BunString::static_(<&'static str>::from(errno));
                 *spawn_failed = true;
                 core::ptr::null_mut()
             }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -278,7 +278,7 @@ impl WebWorker {
     /// Allocate the thread object (one ref, owned by the calling proxy), take a
     /// keep-alive on the parent event loop, register as a child of the parent VM,
     /// and spawn the thread. On any failure returns null with `error_message`
-    /// set and nothing to clean up.
+    /// set and nothing to clean up. `spawn_failed`: the OS refused the thread.
     #[unsafe(export_name = "WebWorker__create")]
     pub(crate) unsafe extern "C" fn create(
         proxy: *mut c_void,
@@ -299,6 +299,7 @@ impl WebWorker {
         exec_argv_len: usize,
         preload_modules_ptr: *const BunString,
         preload_modules_len: usize,
+        spawn_failed: &mut bool,
     ) -> *mut WebWorker {
         jsc::mark_binding();
         log!("[{}] create", this_context_id);
@@ -480,10 +481,22 @@ impl WebWorker {
                 unsafe { (*parent).child_workers.push(worker) };
                 worker
             }
-            Err(_) => {
+            Err(err) => {
                 // The thread's ref went down with the closure; ours drops on return.
                 worker_ref.with_parent_poll_ref(|p| p.unref(bun_io::js_vm_ctx()));
-                *error_message = BunString::static_("Failed to spawn worker thread");
+                // Windows: raw_os_error() is a Win32 code, not an errno.
+                #[cfg(windows)]
+                let errno = err
+                    .raw_os_error()
+                    .and_then(|c| bun_errno::SystemErrno::init(c as u32))
+                    .unwrap_or(bun_errno::SystemErrno::EAGAIN);
+                #[cfg(not(windows))]
+                let errno = err
+                    .raw_os_error()
+                    .map(bun_errno::from_errno)
+                    .unwrap_or(bun_errno::SystemErrno::EAGAIN);
+                *error_message = BunString::clone_utf8(errno.to_string().as_bytes());
+                *spawn_failed = true;
                 core::ptr::null_mut()
             }
         }

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, isDebug, isLinux, tempDir } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -813,5 +814,70 @@ describe("worker_threads", () => {
     });
     await p;
     expect(message).toEqual("hello");
+  });
+});
+
+describe("worker thread limit", () => {
+  // On Linux, threads count toward RLIMIT_NPROC (the same counter a cgroup
+  // pids.max enforces). The kernel does not enforce the limit for root, so a
+  // root test runner drops to `nobody` through runuser.
+  const isRoot = process.getuid?.() === 0;
+  const hasPrlimit = isLinux && !!Bun.which("prlimit");
+  const hasNobody =
+    isRoot &&
+    !!Bun.which("runuser") &&
+    readFileSync("/etc/passwd", "utf8")
+      .split("\n")
+      .some(line => line.startsWith("nobody:"));
+  const canLimitThreads = hasPrlimit && (!isRoot || hasNobody);
+
+  test.skipIf(!canLimitThreads)("new Worker throws ERR_WORKER_INIT_FAILED when the OS refuses the thread", async () => {
+    // The child lowers its own limit to the number of tasks its uid already
+    // owns, once its lazy runtime threads exist, so only the worker's thread
+    // is refused.
+    const cmd = [
+      bunExe(),
+      "-e",
+      `import { readdirSync, readFileSync } from "node:fs";
+       let keep = [];
+       for (let i = 0; i < 50; i++) keep.push(new Array(10000).fill(i));
+       keep = [];
+       Bun.gc(true);
+       const uid = process.getuid();
+       let tasks = 0;
+       for (const pid of readdirSync("/proc")) {
+         if (!/^\\d+$/.test(pid)) continue;
+         let status;
+         try { status = readFileSync("/proc/" + pid + "/status", "utf8"); } catch { continue; }
+         const owner = status.match(/^Uid:\\s+(\\d+)/m);
+         if (!owner || Number(owner[1]) !== uid) continue;
+         const threads = status.match(/^Threads:\\s+(\\d+)/m);
+         tasks += threads ? Number(threads[1]) : 1;
+       }
+       const limited = Bun.spawnSync([${JSON.stringify(Bun.which("prlimit"))}, "--pid", String(process.pid), "--nproc=" + tasks]);
+       if (limited.exitCode !== 0) throw new Error("prlimit: " + limited.stderr);
+       try {
+         new Worker("data:text/javascript,postMessage(1)");
+         console.log("started");
+       } catch (e) {
+         console.log(JSON.stringify({ code: e.code, message: e.message, name: e.name }));
+       }`,
+    ];
+    if (isRoot) cmd.unshift(Bun.which("runuser")!, "-u", "nobody", "--");
+    await using proc = Bun.spawn({
+      cmd,
+      env: {
+        ...bunEnv,
+        // `nobody` has no writable home.
+        HOME: "/tmp",
+        // LeakSanitizer needs a tracer thread at exit, which the limit refuses.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ code: "ERR_WORKER_INIT_FAILED", message: "EAGAIN", name: "Error" });
+    expect(exitCode, stderr).toBe(0);
   });
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -861,7 +861,9 @@ describe("worker thread limit", () => {
          console.log("started");
        } catch (e) {
          console.log(JSON.stringify({ code: e.code, message: e.message, name: e.name }));
-       }`,
+       }
+       // A normal exit runs a GC, and its collector thread would be refused too.
+       process.exit(0);`,
     ];
     if (isRoot) cmd.unshift(Bun.which("runuser")!, "-u", "nobody", "--");
     await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- `new Worker()` at a cgroup `pids.max` or `RLIMIT_NPROC` limit throws `TypeError: Failed to spawn worker thread` with no `code`. Node throws `Error [ERR_WORKER_INIT_FAILED]: EAGAIN` (`node_worker.cc`, `uv_err_name_r` of the `uv_thread_create` result).
- The spawn error from `std::thread::Builder::spawn` was dropped in `WebWorker::create` (`src/jsc/web_worker.rs`), and `WorkerMessagingProxy::startWorkerGlobalScope` had no way to tell a refused thread from a bad specifier.

### Fix
- `WebWorker__create` gets a `spawn_failed` out parameter and puts the errno name in `error_message` (`bun_errno::from_errno`, the Win32 mapper on Windows).
- `WorkerMessagingProxy::startWorkerGlobalScope` throws `ERR_WORKER_INIT_FAILED` for that case through `ExistingExceptionError`. Other failures keep the `TypeError`.
- Verified: `test/js/web/workers/worker.test.ts` "new Worker throws ERR_WORKER_INIT_FAILED when the OS refuses the thread" (fails on main with the `TypeError`). The child lowers its own `RLIMIT_NPROC` to the tasks its uid already owns, after its lazy runtime threads exist, so only the worker's thread is refused.

### Background
- On Linux every thread counts toward `RLIMIT_NPROC`, and a cgroup v2 `pids.max` counts threads too. Root is exempt, so as root the test runs the child as `nobody` through `runuser`. It skips where `prlimit` or `runuser` is missing.
- This is the bun-side half of a larger problem: JSC itself aborts on a refused thread (GC helpers, collector thread, VMTraps, libpas scavenger). That part is oven-sh/WebKit#569 and the bump in #41587. This PR has no WebKit dependency.
- The related refused-thread crashes in bun's own HTTP, IO and thread pool code are #39864 and a separate ThreadPool fix.

<details><summary>Notes</summary>

- Split out of #41587 after review: the Worker change is independent of the WebKit change and Node parity on its own.
- Node's message is the bare errno name (`EAGAIN`). The `Worker initialization failure: %s` template in Node's `errors.js` is not what this C++ path emits.
- The test warms the child (allocations plus `Bun.gc(true)`) before lowering the limit so the mimalloc and libpas scavengers and the GC threads exist. A lazy thread that starts after the limit would hit the JSC assert on main's WebKit.
- The limited child runs with `detect_leaks=0`: LeakSanitizer needs a tracer thread at exit.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/workers/worker.test.ts

<!-- robobun:evidence:end -->