### PR TITLE
Bun.serve: stop leaking a uWS WebSocketContext per route on every reload()

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -129,6 +129,17 @@ private:
     /* WebSocketContexts are of differing type, but we as owners and creators must delete them correctly */
     std::vector<MoveOnlyFunction<void()>> webSocketContextDeleters;
     std::vector<us_socket_group_t *> webSocketGroups;
+    /* One WebSocketContext per UserData type, shared by every ws() route and
+     * by every re-registration after clearRoutes(). A context can only be
+     * freed once all of its sockets are gone, which is at app destruction, so
+     * a context per ws() call would leak one per route per server.reload().
+     * The per-route state (upgrade handler, user data) lives in the HTTP
+     * route closure, which clearRoutes() drops. Each ws() call writes the
+     * behavior's handlers and limits into the shared context, so a reload
+     * applies its new limits to the sockets that are already open. */
+    void *sharedWebSocketContext = nullptr;
+    template <typename UserData> static inline char sharedWebSocketContextTag = 0;
+    const void *sharedWebSocketContextType = nullptr;
 
 public:
 
@@ -522,16 +533,25 @@ public:
             });
         }
 
-        /* Every route has its own websocket context with its own behavior and user data type */
-        auto *webSocketContext = WebSocketContext<SSL, true, UserData>::create(Loop::get(), topicTree);
+        WebSocketContext<SSL, true, UserData> *webSocketContext;
+        if (sharedWebSocketContext && sharedWebSocketContextType == &sharedWebSocketContextTag<UserData>) {
+            webSocketContext = (WebSocketContext<SSL, true, UserData> *) sharedWebSocketContext;
+        } else {
+            /* The socket group is sized for this UserData type */
+            webSocketContext = WebSocketContext<SSL, true, UserData>::create(Loop::get(), topicTree);
+            if (!sharedWebSocketContext) {
+                sharedWebSocketContext = webSocketContext;
+                sharedWebSocketContextType = &sharedWebSocketContextTag<UserData>;
+            }
 
-        /* We need to clear this later on */
-        webSocketContextDeleters.push_back([webSocketContext]() {
-            webSocketContext->free();
-        });
+            /* We need to clear this later on */
+            webSocketContextDeleters.push_back([webSocketContext]() {
+                webSocketContext->free();
+            });
 
-        /* We also keep this list for easy closing */
-        webSocketGroups.push_back(webSocketContext->getSocketGroup());
+            /* We also keep this list for easy closing */
+            webSocketGroups.push_back(webSocketContext->getSocketGroup());
+        }
 
         /* If we are the first one to use compression, initialize it */
         if (behavior.compression) {

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -129,17 +129,14 @@ private:
     /* WebSocketContexts are of differing type, but we as owners and creators must delete them correctly */
     std::vector<MoveOnlyFunction<void()>> webSocketContextDeleters;
     std::vector<us_socket_group_t *> webSocketGroups;
-    /* One WebSocketContext per UserData type, shared by every ws() route and
-     * by every re-registration after clearRoutes(). A context can only be
+    /* WebSocketContexts that ws() calls share by key. A context can only be
      * freed once all of its sockets are gone, which is at app destruction, so
-     * a context per ws() call would leak one per route per server.reload().
+     * a context per ws() call leaks one per route per clearRoutes() cycle.
      * The per-route state (upgrade handler, user data) lives in the HTTP
-     * route closure, which clearRoutes() drops. Each ws() call writes the
-     * behavior's handlers and limits into the shared context, so a reload
-     * applies its new limits to the sockets that are already open. */
-    void *sharedWebSocketContext = nullptr;
-    template <typename UserData> static inline char sharedWebSocketContextTag = 0;
-    const void *sharedWebSocketContextType = nullptr;
+     * route closure, which clearRoutes() drops. Every ws() call with a key
+     * writes the behavior's handlers and limits into that key's context, so
+     * the sockets already open on it get the latest behavior. */
+    std::vector<std::pair<const void *, void *>> sharedWebSocketContexts;
 
 public:
 
@@ -452,8 +449,11 @@ public:
         return closed;
     }
 
+    /* With a non-null sharedContextKey the route uses the WebSocketContext
+     * registered under that key, creating it on the first call. Every call
+     * with the same key must use the same UserData type. */
     template <typename UserData>
-    TemplatedApp &&ws(std::string_view pattern, WebSocketBehavior<UserData> &&behavior) {
+    TemplatedApp &&ws(std::string_view pattern, WebSocketBehavior<UserData> &&behavior, const void *sharedContextKey = nullptr) {
         /* Don't compile if alignment rules cannot be satisfied */
         static_assert(alignof(UserData) <= LIBUS_EXT_ALIGNMENT,
         "µWebSockets cannot satisfy UserData alignment requirements. You need to recompile µSockets with LIBUS_EXT_ALIGNMENT adjusted accordingly.");
@@ -533,15 +533,19 @@ public:
             });
         }
 
-        WebSocketContext<SSL, true, UserData> *webSocketContext;
-        if (sharedWebSocketContext && sharedWebSocketContextType == &sharedWebSocketContextTag<UserData>) {
-            webSocketContext = (WebSocketContext<SSL, true, UserData> *) sharedWebSocketContext;
-        } else {
-            /* The socket group is sized for this UserData type */
+        WebSocketContext<SSL, true, UserData> *webSocketContext = nullptr;
+        if (sharedContextKey) {
+            for (auto &[key, context] : sharedWebSocketContexts) {
+                if (key == sharedContextKey) {
+                    webSocketContext = (WebSocketContext<SSL, true, UserData> *) context;
+                    break;
+                }
+            }
+        }
+        if (!webSocketContext) {
             webSocketContext = WebSocketContext<SSL, true, UserData>::create(Loop::get(), topicTree);
-            if (!sharedWebSocketContext) {
-                sharedWebSocketContext = webSocketContext;
-                sharedWebSocketContextType = &sharedWebSocketContextTag<UserData>;
+            if (sharedContextKey) {
+                sharedWebSocketContexts.emplace_back(sharedContextKey, webSocketContext);
             }
 
             /* We need to clear this later on */

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1320,6 +1320,7 @@ impl DevServer {
             dev,
             0,
             hmr_socket_behavior::<SSL>(),
+            dev.cast_const().cast(),
         );
 
         // Only attach a catch-all handler if the framework has filesystem

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2323,6 +2323,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // `unsafe { &*p }` pattern with one safe accessor.
         let websocket_ptr: Option<bun_ptr::BackRef<WebSocketServerContext>> =
             self.config.websocket.as_ref().map(bun_ptr::BackRef::new);
+        // Every `ServerWebSocket` route of this server, across every
+        // `set_routes` pass, shares one uWS context. The DevServer's HMR
+        // socket has its own behavior and keys its context on itself.
+        let ws_context_key: *const c_void = self_ptr.cast_const().cast();
 
         for user_route in self.user_routes.iter_mut() {
             let ud: *mut c_void = std::ptr::from_mut::<UserRoute<SSL, DEBUG>>(user_route).cast();
@@ -2364,6 +2368,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             ud,
                             1, // id 1 means is a user route
                             ServerWebSocket::behavior::<Self, SSL>(&websocket.to_behavior()),
+                            ws_context_key,
                         );
                     }
                 }
@@ -2394,6 +2399,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 ud,
                                 1, // id 1 means is a user route
                                 ServerWebSocket::behavior::<Self, SSL>(&websocket.to_behavior()),
+                                ws_context_key,
                             );
                         }
                     }
@@ -2614,6 +2620,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     self_ptr.cast(),
                     0, // id 0 means is a fallback route and ctx is the server
                     ServerWebSocket::behavior::<Self, SSL>(&websocket.to_behavior()),
+                    ws_context_key,
                 );
             }
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2323,9 +2323,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // `unsafe { &*p }` pattern with one safe accessor.
         let websocket_ptr: Option<bun_ptr::BackRef<WebSocketServerContext>> =
             self.config.websocket.as_ref().map(bun_ptr::BackRef::new);
-        // Every `ServerWebSocket` route of this server, across every
-        // `set_routes` pass, shares one uWS context. The DevServer's HMR
-        // socket has its own behavior and keys its context on itself.
+        // One uWS websocket context per server, kept across reloads.
         let ws_context_key: *const c_void = self_ptr.cast_const().cast();
 
         for user_route in self.user_routes.iter_mut() {

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -423,8 +423,6 @@ impl<const SSL: bool> App<SSL> {
         c::uws_filter(Self::SSL_FLAG, self.as_raw(), Some(handler), user_data)
     }
 
-    /// Calls with the same non-null `shared_context_key` share one uWS
-    /// `WebSocketContext`, and the latest `behavior` applies to it.
     pub fn ws(
         &mut self,
         pattern: &[u8],

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -423,10 +423,8 @@ impl<const SSL: bool> App<SSL> {
         c::uws_filter(Self::SSL_FLAG, self.as_raw(), Some(handler), user_data)
     }
 
-    /// Registers a websocket route. Calls with the same non-null
-    /// `shared_context_key` share one uWS `WebSocketContext`, so they do not
-    /// allocate a context each time the routes are set again. The latest
-    /// call's `behavior` applies to every socket open on that context.
+    /// Calls with the same non-null `shared_context_key` share one uWS
+    /// `WebSocketContext`, and the latest `behavior` applies to it.
     pub fn ws(
         &mut self,
         pattern: &[u8],

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -423,12 +423,17 @@ impl<const SSL: bool> App<SSL> {
         c::uws_filter(Self::SSL_FLAG, self.as_raw(), Some(handler), user_data)
     }
 
+    /// Registers a websocket route. Calls with the same non-null
+    /// `shared_context_key` share one uWS `WebSocketContext`, so they do not
+    /// allocate a context each time the routes are set again. The latest
+    /// call's `behavior` applies to every socket open on that context.
     pub fn ws(
         &mut self,
         pattern: &[u8],
         ctx: *mut c_void,
         id: usize,
         behavior_: WebSocketBehavior,
+        shared_context_key: *const c_void,
     ) {
         let behavior = behavior_;
         // SAFETY: self is a valid app; pattern valid for the call; behavior is stack-local.
@@ -441,6 +446,7 @@ impl<const SSL: bool> App<SSL> {
                 pattern.len(),
                 id,
                 &raw const behavior,
+                shared_context_key,
             )
         }
     }

--- a/src/uws_sys/WebSocket.rs
+++ b/src/uws_sys/WebSocket.rs
@@ -523,6 +523,7 @@ pub mod c {
             pattern_len: usize,
             id: usize,
             behavior: *const WebSocketBehavior,
+            shared_context_key: *const c_void,
         );
         pub(crate) safe fn uws_ws_get_user_data(ssl: i32, ws: &mut RawWebSocket) -> *mut c_void;
         pub(crate) safe fn uws_ws_close(ssl: i32, ws: &mut RawWebSocket);

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -600,7 +600,8 @@ extern "C"
 
   void uws_ws(int ssl, uws_app_t *app, void *upgradeContext, const char *pattern,
               size_t pattern_length, size_t id,
-              const uws_socket_behavior_t *behavior_)
+              const uws_socket_behavior_t *behavior_,
+              const void *shared_context_key)
   {
     uws_socket_behavior_t behavior = *behavior_;
 
@@ -660,7 +661,7 @@ extern "C"
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
 
       uwsApp->ws<void *>(std::string(pattern, pattern_length),
-                         std::move(generic_handler));
+                         std::move(generic_handler), shared_context_key);
     }
     else
     {
@@ -717,7 +718,7 @@ extern "C"
         };
       uWS::App *uwsApp = (uWS::App *)app;
       uwsApp->ws<void *>(std::string(pattern, pattern_length),
-                         std::move(generic_handler));
+                         std::move(generic_handler), shared_context_key);
     }
   }
 

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1097,6 +1097,91 @@ test.concurrent("server.reload() while an html route's first bundle is still in 
   });
 });
 
+// The dev server's HMR socket and the user's `websocket` handlers are two
+// different uWS websocket behaviors on one app. Each keeps its own context, so
+// an HMR client is not handed to the user's handlers, before or after a reload.
+test.concurrent("dev server HMR socket and the user websocket handlers stay separate across a reload", async () => {
+  using dir = tempDir("bun-serve-html-hmr-and-user-websocket", {
+    "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body><script type="module" src="./app.ts"></script></body></html>`,
+    "app.ts": `console.log("app");`,
+    "serve.ts": /*ts*/ `
+      import html from "./index.html";
+
+      const options = version => ({
+        port: 0,
+        development: true,
+        routes: { "/": html },
+        fetch(req, server) {
+          if (server.upgrade(req)) return;
+          return new Response("not a websocket", { status: 400 });
+        },
+        websocket: {
+          message(ws, message) {
+            ws.send("user v" + version + " got " + message);
+          },
+        },
+      });
+      const server = Bun.serve(options(1));
+
+      // The HMR client's "set url" message ('n' + route pattern) is answered
+      // with 'n' + the route bundle index as a u32.
+      async function hmrRouteBundleIndex() {
+        const url = new URL("/_bun/hmr", server.url);
+        url.protocol = "ws:";
+        const ws = new WebSocket(url);
+        ws.binaryType = "arraybuffer";
+        const { promise, resolve, reject } = Promise.withResolvers();
+        ws.onerror = reject;
+        ws.onclose = () => reject(new Error("hmr socket closed before answering"));
+        ws.onmessage = ({ data }) => {
+          if (typeof data === "string") return reject(new Error("hmr socket answered with " + data));
+          const view = new DataView(data);
+          if (view.getUint8(0) === "n".charCodeAt(0)) resolve(view.getUint32(1, true));
+        };
+        ws.onopen = () => ws.send(new TextEncoder().encode("n/"));
+        try {
+          return await promise;
+        } finally {
+          ws.onclose = null;
+          ws.close();
+        }
+      }
+
+      async function userEcho(message) {
+        const url = new URL("/ws", server.url);
+        url.protocol = "ws:";
+        const ws = new WebSocket(url);
+        const { promise, resolve, reject } = Promise.withResolvers();
+        ws.onerror = reject;
+        ws.onclose = () => reject(new Error("user socket closed before answering"));
+        ws.onmessage = ({ data }) => resolve(data);
+        ws.onopen = () => ws.send(message);
+        try {
+          return await promise;
+        } finally {
+          ws.onclose = null;
+          ws.close();
+        }
+      }
+
+      await fetch(server.url);
+      const before = { hmr: await hmrRouteBundleIndex(), user: await userEcho("hello") };
+      server.reload(options(2));
+      const after = { hmr: await hmrRouteBundleIndex(), user: await userEcho("hello") };
+      console.log(JSON.stringify({ before, after }));
+      server.stop(true);
+    `,
+  });
+  const { stdout, stderr, exitCode } = await runServeFixture(dir);
+  expect({ stdout, exitCode }, stderr).toEqual({
+    stdout: JSON.stringify({
+      before: { hmr: 0, user: "user v1 got hello" },
+      after: { hmr: 0, user: "user v2 got hello" },
+    }),
+    exitCode: 0,
+  });
+});
+
 // process.chdir() leaves the cached top-level directory with a trailing slash,
 // which the dev server then used as its root. Reporting a bundle failure
 // relativizes the failing file against that root and hit a debug assertion

--- a/test/js/bun/websocket/websocket-server-reload-context-fixture.ts
+++ b/test/js/bun/websocket/websocket-server-reload-context-fixture.ts
@@ -1,0 +1,41 @@
+// Reloads a websocket-enabled server many times and prints the RSS growth
+// between the warmup and the end. Every ws() registration used to allocate a
+// uWS WebSocketContext that lived until the app was destroyed, so the growth
+// scaled with reloads * GET-capable routes.
+const rss =
+  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
+    ? Bun.unsafe.memoryFootprint
+    : process.memoryUsage.rss;
+const reloads = parseInt(process.env.RELOADS || "1000", 10);
+const warmup = parseInt(process.env.WARMUP || "100", 10);
+const routeCount = parseInt(process.env.ROUTES || "12", 10);
+
+const routes: Record<string, () => Response> = {};
+for (let i = 0; i < routeCount; i++) routes[`/r${i}/:id`] = () => new Response("r");
+
+const config = (i: number) => ({
+  port: 0,
+  hostname: "127.0.0.1",
+  routes,
+  fetch(req: Request, server: import("bun").Server) {
+    if (server.upgrade(req)) return;
+    return new Response("f" + i);
+  },
+  websocket: {
+    message(ws: import("bun").ServerWebSocket, message: string | Buffer) {
+      ws.send(message);
+    },
+  },
+});
+
+using server = Bun.serve(config(0));
+
+for (let i = 1; i <= warmup; i++) server.reload(config(i));
+Bun.gc(true);
+const baseline = rss();
+
+for (let i = 1; i <= reloads; i++) server.reload(config(i));
+Bun.gc(true);
+const final = rss();
+
+console.log(JSON.stringify({ reloads, routeCount, deltaMiB: Math.round(((final - baseline) / 1024 / 1024) * 10) / 10 }));

--- a/test/js/bun/websocket/websocket-server-reload-context-fixture.ts
+++ b/test/js/bun/websocket/websocket-server-reload-context-fixture.ts
@@ -6,8 +6,8 @@ const rss =
   process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
-const reloads = parseInt(process.env.RELOADS || "1000", 10);
-const warmup = parseInt(process.env.WARMUP || "100", 10);
+const reloads = parseInt(process.env.RELOADS || "600", 10);
+const warmup = parseInt(process.env.WARMUP || "200", 10);
 const routeCount = parseInt(process.env.ROUTES || "12", 10);
 
 const routes: Record<string, () => Response> = {};

--- a/test/js/bun/websocket/websocket-server-reload-leak.test.ts
+++ b/test/js/bun/websocket/websocket-server-reload-leak.test.ts
@@ -127,49 +127,50 @@ test("server.reload() applies the new websocket maxPayloadLength to sockets open
 // The per-route upgrade data (which route matched, its params) lives in the
 // HTTP route, not in the shared context, so every route still upgrades with
 // its own data, with or without the `/*` fallback, before and after a reload.
-test("websocket routes keep their own upgrade data on the shared context", async () => {
-  const config = (version: number, withFallback: boolean) => ({
-    port: 0,
-    routes: {
-      "/a/:name": (req: Bun.BunRequest<"/a/:name">, server: Bun.Server) =>
-        server.upgrade(req, { data: `a:${req.params.name}` }) ? undefined : new Response("no", { status: 500 }),
-      "/b/:name": (req: Bun.BunRequest<"/b/:name">, server: Bun.Server) =>
-        server.upgrade(req, { data: `b:${req.params.name}` }) ? undefined : new Response("no", { status: 500 }),
-    },
-    fetch: withFallback
-      ? (req: Request, server: Bun.Server) =>
-          server.upgrade(req, { data: "fallback" }) ? undefined : new Response("no", { status: 500 })
-      : undefined,
-    websocket: {
-      message(ws: Bun.ServerWebSocket<string>, message: string | Buffer) {
-        ws.send(`v${version} ${ws.data} ${message}`);
+test.each([true, false])(
+  "websocket routes keep their own upgrade data on the shared context (fallback: %p)",
+  async withFallback => {
+    const config = (version: number) => ({
+      port: 0,
+      routes: {
+        "/a/:name": (req: Bun.BunRequest<"/a/:name">, server: Bun.Server) =>
+          server.upgrade(req, { data: `a:${req.params.name}` }) ? undefined : new Response("no", { status: 500 }),
+        "/b/:name": (req: Bun.BunRequest<"/b/:name">, server: Bun.Server) =>
+          server.upgrade(req, { data: `b:${req.params.name}` }) ? undefined : new Response("no", { status: 500 }),
       },
-    },
-  });
+      fetch: withFallback
+        ? (req: Request, server: Bun.Server) =>
+            server.upgrade(req, { data: "fallback" }) ? undefined : new Response("no", { status: 500 })
+        : undefined,
+      websocket: {
+        message(ws: Bun.ServerWebSocket<string>, message: string | Buffer) {
+          ws.send(`v${version} ${ws.data} ${message}`);
+        },
+      },
+    });
 
-  const echo = (server: Bun.Server, path: string) => {
-    const { promise, resolve, reject } = Promise.withResolvers<string>();
-    const ws = new WebSocket(new URL(path, server.url));
-    ws.onerror = reject;
-    ws.onclose = event => reject(new Error(`closed ${event.code}`));
-    ws.onmessage = event => {
-      ws.onclose = null;
-      ws.close();
-      resolve(String(event.data));
+    const echo = (server: Bun.Server, path: string) => {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const ws = new WebSocket(new URL(path, server.url));
+      ws.onerror = reject;
+      ws.onclose = event => reject(new Error(`closed ${event.code}`));
+      ws.onmessage = event => {
+        ws.onclose = null;
+        ws.close();
+        resolve(String(event.data));
+      };
+      ws.onopen = () => ws.send("hi");
+      return promise;
     };
-    ws.onopen = () => ws.send("hi");
-    return promise;
-  };
 
-  for (const withFallback of [true, false]) {
-    using server = Bun.serve(config(1, withFallback));
+    using server = Bun.serve(config(1));
     const paths = withFallback ? ["/a/x", "/b/y", "/other"] : ["/a/x", "/b/y"];
     expect(await Promise.all(paths.map(path => echo(server, path)))).toEqual(
       withFallback ? ["v1 a:x hi", "v1 b:y hi", "v1 fallback hi"] : ["v1 a:x hi", "v1 b:y hi"],
     );
-    server.reload(config(2, withFallback));
+    server.reload(config(2));
     expect(await Promise.all(paths.map(path => echo(server, path)))).toEqual(
       withFallback ? ["v2 a:x hi", "v2 b:y hi", "v2 fallback hi"] : ["v2 a:x hi", "v2 b:y hi"],
     );
-  }
-});
+  },
+);

--- a/test/js/bun/websocket/websocket-server-reload-leak.test.ts
+++ b/test/js/bun/websocket/websocket-server-reload-leak.test.ts
@@ -70,12 +70,13 @@ test("server.reload() with websocket config lacking open/message does not leak p
 // more generation of contexts. Now the app keeps one context and each ws()
 // registration writes the behavior into it.
 test("server.reload() on a websocket-enabled server does not keep a WebSocketContext per reload", async () => {
-  // 1000 reloads of 12 routes keep about 15 MiB of contexts on bun 1.4.3, and
-  // 14 to 18 MiB on an ASAN build with the quarantine off. Fixed: about 1 MiB
-  // and 5 MiB.
+  // 600 reloads of 12 routes keep 7 to 9 MiB of contexts on bun 1.4.3. Fixed:
+  // 0 to 1 MiB, on release and on an ASAN build with the quarantine off.
+  // Each reload registers 13 websocket routes and an ASAN build spends about
+  // 1 ms on each, so the fixture runs for 10 to 15 s there.
   await expectRssDeltaBelow([join(import.meta.dir, "websocket-server-reload-context-fixture.ts")], {
-    release: 7,
-    debug: 10,
+    release: 4,
+    debug: 5,
   });
 }, 60_000);
 

--- a/test/js/bun/websocket/websocket-server-reload-leak.test.ts
+++ b/test/js/bun/websocket/websocket-server-reload-leak.test.ts
@@ -123,3 +123,53 @@ test("server.reload() applies the new websocket maxPayloadLength to sockets open
   expect(await ask(before, "small")).toBe("got 5 bytes");
   expect(await Promise.all([ask(before, big), ask(after, big)])).toEqual(["closed 1006", "closed 1006"]);
 });
+
+// The per-route upgrade data (which route matched, its params) lives in the
+// HTTP route, not in the shared context, so every route still upgrades with
+// its own data, with or without the `/*` fallback, before and after a reload.
+test("websocket routes keep their own upgrade data on the shared context", async () => {
+  const config = (version: number, withFallback: boolean) => ({
+    port: 0,
+    routes: {
+      "/a/:name": (req: Bun.BunRequest<"/a/:name">, server: Bun.Server) =>
+        server.upgrade(req, { data: `a:${req.params.name}` }) ? undefined : new Response("no", { status: 500 }),
+      "/b/:name": (req: Bun.BunRequest<"/b/:name">, server: Bun.Server) =>
+        server.upgrade(req, { data: `b:${req.params.name}` }) ? undefined : new Response("no", { status: 500 }),
+    },
+    fetch: withFallback
+      ? (req: Request, server: Bun.Server) =>
+          server.upgrade(req, { data: "fallback" }) ? undefined : new Response("no", { status: 500 })
+      : undefined,
+    websocket: {
+      message(ws: Bun.ServerWebSocket<string>, message: string | Buffer) {
+        ws.send(`v${version} ${ws.data} ${message}`);
+      },
+    },
+  });
+
+  const echo = (server: Bun.Server, path: string) => {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const ws = new WebSocket(new URL(path, server.url));
+    ws.onerror = reject;
+    ws.onclose = event => reject(new Error(`closed ${event.code}`));
+    ws.onmessage = event => {
+      ws.onclose = null;
+      ws.close();
+      resolve(String(event.data));
+    };
+    ws.onopen = () => ws.send("hi");
+    return promise;
+  };
+
+  for (const withFallback of [true, false]) {
+    using server = Bun.serve(config(1, withFallback));
+    const paths = withFallback ? ["/a/x", "/b/y", "/other"] : ["/a/x", "/b/y"];
+    expect(await Promise.all(paths.map(path => echo(server, path)))).toEqual(
+      withFallback ? ["v1 a:x hi", "v1 b:y hi", "v1 fallback hi"] : ["v1 a:x hi", "v1 b:y hi"],
+    );
+    server.reload(config(2, withFallback));
+    expect(await Promise.all(paths.map(path => echo(server, path)))).toEqual(
+      withFallback ? ["v2 a:x hi", "v2 b:y hi", "v2 fallback hi"] : ["v2 a:x hi", "v2 b:y hi"],
+    );
+  }
+});

--- a/test/js/bun/websocket/websocket-server-reload-leak.test.ts
+++ b/test/js/bun/websocket/websocket-server-reload-leak.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, expectRssDeltaBelow } from "harness";
+import { join } from "node:path";
 
 // server.reload({ websocket: { close() {} } }) — i.e. a websocket config
 // without `open` or `message` — is silently discarded by onReloadFromZig.
@@ -61,4 +62,63 @@ test("server.reload() with websocket config lacking open/message does not leak p
   // Without it, the delta should be a small constant independent of `iters`.
   expect(after - before).toBeLessThan(iters);
   expect(exitCode).toBe(0);
+});
+
+// Every ws() registration (the "/*" fallback plus each GET-capable callback
+// route) allocated a uWS WebSocketContext that the app only freed when it was
+// destroyed. So each server.reload() of a websocket-enabled server kept one
+// more generation of contexts. Now the app keeps one context and each ws()
+// registration writes the behavior into it.
+test("server.reload() on a websocket-enabled server does not keep a WebSocketContext per reload", async () => {
+  // 1000 reloads of 12 routes keep about 15 MiB of contexts on bun 1.4.3, and
+  // 14 to 18 MiB on an ASAN build with the quarantine off. Fixed: about 1 MiB
+  // and 5 MiB.
+  await expectRssDeltaBelow([join(import.meta.dir, "websocket-server-reload-context-fixture.ts")], {
+    release: 7,
+    debug: 10,
+  });
+}, 60_000);
+
+// With one shared context, the limits of the latest reload apply to sockets
+// that were open before it, like the handlers already did.
+test("server.reload() applies the new websocket maxPayloadLength to sockets opened before the reload", async () => {
+  const config = (maxPayloadLength: number) => ({
+    port: 0,
+    fetch(req: Request, server: Bun.Server) {
+      if (server.upgrade(req)) return;
+      return new Response("not a websocket", { status: 400 });
+    },
+    websocket: {
+      maxPayloadLength,
+      message(ws: Bun.ServerWebSocket, message: string | Buffer) {
+        ws.send(`got ${message.length} bytes`);
+      },
+    },
+  });
+  using server = Bun.serve(config(1 << 20));
+
+  const open = () => {
+    const { promise, resolve, reject } = Promise.withResolvers<WebSocket>();
+    const ws = new WebSocket(server.url);
+    ws.onopen = () => resolve(ws);
+    ws.onerror = reject;
+    return promise;
+  };
+  const ask = (ws: WebSocket, message: string) => {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    ws.onmessage = event => resolve(String(event.data));
+    ws.onclose = event => resolve(`closed ${event.code}`);
+    ws.send(message);
+    return promise;
+  };
+
+  const before = await open();
+  const big = Buffer.alloc(1000, "x").toString();
+  expect(await ask(before, big)).toBe("got 1000 bytes");
+
+  server.reload(config(64));
+  const after = await open();
+
+  expect(await ask(before, "small")).toBe("got 5 bytes");
+  expect(await Promise.all([ask(before, big), ask(after, big)])).toEqual(["closed 1006", "closed 1006"]);
 });


### PR DESCRIPTION
### Problem
- Every `server.reload()` of a websocket-enabled `Bun.serve` leaks memory, linearly, for the life of the server. On bun 1.4.3, 1000 reloads of a server with 12 callback routes keep about 15 MiB. A server with only `fetch` keeps about 1 KB per reload. `bun --hot` hits this on every save.
- The cause: `set_routes` (`src/runtime/server/mod.rs:2362`, `:2392`, `:2612`) calls `app.ws()` for the `/*` fallback and for every GET-capable callback route on each pass. uWS `TemplatedApp::ws()` (`packages/bun-uws/src/App.h:526`) created a new `WebSocketContext` and socket group per call and only freed them in `~TemplatedApp`. `clearRoutes()` drops the HTTP upgrade closures, not the contexts.

### Fix
- `ws()` takes a `sharedContextKey`. Calls with the same key share one `WebSocketContext`, created on the first call. Each call writes the behavior's handlers and limits into it. The per-route state (upgrade handler, user data) already lives in the HTTP route closure, which `clearRoutes()` drops. A null key keeps the old per-call context.
- `set_routes` keys every `ServerWebSocket` route on the server. The DevServer keys its `/_bun/hmr` route on itself, because it has its own behavior on the same app. A server keeps at most two contexts, whatever the reload count.
- Behavior change: sockets opened before a reload now get the limits of the latest reload (`maxPayloadLength`, `idleTimeout`, `perMessageDeflate` for new upgrades, and so on). They already got its handlers, because the handlers read the server's current config.
- Verified: `test/js/bun/websocket/websocket-server-reload-leak.test.ts` (RSS delta with the new fixture, fails on 1.4.3 with 15 MiB vs a 7 MiB bound, and the old-socket limit case) and a new HMR-plus-user-websocket case in `bun-serve-html.test.ts`. Also bun-serve-html, bun-serve-routes, bun-serve-ssl, websocket-server-upgrade-reentrant, websocket-server-stop-retained-ws and bake/dev/esm.

### Background
- A uWS `WebSocketContext` is a `us_socket_context` for upgraded sockets. It holds the handlers, the limits and a socket group. A socket upgraded into it stays in it until it closes, so a context can only be freed once its sockets are gone.
- In Bun the handlers in a context are trampolines that dispatch to the server's current JS handlers. Within one `set_routes` pass every `ws()` call gets the same behavior from `websocket.to_behavior()`.
- `server.reload()` runs `clear_routes()` then `set_routes()` (`on_reload_from_zig`, `src/runtime/server/server_body.rs`).

<details><summary>Notes</summary>

Measurements with `test/js/bun/websocket/websocket-server-reload-context-fixture.ts` (1000 reloads, 12 routes, RSS after `Bun.gc(true)`):

- bun 1.4.3 release: 15 MiB (12 to 13 MiB at 800 reloads).
- debug ASAN with the quarantine off, before: 14 to 18 MiB. After: 4 to 5 MiB (heap noise, not linear: 2000 reloads of 20 routes gave 2 MiB).

The 8-line repro from the report (`reload({ fetch })` 100k times on a server with `websocket`) plateaus after 40k reloads on the fixed debug build.

The first version of this change shared one context per app. That is wrong for a development server with an HTML route and a `websocket` option: the DevServer's `/_bun/hmr` route has its own behavior, and the user's `/*` route registered after it would have overwritten the handlers its sockets dispatch to. The explicit key keeps the two apart, and the new test in bun-serve-html.test.ts opens both socket kinds before and after a reload.

Freeing old contexts instead of sharing would need per-context socket counts and a retire list, and a deferred node:http upgrade holds a context pointer across ticks (`NodeHTTPResponse.upgrade_context`), so sharing is the smaller and safer change.
</details>
