### PR TITLE
install: warn when a present .npmrc or bunfig.toml cannot be read

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -46,6 +46,14 @@ fn load_bunfig(
             Ok(s) => s,
             Err(err) => {
                 if auto_loaded {
+                    if !err.is_missing_file(config_path) {
+                        bun_core::warn!(
+                            "{}\nThe settings in <b>{}<r> are not applied.\n",
+                            err,
+                            BStr::new(config_path.as_bytes()),
+                        );
+                        Output::flush();
+                    }
                     return Ok(());
                 }
                 bun_core::pretty_errorln!(

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1253,6 +1253,14 @@ mod draft {
                 Ok(s) => s,
                 Err(err) => {
                     if auto_loaded {
+                        if !err.is_missing_file(npmrc_path) {
+                            bun_core::warn!(
+                                "{}\nThe registry and auth settings in <b>{}<r> are not applied.\n",
+                                err,
+                                bstr::BStr::new(npmrc_path.as_bytes()),
+                            );
+                            Output::flush();
+                        }
                         continue;
                     }
                     Output::err(

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1933,12 +1933,13 @@ pub fn init(
         let parts = [b"./.npmrc" as &[u8]];
 
         // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
-        // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
+        // `$XDG_CONFIG_HOME/.npmrc` only when that entry exists. `lstat`, so
+        // that a dangling symlink is kept and reported by `load_npmrc_config`.
         let mut global_len: usize = 0;
         if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
             let p =
                 resolve_path::join_abs_string_buf_z::<platform::Auto>(xdg_dir, &mut buf, &parts);
-            if bun_sys::exists_z(p) {
+            if bun_sys::lstat(p).is_ok() {
                 global_len = p.len();
             }
         }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1933,8 +1933,8 @@ pub fn init(
         let parts = [b"./.npmrc" as &[u8]];
 
         // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
-        // `$XDG_CONFIG_HOME/.npmrc` only when that entry exists. `lstat`, so
-        // that a dangling symlink is kept and reported by `load_npmrc_config`.
+        // `$XDG_CONFIG_HOME/.npmrc` only when that entry exists (a dangling
+        // symlink counts, `load_npmrc_config` reports it).
         let mut global_len: usize = 0;
         if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
             let p =

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -120,6 +120,18 @@ impl Error {
         self.get_errno() == E::EAGAIN
     }
 
+    /// For an error from an open or read of `path`: `true` when no file
+    /// exists at `path` (ENOENT, ENOTDIR). `false` for a file that exists
+    /// but cannot be read (EACCES, EISDIR, ...) and for a dangling symlink,
+    /// which `open` also reports as ENOENT.
+    pub fn is_missing_file(&self, path: &bun_core::ZStr) -> bool {
+        match self.get_errno() {
+            E::ENOENT => crate::lstat(path).is_err(),
+            E::ENOTDIR => true,
+            _ => false,
+        }
+    }
+
     /// `bun.sys.Error.oom` — `ENOMEM` with no syscall context. (The `Box<[u8]>`
     /// fields prevent a true `const` item.)
     #[inline]

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -120,10 +120,8 @@ impl Error {
         self.get_errno() == E::EAGAIN
     }
 
-    /// For an error from an open or read of `path`: `true` when no file
-    /// exists at `path` (ENOENT, ENOTDIR). `false` for a file that exists
-    /// but cannot be read (EACCES, EISDIR, ...) and for a dangling symlink,
-    /// which `open` also reports as ENOENT.
+    /// No entry at `path`. A dangling symlink is an entry (`open` reports
+    /// ENOENT for it too).
     pub fn is_missing_file(&self, path: &bun_core::ZStr) -> bool {
         match self.get_errno() {
             E::ENOENT => crate::lstat(path).is_err(),

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1,7 +1,8 @@
 import { write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { chmodSync, readFileSync, symlinkSync } from "fs";
 import { rm } from "fs/promises";
-import { VerdaccioRegistry, bunExe, bunEnv as env, isIPv6, tempDir } from "harness";
+import { VerdaccioRegistry, bunExe, bunEnv as env, isIPv6, isLinux, isWindows, tempDir } from "harness";
 import { join } from "path";
 const { iniInternals } = require("bun:internal-for-testing");
 const { loadNpmrc } = iniInternals;
@@ -812,5 +813,112 @@ describe.skipIf(!isIPv6())("registry on a bracketed IPv6 host", () => {
     ]);
     // The registry answers 404 to both manifest requests, so the install itself fails.
     expect(exitCode).not.toBe(0);
+  });
+});
+
+// A present config file that cannot be read must not be skipped in silence:
+// without its `registry=` and `_authToken`, every package name goes to the
+// public registry with no token.
+describe("unreadable config files", () => {
+  const isRoot = !isWindows && process.getuid?.() === 0;
+  const hasNobody = (() => {
+    try {
+      return /^nobody:/m.test(readFileSync("/etc/passwd", "utf8"));
+    } catch {
+      return false;
+    }
+  })();
+  // root bypasses file modes, so drop to `nobody` with runuser when root.
+  const canUseRunuser = isLinux && isRoot && !!Bun.which("runuser") && hasNobody;
+  const canTriggerEACCES = !isWindows && (!isRoot || canUseRunuser);
+
+  /** Runs `bun install` in `dir` (no dependencies, so no network) and returns stderr. */
+  async function installStderr(dir: string, home: string): Promise<string> {
+    const bunCmd = [bunExe(), "install"];
+    const cmd = canUseRunuser ? ["runuser", "-m", "-u", "nobody", "--", ...bunCmd] : bunCmd;
+    await using proc = Bun.spawn({
+      cmd,
+      cwd: dir,
+      env: {
+        ...env,
+        HOME: home,
+        XDG_CONFIG_HOME: home,
+        BUN_INSTALL_CACHE_DIR: join(dir, ".cache"),
+        TMPDIR: join(dir, ".tmp"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    return stderr;
+  }
+
+  function makeDir(files: Record<string, string>) {
+    const dir = tempDir("npmrc-unreadable", {
+      "proj/package.json": JSON.stringify({ name: "app", version: "1.0.0" }),
+      "proj/.cache/.keep": "",
+      "proj/.tmp/.keep": "",
+      "home/.keep": "",
+      ...files,
+    });
+    // `nobody` must traverse the tree and write the lockfile in `proj`.
+    for (const p of [
+      String(dir),
+      join(dir, "proj"),
+      join(dir, "proj", ".cache"),
+      join(dir, "proj", ".tmp"),
+      join(dir, "home"),
+    ]) {
+      chmodSync(p, 0o777);
+    }
+    chmodSync(join(dir, "proj", "package.json"), 0o644);
+    return dir;
+  }
+
+  test.skipIf(!canTriggerEACCES)("warns when the project .npmrc cannot be read", async () => {
+    using dir = makeDir({ "proj/.npmrc": "registry=http://127.0.0.1:1/\n" });
+    chmodSync(join(dir, "proj", ".npmrc"), 0o000);
+    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    expect(stderr).toContain("EACCES");
+    expect(stderr).toContain("The registry and auth settings in .npmrc are not applied");
+  });
+
+  test.skipIf(!canTriggerEACCES)("warns when ~/.npmrc cannot be read", async () => {
+    using dir = makeDir({ "home/.npmrc": "registry=http://127.0.0.1:1/\n" });
+    chmodSync(join(dir, "home", ".npmrc"), 0o000);
+    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    expect(stderr).toContain("EACCES");
+    expect(stderr).toContain(`The registry and auth settings in ${join(dir, "home", ".npmrc")} are not applied`);
+  });
+
+  test.skipIf(!canTriggerEACCES)("warns when the project bunfig.toml cannot be read", async () => {
+    using dir = makeDir({ "proj/bunfig.toml": '[install]\nregistry = "http://127.0.0.1:1/"\n' });
+    chmodSync(join(dir, "proj", "bunfig.toml"), 0o000);
+    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    expect(stderr).toContain("EACCES");
+    expect(stderr).toContain(`The settings in ${join(dir, "proj", "bunfig.toml")} are not applied`);
+  });
+
+  test.skipIf(!canTriggerEACCES)("warns when the global .bunfig.toml cannot be read", async () => {
+    using dir = makeDir({ "home/.bunfig.toml": '[install]\nregistry = "http://127.0.0.1:1/"\n' });
+    chmodSync(join(dir, "home", ".bunfig.toml"), 0o000);
+    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    expect(stderr).toContain("EACCES");
+    expect(stderr).toContain(`The settings in ${join(dir, "home", ".bunfig.toml")} are not applied`);
+  });
+
+  test.skipIf(isWindows)("warns when .npmrc is a dangling symlink", async () => {
+    using dir = makeDir({});
+    symlinkSync("missing-target", join(dir, "proj", ".npmrc"));
+    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    expect(stderr).toContain("ENOENT");
+    expect(stderr).toContain("The registry and auth settings in .npmrc are not applied");
+  });
+
+  test.skipIf(isWindows)("stays silent when no config file exists", async () => {
+    using dir = makeDir({});
+    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    expect(stderr).not.toContain("not applied");
   });
 });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -832,8 +832,8 @@ describe("unreadable config files", () => {
   const canUseRunuser = isLinux && isRoot && !!Bun.which("runuser") && hasNobody;
   const canTriggerEACCES = !isWindows && (!isRoot || canUseRunuser);
 
-  /** Runs `bun install` in `dir` (no dependencies, so no network) and returns stderr. */
-  async function installStderr(dir: string, home: string): Promise<string> {
+  /** Runs `bun install` in `dir` (no dependencies, so no network). `home` is both HOME and XDG_CONFIG_HOME. */
+  async function install(dir: string, home: string) {
     const bunCmd = [bunExe(), "install"];
     const cmd = canUseRunuser ? ["runuser", "-m", "-u", "nobody", "--", ...bunCmd] : bunCmd;
     await using proc = Bun.spawn({
@@ -850,8 +850,7 @@ describe("unreadable config files", () => {
       stderr: "pipe",
     });
     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    return stderr;
+    return { stderr, exitCode };
   }
 
   function makeDir(files: Record<string, string>) {
@@ -879,46 +878,61 @@ describe("unreadable config files", () => {
   test.skipIf(!canTriggerEACCES)("warns when the project .npmrc cannot be read", async () => {
     using dir = makeDir({ "proj/.npmrc": "registry=http://127.0.0.1:1/\n" });
     chmodSync(join(dir, "proj", ".npmrc"), 0o000);
-    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    const { stderr, exitCode } = await install(join(dir, "proj"), join(dir, "home"));
     expect(stderr).toContain("EACCES");
     expect(stderr).toContain("The registry and auth settings in .npmrc are not applied");
+    expect(exitCode).toBe(0);
   });
 
   test.skipIf(!canTriggerEACCES)("warns when ~/.npmrc cannot be read", async () => {
     using dir = makeDir({ "home/.npmrc": "registry=http://127.0.0.1:1/\n" });
     chmodSync(join(dir, "home", ".npmrc"), 0o000);
-    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    const { stderr, exitCode } = await install(join(dir, "proj"), join(dir, "home"));
     expect(stderr).toContain("EACCES");
     expect(stderr).toContain(`The registry and auth settings in ${join(dir, "home", ".npmrc")} are not applied`);
+    expect(exitCode).toBe(0);
   });
 
   test.skipIf(!canTriggerEACCES)("warns when the project bunfig.toml cannot be read", async () => {
     using dir = makeDir({ "proj/bunfig.toml": '[install]\nregistry = "http://127.0.0.1:1/"\n' });
     chmodSync(join(dir, "proj", "bunfig.toml"), 0o000);
-    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    const { stderr, exitCode } = await install(join(dir, "proj"), join(dir, "home"));
     expect(stderr).toContain("EACCES");
     expect(stderr).toContain(`The settings in ${join(dir, "proj", "bunfig.toml")} are not applied`);
+    expect(exitCode).toBe(0);
   });
 
   test.skipIf(!canTriggerEACCES)("warns when the global .bunfig.toml cannot be read", async () => {
     using dir = makeDir({ "home/.bunfig.toml": '[install]\nregistry = "http://127.0.0.1:1/"\n' });
     chmodSync(join(dir, "home", ".bunfig.toml"), 0o000);
-    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    const { stderr, exitCode } = await install(join(dir, "proj"), join(dir, "home"));
     expect(stderr).toContain("EACCES");
     expect(stderr).toContain(`The settings in ${join(dir, "home", ".bunfig.toml")} are not applied`);
+    expect(exitCode).toBe(0);
   });
 
   test.skipIf(isWindows)("warns when .npmrc is a dangling symlink", async () => {
     using dir = makeDir({});
     symlinkSync("missing-target", join(dir, "proj", ".npmrc"));
-    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    const { stderr, exitCode } = await install(join(dir, "proj"), join(dir, "home"));
     expect(stderr).toContain("ENOENT");
     expect(stderr).toContain("The registry and auth settings in .npmrc are not applied");
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(isWindows)("warns when $XDG_CONFIG_HOME/.npmrc is a dangling symlink", async () => {
+    using dir = makeDir({});
+    symlinkSync("missing-target", join(dir, "home", ".npmrc"));
+    const { stderr, exitCode } = await install(join(dir, "proj"), join(dir, "home"));
+    expect(stderr).toContain("ENOENT");
+    expect(stderr).toContain(`The registry and auth settings in ${join(dir, "home", ".npmrc")} are not applied`);
+    expect(exitCode).toBe(0);
   });
 
   test.skipIf(isWindows)("stays silent when no config file exists", async () => {
     using dir = makeDir({});
-    const stderr = await installStderr(join(dir, "proj"), join(dir, "home"));
+    const { stderr, exitCode } = await install(join(dir, "proj"), join(dir, "home"));
     expect(stderr).not.toContain("not applied");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- A `.npmrc` or `bunfig.toml` that exists but cannot be opened is skipped with no output. `chmod 000 .npmrc`, then `bun install` as another uid: the `registry=` and `_authToken` in it vanish and every package name goes to registry.npmjs.org without a token. `--verbose` adds nothing. A dangling `.npmrc` symlink behaves the same. So do `~/.npmrc`, the project `bunfig.toml`, and `$XDG_CONFIG_HOME/.bunfig.toml`.
- The cause: both auto-load paths treat every read error as "file absent". `load_npmrc_config` (`src/ini/lib.rs:1254`) does `continue`, `load_bunfig` (`src/bunfig/arguments.rs:48`) returns `Ok(())`.

### Fix
- Add `bun_sys::Error::is_missing_file(path)`. It is true for ENOENT and ENOTDIR, except when `lstat` shows a symlink at `path` (a dangling symlink also opens with ENOENT).
- Both auto-load paths stay silent only when `is_missing_file` is true. For any other error they print a warning with the errno and the path, and say that the settings in that file are not applied. Install continues as before. npm does the same with `--loglevel verbose` (`@npmcli/config`, `#loadFile`: ENOENT is the only silenced code).
- `$XDG_CONFIG_HOME/.npmrc` is selected with `lstat` instead of `access(F_OK)`, so a dangling symlink there reaches the loader and gets the same warning. An explicit `--config` path still exits with an error as before.
- Verified: `test/cli/install/npmrc.test.ts` (7 new tests, 6 fail on the released bun). Also `bun-run-bunfig.test.ts`, `config-precedence.test.ts`, and `cargo check` for windows-msvc and apple-darwin.

### Background
- `bun install` reads `~/.npmrc` (or `$XDG_CONFIG_HOME/.npmrc`), then `./.npmrc`, then `bunfig.toml` and the global `.bunfig.toml`. Each is "auto-loaded": a missing file is normal and must stay quiet.
- The warning text:
  ```
  warn: EACCES: .npmrc: Permission denied (open())
  The registry and auth settings in .npmrc are not applied.
  ```

<details><summary>Notes</summary>

- The tests run `bun install` in a project with no dependencies, so no network is needed. When the test process is root (file modes do not apply to root), they drop to `nobody` through `runuser -m`, the same pattern as `test/cli/run/env.test.ts`. Both branches were run locally: as root, and as `nobody`.
- The extra `lstat` runs only on the ENOENT path, once per config location that does not exist.
- Opening `/root/.npmrc` as a non-root user with `HOME=/root` now warns too (EACCES on the directory). That is a real case of "present config not applied".
- A sibling branch takes a stricter shape for the project `bunfig.toml` (exit 1 instead of a warning) and keeps the global config silent: `robobun/5a2287a4/bunfig-unreadable-error`. Either shape fixes the silent skip. A maintainer can pick one.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/npmrc.test.ts

<!-- robobun:evidence:end -->