### PR TITLE
patch: position zero-length hunk ranges after the named line

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -341,7 +341,15 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
     }
 
     for hunk in &patch.hunks {
-        let mut line_cursor = (hunk.header.patched.start - 1) as usize;
+        // In the unified format a range with a length of 0 (`+5,0`, as `git diff -U0`
+        // emits for a pure deletion) names the line *after which* the gap sits, not
+        // the first line of the range. `+0,0` is the gap before the first line.
+        let patched_start = hunk.header.patched.start as usize;
+        let mut line_cursor = if hunk.header.patched.len == 0 {
+            patched_start
+        } else {
+            patched_start.saturating_sub(1)
+        };
 
         // Validate hunk start position is within bounds
         if line_cursor > lines.len() {
@@ -1447,7 +1455,7 @@ fn parse_hunk_header_line_impl(text_: &[u8]) -> Result<HunkHeaderLineImpl<'_>, P
     }
 
     Ok(HunkHeaderLineImpl {
-        line_nr: 1.max(bun_core::parse_decimal::<u32>(line_nr).ok_or(ParseErr::bad_header_line)?),
+        line_nr: bun_core::parse_decimal::<u32>(line_nr).ok_or(ParseErr::bad_header_line)?,
         line_count: bun_core::parse_decimal::<u32>(line_nr_count)
             .ok_or(ParseErr::bad_header_line)?,
         rest: text,

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -341,9 +341,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
     }
 
     for hunk in &patch.hunks {
-        // In the unified format a range with a length of 0 (`+5,0`, as `git diff -U0`
-        // emits for a pure deletion) names the line *after which* the gap sits, not
-        // the first line of the range. `+0,0` is the gap before the first line.
+        // A zero-length range (`+5,0`) names the line after which the gap sits.
         let patched_start = hunk.header.patched.start as usize;
         let mut line_cursor = if hunk.header.patched.len == 0 {
             patched_start

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -542,16 +542,36 @@ describe("apply", () => {
   describe("zero context (-U0) hunks", () => {
     const numbered = (n: number) => Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
     const cases: [name: string, before: string, hunks: string, after: string][] = [
-      ["delete one line", numbered(8), "@@ -6 +5,0 @@\n-line 6\n", "line 1\nline 2\nline 3\nline 4\nline 5\nline 7\nline 8\n"],
-      ["delete a run of lines", numbered(8), "@@ -3,3 +2,0 @@\n-line 3\n-line 4\n-line 5\n", "line 1\nline 2\nline 6\nline 7\nline 8\n"],
+      [
+        "delete one line",
+        numbered(8),
+        "@@ -6 +5,0 @@\n-line 6\n",
+        "line 1\nline 2\nline 3\nline 4\nline 5\nline 7\nline 8\n",
+      ],
+      [
+        "delete a run of lines",
+        numbered(8),
+        "@@ -3,3 +2,0 @@\n-line 3\n-line 4\n-line 5\n",
+        "line 1\nline 2\nline 6\nline 7\nline 8\n",
+      ],
       ["delete the first line", numbered(3), "@@ -1 +0,0 @@\n-line 1\n", "line 2\nline 3\n"],
       ["delete the last line", numbered(3), "@@ -3 +2,0 @@\n-line 3\n", "line 1\nline 2\n"],
       ["delete every line", numbered(2), "@@ -1,2 +0,0 @@\n-line 1\n-line 2\n", ""],
-      ["two deletions", numbered(8), "@@ -2 +1,0 @@\n-line 2\n@@ -6 +4,0 @@\n-line 6\n", "line 1\nline 3\nline 4\nline 5\nline 7\nline 8\n"],
+      [
+        "two deletions",
+        numbered(8),
+        "@@ -2 +1,0 @@\n-line 2\n@@ -6 +4,0 @@\n-line 6\n",
+        "line 1\nline 3\nline 4\nline 5\nline 7\nline 8\n",
+      ],
       ["insert after a line", numbered(4), "@@ -3,0 +4,2 @@\n+X\n+Y\n", "line 1\nline 2\nline 3\nX\nY\nline 4\n"],
       ["insert at the top", numbered(2), "@@ -0,0 +1 @@\n+X\n", "X\nline 1\nline 2\n"],
       ["replace a line", numbered(3), "@@ -2 +2 @@\n-line 2\n+TWO\n", "line 1\nTWO\nline 3\n"],
-      ["delete then insert", numbered(6), "@@ -2 +1,0 @@\n-line 2\n@@ -5,0 +5 @@\n+X\n", "line 1\nline 3\nline 4\nline 5\nX\nline 6\n"],
+      [
+        "delete then insert",
+        numbered(6),
+        "@@ -2 +1,0 @@\n-line 2\n@@ -5,0 +5 @@\n+X\n",
+        "line 1\nline 3\nline 4\nline 5\nX\nline 6\n",
+      ],
     ];
 
     test.each(cases)("%s", async (_name, before, hunks, after) => {

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -536,6 +536,32 @@ describe("apply", () => {
     // TODO: simple, multiline, multiple hunks
   });
 
+  // `git diff -U0` emits hunks with no context lines. A range of length 0
+  // (`+5,0`) names the line after which the gap sits, so a pure deletion must
+  // not be positioned as if the range started at that line.
+  describe("zero context (-U0) hunks", () => {
+    const numbered = (n: number) => Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
+    const cases: [name: string, before: string, hunks: string, after: string][] = [
+      ["delete one line", numbered(8), "@@ -6 +5,0 @@\n-line 6\n", "line 1\nline 2\nline 3\nline 4\nline 5\nline 7\nline 8\n"],
+      ["delete a run of lines", numbered(8), "@@ -3,3 +2,0 @@\n-line 3\n-line 4\n-line 5\n", "line 1\nline 2\nline 6\nline 7\nline 8\n"],
+      ["delete the first line", numbered(3), "@@ -1 +0,0 @@\n-line 1\n", "line 2\nline 3\n"],
+      ["delete the last line", numbered(3), "@@ -3 +2,0 @@\n-line 3\n", "line 1\nline 2\n"],
+      ["delete every line", numbered(2), "@@ -1,2 +0,0 @@\n-line 1\n-line 2\n", ""],
+      ["two deletions", numbered(8), "@@ -2 +1,0 @@\n-line 2\n@@ -6 +4,0 @@\n-line 6\n", "line 1\nline 3\nline 4\nline 5\nline 7\nline 8\n"],
+      ["insert after a line", numbered(4), "@@ -3,0 +4,2 @@\n+X\n+Y\n", "line 1\nline 2\nline 3\nX\nY\nline 4\n"],
+      ["insert at the top", numbered(2), "@@ -0,0 +1 @@\n+X\n", "X\nline 1\nline 2\n"],
+      ["replace a line", numbered(3), "@@ -2 +2 @@\n-line 2\n+TWO\n", "line 1\nTWO\nline 3\n"],
+      ["delete then insert", numbered(6), "@@ -2 +1,0 @@\n-line 2\n@@ -5,0 +5 @@\n+X\n", "line 1\nline 3\nline 4\nline 5\nX\nline 6\n"],
+    ];
+
+    test.each(cases)("%s", async (_name, before, hunks, after) => {
+      await using dir = tempDir("patch-u0", { "index.js": before });
+      const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunks}`;
+      await apply(patchfile, String(dir));
+      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe(after);
+    });
+  });
+
   // Each of these hits an error path in `parse_apply_args`. The native code must
   // surface the failure as a catchable JS exception; it used to return a normal
   // value while the exception was still pending, which aborts debug/ASAN builds
@@ -716,7 +742,7 @@ describe("parse", () => {
               "path": "banana.ts",
               "mode": "non_executable",
               "hunk": {
-                "header": { "original": { "start": 1, "len": 0 }, "patched": { "start": 1, "len": 1 } },
+                "header": { "original": { "start": 0, "len": 0 }, "patched": { "start": 1, "len": 1 } },
                 "parts": {
                   "items": [
                     {


### PR DESCRIPTION
### Problem
- A `patchedDependencies` patch made with `git diff -U0` that only deletes lines removes the wrong line. For `@@ -6 +5,0 @@` on an 8-line file, bun deletes line 5 and keeps line 6. `git apply --unidiff-zero` and GNU patch delete line 6. `bun install` exits 0, so the user gets a wrong tree with no message.
- The cause is in `apply_patch` (`src/patch/lib.rs:344`). It sets the cursor to `patched.start - 1` for every hunk. In the unified format a range of length 0 names the line after which the gap sits, so the cursor is one line too early. The parser also clamped a start of 0 to 1, so `+0,0` and `+1,0` parsed the same.

### Fix
- When `patched.len == 0`, the cursor starts at `patched.start` instead of `patched.start - 1`.
- The parser keeps the raw start value. `+0,0` now parses as `start: 0`, and the cursor for it is 0 (the gap before the first line). Non-empty ranges use `saturating_sub(1)` so a malformed `+0,3` cannot underflow.
- Correct because the applier walks hunks in order and keeps `lines` in new-file coordinates. For a hunk with new content, index `start - 1` is the first line of that content. For an empty new range, index `start` is the gap. This matches what git emits and applies.
- Verified: `test/js/bun/patch/patch.test.ts` (new `zero context (-U0) hunks` block, 10 cases, 5 fail on stock bun). Also `test/cli/install/bun-patch.test.ts` and `bun-install-patch.test.ts`.

### Background
- A unified diff hunk header is `@@ -<old start>,<old len> +<new start>,<new len> @@`. A missing `,len` means 1. Git emits a 0 length when the hunk adds or removes lines and has no context lines around them. The start of such a range is the line before the gap, and 0 means the gap is before the first line.
- `git diff -U0` emits no context lines at all, so a pure deletion always has `+N,0`. A patch made with the default 3 context lines never has a 0-length new range unless the file ends up empty, which is why the bug went unseen.
- `patchInternals.apply` from `bun:internal-for-testing` runs the same applier that `bun install` uses for `patchedDependencies`.

<details><summary>Notes</summary>

The `can handle files with CRLF line breaks` parse snapshot changes from `original.start: 1` to `0` for `@@ -0,0 +1 @@`. That is the raw value git writes.

Suites run with the debug build: `test/js/bun/patch/patch.test.ts` (37 pass), `test/cli/install/bun-patch.test.ts` and `test/cli/install/bun-install-patch.test.ts` (68 pass). Under `USE_SYSTEM_BUN=1` the patch test file has 6 failures: the 5 deletion cases and the snapshot line.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/patch/patch.test.ts

<!-- robobun:evidence:end -->