### PR TITLE
spawn: open /dev/null without O_CREAT for ignored stdio

### DIFF
--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -766,13 +766,13 @@ pub unsafe fn spawn_process_posix(
             PosixStdio::Inherit => {
                 // A closed slot would inherit whatever fd is created later at that number (e.g. the ipc socketpair); libuv gives it /dev/null.
                 if bun_sys::get_fcntl_flags(fileno).is_err() {
-                    actions.open_z(fileno, c"/dev/null", flag | bun_sys::O::CREAT as u32, 0o664)?;
+                    actions.open_z(fileno, c"/dev/null", flag, 0)?;
                 } else {
                     actions.inherit(fileno)?;
                 }
             }
             PosixStdio::Ipc | PosixStdio::Ignore => {
-                actions.open_z(fileno, c"/dev/null", flag | bun_sys::O::CREAT as u32, 0o664)?;
+                actions.open_z(fileno, c"/dev/null", flag, 0)?;
             }
             PosixStdio::Path(path) => {
                 actions.open(fileno, path, flag | bun_sys::O::CREAT as u32, 0o664)?;

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1719,3 +1719,71 @@ it.if(parentThp() === "1")("spawned children keep the system THP policy", async 
   expect(thpEnabled(readFileSync("/proc/self/status", "utf8"))).toBe("1");
   expect(exitCode).toBe(0);
 });
+
+// stdio "ignore" opens /dev/null. The open must not carry O_CREAT: on a rootfs
+// without /dev/null that creates a regular file there. A seccomp filter that
+// fails every openat(2) with O_CREAT proves the flag is gone.
+it.if(isLinux && (process.arch === "x64" || process.arch === "arm64"))(
+  "stdio ignore opens /dev/null without O_CREAT",
+  async () => {
+    using dir = tempDir("spawn-ignore-no-creat", {
+      "deny-creat.c": `
+        typedef unsigned short u16; typedef unsigned char u8; typedef unsigned int u32;
+        struct sock_filter { u16 code; u8 jt; u8 jf; u32 k; };
+        struct sock_fprog { u16 len; struct sock_filter *filter; };
+        int prctl(int option, ...);
+        #if defined(__x86_64__)
+        #define NR_OPENAT 257
+        #else
+        #define NR_OPENAT 56
+        #endif
+        int deny_openat_with_creat(void) {
+          struct sock_filter f[] = {
+            { 0x20, 0, 0, 0 },               /* A = nr                     (BPF_LD|BPF_W|BPF_ABS)  */
+            { 0x15, 0, 3, NR_OPENAT },       /* if nr != openat: allow     (BPF_JMP|BPF_JEQ|BPF_K) */
+            { 0x20, 0, 0, 16 + 2 * 8 },      /* A = args[2] (flags)                                 */
+            { 0x45, 0, 1, 0100 },            /* if !(A & O_CREAT): allow   (BPF_JMP|BPF_JSET|BPF_K) */
+            { 0x06, 0, 0, 0x00050000 | 13 }, /* SECCOMP_RET_ERRNO | EACCES (BPF_RET|BPF_K)          */
+            { 0x06, 0, 0, 0x7fff0000 },      /* SECCOMP_RET_ALLOW                                   */
+          };
+          struct sock_fprog prog = { sizeof(f) / sizeof(f[0]), f };
+          if (prctl(38 /* PR_SET_NO_NEW_PRIVS */, 1, 0, 0, 0) != 0) return -1;
+          if (prctl(22 /* PR_SET_SECCOMP */, 2 /* SECCOMP_MODE_FILTER */, &prog) != 0) return -2;
+          return 0;
+        }
+      `,
+      "fixture.ts": `
+        import { cc } from "bun:ffi";
+        import { spawnSync as nodeSpawnSync } from "node:child_process";
+        const { symbols } = cc({
+          source: new URL("./deny-creat.c", import.meta.url).pathname,
+          symbols: { deny_openat_with_creat: { args: [], returns: "i32" } },
+        });
+        const seccomp = symbols.deny_openat_with_creat();
+        const result: Record<string, unknown> = { seccomp };
+        try {
+          result.bun = Bun.spawnSync({
+            cmd: [process.execPath, "-e", "process.exit(7)"],
+            stdio: ["ignore", "ignore", "ignore"],
+          }).exitCode;
+        } catch (e) {
+          result.bun = String(e);
+        }
+        const node = nodeSpawnSync(process.execPath, ["-e", "process.exit(8)"], { stdio: "ignore" });
+        result.node = node.error ? String(node.error) : node.status;
+        console.log(JSON.stringify(result));
+      `,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ seccomp: 0, bun: 7, node: 8 });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
### Problem
- `stdio: "ignore"` (Bun.spawn, Bun.spawnSync, node `child_process`) opens `/dev/null` in the child with `O_CREAT`, mode `0664`. strace: `openat(AT_FDCWD, "/dev/null", O_RDONLY|O_CREAT, 0664)`.
- On a rootfs without `/dev/null` and a writable `/dev` (a scratch image, a chroot being populated, initramfs) the first ignored spawn creates a regular file at `/dev/null`. Every later `> /dev/null` appends to it and every read of `/dev/null` returns data. Node fails with ENOENT and creates nothing.
- The cause is `src/spawn_sys/spawn_process.rs:775` (and the same flags at `:769` for an inherited slot whose fd is closed). The `O_CREAT | 0664` was copied from the user-path case at `:778`, where it is intended.

### Fix
- Open `/dev/null` with `O_RDONLY` or `O_WRONLY` only, mode 0. The user-path case keeps `O_CREAT`.
- On a rootfs without `/dev/null` the spawn now fails with `ENOENT` from the child, like Node.
- Verified: `test/js/bun/spawn/spawn.test.ts` ("stdio ignore opens /dev/null without O_CREAT"). The test installs a seccomp filter in a child bun that fails every `openat(2)` carrying `O_CREAT`, then spawns with `stdio: "ignore"` through both `Bun.spawnSync` and `child_process.spawnSync`. Stock bun fails the spawn with EACCES. Also ran `spawn.test.ts`, `spawnSync.test.ts`, `child_process.test.ts`.

### Background
- The POSIX spawn path builds a list of file actions that run in the child between `vfork` and `exec` (`src/jsc/bindings/bun-spawn.cpp:387`, or `posix_spawn_file_actions_addopen` on the libc fallback). `actions.open_z(fd, path, flags, mode)` becomes `open(path, flags, mode)` then `dup2` onto the stdio fd.
- The test uses `bun:ffi`'s `cc` to compile a small C function that installs a seccomp-bpf filter. Filters are inherited across `fork` and `execve`, so the check happens in the spawned child. The test runs on Linux x64 and arm64 only.

<details><summary>Notes</summary>

The other `/dev/null` opens in the tree (`src/bun_core/util.rs`, `src/runtime/shell/interpreter.rs`, `src/jsc/bindings/c-bindings.cpp`) already open without `O_CREAT`. Windows maps `"ignore"` to libuv `UV_IGNORE` and does not open a path.

Ledger repro (root, private mount namespace, host untouched):

```
unshare -m --propagation private sh -c '
  mount -t tmpfs -o mode=755 none /dev && mknod -m 666 /dev/urandom c 1 9
  bun -e "require(\"child_process\").spawnSync(\"sh\",[\"-c\",\"echo x\"],{stdio:\"ignore\"})"
  ls -l /dev/null; cat /dev/null'
```

Before: `-rw-r--r-- 1 root root 2 /dev/null` containing `x`. After: `ls: /dev/null: No such file or directory` and the spawn rejects with ENOENT.

The seccomp probe in the test: `{ 0x45, 0, 1, 0100 }` is `BPF_JMP|BPF_JSET|BPF_K` on `args[2]` (the open flags) against `O_CREAT` (0100). The filter returns `SECCOMP_RET_ERRNO|EACCES` for a match and `SECCOMP_RET_ALLOW` otherwise.

</details>
