### PR TITLE
js_parser: accept import attributes on the next line, for await (async of, and keep (let)[0] parentheses

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1342,15 +1342,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.expect(T::TStringLiteral)?;
         }
 
-        if !p.lexer.has_newline_before
-            && (
-                // Import Assertions are deprecated.
-                // Import Attributes are the new way to do this.
-                // But some code may still use "assert"
-                // We support both and treat them identically.
-                // Once Prettier & TypeScript support import attributes, we will add runtime support
-                p.lexer.is_contextual_keyword(b"assert") || p.lexer.token == T::TWith
-            )
+        // Import Assertions are deprecated.
+        // Import Attributes are the new way to do this.
+        // But some code may still use "assert"
+        // We support both and treat them identically.
+        // Only "assert" has a [no LineTerminator here] restriction. "with" may
+        // start on the next line.
+        if p.lexer.token == T::TWith
+            || (!p.lexer.has_newline_before && p.lexer.is_contextual_keyword(b"assert"))
         {
             p.lexer.next()?;
             p.lexer.expect(T::TOpenBrace)?;
@@ -1622,7 +1621,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // In TypeScript, "async <ident>" not followed by "=>" treats "async" as
                         // a plain identifier (e.g. "async as T"), matching tsc's two-token
                         // lookahead in isUnParenthesizedAsyncArrowFunctionWorker (TypeScript#8444).
-                        let is_arrow_fn = !Self::IS_TYPESCRIPT_ENABLED
+                        // "async of" is only an arrow function if "=>" follows, so that
+                        // "for await (async of xs)" parses as a for-of over the identifier "async".
+                        let is_arrow_fn = (!Self::IS_TYPESCRIPT_ENABLED
+                            && !p.lexer.is_contextual_keyword(b"of"))
                             || p.check_for_arrow_after_the_current_token();
 
                         if is_arrow_fn {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1342,8 +1342,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.expect(T::TStringLiteral)?;
         }
 
-        // Import attributes ("with") and the deprecated import assertions ("assert")
-        // are treated identically. Only "assert" has a [no LineTerminator here] restriction.
+        // Only the deprecated "assert" form has a [no LineTerminator here] restriction.
         if p.lexer.token == T::TWith
             || (!p.lexer.has_newline_before && p.lexer.is_contextual_keyword(b"assert"))
         {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1342,12 +1342,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.expect(T::TStringLiteral)?;
         }
 
-        // Import Assertions are deprecated.
-        // Import Attributes are the new way to do this.
-        // But some code may still use "assert"
-        // We support both and treat them identically.
-        // Only "assert" has a [no LineTerminator here] restriction. "with" may
-        // start on the next line.
+        // Import attributes ("with") and the deprecated import assertions ("assert")
+        // are treated identically. Only "assert" has a [no LineTerminator here] restriction.
         if p.lexer.token == T::TWith
             || (!p.lexer.has_newline_before && p.lexer.is_contextual_keyword(b"assert"))
         {
@@ -1621,8 +1617,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // In TypeScript, "async <ident>" not followed by "=>" treats "async" as
                         // a plain identifier (e.g. "async as T"), matching tsc's two-token
                         // lookahead in isUnParenthesizedAsyncArrowFunctionWorker (TypeScript#8444).
-                        // "async of" is only an arrow function if "=>" follows, so that
-                        // "for await (async of xs)" parses as a for-of over the identifier "async".
+                        // "async of" needs the same lookahead: "for await (async of xs)".
                         let is_arrow_fn = (!Self::IS_TYPESCRIPT_ENABLED
                             && !p.lexer.is_contextual_keyword(b"of"))
                             || p.check_for_arrow_after_the_current_token();

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1658,8 +1658,7 @@ pub(crate) mod __gated_printer {
         pub(crate) export_default_start: i32,
         pub(crate) arrow_expr_start: i32,
         pub(crate) for_of_init_start: i32,
-        /// Start of the expression in a for, for-in, or for-of head. No such
-        /// expression may begin with the tokens `let [`.
+        /// Start of the expression in a for, for-in, or for-of head.
         pub(crate) for_init_start: i32,
         pub(crate) prev_op: Op::Code,
         pub(crate) prev_op_end: i32,
@@ -3757,8 +3756,7 @@ pub(crate) mod __gated_printer {
                     // The index target is not directly followed by `of`.
                     flags.remove(ExprFlag::IsFollowedByOf);
 
-                    // An expression statement or a for loop head must not start
-                    // with the tokens "let [", so "let[0] = 1" prints as "(let)[0] = 1".
+                    // A statement or for loop head must not start with "let [".
                     let wrap_let = {
                         let n = self.writer.written();
                         (n == self.stmt_start || n == self.for_init_start)

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3764,7 +3764,9 @@ pub(crate) mod __gated_printer {
                         (n == self.stmt_start || n == self.for_init_start)
                             && !matches!(e.index.data, ExprData::EPrivateIdentifier(_))
                             && match &e.target.data {
-                                ExprData::EIdentifier(id) => self.name_for_symbol(id.ref_) == b"let",
+                                ExprData::EIdentifier(id) => {
+                                    self.name_for_symbol(id.ref_) == b"let"
+                                }
                                 _ => false,
                             }
                     };

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1658,6 +1658,9 @@ pub(crate) mod __gated_printer {
         pub(crate) export_default_start: i32,
         pub(crate) arrow_expr_start: i32,
         pub(crate) for_of_init_start: i32,
+        /// Start of the expression in a for, for-in, or for-of head. No such
+        /// expression may begin with the tokens `let [`.
+        pub(crate) for_init_start: i32,
         pub(crate) prev_op: Op::Code,
         pub(crate) prev_op_end: i32,
         pub(crate) prev_num_end: i32,
@@ -3753,7 +3756,25 @@ pub(crate) mod __gated_printer {
 
                     // The index target is not directly followed by `of`.
                     flags.remove(ExprFlag::IsFollowedByOf);
+
+                    // An expression statement or a for loop head must not start
+                    // with the tokens "let [", so "let[0] = 1" prints as "(let)[0] = 1".
+                    let wrap_let = {
+                        let n = self.writer.written();
+                        (n == self.stmt_start || n == self.for_init_start)
+                            && !matches!(e.index.data, ExprData::EPrivateIdentifier(_))
+                            && match &e.target.data {
+                                ExprData::EIdentifier(id) => self.name_for_symbol(id.ref_) == b"let",
+                                _ => false,
+                            }
+                    };
+                    if wrap_let {
+                        self.print(b"(");
+                    }
                     self.print_expr(e.target, Level::Postfix, flags);
+                    if wrap_let {
+                        self.print(b")");
+                    }
 
                     let is_optional_chain_start =
                         e.optional_chain == Some(js_ast::OptionalChain::Start);
@@ -6529,6 +6550,7 @@ pub(crate) mod __gated_printer {
         pub(crate) fn print_for_loop_init(&mut self, init_st: Stmt, extra_flags: ExprFlagSet) {
             match &init_st.data {
                 StmtData::SExpr(s) => {
+                    self.for_init_start = self.writer.written();
                     self.print_expr(
                         s.value,
                         Level::Lowest,
@@ -7012,6 +7034,7 @@ pub(crate) mod __gated_printer {
                 export_default_start: -1,
                 arrow_expr_start: -1,
                 for_of_init_start: -1,
+                for_init_start: -1,
                 prev_op: Op::Code::BinAdd,
                 prev_op_end: -1,
                 prev_num_end: -1,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2958,12 +2958,41 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_("for ((let) of [7]);", "for ((let) of [7])\n  ;\n");
 
       // The keyword spelling is a syntax error, which is why the parentheses matter
-      expect(() => parsed("for (async of [7]);", false, false)).toThrow();
+      expectParseError("for (async of [7]);", 'For loop initializers cannot start with "async of"');
       expectParseError("for (async\nof [7]);", 'For loop initializers cannot start with "async of"');
       expectPrinted_(
         "async function f() { for await (async\nof [7]); }",
         "async function f() {\n  for await ((async) of [7])\n    ;\n}",
       );
+
+      // "for await (async of" has no such restriction: "async" is a plain identifier there
+      expectPrinted_(
+        "async function f() { for await (async of [7]); }",
+        "async function f() {\n  for await ((async) of [7])\n    ;\n}",
+      );
+      expectPrinted_("for (async of => {};;);", "for (async (of) => {};; )\n  ;\n");
+      expectPrinted_("x = async of => of", "x = async (of) => of");
+      expectParseError("async of", 'Expected ";" but found "of"');
+    });
+
+    it("let [ at the start of a statement keeps its parentheses", () => {
+      // An expression statement and a for loop head must not start with "let [".
+      expectPrinted_("var let = []; (let)[0] = 1;", "var let = [];\n(let)[0] = 1;\n");
+      expectPrinted_("if (1) (let)[0] = 2;", "if (1)\n  (let)[0] = 2;\n");
+      expectPrinted_("(let)[0].x = 1;", "(let)[0].x = 1;\n");
+      expectPrinted_("(let)[0]();", "(let)[0]();\n");
+      expectPrinted_("(let)[0]++;", "(let)[0]++;\n");
+      expectPrinted_("for ((let)[0] in x);", "for ((let)[0] in x)\n  ;\n");
+      expectPrinted_("for ((let)[0] of x);", "for ((let)[0] of x)\n  ;\n");
+      expectPrinted_("for ((let)[0];;);", "for ((let)[0];; )\n  ;\n");
+
+      // No parentheses are needed anywhere else
+      expectPrinted_("var let = {}; (let).x = 1;", "var let = {};\nlet.x = 1;\n");
+      expectPrinted_("x = (let)[0];", "x = let[0];\n");
+      expectPrinted_("x, (let)[0] = 1;", "x, let[0] = 1;\n");
+      expectPrinted_("for (x; (let)[0];);", "for (x;let[0]; )\n  ;\n");
+      expectPrinted_("for (x in (let)[0]);", "for (x in let[0])\n  ;\n");
+      expectPrinted_("(lett)[0] = 1;", "lett[0] = 1;\n");
     });
 
     it("await", () => {
@@ -2993,6 +3022,16 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_(`import json from "./foo.json" assert { type: "json" };`, `import json from "./foo.json"`);
       expectPrinted_(`import json from "./foo.json";`, `import json from "./foo.json"`);
       expectPrinted_(`import("./foo.json", { type: "json" });`, `import("./foo.json", { type: \"json\" })`);
+    });
+
+    it("import attributes on the next line", () => {
+      // "with" has no [no LineTerminator here] restriction, unlike the legacy "assert"
+      expectPrinted_(`import json from "./foo.json"\nwith { type: "json" };`, `import json from "./foo.json"`);
+      expectPrinted_(`import json from "./foo.json"\n  with { type: "json" };`, `import json from "./foo.json"`);
+      expectPrinted_(`import "./foo.json"\nwith { type: "json" };`, `import"./foo.json"`);
+      expectPrinted_(`export { a } from "./foo.json"\nwith { type: "json" };`, `export { a } from "./foo.json"`);
+      expectPrinted_(`export * from "./foo.json"\nwith { type: "json" };`, `export * from "./foo.json"`);
+      expect(() => parsed(`import json from "./foo.json"\nassert { type: "json" };`, false, false)).toThrow();
     });
 
     it("import with unicode", () => {


### PR DESCRIPTION
### Problem
- Three valid programs fail in bun 1.4.3 (and 1.3.14 and canary) while node 26 runs each. `import a from "./m.mjs"` followed by `with { type: "json" }` on the next line fails with `Expected "(" but found "{"`. `for await (async of xs)` fails with `Expected "=>" but found "["`. Sloppy code `(let)[0] = 1` parses, but the printer emits `let[0] = 1`, a `let` declaration, and JSC rejects the output with `SyntaxError: Unexpected number '0'`. `(let)` + line break + `[a] = b` prints as `let[a] = b`, which still parses, as a destructuring declaration. Since #40814 this also happens at the very start of a file.
- The causes: `parse_path` (`src/js_parser/parse/mod.rs:1345`) requires no newline before `with`, but only the legacy `assert` form has that restriction. `parse_async_prefix_expr` (`mod.rs:1625`) commits to an async arrow for every `async <identifier>` in JS mode. The printer wraps `let` only at a for-of head (`src/js_printer/lib.rs:4258`) and not at the other positions with a `let [` lookahead restriction.

### Fix
- The newline check in `parse_path` applies to `assert` only. `with` on the next line starts the attributes clause, as in esbuild.
- For `async of`, JS mode now does the `=>` lookahead that TypeScript mode already does. `for await (async of xs)` is a for-of over the identifier `async`. `for (async of xs)` now reports the existing error `For loop initializers cannot start with "async of"`. `async of => {}` is still an arrow.
- The printer gets a `for_init_start` mark next to `stmt_start`. An `EIndex` whose target is the identifier `let` prints as `(let)[...]` at a statement start or at the start of a for, for-in, or for-of head. esbuild 0.28 still has this printer bug, so the precedent is the printer's own for-of rule.
- Verified: `test/bundler/transpiler/transpiler.test.js` (three new blocks, all fail on 1.4.3 and on main 627e407264) and one new case in `test/bundler/bundler_edgecase.test.ts` (a `/* @__PURE__ */` comment before `(let)[0]()` in a for head). Also `test/bundler/esbuild/{default,ts,lower}.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/js/bun/transpiler/`.

### Background
- ECMA-262 puts `[no LineTerminator here]` before `assert` in the legacy import assertions grammar. The import attributes grammar (`with`) has no such restriction.
- The for-of grammar has `[lookahead ∉ { let, async of }]` before the left-hand side. `for await` has no `async of` restriction because `async` cannot start an arrow there.
- An ExpressionStatement and the expression forms of for, for-in and for-of heads have `[lookahead ≠ let []`. So a transpiler must keep the parentheses in `(let)[0]` at those positions. The printer re-derives parentheses from position, which is why the parser does not keep them.
- The first hunk (`parse_path`) also appears in #40836. The hunks are identical, so whichever lands second rebases cleanly.

<details><summary>Notes</summary>

Reported by the parser conformance ledger (entries 24993, 24992, 24994).

Self-reviewed: 4 concerns raised, 2 addressed (the overlap with #40836 and the esbuild precedent claim are stated above). Two rejected: "split into three PRs" (the changes are three lines of parser and one printer mark, one test file), and "measure the printer hot path" (the check is one integer compare on `written()` before any symbol lookup, and the name lookup only runs at a statement or for-head start).

Repros on bun 1.4.3:

```
printf 'import v from "./m.mjs"\nwith { type: "json" };\nconsole.log(v)\n' > h1.mjs
printf 'async function f(){ var async = 0, n = 0; for await (async of [1,2]) n += async; return n }\nf().then(console.log)\n' > e2.mjs
printf 'var let = [0]; if (1) (let)[0] = 2; (let)[0] = 3; console.log(let[0])\n' > j1.cjs
```

A newline before `assert` still ends the import statement. `import json from "./foo.json"` followed by `assert { type: "json" }` on the next line is then `assert` followed by `{` on the same line, which is a syntax error in every engine. The test asserts that it still fails.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 33 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (09bb54630)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [531.67ms]
(pass) bundler > edgecase/EmptyCommonJSModule [369.06ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [409.04ms]
(pass) bundler > edgecase/ImportStarFunction [363.40ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [362.75ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [111.57ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [378.55ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [311.98ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [280.32ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [209.69ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [110.70ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [380.60ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/Impo
... (truncated)

release without fix: 1 failed, 33 skipped
bun test v1.4.3-canary.1 (d20756d24)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [18.66ms]
(pass) bundler > edgecase/EmptyCommonJSModule [11.14ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [11.78ms]
(pass) bundler > edgecase/ImportStarFunction [11.49ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [12.07ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [6.33ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [11.53ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [7.18ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [6.60ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [4.80ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [5.76ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [13.63ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [12.77ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [4.93ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [2.61ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDefaul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 33 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (09bb54630)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [527.11ms]
(pass) bundler > edgecase/EmptyCommonJSModule [405.30ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [437.96ms]
(pass) bundler > edgecase/ImportStarFunction [440.27ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [378.73ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [121.36ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [391.14ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [228.32ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [221.96ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [219.73ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [139.37ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [430.25ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/Impo
... (truncated)

release with fix: 33 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 927ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/mod.rs                 | 16 ++++-------
 src/js_printer/lib.rs                      | 30 ++++++++++++++++++-
 test/bundler/bundler_edgecase.test.ts      | 17 +++++++++++
 test/bundler/transpiler/transpiler.test.js | 46 +++++++++++++++++++++++++++++-
 4 files changed, 97 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/mod.rs                      5      2     56
src/js_printer/lib.rs                           2      0     56
test/bundler/bundler_edgecase.test.ts           0      0     16
test/bundler/transpiler/transpiler.test.js      0      0     43
```

</details>

<!-- robobun:evidence:end -->
