### PR TITLE
pm: honor --dry-run on cache rm, migrate, pkg and trust, and --ignore-scripts on trust

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -371,7 +371,7 @@ Options for the `trust` command:
 
 - `--all`: Trust all untrusted dependencies.
 - `--dry-run`: Print the scripts that would run. Run nothing and write nothing.
-- `--ignore-scripts`: Add the packages to `trustedDependencies` without running their scripts. The next `bun install` runs them.
+- `--ignore-scripts`: Add the packages to `trustedDependencies` in `package.json` without running their scripts. The next `bun install` runs them and updates the lockfile.
 
 ## default-trusted
 

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -332,6 +332,8 @@ To clear Bun's global module cache:
 bun pm cache rm
 ```
 
+With `--dry-run`, `bun pm cache rm` prints what it would clear and deletes nothing.
+
 ## migrate
 
 To migrate another package manager's lockfile without installing anything:
@@ -339,6 +341,8 @@ To migrate another package manager's lockfile without installing anything:
 ```bash terminal icon="terminal"
 bun pm migrate
 ```
+
+With `--dry-run`, `bun pm migrate` reads the other lockfile but does not write `bun.lock`.
 
 ## untrusted
 
@@ -366,6 +370,8 @@ bun pm trust <names>
 Options for the `trust` command:
 
 - `--all`: Trust all untrusted dependencies.
+- `--dry-run`: Print the scripts that would run. Run nothing and write nothing.
+- `--ignore-scripts`: Add the packages to `trustedDependencies` without running their scripts. The next `bun install` runs them.
 
 ## default-trusted
 
@@ -428,6 +434,8 @@ Supports `patch`, `minor`, `major`, `premajor`, `preminor`, `prepatch`, `prerele
 ## pkg
 
 Manage `package.json` data with get, set, delete, and fix operations.
+
+With `--dry-run`, `set`, `delete`, and `fix` print the resulting `package.json` and do not write it.
 
 All commands support dot and bracket notation:
 

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -371,7 +371,7 @@ Options for the `trust` command:
 
 - `--all`: Trust all untrusted dependencies.
 - `--dry-run`: Print the scripts that would run. Run nothing and write nothing.
-- `--ignore-scripts`: Add the packages to `trustedDependencies` in `package.json` without running their scripts. The next `bun install` runs them and updates the lockfile.
+- `--ignore-scripts`: Add the packages to `trustedDependencies` in `package.json` without running their scripts. The next `bun install` runs them and updates the lockfile. Only the flag does this. `ignoreScripts` in `bunfig.toml` or `.npmrc` does not stop `bun pm trust` from running the scripts you name.
 
 ## default-trusted
 

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -941,8 +941,7 @@ pub fn install_with_manager(
     // It's unnecessary work to re-save the lockfile if there are no changes.
     // A loaded text lockfile is never re-saved just to bump its version: an
     // existing `bun.lock` keeps the version it was written with.
-    let should_save_lockfile = (saves_migrated_lockfile(&load_result, save_format)
-        && !manager.options.dry_run)
+    let should_save_lockfile = saves_migrated_lockfile(&load_result, save_format)
         // check `save_lockfile` after checking if loaded from binary and save format is text
         // because `save_lockfile` is set to false for `--frozen-lockfile`
         || (manager.options.do_.save_lockfile()

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -941,7 +941,8 @@ pub fn install_with_manager(
     // It's unnecessary work to re-save the lockfile if there are no changes.
     // A loaded text lockfile is never re-saved just to bump its version: an
     // existing `bun.lock` keeps the version it was written with.
-    let should_save_lockfile = saves_migrated_lockfile(&load_result, save_format)
+    let should_save_lockfile = (saves_migrated_lockfile(&load_result, save_format)
+        && !manager.options.dry_run)
         // check `save_lockfile` after checking if loaded from binary and save format is text
         // because `save_lockfile` is set to false for `--frozen-lockfile`
         || (manager.options.do_.save_lockfile()

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -309,7 +309,7 @@ pub enum LockfileFormat {
 }
 
 impl LockfileFormat {
-    pub(crate) fn filename(self) -> &'static ZStr {
+    pub fn filename(self) -> &'static ZStr {
         match self {
             LockfileFormat::Text => zstr!("bun.lock"),
             LockfileFormat::Binary => zstr!("bun.lockb"),
@@ -396,7 +396,7 @@ impl<'a> LoadResult<'a> {
         }
     }
 
-    pub(crate) fn save_format(&self, options: &PackageManagerOptions) -> LockfileFormat {
+    pub fn save_format(&self, options: &PackageManagerOptions) -> LockfileFormat {
         match self {
             LoadResult::NotFound => {
                 // saving a lockfile for a new project. default to text lockfile

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -403,6 +403,8 @@ impl Scripts {
 pub enum PrintFormat {
     Completed,
     Untrusted,
+    /// Selected by `bun pm trust` but not run (`--dry-run` or `--ignore-scripts`).
+    Skipped,
 }
 
 // `Clone` — `List` owns `cwd`/`package_name`/`items`, but
@@ -455,6 +457,11 @@ impl List {
                     ),
                     PrintFormat::Untrusted => bun_core::pretty!(
                         " <yellow>»<r> [{s}]<d>:<r> <cyan>{s}<r>\n",
+                        BStr::new(name),
+                        BStr::new(script),
+                    ),
+                    PrintFormat::Skipped => bun_core::pretty!(
+                        " <d>-<r> [{s}]<d>:<r> <cyan>{s}<r>\n",
                         BStr::new(name),
                         BStr::new(script),
                     ),

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -220,7 +220,9 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything\n\
   <b><green>bun pm<r> <blue>untrusted<r>            print current untrusted dependencies with scripts\n\
   <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>      run scripts for untrusted dependencies and add to `trustedDependencies`\n\
-  <d>└<r>  <cyan>--all<r>                    trust all untrusted dependencies\n\
+  <d>├<r>  <cyan>--all<r>                    trust all untrusted dependencies\n\
+  <d>├<r>  <cyan>--dry-run<r>                print the scripts that would run, without running them or saving\n\
+  <d>└<r>  <cyan>--ignore-scripts<r>         add to `trustedDependencies` without running the scripts\n\
   <b><green>bun pm<r> <blue>default-trusted<r>      print the default trusted dependencies list\n\
 \n\
 Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
@@ -436,38 +438,47 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 && strings::eql_comptime(pm.options.positionals[1], b"rm")
             {
                 let mut had_err = false;
+                let dry_run = pm.options.dry_run;
 
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
                 let cache_dir = fetch_cache_directory_path(&mut process_env, None);
-                let mut rm_buf = bun_paths::path_buffer_pool::get();
-                let rm_dir = match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
-                    Ok(d) => d,
-                    Err(err) => {
-                        bun_core::pretty_errorln!(
-                            "{} getting cache directory",
-                            crate::Error::from(err).name(),
-                        );
-                        Global::crash();
-                    }
-                };
-                let rm_path = match rm_dir.get_fd_path(&mut rm_buf) {
-                    Ok(p) => &p[..],
-                    Err(err) => {
-                        bun_core::pretty_errorln!(
-                            "{} getting cache directory",
-                            crate::Error::from(err).name(),
-                        );
-                        Global::crash();
-                    }
-                };
-                rm_dir.close();
+                if dry_run {
+                    bun_core::prettyln!(
+                        "Would clear 'bun install' cache at {}",
+                        bstr::BStr::new(&cache_dir.path),
+                    );
+                } else {
+                    let mut rm_buf = bun_paths::path_buffer_pool::get();
+                    let rm_dir =
+                        match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
+                            Ok(d) => d,
+                            Err(err) => {
+                                bun_core::pretty_errorln!(
+                                    "{} getting cache directory",
+                                    crate::Error::from(err).name(),
+                                );
+                                Global::crash();
+                            }
+                        };
+                    let rm_path = match rm_dir.get_fd_path(&mut rm_buf) {
+                        Ok(p) => &p[..],
+                        Err(err) => {
+                            bun_core::pretty_errorln!(
+                                "{} getting cache directory",
+                                crate::Error::from(err).name(),
+                            );
+                            Global::crash();
+                        }
+                    };
+                    rm_dir.close();
 
-                if let Err(err) = bun_sys::delete_tree_absolute(rm_path) {
-                    Output::err(err, "Could not delete {s}", (bstr::BStr::new(rm_path),));
-                    had_err = true;
+                    if let Err(err) = bun_sys::delete_tree_absolute(rm_path) {
+                        Output::err(err, "Could not delete {s}", (bstr::BStr::new(rm_path),));
+                        had_err = true;
+                    }
+                    bun_core::prettyln!("Cleared 'bun install' cache");
                 }
-                bun_core::prettyln!("Cleared 'bun install' cache");
 
                 'bunx: {
                     let tmp = Fs::RealFS::platform_temp_dir();
@@ -516,17 +527,27 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                         };
                         let name = entry.name.slice_u8();
                         if name.starts_with(prefix.as_slice()) {
-                            if let Err(err) = tmp_dir.delete_tree(name) {
-                                Output::err(err, "Could not delete {s}", (bstr::BStr::new(name),));
-                                had_err = true;
-                                continue;
+                            if !dry_run {
+                                if let Err(err) = tmp_dir.delete_tree(name) {
+                                    Output::err(
+                                        err,
+                                        "Could not delete {s}",
+                                        (bstr::BStr::new(name),),
+                                    );
+                                    had_err = true;
+                                    continue;
+                                }
                             }
 
                             deleted += 1;
                         }
                     }
 
-                    bun_core::prettyln!("Cleared {} cached 'bunx' packages", deleted);
+                    if dry_run {
+                        bun_core::prettyln!("Would clear {} cached 'bunx' packages", deleted);
+                    } else {
+                        bun_core::prettyln!("Cleared {} cached 'bunx' packages", deleted);
+                    }
                 }
 
                 Global::exit(if had_err { 1 } else { 0 });
@@ -742,6 +763,15 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 Global::exit(1);
             }
             Self::handle_load_lockfile_errors(&load_lockfile, log_level);
+            // SAFETY: `pm_raw` singleton; `options` is CLI config set at init.
+            let options = unsafe { &(*pm_raw).options };
+            if options.dry_run {
+                bun_core::pretty_errorln!(
+                    "Would save {} <d>(dry run)<r>",
+                    bstr::BStr::new(load_lockfile.save_format(options).filename().as_bytes()),
+                );
+                Global::exit(0);
+            }
             // Reshaped for borrowck — `save_to_disk` needs
             // `&mut Lockfile` (self) and `&LoadResult` simultaneously, but
             // `LoadResultOk.lockfile` already holds the only `&mut` into the

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -326,14 +326,14 @@ impl PmPkgCommand {
         }
 
         if modified {
-            Self::save_package_json(&path, root, &pkg)?;
+            Self::save_package_json(&path, root, &pkg, pm.options.dry_run)?;
         }
         Ok(())
     }
 
     fn exec_delete(
         ctx: &Context,
-        _pm: &mut PackageManager,
+        pm: &mut PackageManager,
         args: &[&[u8]],
         cwd: &[u8],
     ) -> Result<(), Error> {
@@ -369,12 +369,12 @@ impl PmPkgCommand {
         }
 
         if modified {
-            Self::save_package_json(&path, root, &pkg)?;
+            Self::save_package_json(&path, root, &pkg, pm.options.dry_run)?;
         }
         Ok(())
     }
 
-    fn exec_fix(ctx: &Context, _pm: &mut PackageManager, cwd: &[u8]) -> Result<(), Error> {
+    fn exec_fix(ctx: &Context, pm: &mut PackageManager, cwd: &[u8]) -> Result<(), Error> {
         let path = Self::find_package_json(cwd)?;
 
         let pkg = Self::load_package_json(ctx, &path)?;
@@ -426,7 +426,7 @@ impl PmPkgCommand {
         }
 
         if modified {
-            Self::save_package_json(&path, root, &pkg)?;
+            Self::save_package_json(&path, root, &pkg, pm.options.dry_run)?;
         }
         Ok(())
     }
@@ -825,7 +825,12 @@ impl PmPkgCommand {
         Ok(true)
     }
 
-    fn save_package_json(path: &[u8], root: Expr, pkg: &PackageJson) -> Result<(), Error> {
+    fn save_package_json(
+        path: &[u8],
+        root: Expr,
+        pkg: &PackageJson,
+        dry_run: bool,
+    ) -> Result<(), Error> {
         let preserve_newline =
             !pkg.contents.is_empty() && pkg.contents[pkg.contents.len() - 1] == b'\n';
 
@@ -853,6 +858,14 @@ impl PmPkgCommand {
         }
 
         let content = writer.ctx.written_without_trailing_zero();
+        if dry_run {
+            let _ = Output::writer().write_all(content);
+            if !preserve_newline {
+                let _ = Output::writer().write_all(b"\n");
+            }
+            Output::flush();
+            return Ok(());
+        }
         let path_z = bun_core::ZBox::from_bytes(path);
         if let Err(e) = bun_sys::File::write_file(bun_sys::Fd::cwd(), path_z.as_zstr(), content) {
             Output::err_generic(

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -441,10 +441,11 @@ impl TrustCommand {
 
         // SAFETY: `pm_raw` singleton; `options` is CLI config set at init.
         let dry_run = unsafe { (*pm_raw).options.dry_run };
-        // `--ignore-scripts` (or `ignoreScripts` in config) still records the
-        // trust, so the next `bun install` runs the scripts.
-        // SAFETY: see above.
-        let run_scripts = !dry_run && unsafe { (*pm_raw).options.do_.run_scripts() };
+        // Only the flag skips the scripts. `ignoreScripts` in bunfig or
+        // `.npmrc` does not, because `bun pm trust <name>` is the explicit
+        // request to run them and there is no flag to override the config.
+        let ignore_scripts = strings::left_has_any_in_right(args, &[b"--ignore-scripts"]);
+        let run_scripts = !dry_run && !ignore_scripts;
 
         let mut scripts_node: Progress::Node;
         // SAFETY: `pm_raw` singleton; `progress` is owned inline.

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -577,9 +577,7 @@ impl TrustCommand {
         }
 
         if !dry_run {
-            // The next install runs the scripts of a package that package.json
-            // trusts and the lockfile does not. So when the scripts were
-            // skipped, only package.json records the trust.
+            // Skipped scripts run on the next install only if the lockfile does not trust the package yet.
             Self::write_trusted_dependencies(
                 ctx,
                 pm_raw,

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -441,9 +441,7 @@ impl TrustCommand {
 
         // SAFETY: `pm_raw` singleton; `options` is CLI config set at init.
         let dry_run = unsafe { (*pm_raw).options.dry_run };
-        // Only the flag skips the scripts. `ignoreScripts` in bunfig or
-        // `.npmrc` does not, because `bun pm trust <name>` is the explicit
-        // request to run them and there is no flag to override the config.
+        // The config setting does not apply here: `bun pm trust <name>` is the explicit request to run them.
         let ignore_scripts = strings::left_has_any_in_right(args, &[b"--ignore-scripts"]);
         let run_scripts = !dry_run && !ignore_scripts;
 

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -439,9 +439,16 @@ impl TrustCommand {
             Global::crash();
         }
 
+        // SAFETY: `pm_raw` singleton; `options` is CLI config set at init.
+        let dry_run = unsafe { (*pm_raw).options.dry_run };
+        // `--ignore-scripts` (or `ignoreScripts` in config) still records the
+        // trust, so the next `bun install` runs the scripts.
+        // SAFETY: see above.
+        let run_scripts = !dry_run && unsafe { (*pm_raw).options.do_.run_scripts() };
+
         let mut scripts_node: Progress::Node;
         // SAFETY: `pm_raw` singleton; `progress` is owned inline.
-        let show_progress = unsafe { (*pm_raw).options.log_level.show_progress() };
+        let show_progress = run_scripts && unsafe { (*pm_raw).options.log_level.show_progress() };
 
         if show_progress {
             // SAFETY: see above; `progress.start()` returns `&mut root` which is
@@ -462,6 +469,9 @@ impl TrustCommand {
         // `spawn_package_lifecycle_scripts` and still print it later, so clone
         // the `List` per spawn.
         for entry in scripts_at_depth.values().iter().rev() {
+            if !run_scripts {
+                break;
+            }
             for info in entry.iter() {
                 if info.skip {
                     continue;
@@ -533,6 +543,107 @@ impl TrustCommand {
             }
         }
 
+        let mut total_scripts: usize = 0;
+        let mut total_packages_with_scripts: usize = 0;
+        let mut total_skipped_packages: usize = 0;
+
+        Output::print(format_args!("\n"));
+
+        // SAFETY: `pm_raw` singleton; read-only borrow for printing.
+        let lockfile: &Lockfile = unsafe { &*(*pm_raw).lockfile };
+        let buf = lockfile.buffers.string_bytes.as_slice();
+        for entry in scripts_at_depth.values().iter().rev() {
+            for info in entry.iter() {
+                let resolution = &lockfile.packages.items_resolution()[info.package_id as usize];
+                if info.skip {
+                    info.scripts_list
+                        .print_scripts(resolution, buf, PrintFormat::Untrusted);
+                    total_skipped_packages += 1;
+                } else {
+                    total_packages_with_scripts += 1;
+                    total_scripts += info.scripts_list.total as usize;
+                    info.scripts_list.print_scripts(
+                        resolution,
+                        buf,
+                        if run_scripts {
+                            PrintFormat::Completed
+                        } else {
+                            PrintFormat::Skipped
+                        },
+                    );
+                }
+                Output::print(format_args!("\n"));
+            }
+        }
+
+        if !dry_run {
+            Self::write_trusted_dependencies(
+                ctx,
+                pm_raw,
+                &load_lockfile,
+                &mut package_names_to_add,
+            )?;
+        }
+
+        debug_assert!(total_scripts > 0);
+
+        let scripts_plural = if total_scripts > 1 { "s" } else { "" };
+        let packages_plural = if total_packages_with_scripts > 1 {
+            "s"
+        } else {
+            ""
+        };
+        if run_scripts {
+            bun_core::pretty!(
+                " <green>{}<r> script{} ran across {} package{} ",
+                total_scripts,
+                scripts_plural,
+                total_packages_with_scripts,
+                packages_plural,
+            );
+            Output::print_start_end_stdout(
+                bun_core::start_time(),
+                bun_core::time::nano_timestamp(),
+            );
+        } else if dry_run {
+            bun_core::pretty!(
+                " <yellow>{}<r> script{} would run across {} package{} <d>(dry run)<r>",
+                total_scripts,
+                scripts_plural,
+                total_packages_with_scripts,
+                packages_plural,
+            );
+        } else {
+            bun_core::pretty!(
+                " <yellow>{}<r> script{} skipped across {} package{} <d>(--ignore-scripts)<r>",
+                total_scripts,
+                scripts_plural,
+                total_packages_with_scripts,
+                packages_plural,
+            );
+        }
+        Output::print(format_args!("\n"));
+
+        if total_skipped_packages > 0 {
+            Output::print(format_args!("\n"));
+            bun_core::prettyln!(
+                " <yellow>{}<r> package{} with blocked scripts",
+                total_skipped_packages,
+                if total_skipped_packages > 1 { "s" } else { "" },
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Adds `package_names` to `trustedDependencies` in both package.json and
+    /// the lockfile, then writes both.
+    fn write_trusted_dependencies(
+        ctx: Command::Context,
+        pm_raw: *mut PackageManager,
+        load_lockfile: &LoadResult<'_>,
+        package_names: &mut StringArrayHashMap<()>,
+    ) -> crate::Result<()> {
         // SAFETY: `pm_raw` singleton; this scope takes over the descriptor
         // (the original `pm.root_package_json_file` is replaced with INVALID so
         // its eventual drop is a no-op).
@@ -573,8 +684,7 @@ impl TrustCommand {
             }
         };
 
-        // now add the package names to lockfile.trustedDependencies and package.json `trustedDependencies`
-        debug_assert!(!package_names_to_add.keys().is_empty());
+        debug_assert!(!package_names.keys().is_empty());
 
         // could be null if these are the first packages to be trusted
         // SAFETY: `pm_raw` singleton; mutates `lockfile.trusted_dependencies`.
@@ -584,38 +694,9 @@ impl TrustCommand {
             }
         }
 
-        let mut total_scripts_ran: usize = 0;
-        let mut total_packages_with_scripts: usize = 0;
-        let mut total_skipped_packages: usize = 0;
+        PackageJSONEditor::edit_trusted_dependencies(&mut package_json, package_names.keys_mut())?;
 
-        Output::print(format_args!("\n"));
-
-        // SAFETY: `pm_raw` singleton; read-only borrow for printing.
-        let lockfile: &Lockfile = unsafe { &*(*pm_raw).lockfile };
-        let buf = lockfile.buffers.string_bytes.as_slice();
-        for entry in scripts_at_depth.values().iter().rev() {
-            for info in entry.iter() {
-                let resolution = &lockfile.packages.items_resolution()[info.package_id as usize];
-                if info.skip {
-                    info.scripts_list
-                        .print_scripts(resolution, buf, PrintFormat::Untrusted);
-                    total_skipped_packages += 1;
-                } else {
-                    total_packages_with_scripts += 1;
-                    total_scripts_ran += info.scripts_list.total as usize;
-                    info.scripts_list
-                        .print_scripts(resolution, buf, PrintFormat::Completed);
-                }
-                Output::print(format_args!("\n"));
-            }
-        }
-
-        PackageJSONEditor::edit_trusted_dependencies(
-            &mut package_json,
-            package_names_to_add.keys_mut(),
-        )?;
-
-        for name in package_names_to_add.keys() {
+        for name in package_names.keys() {
             // SAFETY: `pm_raw` singleton; `trusted_dependencies` set Some above.
             unsafe {
                 (*pm_raw)
@@ -640,7 +721,7 @@ impl TrustCommand {
         // only for `save_format()` (scalar `format`/`migrated` fields).
         unsafe {
             let lf: *mut Lockfile = &raw mut *(*pm_raw).lockfile;
-            (*lf).save_to_disk(&load_lockfile, &(*pm_raw).options);
+            (*lf).save_to_disk(load_lockfile, &(*pm_raw).options);
         }
 
         let mut buffer_writer = bun_js_printer::BufferWriter::init();
@@ -674,32 +755,6 @@ impl TrustCommand {
             .map_err(crate::Error::from)?;
         let _ = bun_sys::ftruncate(root_file.handle, new_package_json_contents.len() as i64);
         let _ = root_file.close();
-
-        debug_assert!(total_scripts_ran > 0);
-
-        bun_core::pretty!(
-            " <green>{}<r> script{} ran across {} package{} ",
-            total_scripts_ran,
-            if total_scripts_ran > 1 { "s" } else { "" },
-            total_packages_with_scripts,
-            if total_packages_with_scripts > 1 {
-                "s"
-            } else {
-                ""
-            },
-        );
-
-        Output::print_start_end_stdout(bun_core::start_time(), bun_core::time::nano_timestamp());
-        Output::print(format_args!("\n"));
-
-        if total_skipped_packages > 0 {
-            Output::print(format_args!("\n"));
-            bun_core::prettyln!(
-                " <yellow>{}<r> package{} with blocked scripts",
-                total_skipped_packages,
-                if total_skipped_packages > 1 { "s" } else { "" },
-            );
-        }
 
         Ok(())
     }

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -577,11 +577,15 @@ impl TrustCommand {
         }
 
         if !dry_run {
+            // The next install runs the scripts of a package that package.json
+            // trusts and the lockfile does not. So when the scripts were
+            // skipped, only package.json records the trust.
             Self::write_trusted_dependencies(
                 ctx,
                 pm_raw,
                 &load_lockfile,
                 &mut package_names_to_add,
+                run_scripts,
             )?;
         }
 
@@ -636,13 +640,14 @@ impl TrustCommand {
         Ok(())
     }
 
-    /// Adds `package_names` to `trustedDependencies` in both package.json and
-    /// the lockfile, then writes both.
+    /// Adds `package_names` to `trustedDependencies` in package.json, and in
+    /// the lockfile too when `scripts_ran`, then writes the edited files.
     fn write_trusted_dependencies(
         ctx: Command::Context,
         pm_raw: *mut PackageManager,
         load_lockfile: &LoadResult<'_>,
         package_names: &mut StringArrayHashMap<()>,
+        scripts_ran: bool,
     ) -> crate::Result<()> {
         // SAFETY: `pm_raw` singleton; this scope takes over the descriptor
         // (the original `pm.root_package_json_file` is replaced with INVALID so
@@ -663,11 +668,6 @@ impl TrustCommand {
 
         let bump = Bump::new();
         // SAFETY: `ctx.log` set by `Command::init`, non-null for the command.
-        // Layering: `parse_utf8` returns the T2
-        // `bun_ast::Expr`; `PackageJSONEditor` and
-        // `js_printer::print_json` consume the T4 `bun_ast::Expr`. Lift
-        // once via `From<T2> for T4` (same as `updatePackageJSONAndInstall` /
-        // `pack_command`).
         let mut package_json: bun_ast::Expr = match bun_parsers::json::parse_utf8(
             &package_json_source,
             unsafe { ctx.log_mut() },
@@ -686,42 +686,41 @@ impl TrustCommand {
 
         debug_assert!(!package_names.keys().is_empty());
 
-        // could be null if these are the first packages to be trusted
-        // SAFETY: `pm_raw` singleton; mutates `lockfile.trusted_dependencies`.
-        unsafe {
-            if (*pm_raw).lockfile.trusted_dependencies.is_none() {
-                (*pm_raw).lockfile.trusted_dependencies = Some(Default::default());
-            }
-        }
-
         PackageJSONEditor::edit_trusted_dependencies(&mut package_json, package_names.keys_mut())?;
 
-        for name in package_names.keys() {
-            // SAFETY: `pm_raw` singleton; `trusted_dependencies` set Some above.
+        if scripts_ran {
+            // could be null if these are the first packages to be trusted
+            // SAFETY: `pm_raw` singleton; mutates `lockfile.trusted_dependencies`.
             unsafe {
-                (*pm_raw)
-                    .lockfile
-                    .trusted_dependencies
-                    .as_mut()
-                    .unwrap()
-                    .put(
-                        bun_semver::string::Builder::string_hash(name)
-                            as install::TruncatedPackageNameHash,
-                        Box::<[u8]>::from(&**name),
-                    )?;
+                if (*pm_raw).lockfile.trusted_dependencies.is_none() {
+                    (*pm_raw).lockfile.trusted_dependencies = Some(Default::default());
+                }
             }
-        }
 
-        // Reshaped for borrowck — `save_to_disk` needs `&mut Lockfile`
-        // and `&LoadResult` simultaneously, but `LoadResultOk.lockfile` already
-        // holds the only `&mut`. Same projection pattern as `migrate` in
-        // `package_manager_command.rs`.
-        // SAFETY: `load_lockfile` is `Ok` (errors exited in
-        // `handle_load_lockfile_errors`). `save_to_disk` reads `load_result`
-        // only for `save_format()` (scalar `format`/`migrated` fields).
-        unsafe {
-            let lf: *mut Lockfile = &raw mut *(*pm_raw).lockfile;
-            (*lf).save_to_disk(load_lockfile, &(*pm_raw).options);
+            for name in package_names.keys() {
+                // SAFETY: `pm_raw` singleton; `trusted_dependencies` set Some above.
+                unsafe {
+                    (*pm_raw)
+                        .lockfile
+                        .trusted_dependencies
+                        .as_mut()
+                        .unwrap()
+                        .put(
+                            bun_semver::string::Builder::string_hash(name)
+                                as install::TruncatedPackageNameHash,
+                            Box::<[u8]>::from(&**name),
+                        )?;
+                }
+            }
+
+            // SAFETY: `load_lockfile` is `Ok` (errors exited in
+            // `handle_load_lockfile_errors`). `save_to_disk` reads `load_result`
+            // only for `save_format()` (scalar `format`/`migrated` fields), so the
+            // `&mut Lockfile` it also needs does not alias. Same as `migrate`.
+            unsafe {
+                let lf: *mut Lockfile = &raw mut *(*pm_raw).lockfile;
+                (*lf).save_to_disk(load_lockfile, &(*pm_raw).options);
+            }
         }
 
         let mut buffer_writer = bun_js_printer::BufferWriter::init();

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -637,8 +637,7 @@ impl TrustCommand {
         Ok(())
     }
 
-    /// Adds `package_names` to `trustedDependencies` in package.json, and in
-    /// the lockfile too when `scripts_ran`, then writes the edited files.
+    /// Writes `trustedDependencies` to package.json, and to the lockfile only when `scripts_ran`.
     fn write_trusted_dependencies(
         ctx: Command::Context,
         pm_raw: *mut PackageManager,

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -139,6 +139,47 @@ test.concurrent("ignore-scripts is read from npmrc", async () => {
   expect(await checkScripts()).toEqual([true, true]);
 });
 
+test.concurrent("bun pm trust --ignore-scripts records the trust and the next install runs the scripts", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      version: "1.2.3",
+      dependencies: {
+        "uses-what-bin": "1.0.0",
+      },
+    }),
+  );
+  const whatBinTxt = join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt");
+
+  await runBunInstall(env, packageDir);
+  expect(await exists(whatBinTxt)).toBeFalse();
+
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "pm", "trust", "uses-what-bin", "--ignore-scripts"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 script skipped across 1 package (--ignore-scripts)");
+    expect(exitCode).toBe(0);
+  }
+  expect(await exists(whatBinTxt)).toBeFalse();
+  expect((await file(packageJson).json()).trustedDependencies).toEqual(["uses-what-bin"]);
+  // The lockfile is left alone so that the next install sees the newly trusted package.
+  expect(await file(join(packageDir, "bun.lock")).text()).not.toContain("trustedDependencies");
+
+  await runBunInstall(env, packageDir);
+  expect(await exists(whatBinTxt)).toBeTrue();
+  expect(await file(join(packageDir, "bun.lock")).text()).toContain("trustedDependencies");
+});
+
 test.concurrent("trustedDependencies matches the resolved package name, not the dependency alias", async () => {
   using ctx = await setupTest();
   const { packageDir, packageJson, env } = ctx;

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -413,6 +413,26 @@ describe.concurrent("bun pm pkg", () => {
     });
   });
 
+  describe("--dry-run", () => {
+    it("set prints the result and does not write package.json", async () => {
+      using dir = makeTestDir();
+      const before = await Bun.file(join(dir, "package.json")).text();
+      const { output, code } = await runPmPkg(["set", "foo=bar", "--dry-run"], dir);
+      expect(JSON.parse(output).foo).toBe("bar");
+      expect(await Bun.file(join(dir, "package.json")).text()).toBe(before);
+      expect(code).toBe(0);
+    });
+
+    it("delete prints the result and does not write package.json", async () => {
+      using dir = makeTestDir();
+      const before = await Bun.file(join(dir, "package.json")).text();
+      const { output, code } = await runPmPkg(["delete", "scripts", "--dry-run"], dir);
+      expect(JSON.parse(output).scripts).toBeUndefined();
+      expect(await Bun.file(join(dir, "package.json")).text()).toBe(before);
+      expect(code).toBe(0);
+    });
+  });
+
   describe("help command", () => {
     it("should show help", async () => {
       const { output, code } = await runPmPkg(["help"], readonlyDir);

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1084,3 +1084,179 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+test("bun pm cache rm --dry-run leaves the cache and the bunx temp dirs in place", async () => {
+  using dir = tempDir("pm-cache-rm-dry-run", {
+    "package.json": JSON.stringify({ name: "cache-rm-dry-run", version: "1.0.0" }),
+    "cache/cached-package.txt": "cached artifact",
+  });
+  const cacheDir = join(String(dir), "cache");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "cache", "rm", "--dry-run"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain(`Would clear 'bun install' cache at ${cacheDir}`);
+  expect(stdout).toMatch(/Would clear \d+ cached 'bunx' packages/);
+  expect(stdout).not.toContain("Cleared");
+  expect(stderr).not.toContain("error");
+  expect(await exists(join(cacheDir, "cached-package.txt"))).toBeTrue();
+  expect(exitCode).toBe(0);
+});
+
+const npmLockfileWithLocalDep = {
+  "package.json": JSON.stringify({
+    name: "app",
+    version: "1.0.0",
+    dependencies: { dep: "file:./dep" },
+  }),
+  "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+  "package-lock.json": JSON.stringify({
+    name: "app",
+    version: "1.0.0",
+    lockfileVersion: 3,
+    packages: {
+      "": { dependencies: { dep: "file:./dep" } },
+      "dep": { version: "1.0.0" },
+      "node_modules/dep": { resolved: "dep", link: true },
+    },
+  }),
+};
+
+test("bun pm migrate --dry-run does not write bun.lock", async () => {
+  using dir = tempDir("pm-migrate-dry-run", npmLockfileWithLocalDep);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "migrate", "--dry-run"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(stderr).toContain("migrated lockfile from package-lock.json");
+  expect(stderr).toContain("Would save bun.lock");
+  expect(await exists(join(String(dir), "bun.lock"))).toBeFalse();
+  expect(await exists(join(String(dir), "bun.lockb"))).toBeFalse();
+  expect(exitCode).toBe(0);
+});
+
+test("bun install --dry-run does not write a migrated bun.lock", async () => {
+  using dir = tempDir("install-migrate-dry-run", npmLockfileWithLocalDep);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--dry-run"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("migrated lockfile from package-lock.json");
+  expect(stderr).not.toContain("Saved lockfile");
+  expect(stdout).toContain("dep@dep");
+  expect(await exists(join(String(dir), "bun.lock"))).toBeFalse();
+  expect(await exists(join(String(dir), "node_modules"))).toBeFalse();
+  expect(exitCode).toBe(0);
+});
+
+function projectWithBlockedPostinstall() {
+  return {
+    "package.json": JSON.stringify({ name: "app", dependencies: { dep: "file:./dep" } }),
+    "dep/package.json": JSON.stringify({
+      name: "dep",
+      version: "1.0.0",
+      scripts: { postinstall: "echo ran > postinstall-ran.txt" },
+    }),
+  };
+}
+
+async function installWithBlockedPostinstall(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("Blocked 1 postinstall");
+  expect(exitCode).toBe(0);
+  expect(await exists(join(dir, "node_modules", "dep", "postinstall-ran.txt"))).toBeFalse();
+}
+
+test("bun pm trust --dry-run lists the scripts, runs none, and writes nothing", async () => {
+  using dir = tempDir("pm-trust-dry-run", projectWithBlockedPostinstall());
+  const dirStr = String(dir);
+  await installWithBlockedPostinstall(dirStr);
+  const packageJsonBefore = await Bun.file(join(dirStr, "package.json")).text();
+  const lockfileBefore = await Bun.file(join(dirStr, "bun.lock")).text();
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "trust", "dep", "--dry-run"],
+    cwd: dirStr,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("bun pm trust");
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("[postinstall]: echo ran > postinstall-ran.txt");
+  expect(stdout).toContain("1 script would run across 1 package (dry run)");
+  expect(stdout).not.toContain("ran across");
+  expect(await exists(join(dirStr, "node_modules", "dep", "postinstall-ran.txt"))).toBeFalse();
+  expect(await Bun.file(join(dirStr, "package.json")).text()).toBe(packageJsonBefore);
+  expect(await Bun.file(join(dirStr, "bun.lock")).text()).toBe(lockfileBefore);
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm trust --ignore-scripts records the trust without running the scripts", async () => {
+  using dir = tempDir("pm-trust-ignore-scripts", projectWithBlockedPostinstall());
+  const dirStr = String(dir);
+  await installWithBlockedPostinstall(dirStr);
+
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "trust", "dep", "--ignore-scripts"],
+      cwd: dirStr,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toContain("1 script skipped across 1 package (--ignore-scripts)");
+    expect(await exists(join(dirStr, "node_modules", "dep", "postinstall-ran.txt"))).toBeFalse();
+    expect((await Bun.file(join(dirStr, "package.json")).json()).trustedDependencies).toEqual(["dep"]);
+    expect(await Bun.file(join(dirStr, "bun.lock")).text()).toContain('"trustedDependencies"');
+    expect(exitCode).toBe(0);
+  }
+
+  // The next install sees the new trust and runs the script.
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: dirStr,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(stdout).not.toContain("Blocked");
+    expect(await exists(join(dirStr, "node_modules", "dep", "postinstall-ran.txt"))).toBeTrue();
+    expect(exitCode).toBe(0);
+  }
+});

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1201,6 +1201,29 @@ test("bun pm trust --dry-run lists the scripts, runs none, and writes nothing", 
   expect(exitCode).toBe(0);
 });
 
+test("bun pm trust runs the scripts when only .npmrc sets ignore-scripts", async () => {
+  using dir = tempDir("pm-trust-npmrc-ignore-scripts", {
+    ...projectWithBlockedPostinstall(),
+    ".npmrc": "ignore-scripts=true\n",
+  });
+  const dirStr = String(dir);
+  await installWithBlockedPostinstall(dirStr);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "trust", "dep"],
+    cwd: dirStr,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("1 script ran across 1 package");
+  expect(await exists(join(dirStr, "node_modules", "dep", "postinstall-ran.txt"))).toBeTrue();
+  expect(exitCode).toBe(0);
+});
+
 test("bun pm trust --ignore-scripts records the trust without running the scripts", async () => {
   using dir = tempDir("pm-trust-ignore-scripts", projectWithBlockedPostinstall());
   const dirStr = String(dir);

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1220,7 +1220,8 @@ test("bun pm trust --ignore-scripts records the trust without running the script
     expect(stdout).toContain("1 script skipped across 1 package (--ignore-scripts)");
     expect(await exists(join(dirStr, "node_modules", "dep", "postinstall-ran.txt"))).toBeFalse();
     expect((await Bun.file(join(dirStr, "package.json")).json()).trustedDependencies).toEqual(["dep"]);
-    expect(await Bun.file(join(dirStr, "bun.lock")).text()).toContain('"trustedDependencies"');
+    // Only package.json records the trust. The next install diffs it against the lockfile.
+    expect(await Bun.file(join(dirStr, "bun.lock")).text()).not.toContain("trustedDependencies");
     expect(exitCode).toBe(0);
   }
 
@@ -1237,6 +1238,7 @@ test("bun pm trust --ignore-scripts records the trust without running the script
     expect(stderr).not.toContain("error:");
     expect(stdout).not.toContain("Blocked");
     expect(await exists(join(dirStr, "node_modules", "dep", "postinstall-ran.txt"))).toBeTrue();
+    expect(await Bun.file(join(dirStr, "bun.lock")).text()).toContain("trustedDependencies");
     expect(exitCode).toBe(0);
   }
 });

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1148,26 +1148,6 @@ test("bun pm migrate --dry-run does not write bun.lock", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("bun install --dry-run does not write a migrated bun.lock", async () => {
-  using dir = tempDir("install-migrate-dry-run", npmLockfileWithLocalDep);
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install", "--dry-run"],
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toContain("migrated lockfile from package-lock.json");
-  expect(stderr).not.toContain("Saved lockfile");
-  expect(stdout).toContain("dep@dep");
-  expect(await exists(join(String(dir), "bun.lock"))).toBeFalse();
-  expect(await exists(join(String(dir), "node_modules"))).toBeFalse();
-  expect(exitCode).toBe(0);
-});
-
 function projectWithBlockedPostinstall() {
   return {
     "package.json": JSON.stringify({ name: "app", dependencies: { dep: "file:./dep" } }),


### PR DESCRIPTION
### Problem
- Several `bun pm` verbs parse `--dry-run` from the shared install CLI table and then ignore it. `bun pm trust <pkg> --dry-run` runs the blocked lifecycle scripts and writes `trustedDependencies` to package.json and bun.lock. `bun pm cache rm --dry-run` deletes the cache. `bun pm migrate --dry-run` writes the migrated bun.lock. `bun pm pkg set/delete --dry-run` write package.json.
- `bun pm trust <pkg> --ignore-scripts` also runs the scripts. The only job of `pm trust` is to run untrusted scripts, so both flags are the preview a cautious user reaches for first.
- Cause: `TrustCommand::exec` (`src/runtime/cli/pm_trusted_command.rs`), the `cache rm` and `migrate` arms of `PackageManagerCommand::exec` (`src/runtime/cli/package_manager_command.rs`) and `PmPkgCommand::save_package_json` never read `options.dry_run` or `Do::RUN_SCRIPTS`.

### Fix
- `pm trust --dry-run` lists the selected scripts with a `-` marker, prints `N scripts would run across M packages (dry run)` and exits without running or writing anything. `pm trust --ignore-scripts` records the trust in package.json only and skips the scripts. The next `bun install` sees a package that package.json trusts and the lockfile does not, runs the scripts, and writes the lockfile. Only the flag does this: `ignoreScripts` in bunfig or `.npmrc` does not stop `pm trust`, because the command is the explicit request to run the scripts and no flag overrides the config.
- `pm cache rm --dry-run` prints the cache path and the bunx count. `pm migrate --dry-run` prints `Would save bun.lock`. `pm pkg --dry-run` prints the resulting package.json to stdout.
- `LockfileFormat::filename` and `LoadResult::save_format` become `pub` so the migrate arm can name the file it would write.
- Verified: 5 new tests in `test/cli/install/bun-pm.test.ts`, 2 in `test/cli/install/bun-pm-pkg.test.ts`, and 1 in `test/cli/install/bun-install-lifecycle-scripts.test.ts` (a registry package: trust with `--ignore-scripts`, then the next install runs the script). All fail on the release binary. Also ran those files in full and `migration/migrate.test.ts`.

### Background
- `--dry-run`, `--ignore-scripts` and the other install flags live in one `CommandLineArguments` table shared by every `bun pm` verb. Each verb reads only the options it implements, so a flag can parse cleanly and do nothing.
- `Options::load` turns `--dry-run` into `dry_run = true` and clears `Do::INSTALL_PACKAGES`, `Do::SAVE_LOCKFILE` and `Do::WRITE_PACKAGE_JSON`. `--ignore-scripts` clears `Do::RUN_SCRIPTS`.
- `bun pm trust` walks the lockfile tree, collects the untrusted packages that match the arguments, runs their scripts depth-first, then adds the names to `trustedDependencies` in package.json and the lockfile. This PR splits the write step into `write_trusted_dependencies` so the dry run can stop before it.
- `bun install --dry-run` is not touched here. #38830 covers its root lifecycle scripts and yarn.lock write. #38804 covers the migrated bun.lock it writes when a package-lock.json, yarn.lock or pnpm-lock.yaml is present.

<details><summary>Notes</summary>

Manual repro on 1.4.2 and 1.4.3 (d316760e8), temp dir, no network:

```
mkdir dep && echo '{"name":"dep","version":"1.0.0","scripts":{"postinstall":"touch MARKER"}}' > dep/package.json
echo '{"name":"app","dependencies":{"dep":"file:./dep"}}' > package.json
bun install                     # Blocked 1 postinstall
bun pm trust dep --dry-run      # ran the script, wrote trustedDependencies
bun pm trust dep --ignore-scripts   # ran the script
bun pm cache rm --dry-run       # Cleared 'bun install' cache
bun pm migrate --dry-run        # bun.lock written
bun pm pkg set foo=bar --dry-run    # package.json written
```

`--no-save` with a migrated lockfile is left as is. `--frozen-lockfile` with a `bun.lockb` relies on the same bypass to write the text lockfile, and `--no-save` has no stated contract for migration.

Review history: the first version recorded the `--ignore-scripts` trust in bun.lock too. A registry package already in node_modules then never ran its scripts, because the next install finds new trusted packages by diffing package.json against the lockfile (`DiffSummary` in `src/install/lockfile/Package.rs`). The `file:` dependency in the first test hid this, because bun reinstalls those each time. The lifecycle test with `uses-what-bin` covers the real case now. The same version also honored `ignoreScripts` from config, which would have left users with `.npmrc` `ignore-scripts=true` no way to run a trusted script. Now only the flag skips them.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->