### PR TITLE
s3: abort an upload that can never finish (collected writer, Create after fail)

### DIFF
--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -641,11 +641,16 @@ impl MultiPartUpload {
         let _guard = unsafe { RefPtr::from_raw(this) };
         // SAFETY: `this` is live for at least the guard's duration.
         let self_ = unsafe { &*this };
-        if self_.state.get() == State::Finished {
-            return Ok(());
-        }
+        // `fail` ran while this request was in flight (the writer was
+        // collected, or the source stream errored). Its deref already
+        // released the owner ref, so there is nothing to finish here, but an
+        // upload the server did create must still be aborted.
+        let failed = self_.state.get() == State::Finished;
         match result {
             S3DownloadResult::Failure(err) => {
+                if failed {
+                    return Ok(());
+                }
                 scoped_log!(
                     S3MultiPartUpload,
                     "startMultiPartRequestResult {} failed {}: {}",
@@ -678,6 +683,20 @@ impl MultiPartUpload {
                 if let Some(upload_id) = upload_id {
                     self_.upload_id.set(upload_id);
                 }
+                if failed {
+                    if valid {
+                        scoped_log!(
+                            S3MultiPartUpload,
+                            "startMultiPartRequestResult {} aborting after fail id: {}",
+                            BStr::new(&self_.path),
+                            BStr::new(self_.upload_id.get())
+                        );
+                        // The rollback callback releases this ref.
+                        self_.ref_();
+                        self_.rollback_multi_part_request()?;
+                    }
+                    return Ok(());
+                }
                 if !valid {
                     // Unknown type of response error from AWS
                     scoped_log!(
@@ -702,10 +721,15 @@ impl MultiPartUpload {
                 self_.drain_enqueued_parts(0)
             }
             // this is "unreachable" but we cover in case AWS returns 404
-            S3DownloadResult::NotFound(_) => self_.fail(S3Error {
-                code: b"UnknownError",
-                message: b"Failed to initiate multipart upload",
-            }),
+            S3DownloadResult::NotFound(_) => {
+                if failed {
+                    return Ok(());
+                }
+                self_.fail(S3Error {
+                    code: b"UnknownError",
+                    message: b"Failed to initiate multipart upload",
+                })
+            }
         }
     }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2200,6 +2200,43 @@ impl NetworkSink {
         self.task = None;
     }
 
+    /// The `writer()` wrapper was collected before `end()`. Nothing can finish
+    /// the upload any more, so fail it: that frees the queued parts, aborts a
+    /// started multipart upload on the server, and releases the upload's
+    /// event-loop ref. Deferred to a task because this runs inside a GC sweep
+    /// and `fail` settles a pending `flush()` promise.
+    ///
+    /// # Safety
+    /// `this` is the live heap box from `writable()`.
+    unsafe fn abort_on_collect(this: *mut NetworkSink) {
+        // SAFETY: fn contract.
+        let task = unsafe {
+            if (*this).ended || (*this).writer_holders.get() == 0 {
+                return;
+            }
+            (*this).ended = true;
+            (*this).done = true;
+            (*this).task.clone()
+        };
+        let Some(task) = task else {
+            return;
+        };
+        fn fail_collected(task: *mut RefPtr<bun_s3::MultiPartUpload>) -> JsResult<()> {
+            // SAFETY: the box leaked below; ManagedTask hands it over once.
+            let task = unsafe { bun_core::heap::take(task) };
+            task.fail(bun_s3_signing::error::S3Error {
+                code: b"UnknownError",
+                message: b"S3 writer was garbage collected before end() was called",
+            })
+        }
+        VirtualMachine::get().event_loop_ref().enqueue_task(
+            bun_event_loop::ManagedTask::ManagedTask::new_owned(
+                bun_core::heap::into_raw(Box::new(task)),
+                fail_collected,
+            ),
+        );
+    }
+
     /// The S3 upload drained: settle the flush/write promises (terminal, like
     /// `flush_promise`) and wake the source.
     pub(crate) fn on_writable(
@@ -2521,6 +2558,7 @@ impl crate::webcore::sink::JsSinkType for NetworkSink {
     unsafe fn finalize(this: *mut Self) {
         // SAFETY: trait contract — `this` is live and not used after this call.
         unsafe {
+            Self::abort_on_collect(this);
             (*this).finalize();
             Self::release_writer_holder(this);
         }

--- a/test/js/bun/s3/s3-upload-abort.test.ts
+++ b/test/js/bun/s3/s3-upload-abort.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// An upload that can never finish must be aborted on the server and released
+// natively: the queued part buffers are freed, a started multipart upload gets
+// an AbortMultipartUpload, and nothing keeps the event loop alive.
+//
+// The stub counts each S3 request and the child prints the counts at exit.
+// `body` runs with `client` in scope and must leave the upload abandoned.
+// The child then waits for `waitFor` before it runs `then`. With `gateCreate`,
+// the stub holds the CreateMultipartUpload response until `then` ran.
+function fixture(opts: { body: string; waitFor: string; then?: string; gateCreate?: boolean }) {
+  return `
+    const reqs = { create: 0, part: 0, complete: 0, abort: 0, put: 0 };
+    const createGate = Promise.withResolvers();
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (req.method === "POST" && url.searchParams.has("uploads")) {
+          reqs.create++;
+          ${opts.gateCreate ? "await createGate.promise;" : ""}
+          return new Response(
+            "<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>",
+            { headers: { "content-type": "application/xml" } },
+          );
+        }
+        if (req.method === "PUT") {
+          await req.arrayBuffer();
+          if (url.searchParams.has("uploadId")) {
+            reqs.part++;
+            return new Response("", { headers: { ETag: '"etag"' } });
+          }
+          reqs.put++;
+          return new Response("");
+        }
+        if (req.method === "DELETE") {
+          reqs.abort++;
+          return new Response("", { status: 204 });
+        }
+        await req.text();
+        reqs.complete++;
+        return new Response('<CompleteMultipartUploadResult><ETag>"etag"</ETag></CompleteMultipartUploadResult>');
+      },
+    });
+    // Only the abandoned upload may keep the process alive.
+    server.unref();
+    const client = new Bun.S3Client({
+      endpoint: "http://127.0.0.1:" + server.port,
+      bucket: "bucket",
+      accessKeyId: "key",
+      secretAccessKey: "secret",
+      region: "us-east-1",
+    });
+    const partSize = 5 * 1024 * 1024;
+    const opts = { partSize, queueSize: 2, retry: 0 };
+    const deadline = Date.now() + 4_000;
+    ${opts.body}
+    while (Date.now() < deadline && !(${opts.waitFor})) {
+      await Bun.sleep(10);
+    }
+    ${opts.then ?? ""}
+    createGate.resolve();
+    process.on("exit", () => console.log(JSON.stringify(reqs)));
+  `;
+}
+
+const env = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+async function run(opts: Parameters<typeof fixture>[0]) {
+  using dir = tempDir("s3-upload-abort", {});
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture(opts)],
+    env,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // A leaked upload pins the event loop, so the child never exits and the
+  // test times out.
+  const [stdout, stderr, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exited };
+}
+
+// The source stream errors after one full part, while the
+// CreateMultipartUpload request is still in flight. The write rejects at
+// once. When the Create response lands, the upload it names must be aborted.
+test.concurrent("stream error while CreateMultipartUpload is in flight aborts the upload", async () => {
+  const body = `
+    let pulls = 0;
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (pulls++ === 0) {
+          controller.enqueue(new Uint8Array(partSize));
+          return;
+        }
+        controller.error(new Error("source failed"));
+      },
+    });
+    const result = await client.write("key", new Response(stream), opts).then(
+      () => "resolved",
+      e => "rejected: " + e.message,
+    );
+    console.log(result);
+  `;
+  expect(
+    await run({
+      body,
+      waitFor: `true`,
+      then: `createGate.resolve(); while (Date.now() < deadline && reqs.abort === 0) await Bun.sleep(10);`,
+      gateCreate: true,
+    }),
+  ).toEqual({
+    stdout: `rejected: source failed\n{"create":1,"part":0,"complete":0,"abort":1,"put":0}\n`,
+    stderr: "",
+    exited: 0,
+  });
+});

--- a/test/js/bun/s3/s3-upload-abort.test.ts
+++ b/test/js/bun/s3/s3-upload-abort.test.ts
@@ -122,3 +122,53 @@ test.concurrent("stream error while CreateMultipartUpload is in flight aborts th
     exited: 0,
   });
 });
+
+// An `S3File.writer()` that is dropped before `end()` can never finish its
+// upload. Once the wrapper is collected the upload is aborted and the process
+// exits.
+const droppedWriter = (writes: string) => `
+  let finalized = 0;
+  const registry = new FinalizationRegistry(() => finalized++);
+  (() => {
+    const w = client.file("key").writer(opts);
+    registry.register(w, 1);
+    ${writes}
+  })();
+`;
+const collectWriter = `
+  while (Date.now() < deadline && finalized === 0) {
+    Bun.gc(true);
+    await Bun.sleep(10);
+  }
+  console.log("finalized", finalized);
+`;
+const twoParts = droppedWriter(`w.write(new Uint8Array(6 * 1024 * 1024)); w.write(new Uint8Array(6 * 1024 * 1024));`);
+
+test.concurrent(
+  "dropped writer with uploaded parts aborts the multipart upload and lets the process exit",
+  async () => {
+    expect(await run({ body: twoParts, waitFor: `reqs.part === 2`, then: collectWriter })).toEqual({
+      stdout: `finalized 1\n{"create":1,"part":2,"complete":0,"abort":1,"put":0}\n`,
+      stderr: "",
+      exited: 0,
+    });
+  },
+);
+
+test.concurrent("dropped writer collected while CreateMultipartUpload is in flight still aborts it", async () => {
+  expect(await run({ body: twoParts, waitFor: `reqs.create === 1`, then: collectWriter, gateCreate: true })).toEqual({
+    stdout: `finalized 1\n{"create":1,"part":0,"complete":0,"abort":1,"put":0}\n`,
+    stderr: "",
+    exited: 0,
+  });
+});
+
+test.concurrent("dropped writer with only buffered bytes lets the process exit", async () => {
+  expect(
+    await run({ body: droppedWriter(`w.write(new Uint8Array(1000));`), waitFor: `true`, then: collectWriter }),
+  ).toEqual({
+    stdout: `finalized 1\n{"create":0,"part":0,"complete":0,"abort":0,"put":0}\n`,
+    stderr: "",
+    exited: 0,
+  });
+});


### PR DESCRIPTION
### Problem
- `S3Client.file(k).writer()` written to and dropped without `end()`: the JS wrapper is finalized, but every byte written stays resident, the multipart upload is never completed nor aborted on the server, and one such writer keeps the event loop alive forever. A writer with only 1000 buffered bytes pins the loop too. `Bun.file(path).writer()` dropped the same way closes its fd and lets the process exit.
- The cause is `NetworkSink::finalize` (`src/runtime/webcore/streams.rs:2177`). It only drops the sink's ref on the `MultiPartUpload`. The upload keeps its own owner ref, the queued part buffers and its `KeepAlive` until `done()` or `fail()`, and nothing can call those once the wrapper is gone.
- A second, non-GC hole: when `fail()` runs while the CreateMultipartUpload request is in flight (a source stream that errors), `start_multi_part_request_result` (`src/runtime/webcore/s3/multipart.rs:644`) returned early and never used the upload id the server returned. That upload stayed open on the server.

### Fix
- Commit 1 (`multipart.rs`): when the Create response lands on a finished upload, take a ref and send AbortMultipartUpload for the returned id. The rollback callback releases that ref, as it does on the normal rollback path.
- Commit 2 (`streams.rs`): the `writer()` finalizer marks the sink ended and enqueues a task that calls `MultiPartUpload::fail`. `fail` frees the queued parts, aborts a started multipart upload, and the `KeepAlive` is released when the last ref drops. The task is deferred because the finalizer runs inside a GC sweep and `fail` settles a pending `flush()` promise. A writer that called `end()` is not touched: its upload finishes as before.
- Abort, not commit, is the safe outcome: S3 has no partial object, and `fail` already aborts for a source stream error.
- Verified: `test/js/bun/s3/s3-upload-abort.test.ts` (4 cases against a loopback stub, all 4 fail on 1.4.3). Also `s3-upload-stream-gc`, `s3-stream-error-gc`, `s3-stream-cancel-leak`, `s3-connection-close`, `s3.leak`, `s3-queueSize-validation`.

### Background
- `MultiPartUpload` is the native object behind one S3 upload. It buffers writes, sends parts once `partSize` bytes are buffered, and commits (CompleteMultipartUpload) or rolls back (AbortMultipartUpload) at the end. It is intrusively refcounted: one ref for the sink, one owner ref released by the final commit or rollback, one per part in flight.
- `NetworkSink` is the sink behind `S3File.writer()` and the streaming upload paths. `writer_holders` counts the JS wrapper and the upload's completion callback. 0 means the `S3UploadStreamWrapper` owns the box, so the finalizer hook only acts on the `writer()` path.
- `KeepAlive` (`poll_ref`) is the event-loop ref. The process cannot exit while the upload holds it.
- A `ManagedTask` is a one-off task on the JS event loop. The finalizer runs inside a GC sweep, where settling promises is not allowed, so the abort runs on the next tick.

<details><summary>Notes</summary>

Repro from the report (80 dropped writers, 2 parts each, loopback stub): on 1.4.3 the stub sees 80 Create and 160 UploadPart, 0 Complete, 0 Abort, and the process never exits. On this branch the stub sees 80 Create and 80 Abort, and the process exits on its own.

The three writer cases in the test: parts already uploaded (Abort sent at once), collected while Create is in flight (Abort sent when the response lands, through commit 1), and only buffered bytes (no request was ever sent, the process just exits). The stream-error case does not involve GC.

Related open PRs: #39692 covers the VM-teardown half of the same leak and rewrites `fail`. This PR changes the "a request still out drops its ref on Finished" rule for the Create response only. #34999 is an older take on freeing the sink box that `writer_holders` replaced.

The writer-collected path was also checked with the ASAN debug build: no reports, the test's stderr is empty.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3-upload-abort.test.ts"
bun test v1.4.3 (f42e98025)

test/js/bun/s3/s3-upload-abort.test.ts:
114 |       body,
115 |       waitFor: `true`,
116 |       then: `createGate.resolve(); while (Date.now() < deadline && reqs.abort === 0) await Bun.sleep(10);`,
117 |       gateCreate: true,
118 |     }),
119 |   ).toEqual({
          ^
error: expect(received).toEqual(expected)

  {
    "exited": 0,
    "stderr": "",
    "stdout": 
  "rejected: source failed
- {"create":1,"part":0,"complete":0,"abort":1,"put":0}
+ {"create":1,"part":0,"complete":0,"abort":0,"put":0}
  "
  ,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-upload-abort.test.ts:119:5)
(fail) stream error while CreateMultipartUpload is in flight aborts the upload [4744.02ms]
(fail) dropped writer with uploaded parts aborts the multipart upload and lets the process exit [5008.67ms]
  ^ this test timed out after 5000ms.
(fail) dropped writer collected while CreateMultipartUpload is in flight still aborts it [5000.30ms]
  ^ 
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/s3/s3-upload-abort.test.ts:
114 |       body,
115 |       waitFor: `true`,
116 |       then: `createGate.resolve(); while (Date.now() < deadline && reqs.abort === 0) await Bun.sleep(10);`,
117 |       gateCreate: true,
118 |     }),
119 |   ).toEqual({
          ^
error: expect(received).toEqual(expected)

  {
    "exited": 0,
    "stderr": "",
    "stdout": 
  "rejected: source failed
- {"create":1,"part":0,"complete":0,"abort":1,"put":0}
+ {"create":1,"part":0,"complete":0,"abort":0,"put":0}
  "
  ,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-upload-abort.test.ts:119:5)
(fail) stream error while CreateMultipartUpload is in flight aborts the upload [4020.02ms]
(fail) dropped writer with uploaded parts aborts the multipart upload and lets the process exit [5000.07ms]
  ^ this test timed out after 5000ms.
(fail) dropped writer collected while CreateMultipartUpload is in flight still aborts it [5000.08ms]
  ^ this test timed out after 5000ms.
(fail) dropped writer with only buffered bytes lets the process exit [5000.19ms]
  ^ this test timed out after 5000ms.

 0 pass
 4
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3-upload-abort.test.ts"
bun test v1.4.3 (f42e98025)

test/js/bun/s3/s3-upload-abort.test.ts:
(pass) dropped writer with only buffered bytes lets the process exit [512.89ms]
(pass) dropped writer with uploaded parts aborts the multipart upload and lets the process exit [642.90ms]
(pass) stream error while CreateMultipartUpload is in flight aborts the upload [804.41ms]
(pass) dropped writer collected while CreateMultipartUpload is in flight still aborts it [622.72ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [3.40s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 5241ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 52s
[3/8] link bun-profile
rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSSLConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80128674)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: Linking two modules of different target triples: 'obj/codegen/GeneratedSocketConfig.cpp.o' is 'x86_64-pc-linux-gnu' whereas 'rust-target/x86_64-unknown-linux-gnu/release/libbun_runtime.a(bun_jsc-e420352fc50a33cc.bun_jsc.782f39e5b0322f0c-cgu.0.rcgu.o at 80128674)' is 'x86_64-unknown-linux-gnu'


rust-lld: warning: L
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/s3/multipart.rs    |  38 +++++--
 src/runtime/webcore/streams.rs         |  38 +++++++
 test/js/bun/s3/s3-upload-abort.test.ts | 174 +++++++++++++++++++++++++++++++++
 3 files changed, 243 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/webcore/s3/multipart.rs         1      3     12
src/runtime/webcore/streams.rs              2      3     12
test/js/bun/s3/s3-upload-abort.test.ts      1      3     11
```

</details>

<!-- robobun:evidence:end -->