### PR TITLE
docs: Bun.zstdCompress and Bun.zstdDecompress borrow the input until the promise settles

### DIFF
--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -624,6 +624,8 @@ const compressedAsync = await Bun.zstdCompress(buf);
 const compressedLevel = Bun.zstdCompressSync(buf, { level: 6 });
 ```
 
+When passing a `TypedArray`/`ArrayBuffer` to `Bun.zstdCompress()`, don't modify it until the promise settles. Compression runs off-thread and borrows the bytes. To reuse the buffer right away, pass a copy: `Buffer.from(buf)` or `new Uint8Array(buf)`. `Buffer#slice()` and `subarray()` return views, not copies.
+
 ## `Bun.zstdDecompress()` / `Bun.zstdDecompressSync()`
 
 Decompresses a `Uint8Array` using the Zstandard algorithm.
@@ -641,6 +643,8 @@ const dec = new TextDecoder();
 dec.decode(decompressedSync);
 // => "hellohellohello..."
 ```
+
+The same rule applies to `Bun.zstdDecompress()`: don't modify the input buffer until the promise settles. If the bytes change while the job runs, the promise rejects with `ERR_ZSTD` or resolves with the wrong output.
 
 ---
 

--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -624,7 +624,7 @@ const compressedAsync = await Bun.zstdCompress(buf);
 const compressedLevel = Bun.zstdCompressSync(buf, { level: 6 });
 ```
 
-When passing a `TypedArray`/`ArrayBuffer` to `Bun.zstdCompress()`, don't modify it until the promise settles. Compression runs off-thread and borrows the bytes. To reuse the buffer right away, pass a copy: `Buffer.from(buf)` or `new Uint8Array(buf)`. `Buffer#slice()` and `subarray()` return views, not copies.
+When passing a `TypedArray`/`ArrayBuffer` to `Bun.zstdCompress()`, don't modify it until the promise settles. Compression runs off-thread and borrows the bytes. To reuse the buffer right away, pass a copy: `new Uint8Array(buf)` for a `Uint8Array` or `Buffer`, `ab.slice(0)` for an `ArrayBuffer`. `Buffer#slice()`, `subarray()`, `Buffer.from(arrayBuffer)` and `new Uint8Array(arrayBuffer)` return views, not copies.
 
 ## `Bun.zstdDecompress()` / `Bun.zstdDecompressSync()`
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5982,8 +5982,9 @@ declare module "bun" {
    * Compresses a chunk of data with the Zstandard (zstd) compression algorithm.
    *
    * Compression runs off-thread and borrows the bytes of a `TypedArray`/`ArrayBuffer` input.
-   * Don't modify the buffer until the promise settles. To reuse it right away, pass a copy
-   * (`Buffer.from(data)` or `new Uint8Array(data)`). `Buffer#slice()` and `subarray()` return views.
+   * Don't modify the buffer until the promise settles. To reuse it right away, pass a copy:
+   * `new Uint8Array(data)` for a `Uint8Array` or `Buffer`, `ab.slice(0)` for an `ArrayBuffer`.
+   * `Buffer#slice()`, `subarray()`, `Buffer.from(arrayBuffer)` and `new Uint8Array(arrayBuffer)` return views.
    * @param data The buffer of data to compress
    * @param options Compression options to use
    * @returns A promise that resolves to the output buffer with the compressed data
@@ -6004,8 +6005,9 @@ declare module "bun" {
    * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
    *
    * Decompression runs off-thread and borrows the bytes of a `TypedArray`/`ArrayBuffer` input.
-   * Don't modify the buffer until the promise settles. To reuse it right away, pass a copy
-   * (`Buffer.from(data)` or `new Uint8Array(data)`). `Buffer#slice()` and `subarray()` return views.
+   * Don't modify the buffer until the promise settles. To reuse it right away, pass a copy:
+   * `new Uint8Array(data)` for a `Uint8Array` or `Buffer`, `ab.slice(0)` for an `ArrayBuffer`.
+   * `Buffer#slice()`, `subarray()`, `Buffer.from(arrayBuffer)` and `new Uint8Array(arrayBuffer)` return views.
    * @param data The buffer of data to decompress
    * @returns A promise that resolves to the output buffer with the decompressed data
    */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5980,6 +5980,10 @@ declare module "bun" {
 
   /**
    * Compresses a chunk of data with the Zstandard (zstd) compression algorithm.
+   *
+   * Compression runs off-thread and borrows the bytes of a `TypedArray`/`ArrayBuffer` input.
+   * Don't modify the buffer until the promise settles. To reuse it right away, pass a copy
+   * (`Buffer.from(data)` or `new Uint8Array(data)`). `Buffer#slice()` and `subarray()` return views.
    * @param data The buffer of data to compress
    * @param options Compression options to use
    * @returns A promise that resolves to the output buffer with the compressed data
@@ -5998,6 +6002,10 @@ declare module "bun" {
 
   /**
    * Decompresses a chunk of data with the Zstandard (zstd) decompression algorithm.
+   *
+   * Decompression runs off-thread and borrows the bytes of a `TypedArray`/`ArrayBuffer` input.
+   * Don't modify the buffer until the promise settles. To reuse it right away, pass a copy
+   * (`Buffer.from(data)` or `new Uint8Array(data)`). `Buffer#slice()` and `subarray()` return views.
    * @param data The buffer of data to decompress
    * @returns A promise that resolves to the output buffer with the decompressed data
    */

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -752,6 +752,39 @@ describe.concurrent("async compression of a resizable ArrayBuffer that shrinks a
   });
 });
 
+// The async functions borrow a fixed-length buffer until the promise settles (documented in
+// docs/runtime/utils.mdx). The documented way to reuse the buffer right away is to pass a copy.
+describe.concurrent("async compression of a copy of a buffer the caller reuses", () => {
+  it("zstdCompress of Buffer.from(data) is not affected by a later write to data", async () => {
+    const data = Buffer.alloc(64 * 1024, 0x61);
+    const promise = zstdCompress(Buffer.from(data));
+    data.fill(0x62);
+    const out = zstdDecompressSync(await promise);
+    expect(out.length).toBe(data.length);
+    expect(out.every(b => b === 0x61)).toBe(true);
+  });
+
+  it("zstdCompress of arrayBuffer.slice(0) is not affected by a later write to arrayBuffer", async () => {
+    const ab = new ArrayBuffer(64 * 1024);
+    new Uint8Array(ab).fill(0x61);
+    const promise = zstdCompress(ab.slice(0));
+    new Uint8Array(ab).fill(0x62);
+    const out = zstdDecompressSync(await promise);
+    expect(out.length).toBe(ab.byteLength);
+    expect(out.every(b => b === 0x61)).toBe(true);
+  });
+
+  it("zstdDecompress of new Uint8Array(data) is not affected by a later write to data", async () => {
+    const original = Buffer.alloc(64 * 1024, 0x61);
+    const compressed = zstdCompressSync(original);
+    const promise = zstdDecompress(new Uint8Array(compressed));
+    compressed.fill(0);
+    const out = await promise;
+    expect(out.length).toBe(original.length);
+    expect(out.every(b => b === 0x61)).toBe(true);
+  });
+});
+
 describe.concurrent("Zstandard HTTP compression", () => {
   // Sample data for HTTP tests
   const testData = {


### PR DESCRIPTION
### Problem
- `Bun.zstdCompress(buf)` and `Bun.zstdDecompress(buf)` run on the work pool and read the caller's buffer there. The input is pinned and GC-rooted, not copied (`JSZstd::get_options_async` in `src/runtime/api/BunObject.rs:2604`, via `StringOrBuffer::from_js_async`). A caller that writes to the buffer right after the call changes the output. For `zstdDecompress` the promise rejects with `ERR_ZSTD`.
- Nothing told the user. Node's `zlib.zstdCompress(buf, cb)` borrows the same way, and Node documents the rule for its borrowing APIs.

### Fix
- Add one note under `Bun.zstdCompress()` and `Bun.zstdDecompress()` in `docs/runtime/utils.mdx`, and in the JSDoc for both functions in `packages/bun-types/bun.d.ts`: do not modify the buffer until the promise settles. To reuse it right away, pass a copy: `new Uint8Array(data)` for a `Uint8Array` or `Buffer`, `ab.slice(0)` for an `ArrayBuffer`. `Buffer#slice()`, `subarray()`, `Buffer.from(arrayBuffer)` and `new Uint8Array(arrayBuffer)` are views.
- The wording follows the same note for `Bun.Image` in `docs/runtime/image.mdx`.
- No runtime change. The zero-copy borrow for a fixed-length buffer is the intended design (see #40641 and the review on #30158). A copy at call would add a memcpy stall for every caller, about 2.6 ms per 16 MiB.
- Three tests in `test/js/bun/util/zstd.test.ts` check that each documented copy is safe to overwrite after the call. They pass on the current build and on the debug build.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts` passes (21 tests). Prettier is clean.

### Background
- An argument-capture sweep found the borrow. Repro on bun 1.4.3: `const p = Bun.zstdCompress(u8); u8.fill(0x62);` then decompress `await p`: the first byte is `0x62`.
- Resizable `ArrayBuffer` inputs are already copied at call time (`PinnedArrayBuffer::copy_if_resizable`), so only a fixed-length buffer that the caller writes to is affected.
