### PR TITLE
node:http: give urlToHttpOptions a null prototype

### DIFF
--- a/src/js/internal/url.ts
+++ b/src/js/internal/url.ts
@@ -1,5 +1,6 @@
 function urlToHttpOptions(url) {
   const options = {
+    __proto__: null,
     ...url,
     protocol: url.protocol,
     hostname:

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1581,6 +1581,63 @@ it("should propagate exception in async data handler", async () => {
   expect(exitCode).toBe(0);
 });
 
+it("request(urlString, cb) does not read options from Object.prototype", async () => {
+  // Pollutes Object.prototype, so it runs in a subprocess.
+  const script = `
+    const net = require("node:net");
+    const http = require("node:http");
+    const heads = [];
+    const server = net.createServer(socket => {
+      socket.once("data", data => {
+        heads.push(String(data).split("\\r\\n\\r\\n")[0]);
+        socket.end("HTTP/1.1 200 OK\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n");
+      });
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const url = "http://127.0.0.1:" + server.address().port + "/victim";
+    const get = () =>
+      new Promise((resolve, reject) => {
+        http.get(url, res => {
+          res.resume();
+          res.on("end", resolve);
+        }).on("error", reject);
+      });
+    const clean = await get().then(() => heads[0]);
+
+    Object.prototype.headers = { "x-injected": "1", host: "attacker.example" };
+    Object.prototype.auth = "attacker:pw";
+    Object.prototype.method = "DELETE";
+    await get();
+
+    let hijacked = false;
+    const { promise: hijack, resolve: onHijack } = Promise.withResolvers();
+    Object.prototype.agent = {
+      addRequest(req) {
+        hijacked = true;
+        req.destroy();
+        onHijack();
+      },
+    };
+    await Promise.race([get(), hijack]);
+    server.close();
+    console.log(JSON.stringify({ same: heads[1] === clean, hijacked, head: heads[1] }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout);
+  expect(result.head).not.toContain("x-injected");
+  expect(result.head).not.toContain("Authorization");
+  expect(result.head).toStartWith("GET /victim HTTP/1.1");
+  expect(result).toMatchObject({ same: true, hijacked: false });
+  expect(exitCode).toBe(0);
+});
+
 // This test is disabled because it can OOM the CI
 it.skip("should be able to stream huge amounts of data", async () => {
   const buf = Buffer.alloc(1024 * 1024 * 256);

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "url";
+import { parse, urlToHttpOptions } from "url";
 
 describe("Url.prototype.parse", () => {
   it("parses URL correctly", () => {
@@ -64,6 +64,22 @@ describe("Url.prototype.parse", () => {
       path: "/",
       href: "http://xn--hs8h.net/",
     });
+  });
+});
+
+it("urlToHttpOptions returns a null-prototype object", () => {
+  const options = urlToHttpOptions(new URL("http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test"));
+  expect(Object.getPrototypeOf(options)).toBe(null);
+  expect({ ...options }).toEqual({
+    protocol: "http:",
+    hostname: "foo.bar.com",
+    hash: "#test",
+    search: "?l=24",
+    pathname: "/aaa/zzz",
+    path: "/aaa/zzz?l=24",
+    href: "http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test",
+    port: 21,
+    auth: "user:pass",
   });
 });
 


### PR DESCRIPTION
### Problem
- `http.get("http://…", cb)` and `http.request(urlString, cb)` read `headers`, `auth`, `method`, `agent` and `createConnection` from `Object.prototype`. A polluted `Object.prototype` injects headers, an `Authorization` header and a `Host` header, rewrites the verb, or intercepts the socket on every string-URL request. Node does not.
- The cause: `urlToHttpOptions` (`src/js/internal/url.ts:2`) returns an ordinary object. `ClientRequest` (`src/js/node/_http_client.ts:181`) uses that object directly as `options` when the second argument is the callback. The other call forms go through `ObjectAssign({ __proto__: null }, …)` and are not affected.

### Fix
- `urlToHttpOptions` returns an object with a null prototype. This matches Node's `lib/internal/url.js`.
- The public `url.urlToHttpOptions()` now also returns a null-prototype object, as in Node.
- Verified: `test/js/node/http/node-http.test.ts` (new test, spawns a bun process, pollutes `Object.prototype`, checks the raw request line and headers; fails on 1.4.3) and `test/js/node/url/url.test.ts` (null prototype and shape). Also ran all of `node-http.test.ts` and `test/js/node/test/parallel/test-url-urltooptions.js`.

### Background
- `urlToHttpOptions` converts a WHATWG `URL` into the options object that `http.request` accepts (`protocol`, `hostname`, `port`, `path`, `auth`, …).
- A null-prototype object has no inherited properties, so a lookup of a key that is not set returns `undefined` even when `Object.prototype` carries that key.

<details><summary>Notes</summary>

Repro (bun 1.4.3 and canary `d316760e8`): start a raw `net` server, `http.get(url, cb)` once, then set `Object.prototype.headers`, `.auth`, `.method`, `.agent`, and `http.get(url, cb)` again. Bun sent `DELETE /victim` with `x-injected`, `host: attacker.example` and `Authorization: Basic …`, and called the polluted `agent.addRequest`. Node v26.3.0 sent `GET /victim` unchanged each time.

Call forms checked: `http.request(str)` with no callback and `http.request(str, {}, cb)` are already immune because they build `options` with `ObjectAssign({ __proto__: null }, input, options)`. Only the `(string | URL, cb)` form is affected.

#35257 (arg validation for `urlToHttpOptions`) includes the same `__proto__: null` line. This PR is the minimal change for the prototype pollution path.

`test/js/node/http/node-http-proxy-url.test.ts` fails on this branch and on main in this container. The inner test run exceeds the 5s timeout under the debug build. Not related.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/url/url.test.ts

<!-- robobun:evidence:end -->