### PR TITLE
sys: delete the displaced entry after move_file_z swaps it out

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8884,10 +8884,21 @@ pub fn exists(path: &[u8]) -> bool {
 /// [`renameat_concurrently_without_fallback`] (renameat2 NOREPLACE → EXCHANGE →
 /// delete-tree + rename); on EISDIR removes the dest dir and
 /// retries; on EXDEV falls back to the slow open+copy path. Only opens the
-/// source inside the EXDEV branch.
+/// source inside the EXDEV branch. On success nothing is left at `filename`:
+/// an EXCHANGE parks the old destination there, so it is deleted.
 pub fn move_file_z(from_dir: Fd, filename: &ZStr, to_dir: Fd, destination: &ZStr) -> Maybe<()> {
     match renameat_concurrently_without_fallback(from_dir, filename, to_dir, destination) {
-        Ok(()) => Ok(()),
+        Ok(RenameOutcome::Moved) => Ok(()),
+        Ok(RenameOutcome::Exchanged) => {
+            if unlinkat(from_dir, filename).is_err() {
+                let _ = if from_dir.is_valid() {
+                    Dir::borrow(&from_dir).delete_tree(filename.as_bytes())
+                } else {
+                    delete_tree_absolute(filename.as_bytes())
+                };
+            }
+            Ok(())
+        }
         // allow over-writing an empty directory
         Err(e) if e.get_errno() == E::EISDIR => {
             #[cfg(unix)]
@@ -8994,7 +9005,7 @@ pub fn renameat_concurrently(
     opts: RenameatConcurrentlyOptions,
 ) -> Maybe<()> {
     match renameat_concurrently_without_fallback(from_dir_fd, from, to_dir_fd, to) {
-        Ok(()) => Ok(()),
+        Ok(_) => Ok(()),
         Err(e) => {
             if opts.move_fallback && e.get_errno() == E::EXDEV {
                 bun_core::output::debug_warn(
@@ -9007,13 +9018,23 @@ pub fn renameat_concurrently(
     }
 }
 
+/// How [`renameat_concurrently_without_fallback`] published `from` at `to`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum RenameOutcome {
+    /// `from` no longer exists.
+    Moved,
+    /// `from` now holds the entry that was at `to`. Never produced on Windows.
+    #[cfg_attr(windows, allow(dead_code))]
+    Exchanged,
+}
+
 /// `renameatConcurrentlyWithoutFallback`.
 pub(crate) fn renameat_concurrently_without_fallback(
     from_dir_fd: Fd,
     from: &ZStr,
     to_dir_fd: Fd,
     to: &ZStr,
-) -> Maybe<()> {
+) -> Maybe<RenameOutcome> {
     'attempt: {
         {
             // Happy path: the folder doesn't exist in the cache dir, so we can
@@ -9055,7 +9076,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
                         },
                     ) {
                         Err(_) => {}
-                        Ok(()) => break 'attempt,
+                        Ok(()) => return Ok(RenameOutcome::Exchanged),
                     }
                 }
             }
@@ -9077,7 +9098,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
         }
     }
 
-    Ok(())
+    Ok(RenameOutcome::Moved)
 }
 
 /// `eventfd(initval, flags)` — kernel notification fd. Linux native (Android

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "path";
 
 test("coverage crash", () => {
@@ -696,4 +696,29 @@ test("calls second", () => {
   const record = lcov.split("end_of_record").find(r => r.includes("SF:subject.ts"));
   expect(record).toMatch(/FNF:2\nFNH:2\n/);
   expect(exitCode).toBe(0);
+});
+
+test("lcov reporter leaves no temp file behind when it replaces an existing report", async () => {
+  using dir = tempDir("cov-lcov-rerun", {
+    "lib.ts": `export const f = (x: number) => (x > 1 ? 1 : 2);`,
+    "c.test.ts": `import { expect, test } from "bun:test";
+import { f } from "./lib";
+test("c", () => {
+  expect(f(3)).toBe(1);
+});
+`,
+  });
+  for (let run = 0; run < 3; run++) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=lcov"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  }
+  expect(readdirSync(path.join(String(dir), "coverage"))).toEqual(["lcov.info"]);
 });


### PR DESCRIPTION
### Problem
- Every re-run of `bun test --coverage --coverage-reporter=lcov` leaves one `.lcov.info.<hex>.tmp` file in the coverage directory. The file holds the previous report. Four runs leave three of them. The same happens with `--coverage-dir`.
- The cause is `move_file_z` (`src/sys/lib.rs:8888`). It publishes the temp file with `renameat2(RENAME_NOREPLACE)`. When `lcov.info` exists that fails with `EEXIST`, so it falls back to `RENAME_EXCHANGE`. The exchange parks the old `lcov.info` under the temp name, and nothing removed it.

### Fix
- `renameat_concurrently_without_fallback` now returns `RenameOutcome::Moved` or `RenameOutcome::Exchanged` instead of `()`.
- After an exchange, `move_file_z` deletes the source name. It tries `unlinkat` first. If that fails (the displaced entry was a directory) it runs `delete_tree`. After a plain rename nothing is left at the source, so nothing changes there.
- `renameat_concurrently` (the install cache publisher) keeps its contract. #41579 handles its call sites, where the displaced entry needs a per-site decision.
- Verified: `test/cli/test/coverage.test.ts` (new test, stock bun fails with two leftover `.tmp` files). Also ran the rest of that file. `cargo check -p bun_sys` passes for Linux, `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.

### Background
- `renameat2(2)` with `RENAME_NOREPLACE` fails instead of replacing an existing destination. With `RENAME_EXCHANGE` it swaps the two names atomically, so the old destination survives under the source name.
- `move_file_z` is the "move this file over that path" helper. Three callers use it: the lcov writer, the `--compile` cross-target download (the temp dir is deleted afterwards), and `bun upgrade` (it renames the old binary aside first, so the destination is free). Only the lcov writer hits the exchange arm.
- On Windows there is no exchange, so `Exchanged` is never produced there.

<details><summary>Notes</summary>

Repro with bun 1.4.2:

```
echo 'export const f=(x:number)=>x>1?1:2' > lib.ts
printf 'import {test,expect} from "bun:test"; import {f} from "./lib"; test("c",()=>{expect(f(3)).toBe(1)})\n' > c.test.ts
for i in 1 2 3 4; do bun test --coverage --coverage-reporter=lcov >/dev/null 2>&1; done
ls -A coverage/    # lcov.info .lcov.info.<hex>.tmp x3
```

strace: `openat(".lcov.info.<hex>.tmp", O_WRONLY|O_CREAT|O_TRUNC)`, `renameat2(tmp, "lcov.info", RENAME_NOREPLACE) = EEXIST`, `renameat2(..., RENAME_EXCHANGE) = 0`, no `unlinkat`.

Also checked with the debug build: a directory with content at `coverage/lcov.info` is replaced by the report and the directory is removed, nothing is left behind.

The `bun_sys` unit tests do not link on their own on this machine (`cargo test -p bun_sys` fails in the linker before and after this change), so the existing `renameat_concurrently_does_not_close_caller_fd` test was checked with `cargo check` only.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/coverage.test.ts
bun test v1.4.3 (f42e98025)

test/cli/test/coverage.test.ts:
bun test v1.4.3 (f42e98025)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 1
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [317.00ms]
(pass) coverage crash [434.90ms]
bun test v1.4.3 (f42e98025)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [257.00ms]
(pass) lcov coverage reporter [323.30ms]
(pass) coverage excludes node_modules directory [355.04ms]
(pass) coveragePathIgnorePatterns - single pattern string [349.50ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [334.41ms]
(pass) coveragePathIgnorePatterns - array of patterns [332.90ms]
(pass) coveragePathIgnorePatterns - glob patterns [441.76ms]
(pass) coveragePathIgnorePatterns - lcov reporter [412.57ms]
(pass) cov
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/cli/test/coverage.test.ts:
bun test v1.4.3-canary.1 (f42e98025)

demo.test.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [13.00ms]
(pass) coverage crash [19.22ms]
bun test v1.4.3-canary.1 (f42e98025)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [7.00ms]
(pass) lcov coverage reporter [15.73ms]
(pass) coverage excludes node_modules directory [16.43ms]
(pass) coveragePathIgnorePatterns - single pattern string [14.82ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [32.07ms]
(pass) coveragePathIgnorePatterns - array of patterns [15.69ms]
(pass) coveragePathIgnorePatterns - glob patterns [8.30ms]
(pass) coveragePathIgnorePatterns - lcov reporter [8.11ms]
(pass) coveragePathIgnorePatterns - invalid config type [2.31ms]
(pass) coveragePathIgnorePatterns - invalid array item [2.18ms]
(pass) coveragePathIgnorePatterns - empty array [8.90ms]
(pass) coveragePathIgnorePatterns - ignore all files [8.13ms]
(pass) --parallel merges line coverage across workers [157.16ms]
(pass) --parallel merges function coverage across workers [65.73ms]
718 |     });
719 |     const [, stderr, exitCode] = await Promise.all(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/coverage.test.ts
bun test v1.4.3 (f42e98025)

test/cli/test/coverage.test.ts:
bun test v1.4.3 (f42e98025)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 1
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [289.00ms]
(pass) coverage crash [488.28ms]
bun test v1.4.3 (f42e98025)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [478.00ms]
(pass) lcov coverage reporter [676.08ms]
(pass) coverage excludes node_modules directory [454.98ms]
(pass) coveragePathIgnorePatterns - single pattern string [450.23ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [478.81ms]
(pass) coveragePathIgnorePatterns - array of patterns [422.17ms]
(pass) coveragePathIgnorePatterns - glob patterns [575.86ms]
(pass) coveragePathIgnorePatterns - lcov reporter [434.24ms]
(pass) cov
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 3857ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_which v0.0.0 (/workspace/bun/src/which)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn_sys)
[1m[92m   Compiling[0m bun_boringssl v0.0.0 (/workspace/bun/src/boringssl)
[1m[92m   Compiling[0m bun_glob v0.0.0 (/workspace/bun/src/glob)
[1m[92m   Compiling[0m bun_md v0.0.0 (/workspace/bun/src/md)
[1m[92m   Compiling[0m bun_dns v0.0.0 (/workspace/bun/src/dns)
[1m[92m   Compiling[0m bun_libarchive v0.0.0 (/workspace/bun/src/libarchive)
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_sha_hmac v0.0.0 (/workspace/bun/src/sha_hmac)
[1m[92m   Compiling[0m bun_uws v0.0.0 (/wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sys/lib.rs                 | 33 +++++++++++++++++++++++++++------
 test/cli/test/coverage.test.ts | 27 ++++++++++++++++++++++++++-
 2 files changed, 53 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/sys/lib.rs                      3      6      7
test/cli/test/coverage.test.ts      0      0      7
```

</details>

**root cause** · written by the author bot

When the lcov coverage reporter published a new report over an existing `lcov.info`, `move_file_z` used `renameat2` with `RENAME_EXCHANGE` after `NOREPLACE` failed, which atomically swapped the old report into the temp path and then left that displaced file behind because the rename helper returned no indication that an exchange had occurred. The fix has `renameat_concurrently_without_fallback` return a `RenameOutcome` (`Moved` or `Exchanged`), and `move_file_z` now unlinks the exchanged-out temp entry (falling back to a tree delete) whenever the exchange path was taken, so repeated coverag…

<!-- robobun:evidence:end -->