### PR TITLE
bun run: print the package.json parse error instead of "Script not found"

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2659,6 +2659,20 @@ impl RunCommand {
         }
 
         if log_errors {
+            // The resolver records a package.json that fails to load (a
+            // syntax error, an unreadable file) in `ctx.log` and returns a
+            // `DirInfo` without it.
+            //
+            // SAFETY: `ctx.log` set in `create_context_data` (single-threaded
+            // CLI startup), process-lifetime.
+            let log = unsafe { ctx.log() };
+            let has_log_errors = log.has_errors();
+            if has_log_errors {
+                let _ = log.print(std::ptr::from_mut::<bun_core::io::Writer>(
+                    Output::error_writer(),
+                ));
+            }
+
             if let Some((path, loader)) = resolved_to_unrunnable_file {
                 bun_core::pretty_error!(
                     "<r><red>error<r><d>:<r> <b>Cannot run \"{}\"<r>\n",
@@ -2687,7 +2701,11 @@ impl RunCommand {
                         "<r><red>error<r><d>:<r> <b>File not found \"<b>{}<r>\"",
                         bstr::BStr::new(target_name),
                     );
-                } else {
+                } else if !(has_log_errors && root_dir.enclosing_package_json.is_none()) {
+                    // With no usable package.json and an error that says
+                    // why, the error is the message. "Script not found"
+                    // would claim the script is absent from a file that
+                    // did not load.
                     pretty_errorln!(
                         "<r><red>error<r><d>:<r> <b>Script not found \"<b>{}<r>\"",
                         bstr::BStr::new(target_name),

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -40,6 +40,45 @@ describe("bun", () => {
     expect(stderr.toString()).toMatch(/Script not found/);
     expect(exitCode).toBe(1);
   });
+
+  test("a package.json that fails to parse reports the parse error, not 'Script not found'", () => {
+    using dir = tempDir("broken-package-json", {
+      "package.json": `{"name": "p", "scripts": {"s": "echo hi"`,
+    });
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: String(dir),
+      cmd: [bunExe(), "run", "s"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    const err = stderr.toString();
+    expect(err).toContain(`Expected "}" but found end of file`);
+    expect(err).toContain(join(String(dir), "package.json") + ":1:40");
+    expect(err).not.toContain("Script not found");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a package.json that fails to parse in an ancestor is printed before 'Script not found'", () => {
+    using dir = tempDir("broken-ancestor-package-json", {
+      "package.json": `{"name": "top", "private": tru`,
+      "a/b/package.json": JSON.stringify({ name: "deep", scripts: { s: "echo hi" } }),
+    });
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: join(String(dir), "a", "b"),
+      cmd: [bunExe(), "run", "nope"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    const err = stderr.toString();
+    expect(err).toContain("Unexpected tru");
+    expect(err).toContain(join(String(dir), "package.json") + ":1:28");
+    expect(err).toContain('Script not found "nope"');
+    expect(exitCode).toBe(1);
+  });
 });
 
 test.if(isWindows)("[windows] A file in drive root runs", async () => {


### PR DESCRIPTION
### Problem
- When the project's `package.json` does not parse, `bun run <script>` prints only `error: Script not found "<script>"` and exits 1. The parse error that `bun -e`, `bun build`, and `bun install` print for the same file never appears. `npm run` prints `EJSONPARSE` and names the file.
- The cause is the not-found exit in `Run::exec` (`src/runtime/cli/run_command.rs:2661`). The resolver records the parse error in `ctx.log` and returns a `DirInfo` with no `package_json`. The script lookup sees no scripts and prints "Script not found" without that log.

### Fix
- On the not-found exit, print `ctx.log` to stderr when it holds errors. This is the same dump `configure_env_for_run` and `boot_failed_exit` already use in this file.
- When no package.json loaded at all (`enclosing_package_json` is `None`) and the log explains why, skip "Script not found". The parse error is the message. A missing script in a file that did not load is not a fact bun can report.
- When a package.json did load (for example the project's own file is valid and an ancestor's is broken), "Script not found" is still printed after the log. The script really is absent from the file bun used.
- Verified: `test/cli/run/run_command.test.ts` (two new tests, stock bun fails both). Also ran `test/cli/run/if-present.test.ts`.

### Background
- `Run::exec` calls `configure_env_for_run`, which asks the resolver for the cwd `DirInfo`. The resolver walks up the directory tree and parses each `package.json` it finds. A parse failure goes to the resolver's log (`PackageJSON::parse` in `src/resolver/package_json.rs:461`) and the directory is treated as having no package.json.
- `ctx.log` is the process-lifetime `bun_ast::Log` that the resolver writes to. Other exits in `run_command.rs` print it before their own error line. The not-found exit did not.

<details><summary>Notes</summary>

Reproduction with stock bun (1.4.3):

```
printf '{"name": "p", "scripts": {"s": "echo hi"' > package.json
bun run s      # error: Script not found "s"
bun -e '1'     # error: Expected "}" but found end of file, at package.json:1:40
```

With this change, `bun run s` prints the parse error with the file path and line:column, and exits 1.

`bun run ./missing.js` with the same broken package.json prints the parse error and then `Module not found "./missing.js"`. That message is about the file argument, so it stays.

Not covered here: a `package.json` that is a directory. The resolver only parses regular files, so nothing is logged and the output stays `Script not found`. Also not covered: `bun build` failing on a broken ancestor package.json when the project's own file is valid. That is a resolver-level decision about ancestor manifests and is separate from this exit path.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run_command.test.ts

<!-- robobun:evidence:end -->