### PR TITLE
ini: cut unquoted .npmrc values at the first unescaped comment char

### DIFF
--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -631,7 +631,14 @@ mod draft {
                                 }
                                 unesc.push(b'$');
                             }
-                            b';' | b'#' => break,
+                            b';' | b'#' => {
+                                // npm/ini cuts the value at the first unescaped
+                                // comment char and trims the rest.
+                                let kept = bun_core::trim_right(&unesc, b" \n\r\t").len();
+                                unesc.truncate(kept);
+                                did_any_escape = true;
+                                break;
+                            }
                             b'\\' => {
                                 esc = true;
                                 did_any_escape = true;

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -550,6 +550,23 @@ registry=https://somehost.com/org1/npm/registry/
     expect(result.default_registry_token).toBe("");
   });
 
+  test("inline comments after a value do not become part of the registry URL or token", () => {
+    // npm/ini cuts an unquoted value at the first unescaped `;` or `#`.
+    // With the comment left in, the registry URL no longer matched its `//host/` credential.
+    const ini = `
+registry=http://127.0.0.1:4873/ ; default registry
+//127.0.0.1:4873/:_authToken=SECRET # token
+`;
+    const result = loadNpmrc(ini);
+    expect(result).toEqual({
+      default_registry_url: "http://127.0.0.1:4873/",
+      default_registry_token: "SECRET",
+      default_registry_username: "",
+      default_registry_password: "",
+      default_registry_email: "",
+    });
+  });
+
   describe("credentials keyed to a bracketed IPv6 host", () => {
     // The `//` is stripped off the key before it is parsed as a URL, leaving
     // `[::1]:4873/`. A leading `[` used to parse to an empty host, so these keys

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -404,6 +404,32 @@ bar = 'baz'
     });
   });
 
+  test("inline comments are cut from unquoted values, keys and sections", () => {
+    // npm/ini cuts an unquoted value at the first unescaped `;` or `#` and
+    // trims what is left. An escaped comment char stays in the value.
+    const ini = /* ini */ `
+a = hello ; comment
+b = world # comment
+c = x\\;y ; z
+d = foo#bar
+e ; comment = v
+[sec ; comment]
+f = 1
+[x.y # comment]
+g = 2
+`;
+
+    expect(parse(ini)).toEqual({
+      a: "hello",
+      b: "world",
+      c: "x;y",
+      d: "foo",
+      e: "v",
+      sec: { f: "1" },
+      x: { y: { g: "2" } },
+    });
+  });
+
   test("key and then section edgecase", () => {
     const ini = /* ini */ `
 foo = 'hihihi'


### PR DESCRIPTION
### Problem
- The .npmrc parser keeps an inline comment in an unquoted value. `registry=http://127.0.0.1:4873/ ; comment` gives the registry URL `http://127.0.0.1:4873/ ; comment`. The `//127.0.0.1:4873/:_authToken` line on the next line then never matches the registry, so the token is dropped.
- The cause is in `Parser::prepare_str` (`src/ini/lib.rs:634`). The walk stops at the first unescaped `;` or `#`, but it does not set `did_any_escape`. The `Value` and `Key` tails then return the full input `val` instead of the cut buffer `unesc`. The `Section` tail uses `unesc` but keeps the trailing space before the comment (`[sec ; c]` becomes `"sec "`).

### Fix
- On an unescaped `;` or `#`, trim trailing whitespace from `unesc`, set `did_any_escape`, and stop the walk. Every tail then returns the cut value.
- This is what npm's bundled `ini` (6.0.0) does: it cuts at the first unescaped comment char and returns `unesc.trim()`. Escaped `\;` and `\#` are unchanged. Quoted values are unchanged because they never reach this branch.
- Verified: `test/js/bun/ini/ini.test.ts` (new test: values, keys, and sections with inline comments) and `test/cli/install/npmrc.test.ts` (new test: registry URL and token with inline comments). Both new tests fail on bun 1.4.3 and pass with this change. Both files pass in full.

### Background
- `src/ini/lib.rs` is bun's port of npm's `ini` package. `bun install` reads `.npmrc` through it. `prepare_str` unescapes one key, value, or section name.
- An unquoted value in the ini format ends at the first `;` or `#` that is not escaped with a backslash. The rest of the line is a comment.
- `did_any_escape` is the flag that tells the tail of `prepare_str` to return the rebuilt `unesc` buffer instead of the original slice. A comment cut is one more reason to use the buffer.

<details><summary>Notes</summary>

Edge cases checked against `node_modules/npm/node_modules/ini` 6.0.0, same output for both:

```
a = ; c        -> ""
b = x\ ; c     -> "x\\"
c = \;         -> ";"
d = 'q ; not'  -> "q ; not"
e = ${X} ; c   -> "${X}"  (X unset)
f=\            -> "\\"
e ; comment = v -> key "e"
[x.y # comment] -> nested section x.y
```

The trim uses the same byte set as the initial trim at the top of `prepare_str` (space, newline, CR, tab).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/npmrc.test.ts test/js/bun/ini/ini.test.ts
bun test v1.4.3 (f42e98025)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_IhG2Qu/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [280.34ms]
package dir /tmp/verdaccio-test-_oZBBAl
bun install v1.4.3 (f42e98025)
No packages! Deleted empty lockfile

[159.00ms] done
(pass) npmrc > works with empty file [328.47ms]
package dir /tmp/verdaccio-test-_dWZQ1U
bun install v1.4.3 (f42e98025)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [193.00ms]
(pass) npmrc > sets default registry [344.30ms]
bun install v1.4.3 (f42e98025)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [214.00ms]
(pass) npmrc > sets scoped registry [347.75ms]
package dir /tmp/verdaccio-test-_1OfZvW
home dir /tmp/verdaccio-test-_1OfZvW/home_dir
bun install v1.4.3 (f42e98025)
Saved lockfile

+ no-deps@1.0.0 (v2.
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_DXXz8P/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [5.14ms]
package dir /tmp/verdaccio-test-_RHz15s
bun install v1.4.3-canary.1 (f42e98025)
No packages! Deleted empty lockfile

[11.00ms] done
(pass) npmrc > works with empty file [24.94ms]
package dir /tmp/verdaccio-test-_J1WMh2
bun install v1.4.3-canary.1 (f42e98025)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [60.00ms]
(pass) npmrc > sets default registry [68.66ms]
bun install v1.4.3-canary.1 (f42e98025)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [15.00ms]
(pass) npmrc > sets scoped registry [18.93ms]
package dir /tmp/verdaccio-test-_ADiFaS
home dir /tmp/verdaccio-test-_ADiFaS/home_dir
bun install v1.4.3-canary.1 (f42e98025)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [16.00ms]
(pass) npmrc > works with home config [20.76ms]
package dir /tmp/verdaccio-test-_IrDI20
home dir /tmp/verdac
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/npmrc.test.ts test/js/bun/ini/ini.test.ts
bun test v1.4.3 (f42e98025)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_idbE05/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [291.74ms]
package dir /tmp/verdaccio-test-_KHlYG7
bun install v1.4.3 (f42e98025)
No packages! Deleted empty lockfile

[85.00ms] done
(pass) npmrc > works with empty file [401.55ms]
package dir /tmp/verdaccio-test-_aH3bhC
bun install v1.4.3 (f42e98025)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [133.00ms]
(pass) npmrc > sets default registry [230.86ms]
bun install v1.4.3 (f42e98025)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [173.00ms]
(pass) npmrc > sets scoped registry [311.91ms]
package dir /tmp/verdaccio-test-_4XyN8L
home dir /tmp/verdaccio-test-_4XyN8L/home_dir
bun install v1.4.3 (f42e98025)
Saved lockfile

+ no-deps@1.0.0 (v2.0
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 4844ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/10] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ini/lib.rs                 |  9 ++++++++-
 test/cli/install/npmrc.test.ts | 17 +++++++++++++++++
 test/js/bun/ini/ini.test.ts    | 26 ++++++++++++++++++++++++++
 3 files changed, 51 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/ini/lib.rs                      1      1      8
test/cli/install/npmrc.test.ts      1      1      7
test/js/bun/ini/ini.test.ts         1      2      7
```

</details>

**root cause** · written by the author bot

In the unquoted branch of Parser::prepare_str, reaching an unescaped `;` or `#` broke out of the scan loop without setting did_any_escape, so the Usage::Value and Usage::Key tails returned the raw input slice with the inline comment still attached instead of the truncated unesc buffer. The fix trims trailing whitespace from unesc at the comment character, sets did_any_escape, and then breaks, so every usage path commits the cut and trimmed buffer, matching npm's ini behavior.

<!-- robobun:evidence:end -->