### PR TITLE
run: report tsconfig.json load errors before the entry point runs

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1421,6 +1421,17 @@ impl Run<'_> {
             }
         }
 
+        // VM setup already read the project root (`configure_linker`,
+        // `run_env_loader`). A tsconfig.json or package.json there that
+        // fails to parse is in the log now. Print it before the entry
+        // point runs: a rejected entry point exits below without reaching
+        // the end-of-run dump, and the parse error is the real cause of
+        // a `Cannot find module` for a `paths` alias.
+        if log_has_msgs(vm) {
+            dump_build_error(vm);
+            log_clear_msgs(vm);
+        }
+
         match vm.load_entry_point(entry) {
             Ok(promise) => {
                 // SAFETY: `promise` is a live GC cell returned by the module loader.

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1758,6 +1758,88 @@ describe("tsconfig paths skip `.d.ts` substitutions", () => {
   });
 });
 
+// A project-root tsconfig.json that cannot be loaded is reported before the
+// entry point runs. Before, the report was queued in the VM log and only
+// printed after a clean exit, so a `Cannot find module` for a `paths` alias
+// (the entry point rejects), a `process.exit()`, or a long-lived process
+// never showed the cause.
+describe("tsconfig.json load errors are reported before the entry point runs", () => {
+  // "compilerOptions"<ZWSP>: is what a web copy-paste produces.
+  const zwspTsconfig = `{\n  "compilerOptions"\u200b: { "paths": { "@m/*": ["./src/*"] } }\n}\n`;
+  const aliasFiles = {
+    "src/x.ts": `export const x = "via-alias";`,
+    "entry.ts": `import { x } from "@m/x";\nconsole.log("ALIAS-OK", x);`,
+  };
+
+  test.concurrent("a syntax error in tsconfig.json is printed before the alias failure", async () => {
+    using dir = tempDir("tsconfig-parse-error-alias", {
+      ...aliasFiles,
+      "tsconfig.json": zwspTsconfig,
+    });
+
+    const result = await runWildcardScript(String(dir), "entry.ts");
+    expect(result.stdout).toBe("");
+    const parseErrorAt = result.stderr.indexOf(`error: Expected ":" but found`);
+    const notFoundAt = result.stderr.indexOf(`Cannot find module '@m/x'`);
+    expect(parseErrorAt).toBeGreaterThanOrEqual(0);
+    expect(notFoundAt).toBeGreaterThan(parseErrorAt);
+    expect(result.stderr).toContain(`${join(realpathSync(String(dir)), "tsconfig.json")}:2:20`);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent("a syntax error in an `extends` base is printed", async () => {
+    using dir = tempDir("tsconfig-parse-error-extends", {
+      ...aliasFiles,
+      "tsconfig.json": JSON.stringify({ extends: "./base.json" }),
+      "base.json": zwspTsconfig,
+    });
+
+    const result = await runWildcardScript(String(dir), "entry.ts");
+    expect(result.stderr).toContain(`error: Expected ":" but found`);
+    expect(result.stderr).toContain(`${join(realpathSync(String(dir)), "base.json")}:2:20`);
+    expect(result.stderr).toContain(`Cannot find module '@m/x'`);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test.concurrent("the report is printed even when the script calls process.exit()", async () => {
+    using dir = tempDir("tsconfig-parse-error-exit", {
+      "tsconfig.json": zwspTsconfig,
+      "entry.ts": `console.log("ran"); process.exit(0);`,
+    });
+
+    const result = await runWildcardScript(String(dir), "entry.ts");
+    expect(result.stdout).toBe("ran");
+    expect(result.stderr).toContain(`error: Expected ":" but found`);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
+    "an unreadable tsconfig.json is reported with its errno",
+    async () => {
+      using dir = tempDir("tsconfig-eacces", {
+        ...aliasFiles,
+        "tsconfig.json": JSON.stringify({ compilerOptions: { paths: { "@m/*": ["./src/*"] } } }),
+      });
+      chmodSync(join(String(dir), "tsconfig.json"), 0o000);
+
+      const result = await runWildcardScript(String(dir), "entry.ts");
+      expect(result.stderr).toContain(`Cannot read file "${join(realpathSync(String(dir)), "tsconfig.json")}": EACCES`);
+      expect(result.stderr).toContain(`Cannot find module '@m/x'`);
+      expect(result.exitCode).toBe(1);
+    },
+  );
+
+  test.concurrent.skipIf(isWindows)("a dangling tsconfig.json symlink is reported", async () => {
+    using dir = tempDir("tsconfig-dangling-symlink", aliasFiles);
+    symlinkSync(join(String(dir), "missing.json"), join(String(dir), "tsconfig.json"));
+
+    const result = await runWildcardScript(String(dir), "entry.ts");
+    expect(result.stderr).toContain(`Cannot find tsconfig file "${join(realpathSync(String(dir)), "tsconfig.json")}"`);
+    expect(result.stderr).toContain(`Cannot find module '@m/x'`);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
 it.skipIf(isWindows)("runs a script from a working directory nested 256 directories deep", async () => {
   using dir = tempDir("resolver-deep-cwd", { ".keep": "" });
   const base = realpathSync(String(dir));


### PR DESCRIPTION
### Problem
- `bun run app.ts` prints only `error: Cannot find module '@m/x'` when the project `tsconfig.json` has a syntax error and the `paths` alias vanishes with it. `bun build` on the same project prints the real cause (`Expected ":" but found "..."` at `tsconfig.json:2:20`). The trigger in the report is a zero width space after a key. A NUL, a NEL byte, a plain syntax error, an unreadable file (EACCES), a dangling symlink, and a broken `extends` base behave the same.
- The cause is the timing of the log dump in `Run::start` (`src/runtime/cli/run_command.rs`). VM setup (`configure_linker`, `run_env_loader`) reads the project root and the resolver queues the report in the VM log. `bun run` prints that log only after the entry point settles (the `log_has_msgs` / `dump_build_error` calls after `promise.result`). A rejected entry point takes `exit_with_unhandled_note` first, so the report is lost. On a clean exit it prints after the program's own output. On `process.exit()` it never prints.

### Fix
- Flush the VM log once, right before `vm.load_entry_point(entry)`. Any report queued during VM setup reaches stderr before the entry point runs and before any module error it causes.
- This is the same dump the end-of-run path already uses (`dump_build_error` + `log_clear_msgs`). No message kind or format changes. The later dumps still run for anything queued during the run.
- Verified: `test/js/bun/resolve/resolve.test.ts`, block "tsconfig.json load errors are reported before the entry point runs" (5 tests: ZWSP syntax error, syntax error in an `extends` base, `process.exit()`, EACCES, dangling symlink). Stock bun fails the four that run as root. Also ran all of `resolve.test.ts`, `jsonc.test.ts`, `tsconfig-extends-leak.test.ts`, `test/cli/run/tsconfig-override.test.ts`, `run_command.test.ts`, `run-eval.test.ts`, `env.test.ts`.

### Background
- `VirtualMachine.log` is a process-lifetime `bun_ast::Log`. The resolver, transpiler, and linker write diagnostics there when no per-call log is swapped in.
- `Resolver::dir_info_uncached` parses `tsconfig.json` once per directory and caches it. A parse failure is logged with `ParseErrorAlreadyLogged`, and the directory is treated as having no tsconfig. Later lookups hit the cache and log nothing.
- During `import` resolution the VM swaps in a stack-local log (`resolve_maybe_needs_trailing_slash`) and keeps only the `Resolve` message. So a broken tsconfig first seen during a nested import is still dropped. This PR covers the project root, which is the case that controls `paths` for the whole project.

<details><summary>Notes</summary>

Reproduction with stock bun (1.4.2, canary):

```
printf 'import { x } from "@m/x";\nconsole.log("ALIAS-OK", x);\n' > app.ts
printf '{\n  "compilerOptions"\xe2\x80\x8b: { "paths": { "@m/*": ["./src/*"] } }\n}\n' > tsconfig.json
bun run app.ts      # error: Cannot find module '@m/x' from '.../app.ts'   (nothing else)
bun build app.ts    # error: Expected ":" but found "..." at tsconfig.json:2:20
```

With a script that succeeds, stock bun prints the tsconfig error after the program's output. With `process.exit(0)` it prints nothing. With this change the report is the first thing on stderr in all three cases, and the `moduleSuffixes is not supported yet` warning moves to the front too.

Not covered here: `extends` targets that do not exist, a package `extends` that is not installed, and a cyclic `extends`. Those never queue a message, on any path including `bun build`. The raw invisible character in `found "..."` is also unchanged.

The EACCES test skips when the test runs as root (root reads a mode 000 file). It was checked by hand as `nobody`: stock bun prints only `Cannot find module`, this branch prints `Cannot read file ".../tsconfig.json": EACCES` first.

`test/cli/run/env.test.ts` > "a worker in a compiled executable" times out at 5 s on this machine with and without this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->