### PR TITLE
jsx: remove the dead Solid runtime from bunfig, the CLI, and tsconfig

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -954,8 +954,6 @@ impl<'a> Parser<'a> {
             if let Some(value) = expr.as_string(self.bump) {
                 if value == b"react" {
                     jsx_runtime = api::JsxRuntime::Classic;
-                } else if value == b"solid" {
-                    jsx_runtime = api::JsxRuntime::Solid;
                 } else if value == b"react-jsx" {
                     jsx_runtime = api::JsxRuntime::Automatic;
                     jsx_dev = false;
@@ -965,7 +963,7 @@ impl<'a> Parser<'a> {
                 } else {
                     self.add_error(
                         expr.loc,
-                        b"Invalid jsx runtime, only 'react', 'solid', 'react-jsx', and 'react-jsxDEV' are supported",
+                        b"Invalid jsx runtime, only 'react', 'react-jsx', and 'react-jsxDEV' are supported",
                     )?;
                 }
             }

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -12,7 +12,7 @@ use crate::schema::api;
 use bun_core::strings;
 use std::borrow::Cow;
 
-/// 4-state including `_None` so `Pragma.runtime` preserves the zero value
+/// 3-state including `_None` so `Pragma.runtime` preserves the zero value
 /// when an `api.Jsx` arrives with `runtime == _none`. `#[default]` is
 /// `Automatic`.
 #[repr(u8)]
@@ -22,7 +22,6 @@ pub enum Runtime {
     #[default]
     Automatic,
     Classic,
-    Solid,
 }
 
 impl From<api::JsxRuntime> for Runtime {
@@ -30,7 +29,6 @@ impl From<api::JsxRuntime> for Runtime {
         match r {
             api::JsxRuntime::_none => Runtime::_None,
             api::JsxRuntime::Classic => Runtime::Classic,
-            api::JsxRuntime::Solid => Runtime::Solid,
             api::JsxRuntime::Automatic => Runtime::Automatic,
         }
     }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -365,7 +365,6 @@ pub mod api {
         _none = 0,
         Automatic = 1,
         Classic = 2,
-        Solid = 3,
     }
 
     /// JSX transform configuration (factory, fragment, runtime, …).

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -496,11 +496,6 @@ impl TSConfigJSON {
             // Parse "jsxImportSource"
             if let Some(jsx_prop) = jsx_import_source_v {
                 if let Some(str) = jsx_prop.as_str() {
-                    if str.len() >= b"solid-js".len() && &str[..b"solid-js".len()] == b"solid-js" {
-                        result.jsx.runtime = options::jsx::Runtime::Solid;
-                        result.jsx_flags.insert(JsxField::Runtime);
-                    }
-
                     result.jsx.package_name = str.to_vec().into();
                     result.jsx.set_import_source();
                     result.jsx_flags.insert(JsxField::ImportSource);

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -38,7 +38,6 @@ pub mod js_bundler {
             options::JSX::Runtime::_None => api::JsxRuntime::_none,
             options::JSX::Runtime::Automatic => api::JsxRuntime::Automatic,
             options::JSX::Runtime::Classic => api::JsxRuntime::Classic,
-            options::JSX::Runtime::Solid => api::JsxRuntime::Solid,
         }
     }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -40,15 +40,17 @@ pub(crate) fn loader_resolver(input: &[u8]) -> crate::Result<api::Loader> {
     Ok(option_loader.to_api())
 }
 
-fn resolve_jsx_runtime(s: &[u8]) -> crate::Result<api::JsxRuntime> {
+fn resolve_jsx_runtime(s: &[u8]) -> api::JsxRuntime {
     if s == b"automatic" {
-        Ok(api::JsxRuntime::Automatic)
+        api::JsxRuntime::Automatic
     } else if s == b"fallback" || s == b"classic" {
-        Ok(api::JsxRuntime::Classic)
-    } else if s == b"solid" {
-        Ok(api::JsxRuntime::Solid)
+        api::JsxRuntime::Classic
     } else {
-        Err(crate::Error::InvalidJSXRuntime)
+        bun_core::pretty_errorln!(
+            "<r><red>error<r>: Invalid --jsx-runtime: \"{}\", expected \"automatic\" or \"classic\"",
+            BStr::new(s)
+        );
+        Global::exit(1);
     }
 }
 
@@ -1601,7 +1603,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 fragment: jsx_fragment.unwrap_or(default_fragment).into(),
                 import_source: jsx_import_source.unwrap_or(default_import_source).into(),
                 runtime: if let Some(runtime) = jsx_runtime {
-                    resolve_jsx_runtime(runtime)?
+                    resolve_jsx_runtime(runtime)
                 } else {
                     api::JsxRuntime::Automatic
                 },
@@ -1617,7 +1619,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                     .map(Box::<[u8]>::from)
                     .unwrap_or(prev.import_source),
                 runtime: if let Some(runtime) = jsx_runtime {
-                    resolve_jsx_runtime(runtime)?
+                    resolve_jsx_runtime(runtime)
                 } else {
                     prev.runtime
                 },

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -456,7 +456,6 @@ fn jsx_runtime_tag_name(r: bun_options_types::schema::api::JsxRuntime) -> &'stat
     match r {
         J::Automatic => "automatic",
         J::Classic => "classic",
-        J::Solid => "solid",
         J::_none => "_none",
     }
 }

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -132,8 +132,6 @@ pub enum Error {
     ModuleNotFound,
     #[error("InvalidLoader")]
     InvalidLoader,
-    #[error("InvalidJSXRuntime")]
-    InvalidJSXRuntime,
     #[error("ThreadSpawnFailed")]
     ThreadSpawnFailed,
     #[error("CouldntReadCurrentDirectory")]
@@ -460,7 +458,6 @@ impl Error {
             Self::AssertionError => "AssertionError",
             Self::ModuleNotFound => "ModuleNotFound",
             Self::InvalidLoader => "InvalidLoader",
-            Self::InvalidJSXRuntime => "InvalidJSXRuntime",
             Self::ThreadSpawnFailed => "ThreadSpawnFailed",
             Self::CouldntReadCurrentDirectory => "CouldntReadCurrentDirectory",
             Self::FailedToGetTempPath => "FailedToGetTempPath",

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -98,10 +98,12 @@ describe("tsconfig compilerOptions.jsx", () => {
     jsx => {
       const transpiler = new Bun.Transpiler({
         loader: "tsx",
+        autoImportJSX: true,
         tsconfig: { compilerOptions: { jsx, jsxImportSource: "solid-js" } },
       });
       const out = transpiler.transformSync(`export default <div>hi</div>;`);
-      expect(out).toMatch(/^export default jsx(DEV)?_\w+\("div"/);
+      expect(out).toMatch(/^import \{ jsx(DEV)? as \w+ \} from "solid-js\/jsx(-dev)?-runtime";\n/);
+      expect(out).toMatch(/\nexport default jsx(DEV)?_\w+\("div"/);
       expect(out).not.toContain("React.createElement");
     },
   );

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -68,4 +68,64 @@ describe("tsconfig compilerOptions.jsx", () => {
       expect(exitCode).toBe(0);
     }
   });
+
+  // The Solid.js JSX transform was removed in 88538b7c2c. The parser only knows
+  // the classic and automatic runtimes, so "solid-js" must not select anything else.
+  test.concurrent('jsxImportSource "solid-js" uses the automatic runtime', async () => {
+    using dir = tempDir("jsx-tsconfig-solid", {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { jsx: "react-jsx", jsxImportSource: "solid-js" },
+      }),
+      "m.jsx": `export const a = <div p="1">x</div>;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "m.jsx", "--external", "solid-js*"],
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain('"solid-js/jsx-runtime"');
+    expect(stdout).not.toContain("React.createElement");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("removed solid jsx runtime", () => {
+  test.concurrent('bunfig.toml jsx = "solid" is an error', async () => {
+    using dir = tempDir("jsx-bunfig-solid", {
+      "bunfig.toml": `jsx = "solid"\n`,
+      "m.jsx": `export const a = <div />;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "m.jsx"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Invalid jsx runtime, only 'react', 'react-jsx', and 'react-jsxDEV' are supported");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("--jsx-runtime=solid is an error", async () => {
+    using dir = tempDir("jsx-flag-solid", {
+      "m.jsx": `export const a = <div />;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--jsx-runtime=solid", "m.jsx"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain('Invalid --jsx-runtime: "solid", expected "automatic" or "classic"');
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -91,6 +91,20 @@ describe("tsconfig compilerOptions.jsx", () => {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/3528
+  test.each(["react-jsx", "preserve"])(
+    'Bun.Transpiler with jsx "%s" and jsxImportSource "solid-js" uses the automatic runtime',
+    jsx => {
+      const transpiler = new Bun.Transpiler({
+        loader: "tsx",
+        tsconfig: { compilerOptions: { jsx, jsxImportSource: "solid-js" } },
+      });
+      const out = transpiler.transformSync(`export default <div>hi</div>;`);
+      expect(out).toMatch(/^export default jsx(DEV)?_\w+\("div"/);
+      expect(out).not.toContain("React.createElement");
+    },
+  );
 });
 
 describe("removed solid jsx runtime", () => {


### PR DESCRIPTION
Supersedes #35442

### Problem
- `jsx = "solid"` in bunfig.toml, `--jsx-runtime=solid`, and a tsconfig with `jsxImportSource: "solid-js"` all emit `React.createElement(...)` with no warning. A Solid project then fails at run time with `ReferenceError: React is not defined`.
- The Solid.js JSX transform was removed in 88538b7c2c (Dec 2022). The `Runtime::Solid` enum variant and the three option paths that produce it survived. The parser (`src/js_parser/visit/visit_expr.rs`, the `e_jsx_element` visitor) only implements `Classic` and `Automatic`. It treats every other runtime as `Classic`.

### Fix
- Remove `Solid` from `api::JsxRuntime` (`src/options_types/schema.rs`) and `jsx::Runtime` (`src/options_types/jsx.rs`), and every arm that mapped to it. No serialized format carries this enum, so the value change is safe.
- bunfig `jsx = "solid"` now fails with the existing "Invalid jsx runtime" error, with `'solid'` removed from the listed values. `--jsx-runtime=solid` now fails with `Invalid --jsx-runtime: "solid", expected "automatic" or "classic"` instead of `An internal error occurred (InvalidJSXRuntime)`. A hard error was chosen over a silent alias to `automatic` because `solid` was never documented for either option (`docs/runtime/bunfig.mdx`, `docs/runtime/jsx.mdx`, the `--jsx-runtime` help text) and a silent alias would hide the same class of mistake this PR removes.
- tsconfig `jsxImportSource: "solid-js"` no longer forces a runtime. It behaves like `preact` or any other import source: the automatic runtime with imports from `solid-js/jsx-runtime`. This matches TypeScript and esbuild. It is the same `tsconfig_json.rs` deletion as #35442, which deferred the enum removal to a separate change.
- Verified: `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts` (5 new cases fail on bun 1.4.3 and pass with this change). Also `test/bundler/transpiler/transpiler.test.js`, `test/bundler/esbuild/tsconfig.test.ts`, `test/bundler/bundler_jsx.test.ts`.

### Background
- Bun has two JSX transforms. `classic` emits `React.createElement(tag, props, ...children)` and needs a `React` in scope. `automatic` emits `jsx(tag, props)` and imports `jsx` from `<jsxImportSource>/jsx-runtime`.
- The old Solid transform compiled JSX to DOM expressions, the way `babel-preset-solid` does. That is a different output shape from both transforms above, and it is what was deleted in 88538b7c2c.
- This change does not make Solid work out of the box. `solid-js/jsx-runtime` is a types-only entry point. A Solid project still needs a plugin such as `bun-plugin-solid`. What changes is that Bun no longer emits code that references an undefined `React` global for these configs.

<details><summary>Notes</summary>

- Repro on 1.4.3: `printf 'jsx = "solid"\n' > bunfig.toml`, `printf 'console.log(<a />);\n' > index.tsx`, `bun build --no-bundle index.tsx` prints `console.log(/* @__PURE__ */ React.createElement("a", null));`. Same with `--jsx-runtime=solid` and no bunfig.
- #35460 folded `Solid` to `Automatic` instead of removing it. It was closed as a duplicate of #35442.
- #41643 (case-insensitive bunfig `jsx` matching) edits the same lines in `src/bunfig/bunfig.rs` and still lists `solid`. Whichever lands second needs a small rebase.
- `Bun.Transpiler` does not auto-inject the jsx import (`autoImportJSX` is off by default there), so the new `Bun.Transpiler` cases assert on the `jsx_...(` / `jsxDEV_...(` call shape instead of the import line.
- Self-reviewed: 6 concerns raised, all addressed (issue links, supersede note, #41643 coordination note, `Bun.Transpiler` coverage including `jsx: "preserve"`, plain statement that Solid does not work without a plugin, reason for the hard error).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [908.74ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [754.71ms]
84 |       cwd: String(dir),
85 |       stdout: "pipe",
86 |       stderr: "pipe",
87 |     });
88 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
89 |     expect(stdout).toContain('"solid-js/jsx-runtime"');
                        ^
error: expect(received).toContain(expected)

Expected to contain: "\"solid-js/jsx-runtime\""
Received: "// m.jsx\nvar a = /* @__PURE__ */ React.createElement(\"div\", {\n  p: \"1\"\n}, \"x\");\nexport {\n  a\n};\n"

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:89:20)
(fail) tsconfig compilerOptions.jsx > jsxImportSource "solid-js" uses the automatic runtime [
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [24.53ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [83.32ms]
84 |       cwd: String(dir),
85 |       stdout: "pipe",
86 |       stderr: "pipe",
87 |     });
88 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
89 |     expect(stdout).toContain('"solid-js/jsx-runtime"');
                        ^
error: expect(received).toContain(expected)

Expected to contain: "\"solid-js/jsx-runtime\""
Received: "// m.jsx\nvar a = /* @__PURE__ */ React.createElement(\"div\", {\n  p: \"1\"\n}, \"x\");\nexport {\n  a\n};\n"

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:89:20)
(fail) tsconfig compilerOptions.jsx > jsxImportSource "solid-js" uses the automatic runtime [48.58ms]
 99 |       const transpiler = new Bun.Transpiler({
100 |         loader: "tsx",
101 |         tsconfig: { compilerOptions: { jsx, jsxImportSource: "solid-js" } },
102 |  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [1285.82ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [776.64ms]
(pass) tsconfig compilerOptions.jsx > jsxImportSource "solid-js" uses the automatic runtime [355.94ms]
(pass) tsconfig compilerOptions.jsx > Bun.Transpiler with jsx "react-jsx" and jsxImportSource "solid-js" uses the automatic runtime [18.32ms]
(pass) tsconfig compilerOptions.jsx > Bun.Transpiler with jsx "preserve" and jsxImportSource "solid-js" uses the automatic runtime [7.49ms]
(pass) removed solid jsx runtime > bunfig.toml jsx = "solid" is an error [203.39ms]
(pass) removed solid jsx runtime > --jsx-runtime=solid is an error [311.98ms]

 7 pass
 0 fail
 22 expect() calls
Ran 7 tests across 1 file. [7.98s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9fc97f82d6
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 4819ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir pch
[2/2863] mkdir obj
[3/2863] mkdir codegen
[4/2863] mkdir stamps
[5/2863] gen ErrorCode+*.h
[6/2863] fetch mimalloc
[mimalloc] up to date
[7/2863] fetch icu
[icu] up to date
[8/2863] fetch WebKit
[WebKit] up to date
[9/2863] fetch tinycc
[tinycc] up to date
[10/2863] gen bindgenv2
[11/2863] gen .bind.ts → GeneratedBindings.cpp
[12/2863] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[13/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[14/2863] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[15/2863] fetch zlib
[zlib] up to date
[16/2863] gen CombinedDomains.json
[17/2863] cc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bunfig/bunfig.rs                               |  4 +-
 src/options_types/jsx.rs                           |  4 +-
 src/options_types/schema.rs                        |  1 -
 src/resolver/tsconfig_json.rs                      |  5 --
 src/runtime/api/JSBundler.rs                       |  1 -
 src/runtime/cli/Arguments.rs                       | 18 +++---
 src/runtime/cli/test/parallel/runner.rs            |  1 -
 src/runtime/error.rs                               |  3 -
 .../transpiler/jsx-tsconfig-react-jsx.test.ts      | 74 ++++++++++++++++++++++
 9 files changed, 86 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bunfig/bunfig.rs                                        1      2      6
src/options_types/jsx.rs                                    1      1      6
src/options_types/schema.rs                                 1      2      6
src/resolver/tsconfig_json.rs                               0      0      6
src/runtime/api/JSBundler.rs                                0      0      6
src/runtime/cli/Arguments.rs                                1      1      7
src/runtime/cli/test/parallel/runner.rs                     0      0      6
src/runtime/error.rs                                        0      0      6
test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts      1      4      6
```

</details>

<!-- robobun:evidence:end -->