### PR TITLE
FinalizationRegistry: drain the rest of a cleanup batch after a callback throws (WebKit bump)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "0bbbaad720e0ce2deef20022c1cbdad2786bbb9b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/test/js/bun/util/finalization-registry-throwing-callback.test.ts
+++ b/test/js/bun/util/finalization-registry-throwing-callback.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// JSC's JSFinalizationRegistry::runFinalizationCleanup stops at the first
+// cleanup callback that throws. Nothing re-armed the cleanup task until a
+// later GC noticed the registry still had dead holdings, so in an idle
+// process the rest of the batch never ran. V8 re-posts its cleanup task after
+// a throw; the fork does the same now.
+
+test("FinalizationRegistry cleanup reaches every dead holding without another GC when callbacks throw", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const ran = [];
+        let uncaught = 0;
+        process.on("uncaughtException", err => {
+          if (String(err?.message).startsWith("fr-")) uncaught++;
+        });
+        const registry = (globalThis.PINNED = new FinalizationRegistry(h => {
+          ran.push(h);
+          if (h % 2 === 0) throw new Error("fr-" + h);
+        }));
+        (function () {
+          for (let i = 0; i < 20; i++) registry.register({}, i);
+        })();
+        // Two collections (the second from another frame so the last
+        // registered target is not still held by a stack slot). After that no
+        // GC runs: only the cleanup task re-arming itself can reach the rest.
+        Bun.gc(true);
+        await new Promise(resolve => setImmediate(resolve));
+        Bun.gc(true);
+        for (let i = 0; i < 100 && ran.length < 20; i++) {
+          await new Promise(resolve => setImmediate(resolve));
+        }
+        ran.sort((a, b) => a - b);
+        console.log(JSON.stringify({ ran, uncaught, reachable: globalThis.PINNED === registry }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ ...JSON.parse(stdout.trim() || "{}"), stderr, signal: proc.signalCode }).toEqual({
+    ran: Array.from({ length: 20 }, (_, i) => i),
+    uncaught: 10,
+    reachable: true,
+    stderr: "",
+    signal: null,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- A `FinalizationRegistry` cleanup callback that throws stops the cleanup pass. `JSFinalizationRegistry::runFinalizationCleanup` returns on the exception and nothing schedules a task for the holdings still queued. Only the next collection that finds the registry with dead holdings does. A batch with N throwing callbacks takes N collections to drain. In an idle process the rest of the batch never runs.
- The throw itself is reported as `uncaughtException` since #37075. That part is fine. Node drains the rest without another GC: V8 re-posts its cleanup task after a throw.

### Fix
- oven-sh/WebKit#580 (this PR builds against its commit until it lands): on the throw path, if dead holdings remain and no task is scheduled, schedule another cleanup task. The GC-end path and the re-arm share one `scheduleCleanup()`.
- Here: the `WEBKIT_VERSION` bump and a test. No bun source changes. `runPendingWork` already reports the exception each task leaves.
- Verified: `test/js/bun/util/finalization-registry-throwing-callback.test.ts`. It pins a registry, registers 20 targets, collects, then idles on `setImmediate` with no further GC. With the pinned WebKit on main it stops at 2 callbacks and 1 `uncaughtException`. With the bump it reaches 20 and 10. Also `test-finalization-registry-shutdown.js` and `BUN_JSC_validateExceptionChecks=1` on the repro.

### Background
- JSC delivers cleanup through `DeferredWorkTimer`: one ticket and one task per registry. Bun's `JSCTaskScheduler::runPendingWork` runs the task from the event loop and reports any exception it leaves.
- `m_hasAlreadyScheduledWork` is the registry's one-task-at-a-time flag. The task clears it before the drain, so a re-arm from inside the drain is allowed. A GC that runs inside a callback can schedule first. The re-arm then sees the flag set and skips.

<details><summary>Notes</summary>

Repro from the report (bun main: `0ms:2 10ms:2 500ms:2 1500ms:6 2nd-gc:8 many-gc:20`, with the bump: `0ms:18 10ms:20 ...`, node v26: `0ms:2 10ms:20 ...`):

```js
const gc = globalThis.Bun ? () => Bun.gc(true) : globalThis.gc, sleep = (ms) => new Promise((r) => setTimeout(r, ms));
let ran = []; process.on("uncaughtException", () => {});
const r = (globalThis.PINNED = new FinalizationRegistry((h) => { ran.push(h); if (h % 2 === 0) throw new Error("fr-" + h); }));
(function () { for (let i = 0; i < 20; i++) r.register({}, i); })();
await sleep(0); gc(); const snap = [];
for (const ms of [0, 10, 500, 1500]) { await sleep(ms); snap.push(ms + "ms:" + ran.length); }
gc(); await sleep(10); snap.push("2nd-gc:" + ran.length);
for (let i = 0; i < 30 && ran.length < 20; i++) { gc(); await sleep(2); } snap.push("many-gc:" + ran.length);
console.log(snap.join(" "), "| registry reachable:", globalThis.PINNED === r);
```

Node does not drain the batch in one task. Measured per `setImmediate` tick on node v26.3.0 after one GC: `3/2 5/3 7/4 ... 20/10` (ran/uncaught), one task per throw. Bun with the bump reaches 20/10 in the first tick because the re-posted task is drained in the same event loop turn. The test asserts the eventual count, not the per-tick shape.

A first version fixed this on the bun side, in `runPendingWork`, by calling `runFinalizationCleanup` in a loop after each reported throw. Self-review: the invariant belongs in the engine file bun already patches, `#39994` rewrites that block, and the loop's "one task" shape was stricter than Node. Replaced by the fork change.

An earlier `const reg` repro that reported "cleaned=2 of 10" was the registry itself being collected: it had no use after registration, so the GC that followed the throw freed it with its queued holdings. The test pins the registry on `globalThis` and asserts it is still reachable at the end.

The first 8 cells of the registry's IsoSubspace and a stack slot can keep the last registered target alive across the first `Bun.gc(true)`. The test collects twice, the second time from another frame, then never again.
</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/util/finalization-registry-throwing-callback.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/util/finalization-registry-throwing-callback.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/util/finalization-registry-throwing-callback.test.ts:
(pass) FinalizationRegistry cleanup reaches every dead holding without another GC when callbacks throw [664.60ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [4.52s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 ...finalization-registry-throwing-callback.test.ts | 56 ++++++++++++++++++++++
 2 files changed, 57 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  0      0     13
…un/util/finalization-registry-throwing-callback.test.ts      0      6     13
```

</details>

<!-- robobun:evidence:end -->