### PR TITLE
docs: explain memory cost of large Response bodies and published WebSocket messages

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -270,7 +270,7 @@ Bun.serve({
 
 `new Response(body)` copies an `ArrayBuffer` or typed array body at construction time, as the Fetch spec requires. A `fetch` handler that returns the same large `Uint8Array` on every request pays that copy per request. Each copy lives until the client reads the whole body. If clients are slow or stall, memory grows by the body size per connection.
 
-A `Blob` body is not copied. `Response` takes a reference to the `Blob`'s immutable bytes, so every connection shares one copy. The same is true for a `BunFile` and for a static route. A Latin-1 `string` body is sent from the string's own storage without a copy. A string with non-Latin-1 characters is transcoded once per response.
+A `Blob` body is not copied. `Response` takes a reference to the `Blob`'s immutable bytes, so every connection shares one copy. The same is true for a `BunFile`. A static route copies a typed array body once, when the route is registered, and every request reuses that one `Response`. An ASCII-only `string` body is sent from the string's own storage without a copy. A string with any non-ASCII character (including Latin-1 characters such as `é`) is transcoded to UTF-8 once per response.
 
 For a large payload that many requests share, build it once as a `Blob`, or register it as a static route:
 
@@ -280,7 +280,7 @@ const blob = new Blob([bytes], { type: "text/javascript" });
 
 Bun.serve({
   routes: {
-    // Shared by reference: the Response is built once.
+    // Copied once at startup. Every request reuses this Response.
     "/static/bundle.js": new Response(bytes, { headers: { "Content-Type": "text/javascript" } }),
   },
   fetch(req) {

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -266,6 +266,36 @@ Bun.serve({
 
 ---
 
+## Large in-memory bodies
+
+`new Response(body)` copies an `ArrayBuffer` or typed array body at construction time, as the Fetch spec requires. A `fetch` handler that returns the same large `Uint8Array` on every request pays that copy per request. Each copy lives until the client reads the whole body. If clients are slow or stall, memory grows by the body size per connection.
+
+A `Blob` body is not copied. `Response` takes a reference to the `Blob`'s immutable bytes, so every connection shares one copy. The same is true for a `BunFile` and for a static route. A Latin-1 `string` body is sent from the string's own storage without a copy. A string with non-Latin-1 characters is transcoded once per response.
+
+For a large payload that many requests share, build it once as a `Blob`, or register it as a static route:
+
+```ts
+const bytes = await Bun.file("./bundle.js").bytes();
+const blob = new Blob([bytes], { type: "text/javascript" });
+
+Bun.serve({
+  routes: {
+    // Shared by reference: the Response is built once.
+    "/static/bundle.js": new Response(bytes, { headers: { "Content-Type": "text/javascript" } }),
+  },
+  fetch(req) {
+    // Copied once per request. With N stalled clients, N copies are held.
+    return new Response(bytes); // [!code --]
+    // Shared by reference. Build the Blob once at startup.
+    return new Response(blob); // [!code ++]
+  },
+});
+```
+
+With 40 stalled clients and a 32 MB body, `new Response(uint8Array)` holds 1.28 GB. `new Response(blob)` and a static route hold a few MB.
+
+---
+
 ## `fetch` request handler
 
 The `fetch` handler runs for incoming requests that no route matched. It receives a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object and returns a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) or [`Promise<Response>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -270,10 +270,12 @@ For fine-grained control over compression characteristics, refer to the [Referen
 The `.send(message)` method of `ServerWebSocket` returns a `number` indicating the result of the operation.
 
 - `-1` — The message was enqueued but there is backpressure
-- `0` — The message was dropped due to a connection issue
+- `0` — The message was dropped: the connection is closed, or it already buffers more than `backpressureLimit`
 - `1+` — The number of bytes sent
 
-`backpressureLimit` sets how many bytes a single connection can buffer. Bun checks the limit before it queues a message. If the connection already buffers more than the limit, Bun drops the message and `.send()` returns `0`. If the connection buffers less than the limit, Bun queues the whole message, even when the message is larger than the limit. So a single message can push a connection past the limit by its own size.
+`backpressureLimit` sets how many bytes a single connection can buffer. Bun checks the limit before it queues a message. If the connection already buffers more than the limit, Bun drops the message and `.send()` returns `0`. If the connection buffers less than the limit, Bun queues the whole message, even when the message is larger than the limit. So a connection buffers at most `backpressureLimit` plus one message, and a single message larger than the limit is always queued whole.
+
+A subscriber that stops reading stays subscribed. Once its buffer passes the limit, every later `.publish()` drops the message for that subscriber only. Other subscribers still receive it, and `.publish()` returns `0` because one receiver dropped it. The `drain` handler does not run for a dropped message. Set `closeOnBackpressureLimit: true` to close such a connection instead.
 
 `.publish()` writes the message to every subscriber in turn, on the JS thread. The part a subscriber's socket does not accept at once is copied into that subscriber's own buffer. There is no shared buffer between subscribers. A large message to many subscribers costs one copy of the message per subscriber, in both memory and loop time. With 150 subscribers and an 8 MB message, one `.publish()` call takes about 1 second and holds about 1.2 GB until the subscribers drain. A `backpressureLimit` below the message size does not change this, because every connection starts below the limit.
 

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -273,6 +273,12 @@ The `.send(message)` method of `ServerWebSocket` returns a `number` indicating t
 - `0` — The message was dropped due to a connection issue
 - `1+` — The number of bytes sent
 
+`backpressureLimit` sets how many bytes a single connection can buffer. Bun checks the limit before it queues a message. If the connection already buffers more than the limit, Bun drops the message and `.send()` returns `0`. If the connection buffers less than the limit, Bun queues the whole message, even when the message is larger than the limit. So a single message can push a connection past the limit by its own size.
+
+`.publish()` writes the message to every subscriber in turn, on the JS thread. The part a subscriber's socket does not accept at once is copied into that subscriber's own buffer. There is no shared buffer between subscribers. A large message to many subscribers costs one copy of the message per subscriber, in both memory and loop time. With 150 subscribers and an 8 MB message, one `.publish()` call takes about 1 second and holds about 1.2 GB until the subscribers drain. A `backpressureLimit` below the message size does not change this, because every connection starts below the limit.
+
+Keep published messages small. To share a large payload with many clients, publish a short message that points at it, and serve the bytes over HTTP from a `Blob`, a `BunFile`, or a static route.
+
 ### Timeouts and limits
 
 By default, Bun closes a WebSocket connection that has been idle for 120 seconds. Configure this with the `idleTimeout` parameter.

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -479,9 +479,6 @@ declare module "bun" {
     /**
      * Sets the maximum number of bytes that can be buffered on a single connection.
      *
-     * The limit is checked before a message is queued. A connection that is
-     * under the limit accepts the whole message, even one larger than the limit.
-     *
      * @default 1024 * 1024 * 16 // 16 MB
      */
     backpressureLimit?: number;

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -479,6 +479,9 @@ declare module "bun" {
     /**
      * Sets the maximum number of bytes that can be buffered on a single connection.
      *
+     * The limit is checked before a message is queued. A connection that is
+     * under the limit accepts the whole message, even one larger than the limit.
+     *
      * @default 1024 * 1024 * 16 // 16 MB
      */
     backpressureLimit?: number;


### PR DESCRIPTION
### Problem
- A `fetch` handler that returns `new Response(sharedUint8Array)` copies the body on every request (`src/runtime/webcore/Body.rs:948`, `bytes.to_vec()`). Under slow or stalled clients each copy is held until the socket drains. 40 stalled clients and a 32 MB body hold 1.28 GB. The same body as a `Blob`, an ASCII string, or a static route holds a few MB. The docs do not say which shape is shared.
- `server.publish()` copies the unsent part of a message into each subscriber's own buffer (`packages/bun-uws/src/WebSocket.h:133-165`). `backpressureLimit` is checked before the queue, so a single message larger than the limit is still queued whole. 150 subscribers and an 8 MB message cost about 1 second of loop time and 1.2 GB, with or without a 1 MB limit. The docs say nothing about either.

### Fix
- Add a "Large in-memory bodies" section to `docs/runtime/http/routing.mdx`. It says that `ArrayBuffer` and typed array bodies are copied per `Response` (as the Fetch spec requires), that `Blob` and `BunFile` bodies are shared by reference, that a static route copies once at startup, that only an ASCII string is sent without a copy, and shows the `Blob` shape.
- Extend the "Backpressure" section of `docs/runtime/http/websockets.mdx`. It explains when `backpressureLimit` is checked, the queue bound (limit plus one message), what happens to a subscriber that stops reading, the per-subscriber copy in `publish()`, and the measured cost.
- Verified: all numbers reproduce on bun 1.4.3 with the probes in Notes. Docs only, no code change. Prettier passes on both files.

### Background
- The Fetch spec's "extract a body" step makes a copy of a `BufferSource` body. A `Blob` body is extracted by reference. Bun follows both. So the `Blob` shape is the spec-conformant way to share one payload across requests.
- #35138 proposes to borrow large `ArrayBuffer` bodies instead of copying them. That PR is open on the spec question. This docs change is the alternative it lists as option 4, and it stays correct if that PR lands, because the `Blob` shape is still the cheaper one.
- uWS `publish()` walks the topic's subscribers and calls `send()` on each. Each socket keeps its own backpressure buffer. There is no shared outgoing buffer.

<details><summary>Notes</summary>

Probe for the Response shapes (40 clients send a GET and never read, 32 MB body, server child RSS sampled after 4 s):

```
{"path":"/blob","stalledClients":40,"bodyMB":32,"rssDeltaMB":4,"perClientMB":0.1}
{"path":"/str","stalledClients":40,"bodyMB":32,"rssDeltaMB":0,"perClientMB":0}
{"path":"/u8","stalledClients":40,"bodyMB":32,"rssDeltaMB":1280,"perClientMB":32}
```

String bodies, same rig. `/ascii` is `"A".repeat(32 MB)`. `/latin1` is `"é".repeat(16 M)`, which is 32 MB of UTF-8:

```
{"path":"/ascii","stalledClients":40,"bodyMB":32,"rssDeltaMB":2,"perClientMB":0.1}
{"path":"/latin1","stalledClients":40,"bodyMB":32,"rssDeltaMB":1281,"perClientMB":32}
```

Probe for `publish` (150 raw WebSocket subscribers, every second one paused, one 8 MB publish):

```
{"bun":"1.4.3","subscribers":150,"msgMB":8,"backpressureLimit":"default","publishReturn":-1,"publishMs":1045,"rssBeforeMB":54,"rssAfterMB":1255,"perSubscriberMB":8}
{"bun":"1.4.3","subscribers":150,"msgMB":8,"backpressureLimit":1048576,"publishReturn":-1,"publishMs":1022,"rssBeforeMB":54,"rssAfterMB":1255,"perSubscriberMB":8}
```

Source anchors:
- `Body::Value::from_js`: typed array and `ArrayBuffer` go through `bytes.to_vec()`. A `Blob` goes through `dupe_with_content_type`, which clones the store ref. A string keeps a `WTFStringImpl` ref. `to_blob_if_possible` (`Body.rs:693`) calls `to_utf8()`, and `to_utf8_from_latin1` (`src/bun_core/lib.rs:1629`) borrows only when the bytes are all ASCII. Any other string is transcoded into a fresh buffer once per response.
- `WebSocket::send` in `packages/bun-uws/src/WebSocket.h`: the `maxBackpressure` check at line 133 runs before any write. The unsent remainder is appended to `webSocketData->buffer` per socket. `TopicTree::drainImpl` calls the send callback once per subscriber with the same message.
- `SendStatus::Dropped` maps to `0` in `src/runtime/server/ServerWebSocket.rs:196`. `WebSocket::publish` returns the worst status across receivers (`WebSocket.h:363-400`), so one dropped subscriber makes `publish()` return `0` while the others still receive the message.
- Review: three findings on the first revision (ASCII vs Latin-1 boundary, a static-route comment, the `0` bullet). All three are fixed in 4233b292d5.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->
