### PR TITLE
Bun.write: handle an O_APPEND destination fd

### DIFF
--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -19,8 +19,6 @@ use bun_sys::windows::libuv;
 use bun_sys::{self, Fd, FdExt, Mode, SystemError};
 #[cfg(windows)]
 use bun_sys_jsc::ErrorJsc as _;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use core::ffi::c_int;
 #[cfg(windows)]
 use core::ffi::c_void;
 use core::marker::ConstParamTy;
@@ -340,9 +338,7 @@ impl CopyFile {
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub(crate) fn do_copy_file_range<const USE: TryWith, const CLEAR_APPEND_IF_INVALID: bool>(
-        &mut self,
-    ) -> Result<(), crate::Error> {
+    pub(crate) fn do_copy_file_range<const USE: TryWith>(&mut self) -> Result<(), crate::Error> {
         use bun_sys::linux;
 
         let mut remain: usize = self.max_length as usize;
@@ -367,11 +363,23 @@ impl CopyFile {
             unsafe { *read_len_slot = *total_written_slot as SizeType };
         }
 
-        let mut has_unset_append = false;
-
         // If they can't use copy_file_range, they probably also can't
         // use sendfile() or splice()
         if !bun_sys::copy_file::can_use_copy_file_range_syscall() {
+            return self.fallback_read_write(remain, unknown_size, &mut total_written);
+        }
+
+        // copy_file_range(2), sendfile(2) and splice(2) refuse a destination
+        // whose open file description has O_APPEND (EBADF or EINVAL). Bun
+        // never opens its own destination that way, but an inherited fd can
+        // carry it: `bun x.js >> log`, a GNU make recipe, `fs.openSync(p, "a")`.
+        // The description is shared with the parent, so the flag must stay.
+        if matches!(
+            self.destination_file_store.pathlike,
+            PathOrFileDescriptor::Fd(_)
+        ) && bun_sys::get_fcntl_flags(dest_fd)
+            .is_ok_and(|flags| flags as i32 & bun_sys::O::APPEND != 0)
+        {
             return self.fallback_read_write(remain, unknown_size, &mut total_written);
         }
 
@@ -431,29 +439,6 @@ impl CopyFile {
                 // EINVAL: eCryptfs and other filesystems may not support copy_file_range.
                 // Also returned when the file descriptor is incompatible with the syscall.
                 bun_sys::E::EINVAL => {
-                    if CLEAR_APPEND_IF_INVALID {
-                        if !has_unset_append {
-                            // https://kylelaker.com/2018/08/31/stdout-oappend.html
-                            // make() can set STDOUT / STDERR to O_APPEND
-                            // this messes up sendfile()
-                            has_unset_append = true;
-                            // SAFETY: dest_fd is a valid open fd; raw fcntl(2).
-                            let flags =
-                                unsafe { libc::fcntl(dest_fd.native(), libc::F_GETFL, 0 as c_int) };
-                            if (flags & bun_sys::O::APPEND) != 0 {
-                                // SAFETY: dest_fd is a valid open fd; raw fcntl(2).
-                                let _ = unsafe {
-                                    libc::fcntl(
-                                        dest_fd.native(),
-                                        libc::F_SETFL,
-                                        flags ^ bun_sys::O::APPEND,
-                                    )
-                                };
-                                continue;
-                            }
-                        }
-                    }
-
                     // If the Linux machine doesn't support
                     // copy_file_range or the file descriptor is
                     // incompatible with the chosen syscall, fall back
@@ -820,12 +805,7 @@ impl CopyFile {
                     && (bun_sys::S::ISREG(self.destination_file_store.mode as _)
                         || self.destination_file_store.mode == 0)
                 {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
-                        let _ = self.do_copy_file_range::<{ TryWith::CopyFileRange }, true>();
-                    } else {
-                        let _ = self.do_copy_file_range::<{ TryWith::CopyFileRange }, false>();
-                    }
-
+                    let _ = self.do_copy_file_range::<{ TryWith::CopyFileRange }>();
                     self.do_close();
                     return;
                 }
@@ -834,12 +814,7 @@ impl CopyFile {
                 if bun_sys::S::ISFIFO(stat.st_mode as _)
                     && bun_sys::S::ISFIFO(self.destination_file_store.mode as _)
                 {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
-                        let _ = self.do_copy_file_range::<{ TryWith::Splice }, true>();
-                    } else {
-                        let _ = self.do_copy_file_range::<{ TryWith::Splice }, false>();
-                    }
-
+                    let _ = self.do_copy_file_range::<{ TryWith::Splice }>();
                     self.do_close();
                     return;
                 }
@@ -848,12 +823,7 @@ impl CopyFile {
                     || bun_sys::S::ISCHR(stat.st_mode as _)
                     || bun_sys::S::ISSOCK(stat.st_mode as _)
                 {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
-                        let _ = self.do_copy_file_range::<{ TryWith::Sendfile }, true>();
-                    } else {
-                        let _ = self.do_copy_file_range::<{ TryWith::Sendfile }, false>();
-                    }
-
+                    let _ = self.do_copy_file_range::<{ TryWith::Sendfile }>();
                     self.do_close();
                     return;
                 }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -411,6 +411,16 @@ impl WriteFile {
             .is_path()
     }
 
+    /// Preallocating grows the file from offset 0. A caller's fd opened
+    /// O_APPEND (`>> log`, `fs.openSync(p, "a")`) writes after the grown end,
+    /// which leaves a hole of NUL bytes before the data. Bun opens its own
+    /// destination with O_TRUNC, so only a caller's fd can append.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn appends_to_caller_fd(&self, fd: Fd) -> bool {
+        !self.is_allowed_to_close()
+            && sys::get_fcntl_flags(fd).is_ok_and(|flags| flags as i32 & sys::O::APPEND != 0)
+    }
+
     #[cfg(not(windows))]
     fn on_finish(&mut self) {
         bun_output::scoped_log!(WriteFile, "WriteFile.onFinish()");
@@ -473,7 +483,10 @@ impl WriteFile {
             // We only do this on Linux because the equivalent on macOS
             // seemed to have zero performance impact in
             // microbenchmarks.
-            if !self.could_block && self.bytes_blob.shared_view().len() > 1024 {
+            if !self.could_block
+                && self.bytes_blob.shared_view().len() > 1024
+                && !self.appends_to_caller_fd(fd)
+            {
                 let _ = sys::preallocate_file(
                     fd.native(),
                     0,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -7,6 +7,7 @@ import {
   exampleSite,
   gcTick,
   isASAN,
+  isLinux,
   isWindows,
   tempDir,
   withoutAggressiveGC,
@@ -511,6 +512,121 @@ const IS_UV_FS_COPYFILE_DISABLED =
         head: "AAAAAAAAAASSSSS",
         size: 10 + size,
       });
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  // copy_file_range(2) and sendfile(2) reject a destination whose open file
+  // description has O_APPEND (EBADF / EINVAL). `>> log`, a GNU make recipe
+  // and fs.openSync(p, "a") all hand Bun such a destination.
+  describe.skipIf(isWindows)("Bun.write(dest, Bun.file(src)) with an O_APPEND destination", () => {
+    it("appends to stdout redirected with >>", async () => {
+      using dir = tempDir("bun-write-stdout-append-cfr", {
+        "src.txt": "file-content\n",
+        "log.txt": "header\n",
+      });
+      const src = join(String(dir), "src.txt");
+      const log = join(String(dir), "log.txt");
+      const script = `process.stderr.write(String(await Bun.write(Bun.stdout, Bun.file(${JSON.stringify(src)}))))`;
+
+      await using proc = Bun.spawn({
+        cmd: ["sh", "-c", `"$BUN" -e ${JSON.stringify(script)} >> ${JSON.stringify(log)}`],
+        env: { ...bunEnv, BUN: bunExe() },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, resolved: stderr, content: fs.readFileSync(log, "utf8") }).toEqual({
+        stdout: "",
+        resolved: "13",
+        content: "header\nfile-content\n",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    it("appends to an fd opened with 'a' and 'a+'", async () => {
+      using dir = tempDir("bun-write-fd-append-cfr", {
+        "src.txt": "payload\n",
+        "log.txt": "header\n",
+      });
+      const src = join(String(dir), "src.txt");
+      const log = join(String(dir), "log.txt");
+      const script = `
+        const fs = require("fs");
+        const out = [];
+        for (const flag of ["a", "a+"]) {
+          const fd = fs.openSync(${JSON.stringify(log)}, flag);
+          try {
+            out.push(await Bun.write(Bun.file(fd), Bun.file(${JSON.stringify(src)})));
+          } finally { fs.closeSync(fd); }
+        }
+        process.stdout.write(JSON.stringify(out));
+      `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, content: fs.readFileSync(log, "utf8") }).toEqual({
+        stdout: "[8,8]",
+        stderr: "",
+        content: "header\npayload\npayload\n",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    it("appends a string above the preallocate threshold to stdout redirected with >>", async () => {
+      using dir = tempDir("bun-write-stdout-append-string", { "log.txt": "header\n" });
+      const log = join(String(dir), "log.txt");
+      const size = 4000;
+      const script = `process.stderr.write(String(await Bun.write(Bun.stdout, Buffer.alloc(${size}, "y").toString() + "\\n")))`;
+
+      await using proc = Bun.spawn({
+        cmd: ["sh", "-c", `"$BUN" -e ${JSON.stringify(script)} >> ${JSON.stringify(log)}`],
+        env: { ...bunEnv, BUN: bunExe() },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, resolved: stderr, content: fs.readFileSync(log, "utf8") }).toEqual({
+        stdout: "",
+        resolved: String(size + 1),
+        content: "header\n" + Buffer.alloc(size, "y").toString() + "\n",
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    // A GNU make recipe on a terminal gets a tty stdout with O_APPEND. The
+    // description is shared with the parent shell, so Bun must not clear it.
+    it.skipIf(!isLinux)("keeps O_APPEND on an inherited tty description", async () => {
+      using dir = tempDir("bun-write-tty-append-flag", { "src.txt": "payload\n" });
+      const src = join(String(dir), "src.txt");
+      const flags = "grep flags /proc/$$/fdinfo/1 | tr -d '\\t'";
+      const sh = [
+        "exec 1>>/dev/tty",
+        `before=$(${flags})`,
+        `"$BUN" -e 'await Bun.write(Bun.stdout, Bun.file(${JSON.stringify(src)}))'`,
+        `echo "rc=$? before=$before after=$(${flags})" >&2`,
+      ].join("; ");
+      let output = "";
+      await using proc = Bun.spawn({
+        cmd: ["sh", "-c", sh],
+        env: { ...bunEnv, BUN: bunExe() },
+        terminal: {
+          data(_, chunk) {
+            output += chunk.toString();
+          },
+        },
+      });
+      const exitCode = await proc.exited;
+
+      const [, rc, before, after] = /rc=(\d+) before=flags:(\d+) after=flags:(\d+)/.exec(output) ?? [];
+      expect({ output: output.replace(/\r/g, ""), rc, appendBefore: Number(`0o${before}`) & 0o2000 }).toEqual({
+        output: "payload\n" + `rc=0 before=flags:${before} after=flags:${before}\n`,
+        rc: "0",
+        appendBefore: 0o2000,
+      });
+      expect(after).toBe(before);
       expect(exitCode).toBe(0);
     });
   });


### PR DESCRIPTION
### Problem
- `Bun.write(Bun.stdout, Bun.file(p))` rejects with `EBADF: bad file descriptor, copy_file_range` when stdout is a regular file with O_APPEND: `bun x.js >> log`, `2>> log`, every `>` redirect in a GNU make recipe. `Bun.write(Bun.file(fd), Bun.file(p))` rejects the same way for an fd from `fs.openSync(p, "a")`. `copy_file_range(2)` and `sendfile(2)` document this for an O_APPEND destination. `do_copy_file_range` (`src/runtime/webcore/blob/copy_file.rs:420`) treated the EBADF as fatal.
- On a tty destination with O_APPEND (a make recipe on a terminal) `sendfile` returned EINVAL and the `CLEAR_APPEND_IF_INVALID` branch ran `fcntl(F_SETFL, flags ^ O_APPEND)` on the open file description. That description is shared with the parent shell and make, and the flag was never restored.
- For a string or Blob source above 1 KiB, `write_file.rs:476` called `fallocate(fd, 0, 0, len)` on the caller's O_APPEND fd. The append then landed after the grown end, so the log got a block of NUL bytes before the data.

### Fix
- Before the kernel copy, read `F_GETFL` on a destination that is a caller's fd (`PathOrFileDescriptor::Fd`). If O_APPEND is set, use the existing `fallback_read_write` loop. `write(2)` honours O_APPEND. Bun opens its own path destinations with `O_TRUNC | O_WRONLY | O_CREAT`, so those are not checked.
- Remove the `CLEAR_APPEND_IF_INVALID` const generic, the `has_unset_append` state and the `is_atty` branching at the three call sites. Bun no longer changes flags on a description it did not open.
- `WriteFile::run_with_fd` skips the preallocate when the caller's fd has O_APPEND, with the same check `node_fs.rs` already makes for `fs.writeFile(fd)`.
- Verified: `test/js/bun/io/bun-write.test.js` (four new tests: `>>` with a file source, `'a'` and `'a+'` fds, a string source above the preallocate threshold, and a pty whose `/proc/$$/fdinfo` flags must not change). All four fail on the shipped binary. Also ran `bun-stdin-slice.test.ts`, `blob.test.ts`, `streams.test.js`, `filesink.test.ts`, `bun-serve-file.test.ts`.

### Background
- `Bun.write(dest, Bun.file(src))` with a regular-file source runs `CopyFile` on the work pool. On Linux it picks `copy_file_range` for a regular-file destination, `splice` for a FIFO, and `sendfile` for a char device or socket. `fallback_read_write` is the plain `read`/`write` loop that already serves ENOSYS, EXDEV and ENOTSUP.
- An open file description is the kernel object behind an fd. `dup` and `fork` share it, so a child that changes its status flags with `F_SETFL` changes them for the parent too. GNU make sets O_APPEND on the stdout it hands to recipes.
- `Bun.write(dest, string)` runs `WriteFile`. On Linux it preallocates the destination with `fallocate` before the write loop, which grows the file to the payload length from offset 0.

<details><summary>Notes</summary>

Repro on the shipped binary (1.4.3 canary):

```
echo 'file-content' > src.txt
echo 'await Bun.write(Bun.stdout, Bun.file("src.txt"))' > cat.mjs
bun cat.mjs >  log1   # rc=0
bun cat.mjs >> log2   # EBADF: bad file descriptor, copy_file_range, rc=1, log2 empty
printf 'all:\n\t@bun cat.mjs\n' > Makefile; make > build.log   # rc=2, same error
```

strace: `copy_file_range(7, NULL, 1, NULL, 13, 0) = -1 EBADF`.

The tty case: a pty slave with O_APPEND set, `F_GETFL` before `02002`, after bun exits `02`. With this change the flags stay `02002`.

The string case: `printf 'header\n' > log; bun -e 'await Bun.write(Bun.stdout, "y".repeat(4000)+"\n")' >> log` wrote 8002 bytes with 3994 NUL bytes. Now 4008 bytes, no NUL.

Self-reviewed: one concern raised (the preallocate hole for memory sources on the same O_APPEND fd), addressed in this PR.

The whole `bun-write.test.js` file is `describe.concurrent`. On a slow debug build some of its tests hit the 5 s limit under load, on main as well as on this branch. The new tests pass alone and together with their neighbours.
</details>
