### PR TITLE
js_parser: reject a parenthesized assignment as a destructuring target

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -41,8 +41,7 @@ impl Default for NameOfSymbol {
 pub struct Array {
     pub items: ExprNodeList,
     pub comma_after_spread: crate::Loc,
-    /// `[(a = 1)]`: an item that is a parenthesized assignment. Like
-    /// `comma_after_spread`, an error only if this literal is a pattern.
+    /// `[(a = 1)]`: an error only if this literal is a pattern.
     pub parenthesized_assign: crate::Loc,
     pub is_single_line: bool,
     pub is_parenthesized: bool,

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -41,6 +41,9 @@ impl Default for NameOfSymbol {
 pub struct Array {
     pub items: ExprNodeList,
     pub comma_after_spread: crate::Loc,
+    /// `[(a = 1)]`: an item that is a parenthesized assignment. Like
+    /// `comma_after_spread`, an error only if this literal is a pattern.
+    pub parenthesized_assign: crate::Loc,
     pub is_single_line: bool,
     pub is_parenthesized: bool,
     pub was_originally_macro: bool,
@@ -51,6 +54,7 @@ impl Default for Array {
         Self {
             items: bun_alloc::AstAlloc::vec(),
             comma_after_spread: crate::Loc::EMPTY,
+            parenthesized_assign: crate::Loc::EMPTY,
             is_single_line: false,
             is_parenthesized: false,
             was_originally_macro: false,
@@ -1274,6 +1278,8 @@ impl ArrayJSON {
 pub struct Object {
     pub properties: G::PropertyList,
     pub comma_after_spread: crate::Loc,
+    /// `{ x: (a = 1) }`: see `Array::parenthesized_assign`.
+    pub parenthesized_assign: crate::Loc,
     pub is_single_line: bool,
     pub is_parenthesized: bool,
     pub was_originally_macro: bool,
@@ -1285,6 +1291,7 @@ impl Default for Object {
         Self {
             properties: bun_alloc::AstAlloc::vec(),
             comma_after_spread: crate::Loc::EMPTY,
+            parenthesized_assign: crate::Loc::EMPTY,
             is_single_line: false,
             is_parenthesized: false,
             was_originally_macro: false,
@@ -1351,6 +1358,7 @@ impl Object {
     pub const EMPTY: Object = Object {
         properties: bun_alloc::AstAlloc::vec(),
         comma_after_spread: crate::Loc::EMPTY,
+        parenthesized_assign: crate::Loc::EMPTY,
         is_single_line: false,
         is_parenthesized: false,
         was_originally_macro: false,

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1878,6 +1878,7 @@ impl Data {
                 let item = bump.alloc(E::Array {
                     items,
                     comma_after_spread: el.comma_after_spread,
+                    parenthesized_assign: el.parenthesized_assign,
                     was_originally_macro: el.was_originally_macro,
                     is_single_line: el.is_single_line,
                     is_parenthesized: el.is_parenthesized,
@@ -2065,6 +2066,7 @@ impl Data {
                 let item = bump.alloc(E::Object {
                     properties: el.properties.try_deep_clone_with(|p| p.deep_clone(bump))?,
                     comma_after_spread: el.comma_after_spread,
+                    parenthesized_assign: el.parenthesized_assign,
                     is_single_line: el.is_single_line,
                     is_parenthesized: el.is_parenthesized,
                     was_originally_macro: el.was_originally_macro,

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -924,6 +924,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ))
     }
 
+    pub(crate) fn maybe_parenthesized_assign_error(&mut self, parenthesized_assign: bun_ast::Loc) {
+        if let Some(loc) = parenthesized_assign.to_nullable() {
+            self.log()
+                .add_error(Some(self.source), loc, b"Invalid assignment target");
+        }
+    }
+
     pub(crate) fn maybe_comma_spread_error(&mut self, comma_after_spread: bun_ast::Loc) {
         let p = self;
         if comma_after_spread.is_empty() {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3959,6 +3959,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         kind: crate::parser::InvalidLocTag::Spread,
                     });
                 }
+                if let Some(paren) = ex.parenthesized_assign.to_nullable() {
+                    invalid_loc.push(InvalidLoc {
+                        loc: paren,
+                        kind: crate::parser::InvalidLocTag::Parentheses,
+                    });
+                }
 
                 if ex.is_parenthesized {
                     invalid_loc.push(InvalidLoc {
@@ -4012,6 +4018,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     invalid_loc.push(InvalidLoc {
                         loc: sp,
                         kind: crate::parser::InvalidLocTag::Spread,
+                    });
+                }
+                if let Some(paren) = ex.parenthesized_assign.to_nullable() {
+                    invalid_loc.push(InvalidLoc {
+                        loc: paren,
+                        kind: crate::parser::InvalidLocTag::Parentheses,
                     });
                 }
 
@@ -4117,17 +4129,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         let bind = self.convert_expr_to_binding(expr, invalid_log);
-        if let Some(initial) = initializer {
-            let equals_range = self.source.range_of_operator_before(initial.loc, b"=");
-            if is_spread {
-                self.log().add_range_error(
-                    Some(self.source),
-                    equals_range,
-                    b"A rest argument cannot have a default initializer",
-                );
-            } else {
-                // p.markSyntaxFeature();
-            }
+        if is_spread && let Some(initial) = initializer {
+            invalid_log.push(InvalidLoc {
+                loc: self.source.range_of_operator_before(initial.loc, b"=").loc,
+                kind: crate::parser::InvalidLocTag::RestInitializer,
+            });
         }
         ExprBindingTuple {
             binding: bind,
@@ -4153,14 +4159,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Rust, so this is a runtime assertion instead.
         if !TYPESCRIPT {
             unreachable!();
-        }
-    }
-
-    /// The literal turned out to be an assignment pattern.
-    pub(crate) fn log_pattern_errors(&mut self, errors: &DeferredErrors) {
-        if let Some(r) = errors.invalid_pattern_paren_assign {
-            self.log()
-                .add_range_error(Some(self.source), r, b"Invalid assignment target");
         }
     }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4050,7 +4050,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         invalid_loc,
                         is_spread,
                     );
-                    // An object rest binding must be an identifier: "({ ...[a] }) => 0"
+                    // "({ ...[a] }) => 0"
                     if is_spread
                         && let Some(binding) = &tup.binding
                         && matches!(binding.data, js_ast::b::B::BArray(_) | js_ast::b::B::BObject(_))
@@ -4156,8 +4156,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Logs the errors that apply once an array or object literal is known to
-    /// be an assignment pattern.
+    /// The literal turned out to be an assignment pattern.
     pub(crate) fn log_pattern_errors(&mut self, errors: &DeferredErrors) {
         if let Some(r) = errors.invalid_pattern_paren_assign {
             self.log()

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4045,15 +4045,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let value = item.value.as_mut().unwrap();
                     let is_spread = item.kind == js_ast::g::PropertyKind::Spread
                         || item.flags.contains(Flags::Property::IsSpread);
-                    let tup = self.convert_expr_to_binding_and_initializer(
-                        value,
-                        invalid_loc,
-                        is_spread,
-                    );
+                    let tup =
+                        self.convert_expr_to_binding_and_initializer(value, invalid_loc, is_spread);
                     // "({ ...[a] }) => 0"
                     if is_spread
                         && let Some(binding) = &tup.binding
-                        && matches!(binding.data, js_ast::b::B::BArray(_) | js_ast::b::B::BObject(_))
+                        && matches!(
+                            binding.data,
+                            js_ast::b::B::BArray(_) | js_ast::b::B::BObject(_)
+                        )
                     {
                         invalid_loc.push(InvalidLoc {
                             loc: binding.loc,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4043,11 +4043,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         continue;
                     }
                     let value = item.value.as_mut().unwrap();
-                    let tup =
-                        self.convert_expr_to_binding_and_initializer(value, invalid_loc, false);
-                    let initializer = tup.expr.or(item.initializer);
                     let is_spread = item.kind == js_ast::g::PropertyKind::Spread
                         || item.flags.contains(Flags::Property::IsSpread);
+                    let tup = self.convert_expr_to_binding_and_initializer(
+                        value,
+                        invalid_loc,
+                        is_spread,
+                    );
+                    // An object rest binding must be an identifier: "({ ...[a] }) => 0"
+                    if is_spread
+                        && let Some(binding) = &tup.binding
+                        && matches!(binding.data, js_ast::b::B::BArray(_) | js_ast::b::B::BObject(_))
+                    {
+                        invalid_loc.push(InvalidLoc {
+                            loc: binding.loc,
+                            kind: crate::parser::InvalidLocTag::Unknown,
+                        });
+                    }
+                    let initializer = tup.expr.or(item.initializer);
                     let mut flags = Flags::PropertySet::empty();
                     if is_spread {
                         flags |= Flags::Property::IsSpread;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4143,6 +4143,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Logs the errors that apply once an array or object literal is known to
+    /// be an assignment pattern.
+    pub(crate) fn log_pattern_errors(&mut self, errors: &DeferredErrors) {
+        if let Some(r) = errors.invalid_pattern_paren_assign {
+            self.log()
+                .add_range_error(Some(self.source), r, b"Invalid assignment target");
+        }
+    }
+
     pub(crate) fn log_expr_errors(&mut self, errors: &mut DeferredErrors) {
         if let Some(r) = errors.invalid_expr_default_value {
             self.log()

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -76,11 +76,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.lexer.has_pure_comment_before && !self.options.ignore_dce_annotations;
         let paren_assign_before = errors
             .as_deref()
-            .and_then(|errors| errors.invalid_pattern_paren_assign);
+            .and_then(|errors| errors.parenthesized_assign);
         *expr = self.parse_prefix(level, errors.as_deref_mut(), flags)?;
         let paren_assign_prefix = match errors.as_deref() {
-            Some(errors) if errors.invalid_pattern_paren_assign != paren_assign_before => {
-                Some(Self::pattern_item_ptr(expr))
+            Some(errors) if errors.parenthesized_assign != paren_assign_before => {
+                Self::assign_ptr(expr)
             }
             _ => None,
         };
@@ -108,24 +108,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // "[(a = 1)] = []" is an error, "[(a = {}).b] = [1]" is not.
         if let (Some(errors), Some(prefix)) = (errors, paren_assign_prefix) {
-            let is_whole_item = Self::pattern_item_ptr(expr) == prefix
+            let is_whole_item = Self::assign_ptr(expr) == Some(prefix)
                 || matches!(&expr.data, js_ast::ExprData::EBinary(bin)
                     if bin.op == js_ast::OpCode::BinAssign
-                        && Self::pattern_item_ptr(&bin.left) == prefix);
+                        && Self::assign_ptr(&bin.left) == Some(prefix));
             if !is_whole_item {
-                errors.invalid_pattern_paren_assign = paren_assign_before;
+                errors.parenthesized_assign = paren_assign_before;
             }
         }
         Ok(())
     }
 
-    /// Identity of the nodes that can carry `invalid_pattern_paren_assign`.
-    fn pattern_item_ptr(expr: &Expr) -> *const u8 {
+    fn assign_ptr(expr: &Expr) -> Option<*const E::Binary> {
         match &expr.data {
-            js_ast::ExprData::EBinary(e) => e.as_ptr().cast(),
-            js_ast::ExprData::EArray(e) => e.as_ptr().cast(),
-            js_ast::ExprData::EObject(e) => e.as_ptr().cast(),
-            _ => core::ptr::null(),
+            js_ast::ExprData::EBinary(e) if e.op == js_ast::OpCode::BinAssign => {
+                Some(e.as_ptr().cast_const())
+            }
+            _ => None,
         }
     }
 
@@ -479,9 +478,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.latest_arrow_arg_loc = p.lexer.loc();
 
             let mut item = Expr::EMPTY;
+            let parenthesized_assign = errors.parenthesized_assign;
             p.parse_expr_or_bindings(Level::Comma, Some(&mut errors), &mut item)?;
 
             if is_spread {
+                // "...(a = 1)" is already an invalid rest argument without the parentheses
+                errors.parenthesized_assign = parenthesized_assign;
                 item = p.new_expr(E::Spread { value: item }, loc);
             }
 
@@ -607,10 +609,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if is_arrow_fn || opts.force_arrow_fn {
                 p.maybe_comma_spread_error(comma_after_spread);
                 p.log_arrow_arg_errors(&mut arrow_arg_errors);
-                if let Some(r) = errors.invalid_pattern_paren_assign {
-                    p.log().add_range_error(
+                if let Some(paren) = errors.parenthesized_assign {
+                    p.log().add_error(
                         Some(p.source),
-                        r,
+                        paren,
                         b"Unexpected parentheses in binding pattern",
                     );
                 }

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -106,15 +106,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         self.parse_suffix(expr, level, errors.as_deref_mut(), flags)?;
 
-        // "[(a = 1)] = []" is an error, "[(a = {}).b] = [1]" is not.
-        if let (Some(errors), Some(prefix)) = (errors, paren_assign_prefix) {
-            let is_whole_item = Self::assign_ptr(expr) == Some(prefix)
-                || matches!(&expr.data, js_ast::ExprData::EBinary(bin)
-                    if bin.op == js_ast::OpCode::BinAssign
-                        && Self::assign_ptr(&bin.left) == Some(prefix));
-            if !is_whole_item {
-                errors.parenthesized_assign = paren_assign_before;
-            }
+        // "[(a = 1)] = []" is an error, "[(a = {}).b] = [1]" is not. With any
+        // other suffix the visit pass already rejects the target.
+        if let (Some(errors), Some(prefix)) = (errors, paren_assign_prefix)
+            && Self::assign_ptr(expr) != Some(prefix)
+        {
+            errors.parenthesized_assign = paren_assign_before;
         }
         Ok(())
     }

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -106,8 +106,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         self.parse_suffix(expr, level, errors.as_deref_mut(), flags)?;
 
-        // "[(a = 1)] = []" is an error, "[(a = {}).b] = [1]" is not. With any
-        // other suffix the visit pass already rejects the target.
+        // Only a bare "(a = 1)" item counts: "[(a = {}).b] = [1]" is valid.
         if let (Some(errors), Some(prefix)) = (errors, paren_assign_prefix)
             && Self::assign_ptr(expr) != Some(prefix)
         {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -74,7 +74,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let had_pure_comment_before =
             self.lexer.has_pure_comment_before && !self.options.ignore_dce_annotations;
+        let paren_assign_before = errors
+            .as_deref()
+            .and_then(|errors| errors.invalid_pattern_paren_assign);
         *expr = self.parse_prefix(level, errors.as_deref_mut(), flags)?;
+        // The prefix that recorded a parenthesized assignment, if any: the
+        // parenthesized assignment itself or the literal it was merged from.
+        let paren_assign_prefix = match errors.as_deref() {
+            Some(errors) if errors.invalid_pattern_paren_assign != paren_assign_before => {
+                Some(Self::pattern_item_ptr(expr))
+            }
+            _ => None,
+        };
         // `errors` is reborrowed via as_deref_mut for each call site.
 
         // There is no formal spec for "__PURE__" comments but from reverse-
@@ -95,8 +106,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        self.parse_suffix(expr, level, errors, flags)?;
+        self.parse_suffix(expr, level, errors.as_deref_mut(), flags)?;
+
+        // A parenthesized assignment is only an invalid pattern item when it is
+        // the whole item, or the whole item before a default value. A suffix
+        // makes it a valid target: "[(a = {}).b] = [1]".
+        if let (Some(errors), Some(prefix)) = (errors, paren_assign_prefix) {
+            let is_whole_item = Self::pattern_item_ptr(expr) == prefix
+                || matches!(&expr.data, js_ast::ExprData::EBinary(bin)
+                    if bin.op == js_ast::OpCode::BinAssign
+                        && Self::pattern_item_ptr(&bin.left) == prefix);
+            if !is_whole_item {
+                errors.invalid_pattern_paren_assign = paren_assign_before;
+            }
+        }
         Ok(())
+    }
+
+    /// Identity of the nodes that can carry `invalid_pattern_paren_assign`.
+    fn pattern_item_ptr(expr: &Expr) -> *const u8 {
+        match &expr.data {
+            js_ast::ExprData::EBinary(e) => e.as_ptr().cast(),
+            js_ast::ExprData::EArray(e) => e.as_ptr().cast(),
+            js_ast::ExprData::EObject(e) => e.as_ptr().cast(),
+            _ => core::ptr::null(),
+        }
     }
 
     pub(crate) fn parse_yield_expr(&mut self, loc: bun_ast::Loc) -> Result<Expr, Error> {
@@ -577,6 +611,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if is_arrow_fn || opts.force_arrow_fn {
                 p.maybe_comma_spread_error(comma_after_spread);
                 p.log_arrow_arg_errors(&mut arrow_arg_errors);
+                if let Some(r) = errors.invalid_pattern_paren_assign {
+                    p.log().add_range_error(
+                        Some(p.source),
+                        r,
+                        b"Unexpected parentheses in binding pattern",
+                    );
+                }
 
                 // Now that we've decided we're an arrow function, report binding pattern
                 // conversion errors

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -78,8 +78,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .as_deref()
             .and_then(|errors| errors.invalid_pattern_paren_assign);
         *expr = self.parse_prefix(level, errors.as_deref_mut(), flags)?;
-        // The prefix that recorded a parenthesized assignment, if any: the
-        // parenthesized assignment itself or the literal it was merged from.
         let paren_assign_prefix = match errors.as_deref() {
             Some(errors) if errors.invalid_pattern_paren_assign != paren_assign_before => {
                 Some(Self::pattern_item_ptr(expr))
@@ -108,9 +106,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         self.parse_suffix(expr, level, errors.as_deref_mut(), flags)?;
 
-        // A parenthesized assignment is only an invalid pattern item when it is
-        // the whole item, or the whole item before a default value. A suffix
-        // makes it a valid target: "[(a = {}).b] = [1]".
+        // "[(a = 1)] = []" is an error, "[(a = {}).b] = [1]" is not.
         if let (Some(errors), Some(prefix)) = (errors, paren_assign_prefix) {
             let is_whole_item = Self::pattern_item_ptr(expr) == prefix
                 || matches!(&expr.data, js_ast::ExprData::EBinary(bin)

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -813,7 +813,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             E::Array {
                 items: items_list,
                 comma_after_spread,
-                parenthesized_assign: self_errors.parenthesized_assign.unwrap_or(bun_ast::Loc::EMPTY),
+                parenthesized_assign: self_errors
+                    .parenthesized_assign
+                    .unwrap_or(bun_ast::Loc::EMPTY),
                 is_single_line,
                 close_bracket_loc,
                 ..Default::default()
@@ -904,7 +906,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             E::Object {
                 properties: properties_list,
                 comma_after_spread,
-                parenthesized_assign: self_errors.parenthesized_assign.unwrap_or(bun_ast::Loc::EMPTY),
+                parenthesized_assign: self_errors
+                    .parenthesized_assign
+                    .unwrap_or(bun_ast::Loc::EMPTY),
                 is_single_line,
                 close_brace_loc,
                 ..Default::default()

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -51,7 +51,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         flags: EFlags,
     ) -> PResult<Expr> {
         let loc = p.lexer.loc();
-        let paren_range = p.lexer.range();
         p.lexer.next()?;
 
         // Arrow functions aren't allowed in the middle of expressions
@@ -83,7 +82,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             && let ExprData::EBinary(bin) = &value.data
             && bin.op == OpCode::BinAssign
         {
-            errors.invalid_pattern_paren_assign = Some(paren_range);
+            errors.parenthesized_assign = Some(loc);
         }
 
         Ok(value)
@@ -758,7 +757,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.lexer.next()?;
                     // Parse into a local then push.
                     let mut value = Expr::EMPTY;
+                    let parenthesized_assign = self_errors.parenthesized_assign;
                     p.parse_expr_or_bindings(Level::Comma, Some(&mut self_errors), &mut value)?;
+                    // "...(a = 1)" is already an invalid rest target without the parentheses
+                    self_errors.parenthesized_assign = parenthesized_assign;
                     items.push(p.new_expr(E::Spread { value }, dots_loc));
 
                     // Commas are not allowed here when destructuring
@@ -798,7 +800,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            p.log_pattern_errors(&self_errors);
+            // noop
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);
@@ -811,6 +813,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             E::Array {
                 items: items_list,
                 comma_after_spread,
+                parenthesized_assign: self_errors.parenthesized_assign.unwrap_or(bun_ast::Loc::EMPTY),
                 is_single_line,
                 close_bracket_loc,
                 ..Default::default()
@@ -836,7 +839,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if p.lexer.token == T::TDotDotDot {
                 p.lexer.next()?;
                 let mut value = Expr::EMPTY;
+                let parenthesized_assign = self_errors.parenthesized_assign;
                 p.parse_expr_or_bindings(Level::Comma, Some(&mut self_errors), &mut value)?;
+                self_errors.parenthesized_assign = parenthesized_assign;
                 properties.push(G::Property {
                     kind: PropertyKind::Spread,
                     value: Some(value),
@@ -885,7 +890,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if p.will_need_binding_pattern() {
             // Is this a binding pattern?
-            p.log_pattern_errors(&self_errors);
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);
@@ -900,6 +904,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             E::Object {
                 properties: properties_list,
                 comma_after_spread,
+                parenthesized_assign: self_errors.parenthesized_assign.unwrap_or(bun_ast::Loc::EMPTY),
                 is_single_line,
                 close_brace_loc,
                 ..Default::default()

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -44,12 +44,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::Super {}, loc))
     }
 
-    fn pfx_t_open_paren(p: &mut Self, level: Level, flags: EFlags) -> PResult<Expr> {
+    fn pfx_t_open_paren(
+        p: &mut Self,
+        level: Level,
+        errors: Option<&mut DeferredErrors>,
+        flags: EFlags,
+    ) -> PResult<Expr> {
         let loc = p.lexer.loc();
+        let paren_range = p.lexer.range();
         p.lexer.next()?;
 
         // Arrow functions aren't allowed in the middle of expressions
-        if level.gt(Level::Assign) {
+        let value = if level.gt(Level::Assign) {
             // Allow "in" inside parentheses
             let old_allow_in = p.allow_in;
             p.allow_in = true;
@@ -59,17 +65,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.expect(T::TCloseParen)?;
 
             p.allow_in = old_allow_in;
-            return Ok(value);
+            value
+        } else {
+            p.parse_paren_expr(
+                loc,
+                level,
+                ParenExprOpts {
+                    is_after_question_and_before_colon: flags
+                        == EFlags::AfterQuestionAndBeforeColon,
+                    ..Default::default()
+                },
+            )?
+        };
+
+        // "[(a = 1)] = []" is not "[a = 1] = []": a parenthesized assignment is
+        // not a valid destructuring target. The enclosing literal reports it if
+        // it turns out to be a pattern. `parse_expr_common` clears it again if
+        // a suffix such as "(a = {}).b" makes the item a valid target.
+        if let Some(errors) = errors
+            && let ExprData::EBinary(bin) = &value.data
+            && bin.op == OpCode::BinAssign
+        {
+            errors.invalid_pattern_paren_assign = Some(paren_range);
         }
 
-        p.parse_paren_expr(
-            loc,
-            level,
-            ParenExprOpts {
-                is_after_question_and_before_colon: flags == EFlags::AfterQuestionAndBeforeColon,
-                ..Default::default()
-            },
-        )
+        Ok(value)
     }
 
     #[inline]
@@ -781,7 +801,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Is this a binding pattern?
         if p.will_need_binding_pattern() {
-            // noop
+            p.log_pattern_errors(&self_errors);
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);
@@ -868,6 +888,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if p.will_need_binding_pattern() {
             // Is this a binding pattern?
+            p.log_pattern_errors(&self_errors);
         } else if errors.is_none() {
             // Is this an expression?
             p.log_expr_errors(&mut self_errors);
@@ -1010,7 +1031,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TOpenBrace => Self::pfx_t_open_brace(p, errors),
             T::TLessThan => Self::pfx_t_less_than(p, level, errors, flags),
             T::TImport => Self::pfx_t_import(p, level),
-            T::TOpenParen => Self::pfx_t_open_paren(p, level, flags),
+            T::TOpenParen => Self::pfx_t_open_paren(p, level, errors, flags),
             T::TPrivateIdentifier => Self::pfx_t_private_identifier(p, level),
             T::TIdentifier => Self::pfx_t_identifier(p, level, flags),
             T::TFalse => Self::pfx_t_false(p),

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -78,10 +78,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             )?
         };
 
-        // "[(a = 1)] = []" is not "[a = 1] = []": a parenthesized assignment is
-        // not a valid destructuring target. The enclosing literal reports it if
-        // it turns out to be a pattern. `parse_expr_common` clears it again if
-        // a suffix such as "(a = {}).b" makes the item a valid target.
+        // "[(a = 1)] = []" is not the pattern "[a = 1] = []".
         if let Some(errors) = errors
             && let ExprData::EBinary(bin) = &value.data
             && bin.op == OpCode::BinAssign

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1093,6 +1093,7 @@ pub struct InvalidLoc {
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum InvalidLocTag {
     Spread,
+    RestInitializer,
     Parentheses,
     Getter,
     Setter,
@@ -1106,6 +1107,7 @@ impl InvalidLoc {
     pub(crate) fn add_error(self, log: &mut bun_ast::Log, source: &bun_ast::Source) {
         let text: &'static [u8] = match self.kind {
             InvalidLocTag::Spread => b"Unexpected trailing comma after rest element",
+            InvalidLocTag::RestInitializer => b"A rest argument cannot have a default initializer",
             InvalidLocTag::Parentheses => b"Unexpected parentheses in binding pattern",
             InvalidLocTag::Getter => b"Unexpected getter in binding pattern",
             InvalidLocTag::Setter => b"Unexpected setter in binding pattern",
@@ -1313,8 +1315,9 @@ pub struct DeferredErrors {
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
 
-    /// A parenthesized assignment used as a whole item: `[(a = 1)] = []`.
-    pub(crate) invalid_pattern_paren_assign: Option<bun_ast::Range>,
+    /// An item that is a parenthesized assignment: `[(a = 1)]`. Stored on the
+    /// enclosing literal (`E::Array::parenthesized_assign`), not merged upward.
+    pub(crate) parenthesized_assign: Option<bun_ast::Loc>,
 }
 
 impl DeferredErrors {
@@ -1325,9 +1328,6 @@ impl DeferredErrors {
         to.invalid_expr_after_question = self
             .invalid_expr_after_question
             .or(to.invalid_expr_after_question);
-        to.invalid_pattern_paren_assign = self
-            .invalid_pattern_paren_assign
-            .or(to.invalid_pattern_paren_assign);
     }
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1315,8 +1315,7 @@ pub struct DeferredErrors {
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
 
-    /// An item that is a parenthesized assignment: `[(a = 1)]`. Stored on the
-    /// enclosing literal (`E::Array::parenthesized_assign`), not merged upward.
+    /// `[(a = 1)]`: stored on the enclosing literal, not merged upward.
     pub(crate) parenthesized_assign: Option<bun_ast::Loc>,
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1312,6 +1312,11 @@ pub struct DeferredErrors {
     /// These are errors for expressions
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
+
+    /// A parenthesized assignment used as a whole item, such as `[(a = 1)] = []`.
+    /// It is an error only if the literal turns out to be a pattern. Without
+    /// the parentheses the `= 1` is a default value.
+    pub(crate) invalid_pattern_paren_assign: Option<bun_ast::Range>,
 }
 
 impl DeferredErrors {
@@ -1322,6 +1327,9 @@ impl DeferredErrors {
         to.invalid_expr_after_question = self
             .invalid_expr_after_question
             .or(to.invalid_expr_after_question);
+        to.invalid_pattern_paren_assign = self
+            .invalid_pattern_paren_assign
+            .or(to.invalid_pattern_paren_assign);
     }
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1313,9 +1313,7 @@ pub struct DeferredErrors {
     pub(crate) invalid_expr_default_value: Option<bun_ast::Range>,
     pub(crate) invalid_expr_after_question: Option<bun_ast::Range>,
 
-    /// A parenthesized assignment used as a whole item, such as `[(a = 1)] = []`.
-    /// It is an error only if the literal turns out to be a pattern. Without
-    /// the parentheses the `= 1` is a default value.
+    /// A parenthesized assignment used as a whole item: `[(a = 1)] = []`.
     pub(crate) invalid_pattern_paren_assign: Option<bun_ast::Range>,
 }
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1578,6 +1578,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = e.data.e_array().expect("infallible: variant checked");
         if in_.assign_target != js_ast::AssignTarget::None {
             p.maybe_comma_spread_error(e_.comma_after_spread);
+            p.maybe_parenthesized_assign_error(e_.parenthesized_assign);
         }
         let items = e_.items.slice_mut();
         let mut spread_item_count: usize = 0;
@@ -1687,6 +1688,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut e_ = e.data.e_object().expect("infallible: variant checked");
         if in_.assign_target != js_ast::AssignTarget::None {
             p.maybe_comma_spread_error(e_.comma_after_spread);
+            p.maybe_parenthesized_assign_error(e_.parenthesized_assign);
         }
 
         let mut has_spread = false;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1726,8 +1726,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 has_spread = true;
             }
 
-            // Extract the initializer for expressions like "({ a: b = c } = d)"
+            // Extract the initializer for expressions like "({ a: b = c } = d)".
+            // A rest property "({ ...a } = d)" takes no initializer, so its
+            // "=" stays an assignment and fails the assignment target check.
             if in_.assign_target != js_ast::AssignTarget::None
+                && property.kind != G::PropertyKind::Spread
                 && property.initializer.is_none()
                 && property.value.is_some()
             {
@@ -1739,6 +1742,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         property.value = Some(bin.left);
                     }
                 }
+            }
+
+            // The target of a rest property must be a simple target, not a
+            // nested pattern: "({ ...[a] } = d)" is a syntax error.
+            if in_.assign_target != js_ast::AssignTarget::None
+                && property.kind == G::PropertyKind::Spread
+                && let Some(value) = &property.value
+                && matches!(value.data, Data::EArray(..) | Data::EObject(..))
+            {
+                p.log()
+                    .add_error(Some(p.source), value.loc, b"Invalid assignment target");
             }
 
             if let Some(value) = &mut property.value {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1726,9 +1726,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 has_spread = true;
             }
 
-            // Extract the initializer for expressions like "({ a: b = c } = d)".
-            // A rest property "({ ...a } = d)" takes no initializer, so its
-            // "=" stays an assignment and fails the assignment target check.
+            // Extract the initializer for "({ a: b = c } = d)". A rest property takes none.
             if in_.assign_target != js_ast::AssignTarget::None
                 && property.kind != G::PropertyKind::Spread
                 && property.initializer.is_none()
@@ -1744,8 +1742,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
-            // The target of a rest property must be a simple target, not a
-            // nested pattern: "({ ...[a] } = d)" is a syntax error.
+            // "({ ...[a] } = d)" is a syntax error.
             if in_.assign_target != js_ast::AssignTarget::None
                 && property.kind == G::PropertyKind::Spread
                 && let Some(value) = &property.value

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3032,6 +3032,8 @@ console.log(<div {...obj} key="after" />);`),
       expectParseError("[{ x: (a = 1) }] = [{}]", message);
       expectParseError("[...(a = 1)] = []", message);
       expectParseError("[((a = 1))] = []", message);
+      expectParseError("[(a = 1) = 2] = []", message);
+      expectParseError("({ x: (a = 1) = 2 } = {})", message);
       expectParseError("({ x: (a = 2) } = {})", message);
       expectParseError("({ ...(a = 3) } = {})", message);
       expectParseError("for ([(a = 1)] of x);", message);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3043,13 +3043,35 @@ console.log(<div {...obj} key="after" />);`),
       expectParseError("({ ...{ a } } = {})", message);
       expectParseError("[{ ...[a] }] = [{}]", message);
 
+      // Several items share one pattern, in either order
+      expectParseError("[(a = 1), (b = 2).c] = []", message);
+      expectParseError("[(a = 1).c, (b = 2)] = []", message);
+      expectPrinted_("[(a = 1).c, (b = 2).d] = []", "[(a = 1).c, (b = 2).d] = []");
+      expectParseError("({ x: (a = 1), y: (b = 2).c } = {})", message);
+      expectParseError("({ x: (a = 1).c, y: (b = 2) } = {})", message);
+      expectPrinted_("({ x: (a = 1).c, y: (b = 2).d } = {})", "({ x: (a = 1).c, y: (b = 2).d } = {})");
+      expectParseError("[x, [(a = 1).c], (b = 2)] = []", message);
+      expectPrinted_("[x, [(a = 1)].c, (b = 2).d] = []", "[x, [a = 1].c, (b = 2).d] = []");
+
+      // A literal in a for-in initializer (Annex B) is not a pattern
+      expectPrinted_("for (var x = [(a = 1)] in o);", "x = [a = 1];\nfor (x in o)\n  ;\nvar x;\n");
+      expectPrinted_("for (var x = { y: (a = 1) } in o);", "x = { y: a = 1 };\nfor (x in o)\n  ;\nvar x;\n");
+
       // The same forms are not valid arrow parameters either
       const arrowMessage = "Unexpected parentheses in binding pattern";
       expectParseError("((a = 1)) => 0", arrowMessage);
       expectParseError("([(a = 1)]) => 0", arrowMessage);
-      expectParseError("([(a = 1)] = []) => 0", message);
+      expectParseError("([(a = 1)] = []) => 0", arrowMessage);
       expectParseError("async ((a = 1)) => 0", arrowMessage);
+      expectParseError("(...(a = 1)) => 0", "A rest argument cannot have a default initializer");
+      expectParseError("([...(a = 1)]) => 0", "A rest argument cannot have a default initializer");
+      expectParseError("(x, (b = 2)) => 0", arrowMessage);
+      expectParseError("((a = 1), x) => 0", arrowMessage);
+      expectPrinted_("x = ((a = 1).c, (b = 2))", "x = ((a = 1).c, b = 2)");
       expectPrinted_("x = ({ ...a }) => a", "x = ({ ...a }) => a");
+      ts.expectPrinted_("x = c ? ({ ...a = 1 }) : b", "x = c ? { ...a = 1 } : b");
+      ts.expectPrinted_("x = c ? ([...a = 1]) : b", "x = c ? [...a = 1] : b");
+      ts.expectPrinted_("x = c ? ([(a = 1)]) : b", "x = c ? [a = 1] : b");
       expectParseError("({ ...a = 1 }) => 0", "A rest argument cannot have a default initializer");
       expectParseError("({ ...[a] }) => 0", "Invalid binding pattern");
       expectParseError("({ ...{ a } }) => 0", "Invalid binding pattern");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2989,6 +2989,68 @@ console.log(<div {...obj} key="after" />);`),
       // );
     });
 
+    it("parenthesized assignment in a destructuring pattern", () => {
+      // A parenthesized simple target may take a default value
+      expectPrinted_("[(a)] = [1]", "[a] = [1]");
+      expectPrinted_("[(a) = 1] = []", "[a = 1] = []");
+      expectPrinted_("[(o.b) = 1] = []", "[o.b = 1] = []");
+      expectPrinted_("({ x: (a) = 1 } = {})", "({ x: a = 1 } = {})");
+      expectPrinted_("({ x: (o.b) = 1 } = {})", "({ x: o.b = 1 } = {})");
+      expectPrinted_("[...(o.r)] = []", "[...o.r] = []");
+      expectPrinted_("[...[a]] = [[1]]", "[...[a]] = [[1]]");
+      expectPrinted_("({ ...(a) } = {})", "({ ...a } = {})");
+      expectPrinted_("({ ...(o.b) } = {})", "({ ...o.b } = {})");
+
+      // A member expression on a parenthesized assignment is a simple target
+      expectPrinted_("[(a = {}).b] = [1]", "[(a = {}).b] = [1]");
+      expectPrinted_("[(a = [])[0]] = [1]", "[(a = [])[0]] = [1]");
+      expectPrinted_("[(a = {}).b = 1] = []", "[(a = {}).b = 1] = []");
+      expectPrinted_("({ x: (a = {}).b } = {})", "({ x: (a = {}).b } = {})");
+      expectPrinted_("({ ...(a = {}).b } = {})", "({ ...(a = {}).b } = {})");
+      expectPrinted_("[[(a = 1)].x] = []", "[[a = 1].x] = []");
+
+      // A default value is an arbitrary expression
+      expectPrinted_("[x = (a = 1)] = []", "[x = a = 1] = []");
+      expectPrinted_("({ x = (a = 1) } = {})", "({ x = a = 1 } = {})");
+      expectPrinted_("x = (y = (a = 1)) => 0", "x = (y = a = 1) => 0");
+
+      // Outside a pattern the parentheses mean nothing
+      expectPrinted_("x = [(a = 1)]", "x = [a = 1]");
+      expectPrinted_("x = [[(a = 1)]]", "x = [[a = 1]]");
+      expectPrinted_("x = { y: (a = 1) }", "x = { y: a = 1 }");
+      expectPrinted_("x = { ...(a = 1) }", "x = { ...a = 1 }");
+      expectPrinted_("f([(a = 1)])", "f([a = 1])");
+      expectPrinted_("x = ([(a = 1)])", "x = [a = 1]");
+      expectPrinted_("x = ((a = 1))", "x = a = 1");
+      expectPrinted_("x = (y = [(a = 1)]) => 0", "x = (y = [a = 1]) => 0");
+
+      // A parenthesized assignment is not a valid destructuring target
+      const message = "Invalid assignment target";
+      expectParseError("[(a = 1)] = []", message);
+      expectParseError("[[(a = 1)]] = [[]]", message);
+      expectParseError("[[(a = 1)] = 2] = []", message);
+      expectParseError("[{ x: (a = 1) }] = [{}]", message);
+      expectParseError("[...(a = 1)] = []", message);
+      expectParseError("[((a = 1))] = []", message);
+      expectParseError("({ x: (a = 2) } = {})", message);
+      expectParseError("({ ...(a = 3) } = {})", message);
+      expectParseError("for ([(a = 1)] of x);", message);
+      expectParseError("for ([(a = 1)] in x);", message);
+
+      // The target of an object rest property is a simple target with no initializer
+      expectParseError("({ ...a = 4 } = {})", message);
+      expectParseError("({ ...[a] } = {})", message);
+      expectParseError("({ ...{ a } } = {})", message);
+      expectParseError("[{ ...[a] }] = [{}]", message);
+
+      // The same forms are not valid arrow parameters either
+      const arrowMessage = "Unexpected parentheses in binding pattern";
+      expectParseError("((a = 1)) => 0", arrowMessage);
+      expectParseError("([(a = 1)]) => 0", arrowMessage);
+      expectParseError("([(a = 1)] = []) => 0", message);
+      expectParseError("async ((a = 1)) => 0", arrowMessage);
+    });
+
     it("import assert", () => {
       expectPrinted_(`import json from "./foo.json" assert { type: "json" };`, `import json from "./foo.json"`);
       expectPrinted_(`import json from "./foo.json";`, `import json from "./foo.json"`);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3049,6 +3049,10 @@ console.log(<div {...obj} key="after" />);`),
       expectParseError("([(a = 1)]) => 0", arrowMessage);
       expectParseError("([(a = 1)] = []) => 0", message);
       expectParseError("async ((a = 1)) => 0", arrowMessage);
+      expectPrinted_("x = ({ ...a }) => a", "x = ({ ...a }) => a");
+      expectParseError("({ ...a = 1 }) => 0", "A rest argument cannot have a default initializer");
+      expectParseError("({ ...[a] }) => 0", "Invalid binding pattern");
+      expectParseError("({ ...{ a } }) => 0", "Invalid binding pattern");
     });
 
     it("import assert", () => {


### PR DESCRIPTION
### Problem
- bun 1.4.3 (and 1.3.14 and canary) accepts `[(a = 1)] = []` and prints `[a = 1] = []`. Node rejects it with `SyntaxError: Invalid destructuring assignment target`. A parenthesized assignment is not a valid destructuring target, but bun reads the `= 1` as a default value. So bun runs a different program. The same happens for `({ x: (a = 2) } = {})` and `({ ...(a = 3) } = {})`. esbuild 0.28.1 shares this bug.
- bun also accepts `({ ...a = 4 } = {})` (printed as `({ ...a } = {})`, the `= 4` is dropped), `({ ...[a] } = {})`, and the arrow parameter forms `({ ...a = 1 }) => 0` and `({ ...[a] }) => 0`. An object rest target takes no initializer and cannot be a nested pattern.
- The causes: `pfx_t_open_paren` (`src/js_parser/parse/parse_prefix.rs:47`) returns the inner expression with no trace of the parentheses. `e_object` (`src/js_parser/visit/visit_expr.rs:1729`) and `convert_expr_to_binding` (`src/js_parser/p.rs:4046`) treat a rest property like any other property.

### Fix
- `pfx_t_open_paren` records a parenthesized assignment in the item's `DeferredErrors`. `parse_expr_common` keeps the record only when that assignment is the whole item, or the whole item before a default, so `[(a = {}).b] = [1]` stays valid. The enclosing literal stores the location in a new `parenthesized_assign: Loc` field on `E::Array` and `E::Object`, next to `comma_after_spread`, and reports it the same way: the visit pass logs `Invalid assignment target` when the literal is an assignment target, and `convert_expr_to_binding` logs `Unexpected parentheses in binding pattern` when the literal becomes an arrow parameter. A parenthesized list reports its own items once it is known to be an arrow parameter list.
- `e_object` skips the initializer extraction for a rest property, so `({ ...a = 4 } = {})` fails the existing `is_valid_assignment_target` check, and a rest property whose target is an array or object literal is an error. `convert_expr_to_binding` applies both rules to arrow parameters. The rest-initializer error now goes through `invalid_loc` instead of the log, so TypeScript `c ? ([...a = 1]) : b` no longer reports it while the arrow function is only a candidate (that array form was already wrong on main).
- Verified: `test/bundler/transpiler/transpiler.test.js` (one new block: 35 valid forms print as before, 29 invalid forms now fail, fails on 1.4.3). Also `test/bundler/esbuild/{default,ts,lower}.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/js/bun/transpiler/`.

### Background
- The parser parses `[...]` and `{...}` as literals first. Whether a literal is a destructuring pattern is only certain later: the visit pass marks the left side of `=` and for-in/for-of heads as assignment targets, and `parse_paren_expr` converts expressions to bindings once it sees `=>`. `comma_after_spread` already uses this shape: the literal remembers the location, the consumer reports it.
- `DeferredErrors` carries facts from an item to the literal that contains it while neither reading is known. It is the only channel from `pfx_t_open_paren` to the enclosing literal, because the AST has no node for parentheses around an assignment.
- In an assignment pattern, `a = 1` means "target `a` with default `1`". `(a = 1)` is a ParenthesizedExpression and not a valid target. `(a = {}).b` is a member expression and a valid target. A `var` initializer in an Annex B `for (var x = [...] in o)` head is a literal, not a pattern, which is why the report cannot happen at parse time from the next token.
- #41624 adds a sibling `invalid_paren` field and the same `errors` parameter on `pfx_t_open_paren`. The two changes are independent. Whichever lands second has a small rebase in those two places.

<details><summary>Notes</summary>

Reported by the parser conformance ledger (entries 24991 and 25002).

Review history: a first draft flagged the parenthesized assignment before the suffix was parsed, so `[(a = {}).b] = [1]` would have been rejected. A second draft reported from the literal using the `will_need_binding_pattern()` lookahead, which is also true for an Annex B `for (var x = [(a = 1)] in o)` initializer, so that valid sloppy program was rejected. Both are covered by tests now. Passing the spread flag into `convert_expr_to_binding_and_initializer` exposed that it wrote to the log during speculative TypeScript arrow parsing; it now pushes to `invalid_loc` like the rest of that function.

Self-reviewed: 5 concerns raised, 3 addressed (above). Two rejected: "store a parenthesized flag on `E::Binary`" (about 90 construction sites for a flag that only this check reads), and "land only the `e_object` half" (the paren half is the reported bug).

Repro on bun 1.4.3:

```
var a, r = [];
[(a = 1)] = [];                 r.push(a);
({ x: (a = 2) } = {});          r.push(a);
({ ...(a = 3) } = { k: 1 });    r.push(a);
({ ...a = 4 } = { q: 1 });      r.push(a);
console.log(JSON.stringify(r));
```

node: SyntaxError. bun 1.4.3: `[1,2,{"k":1},{"q":1}]`. This branch: `Invalid assignment target` at line 2.

Known remaining gap, unchanged by this PR: `[{ a = 1 }.a] = [1]` (a shorthand initializer inside a member expression) is still accepted.
</details>
