### PR TITLE
Bun.serve: throw when top-level TLS options are mixed with tls

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -582,14 +582,16 @@ const TLS_OPTION_KEYS: &[&str] = &[
     "ecdhCurve",
 ];
 
-/// The first legacy top-level TLS key that is set (not `undefined`) on the
-/// options object.
+/// The first legacy top-level TLS key that is set on the options object.
+/// `undefined` and `null` both mean unset, as they do inside `tls`.
 fn first_top_level_tls_key(
     global: &JSGlobalObject,
     arg: JSValue,
 ) -> JsResult<Option<&'static str>> {
     for &key in TLS_OPTION_KEYS {
-        if arg.get(global, key)?.is_some() {
+        if let Some(value) = arg.get(global, key)?
+            && !value.is_null()
+        {
             return Ok(Some(key));
         }
     }
@@ -1288,11 +1290,13 @@ impl ServerConfig {
             // The legacy top-level keys are only read when `tls` is absent.
             // A mix would silently drop the top-level ones (for example
             // `requestCert` and `rejectUnauthorized`), so refuse it.
-            if let Some(key) = first_top_level_tls_key(global, arg)? {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Bun.serve() received both \"tls\" and the top-level TLS option \"{key}\". \
-                     Move \"{key}\" into the \"tls\" object.",
-                )));
+            if tls.is_object() {
+                if let Some(key) = first_top_level_tls_key(global, arg)? {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "Bun.serve() received both \"tls\" and the top-level TLS option \"{key}\". \
+                         Move \"{key}\" into the \"tls\" object.",
+                    )));
+                }
             }
             if tls.is_falsey() {
                 args.ssl_config = None;

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -552,6 +552,50 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     Ok(())
 }
 
+/// Every key `SSLConfig::from_js` reads (see `SSLConfig.bindv2.ts`). The
+/// legacy form (Bun v0.x) read them from the top-level options object.
+const TLS_OPTION_KEYS: &[&str] = &[
+    "passphrase",
+    "dhParamsFile",
+    "serverName",
+    "servername",
+    "lowMemoryMode",
+    "rejectUnauthorized",
+    "requestCert",
+    "ca",
+    "cert",
+    "key",
+    "secureOptions",
+    "minVersion",
+    "maxVersion",
+    "keyFile",
+    "certFile",
+    "caFile",
+    "ALPNProtocols",
+    "ciphers",
+    "clientRenegotiationLimit",
+    "clientRenegotiationWindow",
+    "crl",
+    "allowPartialTrustChain",
+    "sessionTimeout",
+    "sigalgs",
+    "ecdhCurve",
+];
+
+/// The first legacy top-level TLS key that is set (not `undefined`) on the
+/// options object.
+fn first_top_level_tls_key(
+    global: &JSGlobalObject,
+    arg: JSValue,
+) -> JsResult<Option<&'static str>> {
+    for &key in TLS_OPTION_KEYS {
+        if arg.get(global, key)?.is_some() {
+            return Ok(Some(key));
+        }
+    }
+    Ok(None)
+}
+
 fn get_routes_object(global: &JSGlobalObject, arg: JSValue) -> JsResult<Option<JSValue>> {
     for key in ["routes", "static"] {
         if let Some(routes) = arg.get(global, key)? {
@@ -1241,6 +1285,15 @@ impl ServerConfig {
         }
 
         if let Some(tls) = arg.get_truthy(global, "tls")? {
+            // The legacy top-level keys are only read when `tls` is absent.
+            // A mix would silently drop the top-level ones (for example
+            // `requestCert` and `rejectUnauthorized`), so refuse it.
+            if let Some(key) = first_top_level_tls_key(global, arg)? {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "Bun.serve() received both \"tls\" and the top-level TLS option \"{key}\". \
+                     Move \"{key}\" into the \"tls\" object.",
+                )));
+            }
             if tls.is_falsey() {
                 args.ssl_config = None;
             } else if tls.js_type().is_array() {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -552,8 +552,7 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     Ok(())
 }
 
-/// Every key `SSLConfig::from_js` reads (see `SSLConfig.bindv2.ts`). The
-/// legacy form (Bun v0.x) read them from the top-level options object.
+/// The keys of `SSLConfig.bindv2.ts`.
 const TLS_OPTION_KEYS: &[&str] = &[
     "passphrase",
     "dhParamsFile",
@@ -582,8 +581,6 @@ const TLS_OPTION_KEYS: &[&str] = &[
     "ecdhCurve",
 ];
 
-/// The first legacy top-level TLS key that is set on the options object.
-/// `undefined` and `null` both mean unset, as they do inside `tls`.
 fn first_top_level_tls_key(
     global: &JSGlobalObject,
     arg: JSValue,
@@ -1287,9 +1284,6 @@ impl ServerConfig {
         }
 
         if let Some(tls) = arg.get_truthy(global, "tls")? {
-            // The legacy top-level keys are only read when `tls` is absent.
-            // A mix would silently drop the top-level ones (for example
-            // `requestCert` and `rejectUnauthorized`), so refuse it.
             if tls.is_object() {
                 if let Some(key) = first_top_level_tls_key(global, arg)? {
                     return Err(global.throw_invalid_arguments(format_args!(

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -200,13 +200,27 @@ describe("Bun.serve top-level TLS options mixed with tls", () => {
     });
   }
 
-  test("top-level TLS keys set to undefined are not a mix", async () => {
+  test("top-level TLS keys set to undefined or null are not a mix", async () => {
     using server = Bun.serve({
       port: 0,
       fetch,
       ca: undefined,
       requestCert: undefined,
+      cert: null,
+      rejectUnauthorized: null,
       tls: { key: serverKey, cert: serverCert },
+    } as any);
+    const res = await globalThis.fetch(server.url, { tls: { rejectUnauthorized: false } });
+    expect(await res.text()).toBe("Hello, world!");
+  });
+
+  test("tls: false next to top-level keys is not a mix", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch,
+      key: serverKey,
+      cert: serverCert,
+      tls: false,
     } as any);
     const res = await globalThis.fetch(server.url, { tls: { rejectUnauthorized: false } });
     expect(await res.text()).toBe("Hello, world!");

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -153,6 +153,86 @@ describe("Bun.serve SSL validations", () => {
   }
 });
 
+describe("Bun.serve top-level TLS options mixed with tls", () => {
+  const tlsFixtures = join(import.meta.dir, "..", "..", "node", "tls", "fixtures");
+  const serverKey = readFileSync(join(tlsFixtures, "agent10-key.pem"), "utf8");
+  const serverCert = readFileSync(join(tlsFixtures, "agent10-cert.pem"), "utf8");
+  const clientCa = readFileSync(join(tlsFixtures, "ca5-cert.pem"), "utf8");
+  const fetch = () => new Response("Hello, world!");
+
+  const mixed = [
+    {
+      label: "mTLS keys at the top level next to tls: {cert, key}",
+      options: { ca: clientCa, requestCert: true, rejectUnauthorized: true, tls: { key: serverKey, cert: serverCert } },
+      key: "rejectUnauthorized",
+    },
+    {
+      label: "cert and key at the top level next to tls: {ca, requestCert}",
+      options: { key: serverKey, cert: serverCert, tls: { ca: clientCa, requestCert: true, rejectUnauthorized: true } },
+      key: "cert",
+    },
+    {
+      label: "top-level keys next to a tls object that only holds defaults",
+      options: { key: serverKey, cert: serverCert, requestCert: true, tls: { requestCert: false } },
+      key: "requestCert",
+    },
+    {
+      label: "top-level keys next to an empty tls object",
+      options: { key: serverKey, cert: serverCert, tls: {} },
+      key: "cert",
+    },
+    {
+      label: "top-level keys next to a tls array",
+      options: { ca: clientCa, tls: [{ key: serverKey, cert: serverCert }] },
+      key: "ca",
+    },
+    {
+      label: "the servername alias at the top level",
+      options: { servername: "localhost", tls: { key: serverKey, cert: serverCert } },
+      key: "servername",
+    },
+  ];
+  for (const { label, options, key } of mixed) {
+    test(label, () => {
+      expect(() => Bun.serve({ port: 0, fetch, ...(options as any) })).toThrow(
+        `Bun.serve() received both "tls" and the top-level TLS option "${key}". Move "${key}" into the "tls" object.`,
+      );
+    });
+  }
+
+  test("top-level TLS keys set to undefined are not a mix", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch,
+      ca: undefined,
+      requestCert: undefined,
+      tls: { key: serverKey, cert: serverCert },
+    } as any);
+    const res = await globalThis.fetch(server.url, { tls: { rejectUnauthorized: false } });
+    expect(await res.text()).toBe("Hello, world!");
+  });
+
+  test("the legacy top-level form alone still enforces mTLS", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch,
+      key: serverKey,
+      cert: serverCert,
+      ca: clientCa,
+      requestCert: true,
+      rejectUnauthorized: true,
+    } as any);
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const socket = tls.connect({ host: "127.0.0.1", port: server.port, rejectUnauthorized: false });
+    let received = "";
+    socket.on("secureConnect", () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"));
+    socket.on("data", chunk => (received += chunk.toString()));
+    socket.on("error", () => {});
+    socket.on("close", () => resolve(received.split("\r\n")[0] || "connection closed without a response"));
+    expect(await promise).toBe("connection closed without a response");
+  });
+});
+
 describe("Bun.serve per-serverName client certificate policy", () => {
   const tlsFixtures = join(import.meta.dir, "..", "..", "node", "tls", "fixtures");
   const serverKey = readFileSync(join(tlsFixtures, "agent10-key.pem"), "utf8");

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -956,7 +956,6 @@ describe.concurrent("fetch-tls", () => {
       // 127.0.0.1, turning the timeout under test into ConnectionRefused.
       hostname: "127.0.0.1",
       port: 0,
-      rejectUnauthorized: false,
       async fetch() {
         async function* body() {
           yield "Hello, ";


### PR DESCRIPTION
### Problem
- `Bun.serve({ ca, requestCert: true, rejectUnauthorized: true, tls: { cert, key } })` starts an HTTPS server that accepts clients with no certificate. The three top-level keys are dropped with no error. The reverse mix, `{ cert, key, tls: { ca, requestCert, rejectUnauthorized } }`, starts a listener with no certificate that fails every handshake.
- `ServerConfig.rs` parses the `tls` value first. It reads the legacy top-level keys (the Bun v0.x form) only when that parse produced no config. So which form wins depends on the values inside `tls`: `tls: { requestCert: false }` counts as absent and the top-level keys are used.

### Fix
- When `tls` is an object or array, `Bun.serve` now checks the options object for each key that `SSLConfig` reads (the 25 keys in `SSLConfig.bindv2.ts`, plus the `servername` alias). If one is set, it throws: `Bun.serve() received both "tls" and the top-level TLS option "<key>". Move "<key>" into the "tls" object.`
- The check keys on the presence of a top-level key, not on the parsed result. So it covers an empty `tls: {}`, a defaults-only `tls` object, and the `tls: [...]` SNI array.
- A key set to `undefined` or `null` is not a mix, and neither is a falsey `tls` (`tls: false`). Code that spreads an options object with unset fields keeps working. The legacy form alone is unchanged.
- Verified: `test/js/bun/http/bun-serve-ssl.test.ts` (9 new tests, 6 of them fail on bun 1.4.3). One existing test in `fetch.tls.test.ts` passed a stray top-level `rejectUnauthorized: false` next to `tls` and is updated. Also ran `serve.test.ts`, `serve-http2.test.ts`, `serve-protocols.test.ts`, `tls-keepalive.test.ts`, and the node https and tls server suites.

### Background
- `SSLConfig` is the parsed TLS configuration for a listener: certificate, key, CA, client certificate policy, protocol versions, ciphers. `SSLConfig::from_js` reads it from a JS object and returns `None` when every field is at its default.
- Before v0.2.1, `Bun.serve` took the TLS keys at the top level of its options. The `tls` object replaced them, but the top-level keys are still read for compatibility.
- `node:http` and `node:https` servers build on `Bun.serve` and pass a `tls` object only, so they are not affected by the new check.

<details><summary>Notes</summary>

Repro on bun 1.4.3 (fixtures from `test/js/node/tls/fixtures`, anonymous `tls.connect` client):

```
legacy alone             https -> (closed, no response)
nested alone             https -> (closed, no response)
MIXED                    https -> HTTP/1.1 200 OK
MIXED defaults-only tls  https -> (closed, no response)
MIXED reverse            https -> (closed, no response)
```

The `tls: { requestCert: false }` case is what makes a check on the parsed result insufficient: `SSLConfig::from_js` returns `None` for it, so the legacy keys were read in that one shape and ignored in the others.

Related open PRs #35795 and #35810 reject a `tls` object with no certificate. They do not address the mix: with both forms present, the top-level keys were already gone before that check could run.

Suites run with the debug build: `bun-serve-ssl.test.ts` (26 pass), `serve.test.ts`, `serve-http2.test.ts`, `serve-protocols.test.ts`, `tls-keepalive.test.ts`, `node-https-checkServerIdentity.test.ts`, `node-tls-server.test.ts`, `node-http2-server.test.ts`. Two `serve.test.ts` tests (root range port, `/bun:info` loopback) and two `node-tls-server.test.ts` tests fail the same way with the unmodified `ServerConfig.rs` in this container (runs as root, debug-build timeouts).
</details>
