### PR TITLE
Decode windows-1252 in 64-byte blocks instead of one SIMD scan per non-ASCII byte

### DIFF
--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -415,29 +415,34 @@ pub(super) fn convert_utf8_bytes_into_utf16(bytes: &[u8]) -> UTF16Replacement {
 // `immutable.rs` keeps resolving.
 pub use crate::strings_impl::copy_latin1_into_utf8_stop_on_non_ascii;
 
-pub fn copy_cp1252_into_utf16(buf_: &mut [u16], latin1_: &[u8]) -> EncodeIntoResult {
-    let buf_total = buf_.len();
-    let latin1_total = latin1_.len();
-    let mut buf: &mut [u16] = buf_;
-    let mut latin1: &[u8] = latin1_;
-    while !buf.is_empty() && !latin1.is_empty() {
-        let to_write = first_non_ascii(latin1)
-            .map(|v| v as usize)
-            .unwrap_or_else(|| latin1.len().min(buf.len()));
-        copy_u8_into_u16(buf, &latin1[..to_write]);
+/// Decodes windows-1252 bytes into UTF-16 code units. Each input byte maps to
+/// exactly one code unit, so the conversion stops at the shorter of the two
+/// slices.
+pub fn copy_cp1252_into_utf16(buf: &mut [u16], cp1252: &[u8]) -> EncodeIntoResult {
+    let len = buf.len().min(cp1252.len());
+    let buf = &mut buf[..len];
+    let cp1252 = &cp1252[..len];
 
-        latin1 = &latin1[to_write..];
-        buf = &mut buf[to_write..];
-        if !latin1.is_empty() && buf.len() >= 1 {
-            buf[0] = cp1252_to_codepoint_bytes_assume_not_ascii16(u32::from(latin1[0]));
-            latin1 = &latin1[1..];
-            buf = &mut buf[1..];
+    // windows-1252 differs from Latin-1 only in 0x80..=0x9F. A block without
+    // one of those bytes is a plain widening; a block with one goes through
+    // the table.
+    const BLOCK: usize = 64;
+    for (out, input) in buf.chunks_mut(BLOCK).zip(cp1252.chunks(BLOCK)) {
+        let has_c1 = input
+            .iter()
+            .fold(false, |acc, &b| acc | (b.wrapping_sub(0x80) < 0x20));
+        if has_c1 {
+            for (o, &b) in out.iter_mut().zip(input) {
+                *o = CP1252_TO_UTF16_CONVERSION_TABLE[usize::from(b)];
+            }
+        } else {
+            copy_u8_into_u16(out, input);
         }
     }
 
     EncodeIntoResult {
-        read: (buf_total - buf.len()) as u32,
-        written: (latin1_total - latin1.len()) as u32,
+        read: len as u32,
+        written: len as u32,
     }
 }
 
@@ -922,10 +927,6 @@ static CP1252_TO_UTF16_CONVERSION_TABLE: [u16; 256] = [
     0x00F0, 0x00F1, 0x00F2, 0x00F3, 0x00F4, 0x00F5, 0x00F6, 0x00F7, // F0-F7
     0x00F8, 0x00F9, 0x00FA, 0x00FB, 0x00FC, 0x00FD, 0x00FE, 0x00FF, // F8-FF
 ];
-
-fn cp1252_to_codepoint_bytes_assume_not_ascii16(char: u32) -> u16 {
-    CP1252_TO_UTF16_CONVERSION_TABLE[(char as u8) as usize]
-}
 
 // `copy_utf16_into_utf8` (the non-generic wrapper) lives canonically in
 // `crate::strings_impl`; re-exported at `crate::string::immutable`. The

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -383,6 +383,68 @@ describe("TextDecoder", () => {
   });
 });
 
+describe("TextDecoder windows-1252", () => {
+  // https://encoding.spec.whatwg.org/index-windows-1252.txt, bytes 0x80..0x9F.
+  // Every other byte maps to the code point with the same value.
+  const C1 = [
+    0x20ac, 0x0081, 0x201a, 0x0192, 0x201e, 0x2026, 0x2020, 0x2021, 0x02c6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008d,
+    0x017d, 0x008f, 0x0090, 0x2018, 0x2019, 0x201c, 0x201d, 0x2022, 0x2013, 0x2014, 0x02dc, 0x2122, 0x0161, 0x203a,
+    0x0153, 0x009d, 0x017e, 0x0178,
+  ];
+  const reference = bytes => {
+    let out = "";
+    for (const b of bytes) out += String.fromCharCode(b >= 0x80 && b < 0xa0 ? C1[b - 0x80] : b);
+    return out;
+  };
+
+  it("maps every byte across ASCII gaps of any length", () => {
+    const decoder = new TextDecoder("windows-1252");
+    const bytes = [];
+    // Non-ASCII runs separated by ASCII gaps of lengths around the 64-byte
+    // block the decoder classifies at a time.
+    for (const gap of [0, 1, 2, 15, 31, 32, 33, 63, 64, 65, 100, 200]) {
+      for (let b = 0x80; b <= 0xff; b++) bytes.push(b);
+      for (let i = 0; i < gap; i++) bytes.push(0x61 + (i % 26));
+      bytes.push(0xe9, 0x41, 0x80, 0x42, 0x9f, 0x43);
+      for (let i = 0; i < gap; i++) bytes.push(0x30 + (i % 10));
+    }
+    const input = new Uint8Array(bytes);
+    expect(decoder.decode(input)).toBe(reference(input));
+    for (const start of [0, 1, 31, 32, 33, 63, 64, 65, 255, 256, 257]) {
+      for (const length of [1, 63, 64, 65, 300]) {
+        const slice = input.subarray(start, start + length);
+        expect(decoder.decode(slice)).toBe(reference(slice));
+      }
+    }
+  });
+
+  it("decodes dense non-ASCII input at a bounded cost per byte", () => {
+    const decoder = new TextDecoder("windows-1252");
+    const N = 2 << 20;
+    const dense = Buffer.alloc(N, 0xe9);
+    // One non-ASCII byte, then ASCII: the same UTF-16 output path, with the
+    // ASCII tail widened in one pass.
+    const oneAccent = Buffer.alloc(N, 0x61);
+    oneAccent[0] = 0xe9;
+    const best = input => {
+      let b = Infinity;
+      for (let i = 0; i < 10; i++) {
+        const t0 = performance.now();
+        decoder.decode(input);
+        b = Math.min(b, performance.now() - t0);
+      }
+      return b;
+    };
+    withoutAggressiveGC(() => {
+      expect(decoder.decode(dense).charCodeAt(N - 1)).toBe(0xe9);
+      // With one dispatched SIMD scan per non-ASCII byte, the dense input cost
+      // 10x (debug) to 18x (release) the one-accent input.
+      const ratio = best(dense) / Math.max(best(oneAccent), 0.01);
+      expect(ratio).toBeLessThan(5);
+    });
+  });
+});
+
 describe("TextDecoder ignoreBOM", () => {
   it.each([
     {


### PR DESCRIPTION
### Problem
- `new TextDecoder("windows-1252").decode(bytes)` (also the `latin1` label) costs 13 ns per byte on input dense in 0x80..0xFF, against 0.4 ns per byte for ASCII. A 2 MiB buffer of 0xE9 takes 11 ms in release.
- The cause is the loop in `copy_cp1252_into_utf16` (`src/bun_core/string/immutable/unicode.rs:418`). After each non-ASCII byte it calls `first_non_ascii` on the whole remaining input. That is one dispatched simdutf call per byte.
- The loop also slices the output buffer by a length taken from the input. An output buffer shorter than the input would panic. The only caller (`TextDecoder.rs:358`) passes an exact-size buffer, so this is not reachable today.

### Fix
- Walk the input in 64-byte blocks. windows-1252 differs from Latin-1 only in 0x80..=0x9F. A block with none of those bytes is widened in one pass. A block with one goes through the 256-entry table. No byte is scanned twice.
- Clamp the work to the shorter of the two slices and report `read` and `written` from that count (the old code had the two fields swapped).
- Release, 2 MiB, best of 15: dense 0xE9 11 ms to 0.55 ms. English text with `’ “ ”` 0.9 ms to 0.6 ms. One case is slower: a lone 0x80..=0x9F byte at a fixed period of 33 to 100 bytes, by 1.1x to 1.3x. The full table is in the notes.
- Verified: `test/js/web/encoding/text-decoder.test.js` (two new tests, the cost test fails on stock bun). Also `text-decoder-single-byte`, `-stream`, and `-wpt`. Self-reviewed: 1 concern raised, 1 addressed (a first version regressed sparse accented prose, see notes).

### Background
- `TextDecoder` with the `latin1` or `windows-1252` label decodes to UTF-16, because windows-1252 maps 0x80..=0x9F to code points above 0xFF (0x80 is U+20AC). All-ASCII input takes an earlier fast path and never reaches this function.
- `first_non_ascii_usize` (`src/bun_core/lib.rs:1465`) scans slices longer than 32 bytes through simdutf. Each call pays a runtime CPU dispatch: cheap per slice, expensive per byte.
- `copy_u8_into_u16` is a plain widening loop that the compiler vectorizes.

<details><summary>Notes</summary>

Release numbers. Same machine, 2 MiB input, best of 15 decodes, milliseconds. Old is the stock 1.4.3 binary. New is a release build of this branch (no LTO). The host was under load from other tenants, so treat differences under 10% as noise.

| input | old | new |
| --- | --- | --- |
| dense 0xE9 | 11.0 | 0.55 |
| dense 0x80 (every byte in 0x80..=0x9F) | 10.9 | 0.87 |
| alternating ASCII / 0xE9 | 9.9 | 0.55 |
| one 0xE9 then ASCII | 0.62 | 0.53 |
| 0xE9 every 33 bytes | 0.80 | 0.53 |
| 0xE9 every 50 bytes | 0.60 to 0.80 | 0.55 |
| 0xE9 every 200 bytes | 0.54 to 0.63 | 0.54 |
| 0x93 every 33 bytes | 0.78 to 0.83 | 0.87 to 0.90 |
| 0x93 every 100 bytes | 0.55 to 0.79 | 0.71 to 0.73 |
| 0x93 every 200 bytes | 0.56 to 0.71 | 0.60 |
| 0x93 every 1000 bytes | 0.57 to 0.68 | 0.55 to 0.61 |
| English (`docs/*.md`, `'` as 0x92, `"` as 0x93/0x94, one per 79 bytes) | 0.88 to 1.23 | 0.60 to 0.63 |
| English (`docs/*.md`, 0xE9 about every 88 bytes) | 0.80 to 1.09 | 0.46 to 0.51 |

The slower rows are a single 0x80..=0x9F byte at a fixed period shorter than two blocks. Every block then takes the table path at about 0.3 ns per byte, while the old code paid one scan per such byte and widened the rest. Real text clusters its quotes and apostrophes, so many blocks stay on the widening path, and the English rows come out faster. I tried finer-grained variants for the table path (8-byte SWAR masks, 16 and 32-byte sub-blocks, widen-then-patch). All of them lost more to branch mispredictions on these inputs than they saved, and several were slower on dense input.

Debug build (`bun bd`, opt-level 0 with ASAN), 2 MiB, best of 10: dense 0xE9 275 ms to 53 ms, one accent then ASCII 28 ms to 53 ms. The debug one-accent case is slower because the per-block check is an iterator fold that opt-level 0 does not optimize.

The cost test compares dense 0xE9 against one-accent input. Both go through the same function and produce a UTF-16 string of the same length, so allocation and string creation cancel. On the unfixed binary the ratio is 10 (debug) to 18 (release), against a bound of 5. On the fixed build it is about 1.0 in both release and debug. An all-ASCII baseline was tried first and rejected: it takes the 8-bit fast path, and its ratio swung between 12 and 45 on the unfixed binary from run to run.

The first version of this change kept the SIMD prefix scan and only re-entered it after a 32-byte all-ASCII window. In release it made French and German prose 1.3x to 1.4x slower and one accent per 33 bytes 2.5x to 3x slower, because every non-ASCII byte cost a 32-byte scalar scan plus a fresh simdutf dispatch. The block version has no rescans.

</details>
